### PR TITLE
Allow passing binary to the WS connection

### DIFF
--- a/homeassistant/components/websocket_api/connection.py
+++ b/homeassistant/components/websocket_api/connection.py
@@ -131,6 +131,7 @@ class ActiveConnection:
             handler(self.hass, self, payload)
         except Exception:  # pylint: disable=broad-except
             self.logger.exception("Error handling binary message")
+            self.binary_handlers[index] = None
 
     @callback
     def async_handle(self, msg: dict[str, Any]) -> None:

--- a/homeassistant/components/websocket_api/http.py
+++ b/homeassistant/components/websocket_api/http.py
@@ -276,7 +276,7 @@ class WebSocketHandler:
                     break
 
                 if msg.type == WSMsgType.BINARY:
-                    if len(msg.data) < 2:
+                    if len(msg.data) < 1:
                         disconnect_warn = "Received invalid binary message."
                         break
                     handler = msg.data[0]

--- a/homeassistant/components/websocket_api/http.py
+++ b/homeassistant/components/websocket_api/http.py
@@ -275,6 +275,14 @@ class WebSocketHandler:
                 if msg.type in (WSMsgType.CLOSE, WSMsgType.CLOSED, WSMsgType.CLOSING):
                     break
 
+                if msg.type == WSMsgType.BINARY:
+                    if len(msg.data) < 2:
+                        disconnect_warn = "Received invalid binary message."
+                        break
+                    handler = msg.data[0]
+                    payload = msg.data[1:]
+                    connection.async_handle_binary(handler, payload)
+
                 if msg.type != WSMsgType.TEXT:
                     disconnect_warn = "Received non-Text message."
                     break

--- a/homeassistant/components/websocket_api/http.py
+++ b/homeassistant/components/websocket_api/http.py
@@ -282,6 +282,7 @@ class WebSocketHandler:
                     handler = msg.data[0]
                     payload = msg.data[1:]
                     connection.async_handle_binary(handler, payload)
+                    continue
 
                 if msg.type != WSMsgType.TEXT:
                     disconnect_warn = "Received non-Text message."

--- a/tests/components/websocket_api/test_http.py
+++ b/tests/components/websocket_api/test_http.py
@@ -213,7 +213,9 @@ async def test_binary_message(
     # Send message to binary
     await websocket_client.send_bytes((4).to_bytes(1, "big") + b"test4")
     await websocket_client.send_bytes((5).to_bytes(1, "big") + b"test5")
+    await websocket_client.send_bytes((10).to_bytes(1, "big") + b"test5")
 
     # Verify received
     assert await binary_payloads[104] == b"test4"
     assert await binary_payloads[105] == b"test5"
+    assert "Received binary message for non-existing handler 10" in caplog.text

--- a/tests/components/websocket_api/test_http.py
+++ b/tests/components/websocket_api/test_http.py
@@ -169,8 +169,8 @@ async def test_binary_message(
 ) -> None:
     """Test binary messages."""
     binary_payloads = {
-        104: asyncio.Future(),
-        105: asyncio.Future(),
+        104: ([], asyncio.Future()),
+        105: ([], asyncio.Future()),
     }
 
     # Register a handler
@@ -190,8 +190,13 @@ async def test_binary_message(
             hass: HomeAssistant, connection: ActiveConnection, payload: bytes
         ):
             nonlocal unsub
-            binary_payloads[msg["id"]].set_result(payload)
-            unsub()
+            if payload:
+                binary_payloads[msg["id"]][0].append(payload)
+            else:
+                binary_payloads[msg["id"]][1].set_result(
+                    b"".join(binary_payloads[msg["id"]][0])
+                )
+                unsub()
 
         prefix, unsub = connection.async_register_binary_handler(binary_message_handler)
 
@@ -212,10 +217,13 @@ async def test_binary_message(
 
     # Send message to binary
     await websocket_client.send_bytes((4).to_bytes(1, "big") + b"test4")
+    await websocket_client.send_bytes((4).to_bytes(1, "big") + b"")
     await websocket_client.send_bytes((5).to_bytes(1, "big") + b"test5")
-    await websocket_client.send_bytes((10).to_bytes(1, "big") + b"test5")
+    await websocket_client.send_bytes((5).to_bytes(1, "big") + b"test5-2")
+    await websocket_client.send_bytes((5).to_bytes(1, "big") + b"")
+    await websocket_client.send_bytes((10).to_bytes(1, "big") + b"test10")
 
     # Verify received
-    assert await binary_payloads[104] == b"test4"
-    assert await binary_payloads[105] == b"test5"
+    assert await binary_payloads[104][1] == b"test4"
+    assert await binary_payloads[105][1] == b"test5test5-2"
     assert "Received binary message for non-existing handler 10" in caplog.text

--- a/tests/components/websocket_api/test_http.py
+++ b/tests/components/websocket_api/test_http.py
@@ -216,14 +216,16 @@ async def test_binary_message(
         assert result["result"]["prefix"] == i - 100
 
     # Send message to binary
+    await websocket_client.send_bytes((0).to_bytes(1, "big") + b"test0")
+    await websocket_client.send_bytes((10).to_bytes(1, "big") + b"test10")
     await websocket_client.send_bytes((4).to_bytes(1, "big") + b"test4")
     await websocket_client.send_bytes((4).to_bytes(1, "big") + b"")
     await websocket_client.send_bytes((5).to_bytes(1, "big") + b"test5")
     await websocket_client.send_bytes((5).to_bytes(1, "big") + b"test5-2")
     await websocket_client.send_bytes((5).to_bytes(1, "big") + b"")
-    await websocket_client.send_bytes((10).to_bytes(1, "big") + b"test10")
 
     # Verify received
     assert await binary_payloads[104][1] == b"test4"
     assert await binary_payloads[105][1] == b"test5test5-2"
+    assert "Received binary message for non-existing handler 0" in caplog.text
     assert "Received binary message for non-existing handler 10" in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Proposal to allow receiving binary data from a client by registering per-connection temporary handlers. Only 255 handlers are supported and need to be actively registered on a connection.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
