### PR TITLE
Restructure translations for entity components

### DIFF
--- a/homeassistant/components/alarm_control_panel/strings.json
+++ b/homeassistant/components/alarm_control_panel/strings.json
@@ -26,19 +26,21 @@
       "armed_vacation": "{entity_name} armed vacation"
     }
   },
-  "state": {
+  "entity_component": {
     "_": {
-      "armed": "Armed",
-      "disarmed": "Disarmed",
-      "armed_home": "Armed home",
-      "armed_away": "Armed away",
-      "armed_night": "Armed night",
-      "armed_vacation": "Armed vacation",
-      "armed_custom_bypass": "Armed custom bypass",
-      "pending": "Pending",
-      "arming": "Arming",
-      "disarming": "Disarming",
-      "triggered": "Triggered"
+      "state": {
+        "armed": "Armed",
+        "disarmed": "Disarmed",
+        "armed_home": "Armed home",
+        "armed_away": "Armed away",
+        "armed_night": "Armed night",
+        "armed_vacation": "Armed vacation",
+        "armed_custom_bypass": "Armed custom bypass",
+        "pending": "Pending",
+        "arming": "Arming",
+        "disarming": "Disarming",
+        "triggered": "Triggered"
+      }
     }
   }
 }

--- a/homeassistant/components/alert/strings.json
+++ b/homeassistant/components/alert/strings.json
@@ -1,10 +1,12 @@
 {
   "title": "Alert",
-  "state": {
+  "entity_component": {
     "_": {
-      "idle": "[%key:common::state::idle%]",
-      "off": "Acknowledged",
-      "on": "[%key:common::state::active%]"
+      "state": {
+        "idle": "[%key:common::state::idle%]",
+        "off": "Acknowledged",
+        "on": "[%key:common::state::active%]"
+      }
     }
   }
 }

--- a/homeassistant/components/automation/strings.json
+++ b/homeassistant/components/automation/strings.json
@@ -1,9 +1,11 @@
 {
   "title": "Automation",
-  "state": {
+  "entity_component": {
     "_": {
-      "off": "[%key:common::state::off%]",
-      "on": "[%key:common::state::on%]"
+      "state": {
+        "off": "[%key:common::state::off%]",
+        "on": "[%key:common::state::on%]"
+      }
     }
   },
   "issues": {

--- a/homeassistant/components/binary_sensor/strings.json
+++ b/homeassistant/components/binary_sensor/strings.json
@@ -114,182 +114,156 @@
       }
     },
     "battery": {
-      "name": "Battery",
       "state": {
         "off": "Normal",
         "on": "Low"
       }
     },
     "battery_charging": {
-      "name": "Battery charging",
       "state": {
         "off": "Not charging",
         "on": "Charging"
       }
     },
     "carbon_monoxide": {
-      "name": "Carbon monoxide",
       "state": {
         "off": "[%key:component::binary_sensor::entity_component::gas::state::off%]",
         "on": "[key:component::binary_sensor::entity_component::gas::state::on%]"
       }
     },
     "cold": {
-      "name": "Cold",
       "state": {
         "off": "[%key:component::binary_sensor::entity_component::battery::state::off%]",
         "on": "Cold"
       }
     },
     "connectivity": {
-      "name": "Connectivity",
       "state": {
         "off": "[%key:common::state::disconnected%]",
         "on": "[%key:common::state::connected%]"
       }
     },
     "door": {
-      "name": "Door",
       "state": {
         "off": "[%key:common::state::closed%]",
         "on": "[%key:common::state::open%]"
       }
     },
     "garage_door": {
-      "name": "Garage door",
       "state": {
         "off": "[%key:common::state::closed%]",
         "on": "[%key:common::state::open%]"
       }
     },
     "gas": {
-      "name": "Gas",
       "state": {
         "off": "Clear",
         "on": "Detected"
       }
     },
     "heat": {
-      "name": "Heat",
       "state": {
         "off": "[%key:component::binary_sensor::entity_component::battery::state::off%]",
         "on": "Hot"
       }
     },
     "light": {
-      "name": "Light",
       "state": {
         "off": "No light",
         "on": "Light detected"
       }
     },
     "lock": {
-      "name": "Lock",
       "state": {
         "off": "[%key:common::state::locked%]",
         "on": "[%key:common::state::unlocked%]"
       }
     },
     "moisture": {
-      "name": "Moisture",
       "state": {
         "off": "Dry",
         "on": "Wet"
       }
     },
     "motion": {
-      "name": "Motion",
       "state": {
         "off": "[key:component::binary_sensor::entity_component::gas::state::off%]",
         "on": "[key:component::binary_sensor::entity_component::gas::state::on%]"
       }
     },
     "moving": {
-      "name": "Moving",
       "state": {
         "off": "Not moving",
         "on": "Moving"
       }
     },
     "occupancy": {
-      "name": "Occupancy",
       "state": {
         "off": "[key:component::binary_sensor::entity_component::gas::state::off%]",
         "on": "[key:component::binary_sensor::entity_component::gas::state::on%]"
       }
     },
     "opening": {
-      "name": "Opening",
       "state": {
         "off": "[%key:common::state::closed%]",
         "on": "[%key:common::state::open%]"
       }
     },
     "plug": {
-      "name": "Plug",
       "state": {
         "off": "Unplugged",
         "on": "Plugged in"
       }
     },
     "presence": {
-      "name": "Presence",
       "state": {
         "off": "[%key:component::device_tracker::entity_component::_::state::not_home%]",
         "on": "[%key:component::device_tracker::entity_component::_::state::home%]"
       }
     },
     "problem": {
-      "name": "Problem",
       "state": {
         "off": "OK",
         "on": "Problem"
       }
     },
     "running": {
-      "name": "Running",
       "state": {
         "off": "Not running",
         "on": "Running"
       }
     },
     "safety": {
-      "name": "Safety",
       "state": {
         "off": "Safe",
         "on": "Unsafe"
       }
     },
     "smoke": {
-      "name": "Smoke",
       "state": {
         "off": "[key:component::binary_sensor::entity_component::gas::state::off%]",
         "on": "[key:component::binary_sensor::entity_component::gas::state::on%]"
       }
     },
     "sound": {
-      "name": "Sound",
       "state": {
         "off": "[key:component::binary_sensor::entity_component::gas::state::off%]",
         "on": "[key:component::binary_sensor::entity_component::gas::state::on%]"
       }
     },
     "update": {
-      "name": "Update",
       "state": {
         "off": "Up-to-date",
         "on": "Update available"
       }
     },
     "vibration": {
-      "name": "Vibration",
       "state": {
         "off": "[key:component::binary_sensor::entity_component::gas::state::off%]",
         "on": "[key:component::binary_sensor::entity_component::gas::state::on%]"
       }
     },
     "window": {
-      "name": "Window",
       "state": {
         "off": "[%key:common::state::closed%]",
         "on": "[%key:common::state::open%]"

--- a/homeassistant/components/binary_sensor/strings.json
+++ b/homeassistant/components/binary_sensor/strings.json
@@ -106,114 +106,194 @@
       "turned_off": "{entity_name} turned off"
     }
   },
-  "state": {
+  "entity_component": {
+    "_": {
+      "state": {
+        "off": "[%key:common::state::off%]",
+        "on": "[%key:common::state::on%]"
+      }
+    },
     "battery": {
-      "off": "Normal",
-      "on": "Low"
+      "name": "Battery",
+      "state": {
+        "off": "Normal",
+        "on": "Low"
+      }
     },
     "battery_charging": {
-      "off": "Not charging",
-      "on": "Charging"
+      "name": "Battery charging",
+      "state": {
+        "off": "Not charging",
+        "on": "Charging"
+      }
     },
     "carbon_monoxide": {
-      "off": "[%key:component::binary_sensor::state::gas::off%]",
-      "on": "[%key:component::binary_sensor::state::gas::on%]"
+      "name": "Carbon monoxide",
+      "state": {
+        "off": "[%key:component::binary_sensor::entity_component::gas::state::off%]",
+        "on": "[key:component::binary_sensor::entity_component::gas::state::on%]"
+      }
     },
     "cold": {
-      "off": "[%key:component::binary_sensor::state::battery::off%]",
-      "on": "Cold"
+      "name": "Cold",
+      "state": {
+        "off": "[%key:component::binary_sensor::entity_component::battery::state::off%]",
+        "on": "Cold"
+      }
     },
     "connectivity": {
-      "off": "[%key:common::state::disconnected%]",
-      "on": "[%key:common::state::connected%]"
+      "name": "Connectivity",
+      "state": {
+        "off": "[%key:common::state::disconnected%]",
+        "on": "[%key:common::state::connected%]"
+      }
     },
     "door": {
-      "off": "[%key:common::state::closed%]",
-      "on": "[%key:common::state::open%]"
+      "name": "Door",
+      "state": {
+        "off": "[%key:common::state::closed%]",
+        "on": "[%key:common::state::open%]"
+      }
     },
     "garage_door": {
-      "off": "[%key:common::state::closed%]",
-      "on": "[%key:common::state::open%]"
+      "name": "Garage door",
+      "state": {
+        "off": "[%key:common::state::closed%]",
+        "on": "[%key:common::state::open%]"
+      }
     },
     "gas": {
-      "off": "Clear",
-      "on": "Detected"
+      "name": "Gas",
+      "state": {
+        "off": "Clear",
+        "on": "Detected"
+      }
     },
     "heat": {
-      "off": "[%key:component::binary_sensor::state::battery::off%]",
-      "on": "Hot"
+      "name": "Heat",
+      "state": {
+        "off": "[%key:component::binary_sensor::entity_component::battery::state::off%]",
+        "on": "Hot"
+      }
     },
     "light": {
-      "off": "No light",
-      "on": "Light detected"
+      "name": "Light",
+      "state": {
+        "off": "No light",
+        "on": "Light detected"
+      }
     },
     "lock": {
-      "off": "[%key:common::state::locked%]",
-      "on": "[%key:common::state::unlocked%]"
+      "name": "Lock",
+      "state": {
+        "off": "[%key:common::state::locked%]",
+        "on": "[%key:common::state::unlocked%]"
+      }
     },
     "moisture": {
-      "off": "Dry",
-      "on": "Wet"
+      "name": "Moisture",
+      "state": {
+        "off": "Dry",
+        "on": "Wet"
+      }
     },
     "motion": {
-      "off": "[%key:component::binary_sensor::state::gas::off%]",
-      "on": "[%key:component::binary_sensor::state::gas::on%]"
+      "name": "Motion",
+      "state": {
+        "off": "[key:component::binary_sensor::entity_component::gas::state::off%]",
+        "on": "[key:component::binary_sensor::entity_component::gas::state::on%]"
+      }
     },
     "moving": {
-      "off": "Not moving",
-      "on": "Moving"
+      "name": "Moving",
+      "state": {
+        "off": "Not moving",
+        "on": "Moving"
+      }
     },
     "occupancy": {
-      "off": "[%key:component::binary_sensor::state::gas::off%]",
-      "on": "[%key:component::binary_sensor::state::gas::on%]"
+      "name": "Occupancy",
+      "state": {
+        "off": "[key:component::binary_sensor::entity_component::gas::state::off%]",
+        "on": "[key:component::binary_sensor::entity_component::gas::state::on%]"
+      }
     },
     "opening": {
-      "off": "[%key:common::state::closed%]",
-      "on": "[%key:common::state::open%]"
+      "name": "Opening",
+      "state": {
+        "off": "[%key:common::state::closed%]",
+        "on": "[%key:common::state::open%]"
+      }
     },
     "plug": {
-      "off": "Unplugged",
-      "on": "Plugged in"
+      "name": "Plug",
+      "state": {
+        "off": "Unplugged",
+        "on": "Plugged in"
+      }
     },
     "presence": {
-      "off": "[%key:component::device_tracker::state::_::not_home%]",
-      "on": "[%key:component::device_tracker::state::_::home%]"
+      "name": "Presence",
+      "state": {
+        "off": "[%key:component::device_tracker::entity_component::_::state::not_home%]",
+        "on": "[%key:component::device_tracker::entity_component::_::state::home%]"
+      }
     },
     "problem": {
-      "off": "OK",
-      "on": "Problem"
+      "name": "Problem",
+      "state": {
+        "off": "OK",
+        "on": "Problem"
+      }
     },
     "running": {
-      "off": "Not running",
-      "on": "Running"
+      "name": "Running",
+      "state": {
+        "off": "Not running",
+        "on": "Running"
+      }
     },
     "safety": {
-      "off": "Safe",
-      "on": "Unsafe"
+      "name": "Safety",
+      "state": {
+        "off": "Safe",
+        "on": "Unsafe"
+      }
     },
     "smoke": {
-      "off": "[%key:component::binary_sensor::state::gas::off%]",
-      "on": "[%key:component::binary_sensor::state::gas::on%]"
+      "name": "Smoke",
+      "state": {
+        "off": "[key:component::binary_sensor::entity_component::gas::state::off%]",
+        "on": "[key:component::binary_sensor::entity_component::gas::state::on%]"
+      }
     },
     "sound": {
-      "off": "[%key:component::binary_sensor::state::gas::off%]",
-      "on": "[%key:component::binary_sensor::state::gas::on%]"
+      "name": "Sound",
+      "state": {
+        "off": "[key:component::binary_sensor::entity_component::gas::state::off%]",
+        "on": "[key:component::binary_sensor::entity_component::gas::state::on%]"
+      }
     },
     "update": {
-      "off": "Up-to-date",
-      "on": "Update available"
+      "name": "Update",
+      "state": {
+        "off": "Up-to-date",
+        "on": "Update available"
+      }
     },
     "vibration": {
-      "off": "[%key:component::binary_sensor::state::gas::off%]",
-      "on": "[%key:component::binary_sensor::state::gas::on%]"
+      "name": "Vibration",
+      "state": {
+        "off": "[key:component::binary_sensor::entity_component::gas::state::off%]",
+        "on": "[key:component::binary_sensor::entity_component::gas::state::on%]"
+      }
     },
     "window": {
-      "off": "[%key:common::state::closed%]",
-      "on": "[%key:common::state::open%]"
-    },
-    "_": {
-      "off": "[%key:common::state::off%]",
-      "on": "[%key:common::state::on%]"
+      "name": "Window",
+      "state": {
+        "off": "[%key:common::state::closed%]",
+        "on": "[%key:common::state::open%]"
+      }
     }
   },
   "device_class": {

--- a/homeassistant/components/calendar/strings.json
+++ b/homeassistant/components/calendar/strings.json
@@ -1,9 +1,11 @@
 {
   "title": "Calendar",
-  "state": {
+  "entity_component": {
     "_": {
-      "off": "[%key:common::state::off%]",
-      "on": "[%key:common::state::on%]"
+      "state": {
+        "off": "[%key:common::state::off%]",
+        "on": "[%key:common::state::on%]"
+      }
     }
   }
 }

--- a/homeassistant/components/camera/strings.json
+++ b/homeassistant/components/camera/strings.json
@@ -1,10 +1,12 @@
 {
   "title": "Camera",
-  "state": {
+  "entity_component": {
     "_": {
-      "recording": "Recording",
-      "streaming": "Streaming",
-      "idle": "[%key:common::state::idle%]"
+      "state": {
+        "recording": "Recording",
+        "streaming": "Streaming",
+        "idle": "[%key:common::state::idle%]"
+      }
     }
   }
 }

--- a/homeassistant/components/climate/strings.json
+++ b/homeassistant/components/climate/strings.json
@@ -15,92 +15,92 @@
       "set_preset_mode": "Change preset on {entity_name}"
     }
   },
-  "state": {
+  "entity_component": {
     "_": {
-      "off": "[%key:common::state::off%]",
-      "heat": "Heat",
-      "cool": "Cool",
-      "heat_cool": "Heat/Cool",
-      "auto": "Auto",
-      "dry": "Dry",
-      "fan_only": "Fan only"
-    }
-  },
-  "state_attributes": {
-    "_": {
-      "aux_heat": { "name": "Aux heat" },
-      "current_humidity": { "name": "Current humidity" },
-      "current_temperature": { "name": "Current temperature" },
-      "fan_mode": {
-        "name": "Fan mode",
-        "state": {
-          "off": "[%key:common::state::off%]",
-          "on": "[%key:common::state::on%]",
-          "auto": "Auto",
-          "low": "Low",
-          "medium": "Medium",
-          "high": "High",
-          "top": "Top",
-          "middle": "Middle",
-          "focus": "Focus",
-          "diffuse": "Diffuse"
-        }
+      "state": {
+        "off": "[%key:common::state::off%]",
+        "heat": "Heat",
+        "cool": "Cool",
+        "heat_cool": "Heat/Cool",
+        "auto": "Auto",
+        "dry": "Dry",
+        "fan_only": "Fan only"
       },
-      "fan_modes": {
-        "name": "Fan modes"
-      },
-      "humidity": { "name": "Target humidity" },
-      "hvac_action": {
-        "name": "Current action",
-        "state": {
-          "off": "Off",
-          "heating": "Heating",
-          "cooling": "Cooling",
-          "drying": "Drying",
-          "idle": "Idle",
-          "fan": "Fan"
-        }
-      },
-      "hvac_modes": {
-        "name": "HVAC modes"
-      },
-      "max_humidity": { "name": "Max target humidity" },
-      "max_temp": { "name": "Max target temperature" },
-      "min_humidity": { "name": "Min target humidity" },
-      "min_temp": { "name": "Min target temperature" },
-      "preset_mode": {
-        "name": "Preset",
-        "state": {
-          "none": "None",
-          "eco": "Eco",
-          "away": "Away",
-          "boost": "Boost",
-          "comfort": "Comfort",
-          "home": "Home",
-          "sleep": "Sleep",
-          "activity": "Activity"
-        }
-      },
-      "preset_modes": {
-        "name": "Presets"
-      },
-      "swing_mode": {
-        "name": "Swing mode",
-        "state": {
-          "off": "[%key:common::state::off%]",
-          "on": "[%key:common::state::on%]",
-          "both": "Both",
-          "vertical": "Vertical",
-          "horizontal": "Horizontal"
-        }
-      },
-      "swing_modes": {
-        "name": "Swing modes"
-      },
-      "target_temp_high": { "name": "Upper target temperature" },
-      "target_temp_low": { "name": "Lower target temperature" },
-      "target_temp_step": { "name": "Target temperature step" },
-      "temperature": { "name": "Target temperature" }
+      "state_attributes": {
+        "aux_heat": { "name": "Aux heat" },
+        "current_humidity": { "name": "Current humidity" },
+        "current_temperature": { "name": "Current temperature" },
+        "fan_mode": {
+          "name": "Fan mode",
+          "state": {
+            "off": "[%key:common::state::off%]",
+            "on": "[%key:common::state::on%]",
+            "auto": "Auto",
+            "low": "Low",
+            "medium": "Medium",
+            "high": "High",
+            "top": "Top",
+            "middle": "Middle",
+            "focus": "Focus",
+            "diffuse": "Diffuse"
+          }
+        },
+        "fan_modes": {
+          "name": "Fan modes"
+        },
+        "humidity": { "name": "Target humidity" },
+        "hvac_action": {
+          "name": "Current action",
+          "state": {
+            "off": "Off",
+            "heating": "Heating",
+            "cooling": "Cooling",
+            "drying": "Drying",
+            "idle": "Idle",
+            "fan": "Fan"
+          }
+        },
+        "hvac_modes": {
+          "name": "HVAC modes"
+        },
+        "max_humidity": { "name": "Max target humidity" },
+        "max_temp": { "name": "Max target temperature" },
+        "min_humidity": { "name": "Min target humidity" },
+        "min_temp": { "name": "Min target temperature" },
+        "preset_mode": {
+          "name": "Preset",
+          "state": {
+            "none": "None",
+            "eco": "Eco",
+            "away": "Away",
+            "boost": "Boost",
+            "comfort": "Comfort",
+            "home": "Home",
+            "sleep": "Sleep",
+            "activity": "Activity"
+          }
+        },
+        "preset_modes": {
+          "name": "Presets"
+        },
+        "swing_mode": {
+          "name": "Swing mode",
+          "state": {
+            "off": "[%key:common::state::off%]",
+            "on": "[%key:common::state::on%]",
+            "both": "Both",
+            "vertical": "Vertical",
+            "horizontal": "Horizontal"
+          }
+        },
+        "swing_modes": {
+          "name": "Swing modes"
+        },
+        "target_temp_high": { "name": "Upper target temperature" },
+        "target_temp_low": { "name": "Lower target temperature" },
+        "target_temp_step": { "name": "Target temperature step" },
+        "temperature": { "name": "Target temperature" }
+      }
     }
   }
 }

--- a/homeassistant/components/configurator/strings.json
+++ b/homeassistant/components/configurator/strings.json
@@ -1,9 +1,11 @@
 {
   "title": "Configurator",
-  "state": {
+  "entity_component": {
     "_": {
-      "configure": "Configure",
-      "configured": "Configured"
+      "state": {
+        "configure": "Configure",
+        "configured": "Configured"
+      }
     }
   }
 }

--- a/homeassistant/components/cover/strings.json
+++ b/homeassistant/components/cover/strings.json
@@ -27,13 +27,15 @@
       "tilt_position": "{entity_name} tilt position changes"
     }
   },
-  "state": {
+  "entity_component": {
     "_": {
-      "open": "[%key:common::state::open%]",
-      "opening": "Opening",
-      "closed": "[%key:common::state::closed%]",
-      "closing": "Closing",
-      "stopped": "Stopped"
+      "state": {
+        "open": "[%key:common::state::open%]",
+        "opening": "Opening",
+        "closed": "[%key:common::state::closed%]",
+        "closing": "Closing",
+        "stopped": "Stopped"
+      }
     }
   }
 }

--- a/homeassistant/components/device_tracker/strings.json
+++ b/homeassistant/components/device_tracker/strings.json
@@ -10,10 +10,12 @@
       "leaves": "{entity_name} leaves a zone"
     }
   },
-  "state": {
+  "entity_component": {
     "_": {
-      "home": "[%key:common::state::home%]",
-      "not_home": "[%key:common::state::not_home%]"
+      "state": {
+        "home": "[%key:common::state::home%]",
+        "not_home": "[%key:common::state::not_home%]"
+      }
     }
   }
 }

--- a/homeassistant/components/fan/strings.json
+++ b/homeassistant/components/fan/strings.json
@@ -16,10 +16,12 @@
       "turn_off": "Turn off {entity_name}"
     }
   },
