### PR TITLE
Introduce a delay between update entity calls

### DIFF
--- a/homeassistant/components/zwave_js/update.py
+++ b/homeassistant/components/zwave_js/update.py
@@ -43,7 +43,7 @@ async def async_setup_entry(
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up Z-Wave button from config entry."""
+    """Set up Z-Wave update entity from config entry."""
     client: ZwaveClient = hass.data[DOMAIN][config_entry.entry_id][DATA_CLIENT]
 
     lock = asyncio.Lock()

--- a/homeassistant/components/zwave_js/update.py
+++ b/homeassistant/components/zwave_js/update.py
@@ -37,6 +37,8 @@ from .helpers import get_device_info, get_valueless_base_unique_id
 
 PARALLEL_UPDATES = 1
 
+UPDATE_DELAY_TIME = 300
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -77,9 +79,7 @@ class ZWaveNodeFirmwareUpdate(UpdateEntity):
     _attr_has_entity_name = True
     _attr_should_poll = False
 
-    def __init__(
-        self, driver: Driver, node: ZwaveNode, lock: asyncio.Lock
-    ) -> None:
+    def __init__(self, driver: Driver, node: ZwaveNode, lock: asyncio.Lock) -> None:
         """Initialize a Z-Wave device firmware update entity."""
         self.driver = driver
         self.node = node
@@ -199,7 +199,7 @@ class ZWaveNodeFirmwareUpdate(UpdateEntity):
             # update. Useful especially at startup because all the entities get created
             # in parallel and this ensures the first requests get spaced out, avoiding
             # a network traffic flood.
-            await asyncio.sleep(300)
+            await asyncio.sleep(UPDATE_DELAY_TIME)
             self.lock.release()
             self._poll_unsub = async_call_later(
                 self.hass, timedelta(days=1), self._async_update

--- a/homeassistant/components/zwave_js/update.py
+++ b/homeassistant/components/zwave_js/update.py
@@ -37,7 +37,7 @@ from .helpers import get_device_info, get_valueless_base_unique_id
 
 PARALLEL_UPDATES = 1
 
-UPDATE_DELAY_TIME = 300
+UPDATE_DELAY = 300
 
 
 async def async_setup_entry(
@@ -199,7 +199,7 @@ class ZWaveNodeFirmwareUpdate(UpdateEntity):
             # update. Useful especially at startup because all the entities get created
             # in parallel and this ensures the first requests get spaced out, avoiding
             # a network traffic flood.
-            await asyncio.sleep(UPDATE_DELAY_TIME)
+            await asyncio.sleep(UPDATE_DELAY)
             self.lock.release()
             self._poll_unsub = async_call_later(
                 self.hass, timedelta(days=1), self._async_update

--- a/homeassistant/components/zwave_js/update.py
+++ b/homeassistant/components/zwave_js/update.py
@@ -85,6 +85,9 @@ async def async_setup_entry(
     @callback
     def async_add_firmware_update_entity(node: ZwaveNode) -> None:
         """Add firmware update entity."""
+        # We need to delay the first update of each entity to avoid flooding the network
+        # so we maintain a counter to schedule first update in UPDATE_DELAY_INTERVAL
+        # minute increments.
         cnt[UPDATE_DELAY_STRING] += 1
         delay = timedelta(minutes=(cnt[UPDATE_DELAY_STRING] * UPDATE_DELAY_INTERVAL))
         driver = client.driver

--- a/homeassistant/components/zwave_js/update.py
+++ b/homeassistant/components/zwave_js/update.py
@@ -338,7 +338,7 @@ class ZWaveNodeFirmwareUpdate(UpdateEntity):
         # so that the entity starts as off. If we have partial restore data due to an
         # upgrade to an HA version where this feature is released from one that is not
         # the entity will start in an unknown state until we can correct on next update
-        elif not state and not extra_data:
+        elif not state:
             self._attr_latest_version = self._attr_installed_version
 
         # Spread updates out in 5 minute increments to avoid flooding the network

--- a/homeassistant/components/zwave_js/update.py
+++ b/homeassistant/components/zwave_js/update.py
@@ -57,7 +57,9 @@ async def async_setup_entry(
         cnt[UPDATE_DELAY_STRING] += 1
         driver = client.driver
         assert driver is not None  # Driver is ready before platforms are loaded.
-        async_add_entities([ZWaveNodeFirmwareUpdate(driver, node, cnt)])
+        async_add_entities(
+            [ZWaveNodeFirmwareUpdate(driver, node, cnt[UPDATE_DELAY_STRING])]
+        )
 
     config_entry.async_on_unload(
         async_dispatcher_connect(
@@ -81,7 +83,7 @@ class ZWaveNodeFirmwareUpdate(UpdateEntity):
     _attr_has_entity_name = True
     _attr_should_poll = False
 
-    def __init__(self, driver: Driver, node: ZwaveNode, cnt: Counter) -> None:
+    def __init__(self, driver: Driver, node: ZwaveNode, delay_cnt: int) -> None:
         """Initialize a Z-Wave device firmware update entity."""
         self.driver = driver
         self.node = node
@@ -92,7 +94,7 @@ class ZWaveNodeFirmwareUpdate(UpdateEntity):
         self._finished_unsub: Callable[[], None] | None = None
         self._finished_event = asyncio.Event()
         self._result: NodeFirmwareUpdateResult | None = None
-        self._delay_cnt: Final[int] = cnt[UPDATE_DELAY_STRING]
+        self._delay_cnt: Final[int] = delay_cnt
 
         # Entity class attributes
         self._attr_name = "Firmware"

--- a/homeassistant/components/zwave_js/update.py
+++ b/homeassistant/components/zwave_js/update.py
@@ -288,9 +288,11 @@ class ZWaveNodeFirmwareUpdate(UpdateEntity):
             )
         )
 
-        # Spread updates out in 5 minute increments to avoid flooding the network
+        # Turn state off to start if there is no skipped version
         if not getattr(self, "_UpdateEntity__skipped_version"):
             self._attr_latest_version = self._attr_installed_version
+
+        # Spread updates out in 5 minute increments to avoid flooding the network
         self.async_on_remove(
             async_call_later(
                 self.hass,

--- a/homeassistant/components/zwave_js/update.py
+++ b/homeassistant/components/zwave_js/update.py
@@ -334,14 +334,11 @@ class ZWaveNodeFirmwareUpdate(UpdateEntity):
                     extra_data.as_dict()
                 ).latest_version_firmware
             )
-        # Since we don't have the complete previous state, we must set the latest
-        # version to the installed version. This has the unfortunate side effect of
-        # clearing out the skipped version attribute, but this will self correct
-        # after the next update. We have to do this because if we restore a newer
-        # latest version and the user chooses to install it before the next update
-        # occurs, the installation will fail because we don't have the firmware data
-        # cached.
-        else:
+        # If we have no state to restore, we can set the latest version to installed
+        # so that the entity starts as off. If we have partial restore data due to an
+        # upgrade to an HA version where this feature is released from one that is not
+        # the entity will start in an unknown state until we can correct on next update
+        elif not state and not extra_data:
             self._attr_latest_version = self._attr_installed_version
 
         # Spread updates out in 5 minute increments to avoid flooding the network

--- a/homeassistant/components/zwave_js/update.py
+++ b/homeassistant/components/zwave_js/update.py
@@ -287,6 +287,7 @@ class ZWaveNodeFirmwareUpdate(UpdateEntity):
             )
         )
 
+        # Spread updates out in 5 minute increments to avoid flooding the network
         self.async_on_remove(
             async_call_later(
                 self.hass,

--- a/homeassistant/components/zwave_js/update.py
+++ b/homeassistant/components/zwave_js/update.py
@@ -59,7 +59,7 @@ class ZWaveNodeFirmwareUpdateExtraStoredData(ExtraStoredData):
         }
 
     @classmethod
-    def from_dict(cls, data: dict) -> ZWaveNodeFirmwareUpdateExtraStoredData:
+    def from_dict(cls, data: dict[str, Any]) -> ZWaveNodeFirmwareUpdateExtraStoredData:
         """Initialize the extra data from a dict."""
         if not (firmware_dict := data["latest_version_firmware"]):
             return cls(None)

--- a/homeassistant/components/zwave_js/update.py
+++ b/homeassistant/components/zwave_js/update.py
@@ -53,6 +53,7 @@ class ZWaveNodeFirmwareUpdateExtraStoredData(ExtraStoredData):
 
     def as_dict(self) -> dict[str, Any]:
         """Return a dict representation of the extra data."""
+        # We will simplify this upstream later
         if latest_version_firmware := (
             asdict(self.latest_version_firmware)
             if self.latest_version_firmware

--- a/homeassistant/components/zwave_js/update.py
+++ b/homeassistant/components/zwave_js/update.py
@@ -20,6 +20,7 @@ from zwave_js_server.model.node.firmware import (
 )
 
 from homeassistant.components.update import (
+    ATTR_LATEST_VERSION,
     UpdateDeviceClass,
     UpdateEntity,
     UpdateEntityFeature,
@@ -289,8 +290,12 @@ class ZWaveNodeFirmwareUpdate(UpdateEntity):
         )
 
         # Turn state off to start if there is no skipped version
-        if not getattr(self, "_UpdateEntity__skipped_version"):
+        if not (state := await self.async_get_last_state()):
             self._attr_latest_version = self._attr_installed_version
+        else:
+            self._attr_latest_version = state.attributes.get(
+                ATTR_LATEST_VERSION, self._attr_installed_version
+            )
 
         # Spread updates out in 5 minute increments to avoid flooding the network
         self.async_on_remove(

--- a/homeassistant/components/zwave_js/update.py
+++ b/homeassistant/components/zwave_js/update.py
@@ -290,12 +290,12 @@ class ZWaveNodeFirmwareUpdate(UpdateEntity):
         )
 
         # Turn state off to start if there is no skipped version
-        if not (state := await self.async_get_last_state()):
-            self._attr_latest_version = self._attr_installed_version
-        else:
+        if state := await self.async_get_last_state():
             self._attr_latest_version = state.attributes.get(
                 ATTR_LATEST_VERSION, self._attr_installed_version
             )
+        else:
+            self._attr_latest_version = self._attr_installed_version
 
         # Spread updates out in 5 minute increments to avoid flooding the network
         self.async_on_remove(

--- a/homeassistant/components/zwave_js/update.py
+++ b/homeassistant/components/zwave_js/update.py
@@ -132,9 +132,7 @@ class ZWaveNodeFirmwareUpdate(UpdateEntity):
         self._attr_device_info = get_device_info(driver, node)
 
     @property
-    def extra_restore_state_data(  # pylint: disable=[hass-return-type]
-        self,
-    ) -> ZWaveNodeFirmwareUpdateExtraStoredData:
+    def extra_restore_state_data(self) -> ExtraStoredData:
         """Return ZWave Node Firmware Update specific state data to be restored."""
         return ZWaveNodeFirmwareUpdateExtraStoredData(self._latest_version_firmware)
 

--- a/homeassistant/components/zwave_js/update.py
+++ b/homeassistant/components/zwave_js/update.py
@@ -55,11 +55,10 @@ async def async_setup_entry(
     def async_add_firmware_update_entity(node: ZwaveNode) -> None:
         """Add firmware update entity."""
         cnt[UPDATE_DELAY_STRING] += 1
+        delay_cnt = cnt[UPDATE_DELAY_STRING]
         driver = client.driver
         assert driver is not None  # Driver is ready before platforms are loaded.
-        async_add_entities(
-            [ZWaveNodeFirmwareUpdate(driver, node, cnt[UPDATE_DELAY_STRING])]
-        )
+        async_add_entities([ZWaveNodeFirmwareUpdate(driver, node, delay_cnt)])
 
     config_entry.async_on_unload(
         async_dispatcher_connect(

--- a/homeassistant/components/zwave_js/update.py
+++ b/homeassistant/components/zwave_js/update.py
@@ -41,8 +41,7 @@ from .helpers import get_device_info, get_valueless_base_unique_id
 PARALLEL_UPDATES = 1
 
 UPDATE_DELAY_STRING = "delay"
-# In minutes
-UPDATE_DELAY_INTERVAL = 5
+UPDATE_DELAY_INTERVAL = 5  # In minutes
 
 
 @dataclass

--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -18,8 +18,8 @@ from tests.common import MockConfigEntry, load_fixture
 
 @pytest.fixture(name="skip_update_delay", autouse=True)
 def skip_update_delay_fixture():
-    """Set the UPDATE_DELAY_TIME constant to 0."""
-    with patch("homeassistant.components.zwave_js.update.UPDATE_DELAY_TIME", 0):
+    """Set the UPDATE_DELAY constant to 0."""
+    with patch("homeassistant.components.zwave_js.update.UPDATE_DELAY", 0):
         yield
 
 

--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -13,6 +13,16 @@ from zwave_js_server.version import VersionInfo
 
 from tests.common import MockConfigEntry, load_fixture
 
+# Misc fixtures
+
+
+@pytest.fixture(name="skip_update_delay", autouse=True)
+def skip_update_delay_fixture():
+    """Set the UPDATE_DELAY_TIME constant to 0."""
+    with patch("homeassistant.components.zwave_js.update.UPDATE_DELAY_TIME", 0):
+        yield
+
+
 # Add-on fixtures
 
 
@@ -233,6 +243,9 @@ def create_backup_fixture():
         "homeassistant.components.hassio.addon_manager.async_create_backup"
     ) as create_backup:
         yield create_backup
+
+
+# State fixtures
 
 
 @pytest.fixture(name="controller_state", scope="session")
@@ -599,6 +612,9 @@ def light_express_controls_ezmultipli_state_fixture():
 def lock_home_connect_620_state_fixture():
     """Load the Home Connect 620 lock node state fixture data."""
     return json.loads(load_fixture("zwave_js/lock_home_connect_620_state.json"))
+
+
+# model fixtures
 
 
 @pytest.fixture(name="client")

--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -13,16 +13,6 @@ from zwave_js_server.version import VersionInfo
 
 from tests.common import MockConfigEntry, load_fixture
 
-# Misc fixtures
-
-
-@pytest.fixture(name="skip_update_delay", autouse=True)
-def skip_update_delay_fixture():
-    """Set the UPDATE_DELAY constant to 0."""
-    with patch("homeassistant.components.zwave_js.update.UPDATE_DELAY", 0):
-        yield
-
-
 # Add-on fixtures
 
 

--- a/tests/components/zwave_js/test_update.py
+++ b/tests/components/zwave_js/test_update.py
@@ -285,6 +285,7 @@ async def test_update_entity_ha_not_running(
 
     assert len(client.async_send_command.call_args_list) == 0
 
+    # Update should be delayed by a day because HA is not running
     hass.state = CoreState.starting
 
     async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5))

--- a/tests/components/zwave_js/test_update.py
+++ b/tests/components/zwave_js/test_update.py
@@ -35,6 +35,11 @@ from tests.common import (
 from tests.typing import WebSocketGenerator
 
 UPDATE_ENTITY = "update.z_wave_thermostat_firmware"
+LATEST_VERSION_FIRMWARE = {
+    "version": "11.2.4",
+    "changelog": "blah 2",
+    "files": [{"target": 0, "url": "https://example2.com", "integrity": "sha2"}],
+}
 FIRMWARE_UPDATES = {
     "updates": [
         {
@@ -44,31 +49,12 @@ FIRMWARE_UPDATES = {
                 {"target": 0, "url": "https://example1.com", "integrity": "sha1"}
             ],
         },
-        {
-            "version": "11.2.4",
-            "changelog": "blah 2",
-            "files": [
-                {"target": 0, "url": "https://example2.com", "integrity": "sha2"}
-            ],
-        },
+        LATEST_VERSION_FIRMWARE,
         {
             "version": "11.1.5",
             "changelog": "blah 3",
             "files": [
                 {"target": 0, "url": "https://example3.com", "integrity": "sha3"}
-            ],
-        },
-    ]
-}
-
-FIRMWARE_UPDATE_MULTIPLE_FILES = {
-    "updates": [
-        {
-            "version": "11.2.4",
-            "changelog": "blah 2",
-            "files": [
-                {"target": 0, "url": "https://example2.com", "integrity": "sha2"},
-                {"target": 1, "url": "https://example4.com", "integrity": "sha4"},
             ],
         },
     ]
@@ -675,19 +661,7 @@ async def test_update_entity_full_restore_data_skipped(
                         ATTR_SKIPPED_VERSION: "11.2.4",
                     },
                 ),
-                {
-                    "latest_version_firmware": {
-                        "version": "11.2.4",
-                        "changelog": "blah 2",
-                        "files": [
-                            {
-                                "target": 0,
-                                "url": "https://example2.com",
-                                "integrity": "sha2",
-                            }
-                        ],
-                    }
-                },
+                {"latest_version_firmware": LATEST_VERSION_FIRMWARE},
             )
         ],
     )
@@ -723,19 +697,7 @@ async def test_update_entity_full_restore_data_update(
                         ATTR_SKIPPED_VERSION: None,
                     },
                 ),
-                {
-                    "latest_version_firmware": {
-                        "version": "11.2.4",
-                        "changelog": "blah 2",
-                        "files": [
-                            {
-                                "target": 0,
-                                "url": "https://example2.com",
-                                "integrity": "sha2",
-                            }
-                        ],
-                    }
-                },
+                {"latest_version_firmware": LATEST_VERSION_FIRMWARE},
             )
         ],
     )

--- a/tests/components/zwave_js/test_update.py
+++ b/tests/components/zwave_js/test_update.py
@@ -639,13 +639,13 @@ async def test_update_entity_partial_restore_data(
     assert state.state == STATE_UNKNOWN
 
 
-async def test_update_entity_full_restore_data_skipped(
+async def test_update_entity_full_restore_data_skipped_version(
     hass: HomeAssistant,
     client,
     climate_radio_thermostat_ct100_plus_different_endpoints,
     hass_ws_client: WebSocketGenerator,
 ) -> None:
-    """Test update entity with full restore data including skipped restores state."""
+    """Test update entity with full restore data (skipped version) restores state."""
     mock_restore_cache_with_extra_data(
         hass,
         [
@@ -675,13 +675,13 @@ async def test_update_entity_full_restore_data_skipped(
     assert state.attributes[ATTR_LATEST_VERSION] == "11.2.4"
 
 
-async def test_update_entity_full_restore_data_update(
+async def test_update_entity_full_restore_data_update_available(
     hass: HomeAssistant,
     client,
     climate_radio_thermostat_ct100_plus_different_endpoints,
     hass_ws_client: WebSocketGenerator,
 ) -> None:
-    """Test update entity with full restore data including update restores state."""
+    """Test update entity with full restore data (update available) restores state."""
     mock_restore_cache_with_extra_data(
         hass,
         [
@@ -742,13 +742,13 @@ async def test_update_entity_full_restore_data_update(
     install_task.cancel()
 
 
-async def test_update_entity_full_restore_data_no_update(
+async def test_update_entity_full_restore_data_no_update_available(
     hass: HomeAssistant,
     client,
     climate_radio_thermostat_ct100_plus_different_endpoints,
     hass_ws_client: WebSocketGenerator,
 ) -> None:
-    """Test update entity with full restore data without update restores state."""
+    """Test entity with full restore data (no update available) restores state."""
     mock_restore_cache_with_extra_data(
         hass,
         [

--- a/tests/components/zwave_js/test_update.py
+++ b/tests/components/zwave_js/test_update.py
@@ -550,29 +550,3 @@ async def test_update_entity_reload(
     assert state
     assert state.state == STATE_OFF
     assert state.attributes[ATTR_SKIPPED_VERSION] == "11.2.4"
-
-
-async def test_update_entity_delay(
-    hass: HomeAssistant,
-    client,
-    ge_in_wall_dimmer_switch,
-    zen_31,
-    hass_ws_client: WebSocketGenerator,
-) -> None:
-    """Test update occurs after HA starts."""
-    client.async_send_command.reset_mock()
-    await hass.async_stop()
-
-    entry = MockConfigEntry(domain="zwave_js", data={"url": "ws://test.org"})
-    entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
-
-    assert len(client.async_send_command.call_args_list) == 0
-
-    await hass.async_start()
-
-    assert len(client.async_send_command.call_args_list) == 1
-    args = client.async_send_command.call_args_list[0][0][0]
-    assert args["command"] == "controller.get_available_firmware_updates"
-    assert args["nodeId"] == zen_31.node_id

--- a/tests/components/zwave_js/test_update.py
+++ b/tests/components/zwave_js/test_update.py
@@ -565,3 +565,43 @@ async def test_update_entity_reload(
     assert state
     assert state.state == STATE_OFF
     assert state.attributes[ATTR_SKIPPED_VERSION] == "11.2.4"
+
+
+async def test_update_entity_delay(
+    hass: HomeAssistant,
+    client,
+    ge_in_wall_dimmer_switch,
+    zen_31,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test update occurs after HA starts."""
+    client.async_send_command.reset_mock()
+    await hass.async_stop()
+
+    entry = MockConfigEntry(domain="zwave_js", data={"url": "ws://test.org"})
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert len(client.async_send_command.call_args_list) == 0
+
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    assert len(client.async_send_command.call_args_list) == 0
+
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5))
+    await hass.async_block_till_done()
+
+    assert len(client.async_send_command.call_args_list) == 1
+    args = client.async_send_command.call_args_list[0][0][0]
+    assert args["command"] == "controller.get_available_firmware_updates"
+    assert args["nodeId"] == ge_in_wall_dimmer_switch.node_id
+
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=10))
+    await hass.async_block_till_done()
+
+    assert len(client.async_send_command.call_args_list) == 2
+    args = client.async_send_command.call_args_list[1][0][0]
+    assert args["command"] == "controller.get_available_firmware_updates"
+    assert args["nodeId"] == zen_31.node_id

