### PR TITLE
Add keep_days to recorder.purge_entities

### DIFF
--- a/homeassistant/components/recorder/services.py
+++ b/homeassistant/components/recorder/services.py
@@ -9,7 +9,10 @@ import voluptuous as vol
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entityfilter import generate_filter
-from homeassistant.helpers.service import async_extract_entity_ids
+from homeassistant.helpers.service import (
+    async_extract_entity_ids,
+    async_register_admin_service,
+)
 import homeassistant.util.dt as dt_util
 
 from .const import ATTR_APPLY_FILTER, ATTR_KEEP_DAYS, ATTR_REPACK, DOMAIN
@@ -57,8 +60,12 @@ def _async_register_purge_service(hass: HomeAssistant, instance: Recorder) -> No
         purge_before = dt_util.utcnow() - timedelta(days=keep_days)
         instance.queue_task(PurgeTask(purge_before, repack, apply_filter))
 
-    hass.services.async_register(
-        DOMAIN, SERVICE_PURGE, async_handle_purge_service, schema=SERVICE_PURGE_SCHEMA
+    async_register_admin_service(
+        hass,
+        DOMAIN,
+        SERVICE_PURGE,
+        async_handle_purge_service,
+        schema=SERVICE_PURGE_SCHEMA,
     )
 
 
@@ -76,7 +83,8 @@ def _async_register_purge_entities_service(
         purge_before = dt_util.utcnow() - timedelta(days=keep_days)
         instance.queue_task(PurgeEntitiesTask(entity_filter, purge_before))
 
-    hass.services.async_register(
+    async_register_admin_service(
+        hass,
         DOMAIN,
         SERVICE_PURGE_ENTITIES,
         async_handle_purge_entities_service,
@@ -89,7 +97,8 @@ def _async_register_enable_service(hass: HomeAssistant, instance: Recorder) -> N
     async def async_handle_enable_service(service: ServiceCall) -> None:
         instance.set_enable(True)
 
-    hass.services.async_register(
+    async_register_admin_service(
+        hass,
         DOMAIN,
         SERVICE_ENABLE,
         async_handle_enable_service,
@@ -102,7 +111,8 @@ def _async_register_disable_service(hass: HomeAssistant, instance: Recorder) -> 
     async def async_handle_disable_service(service: ServiceCall) -> None:
         instance.set_enable(False)
 
-    hass.services.async_register(
+    async_register_admin_service(
+        hass,
         DOMAIN,
         SERVICE_DISABLE,
         async_handle_disable_service,

--- a/homeassistant/components/recorder/services.yaml
+++ b/homeassistant/components/recorder/services.yaml
@@ -54,6 +54,7 @@ purge_entities:
     keep_days:
       name: Days to keep
       description: Number of history days to keep in database of matching rows. The default of 0 days will remove all matching rows.
+      default: 0
       selector:
         number:
           min: 0

--- a/homeassistant/components/recorder/services.yaml
+++ b/homeassistant/components/recorder/services.yaml
@@ -51,6 +51,15 @@ purge_entities:
       selector:
         object:
 
+    keep_days:
+      name: Days to keep
+      description: Number of history days to keep in database of matching rows. The default of 0 days will remove all matching rows.
+      selector:
+        number:
+          min: 0
+          max: 365
+          unit_of_measurement: days
+
 disable:
   name: Disable
   description: Stop the recording of events and state changes

--- a/tests/components/recorder/test_purge.py
+++ b/tests/components/recorder/test_purge.py
@@ -2079,7 +2079,6 @@ async def test_purge_entities_keep_days(
         SERVICE_PURGE_ENTITIES,
         {
             "entity_id": "sensor.purge",
-            "keep_days": 0,
         },
     )
     await async_recorder_block_till_done(hass)

--- a/tests/components/recorder/test_purge.py
+++ b/tests/components/recorder/test_purge.py
@@ -2061,7 +2061,7 @@ async def test_purge_entities_keep_days(
         recorder.DOMAIN,
         SERVICE_PURGE_ENTITIES,
         {
-            "entity_id": ["sensor.one"],
+            "entity_id": "sensor.purge",
             "keep_days": 1,
         },
     )
@@ -2072,13 +2072,13 @@ async def test_purge_entities_keep_days(
         get_significant_states, hass, one_month_ago
     )
     assert len(states["sensor.keep"]) == 2
-    assert len(states["sensor.purge"]) == 2
+    assert len(states["sensor.purge"]) == 1
 
     await hass.services.async_call(
         recorder.DOMAIN,
         SERVICE_PURGE_ENTITIES,
         {
-            "entity_id": ["sensor.one"],
+            "entity_id": "sensor.purge",
             "keep_days": 0,
         },
     )
@@ -2089,4 +2089,4 @@ async def test_purge_entities_keep_days(
         get_significant_states, hass, one_month_ago
     )
     assert len(states["sensor.keep"]) == 2
-    assert len(states["sensor.purge"]) == 1
+    assert "sensor.purge" not in states

--- a/tests/components/recorder/test_purge.py
+++ b/tests/components/recorder/test_purge.py
@@ -4,6 +4,7 @@ import json
 import sqlite3
 from unittest.mock import patch
 
+from freezegun import freeze_time
 import pytest
 from sqlalchemy.exc import DatabaseError, OperationalError
 from sqlalchemy.orm.session import Session
@@ -25,6 +26,7 @@ from homeassistant.components.recorder.db_schema import (
     StatisticsRuns,
     StatisticsShortTerm,
 )
+from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.components.recorder.purge import purge_old_data
 from homeassistant.components.recorder.queries import select_event_type_ids
 from homeassistant.components.recorder.services import (
@@ -2020,3 +2022,71 @@ async def test_purge_old_states_purges_the_state_metadata_ids(
         assert finished
         assert states.count() == 0
         assert states_meta.count() == 0
+
+
+async def test_purge_entities_keep_days(
+    async_setup_recorder_instance: RecorderInstanceGenerator,
+    hass: HomeAssistant,
+) -> None:
+    """Test purging states with an entity filter and keep_days."""
+    instance = await async_setup_recorder_instance(hass, {})
+    await hass.async_block_till_done()
+    await async_wait_recording_done(hass)
+    start = dt_util.utcnow()
+    two_days_ago = start - timedelta(days=2)
+    one_week_ago = start - timedelta(days=7)
+    one_month_ago = start - timedelta(days=30)
+    with freeze_time(one_week_ago):
+        hass.states.async_set("sensor.keep", "initial")
+        hass.states.async_set("sensor.purge", "initial")
+
+    await async_wait_recording_done(hass)
+
+    with freeze_time(two_days_ago):
+        hass.states.async_set("sensor.purge", "two_days_ago")
+
+    await async_wait_recording_done(hass)
+
+    hass.states.async_set("sensor.purge", "now")
+    hass.states.async_set("sensor.keep", "now")
+    await async_recorder_block_till_done(hass)
+
+    states = await instance.async_add_executor_job(
+        get_significant_states, hass, one_month_ago
+    )
+    assert len(states["sensor.keep"]) == 2
+    assert len(states["sensor.purge"]) == 3
+
+    await hass.services.async_call(
+        recorder.DOMAIN,
+        SERVICE_PURGE_ENTITIES,
+        {
+            "entity_id": ["sensor.one"],
+            "keep_days": 1,
+        },
+    )
+    await async_recorder_block_till_done(hass)
+    await async_wait_purge_done(hass)
+
+    states = await instance.async_add_executor_job(
+        get_significant_states, hass, one_month_ago
+    )
+    assert len(states["sensor.keep"]) == 2
+    assert len(states["sensor.purge"]) == 2
+
+    await hass.services.async_call(
+        recorder.DOMAIN,
+        SERVICE_PURGE_ENTITIES,
+        {
+            "entity_id": ["sensor.one"],
+            "keep_days": 0,
+        },
+    )
+    await async_recorder_block_till_done(hass)
+    await async_wait_purge_done(hass)
+
+    states = await instance.async_add_executor_job(
+        get_significant_states, hass, one_month_ago
+    )
+    assert len(states["sensor.keep"]) == 2
+    assert len(states["sensor.purge"]) == 1


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

I needed to write some more coverage for this so I figured it was a good time to add this

I implemented this as part of the existing service.  I choose this design because:

- It can be modified without having to restart which makes it much easier to test
- External addons can call the service (ie appdaemon, node-red, etc)
- You can control when the purge happens
- It was a not significant change in design to add it and it avoids making the recorder more complicated
- Its possible to setup multiple automations for more granular control
- The target audience is advanced users
- A blueprint can easily be added for this

feature request: https://community.home-assistant.io/t/recorder-retention-period-by-entity/267849 and https://community.home-assistant.io/t/next-generation-recorder/547899/3

The below automation will remove history for `sensor.power_sensor_0` older than 5 days at `04:15:00` in every day.  The service takes a target so its possible to use globs/etc as shown in the docs.

```yaml
alias: Purge noisy power sensors
trigger:
  - platform: time
    at: "04:15:00"
action:
  - service: recorder.purge_entities
    data:
      keep_days: 5
    target:
      entity_id: sensor.power_sensor_0
mode: single
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/26610

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
