### PR TITLE
Fix statistics schema auto repair when there is bad data

### DIFF
--- a/tests/components/recorder/test_statistics.py
+++ b/tests/components/recorder/test_statistics.py
@@ -26,6 +26,7 @@ from homeassistant.components.recorder.statistics import (
     _generate_max_mean_min_statistic_in_sub_period_stmt,
     _generate_statistics_at_time_stmt,
     _generate_statistics_during_period_stmt,
+    _get_future_year,
     _statistics_during_period_with_session,
     async_add_external_statistics,
     async_import_statistics,
@@ -1612,7 +1613,8 @@ async def test_validate_db_schema_fix_float_issue(
     orig_error = MagicMock()
     orig_error.args = [1366]
     precise_number = 1.000000000000001
-    precise_time = datetime(2020, 10, 6, microsecond=1, tzinfo=dt_util.UTC)
+    fixed_future_year = _get_future_year()
+    precise_time = datetime(fixed_future_year, 10, 6, microsecond=1, tzinfo=dt_util.UTC)
     statistics = {
         "recorder.db_test": [
             {
@@ -1632,6 +1634,9 @@ async def test_validate_db_schema_fix_float_issue(
 
     with patch(
         "homeassistant.components.recorder.core.Recorder.dialect_name", db_engine
+    ), patch(
+        "homeassistant.components.recorder.statistics._get_future_year",
+        return_value=fixed_future_year,
     ), patch(
         "homeassistant.components.recorder.statistics._statistics_during_period_with_session",
         side_effect=fake_statistics,


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- If the user had previously duplicated data we could end up picking the next `metadata_id` and there could be stale rows in the database that have that `metadata_id`. This can only happen from bad manual migrations (which is what this is function is validating/repairing in the first place). To solve this we now insert data with a future date and look at the latest inserted row instead of the first.

Example
```
['stored_statistics',
  defaultdict(<class 'list'>,
              {'recorder.db_test_schema': [{'end': 948589200.0,
                                            'last_reset': None,
                                            'max': None,
                                            'mean': 2021.0,
                                            'min': None,
                                            'start': 948585600.0,
                                            'state': None,
                                            'sum': 394.5068},
                                          {'end': 1601946000.000001,
                                            'last_reset': 1601942400.000001,
                                            'max': 1.000000000000001,
                                            'mean': 1.000000000000001,
                                            'min': 1.000000000000001,
                                            'start': 1601942400.000001,
                                            'state': 1.000000000000001,
                                            'sum': 1.000000000000001}]})]
```
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