-  "state": {
+  "entity_component": {
     "_": {
-      "off": "[%key:common::state::off%]",
-      "on": "[%key:common::state::on%]"
+      "state": {
+        "off": "[%key:common::state::off%]",
+        "on": "[%key:common::state::on%]"
+      }
     }
   }
 }

--- a/homeassistant/components/group/strings.json
+++ b/homeassistant/components/group/strings.json
@@ -155,18 +155,20 @@
       }
     }
   },
-  "state": {
+  "entity_component": {
     "_": {
-      "off": "[%key:common::state::off%]",
-      "on": "[%key:common::state::on%]",
-      "home": "[%key:component::device_tracker::state::_::home%]",
-      "not_home": "[%key:component::device_tracker::state::_::not_home%]",
-      "open": "[%key:common::state::open%]",
-      "closed": "[%key:common::state::closed%]",
-      "locked": "[%key:common::state::locked%]",
-      "unlocked": "[%key:common::state::unlocked%]",
-      "ok": "[%key:component::binary_sensor::state::problem::off%]",
-      "problem": "[%key:component::binary_sensor::state::problem::on%]"
+      "state": {
+        "off": "[%key:common::state::off%]",
+        "on": "[%key:common::state::on%]",
+        "home": "[%key:component::device_tracker::entity_component::_::state::home%]",
+        "not_home": "[%key:component::device_tracker::entity_component::_::state::not_home%]",
+        "open": "[%key:common::state::open%]",
+        "closed": "[%key:common::state::closed%]",
+        "locked": "[%key:common::state::locked%]",
+        "unlocked": "[%key:common::state::unlocked%]",
+        "ok": "[%key:component::binary_sensor::entity_component::problem::state::off%]",
+        "problem": "[%key:component::binary_sensor::entity_component::problem::state::on%]"
+      }
     }
   }
 }

