### PR TITLE
Add health mode to gree integration

### DIFF
--- a/homeassistant/components/gree/switch.py
+++ b/homeassistant/components/gree/switch.py
@@ -26,6 +26,7 @@ async def async_setup_entry(
         async_add_entities(
             [
                 GreePanelLightSwitchEntity(coordinator),
+                GreeHealthModeSwitchEntity(coordinator),
                 GreeQuietModeSwitchEntity(coordinator),
                 GreeFreshAirSwitchEntity(coordinator),
                 GreeXFanSwitchEntity(coordinator),
@@ -71,6 +72,42 @@ class GreePanelLightSwitchEntity(GreeEntity, SwitchEntity):
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
         self.coordinator.device.light = False
+        await self.coordinator.push_state_update()
+        self.async_write_ha_state()
+
+
+class GreeHealthModeSwitchEntity(GreeEntity, SwitchEntity):
+    """Representation of the health mode on the device."""
+
+    def __init__(self, coordinator):
+        """Initialize the Gree device."""
+        super().__init__(coordinator, "Health mode")
+        self._attr_entity_registry_enabled_default = False
+
+    @property
+    def icon(self) -> str | None:
+        """Return the icon for the device."""
+        return "mdi:pine-tree"
+
+    @property
+    def device_class(self):
+        """Return the class of this device, from component DEVICE_CLASSES."""
+        return SwitchDeviceClass.SWITCH
+
+    @property
+    def is_on(self) -> bool:
+        """Return if the health mode is turned on."""
+        return self.coordinator.device.anion
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the entity on."""
+        self.coordinator.device.anion = True
+        await self.coordinator.push_state_update()
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the entity off."""
+        self.coordinator.device.anion = False
         await self.coordinator.push_state_update()
         self.async_write_ha_state()
 

--- a/tests/components/gree/test_switch.py
+++ b/tests/components/gree/test_switch.py
@@ -14,11 +14,13 @@ from homeassistant.const import (
     STATE_ON,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
 
 ENTITY_ID_LIGHT_PANEL = f"{DOMAIN}.fake_device_1_panel_light"
+ENTITY_ID_HEALTH_MODE = f"{DOMAIN}.fake_device_1_health_mode"
 ENTITY_ID_QUIET = f"{DOMAIN}.fake_device_1_quiet"
 ENTITY_ID_FRESH_AIR = f"{DOMAIN}.fake_device_1_fresh_air"
 ENTITY_ID_XFAN = f"{DOMAIN}.fake_device_1_xfan"
@@ -31,16 +33,29 @@ async def async_setup_gree(hass):
     await hass.async_block_till_done()
 
 
+async def test_health_mode_disabled_by_default(hass):
+    """Test for making sure health mode is disabled on first load."""
+    await async_setup_gree(hass)
+
+    assert (
+        er.async_get(hass).async_get(ENTITY_ID_HEALTH_MODE).disabled_by
+        == er.RegistryEntryDisabler.INTEGRATION
+    )
+
+
 @pytest.mark.parametrize(
     "entity",
     [
         ENTITY_ID_LIGHT_PANEL,
+        ENTITY_ID_HEALTH_MODE,
         ENTITY_ID_QUIET,
         ENTITY_ID_FRESH_AIR,
         ENTITY_ID_XFAN,
     ],
 )
-async def test_send_switch_on(hass: HomeAssistant, entity) -> None:
+async def test_send_switch_on(
+    hass: HomeAssistant, entity, entity_registry_enabled_by_default
+) -> None:
     """Test for sending power on command to the device."""
     await async_setup_gree(hass)
 
@@ -60,13 +75,14 @@ async def test_send_switch_on(hass: HomeAssistant, entity) -> None:
     "entity",
     [
         ENTITY_ID_LIGHT_PANEL,
+        ENTITY_ID_HEALTH_MODE,
         ENTITY_ID_QUIET,
         ENTITY_ID_FRESH_AIR,
         ENTITY_ID_XFAN,
     ],
 )
 async def test_send_switch_on_device_timeout(
-    hass: HomeAssistant, device, entity
+    hass: HomeAssistant, device, entity, entity_registry_enabled_by_default
 ) -> None:
     """Test for sending power on command to the device with a device timeout."""
     device().push_state_update.side_effect = DeviceTimeoutError
@@ -89,12 +105,15 @@ async def test_send_switch_on_device_timeout(
     "entity",
     [
         ENTITY_ID_LIGHT_PANEL,
+        ENTITY_ID_HEALTH_MODE,
         ENTITY_ID_QUIET,
         ENTITY_ID_FRESH_AIR,
         ENTITY_ID_XFAN,
     ],
 )
-async def test_send_switch_off(hass: HomeAssistant, entity) -> None:
+async def test_send_switch_off(
+    hass: HomeAssistant, entity, entity_registry_enabled_by_default
+) -> None:
     """Test for sending power on command to the device."""
     await async_setup_gree(hass)
 
@@ -114,12 +133,15 @@ async def test_send_switch_off(hass: HomeAssistant, entity) -> None:
     "entity",
     [
         ENTITY_ID_LIGHT_PANEL,
+        ENTITY_ID_HEALTH_MODE,
         ENTITY_ID_QUIET,
         ENTITY_ID_FRESH_AIR,
         ENTITY_ID_XFAN,
     ],
 )
-async def test_send_switch_toggle(hass: HomeAssistant, entity) -> None:
+async def test_send_switch_toggle(
+    hass: HomeAssistant, entity, entity_registry_enabled_by_default
+) -> None:
     """Test for sending power on command to the device."""
     await async_setup_gree(hass)
 
@@ -164,12 +186,15 @@ async def test_send_switch_toggle(hass: HomeAssistant, entity) -> None:
     ("entity", "name"),
     [
         (ENTITY_ID_LIGHT_PANEL, "Panel Light"),
+        (ENTITY_ID_HEALTH_MODE, "Health mode"),
         (ENTITY_ID_QUIET, "Quiet"),
         (ENTITY_ID_FRESH_AIR, "Fresh Air"),
         (ENTITY_ID_XFAN, "XFan"),
     ],
 )
-async def test_entity_name(hass: HomeAssistant, entity, name) -> None:
+async def test_entity_name(
+    hass: HomeAssistant, entity, name, entity_registry_enabled_by_default
+) -> None:
     """Test for name property."""
     await async_setup_gree(hass)
     state = hass.states.get(entity)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds a switch entity to the gree integration so that AC units that support the 'health' function can use it.
Not all units support this feature, but according to the documentation of the underlying python lib, this won't cause a problem if the feature is unsupported.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #75710
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
