### PR TITLE
Fix Todoist end date for all day event

### DIFF
--- a/homeassistant/components/todoist/calendar.py
+++ b/homeassistant/components/todoist/calendar.py
@@ -612,7 +612,7 @@ class TodoistProjectData:
                 event = CalendarEvent(
                     summary=task.content,
                     start=due_date_value,
-                    end=due_date_value,
+                    end=due_date_value + timedelta(days=1),
                 )
                 events.append(event)
         return events

--- a/tests/components/todoist/test_calendar.py
+++ b/tests/components/todoist/test_calendar.py
@@ -182,8 +182,8 @@ async def test_all_day_event(
 
     expected = [
         {
-            "start": {"date": "2023-03-17"},
-            "end": {"date": "2023-03-18"},
+            "start": {"date": dt.now().strftime("%Y-%m-%d")},
+            "end": {"date": (dt.now() + timedelta(days=1)).strftime("%Y-%m-%d")},
             "summary": "A task",
             "description": None,
             "location": None,

--- a/tests/components/todoist/test_calendar.py
+++ b/tests/components/todoist/test_calendar.py
@@ -1,6 +1,8 @@
 """Unit tests for the Todoist calendar platform."""
-from datetime import datetime
+from datetime import datetime, timedelta
+from http import HTTPStatus
 from unittest.mock import AsyncMock, patch
+import urllib
 
 import pytest
 from todoist_api_python.models import Due, Label, Project, Task
@@ -11,6 +13,9 @@ from homeassistant.const import CONF_TOKEN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_component import async_update_entity
+from homeassistant.util import dt
+
+from tests.typing import ClientSessionGenerator
 
 
 @pytest.fixture(name="task")
@@ -66,6 +71,11 @@ def mock_api(task) -> AsyncMock:
     api.get_collaborators.return_value = []
     api.get_tasks.return_value = [task]
     return api
+
+
+def get_events_url(entity: str, start: str, end: str) -> str:
+    """Create a url to get events during the specified time range."""
+    return f"/api/calendars/{entity}?start={urllib.parse.quote(start)}&end={urllib.parse.quote(end)}"
 
 
 @patch("homeassistant.components.todoist.calendar.TodoistAPIAsync")
@@ -139,3 +149,47 @@ async def test_calendar_custom_project_unique_id(
 
     state = hass.states.get("calendar.all_projects")
     assert state.state == "off"
+
+
+@patch("homeassistant.components.todoist.calendar.TodoistAPIAsync")
+async def test_all_day_event(
+    todoist_api, hass: HomeAssistant, hass_client: ClientSessionGenerator, api
+) -> None:
+    """Test for an all day calednar event."""
+    todoist_api.return_value = api
+    assert await setup.async_setup_component(
+        hass,
+        "calendar",
+        {
+            "calendar": {
+                "platform": DOMAIN,
+                CONF_TOKEN: "token",
+                "custom_projects": [{"name": "All projects", "labels": ["Label1"]}],
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    await async_update_entity(hass, "calendar.all_projects")
+    client = await hass_client()
+    start = dt.now() - timedelta(days=1)
+    end = dt.now() + timedelta(days=1)
+    response = await client.get(
+        get_events_url("calendar.all_projects", start.isoformat(), end.isoformat())
+    )
+    assert response.status == HTTPStatus.OK
+    events = await response.json()
+
+    expected = [
+        {
+            "start": {"date": "2023-03-17"},
+            "end": {"date": "2023-03-18"},
+            "summary": "A task",
+            "description": None,
+            "location": None,
+            "uid": None,
+            "recurrence_id": None,
+            "rrule": None,
+        }
+    ]
+    assert events == expected

--- a/tests/components/todoist/test_calendar.py
+++ b/tests/components/todoist/test_calendar.py
@@ -155,7 +155,7 @@ async def test_calendar_custom_project_unique_id(
 async def test_all_day_event(
     todoist_api, hass: HomeAssistant, hass_client: ClientSessionGenerator, api
 ) -> None:
-    """Test for an all day calednar event."""
+    """Test for an all day calendar event."""
     todoist_api.return_value = api
     assert await setup.async_setup_component(
         hass,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR addresses a problem with all day events in Todoist that I just noticed.  If a `CalendarEvent` has the same start and end date, it will cause a 500 error when loading calendar events on the front end.  This url: `http://localhost:8123/api/calendars/calendar.ha_test?start=2023-02-26T08:00:00.000Z&end=2023-04-09T07:00:00.000Z` causes this response:

```json
{"message":"Error reading events: Failed to validate CalendarEvent: Expected positive event duration (2023-03-16, 2023-03-16)"}
```

This update is due to [some recent validation changes](https://github.com/home-assistant/core/pull/89533).



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
