### PR TITLE
Only publish mqtt_statestream when MQTT is started

### DIFF
--- a/homeassistant/components/mqtt_statestream/__init__.py
+++ b/homeassistant/components/mqtt_statestream/__init__.py
@@ -1,31 +1,19 @@
 """Publish simple item state changes via MQTT."""
-import asyncio
 import json
 
 import voluptuous as vol
 
 from homeassistant.components import mqtt
 from homeassistant.components.mqtt import valid_publish_topic
-from homeassistant.const import (
-    EVENT_HOMEASSISTANT_STARTED,
-    EVENT_HOMEASSISTANT_STOP,
-    MATCH_ALL,
-)
-from homeassistant.core import (
-    CALLBACK_TYPE,
-    CoreState,
-    Event,
-    HomeAssistant,
-    State,
-    callback,
-)
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP, EVENT_STATE_CHANGED
+from homeassistant.core import Event, HomeAssistant, State, callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entityfilter import (
     INCLUDE_EXCLUDE_BASE_FILTER_SCHEMA,
     convert_include_exclude_filter,
 )
-from homeassistant.helpers.event import async_track_state_change
 from homeassistant.helpers.json import JSONEncoder
+from homeassistant.helpers.start import async_at_start
 from homeassistant.helpers.typing import ConfigType
 
 CONF_BASE_TOPIC = "base_topic"
