### PR TITLE
Refactor handling of exposed entities for cloud Alexa and Google

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -137,6 +137,7 @@ homeassistant.components.hardkernel.*
 homeassistant.components.hardware.*
 homeassistant.components.here_travel_time.*
 homeassistant.components.history.*
+homeassistant.components.homeassistant.exposed_entities
 homeassistant.components.homeassistant.triggers.event
 homeassistant.components.homeassistant_alerts.*
 homeassistant.components.homeassistant_hardware.*

--- a/homeassistant/components/cloud/alexa_config.py
+++ b/homeassistant/components/cloud/alexa_config.py
@@ -124,6 +124,7 @@ class CloudAlexaConfig(alexa_config.AbstractConfig):
     def _migrate_alexa_entity_settings_v1(self):
         """Migrate alexa entity settings to entity registry options."""
         if not self._config[CONF_FILTER].empty_filter:
+            # Don't migrate if there's a YAML config
             return
 
         entity_registry = er.async_get(self.hass)

--- a/homeassistant/components/cloud/alexa_config.py
+++ b/homeassistant/components/cloud/alexa_config.py
@@ -20,6 +20,11 @@ from homeassistant.components.alexa import (
     errors as alexa_errors,
     state_report as alexa_state_report,
 )
+from homeassistant.components.homeassistant.exposed_entities import (
+    async_get_exposed_entities,
+    async_listen_entity_updates,
+    async_should_expose,
+)
 from homeassistant.const import CLOUD_NEVER_EXPOSED_ENTITIES
 from homeassistant.core import HomeAssistant, callback, split_entity_id
 from homeassistant.helpers import entity_registry as er, start
@@ -30,15 +35,16 @@ from homeassistant.util.dt import utcnow
 from .const import (
     CONF_ENTITY_CONFIG,
     CONF_FILTER,
-    PREF_ALEXA_DEFAULT_EXPOSE,
-    PREF_ALEXA_ENTITY_CONFIGS,
+    DOMAIN as CLOUD_DOMAIN,
     PREF_ALEXA_REPORT_STATE,
     PREF_ENABLE_ALEXA,
     PREF_SHOULD_EXPOSE,
 )
-from .prefs import CloudPreferences
+from .prefs import ALEXA_SETTINGS_VERSION, CloudPreferences
 
 _LOGGER = logging.getLogger(__name__)
+
+CLOUD_ALEXA = f"{CLOUD_DOMAIN}.{ALEXA_DOMAIN}"
 
 # Time to wait when entity preferences have changed before syncing it to
 # the cloud.
@@ -64,7 +70,7 @@ class CloudAlexaConfig(alexa_config.AbstractConfig):
         self._cloud = cloud
         self._token = None
         self._token_valid = None
-        self._cur_entity_prefs = prefs.alexa_entity_configs
+        self._cur_entity_prefs = async_get_exposed_entities(hass, CLOUD_ALEXA)
         self._alexa_sync_unsub: Callable[[], None] | None = None
         self._endpoint = None
 
@@ -115,9 +121,29 @@ class CloudAlexaConfig(alexa_config.AbstractConfig):
         """Return an identifier for the user that represents this config."""
         return self._cloud_user
 
+    def _migrate_alexa_entity_settings_v1(self):
+        """Migrate alexa entity settings to entity registry options."""
+        if not self._config[CONF_FILTER].empty_filter:
+            return
+
+        entity_registry = er.async_get(self.hass)
+
+        for entity_id, entry in entity_registry.entities.items():
+            if CLOUD_ALEXA in entry.options:
+                continue
+            options = {"should_expose": self._should_expose_legacy(entity_id)}
+            entity_registry.async_update_entity_options(entity_id, CLOUD_ALEXA, options)
+
     async def async_initialize(self):
         """Initialize the Alexa config."""
         await super().async_initialize()
+
+        if self._prefs.alexa_settings_version != ALEXA_SETTINGS_VERSION:
+            if self._prefs.alexa_settings_version < 2:
+                self._migrate_alexa_entity_settings_v1()
+            await self._prefs.async_update(
+                alexa_settings_version=ALEXA_SETTINGS_VERSION
+            )
 
         async def hass_started(hass):
             if self.enabled and ALEXA_DOMAIN not in self.hass.config.components:
@@ -126,18 +152,18 @@ class CloudAlexaConfig(alexa_config.AbstractConfig):
         start.async_at_start(self.hass, hass_started)
 
         self._prefs.async_listen_updates(self._async_prefs_updated)
+        async_listen_entity_updates(
+            self.hass, CLOUD_ALEXA, self._async_exposed_entities_updated
+        )
         self.hass.bus.async_listen(
             er.EVENT_ENTITY_REGISTRY_UPDATED,
             self._handle_entity_registry_updated,
         )
 
-    def should_expose(self, entity_id):
+    def _should_expose_legacy(self, entity_id):
         """If an entity should be exposed."""
         if entity_id in CLOUD_NEVER_EXPOSED_ENTITIES:
             return False
-
-        if not self._config[CONF_FILTER].empty_filter:
-            return self._config[CONF_FILTER](entity_id)
 
         entity_configs = self._prefs.alexa_entity_configs
         entity_config = entity_configs.get(entity_id, {})
@@ -159,6 +185,15 @@ class CloudAlexaConfig(alexa_config.AbstractConfig):
             return not auxiliary_entity
 
         return not auxiliary_entity and split_entity_id(entity_id)[0] in default_expose
+
+    def should_expose(self, entity_id):
+        """If an entity should be exposed."""
+        if not self._config[CONF_FILTER].empty_filter:
+            if entity_id in CLOUD_NEVER_EXPOSED_ENTITIES:
+                return False
+            return self._config[CONF_FILTER](entity_id)
+
+        return async_should_expose(self.hass, CLOUD_ALEXA, entity_id)
 
     @callback
     def async_invalidate_access_token(self):
@@ -233,32 +268,30 @@ class CloudAlexaConfig(alexa_config.AbstractConfig):
         if not any(
             key in updated_prefs
             for key in (
-                PREF_ALEXA_DEFAULT_EXPOSE,
-                PREF_ALEXA_ENTITY_CONFIGS,
                 PREF_ALEXA_REPORT_STATE,
                 PREF_ENABLE_ALEXA,
             )
         ):
             return
 
-        # If we update just entity preferences, delay updating
-        # as we might update more
-        if updated_prefs == {PREF_ALEXA_ENTITY_CONFIGS}:
-            if self._alexa_sync_unsub:
-                self._alexa_sync_unsub()
-
-            self._alexa_sync_unsub = async_call_later(
-                self.hass, SYNC_DELAY, self._sync_prefs
-            )
-            return
-
         await self.async_sync_entities()
+
+    @callback
+    def _async_exposed_entities_updated(self) -> None:
+        """Handle updated preferences."""
+        # Delay updating as we might update more
+        if self._alexa_sync_unsub:
+            self._alexa_sync_unsub()
+
+        self._alexa_sync_unsub = async_call_later(
+            self.hass, SYNC_DELAY, self._sync_prefs
+        )
 
     async def _sync_prefs(self, _now):
         """Sync the updated preferences to Alexa."""
         self._alexa_sync_unsub = None
         old_prefs = self._cur_entity_prefs
-        new_prefs = self._prefs.alexa_entity_configs
+        new_prefs = async_get_exposed_entities(self.hass, CLOUD_ALEXA)
 
         seen = set()
         to_update = []

--- a/homeassistant/components/cloud/alexa_config.py
+++ b/homeassistant/components/cloud/alexa_config.py
@@ -21,7 +21,7 @@ from homeassistant.components.alexa import (
     state_report as alexa_state_report,
 )
 from homeassistant.components.homeassistant.exposed_entities import (
-    async_get_exposed_entities,
+    async_get_assistant_settings,
     async_listen_entity_updates,
     async_should_expose,
 )
@@ -70,7 +70,7 @@ class CloudAlexaConfig(alexa_config.AbstractConfig):
         self._cloud = cloud
         self._token = None
         self._token_valid = None
-        self._cur_entity_prefs = async_get_exposed_entities(hass, CLOUD_ALEXA)
+        self._cur_entity_prefs = async_get_assistant_settings(hass, CLOUD_ALEXA)
         self._alexa_sync_unsub: Callable[[], None] | None = None
         self._endpoint = None
 
