### PR TITLE
Fix websocket back pressure bottleneck

### DIFF
--- a/homeassistant/components/websocket_api/http.py
+++ b/homeassistant/components/websocket_api/http.py
@@ -289,7 +289,7 @@ class WebSocketHandler:
             # CPU usage.
             #
             # - Messages latency increases because messages cannot be moved into
-            # the buffer because it is blocked waiting for the drain to happen because
+            # the TCP buffer because it is blocked waiting for the drain to happen because
             # of the low default limit of 16KiB. By increasing the limit, we instead
             # rely on the underlying TCP buffer and stack to deliver the messages which
             # can typically happen much faster.

--- a/homeassistant/components/websocket_api/http.py
+++ b/homeassistant/components/websocket_api/http.py
@@ -282,6 +282,9 @@ class WebSocketHandler:
             # added a way to set the limit but there is no way to actually
             # reach the code to set the limit so we have to set it directly.
             #
+            # We already authenticated so we are less concerned about malicious
+            # clients at this point.
+            #
             wsock._writer._limit = 2**19  # type: ignore[union-attr] # pylint: disable=protected-access
 
             # Command phase

--- a/homeassistant/components/websocket_api/http.py
+++ b/homeassistant/components/websocket_api/http.py
@@ -269,32 +269,41 @@ class WebSocketHandler:
             async_dispatcher_send(self.hass, SIGNAL_WEBSOCKET_CONNECTED)
 
             #
+            #
             # Our websocket implementation is backed by an asyncio.Queue
             #
-            # As back-pressure builds the queue will back up and use more memory
+            # As back-pressure builds, the queue will back up and use more memory
             # until we disconnect the client when the queue size reaches
-            # MAX_PENDING_MSG. When we are generating a high volume of websocket
-            # messages, we hit a bottleneck in aiohttp where it will wait for
+            # MAX_PENDING_MSG. When we are generating a high volume of websocket messages,
+            # we hit a bottleneck in aiohttp where it will wait for
             # the buffer to drain before sending the next message and messages
             # start backing up in the queue.
             #
             # https://github.com/aio-libs/aiohttp/issues/1367 added drains
-            # to the websocket writer to handle malicious clients and
-            # network issues. This causes a problem for us since the buffer
-            # cannot be drained fast enough and we end up disconnecting the
-            # client. The client will than reconnect and the cycle repeats
-            # itself which results in a significant amount of CPU usage.
+            # to the websocket writer to handle malicious clients and network issues.
+            # The drain causes multiple problems for us since the buffer cannot be
+            # drained fast enough when we deliver a high volume or large messages:
+            #
+            # - We end up disconnecting the client. The client will then reconnect,
+            # and the cycle repeats itself, which results in a significant amount of
+            # CPU usage.
+            #
+            # - Messages latency increases because messages cannot be moved into
+            # the buffer because it is blocked waiting for the drain to happen because
+            # of the low default limit of 16KiB. By increasing the limit, we instead
+            # rely on the underlying TCP buffer and stack to deliver the messages which
+            # can typically happen much faster.
             #
             # After the auth phase is completed, and we are not concerned about
-            # the user being a malicious client, we set the limit to 1MiB since
-            # the default limit of 16KiB results in the a bottleneck where
-            # everything that wants to write it blocking on the buffer draining.
+            # the user being a malicious client, we set the limit to force a drain
+            # to 2MiB. 2MiB is the maximum expected size of the serialized entity
+            # registry, which is the largest message we usually send.
             #
             # https://github.com/aio-libs/aiohttp/commit/b3c80ee3f7d5d8f0b8bc27afe52e4d46621eaf99
-            # added a way to set the limit but there is no way to actually
-            # reach the code to set the limit so we have to set it directly.
+            # added a way to set the limit, but there is no way to actually
+            # reach the code to set the limit, so we have to set it directly.
             #
-            wsock._writer._limit = 2**20  # type: ignore[union-attr] # pylint: disable=protected-access
+            wsock._writer._limit = 2 * 2**20  # type: ignore[union-attr] # pylint: disable=protected-access
 
             # Command phase
             while not wsock.closed:

--- a/homeassistant/components/websocket_api/http.py
+++ b/homeassistant/components/websocket_api/http.py
@@ -296,14 +296,14 @@ class WebSocketHandler:
             #
             # After the auth phase is completed, and we are not concerned about
             # the user being a malicious client, we set the limit to force a drain
-            # to 2MiB. 2MiB is the maximum expected size of the serialized entity
+            # to 1MiB. 1MiB is the maximum expected size of the serialized entity
             # registry, which is the largest message we usually send.
             #
             # https://github.com/aio-libs/aiohttp/commit/b3c80ee3f7d5d8f0b8bc27afe52e4d46621eaf99
             # added a way to set the limit, but there is no way to actually
             # reach the code to set the limit, so we have to set it directly.
             #
-            wsock._writer._limit = 2 * 2**20  # type: ignore[union-attr] # pylint: disable=protected-access
+            wsock._writer._limit = 2**20  # type: ignore[union-attr] # pylint: disable=protected-access
 
             # Command phase
             while not wsock.closed:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is yet another redux of `Client unable to keep up with pending messages` with some more insight on how it can happen.

Our websocket implementation is backed by an asyncio.Queue

As back-pressure builds, the queue will back up and use more memory until we disconnect the client when the queue size reaches MAX_PENDING_MSG. When we are generating a high volume of websocket messages, we hit a bottleneck in aiohttp where it will wait for the buffer to drain before sending the next message and messages start backing up in the queue.

https://github.com/aio-libs/aiohttp/issues/1367 added drains to the websocket writer to handle malicious clients and network issues. The drain causes multiple problems for us since the buffer cannot be drained fast enough when we deliver a high volume or large messages:

- We end up disconnecting the client. The client will then reconnect, and the cycle repeats itself, which results in a significant amount of CPU usage.

- Messages latency increases because messages cannot be moved into the TCP buffer because it is blocked waiting for the drain to happen because of the low default limit of 16KiB. By increasing the limit, we instead rely on the underlying TCP buffer and stack to deliver the messages which can typically happen much faster.
 
After the auth phase is completed, and we are not concerned about the user being a malicious client, we set the limit to force a drain to 1MiB. 1MiB is the maximum expected size of the serialized entity registry (for display), which is the largest message we usually send.

https://github.com/aio-libs/aiohttp/commit/b3c80ee3f7d5d8f0b8bc27afe52e4d46621eaf99 added a way to set the limit, but there is no way to actually reach the code to set the limit, so we have to set it directly.

I started looking into this more because of https://github.com/alexarch21/history-explorer-card/issues/156#issuecomment-1475420034 since the results of the websocket having this level of latency where unexpected. In the future we plan on delivering binary data over it as well so any unexpected latency is of great interest in solving.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
