### PR TITLE
Add local calendar diagnostics platform

### DIFF
--- a/homeassistant/components/local_calendar/diagnostics.py
+++ b/homeassistant/components/local_calendar/diagnostics.py
@@ -1,46 +1,15 @@
 """Provides diagnostics for local calendar."""
 
-from collections.abc import Generator
 import datetime
-import itertools
 from typing import Any
+
+from ical.diagnostics import redact_ics
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN
-
-COMPONENT_ALLOWLIST = {
-    "BEGIN",
-    "END",
-    "DTSTAMP",
-    "CREATED",
-    "LAST-MODIFIED",
-    "DTSTART",
-    "DTEND",
-    "RRULE",
-    "PRODID",
-}
-REDACT = "***"
-MAX_CONTENTLINES = 5000
-
-
-def redact_contentline(contentline: str) -> str:
-    """Return a redacted version of an ics calendar."""
-    if ":" in contentline:
-        (component, _) = contentline.split(":", maxsplit=2)
-        if component in COMPONENT_ALLOWLIST:
-            return contentline
-        return f"{component}:{REDACT}"
-    return REDACT
-
-
-def redact_ics(ics: str) -> Generator[str, None, None]:
-    """Generate redacted ics file contents one line at a time."""
-    contentlines = ics.split("\n")
-    for contentline in itertools.islice(contentlines, MAX_CONTENTLINES):
-        yield redact_contentline(contentline)
 
 
 async def async_get_config_entry_diagnostics(

--- a/homeassistant/components/local_calendar/diagnostics.py
+++ b/homeassistant/components/local_calendar/diagnostics.py
@@ -1,0 +1,58 @@
+"""Provides diagnostics for local calendar."""
+
+from collections.abc import Generator
+import datetime
+import itertools
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
+
+from .const import DOMAIN
+
+COMPONENT_ALLOWLIST = {
+    "BEGIN",
+    "END",
+    "DTSTAMP",
+    "CREATED",
+    "LAST-MODIFIED",
+    "DTSTART",
+    "DTEND",
+    "RRULE",
+    "PRODID",
+}
+REDACT = "***"
+MAX_CONTENTLINES = 5000
+
+
+def redact_contentline(contentline: str) -> str:
+    """Return a redacted version of an ics calendar."""
+    if ":" in contentline:
+        (component, _) = contentline.split(":", maxsplit=2)
+        if component in COMPONENT_ALLOWLIST:
+            return contentline
+        return f"{component}:{REDACT}"
+    return REDACT
+
+
+def redact_ics(ics: str) -> Generator[str, None, None]:
+    """Generate redacted ics file contents one line at a time."""
+    contentlines = ics.split("\n")
+    for contentline in itertools.islice(contentlines, MAX_CONTENTLINES):
+        yield redact_contentline(contentline)
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, config_entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    payload: dict[str, Any] = {
+        "now": dt_util.now().isoformat(),
+        "timezone": str(dt_util.DEFAULT_TIME_ZONE),
+        "system_timezone": str(datetime.datetime.utcnow().astimezone().tzinfo),
+    }
+    store = hass.data[DOMAIN][config_entry.entry_id]
+    ics = await store.async_load()
+    payload["ics"] = "\n".join(redact_ics(ics))
+    return payload

--- a/homeassistant/components/local_calendar/manifest.json
+++ b/homeassistant/components/local_calendar/manifest.json
@@ -3,6 +3,7 @@
   "name": "Local Calendar",
   "codeowners": ["@allenporter"],
   "config_flow": true,
+  "dependencies": ["diagnostics"],
   "documentation": "https://www.home-assistant.io/integrations/local_calendar",
   "iot_class": "local_polling",
   "loggers": ["ical"],

--- a/homeassistant/components/local_calendar/manifest.json
+++ b/homeassistant/components/local_calendar/manifest.json
@@ -3,7 +3,6 @@
   "name": "Local Calendar",
   "codeowners": ["@allenporter"],
   "config_flow": true,
-  "dependencies": ["diagnostics"],
   "documentation": "https://www.home-assistant.io/integrations/local_calendar",
   "iot_class": "local_polling",
   "loggers": ["ical"],

--- a/tests/components/local_calendar/snapshots/test_diagnostics.ambr
+++ b/tests/components/local_calendar/snapshots/test_diagnostics.ambr
@@ -1,0 +1,32 @@
+# serializer version: 1
+# name: test_api_date_time_event
+  dict({
+    'ics': '''
+      BEGIN:VCALENDAR
+      PRODID:-//github.com/allenporter/ical//4.5.0//EN
+      VERSION:***
+      BEGIN:VEVENT
+      DTSTAMP:20230313T190500
+      UID:***
+      DTSTART:19970714T110000
+      DTEND:19970714T220000
+      SUMMARY:***
+      CREATED:20230313T190500
+      RRULE:FREQ=DAILY
+      SEQUENCE:***
+      END:VEVENT
+      END:VCALENDAR
+    ''',
+    'now': '2023-03-13T13:05:00-06:00',
+    'system_timezone': 'tzlocal()',
+    'timezone': 'America/Regina',
+  })
+# ---
+# name: test_empty_calendar
+  dict({
+    'ics': '',
+    'now': '2023-03-13T13:05:00-06:00',
+    'system_timezone': 'tzlocal()',
+    'timezone': 'America/Regina',
+  })
+# ---

--- a/tests/components/local_calendar/test_diagnostics.py
+++ b/tests/components/local_calendar/test_diagnostics.py
@@ -35,12 +35,7 @@ async def test_empty_calendar(
 ) -> None:
     """Test diagnostics against an empty calendar."""
     data = await get_diagnostics_for_config_entry(hass, hass_client, config_entry)
-    assert data == {
-        "system_timezone": "tzlocal()",  # Will by python system timezone
-        "timezone": "America/Regina",  # HomeAssistant timezone set by fixture
-        "now": "2023-03-13T13:05:00-06:00",
-        "ics": "",
-    }
+    assert data == snapshot
 
 
 @freeze_time("2023-03-13 12:05:00-07:00")
@@ -68,9 +63,4 @@ async def test_api_date_time_event(
     )
 
     data = await get_diagnostics_for_config_entry(hass, hass_client, config_entry)
-    assert data == {
-        "system_timezone": "tzlocal()",
-        "timezone": "America/Regina",
-        "now": "2023-03-13T13:05:00-06:00",
-        "ics": TEST_ICS,
-    }
+    assert data == snapshot

--- a/tests/components/local_calendar/test_diagnostics.py
+++ b/tests/components/local_calendar/test_diagnostics.py
@@ -11,6 +11,8 @@ from tests.components.diagnostics import get_diagnostics_for_config_entry
 from tests.typing import ClientSessionGenerator
 
 TEST_ICS = """BEGIN:VCALENDAR
+PRODID:-//github.com/allenporter/ical//4.5.0//EN
+VERSION:***
 BEGIN:VEVENT
 DTSTAMP:20230313T190500
 UID:***
@@ -18,6 +20,7 @@ DTSTART:19970714T110000
 DTEND:19970714T220000
 SUMMARY:***
 CREATED:20230313T190500
+RRULE:FREQ=DAILY
 SEQUENCE:***
 END:VEVENT
 END:VCALENDAR"""
@@ -59,6 +62,7 @@ async def test_api_date_time_event(
                 "summary": "Bastille Day Party",
                 "dtstart": "1997-07-14T17:00:00+00:00",
                 "dtend": "1997-07-15T04:00:00+00:00",
+                "rrule": "FREQ=DAILY",
             },
         },
     )

