### PR TITLE
Shield Reolink webhook callback from cancelation

### DIFF
--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -328,6 +328,12 @@ class ReolinkHost:
     async def handle_webhook(
         self, hass: HomeAssistant, webhook_id: str, request: Request
     ):
+        """Shield the incoming webhook callback from cancellation."""
+        await asyncio.shield(self.handle_webhook_shielded(hass, webhook_id, request))
+
+    async def handle_webhook_shielded(
+        self, hass: HomeAssistant, webhook_id: str, request: Request
+    ):
         """Handle incoming webhook from Reolink for inbound messages and calls."""
 
         _LOGGER.debug("Webhook '%s' called", webhook_id)

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -329,7 +329,9 @@ class ReolinkHost:
         self, hass: HomeAssistant, webhook_id: str, request: Request
     ):
         """Shield the incoming webhook callback from cancellation."""
-        self._hass.async_create_task(self.handle_webhook_shielded(hass, webhook_id, request))
+        hass.async_create_task(
+            self.handle_webhook_shielded(hass, webhook_id, request)
+        )
 
     async def handle_webhook_shielded(
         self, hass: HomeAssistant, webhook_id: str, request: Request

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -329,9 +329,7 @@ class ReolinkHost:
         self, hass: HomeAssistant, webhook_id: str, request: Request
     ):
         """Shield the incoming webhook callback from cancellation."""
-        hass.async_create_task(
-            self.handle_webhook_shielded(hass, webhook_id, request)
-        )
+        hass.async_create_task(self.handle_webhook_shielded(hass, webhook_id, request))
 
     async def handle_webhook_shielded(
         self, hass: HomeAssistant, webhook_id: str, request: Request

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -329,7 +329,7 @@ class ReolinkHost:
         self, hass: HomeAssistant, webhook_id: str, request: Request
     ):
         """Shield the incoming webhook callback from cancellation."""
-        hass.async_create_task(self.handle_webhook_shielded(hass, webhook_id, request))
+        await asyncio.shield(self.handle_webhook_shielded(hass, webhook_id, request))
 
     async def handle_webhook_shielded(
         self, hass: HomeAssistant, webhook_id: str, request: Request

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -329,7 +329,7 @@ class ReolinkHost:
         self, hass: HomeAssistant, webhook_id: str, request: Request
     ):
         """Shield the incoming webhook callback from cancellation."""
-        await asyncio.shield(self.handle_webhook_shielded(hass, webhook_id, request))
+        self._hass.async_create_task(self.handle_webhook_shielded(hass, webhook_id, request))
 
     async def handle_webhook_shielded(
         self, hass: HomeAssistant, webhook_id: str, request: Request


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Some camera's like the RLC-520A do not (yet) support rich ONVIF notifications that include both motion and AI detection states.
These camera's only send motion pushes.
Therefore when a motion push is received, the AI detection state will be polled inside the async webhook callback which takes between 0.5 and 1.5 seconds on average. This works since a vehicle/pet/person most of the time will also cause a motion event besides the AI detection event.
This is not ideal, but the best we can do on our site (Reolink schould update the firmware to support rich ONVIF notifications).

However since the poll takes 0.5 to 1.5 seconds, the asyncio webhook callback task would get cancelled while waiting on the response, in the upstream library on line:
https://github.com/starkillerOG/reolink_aio/blob/2362257923badb708543643a2f1e3c7bcb07cdb5/reolink_aio/api.py#L3149
`response = await self._aiohttp_session.post(url=self._url, json=body, params=param, allow_redirects=False)`

This PR shields the callback task, such that it does not get cancelled and the response and further processing of the callback can finish.

Note: it is automatically detected if a camera supports rich ONVIF notifications, if it does, no polling is used inside the webhook callback.

(It took me forever to figure out what was going on, this was a hard bug to solve).

Could this be added to the next milestone?

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #https://github.com/home-assistant/core/issues/89773
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