@@ -292,7 +292,7 @@ class CloudAlexaConfig(alexa_config.AbstractConfig):
         """Sync the updated preferences to Alexa."""
         self._alexa_sync_unsub = None
         old_prefs = self._cur_entity_prefs
-        new_prefs = async_get_exposed_entities(self.hass, CLOUD_ALEXA)
+        new_prefs = async_get_assistant_settings(self.hass, CLOUD_ALEXA)
 
         seen = set()
         to_update = []

--- a/homeassistant/components/cloud/const.py
+++ b/homeassistant/components/cloud/const.py
@@ -20,6 +20,7 @@ PREF_REMOTE_DOMAIN = "remote_domain"
 PREF_ALEXA_DEFAULT_EXPOSE = "alexa_default_expose"
 PREF_GOOGLE_DEFAULT_EXPOSE = "google_default_expose"
 PREF_ALEXA_SETTINGS_VERSION = "alexa_settings_version"
+PREF_GOOGLE_SETTINGS_VERSION = "google_settings_version"
 PREF_TTS_DEFAULT_VOICE = "tts_default_voice"
 DEFAULT_TTS_DEFAULT_VOICE = ("en-US", "female")
 DEFAULT_DISABLE_2FA = False

--- a/homeassistant/components/cloud/const.py
+++ b/homeassistant/components/cloud/const.py
@@ -19,6 +19,7 @@ PREF_USERNAME = "username"
 PREF_REMOTE_DOMAIN = "remote_domain"
 PREF_ALEXA_DEFAULT_EXPOSE = "alexa_default_expose"
 PREF_GOOGLE_DEFAULT_EXPOSE = "google_default_expose"
+PREF_ALEXA_SETTINGS_VERSION = "alexa_settings_version"
 PREF_TTS_DEFAULT_VOICE = "tts_default_voice"
 DEFAULT_TTS_DEFAULT_VOICE = ("en-US", "female")
 DEFAULT_DISABLE_2FA = False

--- a/homeassistant/components/cloud/google_config.py
+++ b/homeassistant/components/cloud/google_config.py
@@ -9,6 +9,10 @@ from hass_nabucasa.google_report_state import ErrorResponse
 
 from homeassistant.components.google_assistant import DOMAIN as GOOGLE_DOMAIN
 from homeassistant.components.google_assistant.helpers import AbstractConfig