--- a/homeassistant/components/humidifier/strings.json
+++ b/homeassistant/components/humidifier/strings.json
@@ -20,10 +20,12 @@
       "turn_off": "Turn off {entity_name}"
     }
   },
-  "state": {
+  "entity_component": {
     "_": {
-      "off": "[%key:common::state::off%]",
-      "on": "[%key:common::state::on%]"
+      "state": {
+        "off": "[%key:common::state::off%]",
+        "on": "[%key:common::state::on%]"
+      }
     }
   }
 }

--- a/homeassistant/components/input_boolean/strings.json
+++ b/homeassistant/components/input_boolean/strings.json
@@ -1,9 +1,11 @@
 {
   "title": "Input boolean",
-  "state": {
+  "entity_component": {
     "_": {
-      "off": "[%key:common::state::off%]",
-      "on": "[%key:common::state::on%]"
+      "state": {
+        "off": "[%key:common::state::off%]",
+        "on": "[%key:common::state::on%]"
+      }
     }
   }
 }

--- a/homeassistant/components/light/strings.json
+++ b/homeassistant/components/light/strings.json
@@ -19,10 +19,12 @@
       "turned_off": "{entity_name} turned off"
     }
   },
-  "state": {
+  "entity_component": {
     "_": {
-      "off": "[%key:common::state::off%]",
-      "on": "[%key:common::state::on%]"
+      "state": {
+        "off": "[%key:common::state::off%]",
+        "on": "[%key:common::state::on%]"
+      }
     }
   }
 }

