### PR TITLE
Make StatesMetaManager thread-safe when an entity_id is fully deleted from the database and than re-added

### DIFF
--- a/homeassistant/components/logbook/processor.py
+++ b/homeassistant/components/logbook/processor.py
@@ -155,7 +155,7 @@ class EventProcessor:
             if self.entity_ids:
                 instance = get_instance(self.hass)
                 entity_id_to_metadata_id = instance.states_meta_manager.get_many(
-                    self.entity_ids, session
+                    self.entity_ids, session, False
                 )
                 metadata_ids = [
                     metadata_id

--- a/homeassistant/components/recorder/core.py
+++ b/homeassistant/components/recorder/core.py
@@ -198,8 +198,6 @@ class Recorder(threading.Thread):
         self.database_engine: DatabaseEngine | None = None
         # Database connection is ready, but non-live migration may be in progress
         db_connected: asyncio.Future[bool] = hass.data[DOMAIN].db_connected
-        # Set to true once events and states are being processed
-        self.event_loop_stated: bool = False
         self.async_db_connected: asyncio.Future[bool] = db_connected
         # Database is ready to use but live migration may be in progress
         self.async_db_ready: asyncio.Future[bool] = asyncio.Future()
@@ -750,7 +748,6 @@ class Recorder(threading.Thread):
         # Use a session for the event read loop
         # with a commit every time the event time
         # has changed. This reduces the disk io.
-        self.event_loop_stated = True
         queue_ = self._queue
         startup_tasks: list[RecorderTask] = []
         while not queue_.empty() and (task := queue_.get_nowait()):

--- a/homeassistant/components/recorder/history/modern.py
+++ b/homeassistant/components/recorder/history/modern.py
@@ -242,7 +242,7 @@ def get_significant_states_with_session(
     if entity_ids:
         instance = recorder.get_instance(hass)
         entity_id_to_metadata_id = instance.states_meta_manager.get_many(
-            entity_ids, session
+            entity_ids, session, False
         )
         metadata_ids = [
             metadata_id
@@ -365,7 +365,7 @@ def state_changes_during_period(
         entity_id_to_metadata_id = None
         if entity_id:
             instance = recorder.get_instance(hass)
-            metadata_id = instance.states_meta_manager.get(entity_id, session)
+            metadata_id = instance.states_meta_manager.get(entity_id, session, False)
             entity_id_to_metadata_id = {entity_id: metadata_id}
         stmt = _state_changed_during_period_stmt(
             start_time,
@@ -426,7 +426,9 @@ def get_last_state_changes(
 
     with session_scope(hass=hass, read_only=True) as session:
         instance = recorder.get_instance(hass)
-        if not (metadata_id := instance.states_meta_manager.get(entity_id, session)):
+        if not (
+            metadata_id := instance.states_meta_manager.get(entity_id, session, False)
+        ):
             return {}
         entity_id_to_metadata_id: dict[str, int | None] = {entity_id_lower: metadata_id}
         stmt = _get_last_state_changes_stmt(number_of_states, metadata_id)

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -1457,7 +1457,9 @@ def migrate_entity_ids(instance: Recorder) -> bool:
     with session_scope(session=instance.get_session()) as session:
         if states := session.execute(find_entity_ids_to_migrate()).all():
             entity_ids = {entity_id for _, entity_id in states}
-            entity_id_to_metadata_id = states_meta_manager.get_many(entity_ids, session, True)
+            entity_id_to_metadata_id = states_meta_manager.get_many(
+                entity_ids, session, True
+            )
             if missing_entity_ids := {
                 # We should never see _EMPTY_ENTITY_ID in the states table
                 # but we need to be defensive so we don't fail the migration

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -1457,7 +1457,7 @@ def migrate_entity_ids(instance: Recorder) -> bool:
     with session_scope(session=instance.get_session()) as session:
         if states := session.execute(find_entity_ids_to_migrate()).all():
             entity_ids = {entity_id for _, entity_id in states}
-            entity_id_to_metadata_id = states_meta_manager.get_many(entity_ids, session)
+            entity_id_to_metadata_id = states_meta_manager.get_many(entity_ids, session, True)
             if missing_entity_ids := {
                 # We should never see _EMPTY_ENTITY_ID in the states table
                 # but we need to be defensive so we don't fail the migration

--- a/homeassistant/components/recorder/table_managers/event_types.py
+++ b/homeassistant/components/recorder/table_managers/event_types.py
@@ -32,20 +32,32 @@ class EventTypeManager(BaseTableManager):
         super().__init__(recorder)
 
     def load(self, events: list[Event], session: Session) -> None:
-        """Load the event_type to event_type_ids mapping into memory."""
+        """Load the event_type to event_type_ids mapping into memory.
+
+        This call is not thread-safe and must be called from the
+        recorder thread.
+        """
         self.get_many(
             {event.event_type for event in events if event.event_type is not None},
             session,
         )
 
     def get(self, event_type: str, session: Session) -> int | None:
-        """Resolve event_type to the event_type_id."""
+        """Resolve event_type to the event_type_id.
+
+        This call is not thread-safe and must be called from the
+        recorder thread.
+        """
         return self.get_many((event_type,), session)[event_type]
 
     def get_many(
         self, event_types: Iterable[str], session: Session
     ) -> dict[str, int | None]:
-        """Resolve event_types to event_type_ids."""
+        """Resolve event_types to event_type_ids.
+
+        This call is not thread-safe and must be called from the
+        recorder thread.
+        """
         results: dict[str, int | None] = {}
         missing: list[str] = []
         for event_type in event_types:
@@ -69,27 +81,47 @@ class EventTypeManager(BaseTableManager):
         return results
 
     def get_pending(self, event_type: str) -> EventTypes | None:
-        """Get pending EventTypes that have not be assigned ids yet."""
+        """Get pending EventTypes that have not be assigned ids yet.
+
+        This call is not thread-safe and must be called from the
+        recorder thread.
+        """
         return self._pending.get(event_type)
 
     def add_pending(self, db_event_type: EventTypes) -> None:
-        """Add a pending EventTypes that will be committed at the next interval."""
+        """Add a pending EventTypes that will be committed at the next interval.
+
+        This call is not thread-safe and must be called from the
+        recorder thread.
+        """
         assert db_event_type.event_type is not None
         event_type: str = db_event_type.event_type
         self._pending[event_type] = db_event_type
 
     def post_commit_pending(self) -> None:
-        """Call after commit to load the event_type_ids of the new EventTypes into the LRU."""
+        """Call after commit to load the event_type_ids of the new EventTypes into the LRU.
+
+        This call is not thread-safe and must be called from the
+        recorder thread.
+        """
         for event_type, db_event_types in self._pending.items():
             self._id_map[event_type] = db_event_types.event_type_id
         self._pending.clear()
 
     def reset(self) -> None:
-        """Reset the event manager after the database has been reset or changed."""
+        """Reset the event manager after the database has been reset or changed.
+
+        This call is not thread-safe and must be called from the
+        recorder thread.
+        """
         self._id_map.clear()
         self._pending.clear()
 
     def evict_purged(self, event_types: Iterable[str]) -> None:
-        """Evict purged event_types from the cache when they are no longer used."""
+        """Evict purged event_types from the cache when they are no longer used.
+
+        This call is not thread-safe and must be called from the
+        recorder thread.
+        """
         for event_type in event_types:
             self._id_map.pop(event_type, None)

--- a/homeassistant/components/recorder/table_managers/states_meta.py
+++ b/homeassistant/components/recorder/table_managers/states_meta.py
@@ -27,7 +27,11 @@ class StatesMetaManager:
         self.active = False
 
     def load(self, events: list[Event], session: Session) -> None:
-        """Load the entity_id to metadata_id mapping into memory."""
+        """Load the entity_id to metadata_id mapping into memory.
+
+        This call is not thread-safe and must be called from the
+        recorder thread.
+        """
         self.get_many(
             {
                 event.data["new_state"].entity_id
@@ -35,21 +39,41 @@ class StatesMetaManager:
                 if event.data.get("new_state") is not None
             },
             session,
+            True,
         )
 
-    def get(self, entity_id: str, session: Session) -> int | None:
-        """Resolve entity_id to the metadata_id."""
-        return self.get_many((entity_id,), session)[entity_id]
+    def get(self, entity_id: str, session: Session, from_recorder: bool) -> int | None:
+        """Resolve entity_id to the metadata_id.
+
+        This call is not thread-safe after startup since
+        purge can remove all references to an entity_id.
+
+        When calling this method from the recorder thread, set
+        from_recorder to True to ensure any missing entity_ids
+        are added to the cache.
+        """
+        return self.get_many((entity_id,), session, from_recorder)[entity_id]
 
     def get_metadata_id_to_entity_id(self, session: Session) -> dict[int, str]:
-        """Resolve all entity_ids to metadata_ids."""
+        """Resolve all entity_ids to metadata_ids.
+
+        This call is always thread-safe.
+        """
         with session.no_autoflush:
             return dict(tuple(session.execute(find_all_states_metadata_ids())))  # type: ignore[arg-type]
 
     def get_many(
-        self, entity_ids: Iterable[str], session: Session
+        self, entity_ids: Iterable[str], session: Session, from_recorder: bool
     ) -> dict[str, int | None]:
-        """Resolve entity_id to metadata_id."""
+        """Resolve entity_id to metadata_id.
+
+        This call is not thread-safe after startup since
+        purge can remove all references to an entity_id.
+
+        When calling this method from the recorder thread, set
+        from_recorder to True to ensure any missing entity_ids
+        are added to the cache.
+        """
         results: dict[str, int | None] = {}
         missing: list[str] = []
         for entity_id in entity_ids:
@@ -61,39 +85,62 @@ class StatesMetaManager:
         if not missing:
             return results
 
+        thread_safe = from_recorder or not self.recorder.event_loop_stated
+
         with session.no_autoflush:
             for missing_chunk in chunked(missing, SQLITE_MAX_BIND_VARS):
                 for metadata_id, entity_id in session.execute(
                     find_states_metadata_ids(missing_chunk)
                 ):
-                    results[entity_id] = self._id_map[entity_id] = cast(
-                        int, metadata_id
-                    )
+                    metadata_id = cast(int, metadata_id)
+                    self._id_map[entity_id] = metadata_id
+                    if thread_safe:
+                        results[entity_id] = metadata_id
 
         return results
 
     def get_pending(self, entity_id: str) -> StatesMeta | None:
-        """Get pending StatesMeta that have not be assigned ids yet."""
+        """Get pending StatesMeta that have not be assigned ids yet.
+
+        This call is not thread-safe and must be called from the
+        recorder thread.
+        """
         return self._pending.get(entity_id)
 
     def add_pending(self, db_states_meta: StatesMeta) -> None:
-        """Add a pending StatesMeta that will be committed at the next interval."""
+        """Add a pending StatesMeta that will be committed at the next interval.
+
+        This call is not thread-safe and must be called from the
+        recorder thread.
+        """
         assert db_states_meta.entity_id is not None
         entity_id: str = db_states_meta.entity_id
         self._pending[entity_id] = db_states_meta
 
     def post_commit_pending(self) -> None:
-        """Call after commit to load the metadata_ids of the new StatesMeta into the LRU."""
+        """Call after commit to load the metadata_ids of the new StatesMeta into the LRU.
+
+        This call is not thread-safe and must be called from the
+        recorder thread.
+        """
         for entity_id, db_states_meta in self._pending.items():
             self._id_map[entity_id] = db_states_meta.metadata_id
         self._pending.clear()
 
     def reset(self) -> None:
-        """Reset the states meta manager after the database has been reset or changed."""
+        """Reset the states meta manager after the database has been reset or changed.
+
+        This call is not thread-safe and must be called from the
+        recorder thread.
+        """
         self._id_map.clear()
         self._pending.clear()
 
     def evict_purged(self, entity_ids: Iterable[str]) -> None:
-        """Evict purged event_types from the cache when they are no longer used."""
+        """Evict purged event_types from the cache when they are no longer used.
+
+        This call is not thread-safe and must be called from the
+        recorder thread.
+        """
         for entity_id in entity_ids:
             self._id_map.pop(entity_id, None)

--- a/tests/components/recorder/test_migrate.py
+++ b/tests/components/recorder/test_migrate.py
@@ -59,7 +59,7 @@ ORIG_TZ = dt_util.DEFAULT_TIME_ZONE
 def _get_native_states(hass, entity_id):
     with session_scope(hass=hass) as session:
         instance = recorder.get_instance(hass)
-        metadata_id = instance.states_meta_manager.get(entity_id, session)
+        metadata_id = instance.states_meta_manager.get(entity_id, session, True)
         states = []
         for dbstate in session.query(States).filter(States.metadata_id == metadata_id):
             dbstate.entity_id = entity_id

--- a/tests/components/recorder/test_purge.py
+++ b/tests/components/recorder/test_purge.py
@@ -684,7 +684,7 @@ def _convert_pending_states_to_meta(instance: Recorder, session: Session) -> Non
             states.add(object)
 
     entity_id_to_metadata_ids = instance.states_meta_manager.get_many(
-        entity_ids, session
+        entity_ids, session, True
     )
 
     for state in states:
@@ -1974,6 +1974,7 @@ async def test_purge_old_states_purges_the_state_metadata_ids(
             return instance.states_meta_manager.get_many(
                 ["sensor.one", "sensor.two", "sensor.three", "sensor.unused"],
                 session,
+                True,
             )
 
     entity_id_to_metadata_id = await instance.async_add_executor_job(_insert_states)

--- a/tests/components/recorder/test_util.py
+++ b/tests/components/recorder/test_util.py
@@ -908,7 +908,7 @@ def test_execute_stmt_lambda_element(
 
     with session_scope(hass=hass) as session:
         # No time window, we always get a list
-        metadata_id = instance.states_meta_manager.get("sensor.on", session)
+        metadata_id = instance.states_meta_manager.get("sensor.on", session, True)
         stmt = _get_single_entity_states_stmt(dt_util.utcnow(), metadata_id, False)
         rows = util.execute_stmt_lambda_element(session, stmt)
         assert isinstance(rows, list)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Refactor `StatesMetaManager` to be thread-safe

There was a very difficult to trigger race (I haven't been able to actually make it happen) here where the `entity_id` could be purged while a history query is running that would load the `metadata_id` into the LRU immediately after it was purged, and than if the same `entity_id` was added back to the system, we would record the old `metadata_id` instead of the newly allocated one.  To make this happen all instances of an `entity_id` would need to be removed from the database via a purge (most likely purge with keep_days=0 to delete the whole db) at the exact same time a history query was running.

This could not happen with any of the table managers since only this one is accessed outside of the recorder (in the database executor).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
