### PR TITLE
Fix lingering timer in bootstrap tests

### DIFF
--- a/homeassistant/components/cloud/__init__.py
+++ b/homeassistant/components/cloud/__init__.py
@@ -68,6 +68,7 @@ SERVICE_REMOTE_DISCONNECT = "remote_disconnect"
 
 SIGNAL_CLOUD_CONNECTION_STATE = "CLOUD_CONNECTION_STATE"
 
+STARTUP_REPAIR_DELAY = 1  # 1 hour
 
 ALEXA_ENTITY_SCHEMA = vol.Schema(
     {
@@ -309,7 +310,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     async_call_later(
         hass=hass,
-        delay=timedelta(hours=1),
+        delay=timedelta(hours=STARTUP_REPAIR_DELAY),
         action=async_startup_repairs,
     )
 

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,6 +1,7 @@
 """Test the bootstrapping."""
 import asyncio
 from collections.abc import Generator
+from datetime import timedelta
 import glob
 import os
 from typing import Any
@@ -14,10 +15,12 @@ from homeassistant.const import SIGNAL_BOOTSTRAP_INTEGRATIONS
 from homeassistant.core import HomeAssistant, async_get_hass, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.util import dt
 
 from .common import (
     MockModule,
     MockPlatform,
+    async_fire_time_changed,
     get_test_config_dir,
     mock_coro,
     mock_entity_platform,
@@ -578,6 +581,10 @@ async def test_setup_hass_invalid_yaml(
     assert "safe_mode" in hass.config.components
     assert len(mock_mount_local_lib_path.mock_calls) == 0
 
+    # Avoid lingering timer: `async_startup_repairs` triggers after 1 hour
+    async_fire_time_changed(hass, dt.utcnow() + timedelta(hours=1))
+    await hass.async_block_till_done()
+
 
 async def test_setup_hass_config_dir_nonexistent(
     mock_enable_logging: Mock,
@@ -638,6 +645,10 @@ async def test_setup_hass_safe_mode(
     assert "browser" not in hass.config.components
     assert len(browser_setup.mock_calls) == 0
 
+    # Avoid lingering timer: `async_startup_repairs` triggers after 1 hour
+    async_fire_time_changed(hass, dt.utcnow() + timedelta(hours=1))
+    await hass.async_block_till_done()
+
 
 @pytest.mark.parametrize("hass_config", [{"homeassistant": {"non-existing": 1}}])
 async def test_setup_hass_invalid_core_config(
@@ -663,6 +674,10 @@ async def test_setup_hass_invalid_core_config(
     )
 
     assert "safe_mode" in hass.config.components
+
+    # Avoid lingering timer: `async_startup_repairs` triggers after 1 hour
+    async_fire_time_changed(hass, dt.utcnow() + timedelta(hours=1))
+    await hass.async_block_till_done()
 
 
 @pytest.mark.parametrize(
@@ -710,6 +725,10 @@ async def test_setup_safe_mode_if_no_frontend(
     assert hass.config.skip_pip
     assert hass.config.internal_url == "http://192.168.1.100:8123"
     assert hass.config.external_url == "https://abcdef.ui.nabu.casa"
+
+    # Avoid lingering timer: `async_startup_repairs` triggers after 1 hour
+    async_fire_time_changed(hass, dt.utcnow() + timedelta(hours=1))
+    await hass.async_block_till_done()
 
 
 @pytest.mark.parametrize("load_registries", [False])

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -581,7 +581,8 @@ async def test_setup_hass_invalid_yaml(
     assert "safe_mode" in hass.config.components
     assert len(mock_mount_local_lib_path.mock_calls) == 0
 
-    # Avoid lingering timer: `async_startup_repairs` triggers after 1 hour
+    # Avoid lingering timer
+    # `cloud.async_setup.async_startup_repairs` triggers after 1 hour
     async_fire_time_changed(hass, dt.utcnow() + timedelta(hours=1))
     await hass.async_block_till_done()
 
@@ -645,7 +646,8 @@ async def test_setup_hass_safe_mode(
     assert "browser" not in hass.config.components
     assert len(browser_setup.mock_calls) == 0
 
-    # Avoid lingering timer: `async_startup_repairs` triggers after 1 hour
+    # Avoid lingering timer
+    # `cloud.async_setup.async_startup_repairs` triggers after 1 hour
     async_fire_time_changed(hass, dt.utcnow() + timedelta(hours=1))
     await hass.async_block_till_done()
 
@@ -675,7 +677,8 @@ async def test_setup_hass_invalid_core_config(
 
     assert "safe_mode" in hass.config.components
 
-    # Avoid lingering timer: `async_startup_repairs` triggers after 1 hour
+    # Avoid lingering timer
+    # `cloud.async_setup.async_startup_repairs` triggers after 1 hour
     async_fire_time_changed(hass, dt.utcnow() + timedelta(hours=1))
     await hass.async_block_till_done()
 
@@ -726,7 +729,8 @@ async def test_setup_safe_mode_if_no_frontend(
     assert hass.config.internal_url == "http://192.168.1.100:8123"
     assert hass.config.external_url == "https://abcdef.ui.nabu.casa"
 
-    # Avoid lingering timer: `async_startup_repairs` triggers after 1 hour
+    # Avoid lingering timer
+    # `cloud.async_setup.async_startup_repairs` triggers after 1 hour
     async_fire_time_changed(hass, dt.utcnow() + timedelta(hours=1))
     await hass.async_block_till_done()
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Linked to #89292

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