--- a/homeassistant/components/lock/strings.json
+++ b/homeassistant/components/lock/strings.json
@@ -15,10 +15,12 @@
       "unlocked": "{entity_name} unlocked"
     }
   },
-  "state": {
+  "entity_component": {
     "_": {
-      "locked": "[%key:common::state::locked%]",
-      "unlocked": "[%key:common::state::unlocked%]"
+      "state": {
+        "locked": "[%key:common::state::locked%]",
+        "unlocked": "[%key:common::state::unlocked%]"
+      }
     }
   }
 }

--- a/homeassistant/components/media_player/strings.json
+++ b/homeassistant/components/media_player/strings.json
@@ -19,15 +19,17 @@
       "changed_states": "{entity_name} changed states"
     }
   },
-  "state": {
+  "entity_component": {
     "_": {
-      "off": "[%key:common::state::off%]",
-      "on": "[%key:common::state::on%]",
-      "playing": "Playing",
-      "paused": "[%key:common::state::paused%]",
-      "idle": "[%key:common::state::idle%]",
-      "standby": "[%key:common::state::standby%]",
-      "buffering": "Buffering"
+      "state": {
+        "off": "[%key:common::state::off%]",
+        "on": "[%key:common::state::on%]",
+        "playing": "Playing",
+        "paused": "[%key:common::state::paused%]",
+        "idle": "[%key:common::state::idle%]",
+        "standby": "[%key:common::state::standby%]",
+        "buffering": "Buffering"
+      }
     }
   }
 }