@@ -50,28 +38,17 @@ CONFIG_SCHEMA = vol.Schema(
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the MQTT state feed."""
-    callback_handler: CALLBACK_TYPE
-
     conf: ConfigType = config[DOMAIN]
     publish_filter = convert_include_exclude_filter(conf)
     base_topic: str = conf[CONF_BASE_TOPIC]
     publish_attributes: bool = conf[CONF_PUBLISH_ATTRIBUTES]
     publish_timestamps: bool = conf[CONF_PUBLISH_TIMESTAMPS]
-    ha_started = asyncio.Event()
     if not base_topic.endswith("/"):
         base_topic = f"{base_topic}/"
 
-    async def _state_publisher(
-        entity_id: str, old_state: State | None, new_state: State | None
-    ) -> None:
-        if not ha_started.is_set():
-            return
-
-        if new_state is None:
-            return
-
-        if not publish_filter(entity_id):
-            return
+    async def _state_publisher(evt: Event) -> None:
+        entity_id: str = evt.data["entity_id"]
+        new_state: State = evt.data["new_state"]
 
         payload = new_state.state
 
@@ -101,21 +78,28 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 encoded_val = json.dumps(val, cls=JSONEncoder)
                 await mqtt.async_publish(hass, mybase + key, encoded_val, 1, True)
 
-    if hass.state == CoreState.running:
-        ha_started.set()
-    else:
+    @callback
+    def _ha_started(hass: HomeAssistant) -> None:
+        @callback
+        def _event_filter(evt: Event) -> bool:
+            entity_id: str = evt.data["entity_id"]
+            new_state: State | None = evt.data["new_state"]
+            if new_state is None:
+                return False
+            if not publish_filter(entity_id):
+                return False
+            return True
+
+        callback_handler = hass.bus.async_listen(
+            EVENT_STATE_CHANGED, _state_publisher, _event_filter
+        )
 
         @callback
-        def _ha_started(_: Event) -> None:
-            ha_started.set()
+        def _ha_stopping(_: Event) -> None:
+            callback_handler()
 
-        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, _ha_started)
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _ha_stopping)
 
-    @callback
-    def _ha_stopping(_: Event) -> None:
-        callback_handler()
+    async_at_start(hass, _ha_started)
 
-    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _ha_stopping)
-
-    callback_handler = async_track_state_change(hass, MATCH_ALL, _state_publisher)
     return True

--- a/homeassistant/components/mqtt_statestream/__init__.py
+++ b/homeassistant/components/mqtt_statestream/__init__.py
@@ -1,5 +1,6 @@
 """Publish simple item state changes via MQTT."""
 import json
+import logging
 
 import voluptuous as vol
 
@@ -35,9 +36,20 @@ CONFIG_SCHEMA = vol.Schema(
     extra=vol.ALLOW_EXTRA,
 )
 
+_LOGGER = logging.getLogger(__name__)
+
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the MQTT state feed."""
+    # Make sure MQTT is available and the entry is loaded
+    if not hass.config_entries.async_entries(
+        mqtt.DOMAIN
+    ) or not await hass.config_entries.async_wait_component(
+        hass.config_entries.async_entries(mqtt.DOMAIN)[0]
+    ):
+        _LOGGER.error("MQTT integration is not available")
+        return False
+
     conf: ConfigType = config[DOMAIN]
     publish_filter = convert_include_exclude_filter(conf)
     base_topic: str = conf[CONF_BASE_TOPIC]

--- a/tests/components/mqtt_statestream/test_init.py
+++ b/tests/components/mqtt_statestream/test_init.py
@@ -144,11 +144,12 @@ async def test_state_changed_event_sends_message(
     mqtt_mock.async_publish.assert_called_with(
         "pub/test_domain/test_platform_1234/state", "unknown", 1, True
     )
+    mqtt_mock.async_publish.reset_mock()
 
     state = hass.states.get("test_domain.test_platform_1234")
     assert state is not None
 
-    # Now remove it, nowthing should be published
+    # Now remove it, nothing should be published
     hass.states.async_remove("test_domain.test_platform_1234")
     await hass.async_block_till_done()
     await hass.async_block_till_done()

--- a/tests/components/mqtt_statestream/test_init.py
+++ b/tests/components/mqtt_statestream/test_init.py
@@ -2,7 +2,7 @@
 from unittest.mock import ANY, call
 
 import homeassistant.components.mqtt_statestream as statestream
-from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, EVENT_HOMEASSISTANT_STOP
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import CoreState, HomeAssistant, State
 from homeassistant.setup import async_setup_component
 
@@ -55,8 +55,8 @@ async def test_setup_and_stop_waits_for_ha(
     """Test the success of the setup with a valid base_topic."""
     e_id = "fake.entity"
 
-    # HA still starting up
-    hass.state = CoreState.starting
+    # HA is not running
+    hass.state = CoreState.not_running
 
     assert await add_statestream(hass, base_topic="pub")
     await hass.async_block_till_done()
@@ -68,9 +68,8 @@ async def test_setup_and_stop_waits_for_ha(
     # Make sure 'on' was not published to pub/fake/entity/state
     mqtt_mock.async_publish.assert_not_called()
 
-    # HA finished start up
-    hass.state = CoreState.running
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+    # HA is starting up
+    await hass.async_start()
     await hass.async_block_till_done()
 
     # Change a state of an entity

--- a/tests/components/mqtt_statestream/test_init.py
+++ b/tests/components/mqtt_statestream/test_init.py
@@ -136,8 +136,8 @@ async def test_state_changed_event_sends_message(
     assert mqtt_mock.async_publish.called
     mqtt_mock.async_publish.reset_mock()
 
-    # Set a state of an entity
-    mock_state_change_event(hass, None)
+    # Renmoving the state does not publish a new state
+    hass.states.async_remove(e_id)
     await hass.async_block_till_done()
     await hass.async_block_till_done()
     mqtt_mock.async_publish.assert_not_called()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Avoid tracking state changes before MQTT is started
- Stop tracking state changes when HA is shutting down.

This PR changes:
- the moment `mqtt_statestream` starts tracking to the moment where ha is starting up and MQTT is available.
- the moment `mqtt_statestream` stops tracking to the moment where ha is shutting down.

This avoids massive state updates during startup or errors when MQTT is not available any more and mqtt_statestream is stll listening.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #89718
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
