### PR TITLE
Improve hass_ws_client type hint in tests

### DIFF
--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -1,11 +1,9 @@
 """The tests for the automation component."""
 import asyncio
-from collections.abc import Awaitable, Callable
 from datetime import timedelta
 import logging
 from unittest.mock import Mock, patch
 
-from aiohttp import ClientWebSocketResponse
 import pytest
 
 import homeassistant.components.automation as automation
@@ -1437,7 +1435,7 @@ async def test_automation_bad_config_validation(
 async def test_automation_with_error_in_script(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
-    hass_ws_client: Callable[[HomeAssistant], Awaitable[ClientWebSocketResponse]],
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test automation with an error in script."""
     assert await async_setup_component(

--- a/tests/components/backup/test_websocket.py
+++ b/tests/components/backup/test_websocket.py
@@ -1,18 +1,18 @@
 """Tests for the Backup integration."""
-from collections.abc import Awaitable, Callable
 from unittest.mock import patch
 
-from aiohttp import ClientWebSocketResponse
 import pytest
 
 from homeassistant.core import HomeAssistant
 
 from .common import TEST_BACKUP, setup_backup_integration
 
+from tests.typing import WebSocketGenerator
+
 
 async def test_info(
     hass: HomeAssistant,
-    hass_ws_client: Callable[[HomeAssistant], Awaitable[ClientWebSocketResponse]],
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test getting backup info."""
     await setup_backup_integration(hass)
@@ -34,7 +34,7 @@ async def test_info(
 
 async def test_remove(
     hass: HomeAssistant,
-    hass_ws_client: Callable[[HomeAssistant], Awaitable[ClientWebSocketResponse]],
+    hass_ws_client: WebSocketGenerator,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test removing a backup file."""
@@ -55,7 +55,7 @@ async def test_remove(
 
 async def test_generate(
     hass: HomeAssistant,
-    hass_ws_client: Callable[[HomeAssistant], Awaitable[ClientWebSocketResponse]],
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test removing a backup file."""
     await setup_backup_integration(hass)

--- a/tests/components/devolo_home_control/test_init.py
+++ b/tests/components/devolo_home_control/test_init.py
@@ -1,8 +1,6 @@
 """Tests for the devolo Home Control integration."""
-from collections.abc import Awaitable, Callable
 from unittest.mock import patch
 
-from aiohttp import ClientWebSocketResponse
 from devolo_home_control_api.exceptions.gateway import GatewayOfflineError
 import pytest
 
@@ -15,6 +13,8 @@ from homeassistant.setup import async_setup_component
 
 from . import configure_integration
 from .mocks import HomeControlMock, HomeControlMockBinarySensor
+
+from tests.typing import WebSocketGenerator
 
 
 async def test_setup_entry(hass: HomeAssistant, mock_zeroconf: None) -> None:
@@ -64,7 +64,7 @@ async def test_unload_entry(hass: HomeAssistant) -> None:
 
 async def test_remove_device(
     hass: HomeAssistant,
-    hass_ws_client: Callable[[HomeAssistant], Awaitable[ClientWebSocketResponse]],
+    hass_ws_client: WebSocketGenerator,
 ):
     """Test removing a device."""
     assert await async_setup_component(hass, "config", {})

--- a/tests/components/dlink/test_switch.py
+++ b/tests/components/dlink/test_switch.py
@@ -1,5 +1,4 @@
 """Switch tests for the D-Link Smart Plug integration."""
-from collections.abc import Awaitable, Callable
 
 from homeassistant.components.dlink import DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
@@ -16,11 +15,12 @@ from homeassistant.setup import async_setup_component
 from .conftest import ComponentSetup
 
 from tests.components.repairs import get_repairs
+from tests.typing import WebSocketGenerator
 
 
 async def test_switch_state(
     hass: HomeAssistant,
-    hass_ws_client: Callable[[HomeAssistant], Awaitable[None]],
+    hass_ws_client: WebSocketGenerator,
     setup_integration: ComponentSetup,
 ) -> None:
     """Test we get the switch status."""

--- a/tests/components/google/test_calendar.py
+++ b/tests/components/google/test_calendar.py
@@ -8,7 +8,6 @@ from typing import Any
 from unittest.mock import patch
 import urllib
 
-from aiohttp import ClientWebSocketResponse
 from aiohttp.client_exceptions import ClientError
 from gcal_sync.auth import API_BASE_URL
 import pytest
@@ -32,7 +31,7 @@ from .conftest import (
 
 from tests.common import async_fire_time_changed
 from tests.test_util.aiohttp import AiohttpClientMocker
-from tests.typing import ClientSessionGenerator
+from tests.typing import ClientSessionGenerator, WebSocketGenerator
 
 TEST_ENTITY = TEST_API_ENTITY
 TEST_ENTITY_NAME = TEST_API_ENTITY_NAME
@@ -134,7 +133,7 @@ ClientFixture = Callable[[], Awaitable[Client]]
 @pytest.fixture
 async def ws_client(
     hass: HomeAssistant,
-    hass_ws_client: Callable[[HomeAssistant], Awaitable[ClientWebSocketResponse]],
+    hass_ws_client: WebSocketGenerator,
 ) -> ClientFixture:
     """Fixture for creating the test websocket client."""
 

--- a/tests/components/matter/test_api.py
+++ b/tests/components/matter/test_api.py
@@ -1,8 +1,6 @@
 """Test the api module."""
-from collections.abc import Awaitable, Callable
 from unittest.mock import MagicMock, call
 
-from aiohttp import ClientWebSocketResponse
 from matter_server.common.errors import InvalidCommand, NodeCommissionFailed
 import pytest
 
@@ -10,13 +8,14 @@ from homeassistant.components.matter.api import ID, TYPE
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
+from tests.typing import WebSocketGenerator
 
 
 # This tests needs to be adjusted to remove lingering tasks
 @pytest.mark.parametrize("expected_lingering_tasks", [True])
 async def test_commission(
     hass: HomeAssistant,
-    hass_ws_client: Callable[[HomeAssistant], Awaitable[ClientWebSocketResponse]],
+    hass_ws_client: WebSocketGenerator,
     matter_client: MagicMock,
     integration: MockConfigEntry,
 ) -> None:
@@ -58,7 +57,7 @@ async def test_commission(
 @pytest.mark.parametrize("expected_lingering_tasks", [True])
 async def test_commission_on_network(
     hass: HomeAssistant,
-    hass_ws_client: Callable[[HomeAssistant], Awaitable[ClientWebSocketResponse]],
+    hass_ws_client: WebSocketGenerator,
     matter_client: MagicMock,
     integration: MockConfigEntry,
 ) -> None:
@@ -100,7 +99,7 @@ async def test_commission_on_network(
 @pytest.mark.parametrize("expected_lingering_tasks", [True])
 async def test_set_thread_dataset(
     hass: HomeAssistant,
-    hass_ws_client: Callable[[HomeAssistant], Awaitable[ClientWebSocketResponse]],
+    hass_ws_client: WebSocketGenerator,
     matter_client: MagicMock,
     integration: MockConfigEntry,
 ) -> None:
@@ -142,7 +141,7 @@ async def test_set_thread_dataset(
 @pytest.mark.parametrize("expected_lingering_tasks", [True])
 async def test_set_wifi_credentials(
     hass: HomeAssistant,
-    hass_ws_client: Callable[[HomeAssistant], Awaitable[ClientWebSocketResponse]],
+    hass_ws_client: WebSocketGenerator,
     matter_client: MagicMock,
     integration: MockConfigEntry,
 ) -> None:

--- a/tests/components/matter/test_init.py
+++ b/tests/components/matter/test_init.py
@@ -2,10 +2,9 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Callable, Generator
+from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
-from aiohttp import ClientWebSocketResponse
 from matter_server.client.exceptions import CannotConnect, InvalidServerVersion
 from matter_server.client.models.node import MatterNode
 from matter_server.common.errors import MatterError
@@ -28,6 +27,7 @@ from homeassistant.setup import async_setup_component
 from .common import load_and_parse_node_fixture, setup_integration_with_node_fixture
 
 from tests.common import MockConfigEntry
+from tests.typing import WebSocketGenerator
 
 
 @pytest.fixture(name="connect_timeout")
@@ -613,7 +613,7 @@ async def test_remove_entry(
 async def test_remove_config_entry_device(
     hass: HomeAssistant,
     matter_client: MagicMock,
-    hass_ws_client: Callable[[HomeAssistant], Awaitable[ClientWebSocketResponse]],
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test that a device can be removed ok."""
     assert await async_setup_component(hass, "config", {})
@@ -656,7 +656,7 @@ async def test_remove_config_entry_device_no_node(
     hass: HomeAssistant,
     matter_client: MagicMock,
     integration: MockConfigEntry,
-    hass_ws_client: Callable[[HomeAssistant], Awaitable[ClientWebSocketResponse]],
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test that a device can be removed ok without an existing node."""
     assert await async_setup_component(hass, "config", {})

--- a/tests/components/mysensors/test_init.py
+++ b/tests/components/mysensors/test_init.py
@@ -1,9 +1,6 @@
 """Test function in __init__.py."""
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
-
-from aiohttp import ClientWebSocketResponse
 from mysensors import BaseSyncGateway
 from mysensors.sensor import Sensor
 
@@ -13,6 +10,7 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
+from tests.typing import WebSocketGenerator
 
 
 async def test_remove_config_entry_device(
@@ -20,7 +18,7 @@ async def test_remove_config_entry_device(
     gps_sensor: Sensor,
     integration: MockConfigEntry,
     gateway: BaseSyncGateway,
-    hass_ws_client: Callable[[HomeAssistant], Awaitable[ClientWebSocketResponse]],
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test that a device can be removed ok."""
     entity_id = "sensor.gps_sensor_1_1"

--- a/tests/components/onewire/test_init.py
+++ b/tests/components/onewire/test_init.py
@@ -1,5 +1,4 @@
 """Tests for 1-Wire config flow."""
-from collections.abc import Awaitable, Callable
 from unittest.mock import MagicMock, patch
 
 import aiohttp
@@ -14,6 +13,8 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 
 from . import setup_owproxy_mock_devices
+
+from tests.typing import WebSocketGenerator
 
 
 async def remove_device(
@@ -78,9 +79,7 @@ async def test_registry_cleanup(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
     owproxy: MagicMock,
-    hass_ws_client: Callable[
-        [HomeAssistant], Awaitable[aiohttp.ClientWebSocketResponse]
-    ],
+    hass_ws_client: WebSocketGenerator,
 ):
     """Test being able to remove a disconnected device."""
     assert await async_setup_component(hass, "config", {})

--- a/tests/components/pushover/test_init.py
+++ b/tests/components/pushover/test_init.py
@@ -1,8 +1,6 @@
 """Test pushbullet integration."""
-from collections.abc import Awaitable, Callable
 from unittest.mock import MagicMock, patch
 
-import aiohttp
 from pushover_complete import BadAPIRequestError
 import pytest
 import requests_mock
@@ -17,6 +15,7 @@ from . import MOCK_CONFIG
 
 from tests.common import MockConfigEntry
 from tests.components.repairs import get_repairs
+from tests.typing import WebSocketGenerator
 
 
 @pytest.fixture(autouse=False)
@@ -30,9 +29,7 @@ def mock_pushover():
 
 async def test_setup(
     hass: HomeAssistant,
-    hass_ws_client: Callable[
-        [HomeAssistant], Awaitable[aiohttp.ClientWebSocketResponse]
-    ],
+    hass_ws_client: WebSocketGenerator,
     mock_pushover: MagicMock,
 ) -> None:
     """Test integration failed due to an error."""

--- a/tests/components/repairs/__init__.py
+++ b/tests/components/repairs/__init__.py
@@ -1,15 +1,15 @@
 """Tests for the repairs integration."""
-from collections.abc import Awaitable, Callable
 
-from aiohttp import ClientWebSocketResponse
 
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
+from tests.typing import WebSocketGenerator
+
 
 async def get_repairs(
     hass: HomeAssistant,
-    hass_ws_client: Callable[[HomeAssistant], Awaitable[ClientWebSocketResponse]],
+    hass_ws_client: WebSocketGenerator,
 ):
     """Return the repairs list of issues."""
     assert await async_setup_component(hass, "repairs", {})

--- a/tests/components/repairs/test_init.py
+++ b/tests/components/repairs/test_init.py
@@ -1,8 +1,6 @@
 """Test the repairs websocket API."""
-from collections.abc import Awaitable, Callable
 from unittest.mock import AsyncMock, Mock
 
-from aiohttp import ClientWebSocketResponse
 from freezegun import freeze_time
 import pytest
 
@@ -489,7 +487,7 @@ async def test_non_compliant_platform(
 @freeze_time("2022-07-21 08:22:00")
 async def test_sync_methods(
     hass: HomeAssistant,
-    hass_ws_client: Callable[[HomeAssistant], Awaitable[ClientWebSocketResponse]],
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test sync method for creating and deleting an issue."""
 

--- a/tests/components/repairs/test_websocket_api.py
+++ b/tests/components/repairs/test_websocket_api.py
@@ -1,12 +1,10 @@
 """Test the repairs websocket API."""
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
 from http import HTTPStatus
 from typing import Any
 from unittest.mock import ANY, AsyncMock, Mock
 
-from aiohttp import ClientWebSocketResponse
 from freezegun import freeze_time
 import pytest
 import voluptuous as vol
@@ -524,7 +522,7 @@ async def test_list_issues(
 async def test_fix_issue_aborted(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
-    hass_ws_client: Callable[[HomeAssistant], Awaitable[ClientWebSocketResponse]],
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test we can fix an issue."""
     assert await async_setup_component(hass, "http", {})

--- a/tests/components/rtsp_to_webrtc/test_init.py
+++ b/tests/components/rtsp_to_webrtc/test_init.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import base64
-from collections.abc import Awaitable, Callable
 from typing import Any
 from unittest.mock import patch
 
@@ -20,6 +19,7 @@ from .conftest import SERVER_URL, STREAM_SOURCE, ComponentSetup
 
 from tests.common import MockConfigEntry
 from tests.test_util.aiohttp import AiohttpClientMocker
+from tests.typing import WebSocketGenerator
 
 # The webrtc component does not inspect the details of the offer and answer,
 # and is only a pass through.
@@ -83,7 +83,7 @@ async def test_setup_communication_failure(
 async def test_offer_for_stream_source(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
-    hass_ws_client: Callable[[...], Awaitable[aiohttp.ClientWebSocketResponse]],
+    hass_ws_client: WebSocketGenerator,
     mock_camera: Any,
     rtsp_to_webrtc_client: Any,
     setup_integration: ComponentSetup,
@@ -124,7 +124,7 @@ async def test_offer_for_stream_source(
 async def test_offer_failure(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
-    hass_ws_client: Callable[[...], Awaitable[aiohttp.ClientWebSocketResponse]],
+    hass_ws_client: WebSocketGenerator,
     mock_camera: Any,
     rtsp_to_webrtc_client: Any,
     setup_integration: ComponentSetup,
@@ -161,7 +161,7 @@ async def test_no_stun_server(
     hass: HomeAssistant,
     rtsp_to_webrtc_client: Any,
     setup_integration: ComponentSetup,
-    hass_ws_client: Callable[[...], Awaitable[aiohttp.ClientWebSocketResponse]],
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test successful setup and unload."""
     await setup_integration()
@@ -188,7 +188,7 @@ async def test_stun_server(
     rtsp_to_webrtc_client: Any,
     setup_integration: ComponentSetup,
     config_entry: MockConfigEntry,
-    hass_ws_client: Callable[[...], Awaitable[aiohttp.ClientWebSocketResponse]],
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test successful setup and unload."""
     await setup_integration()

--- a/tests/components/schedule/test_init.py
+++ b/tests/components/schedule/test_init.py
@@ -1,11 +1,10 @@
 """Test for the Schedule integration."""
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable, Coroutine
+from collections.abc import Callable, Coroutine
 from typing import Any
 from unittest.mock import patch
 
-from aiohttp import ClientWebSocketResponse
 import pytest
 
 from homeassistant.components.schedule import STORAGE_VERSION, STORAGE_VERSION_MINOR
@@ -39,6 +38,7 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockUser, async_capture_events, async_fire_time_changed
+from tests.typing import WebSocketGenerator
 
 
 @pytest.fixture
@@ -537,7 +537,7 @@ async def test_schedule_updates(
 
 async def test_ws_list(
     hass: HomeAssistant,
-    hass_ws_client: Callable[[HomeAssistant], Awaitable[ClientWebSocketResponse]],
+    hass_ws_client: WebSocketGenerator,
     schedule_setup: Callable[..., Coroutine[Any, Any, bool]],
 ) -> None:
     """Test listing via WS."""
@@ -567,7 +567,7 @@ async def test_ws_list(
 
 async def test_ws_delete(
     hass: HomeAssistant,
-    hass_ws_client: Callable[[HomeAssistant], Awaitable[ClientWebSocketResponse]],
+    hass_ws_client: WebSocketGenerator,
     schedule_setup: Callable[..., Coroutine[Any, Any, bool]],
 ) -> None:
     """Test WS delete cleans up entity registry."""
@@ -602,7 +602,7 @@ async def test_ws_delete(
 )
 async def test_update(
     hass: HomeAssistant,
-    hass_ws_client: Callable[[HomeAssistant], Awaitable[ClientWebSocketResponse]],
+    hass_ws_client: WebSocketGenerator,
     schedule_setup: Callable[..., Coroutine[Any, Any, bool]],
     to: str,
     next_event: str,
@@ -672,7 +672,7 @@ async def test_update(
 )
 async def test_ws_create(
     hass: HomeAssistant,
-    hass_ws_client: Callable[[HomeAssistant], Awaitable[ClientWebSocketResponse]],
+    hass_ws_client: WebSocketGenerator,
     schedule_setup: Callable[..., Coroutine[Any, Any, bool]],
     freezer,
     to: str,

--- a/tests/components/unifiprotect/test_init.py
+++ b/tests/components/unifiprotect/test_init.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
 from unittest.mock import AsyncMock, patch
 
 import aiohttp
@@ -23,6 +22,7 @@ from . import _patch_discovery
 from .utils import MockUFPFixture, init_entry, time_changed
 
 from tests.common import MockConfigEntry
+from tests.typing import WebSocketGenerator
 
 
 async def remove_device(
@@ -217,9 +217,7 @@ async def test_device_remove_devices(
     hass: HomeAssistant,
     ufp: MockUFPFixture,
     light: Light,
-    hass_ws_client: Callable[
-        [HomeAssistant], Awaitable[aiohttp.ClientWebSocketResponse]
-    ],
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test we can only remove a device that no longer exists."""
 
@@ -252,9 +250,7 @@ async def test_device_remove_devices(
 async def test_device_remove_devices_nvr(
     hass: HomeAssistant,
     ufp: MockUFPFixture,
-    hass_ws_client: Callable[
-        [HomeAssistant], Awaitable[aiohttp.ClientWebSocketResponse]
-    ],
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test we can only remove a NVR device that no longer exists."""
     assert await async_setup_component(hass, "config", {})

--- a/tests/components/update/test_init.py
+++ b/tests/components/update/test_init.py
@@ -1,8 +1,6 @@
 """The tests for the Update component."""
-from collections.abc import Awaitable, Callable
 from unittest.mock import MagicMock, patch
 
-from aiohttp import ClientWebSocketResponse
 import pytest
 
 from homeassistant.components.update import (
@@ -40,6 +38,7 @@ from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockEntityPlatform, mock_restore_cache
+from tests.typing import WebSocketGenerator
 
 
 class MockUpdateEntity(UpdateEntity):
@@ -681,7 +680,7 @@ async def test_restore_state(
 async def test_release_notes(
     hass: HomeAssistant,
     enable_custom_integrations: None,
-    hass_ws_client: Callable[[HomeAssistant], Awaitable[ClientWebSocketResponse]],
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test getting the release notes over the websocket connection."""
     platform = getattr(hass.components, f"test.{DOMAIN}")
@@ -707,7 +706,7 @@ async def test_release_notes(
 async def test_release_notes_entity_not_found(
     hass: HomeAssistant,
     enable_custom_integrations: None,
-    hass_ws_client: Callable[[HomeAssistant], Awaitable[ClientWebSocketResponse]],
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test getting the release notes for not found entity."""
     platform = getattr(hass.components, f"test.{DOMAIN}")
@@ -734,7 +733,7 @@ async def test_release_notes_entity_not_found(
 async def test_release_notes_entity_does_not_support_release_notes(
     hass: HomeAssistant,
     enable_custom_integrations: None,
-    hass_ws_client: Callable[[HomeAssistant], Awaitable[ClientWebSocketResponse]],
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test getting the release notes for entity that does not support release notes."""
     platform = getattr(hass.components, f"test.{DOMAIN}")


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, spotted reviewing #89674

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