--- a/homeassistant/components/person/strings.json
+++ b/homeassistant/components/person/strings.json
@@ -1,9 +1,11 @@
 {
   "title": "Person",
-  "state": {
+  "entity_component": {
     "_": {
-      "home": "[%key:common::state::home%]",
-      "not_home": "[%key:common::state::not_home%]"
+      "state": {
+        "home": "[%key:common::state::home%]",
+        "not_home": "[%key:common::state::not_home%]"
+      }
     }
   }
 }

--- a/homeassistant/components/plant/strings.json
+++ b/homeassistant/components/plant/strings.json
@@ -1,9 +1,11 @@
 {
   "title": "Plant Monitor",
-  "state": {
+  "entity_component": {
     "_": {
-      "ok": "[%key:component::binary_sensor::state::problem::off%]",
-      "problem": "[%key:component::binary_sensor::state::problem::on%]"
+      "state": {
+        "ok": "[%key:component::binary_sensor::entity_component::problem::state::off%]",
+        "problem": "[%key:component::binary_sensor::entity_component::problem::state::on%]"
+      }
     }
   }
 }

--- a/homeassistant/components/remote/strings.json
+++ b/homeassistant/components/remote/strings.json
@@ -16,10 +16,12 @@
       "turned_off": "{entity_name} turned off"
     }
   },