--- a/tests/components/zwave_js/test_update.py
+++ b/tests/components/zwave_js/test_update.py
@@ -85,7 +85,7 @@ async def test_update_entity_states(
 
     client.async_send_command.return_value = {"updates": []}
 
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(days=1))
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5, days=1))
     await hass.async_block_till_done()
 
     state = hass.states.get(UPDATE_ENTITY)
@@ -272,6 +272,12 @@ async def test_update_entity_ha_not_running(
     assert len(client.async_send_command.call_args_list) == 0
 
     await hass.async_start()
+    await hass.async_block_till_done()
+
+    assert len(client.async_send_command.call_args_list) == 0
+
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5))
+    await hass.async_block_till_done()
 
     assert len(client.async_send_command.call_args_list) == 1
     args = client.async_send_command.call_args_list[0][0][0]
@@ -289,7 +295,7 @@ async def test_update_entity_update_failure(
     assert len(client.async_send_command.call_args_list) == 0
     client.async_send_command.side_effect = FailedZWaveCommand("test", 260, "test")
 
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(days=1))
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5, days=1))
     await hass.async_block_till_done()
 
     state = hass.states.get(UPDATE_ENTITY)
@@ -503,7 +509,7 @@ async def test_update_entity_reload(
 
     client.async_send_command.return_value = {"updates": []}
 
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(days=1))
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5, days=1))
     await hass.async_block_till_done()
 
     state = hass.states.get(UPDATE_ENTITY)
