### PR TITLE
Fix EntityComponent lingering timer in helper tests

### DIFF
--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -952,6 +952,8 @@ async def test_friendly_name(
     state = hass.states.async_all()[0]
     assert state.attributes.get(ATTR_FRIENDLY_NAME) == expected_friendly_name
 
+    await entity_platform.async_shutdown()
+
 
 async def test_translation_key(hass: HomeAssistant) -> None:
     """Test translation key property."""

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -952,8 +952,6 @@ async def test_friendly_name(
     state = hass.states.async_all()[0]
     assert state.attributes.get(ATTR_FRIENDLY_NAME) == expected_friendly_name
 
-    await entity_platform.async_shutdown()
-
 
 async def test_translation_key(hass: HomeAssistant) -> None:
     """Test translation key property."""

--- a/tests/helpers/test_entity_component.py
+++ b/tests/helpers/test_entity_component.py
@@ -168,6 +168,7 @@ async def test_set_entity_namespace_via_config(hass: HomeAssistant) -> None:
 async def test_extract_from_service_available_device(hass: HomeAssistant) -> None:
     """Test the extraction of entity from service and device is available."""
     component = EntityComponent(_LOGGER, DOMAIN, hass)
+    await component.async_setup({})
     await component.async_add_entities(
         [
             MockEntity(name="test_1"),
@@ -236,6 +237,7 @@ async def test_platform_not_ready(hass: HomeAssistant) -> None:
 async def test_extract_from_service_fails_if_no_entity_id(hass: HomeAssistant) -> None:
     """Test the extraction of everything from service."""
     component = EntityComponent(_LOGGER, DOMAIN, hass)
+    await component.async_setup({})
     await component.async_add_entities(
         [MockEntity(name="test_1"), MockEntity(name="test_2")]
     )
@@ -262,6 +264,7 @@ async def test_extract_from_service_filter_out_non_existing_entities(
 ) -> None:
     """Test the extraction of non existing entities from service."""
     component = EntityComponent(_LOGGER, DOMAIN, hass)
+    await component.async_setup({})
     await component.async_add_entities(
         [MockEntity(name="test_1"), MockEntity(name="test_2")]
     )
@@ -280,6 +283,7 @@ async def test_extract_from_service_filter_out_non_existing_entities(
 async def test_extract_from_service_no_group_expand(hass: HomeAssistant) -> None:
     """Test not expanding a group."""
     component = EntityComponent(_LOGGER, DOMAIN, hass)
+    await component.async_setup({})
     await component.async_add_entities([MockEntity(entity_id="group.test_group")])
 
     call = ServiceCall("test", "service", {"entity_id": ["group.test_group"]})
@@ -395,6 +399,7 @@ async def test_unload_entry_fails_if_never_loaded(hass: HomeAssistant) -> None:
 async def test_update_entity(hass: HomeAssistant) -> None:
     """Test that we can update an entity with the helper."""
     component = EntityComponent(_LOGGER, DOMAIN, hass)
+    await component.async_setup({})
     entity = MockEntity()
     entity.async_write_ha_state = Mock()
     entity.async_update_ha_state = AsyncMock(return_value=None)
@@ -422,6 +427,7 @@ async def test_set_service_race(hass: HomeAssistant) -> None:
 
     await async_setup_component(hass, "group", {})
     component = EntityComponent(_LOGGER, DOMAIN, hass)
+    await component.async_setup({})
 
     for _ in range(2):
         hass.async_create_task(component.async_add_entities([MockEntity()]))
@@ -435,6 +441,7 @@ async def test_extract_all_omit_entity_id(
 ) -> None:
     """Test extract all with None and *."""
     component = EntityComponent(_LOGGER, DOMAIN, hass)
+    await component.async_setup({})
     await component.async_add_entities(
         [MockEntity(name="test_1"), MockEntity(name="test_2")]
     )
@@ -451,6 +458,7 @@ async def test_extract_all_use_match_all(
 ) -> None:
     """Test extract all with None and *."""
     component = EntityComponent(_LOGGER, DOMAIN, hass)
+    await component.async_setup({})
     await component.async_add_entities(
         [MockEntity(name="test_1"), MockEntity(name="test_2")]
     )
@@ -477,6 +485,7 @@ async def test_register_entity_service(hass: HomeAssistant) -> None:
     entity.async_called_by_service = appender
 
     component = EntityComponent(_LOGGER, DOMAIN, hass)
+    await component.async_setup({})
     await component.async_add_entities([entity])
 
     component.async_register_entity_service(

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -541,6 +541,7 @@ async def test_using_prescribed_entity_id_which_is_registered(
     """Test not allowing predefined entity ID that already registered."""
     component = EntityComponent(_LOGGER, DOMAIN, hass)
     await component.async_setup({})
+
     # Register test_domain.world
     entity_registry.async_get_or_create(
         DOMAIN, "test", "1234", suggested_object_id="world"

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -46,6 +46,7 @@ async def test_polling_only_updates_entities_it_should_poll(
 ) -> None:
     """Test the polling of only updated entities."""
     component = EntityComponent(_LOGGER, DOMAIN, hass, timedelta(seconds=20))
+    await component.async_setup({})
 
     no_poll_ent = MockEntity(should_poll=False)
     no_poll_ent.async_update = Mock()
@@ -78,6 +79,7 @@ async def test_polling_disabled_by_config_entry(hass: HomeAssistant) -> None:
 async def test_polling_updates_entities_with_exception(hass: HomeAssistant) -> None:
     """Test the updated entities that not break with an exception."""
     component = EntityComponent(_LOGGER, DOMAIN, hass, timedelta(seconds=20))
+    await component.async_setup({})
 
     update_ok = []
     update_err = []
@@ -115,6 +117,7 @@ async def test_polling_updates_entities_with_exception(hass: HomeAssistant) -> N
 async def test_update_state_adds_entities(hass: HomeAssistant) -> None:
     """Test if updating poll entities cause an entity to be added works."""
     component = EntityComponent(_LOGGER, DOMAIN, hass)
+    await component.async_setup({})
 
     ent1 = MockEntity()
     ent2 = MockEntity(should_poll=True)
@@ -134,6 +137,7 @@ async def test_update_state_adds_entities_with_update_before_add_true(
 ) -> None:
     """Test if call update before add to state machine."""
     component = EntityComponent(_LOGGER, DOMAIN, hass)
+    await component.async_setup({})
 
     ent = MockEntity()
     ent.update = Mock(spec_set=True)
@@ -150,6 +154,7 @@ async def test_update_state_adds_entities_with_update_before_add_false(
 ) -> None:
     """Test if not call update before add to state machine."""
     component = EntityComponent(_LOGGER, DOMAIN, hass)
+    await component.async_setup({})
 
     ent = MockEntity()
     ent.update = Mock(spec_set=True)
@@ -199,6 +204,7 @@ async def test_adding_entities_with_generator_and_thread_callback(
     it into an async context.
     """
     component = EntityComponent(_LOGGER, DOMAIN, hass)
+    await component.async_setup({})
 
     def create_entity(number: int) -> MockEntity:
         """Create entity helper."""
@@ -259,6 +265,7 @@ async def test_platform_error_slow_setup(
 async def test_updated_state_used_for_entity_id(hass: HomeAssistant) -> None:
     """Test that first update results used for entity ID generation."""
     component = EntityComponent(_LOGGER, DOMAIN, hass)
+    await component.async_setup({})
 
     class MockEntityNameFetcher(MockEntity):
         """Mock entity that fetches a friendly name."""
@@ -407,6 +414,7 @@ async def test_raise_error_on_update(hass: HomeAssistant) -> None:
     """Test the add entity if they raise an error on update."""
     updates = []
     component = EntityComponent(_LOGGER, DOMAIN, hass)
+    await component.async_setup({})
     entity1 = MockEntity(name="test_1")
     entity2 = MockEntity(name="test_2")
 
@@ -431,6 +439,7 @@ async def test_raise_error_on_update(hass: HomeAssistant) -> None:
 async def test_async_remove_with_platform(hass: HomeAssistant) -> None:
     """Remove an entity from a platform."""
     component = EntityComponent(_LOGGER, DOMAIN, hass)
+    await component.async_setup({})
     entity1 = MockEntity(name="test_1")
     await component.async_add_entities([entity1])
     assert len(hass.states.async_entity_ids()) == 1
@@ -441,6 +450,7 @@ async def test_async_remove_with_platform(hass: HomeAssistant) -> None:
 async def test_async_remove_with_platform_update_finishes(hass: HomeAssistant) -> None:
     """Remove an entity when an update finishes after its been removed."""
     component = EntityComponent(_LOGGER, DOMAIN, hass)
+    await component.async_setup({})
     entity1 = MockEntity(name="test_1")
 
     async def _delayed_update(*args, **kwargs):
@@ -471,6 +481,7 @@ async def test_not_adding_duplicate_entities_with_unique_id(
     """
     caplog.set_level(logging.ERROR)
     component = EntityComponent(_LOGGER, DOMAIN, hass)
+    await component.async_setup({})
 
     ent1 = MockEntity(name="test1", unique_id="not_very_unique")
     await component.async_add_entities([ent1])
@@ -504,6 +515,7 @@ async def test_not_adding_duplicate_entities_with_unique_id(
 async def test_using_prescribed_entity_id(hass: HomeAssistant) -> None:
     """Test for using predefined entity ID."""
     component = EntityComponent(_LOGGER, DOMAIN, hass)
+    await component.async_setup({})
     await component.async_add_entities(
         [MockEntity(name="bla", entity_id="hello.world")]
     )
@@ -513,6 +525,7 @@ async def test_using_prescribed_entity_id(hass: HomeAssistant) -> None:
 async def test_using_prescribed_entity_id_with_unique_id(hass: HomeAssistant) -> None:
     """Test for amending predefined entity ID because currently exists."""
     component = EntityComponent(_LOGGER, DOMAIN, hass)
+    await component.async_setup({})
 
     await component.async_add_entities([MockEntity(entity_id="test_domain.world")])
     await component.async_add_entities(
@@ -527,6 +540,7 @@ async def test_using_prescribed_entity_id_which_is_registered(
 ) -> None:
     """Test not allowing predefined entity ID that already registered."""
     component = EntityComponent(_LOGGER, DOMAIN, hass)
+    await component.async_setup({})
     # Register test_domain.world
     entity_registry.async_get_or_create(
         DOMAIN, "test", "1234", suggested_object_id="world"
@@ -543,7 +557,7 @@ async def test_name_which_conflict_with_registered(
 ) -> None:
     """Test not generating conflicting entity ID based on name."""
     component = EntityComponent(_LOGGER, DOMAIN, hass)
-
+    await component.async_setup({})
     # Register test_domain.world
     entity_registry.async_get_or_create(
         DOMAIN, "test", "1234", suggested_object_id="world"
@@ -559,6 +573,7 @@ async def test_entity_with_name_and_entity_id_getting_registered(
 ) -> None:
     """Ensure that entity ID is used for registration."""
     component = EntityComponent(_LOGGER, DOMAIN, hass)
+    await component.async_setup({})
     await component.async_add_entities(
         [MockEntity(unique_id="1234", name="bla", entity_id="test_domain.world")]
     )
@@ -568,6 +583,7 @@ async def test_entity_with_name_and_entity_id_getting_registered(
 async def test_overriding_name_from_registry(hass: HomeAssistant) -> None:
     """Test that we can override a name via the Entity Registry."""
     component = EntityComponent(_LOGGER, DOMAIN, hass)
+    await component.async_setup({})
     mock_registry(
         hass,
         {
@@ -598,6 +614,8 @@ async def test_registry_respect_entity_namespace(
     await platform.async_add_entities([entity])
     assert entity.entity_id == "test_domain.ns_device_name"
 
+    await platform.async_shutdown()
+
 
 async def test_registry_respect_entity_disabled(hass: HomeAssistant) -> None:
     """Test that the registry respects entity disabled."""
@@ -625,6 +643,7 @@ async def test_unique_id_conflict_has_priority_over_disabled_entity(
 ) -> None:
     """Test that an entity that is not unique has priority over a disabled entity."""
     component = EntityComponent(_LOGGER, DOMAIN, hass)
+    await component.async_setup({})
     entity1 = MockEntity(
         name="test1", unique_id="not_very_unique", enabled_by_default=False
     )
@@ -673,6 +692,8 @@ async def test_entity_registry_updates_name(hass: HomeAssistant) -> None:
     state = hass.states.get("test_domain.world")
     assert state.name == "after update"
 
+    await platform.async_shutdown()
+
 
 async def test_setup_entry(
     hass: HomeAssistant, entity_registry: er.EntityRegistry
@@ -699,6 +720,8 @@ async def test_setup_entry(
     assert (
         entity_registry.entities["test_domain.test1"].config_entry_id == "super-mock-id"
     )
+
+    await entity_platform.async_shutdown()
 
 
 async def test_setup_entry_platform_not_ready(
@@ -884,6 +907,8 @@ async def test_entity_registry_updates_entity_id(hass: HomeAssistant) -> None:
     assert hass.states.get("test_domain.world") is None
     assert hass.states.get("test_domain.planet") is not None
 
+    await platform.async_shutdown()
+
 
 async def test_entity_registry_updates_invalid_entity_id(hass: HomeAssistant) -> None:
     """Test that we can't update to an invalid entity id."""
@@ -933,6 +958,8 @@ async def test_entity_registry_updates_invalid_entity_id(hass: HomeAssistant) ->
     assert hass.states.get("test_domain.world") is not None
     assert hass.states.get("invalid_entity_id") is None
     assert hass.states.get("diff_domain.world") is None
+
+    await platform.async_shutdown()
 
 
 async def test_device_info_called(hass: HomeAssistant) -> None:
@@ -998,6 +1025,8 @@ async def test_device_info_called(hass: HomeAssistant) -> None:
     assert device.hw_version == "test-hw"
     assert device.via_device_id == via.id
 
+    await entity_platform.async_shutdown()
+
 
 async def test_device_info_not_overrides(hass: HomeAssistant) -> None:
     """Test device info is forwarded correctly."""
@@ -1043,6 +1072,8 @@ async def test_device_info_not_overrides(hass: HomeAssistant) -> None:
     assert device.id == device2.id
     assert device2.manufacturer == "test-manufacturer"
     assert device2.model == "test-model"
+
+    await entity_platform.async_shutdown()
 
 
 async def test_device_info_invalid_url(
@@ -1095,6 +1126,8 @@ async def test_device_info_invalid_url(
         in caplog.text
     )
 
+    await entity_platform.async_shutdown()
+
 
 async def test_device_info_homeassistant_url(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
@@ -1140,6 +1173,8 @@ async def test_device_info_homeassistant_url(
     assert device is not None
     assert device.identifiers == {("mqtt", "1234")}
     assert device.configuration_url == "homeassistant://config/mqtt"
+
+    await entity_platform.async_shutdown()
 
 
 async def test_device_info_change_to_no_url(
@@ -1188,10 +1223,13 @@ async def test_device_info_change_to_no_url(
     assert device.identifiers == {("mqtt", "1234")}
     assert device.configuration_url is None
 
+    await entity_platform.async_shutdown()
+
 
 async def test_entity_disabled_by_integration(hass: HomeAssistant) -> None:
     """Test entity disabled by integration."""
     component = EntityComponent(_LOGGER, DOMAIN, hass, timedelta(seconds=20))
+    await component.async_setup({})
 
     entity_default = MockEntity(unique_id="default")
     entity_disabled = MockEntity(
@@ -1254,6 +1292,7 @@ async def test_entity_disabled_by_device(hass: HomeAssistant) -> None:
 async def test_entity_hidden_by_integration(hass: HomeAssistant) -> None:
     """Test entity hidden by integration."""
     component = EntityComponent(_LOGGER, DOMAIN, hass, timedelta(seconds=20))
+    await component.async_setup({})
 
     entity_default = MockEntity(unique_id="default")
     entity_hidden = MockEntity(
@@ -1273,6 +1312,7 @@ async def test_entity_hidden_by_integration(hass: HomeAssistant) -> None:
 async def test_entity_info_added_to_entity_registry(hass: HomeAssistant) -> None:
     """Test entity info is written to entity registry."""
     component = EntityComponent(_LOGGER, DOMAIN, hass, timedelta(seconds=20))
+    await component.async_setup({})
 
     entity_default = MockEntity(
         capability_attributes={"max": 100},
@@ -1323,6 +1363,7 @@ async def test_override_restored_entities(
     hass.states.async_set("test_domain.world", "unavailable", {"restored": True})
 
     component = EntityComponent(_LOGGER, DOMAIN, hass)
+    await component.async_setup({})
 
     await component.async_add_entities(
         [MockEntity(unique_id="1234", state="on", entity_id="test_domain.world")], True
@@ -1390,6 +1431,10 @@ async def test_platforms_sharing_services(hass: HomeAssistant) -> None:
     assert entity1 in entities
     assert entity2 in entities
 
+    await entity_platform1.async_shutdown()
+    await entity_platform2.async_shutdown()
+    await entity_platform3.async_shutdown()
+
 
 async def test_invalid_entity_id(hass: HomeAssistant) -> None:
     """Test specifying an invalid entity id."""
@@ -1441,6 +1486,8 @@ async def test_setup_entry_with_entities_that_block_forever(
     assert "test_domain" in caplog.text
     assert "test" in caplog.text
 
+    await mock_entity_platform.async_shutdown()
+
 
 async def test_two_platforms_add_same_entity(hass: HomeAssistant) -> None:
     """Test two platforms in the same domain adding an entity with the same name."""
@@ -1477,6 +1524,9 @@ async def test_two_platforms_add_same_entity(hass: HomeAssistant) -> None:
     }
     assert entity1 in entities
     assert entity2 in entities
+
+    await entity_platform1.async_shutdown()
+    await entity_platform2.async_shutdown()
 
 
 class SlowEntity(MockEntity):
@@ -1535,3 +1585,5 @@ async def test_entity_name_influences_entity_id(
 
     assert len(hass.states.async_entity_ids()) == 1
     assert registry.async_get(expected_entity_id) is not None
+
+    await entity_platform.async_shutdown()

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -541,7 +541,6 @@ async def test_using_prescribed_entity_id_which_is_registered(
     """Test not allowing predefined entity ID that already registered."""
     component = EntityComponent(_LOGGER, DOMAIN, hass)
     await component.async_setup({})
-
     # Register test_domain.world
     entity_registry.async_get_or_create(
         DOMAIN, "test", "1234", suggested_object_id="world"

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -615,8 +615,6 @@ async def test_registry_respect_entity_namespace(
     await platform.async_add_entities([entity])
     assert entity.entity_id == "test_domain.ns_device_name"
 
-    await platform.async_shutdown()
-
 
 async def test_registry_respect_entity_disabled(hass: HomeAssistant) -> None:
     """Test that the registry respects entity disabled."""
@@ -693,8 +691,6 @@ async def test_entity_registry_updates_name(hass: HomeAssistant) -> None:
     state = hass.states.get("test_domain.world")
     assert state.name == "after update"
 
-    await platform.async_shutdown()
-
 
 async def test_setup_entry(
     hass: HomeAssistant, entity_registry: er.EntityRegistry
@@ -721,8 +717,6 @@ async def test_setup_entry(
     assert (
         entity_registry.entities["test_domain.test1"].config_entry_id == "super-mock-id"
     )
-
-    await entity_platform.async_shutdown()
 
 
 async def test_setup_entry_platform_not_ready(
@@ -908,8 +902,6 @@ async def test_entity_registry_updates_entity_id(hass: HomeAssistant) -> None:
     assert hass.states.get("test_domain.world") is None
     assert hass.states.get("test_domain.planet") is not None
 
-    await platform.async_shutdown()
-
 
 async def test_entity_registry_updates_invalid_entity_id(hass: HomeAssistant) -> None:
     """Test that we can't update to an invalid entity id."""
@@ -959,8 +951,6 @@ async def test_entity_registry_updates_invalid_entity_id(hass: HomeAssistant) ->
     assert hass.states.get("test_domain.world") is not None
     assert hass.states.get("invalid_entity_id") is None
     assert hass.states.get("diff_domain.world") is None
-
-    await platform.async_shutdown()
 
 
 async def test_device_info_called(hass: HomeAssistant) -> None:
@@ -1026,8 +1016,6 @@ async def test_device_info_called(hass: HomeAssistant) -> None:
     assert device.hw_version == "test-hw"
     assert device.via_device_id == via.id
 
-    await entity_platform.async_shutdown()
-
 
 async def test_device_info_not_overrides(hass: HomeAssistant) -> None:
     """Test device info is forwarded correctly."""
@@ -1073,8 +1061,6 @@ async def test_device_info_not_overrides(hass: HomeAssistant) -> None:
     assert device.id == device2.id
     assert device2.manufacturer == "test-manufacturer"
     assert device2.model == "test-model"
-
-    await entity_platform.async_shutdown()
 
 
 async def test_device_info_invalid_url(
@@ -1127,8 +1113,6 @@ async def test_device_info_invalid_url(
         in caplog.text
     )
 
-    await entity_platform.async_shutdown()
-
 
 async def test_device_info_homeassistant_url(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
@@ -1174,8 +1158,6 @@ async def test_device_info_homeassistant_url(
     assert device is not None
     assert device.identifiers == {("mqtt", "1234")}
     assert device.configuration_url == "homeassistant://config/mqtt"
-
-    await entity_platform.async_shutdown()
 
 
 async def test_device_info_change_to_no_url(
@@ -1223,8 +1205,6 @@ async def test_device_info_change_to_no_url(
     assert device is not None
     assert device.identifiers == {("mqtt", "1234")}
     assert device.configuration_url is None
-
-    await entity_platform.async_shutdown()
 
 
 async def test_entity_disabled_by_integration(hass: HomeAssistant) -> None:
@@ -1432,10 +1412,6 @@ async def test_platforms_sharing_services(hass: HomeAssistant) -> None:
     assert entity1 in entities
     assert entity2 in entities
 
-    await entity_platform1.async_shutdown()
-    await entity_platform2.async_shutdown()
-    await entity_platform3.async_shutdown()
-
 
 async def test_invalid_entity_id(hass: HomeAssistant) -> None:
     """Test specifying an invalid entity id."""
@@ -1487,8 +1463,6 @@ async def test_setup_entry_with_entities_that_block_forever(
     assert "test_domain" in caplog.text
     assert "test" in caplog.text
 
-    await mock_entity_platform.async_shutdown()
-
 
 async def test_two_platforms_add_same_entity(hass: HomeAssistant) -> None:
     """Test two platforms in the same domain adding an entity with the same name."""
@@ -1525,9 +1499,6 @@ async def test_two_platforms_add_same_entity(hass: HomeAssistant) -> None:
     }
     assert entity1 in entities
     assert entity2 in entities
-
-    await entity_platform1.async_shutdown()
-    await entity_platform2.async_shutdown()
 
 
 class SlowEntity(MockEntity):
@@ -1586,5 +1557,3 @@ async def test_entity_name_influences_entity_id(
 
     assert len(hass.states.async_entity_ids()) == 1
     assert registry.async_get(expected_entity_id) is not None
-
-    await entity_platform.async_shutdown()

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -559,6 +559,7 @@ async def test_name_which_conflict_with_registered(
     """Test not generating conflicting entity ID based on name."""
     component = EntityComponent(_LOGGER, DOMAIN, hass)
     await component.async_setup({})
+
     # Register test_domain.world
     entity_registry.async_get_or_create(
         DOMAIN, "test", "1234", suggested_object_id="world"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Linked to #89292

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