-  "state": {
+  "entity_component": {
     "_": {
-      "off": "[%key:common::state::off%]",
-      "on": "[%key:common::state::on%]"
+      "state": {
+        "off": "[%key:common::state::off%]",
+        "on": "[%key:common::state::on%]"
+      }
     }
   }
 }

--- a/homeassistant/components/schedule/strings.json
+++ b/homeassistant/components/schedule/strings.json
@@ -1,9 +1,11 @@
 {
   "title": "Schedule",
-  "state": {
+  "entity_component": {
     "_": {
-      "off": "[%key:common::state::off%]",
-      "on": "[%key:common::state::on%]"
+      "state": {
+        "off": "[%key:common::state::off%]",
+        "on": "[%key:common::state::on%]"
+      }
     }
   }
 }

--- a/homeassistant/components/script/strings.json
+++ b/homeassistant/components/script/strings.json
@@ -1,9 +1,11 @@
 {
   "title": "Script",
-  "state": {
+  "entity_component": {
     "_": {
-      "off": "[%key:common::state::off%]",
-      "on": "[%key:common::state::on%]"
+      "state": {
+        "off": "[%key:common::state::off%]",
+        "on": "[%key:common::state::on%]"
+      }
     }
   }
 }

--- a/homeassistant/components/sensor/strings.json
+++ b/homeassistant/components/sensor/strings.json
@@ -94,10 +94,12 @@
       "wind_speed": "{entity_name} wind speed changes"
     }
   },
-  "state": {
+  "entity_component": {
     "_": {
-      "off": "[%key:common::state::off%]",
-      "on": "[%key:common::state::on%]"
+      "state": {
+        "off": "[%key:common::state::off%]",
+        "on": "[%key:common::state::on%]"
+      }
     }
   }
 }

--- a/homeassistant/components/sun/strings.json
+++ b/homeassistant/components/sun/strings.json
@@ -10,10 +10,12 @@
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
     }
   },
-  "state": {
+  "entity_component": {
     "_": {
-      "above_horizon": "Above horizon",
-      "below_horizon": "Below horizon"
+      "state": {
+        "above_horizon": "Above horizon",
+        "below_horizon": "Below horizon"
+      }
     }
   }
 }

--- a/homeassistant/components/switch/strings.json
+++ b/homeassistant/components/switch/strings.json
@@ -16,10 +16,12 @@
       "turned_off": "{entity_name} turned off"
     }
   },
-  "state": {
+  "entity_component": {
     "_": {
-      "off": "[%key:common::state::off%]",
-      "on": "[%key:common::state::on%]"
+      "state": {
+        "off": "[%key:common::state::off%]",
+        "on": "[%key:common::state::on%]"
+      }
     }
   }
 }

--- a/homeassistant/components/timer/strings.json
+++ b/homeassistant/components/timer/strings.json
@@ -1,9 +1,11 @@
 {
-  "state": {
+  "entity_component": {
     "_": {
-      "active": "[%key:common::state::active%]",
-      "idle": "[%key:common::state::idle%]",
-      "paused": "[%key:common::state::paused%]"
+      "state": {
+        "active": "[%key:common::state::active%]",
+        "idle": "[%key:common::state::idle%]",
+        "paused": "[%key:common::state::paused%]"
+      }
     }
   }
 }

--- a/homeassistant/components/vacuum/strings.json
+++ b/homeassistant/components/vacuum/strings.json
@@ -14,16 +14,18 @@
       "dock": "Let {entity_name} return to the dock"
     }
   },