--- a/tests/components/local_calendar/test_diagnostics.py
+++ b/tests/components/local_calendar/test_diagnostics.py
@@ -36,7 +36,7 @@ async def test_empty_calendar(
         "system_timezone": "tzlocal()",  # Will by python system timezone
         "timezone": "America/Regina",  # HomeAssistant timezone set by fixture
         "now": "2023-03-13T13:05:00-06:00",
-        "ics": "***",
+        "ics": "",
     }
 
 

--- a/tests/components/local_calendar/test_diagnostics.py
+++ b/tests/components/local_calendar/test_diagnostics.py
@@ -1,0 +1,72 @@
+"""Tests for diagnostics platform of local calendar."""
+
+from freezegun import freeze_time
+
+from homeassistant.core import HomeAssistant
+
+from .conftest import TEST_ENTITY, ClientFixture
+
+from tests.common import MockConfigEntry
+from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
+
+TEST_ICS = """BEGIN:VCALENDAR
+BEGIN:VEVENT
+DTSTAMP:20230313T190500
+UID:***
+DTSTART:19970714T110000
+DTEND:19970714T220000
+SUMMARY:***
+CREATED:20230313T190500
+SEQUENCE:***
+END:VEVENT
+END:VCALENDAR"""
+
+
+@freeze_time("2023-03-13 12:05:00-07:00")
+async def test_empty_calendar(
+    hass: HomeAssistant,
+    setup_integration: None,
+    hass_client: ClientSessionGenerator,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test diagnostics against an empty calendar."""
+    data = await get_diagnostics_for_config_entry(hass, hass_client, config_entry)
+    assert data == {
+        "system_timezone": "tzlocal()",  # Will by python system timezone
+        "timezone": "America/Regina",  # HomeAssistant timezone set by fixture
+        "now": "2023-03-13T13:05:00-06:00",
+        "ics": "***",
+    }
+
+
+@freeze_time("2023-03-13 12:05:00-07:00")
+async def test_api_date_time_event(
+    hass: HomeAssistant,
+    setup_integration: None,
+    config_entry: MockConfigEntry,
+    hass_client: ClientSessionGenerator,
+    ws_client: ClientFixture,
+) -> None:
+    """Test an event with a start/end date time."""
+
+    client = await ws_client()
+    await client.cmd_result(
+        "create",
+        {
+            "entity_id": TEST_ENTITY,
+            "event": {
+                "summary": "Bastille Day Party",
+                "dtstart": "1997-07-14T17:00:00+00:00",
+                "dtend": "1997-07-15T04:00:00+00:00",
+            },
+        },
+    )
+
+    data = await get_diagnostics_for_config_entry(hass, hass_client, config_entry)
+    assert data == {
+        "system_timezone": "tzlocal()",
+        "timezone": "America/Regina",
+        "now": "2023-03-13T13:05:00-06:00",
+        "ics": TEST_ICS,
+    }

--- a/tests/components/local_calendar/test_diagnostics.py
+++ b/tests/components/local_calendar/test_diagnostics.py
@@ -1,6 +1,7 @@
 """Tests for diagnostics platform of local calendar."""
 
 from freezegun import freeze_time
+from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.core import HomeAssistant
 
@@ -10,21 +11,6 @@ from tests.common import MockConfigEntry
 from tests.components.diagnostics import get_diagnostics_for_config_entry
 from tests.typing import ClientSessionGenerator
 
-TEST_ICS = """BEGIN:VCALENDAR
-PRODID:-//github.com/allenporter/ical//4.5.0//EN
-VERSION:***
-BEGIN:VEVENT
-DTSTAMP:20230313T190500
-UID:***
-DTSTART:19970714T110000
-DTEND:19970714T220000
-SUMMARY:***
-CREATED:20230313T190500
-RRULE:FREQ=DAILY
-SEQUENCE:***
-END:VEVENT
-END:VCALENDAR"""
-
 
 @freeze_time("2023-03-13 12:05:00-07:00")
 async def test_empty_calendar(
@@ -32,6 +18,7 @@ async def test_empty_calendar(
     setup_integration: None,
     hass_client: ClientSessionGenerator,
     config_entry: MockConfigEntry,
+    snapshot: SnapshotAssertion,
 ) -> None:
     """Test diagnostics against an empty calendar."""
     data = await get_diagnostics_for_config_entry(hass, hass_client, config_entry)
@@ -45,6 +32,7 @@ async def test_api_date_time_event(
     config_entry: MockConfigEntry,
     hass_client: ClientSessionGenerator,
     ws_client: ClientFixture,
+    snapshot: SnapshotAssertion,
 ) -> None:
     """Test an event with a start/end date time."""
 

--- a/tests/components/local_calendar/test_diagnostics.py
+++ b/tests/components/local_calendar/test_diagnostics.py
@@ -1,15 +1,23 @@
 """Tests for diagnostics platform of local calendar."""
 
 from freezegun import freeze_time
+import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
 
 from .conftest import TEST_ENTITY, ClientFixture
 
 from tests.common import MockConfigEntry
 from tests.components.diagnostics import get_diagnostics_for_config_entry
 from tests.typing import ClientSessionGenerator
+
+
+@pytest.fixture(autouse=True)
+async def setup_diag(hass):
+    """Set up diagnostics platform."""
+    assert await async_setup_component(hass, "diagnostics", {})
 
 
 @freeze_time("2023-03-13 12:05:00-07:00")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add local calendar diagnostics platform. The diagnostics output includes details about timezones, and a redacted version of the ICS files. The redaction is handled inside the `ical` python library so that it can handle the parsing of ICS contentlines for rfc5545. The parsing, however, is extremely minimal just in case the content itself is malformed or there is a bug in the full parser.  See [ical diagnostics](https://github.com/allenporter/ical/blob/main/ical/diagnostics.py#L14) for details on the redaction.  Adds a test for the diagnostics that shows how it works. The current set of retained fields are just an allowlisted set of timestamp fields that would be common for diagnosing trigger problems or recurring event issues, but not the other sensitive information like title, summary, etc.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