+from homeassistant.components.homeassistant.exposed_entities import (
+    async_listen_entity_updates,
+    async_should_expose,
+)
 from homeassistant.const import CLOUD_NEVER_EXPOSED_ENTITIES
 from homeassistant.core import (
     CoreState,
@@ -22,13 +26,17 @@ from homeassistant.setup import async_setup_component
 
 from .const import (
     CONF_ENTITY_CONFIG,
+    CONF_FILTER,
     DEFAULT_DISABLE_2FA,
+    DOMAIN as CLOUD_DOMAIN,
     PREF_DISABLE_2FA,
     PREF_SHOULD_EXPOSE,
 )
-from .prefs import CloudPreferences
+from .prefs import GOOGLE_SETTINGS_VERSION, CloudPreferences
 
 _LOGGER = logging.getLogger(__name__)
+
+CLOUD_GOOGLE = f"{CLOUD_DOMAIN}.{GOOGLE_DOMAIN}"
 
 
 class CloudGoogleConfig(AbstractConfig):
@@ -48,8 +56,6 @@ class CloudGoogleConfig(AbstractConfig):
         self._user = cloud_user
         self._prefs = prefs
         self._cloud = cloud
-        self._cur_entity_prefs = self._prefs.google_entity_configs
-        self._cur_default_expose = self._prefs.google_default_expose
         self._sync_entities_lock = asyncio.Lock()
 
     @property
@@ -89,9 +95,34 @@ class CloudGoogleConfig(AbstractConfig):
         """Return Cloud User account."""
         return self._user
 
+    def _migrate_google_entity_settings_v1(self):
+        """Migrate Google entity settings to entity registry options."""
+        if not self._config[CONF_FILTER].empty_filter:
+            # Don't migrate if there's a YAML config
+            return
+
+        entity_registry = er.async_get(self.hass)
+
+        for entity_id, entry in entity_registry.entities.items():
+            if CLOUD_GOOGLE in entry.options:
+                continue
+            options = {"should_expose": self._should_expose_legacy(entity_id)}
+            if _2fa_disabled := (self._2fa_disabled_legacy(entity_id) is not None):
+                options[PREF_DISABLE_2FA] = _2fa_disabled
+            entity_registry.async_update_entity_options(
+                entity_id, CLOUD_GOOGLE, options
+            )
+
     async def async_initialize(self):
         """Perform async initialization of config."""
         await super().async_initialize()
+
+        if self._prefs.google_settings_version != GOOGLE_SETTINGS_VERSION:
+            if self._prefs.google_settings_version < 2:
+                self._migrate_google_entity_settings_v1()
+            await self._prefs.async_update(
+                google_settings_version=GOOGLE_SETTINGS_VERSION
+            )
 
         async def hass_started(hass):
             if self.enabled and GOOGLE_DOMAIN not in self.hass.config.components:
@@ -109,7 +140,9 @@ class CloudGoogleConfig(AbstractConfig):
             await self.async_disconnect_agent_user(agent_user_id)
 
         self._prefs.async_listen_updates(self._async_prefs_updated)
-
+        async_listen_entity_updates(
+            self.hass, CLOUD_GOOGLE, self._async_exposed_entities_updated
+        )
         self.hass.bus.async_listen(
             er.EVENT_ENTITY_REGISTRY_UPDATED,
             self._handle_entity_registry_updated,
@@ -123,13 +156,10 @@ class CloudGoogleConfig(AbstractConfig):
         """If a state object should be exposed."""
         return self._should_expose_entity_id(state.entity_id)
 
-    def _should_expose_entity_id(self, entity_id):
+    def _should_expose_legacy(self, entity_id):
         """If an entity ID should be exposed."""
         if entity_id in CLOUD_NEVER_EXPOSED_ENTITIES:
             return False
-
-        if not self._config["filter"].empty_filter:
-            return self._config["filter"](entity_id)
 
         entity_configs = self._prefs.google_entity_configs
         entity_config = entity_configs.get(entity_id, {})
@@ -154,6 +184,15 @@ class CloudGoogleConfig(AbstractConfig):
 
         return not auxiliary_entity and split_entity_id(entity_id)[0] in default_expose
 
+    def _should_expose_entity_id(self, entity_id):
+        """If an entity should be exposed."""
+        if not self._config[CONF_FILTER].empty_filter:
+            if entity_id in CLOUD_NEVER_EXPOSED_ENTITIES:
+                return False
+            return self._config[CONF_FILTER](entity_id)
+
+        return async_should_expose(self.hass, CLOUD_GOOGLE, entity_id)
+
     @property
     def agent_user_id(self):
         """Return Agent User Id to use for query responses."""
@@ -168,11 +207,23 @@ class CloudGoogleConfig(AbstractConfig):
         """Get agent user ID making request."""
         return self.agent_user_id
 
-    def should_2fa(self, state):
+    def _2fa_disabled_legacy(self, entity_id):
         """If an entity should be checked for 2FA."""
         entity_configs = self._prefs.google_entity_configs
-        entity_config = entity_configs.get(state.entity_id, {})
-        return not entity_config.get(PREF_DISABLE_2FA, DEFAULT_DISABLE_2FA)
+        entity_config = entity_configs.get(entity_id, {})
+        return entity_config.get(PREF_DISABLE_2FA)
+
+    def should_2fa(self, state):
+        """If an entity should be checked for 2FA."""
+        entity_registry = er.async_get(self.hass)
+
+        registry_entry = entity_registry.async_get(state.entity_id)
+        if not registry_entry:
+            # Handle the entity has been removed
+            return
+
+        assistant_options = registry_entry.options.get(CLOUD_GOOGLE, {})
+        return not assistant_options.get(PREF_DISABLE_2FA, DEFAULT_DISABLE_2FA)
 
     async def async_report_state(self, message, agent_user_id: str):
         """Send a state report to Google."""
@@ -218,14 +269,6 @@ class CloudGoogleConfig(AbstractConfig):
             # So when we change it, we need to sync all entities.
             sync_entities = True
 
-        # If entity prefs are the same or we have filter in config.yaml,
-        # don't sync.
-        elif (
-            self._cur_entity_prefs is not prefs.google_entity_configs
-            or self._cur_default_expose is not prefs.google_default_expose
-        ) and self._config["filter"].empty_filter:
-            self.async_schedule_google_sync_all()
-
         if self.enabled and not self.is_local_sdk_active:
             self.async_enable_local_sdk()
             sync_entities = True
@@ -233,11 +276,13 @@ class CloudGoogleConfig(AbstractConfig):
             self.async_disable_local_sdk()
             sync_entities = True
 
-        self._cur_entity_prefs = prefs.google_entity_configs
-        self._cur_default_expose = prefs.google_default_expose
-
         if sync_entities and self.hass.is_running:
             await self.async_sync_entities_all()
+
+    @callback
+    def _async_exposed_entities_updated(self) -> None:
+        """Handle updated preferences."""
+        self.async_schedule_google_sync_all()
 
     @callback
     def _handle_entity_registry_updated(self, event: Event) -> None:

--- a/homeassistant/components/cloud/google_config.py
+++ b/homeassistant/components/cloud/google_config.py
@@ -220,7 +220,7 @@ class CloudGoogleConfig(AbstractConfig):
         registry_entry = entity_registry.async_get(state.entity_id)
         if not registry_entry:
             # Handle the entity has been removed
-            return
+            return False
 
         assistant_options = registry_entry.options.get(CLOUD_GOOGLE, {})
         return not assistant_options.get(PREF_DISABLE_2FA, DEFAULT_DISABLE_2FA)

--- a/homeassistant/components/cloud/http_api.py
+++ b/homeassistant/components/cloud/http_api.py
@@ -1,5 +1,6 @@
 """The HTTP api to control the cloud integration."""
 import asyncio
+from collections.abc import Mapping
 import dataclasses
 from functools import wraps
 from http import HTTPStatus
@@ -632,6 +633,7 @@ async def google_assistant_update(
         return
 
     disable_2fa = msg[PREF_DISABLE_2FA]
+    assistant_options: Mapping[str, Any]
     if (
         assistant_options := registry_entry.options.get(CLOUD_GOOGLE, {})
     ) and assistant_options.get(PREF_DISABLE_2FA) == disable_2fa:

--- a/homeassistant/components/cloud/manifest.json
+++ b/homeassistant/components/cloud/manifest.json
@@ -3,7 +3,7 @@
   "name": "Home Assistant Cloud",
   "after_dependencies": ["google_assistant", "alexa"],
   "codeowners": ["@home-assistant/cloud"],
-  "dependencies": ["http", "webhook"],
+  "dependencies": ["homeassistant", "http", "webhook"],
   "documentation": "https://www.home-assistant.io/integrations/cloud",
   "integration_type": "system",
   "iot_class": "cloud_push",

--- a/homeassistant/components/cloud/prefs.py
+++ b/homeassistant/components/cloud/prefs.py
@@ -1,6 +1,8 @@
 """Preference management for cloud."""
 from __future__ import annotations
 
+from typing import Any
+
 from homeassistant.auth.const import GROUP_ID_ADMIN
 from homeassistant.auth.models import User
 from homeassistant.components import webhook
@@ -18,6 +20,7 @@ from .const import (
     PREF_ALEXA_DEFAULT_EXPOSE,
     PREF_ALEXA_ENTITY_CONFIGS,
     PREF_ALEXA_REPORT_STATE,
+    PREF_ALEXA_SETTINGS_VERSION,
     PREF_CLOUD_USER,
     PREF_CLOUDHOOKS,
     PREF_DISABLE_2FA,
@@ -37,6 +40,23 @@ from .const import (
 
 STORAGE_KEY = DOMAIN
 STORAGE_VERSION = 1
+STORAGE_VERSION_MINOR = 2
+
+ALEXA_SETTINGS_VERSION = 2
+
+
+class CloudPreferencesStore(Store):
+    """Store entity registry data."""
+
+    async def _async_migrate_func(
+        self, old_major_version: int, old_minor_version: int, old_data: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Migrate to the new version."""
+        if old_major_version == 1:
+            if old_minor_version < 2:
+                old_data.setdefault(PREF_ALEXA_SETTINGS_VERSION, 1)
+
+        return old_data
 
 
 class CloudPreferences:
@@ -45,7 +65,9 @@ class CloudPreferences:
     def __init__(self, hass):
         """Initialize cloud prefs."""
         self._hass = hass
-        self._store = Store(hass, STORAGE_VERSION, STORAGE_KEY)
+        self._store = CloudPreferencesStore(
+            hass, STORAGE_VERSION, STORAGE_KEY, minor_version=STORAGE_VERSION_MINOR
+        )
         self._prefs = None
         self._listeners = []
         self.last_updated: set[str] = set()
@@ -80,13 +102,12 @@ class CloudPreferences:
         cloudhooks=UNDEFINED,
         cloud_user=UNDEFINED,
         google_entity_configs=UNDEFINED,
-        alexa_entity_configs=UNDEFINED,
         alexa_report_state=UNDEFINED,
         google_report_state=UNDEFINED,
-        alexa_default_expose=UNDEFINED,
         google_default_expose=UNDEFINED,
         tts_default_voice=UNDEFINED,
         remote_domain=UNDEFINED,
+        alexa_settings_version=UNDEFINED,
     ):
         """Update user preferences."""
         prefs = {**self._prefs}
@@ -99,11 +120,10 @@ class CloudPreferences:
             (PREF_CLOUDHOOKS, cloudhooks),
             (PREF_CLOUD_USER, cloud_user),
             (PREF_GOOGLE_ENTITY_CONFIGS, google_entity_configs),
-            (PREF_ALEXA_ENTITY_CONFIGS, alexa_entity_configs),
             (PREF_ALEXA_REPORT_STATE, alexa_report_state),
             (PREF_GOOGLE_REPORT_STATE, google_report_state),
-            (PREF_ALEXA_DEFAULT_EXPOSE, alexa_default_expose),
             (PREF_GOOGLE_DEFAULT_EXPOSE, google_default_expose),
+            (PREF_ALEXA_SETTINGS_VERSION, alexa_settings_version),
             (PREF_TTS_DEFAULT_VOICE, tts_default_voice),
             (PREF_REMOTE_DOMAIN, remote_domain),
         ):
@@ -139,26 +159,6 @@ class CloudPreferences:
         updated_entities = {**entities, entity_id: updated_entity}
         await self.async_update(google_entity_configs=updated_entities)
 
-    async def async_update_alexa_entity_config(
-        self, *, entity_id, should_expose=UNDEFINED
-    ):
-        """Update config for an Alexa entity."""
-        entities = self.alexa_entity_configs
-        entity = entities.get(entity_id, {})
-
-        changes = {}
-        for key, value in ((PREF_SHOULD_EXPOSE, should_expose),):
-            if value is not UNDEFINED:
-                changes[key] = value
-
-        if not changes:
-            return
-
-        updated_entity = {**entity, **changes}
-
-        updated_entities = {**entities, entity_id: updated_entity}
-        await self.async_update(alexa_entity_configs=updated_entities)
-
     async def async_set_username(self, username) -> bool:
         """Set the username that is logged in."""
         # Logging out.
@@ -186,7 +186,6 @@ class CloudPreferences:
         """Return dictionary version."""
         return {
             PREF_ALEXA_DEFAULT_EXPOSE: self.alexa_default_expose,
-            PREF_ALEXA_ENTITY_CONFIGS: self.alexa_entity_configs,
             PREF_ALEXA_REPORT_STATE: self.alexa_report_state,
             PREF_CLOUDHOOKS: self.cloudhooks,
             PREF_ENABLE_ALEXA: self.alexa_enabled,
@@ -234,6 +233,11 @@ class CloudPreferences:
     def alexa_entity_configs(self):
         """Return Alexa Entity configurations."""
         return self._prefs.get(PREF_ALEXA_ENTITY_CONFIGS, {})
+
+    @property
+    def alexa_settings_version(self):
+        """Return version of Alexa settings."""
+        return self._prefs[PREF_ALEXA_SETTINGS_VERSION]
 
     @property
     def google_enabled(self):
@@ -319,6 +323,7 @@ class CloudPreferences:
         return {
             PREF_ALEXA_DEFAULT_EXPOSE: DEFAULT_EXPOSED_DOMAINS,
             PREF_ALEXA_ENTITY_CONFIGS: {},
+            PREF_ALEXA_SETTINGS_VERSION: ALEXA_SETTINGS_VERSION,
             PREF_CLOUD_USER: None,
             PREF_CLOUDHOOKS: {},
             PREF_ENABLE_ALEXA: True,

--- a/homeassistant/components/homeassistant/__init__.py
+++ b/homeassistant/components/homeassistant/__init__.py
@@ -33,10 +33,12 @@ from homeassistant.helpers.service import (
 from homeassistant.helpers.template import async_load_custom_templates
 from homeassistant.helpers.typing import ConfigType
 
+from .const import DATA_EXPOSED_ENTITIES, DOMAIN
+from .exposed_entities import ExposedEntities
+
 ATTR_ENTRY_ID = "entry_id"
 
 _LOGGER = logging.getLogger(__name__)
-DOMAIN = ha.DOMAIN
 SERVICE_RELOAD_CORE_CONFIG = "reload_core_config"
 SERVICE_RELOAD_CONFIG_ENTRY = "reload_config_entry"
 SERVICE_RELOAD_CUSTOM_TEMPLATES = "reload_custom_templates"
@@ -339,5 +341,9 @@ async def async_setup(hass: ha.HomeAssistant, config: ConfigType) -> bool:  # no
     async_register_admin_service(
         hass, ha.DOMAIN, SERVICE_RELOAD_ALL, async_handle_reload_all
     )
+
+    exposed_entities = ExposedEntities(hass)
+    await exposed_entities.async_initialize()
+    hass.data[DATA_EXPOSED_ENTITIES] = exposed_entities
 
     return True

--- a/homeassistant/components/homeassistant/const.py
+++ b/homeassistant/components/homeassistant/const.py
@@ -1,0 +1,6 @@
+"""Constants for the Homeassistant integration."""
+import homeassistant.core as ha
+
+DOMAIN = ha.DOMAIN
+
+DATA_EXPOSED_ENTITIES = f"{DOMAIN}.exposed_entites"

--- a/homeassistant/components/homeassistant/exposed_entities.py
+++ b/homeassistant/components/homeassistant/exposed_entities.py
@@ -18,6 +18,8 @@ from homeassistant.helpers.storage import Store
 
 from .const import DATA_EXPOSED_ENTITIES, DOMAIN
 
+KNOWN_ASSISTANTS = ("cloud.alexa",)
+
 STORAGE_KEY = f"{DOMAIN}.exposed_entities"
 STORAGE_VERSION = 1
 
@@ -231,7 +233,7 @@ class ExposedEntities:
 @websocket_api.websocket_command(
     {
         vol.Required("type"): "homeassistant/expose_entity",
-        vol.Required("assistants"): [str],
+        vol.Required("assistants"): [vol.In(KNOWN_ASSISTANTS)],
         vol.Required("entity_ids"): [str],
         vol.Required("should_expose"): bool,
     }
@@ -262,7 +264,7 @@ def ws_expose_entity(
 @websocket_api.websocket_command(
     {
         vol.Required("type"): "homeassistant/expose_new_entities",
-        vol.Required("assistant"): str,
+        vol.Required("assistant"): vol.In(KNOWN_ASSISTANTS),
         vol.Required("expose_new"): bool,
     }
 )

--- a/homeassistant/components/homeassistant/exposed_entities.py
+++ b/homeassistant/components/homeassistant/exposed_entities.py
@@ -125,7 +125,6 @@ class ExposedEntities:
     @callback
     def async_expose_new_entities(self, assistant: str, expose_new: bool) -> None:
         """Enable an assistant to expose new entities."""
-
         self._assistants[assistant] = AssistantPreferences(expose_new=expose_new)
         self._async_schedule_save()
 
@@ -160,10 +159,10 @@ class ExposedEntities:
             should_expose = registry_entry.options[assistant]["should_expose"]
             return should_expose
 
-        if not (prefs := self._assistants.get(assistant)) or not prefs.expose_new:
-            should_expose = False
-        else:
+        if (prefs := self._assistants.get(assistant)) and prefs.expose_new:
             should_expose = self._is_default_exposed(entity_id, registry_entry)
+        else:
+            should_expose = False
 
         assistant_options = {"should_expose": should_expose}
         entity_registry.async_update_entity_options(

--- a/homeassistant/components/homeassistant/exposed_entities.py
+++ b/homeassistant/components/homeassistant/exposed_entities.py
@@ -1,0 +1,298 @@
+"""Control which entities are exposed to voice assistants."""
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+import dataclasses
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.components import websocket_api
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+from homeassistant.components.sensor import SensorDeviceClass
+from homeassistant.const import CLOUD_NEVER_EXPOSED_ENTITIES
+from homeassistant.core import HomeAssistant, callback, split_entity_id
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.entity import get_device_class
+from homeassistant.helpers.storage import Store
+
+from .const import DATA_EXPOSED_ENTITIES, DOMAIN
+
+STORAGE_KEY = f"{DOMAIN}.exposed_entities"
+STORAGE_VERSION = 1
+
+SAVE_DELAY = 10
+
+DEFAULT_EXPOSED_DOMAINS = [
+    "climate",
+    "cover",
+    "fan",
+    "humidifier",
+    "light",
+    "lock",
+    "scene",
+    "script",
+    "switch",
+    "vacuum",
+    "water_heater",
+]
+
+DEFAULT_EXPOSED_BINARY_SENSOR_DEVICE_CLASSES = [
+    BinarySensorDeviceClass.DOOR,
+    BinarySensorDeviceClass.GARAGE_DOOR,
+    BinarySensorDeviceClass.LOCK,
+    BinarySensorDeviceClass.MOTION,
+    BinarySensorDeviceClass.OPENING,
+    BinarySensorDeviceClass.PRESENCE,
+    BinarySensorDeviceClass.WINDOW,
+]
+
+DEFAULT_EXPOSED_SENSOR_DEVICE_CLASSES = [
+    SensorDeviceClass.AQI,
+    SensorDeviceClass.CO,
+    SensorDeviceClass.CO2,
+    SensorDeviceClass.HUMIDITY,
+    SensorDeviceClass.PM10,
+    SensorDeviceClass.PM25,
+    SensorDeviceClass.TEMPERATURE,
+    SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS,
+]
+
+
+@dataclasses.dataclass(frozen=True)
+class AssistantPreferences:
+    """Preferences for an assistant."""
+
+    expose_new: bool
+
+    def to_json(self) -> dict[str, Any]:
+        """Return a JSON serializable representation for storage."""
+        return {"expose_new": self.expose_new}
+
+
+class ExposedEntities:
+    """Control assistant settings."""
+
+    _assistants: dict[str, AssistantPreferences]
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize."""
+        self._hass = hass
+        self._listeners: dict[str, list[Callable[[], None]]] = {}
+        self._store: Store[dict[str, dict[str, dict[str, Any]]]] = Store(
+            hass, STORAGE_VERSION, STORAGE_KEY
+        )
+
+    async def async_initialize(self) -> None:
+        """Finish initializing."""
+        websocket_api.async_register_command(self._hass, ws_expose_entity)
+        websocket_api.async_register_command(self._hass, ws_expose_new_entities)
+        await self.async_load()
+
+    @callback
+    def async_listen_entity_updates(
+        self, assistant: str, listener: Callable[[], None]
+    ) -> None:
+        """Listen for updates to entity expose settings."""
+        self._listeners.setdefault(assistant, []).append(listener)
+
+    @callback
+    def async_expose_entity(
+        self, assistant: str, entity_id: str, should_expose: bool
+    ) -> None:
+        """Expose an entity to an assistant.
+
+        Notify listeners if expose flag was changed.
+        """
+        entity_registry = er.async_get(self._hass)
+        if not (registry_entry := entity_registry.async_get(entity_id)):
+            return
+
+        if (
+            assistant_options := registry_entry.options.get(assistant)
+        ) and assistant_options["should_expose"] == should_expose:
+            return
+
+        assistant_options = {"should_expose": should_expose}
+        entity_registry.async_update_entity_options(
+            entity_id, assistant, assistant_options
+        )
+        for listener in self._listeners.get(assistant, []):
+            listener()
+
+    @callback
+    def async_expose_new_entities(self, assistant: str, expose_new: bool) -> None:
+        """Enable an assistant to expose new entities."""
+
+        self._assistants[assistant] = AssistantPreferences(expose_new=expose_new)
+        self._async_schedule_save()
+
+    @callback
+    def async_get_exposed_entities(
+        self, assistant: str
+    ) -> dict[str, Mapping[str, Any]]:
+        """Get all exposed entities."""
+        entity_registry = er.async_get(self._hass)
+        result = {}
+
+        for entity_id, entry in entity_registry.entities.items():
+            if options := entry.options.get(assistant):
+                result[entity_id] = options
+
+        return result
+
+    @callback
+    def async_should_expose(self, assistant: str, entity_id: str) -> bool:
+        """Return True if an entity should be exposed to an assistant."""
+        should_expose: bool
+
+        if entity_id in CLOUD_NEVER_EXPOSED_ENTITIES:
+            return False
+
+        entity_registry = er.async_get(self._hass)
+        if not (registry_entry := entity_registry.async_get(entity_id)):
+            # Entities which are not in the entity registry are not exposed
+            return False
+
+        if assistant in registry_entry.options:
+            should_expose = registry_entry.options[assistant]["should_expose"]
+            return should_expose
+
+        if not (prefs := self._assistants.get(assistant)) or not prefs.expose_new:
+            should_expose = False
+        else:
+            should_expose = self._is_default_exposed(entity_id, registry_entry)
+
+        assistant_options = {"should_expose": should_expose}
+        entity_registry.async_update_entity_options(
+            entity_id, assistant, assistant_options
+        )
+
+        return should_expose
+
+    def _is_default_exposed(
+        self, entity_id: str, registry_entry: er.RegistryEntry
+    ) -> bool:
+        """Return True if an entity is exposed by default."""
+        if (
+            registry_entry.entity_category is not None
+            or registry_entry.hidden_by is not None
+        ):
+            return False
+
+        domain = split_entity_id(entity_id)[0]
+        if domain in DEFAULT_EXPOSED_DOMAINS:
+            return True
+
+        device_class = get_device_class(self._hass, entity_id)
+        if (
+            domain == "binary_sensor"
+            and device_class in DEFAULT_EXPOSED_BINARY_SENSOR_DEVICE_CLASSES
+        ):
+            return True
+
+        if domain == "sensor" and device_class in DEFAULT_EXPOSED_SENSOR_DEVICE_CLASSES:
+            return True
+
+        return False
+
+    async def async_load(self) -> None:
+        """Load from the store."""
+        data = await self._store.async_load()
+
+        assistants: dict[str, AssistantPreferences] = {}
+
+        if data:
+            for domain, preferences in data["assistants"].items():
+                assistants[domain] = AssistantPreferences(**preferences)
+
+        self._assistants = assistants
+
+    @callback
+    def _async_schedule_save(self) -> None:
+        """Schedule saving the preferences."""
+        self._store.async_delay_save(self._data_to_save, SAVE_DELAY)
+
+    @callback
+    def _data_to_save(self) -> dict[str, dict[str, dict[str, Any]]]:
+        """Return data to store in a file."""
+        data = {}
+
+        data["assistants"] = {
+            domain: preferences.to_json()
+            for domain, preferences in self._assistants.items()
+        }
+
+        return data
+
+
+@callback
+@websocket_api.require_admin
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "homeassistant/expose_entity",
+        vol.Required("assistant"): str,
+        vol.Required("entity_id"): str,
+        vol.Required("should_expose"): bool,
+    }
+)
+def ws_expose_entity(
+    hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict[str, Any]
+) -> None:
+    """Expose an entity to an assistatant."""
+    entity_id: str = msg["entity_id"]
+
+    if entity_id in CLOUD_NEVER_EXPOSED_ENTITIES:
+        connection.send_error(
+            msg["id"], websocket_api.const.ERR_NOT_ALLOWED, f"can't expose {entity_id}"
+        )
+        return
+
+    exposed_entities: ExposedEntities = hass.data[DATA_EXPOSED_ENTITIES]
+    exposed_entities.async_expose_entity(
+        msg["assistant"], entity_id, msg["should_expose"]
+    )
+    connection.send_result(msg["id"])
+
+
+@callback
+@websocket_api.require_admin
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "homeassistant/expose_new_entities",
+        vol.Required("assistant"): str,
+        vol.Required("expose_new"): bool,
+    }
+)
+def ws_expose_new_entities(
+    hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict[str, Any]
+) -> None:
+    """Expose an entity to an assistatant."""
+    exposed_entities: ExposedEntities = hass.data[DATA_EXPOSED_ENTITIES]
+    exposed_entities.async_expose_new_entities(msg["assistant"], msg["expose_new"])
+    connection.send_result(msg["id"])
+
+
+@callback
+def async_listen_entity_updates(
+    hass: HomeAssistant, assistant: str, listener: Callable[[], None]
+) -> None:
+    """Listen for updates to entity expose settings."""
+    exposed_entities: ExposedEntities = hass.data[DATA_EXPOSED_ENTITIES]
+    exposed_entities.async_listen_entity_updates(assistant, listener)
+
+
+@callback
+def async_get_exposed_entities(
+    hass: HomeAssistant, assistant: str
+) -> dict[str, Mapping[str, Any]]:
+    """Get all exposed entities."""
+    exposed_entities: ExposedEntities = hass.data[DATA_EXPOSED_ENTITIES]
+    return exposed_entities.async_get_exposed_entities(assistant)
+
+
+@callback
+def async_should_expose(hass: HomeAssistant, assistant: str, entity_id: str) -> bool:
+    """Return True if an entity should be exposed to an assistant."""
+    exposed_entities: ExposedEntities = hass.data[DATA_EXPOSED_ENTITIES]
+    return exposed_entities.async_should_expose(assistant, entity_id)

--- a/homeassistant/components/homeassistant/exposed_entities.py
+++ b/homeassistant/components/homeassistant/exposed_entities.py
@@ -139,10 +139,10 @@ class ExposedEntities:
         self._async_schedule_save()
 
     @callback
-    def async_get_exposed_entities(
+    def async_get_assistant_settings(
         self, assistant: str
     ) -> dict[str, Mapping[str, Any]]:
-        """Get all exposed entities."""
+        """Get all entity expose settings for an assistant."""
         entity_registry = er.async_get(self._hass)
         result: dict[str, Mapping[str, Any]] = {}
 
@@ -336,12 +336,12 @@ def async_listen_entity_updates(
 
 
 @callback
-def async_get_exposed_entities(
+def async_get_assistant_settings(
     hass: HomeAssistant, assistant: str
 ) -> dict[str, Mapping[str, Any]]:
-    """Get all exposed entities."""
+    """Get all entity expose settings for an assistant."""
     exposed_entities: ExposedEntities = hass.data[DATA_EXPOSED_ENTITIES]
-    return exposed_entities.async_get_exposed_entities(assistant)
+    return exposed_entities.async_get_assistant_settings(assistant)
 
 
 @callback

--- a/homeassistant/components/homeassistant/exposed_entities.py
+++ b/homeassistant/components/homeassistant/exposed_entities.py
@@ -112,6 +112,7 @@ class ExposedEntities:
         if not (registry_entry := entity_registry.async_get(entity_id)):
             raise HomeAssistantError("Unknown entity")
 
+        assistant_options: Mapping[str, Any]
         if (
             assistant_options := registry_entry.options.get(assistant, {})
         ) and assistant_options.get("should_expose") == should_expose:
@@ -143,7 +144,7 @@ class ExposedEntities:
     ) -> dict[str, Mapping[str, Any]]:
         """Get all exposed entities."""
         entity_registry = er.async_get(self._hass)
-        result = {}
+        result: dict[str, Mapping[str, Any]] = {}
 
         for entity_id, entry in entity_registry.entities.items():
             if options := entry.options.get(assistant):
@@ -174,7 +175,7 @@ class ExposedEntities:
         else:
             should_expose = False
 
-        assistant_options = registry_entry.options.get(assistant, {})
+        assistant_options: Mapping[str, Any] = registry_entry.options.get(assistant, {})
         assistant_options = assistant_options | {"should_expose": should_expose}
         entity_registry.async_update_entity_options(
             entity_id, assistant, assistant_options

--- a/homeassistant/components/homeassistant/exposed_entities.py
+++ b/homeassistant/components/homeassistant/exposed_entities.py
@@ -26,7 +26,7 @@ STORAGE_VERSION = 1
 
 SAVE_DELAY = 10
 
-DEFAULT_EXPOSED_DOMAINS = [
+DEFAULT_EXPOSED_DOMAINS = {
     "climate",
     "cover",
     "fan",
@@ -38,9 +38,9 @@ DEFAULT_EXPOSED_DOMAINS = [
     "switch",
     "vacuum",
     "water_heater",
-]
+}
 
-DEFAULT_EXPOSED_BINARY_SENSOR_DEVICE_CLASSES = [
+DEFAULT_EXPOSED_BINARY_SENSOR_DEVICE_CLASSES = {
     BinarySensorDeviceClass.DOOR,
     BinarySensorDeviceClass.GARAGE_DOOR,
     BinarySensorDeviceClass.LOCK,
@@ -48,9 +48,9 @@ DEFAULT_EXPOSED_BINARY_SENSOR_DEVICE_CLASSES = [
     BinarySensorDeviceClass.OPENING,
     BinarySensorDeviceClass.PRESENCE,
     BinarySensorDeviceClass.WINDOW,
-]
+}
 
-DEFAULT_EXPOSED_SENSOR_DEVICE_CLASSES = [
+DEFAULT_EXPOSED_SENSOR_DEVICE_CLASSES = {
     SensorDeviceClass.AQI,
     SensorDeviceClass.CO,
     SensorDeviceClass.CO2,
@@ -59,7 +59,7 @@ DEFAULT_EXPOSED_SENSOR_DEVICE_CLASSES = [
     SensorDeviceClass.PM25,
     SensorDeviceClass.TEMPERATURE,
     SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS,
-]
+}
 
 
 @dataclasses.dataclass(frozen=True)
@@ -302,7 +302,7 @@ def ws_expose_entity(
 def ws_expose_new_entities_get(
     hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict[str, Any]
 ) -> None:
-    """Check if new entities are exposed to an assistatant."""
+    """Check if new entities are exposed to an assistant."""
     exposed_entities: ExposedEntities = hass.data[DATA_EXPOSED_ENTITIES]
     expose_new = exposed_entities.async_get_expose_new_entities(msg["assistant"])
     connection.send_result(msg["id"], {"expose_new": expose_new})

--- a/mypy.ini
+++ b/mypy.ini
@@ -1132,6 +1132,16 @@ disallow_untyped_defs = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.homeassistant.exposed_entities]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.homeassistant.triggers.event]
 check_untyped_defs = true
 disallow_incomplete_defs = true

--- a/tests/components/cloud/__init__.py
+++ b/tests/components/cloud/__init__.py
@@ -22,6 +22,7 @@ def mock_cloud_prefs(hass, prefs={}):
         const.PREF_ENABLE_ALEXA: True,
         const.PREF_ENABLE_GOOGLE: True,
         const.PREF_GOOGLE_SECURE_DEVICES_PIN: None,
+        const.PREF_GOOGLE_SETTINGS_VERSION: cloud_prefs.GOOGLE_SETTINGS_VERSION,
     }
     prefs_to_set.update(prefs)
     hass.data[cloud.DOMAIN].client._prefs._prefs = prefs_to_set

--- a/tests/components/cloud/__init__.py
+++ b/tests/components/cloud/__init__.py
@@ -3,7 +3,7 @@
 from unittest.mock import AsyncMock, patch
 
 from homeassistant.components import cloud
-from homeassistant.components.cloud import const
+from homeassistant.components.cloud import const, prefs as cloud_prefs
 from homeassistant.setup import async_setup_component
 
 
@@ -18,6 +18,7 @@ async def mock_cloud(hass, config=None):
 def mock_cloud_prefs(hass, prefs={}):
     """Fixture for cloud component."""
     prefs_to_set = {
+        const.PREF_ALEXA_SETTINGS_VERSION: cloud_prefs.ALEXA_SETTINGS_VERSION,
         const.PREF_ENABLE_ALEXA: True,
         const.PREF_ENABLE_GOOGLE: True,
         const.PREF_GOOGLE_SECURE_DEVICES_PIN: None,

--- a/tests/components/cloud/test_alexa_config.py
+++ b/tests/components/cloud/test_alexa_config.py
@@ -12,6 +12,7 @@ from homeassistant.components.homeassistant.exposed_entities import (
 )
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.setup import async_setup_component
@@ -89,7 +90,6 @@ async def test_alexa_config_expose_entity_prefs(
         alexa_report_state=False,
     )
     expose_new(hass, True)
-    expose_entity(hass, "light.kitchen", True)
     expose_entity(hass, entity_entry5.entity_id, False)
     conf = alexa_config.CloudAlexaConfig(
         hass, ALEXA_SCHEMA({}), "mock-user-id", cloud_prefs, cloud_stub
@@ -97,6 +97,8 @@ async def test_alexa_config_expose_entity_prefs(
     await conf.async_initialize()
 
     # can't expose an entity which is not in the entity registry
+    with pytest.raises(HomeAssistantError):
+        expose_entity(hass, "light.kitchen", True)
     assert not conf.should_expose("light.kitchen")
     # categorized and hidden entities should not be exposed
     assert not conf.should_expose(entity_entry1.entity_id)

--- a/tests/components/cloud/test_alexa_config.py
+++ b/tests/components/cloud/test_alexa_config.py
@@ -30,7 +30,7 @@ def cloud_stub():
 def expose_new(hass, expose_new):
     """Enable exposing new entities to Alexa."""
     exposed_entities: ExposedEntities = hass.data[DATA_EXPOSED_ENTITIES]
-    exposed_entities.async_expose_new_entities("cloud.alexa", expose_new)
+    exposed_entities.async_set_expose_new_entities("cloud.alexa", expose_new)
 
 
 def expose_entity(hass, entity_id, should_expose):

--- a/tests/components/cloud/test_client.py
+++ b/tests/components/cloud/test_client.py
@@ -13,8 +13,13 @@ from homeassistant.components.cloud.const import (
     PREF_ENABLE_ALEXA,
     PREF_ENABLE_GOOGLE,
 )
+from homeassistant.components.homeassistant.exposed_entities import (
+    DATA_EXPOSED_ENTITIES,
+    ExposedEntities,
+)
 from homeassistant.const import CONTENT_TYPE_JSON
 from homeassistant.core import HomeAssistant, State
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -245,14 +250,25 @@ async def test_google_config_expose_entity(
     hass: HomeAssistant, mock_cloud_setup, mock_cloud_login
 ) -> None:
     """Test Google config exposing entity method uses latest config."""
+    entity_registry = er.async_get(hass)
+
+    # Enable exposing new entities to Google
+    exposed_entities: ExposedEntities = hass.data[DATA_EXPOSED_ENTITIES]
+    exposed_entities.async_expose_new_entities("cloud.google_assistant", True)
+
+    # Register a light entity
+    entity_entry = entity_registry.async_get_or_create(
+        "light", "test", "unique", suggested_object_id="kitchen"
+    )
+
     cloud_client = hass.data[DOMAIN].client
-    state = State("light.kitchen", "on")
+    state = State(entity_entry.entity_id, "on")
     gconf = await cloud_client.get_google_config()
 
     assert gconf.should_expose(state)
 
-    await cloud_client.prefs.async_update_google_entity_config(
-        entity_id="light.kitchen", should_expose=False
+    exposed_entities.async_expose_entity(
+        "cloud.google_assistant", entity_entry.entity_id, False
     )
 
     assert not gconf.should_expose(state)
@@ -262,14 +278,21 @@ async def test_google_config_should_2fa(
     hass: HomeAssistant, mock_cloud_setup, mock_cloud_login
 ) -> None:
     """Test Google config disabling 2FA method uses latest config."""
+    entity_registry = er.async_get(hass)
+
+    # Register a light entity
+    entity_entry = entity_registry.async_get_or_create(
+        "light", "test", "unique", suggested_object_id="kitchen"
+    )
+
     cloud_client = hass.data[DOMAIN].client
     gconf = await cloud_client.get_google_config()
-    state = State("light.kitchen", "on")
+    state = State(entity_entry.entity_id, "on")
 
     assert gconf.should_2fa(state)
 
-    await cloud_client.prefs.async_update_google_entity_config(
-        entity_id="light.kitchen", disable_2fa=True
+    entity_registry.async_update_entity_options(
+        entity_entry.entity_id, "cloud.google_assistant", {"disable_2fa": True}
     )
 
     assert not gconf.should_2fa(state)

--- a/tests/components/cloud/test_client.py
+++ b/tests/components/cloud/test_client.py
@@ -254,7 +254,7 @@ async def test_google_config_expose_entity(
 
     # Enable exposing new entities to Google
     exposed_entities: ExposedEntities = hass.data[DATA_EXPOSED_ENTITIES]
-    exposed_entities.async_expose_new_entities("cloud.google_assistant", True)
+    exposed_entities.async_set_expose_new_entities("cloud.google_assistant", True)
 
     # Register a light entity
     entity_entry = entity_registry.async_get_or_create(

--- a/tests/components/cloud/test_google_config.py
+++ b/tests/components/cloud/test_google_config.py
@@ -37,7 +37,7 @@ def mock_conf(hass, cloud_prefs):
 def expose_new(hass, expose_new):
     """Enable exposing new entities to Google."""
     exposed_entities: ExposedEntities = hass.data[DATA_EXPOSED_ENTITIES]
-    exposed_entities.async_expose_new_entities("cloud.google_assistant", expose_new)
+    exposed_entities.async_set_expose_new_entities("cloud.google_assistant", expose_new)
 
 
 def expose_entity(hass, entity_id, should_expose):

--- a/tests/components/cloud/test_google_config.py
+++ b/tests/components/cloud/test_google_config.py
@@ -14,6 +14,7 @@ from homeassistant.components.homeassistant.exposed_entities import (
 )
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, EntityCategory
 from homeassistant.core import CoreState, HomeAssistant, State
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
@@ -377,7 +378,6 @@ async def test_google_config_expose_entity_prefs(
     )
 
     expose_new(hass, True)
-    expose_entity(hass, "light.kitchen", True)
     expose_entity(hass, entity_entry5.entity_id, False)
 
     state = State("light.kitchen", "on")
@@ -389,6 +389,8 @@ async def test_google_config_expose_entity_prefs(
     state_exposed_default = State(entity_entry6.entity_id, "on")
 
     # can't expose an entity which is not in the entity registry
+    with pytest.raises(HomeAssistantError):
+        expose_entity(hass, "light.kitchen", True)
     assert not mock_conf.should_expose(state)
     # categorized and hidden entities should not be exposed
     assert not mock_conf.should_expose(state_config)

--- a/tests/components/cloud/test_http_api.py
+++ b/tests/components/cloud/test_http_api.py
@@ -794,8 +794,8 @@ async def test_update_alexa_entity(
     await client.send_json_auto_id(
         {
             "type": "homeassistant/expose_entity",
-            "assistant": "cloud.alexa",
-            "entity_id": entry.entity_id,
+            "assistants": ["cloud.alexa"],
+            "entity_ids": [entry.entity_id],
             "should_expose": False,
         }
     )

--- a/tests/components/homeassistant/test_exposed_entities.py
+++ b/tests/components/homeassistant/test_exposed_entities.py
@@ -1,0 +1,329 @@
+"""Test Home Assistant exposed entities helper."""
+import pytest
+
+from homeassistant.components.homeassistant.exposed_entities import (
+    DATA_EXPOSED_ENTITIES,
+    ExposedEntities,
+    async_get_exposed_entities,
+    async_listen_entity_updates,
+    async_should_expose,
+)
+from homeassistant.const import CLOUD_NEVER_EXPOSED_ENTITIES, EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
+from homeassistant.setup import async_setup_component
+
+from tests.common import flush_store
+from tests.typing import WebSocketGenerator
+
+
+async def test_load_preferences(hass: HomeAssistant) -> None:
+    """Make sure that we can load/save data correctly."""
+    assert await async_setup_component(hass, "homeassistant", {})
+
+    exposed_entities: ExposedEntities = hass.data[DATA_EXPOSED_ENTITIES]
+    assert exposed_entities._assistants == {}
+
+    exposed_entities.async_expose_new_entities("test1", True)
+    exposed_entities.async_expose_new_entities("test2", False)
+
+    assert list(exposed_entities._assistants) == ["test1", "test2"]
+
+    exposed_entities2 = ExposedEntities(hass)
+    await flush_store(exposed_entities._store)
+    await exposed_entities2.async_load()
+
+    assert exposed_entities._assistants == exposed_entities2._assistants
+
+
+async def test_expose_entity(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test expose entity."""
+    ws_client = await hass_ws_client(hass)
+    assert await async_setup_component(hass, "homeassistant", {})
+    await hass.async_block_till_done()
+
+    entry1 = entity_registry.async_get_or_create("test", "test", "unique1")
+    entry2 = entity_registry.async_get_or_create("test", "test", "unique2")
+
+    # Set options
+    await ws_client.send_json_auto_id(
+        {
+            "type": "homeassistant/expose_entity",
+            "assistants": ["cloud.alexa"],
+            "entity_ids": [entry1.entity_id],
+            "should_expose": True,
+        }
+    )
+
+    response = await ws_client.receive_json()
+    assert response["success"]
+
+    entry1 = entity_registry.async_get(entry1.entity_id)
+    assert entry1.options == {"cloud.alexa": {"should_expose": True}}
+    entry2 = entity_registry.async_get(entry2.entity_id)
+    assert entry2.options == {}
+
+    # Update options
+    await ws_client.send_json_auto_id(
+        {
+            "type": "homeassistant/expose_entity",
+            "assistants": ["cloud.alexa", "cloud.google_assistant"],
+            "entity_ids": [entry1.entity_id, entry2.entity_id],
+            "should_expose": False,
+        }
+    )
+
+    response = await ws_client.receive_json()
+    assert response["success"]
+
+    entry1 = entity_registry.async_get(entry1.entity_id)
+    assert entry1.options == {
+        "cloud.alexa": {"should_expose": False},
+        "cloud.google_assistant": {"should_expose": False},
+    }
+    entry2 = entity_registry.async_get(entry2.entity_id)
+    assert entry2.options == {
+        "cloud.alexa": {"should_expose": False},
+        "cloud.google_assistant": {"should_expose": False},
+    }
+
+
+async def test_expose_entity_unknown(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test behavior when exposing an unknown entity."""
+    ws_client = await hass_ws_client(hass)
+    assert await async_setup_component(hass, "homeassistant", {})
+    await hass.async_block_till_done()
+
+    exposed_entities: ExposedEntities = hass.data[DATA_EXPOSED_ENTITIES]
+
+    # Set options
+    await ws_client.send_json_auto_id(
+        {
+            "type": "homeassistant/expose_entity",
+            "assistants": ["cloud.alexa"],
+            "entity_ids": ["test.test"],
+            "should_expose": True,
+        }
+    )
+
+    response = await ws_client.receive_json()
+    assert not response["success"]
+    assert response["error"] == {
+        "code": "not_found",
+        "message": "can't expose 'test.test'",
+    }
+
+    with pytest.raises(HomeAssistantError):
+        exposed_entities.async_expose_entity("cloud.alexa", "test.test", True)
+
+
+async def test_expose_entity_blocked(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test behavior when exposing a blocked entity."""
+    ws_client = await hass_ws_client(hass)
+    assert await async_setup_component(hass, "homeassistant", {})
+    await hass.async_block_till_done()
+
+    # Set options
+    await ws_client.send_json_auto_id(
+        {
+            "type": "homeassistant/expose_entity",
+            "assistants": ["cloud.alexa"],
+            "entity_ids": ["group.all_locks"],
+            "should_expose": True,
+        }
+    )
+
+    response = await ws_client.receive_json()
+    assert not response["success"]
+    assert response["error"] == {
+        "code": "not_allowed",
+        "message": "can't expose 'group.all_locks'",
+    }
+
+
+@pytest.mark.parametrize("expose_new", [True, False])
+async def test_expose_new_entities(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    hass_ws_client: WebSocketGenerator,
+    expose_new,
+) -> None:
+    """Test expose entity."""
+    ws_client = await hass_ws_client(hass)
+    assert await async_setup_component(hass, "homeassistant", {})
+    await hass.async_block_till_done()
+
+    entry1 = entity_registry.async_get_or_create("climate", "test", "unique1")
+    entry2 = entity_registry.async_get_or_create("climate", "test", "unique2")
+
+    # Check if exposed - should be False
+    assert async_should_expose(hass, "cloud.alexa", entry1.entity_id) is False
+
+    # Expose new entities to Alexa
+    await ws_client.send_json_auto_id(
+        {
+            "type": "homeassistant/expose_new_entities",
+            "assistant": "cloud.alexa",
+            "expose_new": expose_new,
+        }
+    )
+    response = await ws_client.receive_json()
+    assert response["success"]
+
+    # Check again if exposed - should still be False
+    assert async_should_expose(hass, "cloud.alexa", entry1.entity_id) is False
+
+    # Check if exposed - should be True
+    assert async_should_expose(hass, "cloud.alexa", entry2.entity_id) == expose_new
+
+
+async def test_listen_updated(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test listen to updates."""
+    calls = []
+
+    def listener():
+        calls.append(None)
+
+    assert await async_setup_component(hass, "homeassistant", {})
+    await hass.async_block_till_done()
+
+    exposed_entities: ExposedEntities = hass.data[DATA_EXPOSED_ENTITIES]
+    async_listen_entity_updates(hass, "cloud.alexa", listener)
+
+    entry = entity_registry.async_get_or_create("climate", "test", "unique1")
+
+    # Call for another assistant - listener not called
+    exposed_entities.async_expose_entity(
+        "cloud.google_assistant", entry.entity_id, True
+    )
+    assert len(calls) == 0
+
+    # Call for our assistant - listener called
+    exposed_entities.async_expose_entity("cloud.alexa", entry.entity_id, True)
+    assert len(calls) == 1
+
+    # Settings not changed - listener not called
+    exposed_entities.async_expose_entity("cloud.alexa", entry.entity_id, True)
+    assert len(calls) == 1
+
+    # Settings changed - listener called
+    exposed_entities.async_expose_entity("cloud.alexa", entry.entity_id, False)
+    assert len(calls) == 2
+
+
+async def test_get_exposed_entities(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test get exposed entities."""
+    assert await async_setup_component(hass, "homeassistant", {})
+    await hass.async_block_till_done()
+
+    exposed_entities: ExposedEntities = hass.data[DATA_EXPOSED_ENTITIES]
+
+    entry = entity_registry.async_get_or_create("climate", "test", "unique1")
+
+    assert async_get_exposed_entities(hass, "cloud.alexa") == {}
+
+    exposed_entities.async_expose_entity("cloud.alexa", entry.entity_id, True)
+    assert async_get_exposed_entities(hass, "cloud.alexa") == {
+        "climate.test_unique1": {"should_expose": True}
+    }
+    assert async_get_exposed_entities(hass, "cloud.google_assistant") == {}
+
+
+async def test_should_expose(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test expose entity."""
+    ws_client = await hass_ws_client(hass)
+    assert await async_setup_component(hass, "homeassistant", {})
+    await hass.async_block_till_done()
+
+    # Expose new entities to Alexa
+    await ws_client.send_json_auto_id(
+        {
+            "type": "homeassistant/expose_new_entities",
+            "assistant": "cloud.alexa",
+            "expose_new": True,
+        }
+    )
+    response = await ws_client.receive_json()
+    assert response["success"]
+
+    # Unknown entity is not exposed
+    assert async_should_expose(hass, "test.test", "test.test") is False
+
+    # Blocked entity is not exposed
+    entry_blocked = entity_registry.async_get_or_create(
+        "group", "test", "unique", suggested_object_id="all_locks"
+    )
+    assert entry_blocked.entity_id == CLOUD_NEVER_EXPOSED_ENTITIES[0]
+    assert async_should_expose(hass, "cloud.alexa", entry_blocked.entity_id) is False
+
+    # Lock is exposed
+    lock1 = entity_registry.async_get_or_create("lock", "test", "unique1")
+    assert entry_blocked.entity_id == CLOUD_NEVER_EXPOSED_ENTITIES[0]
+    assert async_should_expose(hass, "cloud.alexa", lock1.entity_id) is True
+
+    # Hidden entity is not exposed
+    lock2 = entity_registry.async_get_or_create(
+        "lock", "test", "unique2", hidden_by=er.RegistryEntryHider.USER
+    )
+    assert entry_blocked.entity_id == CLOUD_NEVER_EXPOSED_ENTITIES[0]
+    assert async_should_expose(hass, "cloud.alexa", lock2.entity_id) is False
+
+    # Entity with category is not exposed
+    lock3 = entity_registry.async_get_or_create(
+        "lock", "test", "unique3", entity_category=EntityCategory.CONFIG
+    )
+    assert entry_blocked.entity_id == CLOUD_NEVER_EXPOSED_ENTITIES[0]
+    assert async_should_expose(hass, "cloud.alexa", lock3.entity_id) is False
+
+    # Binary sensor without device class is not exposed
+    binarysensor1 = entity_registry.async_get_or_create(
+        "binary_sensor", "test", "unique1"
+    )
+    assert entry_blocked.entity_id == CLOUD_NEVER_EXPOSED_ENTITIES[0]
+    assert async_should_expose(hass, "cloud.alexa", binarysensor1.entity_id) is False
+
+    # Binary sensor with certain device class is exposed
+    binarysensor2 = entity_registry.async_get_or_create(
+        "binary_sensor",
+        "test",
+        "unique2",
+        original_device_class="door",
+    )
+    assert entry_blocked.entity_id == CLOUD_NEVER_EXPOSED_ENTITIES[0]
+    assert async_should_expose(hass, "cloud.alexa", binarysensor2.entity_id) is True
+
+    # Sensor without device class is not exposed
+    sensor1 = entity_registry.async_get_or_create("sensor", "test", "unique1")
+    assert entry_blocked.entity_id == CLOUD_NEVER_EXPOSED_ENTITIES[0]
+    assert async_should_expose(hass, "cloud.alexa", sensor1.entity_id) is False
+
+    # Sensor with certain device class is exposed
+    sensor2 = entity_registry.async_get_or_create(
+        "sensor",
+        "test",
+        "unique2",
+        original_device_class="temperature",
+    )
+    assert entry_blocked.entity_id == CLOUD_NEVER_EXPOSED_ENTITIES[0]
+    assert async_should_expose(hass, "cloud.alexa", sensor2.entity_id) is True

--- a/tests/components/homeassistant/test_exposed_entities.py
+++ b/tests/components/homeassistant/test_exposed_entities.py
@@ -4,7 +4,7 @@ import pytest
 from homeassistant.components.homeassistant.exposed_entities import (
     DATA_EXPOSED_ENTITIES,
     ExposedEntities,
-    async_get_exposed_entities,
+    async_get_assistant_settings,
     async_listen_entity_updates,
     async_should_expose,
 )
@@ -244,11 +244,11 @@ async def test_listen_updates(
     assert len(calls) == 2
 
 
-async def test_get_exposed_entities(
+async def test_get_assistant_settings(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
 ) -> None:
-    """Test get exposed entities."""
+    """Test get assistant settings."""
     assert await async_setup_component(hass, "homeassistant", {})
     await hass.async_block_till_done()
 
@@ -256,13 +256,13 @@ async def test_get_exposed_entities(
 
     entry = entity_registry.async_get_or_create("climate", "test", "unique1")
 
-    assert async_get_exposed_entities(hass, "cloud.alexa") == {}
+    assert async_get_assistant_settings(hass, "cloud.alexa") == {}
 
     exposed_entities.async_expose_entity("cloud.alexa", entry.entity_id, True)
-    assert async_get_exposed_entities(hass, "cloud.alexa") == {
+    assert async_get_assistant_settings(hass, "cloud.alexa") == {
         "climate.test_unique1": {"should_expose": True}
     }
-    assert async_get_exposed_entities(hass, "cloud.google_assistant") == {}
+    assert async_get_assistant_settings(hass, "cloud.google_assistant") == {}
 
 
 async def test_should_expose(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Refactor handling of exposed entities for cloud Alexa and Google assistant:
- Add a common helper for controlling exposing entities to voice assistants and use it for Alexa and Google assistant
- Entity settings are now stored in entity registry options instead of in a separate store
- To expose new entities to Alexa, call WS command `homeassistant/expose_new_entities`with `{"assistant":"cloud.alexa", "expose_new": True}` 
- To expose an entity to Alexa, call WS command `homeassistant/expose_entity`with `{"assistant":"cloud.alexa", "entity_id": "blah.blah", "should_expose": True}` 
- Existing cloud Alexa and Google assistant entity settings will be migrated from cloud store to the entity registry


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