-  "state": {
+  "entity_component": {
     "_": {
-      "cleaning": "Cleaning",
-      "docked": "Docked",
-      "error": "Error",
-      "idle": "[%key:common::state::idle%]",
-      "off": "[%key:common::state::off%]",
-      "on": "[%key:common::state::on%]",
-      "paused": "[%key:common::state::paused%]",
-      "returning": "Returning to dock"
+      "state": {
+        "cleaning": "Cleaning",
+        "docked": "Docked",
+        "error": "Error",
+        "idle": "[%key:common::state::idle%]",
+        "off": "[%key:common::state::off%]",
+        "on": "[%key:common::state::on%]",
+        "paused": "[%key:common::state::paused%]",
+        "returning": "Returning to dock"
+      }
     }
   }
 }

--- a/homeassistant/components/water_heater/strings.json
+++ b/homeassistant/components/water_heater/strings.json
@@ -5,15 +5,17 @@
       "turn_off": "Turn off {entity_name}"
     }
   },
-  "state": {
+  "entity_component": {
     "_": {
-      "off": "[%key:common::state::off%]",
-      "eco": "Eco",
-      "electric": "Electric",
-      "gas": "Gas",
-      "high_demand": "High Demand",
-      "heat_pump": "Heat Pump",
-      "performance": "Performance"
+      "state": {
+        "off": "[%key:common::state::off%]",
+        "eco": "Eco",
+        "electric": "Electric",
+        "gas": "Gas",
+        "high_demand": "High Demand",
+        "heat_pump": "Heat Pump",
+        "performance": "Performance"
+      }
     }
   }
 }

--- a/homeassistant/components/weather/strings.json
+++ b/homeassistant/components/weather/strings.json
@@ -1,21 +1,23 @@
 {
-  "state": {
+  "entity_component": {
     "_": {
-      "clear-night": "Clear, night",
-      "cloudy": "Cloudy",
-      "exceptional": "Exceptional",
-      "fog": "Fog",
-      "hail": "Hail",
-      "lightning": "Lightning",
-      "lightning-rainy": "Lightning, rainy",
-      "partlycloudy": "Partly cloudy",
-      "pouring": "Pouring",
-      "rainy": "Rainy",
-      "snowy": "Snowy",
-      "snowy-rainy": "Snowy, rainy",
-      "sunny": "Sunny",
-      "windy": "Windy",
-      "windy-variant": "Windy"
+      "state": {
+        "clear-night": "Clear, night",
+        "cloudy": "Cloudy",
+        "exceptional": "Exceptional",
+        "fog": "Fog",
+        "hail": "Hail",
+        "lightning": "Lightning",
+        "lightning-rainy": "Lightning, rainy",
+        "partlycloudy": "Partly cloudy",
+        "pouring": "Pouring",
+        "rainy": "Rainy",
+        "snowy": "Snowy",
+        "snowy-rainy": "Snowy, rainy",
+        "sunny": "Sunny",
+        "windy": "Windy",
+        "windy-variant": "Windy"
+      }
     }
   }
 }

--- a/homeassistant/helpers/translation.py
+++ b/homeassistant/helpers/translation.py
@@ -255,13 +255,16 @@ class _TranslationCache:
             categories.update(resource)
 
         for category in categories:
-            resource_func = (
-                _merge_resources if category == "state" else _build_resources
-            )
             new_resources: Mapping[str, dict[str, Any] | str]
-            new_resources = resource_func(  # type: ignore[assignment]
-                translation_strings, components, category
-            )
+
+            if category in ("state", "entity_component"):
+                new_resources = _merge_resources(
+                    translation_strings, components, category
+                )
+            else:
+                new_resources = _build_resources(
+                    translation_strings, components, category
+                )
 
             for component, resource in new_resources.items():
                 category_cache: dict[str, Any] = cached.setdefault(
@@ -299,7 +302,7 @@ async def async_get_translations(
         components = set(integrations)
     elif config_flow:
         components = (await async_get_config_flows(hass)) - hass.config.components
-    elif category == "state":
+    elif category in ("state", "entity_component"):
         components = set(hass.config.components)
     else:
         # Only 'state' supports merging, so remove platforms from selection

--- a/script/hassfest/translations.py
+++ b/script/hassfest/translations.py
@@ -231,25 +231,6 @@ def gen_strings_schema(config: Config, integration: Integration) -> vol.Schema:
                 vol.Optional("trigger_type"): {str: cv.string_with_no_html},
                 vol.Optional("trigger_subtype"): {str: cv.string_with_no_html},
             },
-            vol.Optional("state"): cv.schema_with_slug_keys(
-                cv.schema_with_slug_keys(
-                    cv.string_with_no_html, slug_validator=translation_key_validator
-                ),
-                slug_validator=vol.Any("_", cv.slug),
-            ),
-            vol.Optional("state_attributes"): cv.schema_with_slug_keys(
-                cv.schema_with_slug_keys(
-                    {
-                        vol.Optional("name"): str,
-                        vol.Optional("state"): cv.schema_with_slug_keys(
-                            cv.string_with_no_html,
-                            slug_validator=translation_key_validator,
-                        ),
-                    },
-                    slug_validator=translation_key_validator,
-                ),
-                slug_validator=vol.Any("_", cv.slug),
-            ),
             vol.Optional("system_health"): {
                 vol.Optional("info"): cv.schema_with_slug_keys(
                     cv.string_with_no_html, slug_validator=translation_key_validator
@@ -283,26 +264,49 @@ def gen_strings_schema(config: Config, integration: Integration) -> vol.Schema:
                     ),
                 )
             },
-            vol.Optional("entity"): {
-                str: {
-                    str: {
+            vol.Optional("entity_component"): cv.schema_with_slug_keys(
+                {
+                    vol.Optional("name"): str,
+                    vol.Optional("state"): cv.schema_with_slug_keys(
+                        cv.string_with_no_html,
+                        slug_validator=translation_key_validator,
+                    ),
+                    vol.Optional("state_attributes"): cv.schema_with_slug_keys(
+                        {
+                            vol.Optional("name"): str,
+                            vol.Optional("state"): cv.schema_with_slug_keys(
+                                cv.string_with_no_html,
+                                slug_validator=translation_key_validator,
+                            ),
+                        },
+                        slug_validator=translation_key_validator,
+                    ),
+                },
+                slug_validator=vol.Any("_", cv.slug),
+            ),
+            vol.Optional("entity"): cv.schema_with_slug_keys(
+                cv.schema_with_slug_keys(
+                    {
                         vol.Optional("name"): cv.string_with_no_html,
-                        vol.Optional("state_attributes"): {
-                            str: {
+                        vol.Optional("state"): cv.schema_with_slug_keys(
+                            cv.string_with_no_html,
+                            slug_validator=translation_key_validator,
+                        ),
+                        vol.Optional("state_attributes"): cv.schema_with_slug_keys(
+                            {
                                 vol.Optional("name"): cv.string_with_no_html,
                                 vol.Optional("state"): cv.schema_with_slug_keys(
                                     cv.string_with_no_html,
                                     slug_validator=translation_key_validator,
                                 ),
-                            }
-                        },
-                        vol.Optional("state"): cv.schema_with_slug_keys(
-                            cv.string_with_no_html,
+                            },
                             slug_validator=translation_key_validator,
                         ),
-                    }
-                }
-            },
+                    },
+                    slug_validator=translation_key_validator,
+                ),
+                slug_validator=cv.slug,
+            ),
         }
     )
 