@@ -512,7 +518,7 @@ async def test_update_entity_reload(
 
     client.async_send_command.return_value = FIRMWARE_UPDATES
 
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(days=2))
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5, days=2))
     await hass.async_block_till_done()
 
     state = hass.states.get(UPDATE_ENTITY)
@@ -543,7 +549,7 @@ async def test_update_entity_reload(
     await hass.async_block_till_done()
 
     # Trigger another update and make sure the skipped version is still skipped
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(days=4))
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5, days=4))
     await hass.async_block_till_done()
 
     state = hass.states.get(UPDATE_ENTITY)

--- a/tests/components/zwave_js/test_update.py
+++ b/tests/components/zwave_js/test_update.py
@@ -20,7 +20,7 @@ from homeassistant.components.update import (
 )
 from homeassistant.components.zwave_js.const import DOMAIN, SERVICE_REFRESH_VALUE
 from homeassistant.components.zwave_js.helpers import get_valueless_base_unique_id
-from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON
+from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON, STATE_UNKNOWN
 from homeassistant.core import CoreState, HomeAssistant, State
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_registry import async_get
@@ -636,9 +636,7 @@ async def test_update_entity_partial_restore_data(
 
     state = hass.states.get(UPDATE_ENTITY)
     assert state
-    assert state.state == STATE_OFF
-    assert state.attributes[ATTR_SKIPPED_VERSION] is None
-    assert state.attributes[ATTR_LATEST_VERSION] == "10.7"
+    assert state.state == STATE_UNKNOWN
 
 
 async def test_update_entity_full_restore_data_skipped(

--- a/tests/components/zwave_js/test_update.py
+++ b/tests/components/zwave_js/test_update.py
@@ -550,3 +550,29 @@ async def test_update_entity_reload(
     assert state
     assert state.state == STATE_OFF
     assert state.attributes[ATTR_SKIPPED_VERSION] == "11.2.4"
+
+
+async def test_update_entity_delay(
+    hass: HomeAssistant,
+    client,
+    ge_in_wall_dimmer_switch,
+    zen_31,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test update occurs after HA starts."""
+    client.async_send_command.reset_mock()
+    await hass.async_stop()
+
+    entry = MockConfigEntry(domain="zwave_js", data={"url": "ws://test.org"})
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert len(client.async_send_command.call_args_list) == 0
+
+    await hass.async_start()
+
+    assert len(client.async_send_command.call_args_list) == 1
+    args = client.async_send_command.call_args_list[0][0][0]
+    assert args["command"] == "controller.get_available_firmware_updates"
+    assert args["nodeId"] == zen_31.node_id

--- a/tests/components/zwave_js/test_update.py
+++ b/tests/components/zwave_js/test_update.py
@@ -104,7 +104,7 @@ async def test_update_entity_states(
 
     client.async_send_command.return_value = FIRMWARE_UPDATES
 
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(days=2))
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5, days=2))
     await hass.async_block_till_done()
 
     state = hass.states.get(UPDATE_ENTITY)
@@ -139,6 +139,15 @@ async def test_update_entity_states(
 
     assert "There is no value to refresh for this entity" in caplog.text
 
+    client.async_send_command.return_value = {"updates": []}
+
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5, days=3))
+    await hass.async_block_till_done()
+
+    state = hass.states.get(UPDATE_ENTITY)
+    assert state
+    assert state.state == STATE_OFF
+
     # Assert a node firmware update entity is not created for the controller
     driver = client.driver
     node = driver.controller.nodes[1]
@@ -164,7 +173,7 @@ async def test_update_entity_install_raises(
     """Test update entity install raises exception."""
     client.async_send_command.return_value = FIRMWARE_UPDATES
 
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(days=1))
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5, days=1))
     await hass.async_block_till_done()
 
     # Test failed installation by driver
@@ -197,7 +206,7 @@ async def test_update_entity_sleep(
 
     client.async_send_command.return_value = FIRMWARE_UPDATES
 
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(days=1))
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5, days=1))
     await hass.async_block_till_done()
 
     # Because node is asleep we shouldn't attempt to check for firmware updates
@@ -234,7 +243,7 @@ async def test_update_entity_dead(
 
     client.async_send_command.return_value = FIRMWARE_UPDATES
 
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(days=1))
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5, days=1))
     await hass.async_block_till_done()
 
     # Because node is asleep we shouldn't attempt to check for firmware updates
@@ -320,7 +329,7 @@ async def test_update_entity_progress(
     node = climate_radio_thermostat_ct100_plus_different_endpoints
     client.async_send_command.return_value = FIRMWARE_UPDATES
 
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(days=1))
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5, days=1))
     await hass.async_block_till_done()
 
     state = hass.states.get(UPDATE_ENTITY)
@@ -416,7 +425,7 @@ async def test_update_entity_install_failed(
     node = climate_radio_thermostat_ct100_plus_different_endpoints
     client.async_send_command.return_value = FIRMWARE_UPDATES
 
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(days=1))
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5, days=1))
     await hass.async_block_till_done()
 
     state = hass.states.get(UPDATE_ENTITY)


### PR DESCRIPTION
## Proposed change
It was discovered that in some cases, because of the way we were handling update entity updates, we were causing floods of network traffic. The reason is because even though we used a semaphore to limit parallel requests, as soon as the call was done the next one immediately started. For large networks, at startup, and every 24 hours after, we would generate a lot of traffic which ended up causing bit flips.

To address this issue, we increment a counter in the entry setup logic that assigns each created update entity an initial update delay spaced out in 5 minute intervals which gets persisted across updates because of the 24 hour interval between checks. With a max of 255 nodes, this ensures that two nodes will never be going through an update available check at the same time.

I also fixed a bug where we weren't properly unsubscribing from the callback.

CC @AlCalzone @kpine


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
