### PR TITLE
Fix logbook tests failing because time was not url encoded correctly

### DIFF
--- a/tests/components/logbook/test_init.py
+++ b/tests/components/logbook/test_init.py
@@ -7,7 +7,6 @@ from datetime import datetime, timedelta
 from http import HTTPStatus
 import json
 from unittest.mock import Mock, patch
-from urllib.parse import urlencode
 
 import pytest
 import voluptuous as vol
@@ -517,8 +516,10 @@ async def test_logbook_describe_event(
 
     # Test today entries with filter by end_time
     end_time = start_date + timedelta(hours=24)
-    query = urlencode({"end_time": end_time})
-    response = await client.get(f"/api/logbook/{start_date.isoformat()}?{query}")
+    response = await client.get(
+        f"/api/logbook/{start_date.isoformat()}",
+        params={"end_time": end_time.isoformat()},
+    )
     results = await response.json()
     assert len(results) == 1
     event = results[0]
@@ -590,8 +591,10 @@ async def test_exclude_described_event(
 
     # Test today entries with filter by end_time
     end_time = start_date + timedelta(hours=24)
-    query = urlencode({"end_time": end_time})
-    response = await client.get(f"/api/logbook/{start_date.isoformat()}?{query}")
+    response = await client.get(
+        f"/api/logbook/{start_date.isoformat()}",
+        params={"end_time": end_time.isoformat()},
+    )
     results = await response.json()
     assert len(results) == 1
     event = results[0]
@@ -622,8 +625,10 @@ async def test_logbook_view_end_time_entity(
 
     # Test today entries with filter by end_time
     end_time = start_date + timedelta(hours=24)
-    query = urlencode({"end_time": end_time.isoformat()})
-    response = await client.get(f"/api/logbook/{start_date.isoformat()}?{query}")
+    response = await client.get(
+        f"/api/logbook/{start_date.isoformat()}",
+        params={"end_time": end_time.isoformat()},
+    )
     assert response.status == HTTPStatus.OK
     response_json = await response.json()
     assert len(response_json) == 2
@@ -632,8 +637,10 @@ async def test_logbook_view_end_time_entity(
 
     # Test entries for 3 days with filter by entity_id
     end_time = start + timedelta(hours=72)
-    query = urlencode({"end_time": end_time.isoformat(), "entity": "switch.test"})
-    response = await client.get(f"/api/logbook/{start_date.isoformat()}?{query}")
+    response = await client.get(
+        f"/api/logbook/{start_date.isoformat()}",
+        params={"end_time": end_time.isoformat(), "entity": "switch.test"},
+    )
     assert response.status == HTTPStatus.OK
     response_json = await response.json()
     assert len(response_json) == 1
@@ -645,8 +652,10 @@ async def test_logbook_view_end_time_entity(
 
     # Test entries from today to 3 days with filter by entity_id
     end_time = start_date + timedelta(hours=72)
-    query = urlencode({"end_time": end_time.isoformat(), "entity": "switch.test"})
-    response = await client.get(f"/api/logbook/{start_date.isoformat()}?{query}")
+    response = await client.get(
+        f"/api/logbook/{start_date.isoformat()}",
+        params={"end_time": end_time.isoformat(), "entity": "switch.test"},
+    )
     response_json = await response.json()
     assert response.status == HTTPStatus.OK
     assert len(response_json) == 1
@@ -693,8 +702,10 @@ async def test_logbook_entity_filter_with_automations(
 
     # Test today entries with filter by end_time
     end_time = start_date + timedelta(hours=24)
-    query = urlencode({"end_time": end_time.isoformat()})
-    response = await client.get(f"/api/logbook/{start_date.isoformat()}?{query}")
+    response = await client.get(
+        f"/api/logbook/{start_date.isoformat()}",
+        params={"end_time": end_time.isoformat()},
+    )
     assert response.status == HTTPStatus.OK
     json_dict = await response.json()
 
@@ -706,10 +717,13 @@ async def test_logbook_entity_filter_with_automations(
 
     # Test entries for 3 days with filter by entity_id
     end_time = start + timedelta(hours=72)
-    query = urlencode(
-        {"end_time": end_time.isoformat(), "entity": "alarm_control_panel.area_001"}
+    response = await client.get(
+        f"/api/logbook/{start_date.isoformat()}",
+        params={
+            "end_time": end_time.isoformat(),
+            "entity": "alarm_control_panel.area_001",
+        },
     )
-    response = await client.get(f"/api/logbook/{start_date.isoformat()}?{query}")
     assert response.status == HTTPStatus.OK
     json_dict = await response.json()
     assert len(json_dict) == 1
@@ -721,10 +735,13 @@ async def test_logbook_entity_filter_with_automations(
 
     # Test entries from today to 3 days with filter by entity_id
     end_time = start_date + timedelta(hours=72)
-    query = urlencode(
-        {"end_time": end_time.isoformat(), "entity": "alarm_control_panel.area_002"}
+    response = await client.get(
+        f"/api/logbook/{start_date.isoformat()}",
+        params={
+            "end_time": end_time.isoformat(),
+            "entity": "alarm_control_panel.area_002",
+        },
     )
-    response = await client.get(f"/api/logbook/{start_date.isoformat()}?{query}")
     assert response.status == HTTPStatus.OK
     json_dict = await response.json()
     assert len(json_dict) == 1
@@ -761,8 +778,10 @@ async def test_logbook_entity_no_longer_in_state_machine(
 
     # Test today entries with filter by end_time
     end_time = start_date + timedelta(hours=24)
-    query = urlencode({"end_time": end_time.isoformat()})
-    response = await client.get(f"/api/logbook/{start_date.isoformat()}?{query}")
+    response = await client.get(
+        f"/api/logbook/{start_date.isoformat()}",
+        params={"end_time": end_time.isoformat()},
+    )
     assert response.status == HTTPStatus.OK
     json_dict = await response.json()
     assert json_dict[0]["name"] == "area 001"
@@ -1053,8 +1072,10 @@ async def test_logbook_entity_context_id(
 
     # Test today entries with filter by end_time
     end_time = start_date + timedelta(hours=24)
-    query = urlencode({"end_time": end_time.isoformat()})
-    response = await client.get(f"/api/logbook/{start_date.isoformat()}?{query}")
+    response = await client.get(
+        f"/api/logbook/{start_date.isoformat()}",
+        params={"end_time": end_time.isoformat()},
+    )
     assert response.status == HTTPStatus.OK
     json_dict = await response.json()
 
@@ -1158,8 +1179,10 @@ async def test_logbook_context_id_automation_script_started_manually(
 
     # Test today entries with filter by end_time
     end_time = start_date + timedelta(hours=24)
-    query = urlencode({"end_time": end_time.isoformat()})
-    response = await client.get(f"/api/logbook/{start_date.isoformat()}?{query}")
+    response = await client.get(
+        f"/api/logbook/{start_date.isoformat()}",
+        params={"end_time": end_time.isoformat()},
+    )
     assert response.status == HTTPStatus.OK
     json_dict = await response.json()
 
@@ -1315,8 +1338,10 @@ async def test_logbook_entity_context_parent_id(
 
     # Test today entries with filter by end_time
     end_time = start_date + timedelta(hours=24)
-    query = urlencode({"end_time": end_time.isoformat()})
-    response = await client.get(f"/api/logbook/{start_date.isoformat()}?{query}")
+    response = await client.get(
+        f"/api/logbook/{start_date.isoformat()}",
+        params={"end_time": end_time.isoformat()},
+    )
     assert response.status == HTTPStatus.OK
     json_dict = await response.json()
 
@@ -1432,8 +1457,10 @@ async def test_logbook_context_from_template(
 
     # Test today entries with filter by end_time
     end_time = start_date + timedelta(hours=24)
-    query = urlencode({"end_time": end_time.isoformat()})
-    response = await client.get(f"/api/logbook/{start_date.isoformat()}?{query}")
+    response = await client.get(
+        f"/api/logbook/{start_date.isoformat()}",
+        params={"end_time": end_time.isoformat()},
+    )
     assert response.status == HTTPStatus.OK
     json_dict = await response.json()
 


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The isoformat time was having the `+` decoded as a space so it was dropping the timezone and causing unexpected failures.  They are now encoded with `urlencode` to make sure it comes though as a `+` in the handler.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