--- a/script/hassfest/translations.py
+++ b/script/hassfest/translations.py
@@ -266,7 +266,6 @@ def gen_strings_schema(config: Config, integration: Integration) -> vol.Schema:
             },
             vol.Optional("entity_component"): cv.schema_with_slug_keys(
                 {
-                    vol.Optional("name"): str,
                     vol.Optional("state"): cv.schema_with_slug_keys(
                         cv.string_with_no_html,
                         slug_validator=translation_key_validator,

--- a/tests/helpers/test_translation.py
+++ b/tests/helpers/test_translation.py
@@ -373,32 +373,32 @@ async def test_caching(hass: HomeAssistant) -> None:
         "homeassistant.helpers.translation._merge_resources",
         side_effect=translation._merge_resources,
     ) as mock_merge:
-        load1 = await translation.async_get_translations(hass, "en", "state")
+        load1 = await translation.async_get_translations(hass, "en", "entity_component")
         assert len(mock_merge.mock_calls) == 1
 
-        load2 = await translation.async_get_translations(hass, "en", "state")
+        load2 = await translation.async_get_translations(hass, "en", "entity_component")
         assert len(mock_merge.mock_calls) == 1
 
         assert load1 == load2
 
         for key in load1:
-            assert key.startswith("component.sensor.state.") or key.startswith(
-                "component.light.state."
-            )
+            assert key.startswith(
+                "component.sensor.entity_component._.state."
+            ) or key.startswith("component.light.entity_component._.state.")
 
     load_sensor_only = await translation.async_get_translations(
-        hass, "en", "state", integrations={"sensor"}
+        hass, "en", "entity_component", integrations={"sensor"}
     )
     assert load_sensor_only
     for key in load_sensor_only:
-        assert key.startswith("component.sensor.state.")
+        assert key.startswith("component.sensor.entity_component._.state.")
 
     load_light_only = await translation.async_get_translations(
-        hass, "en", "state", integrations={"light"}
+        hass, "en", "entity_component", integrations={"light"}
     )
     assert load_light_only
     for key in load_light_only:
-        assert key.startswith("component.light.state.")
+        assert key.startswith("component.light.entity_component._.state.")
 
     hass.config.components.add("media_player")
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Restructures the translation strings for entity components

We've added support for more translations in the past months, causing the structure of the translations far from ideal.

```json
"entity_component": {
  "[_|<device_class>]": {
    "state": {
      "<state>": "<translation of state>",
      "<state>": "<translation of state>",
    },
    "state_attributes": {
      "<attribute slug/key>": {
        "name": "<the attribute name>",
        "states": {
          "<state>": "<translation of state attribute>",
          "<state>": "<translation of state attribute>",
        }
      }
    }
  }
}
```

This structure is almost the same as `entity` (but without the extra translation key level), to keep things similar and consistent.

This drops the need for `states` & `state_attributes` as main keys in the `strings.json` file.
The existing schema validation has been made a little more strict to guard against issues better.

Frontend PR: https://github.com/home-assistant/frontend/pull/15820
Dev docs adjustment: https://github.com/home-assistant/developers.home-assistant/pull/1714

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/1714

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
