### PR TITLE
Fix cpu thrashing during purge after all legacy events were removed

### DIFF
--- a/homeassistant/components/recorder/core.py
+++ b/homeassistant/components/recorder/core.py
@@ -221,6 +221,7 @@ class Recorder(threading.Thread):
         self.async_migration_event = asyncio.Event()
         self.migration_in_progress = False
         self.migration_is_live = False
+        self.has_legacy_events_index = False
         self._database_lock_task: DatabaseLockTask | None = None
         self._db_executor: DBInterruptibleThreadPoolExecutor | None = None
 
@@ -743,6 +744,7 @@ class Recorder(threading.Thread):
                         session, TABLE_STATES, LEGACY_STATES_EVENT_ID_INDEX
                     ):
                         self.queue_task(EventIdMigrationTask())
+                        self.has_legacy_events_index = True
 
         # We must only set the db ready after we have set the table managers
         # to active if there is no data to migrate.

--- a/homeassistant/components/recorder/core.py
+++ b/homeassistant/components/recorder/core.py
@@ -221,7 +221,7 @@ class Recorder(threading.Thread):
         self.async_migration_event = asyncio.Event()
         self.migration_in_progress = False
         self.migration_is_live = False
-        self.has_legacy_events_index = False
+        self.use_legacy_events_index = False
         self._database_lock_task: DatabaseLockTask | None = None
         self._db_executor: DBInterruptibleThreadPoolExecutor | None = None
 
@@ -744,7 +744,7 @@ class Recorder(threading.Thread):
                         session, TABLE_STATES, LEGACY_STATES_EVENT_ID_INDEX
                     ):
                         self.queue_task(EventIdMigrationTask())
-                        self.has_legacy_events_index = True
+                        self.use_legacy_events_index = True
 
         # We must only set the db ready after we have set the table managers
         # to active if there is no data to migrate.

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -1531,11 +1531,6 @@ def cleanup_legacy_states_event_ids(instance: Recorder) -> bool:
     If all old states have been purged and existing states are in the new
     format we can drop the index since it can take up ~10MB per 1M rows.
     """
-    if instance.dialect_name == SupportedDialect.SQLITE:
-        # SQLite does not support dropping foreign key constraints
-        # so we can't drop the index at this time
-        return True
-
     session_maker = instance.get_session
     _LOGGER.debug("Cleanup legacy entity_ids")
     with session_scope(session=session_maker()) as session:
@@ -1549,11 +1544,15 @@ def cleanup_legacy_states_event_ids(instance: Recorder) -> bool:
         # Only drop the index if there are no more event_ids in the states table
         # ex all NULL
         assert instance.engine is not None, "engine should never be None"
-        _drop_foreign_key_constraints(
-            session_maker, instance.engine, TABLE_STATES, ["event_id"]
-        )
-        _drop_index(session_maker, "states", LEGACY_STATES_EVENT_ID_INDEX)
-        instance.has_legacy_events_index = False
+        if instance.dialect_name != SupportedDialect.SQLITE:
+            # SQLite does not support dropping foreign key constraints
+            # so we can't drop the index at this time but we can avoid
+            # looking for legacy rows during purge
+            _drop_foreign_key_constraints(
+                session_maker, instance.engine, TABLE_STATES, ["event_id"]
+            )
+            _drop_index(session_maker, "states", LEGACY_STATES_EVENT_ID_INDEX)
+        instance.use_legacy_events_index = False
 
     return True
 

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -1531,6 +1531,11 @@ def cleanup_legacy_states_event_ids(instance: Recorder) -> bool:
     If all old states have been purged and existing states are in the new
     format we can drop the index since it can take up ~10MB per 1M rows.
     """
+    if instance.dialect_name == SupportedDialect.SQLITE:
+        # SQLite does not support dropping foreign key constraints
+        # so we can't drop the index at this time
+        return True
+
     session_maker = instance.get_session
     _LOGGER.debug("Cleanup legacy entity_ids")
     with session_scope(session=session_maker()) as session:

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -513,11 +513,7 @@ def _drop_foreign_key_constraints(
     inspector = sqlalchemy.inspect(engine)
     drops = []
     for foreign_key in inspector.get_foreign_keys(table):
-        if (
-            foreign_key["name"]
-            and foreign_key.get("options", {}).get("ondelete")
-            and foreign_key["constrained_columns"] == columns
-        ):
+        if foreign_key["name"] and foreign_key["constrained_columns"] == columns:
             drops.append(ForeignKeyConstraint((), (), name=foreign_key["name"]))
 
     # Bind the ForeignKeyConstraints to the table
@@ -1547,6 +1543,10 @@ def cleanup_legacy_states_event_ids(instance: Recorder) -> bool:
     if all_gone:
         # Only drop the index if there are no more event_ids in the states table
         # ex all NULL
+        assert instance.engine is not None, "engine should never be None"
+        _drop_foreign_key_constraints(
+            session_maker, instance.engine, TABLE_STATES, ["event_id"]
+        )
         _drop_index(session_maker, "states", LEGACY_STATES_EVENT_ID_INDEX)
         instance.has_legacy_events_index = False
 

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -1548,6 +1548,7 @@ def cleanup_legacy_states_event_ids(instance: Recorder) -> bool:
         # Only drop the index if there are no more event_ids in the states table
         # ex all NULL
         _drop_index(session_maker, "states", LEGACY_STATES_EVENT_ID_INDEX)
+        instance.has_legacy_events_index = False
 
     return True
 

--- a/homeassistant/components/recorder/purge.py
+++ b/homeassistant/components/recorder/purge.py
@@ -73,7 +73,7 @@ def purge_old_data(
     with session_scope(session=instance.get_session()) as session:
         # Purge a max of SQLITE_MAX_BIND_VARS, based on the oldest states or events record
         has_more_to_purge = False
-        if instance.has_legacy_events_index and _purging_legacy_format(session):
+        if instance.use_legacy_events_index and _purging_legacy_format(session):
             _LOGGER.debug(
                 "Purge running in legacy format as there are states with event_id"
                 " remaining"
@@ -671,7 +671,7 @@ def _purge_filtered_events(
         "Selected %s event_ids to remove that should be filtered", len(event_ids_set)
     )
     if (
-        instance.has_legacy_events_index
+        instance.use_legacy_events_index
         and (
             states := session.query(States.state_id)
             .filter(States.event_id.in_(event_ids_set))

--- a/homeassistant/components/recorder/purge.py
+++ b/homeassistant/components/recorder/purge.py
@@ -74,7 +74,7 @@ def purge_old_data(
     with session_scope(session=instance.get_session()) as session:
         # Purge a max of SQLITE_MAX_BIND_VARS, based on the oldest states or events record
         has_more_to_purge = False
-        if _purging_legacy_format(session):
+        if instance.has_legacy_events_index and _purging_legacy_format(session):
             _LOGGER.debug(
                 "Purge running in legacy format as there are states with event_id"
                 " remaining"

--- a/homeassistant/components/recorder/purge.py
+++ b/homeassistant/components/recorder/purge.py
@@ -8,7 +8,6 @@ import logging
 import time
 from typing import TYPE_CHECKING
 
-from sqlalchemy.engine.row import Row
 from sqlalchemy.orm.session import Session
 
 import homeassistant.util.dt as dt_util
@@ -671,14 +670,18 @@ def _purge_filtered_events(
     _LOGGER.debug(
         "Selected %s event_ids to remove that should be filtered", len(event_ids_set)
     )
-    states: list[Row[tuple[int]]] = (
-        session.query(States.state_id).filter(States.event_id.in_(event_ids_set)).all()
-    )
-    if states:
+    if (
+        instance.has_legacy_events_index
+        and (
+            states := session.query(States.state_id)
+            .filter(States.event_id.in_(event_ids_set))
+            .all()
+        )
+        and (state_ids := {state.state_id for state in states})
+    ):
         # These are legacy states that are linked to an event that are no longer
         # created but since we did not remove them when we stopped adding new ones
         # we will need to purge them here.
-        state_ids: set[int] = {state.state_id for state in states}
         _purge_state_ids(instance, session, state_ids)
     _purge_event_ids(session, event_ids_set)
     if unused_data_ids_set := _select_unused_event_data_ids(

--- a/tests/components/recorder/test_purge.py
+++ b/tests/components/recorder/test_purge.py
@@ -1728,15 +1728,15 @@ async def test_purge_can_mix_legacy_and_new_format(
     instance = await async_setup_recorder_instance(hass)
     await async_wait_recording_done(hass)
     # New databases are no longer created with the legacy events index
-    assert instance.has_legacy_events_index is False
+    assert instance.use_legacy_events_index is False
 
     def _recreate_legacy_events_index():
         """Recreate the legacy events index since its no longer created on new instances."""
         migration._create_index(instance.get_session, "states", "ix_states_event_id")
-        instance.has_legacy_events_index = True
+        instance.use_legacy_events_index = True
 
     await instance.async_add_executor_job(_recreate_legacy_events_index)
-    assert instance.has_legacy_events_index is True
+    assert instance.use_legacy_events_index is True
 
     utcnow = dt_util.utcnow()
     eleven_days_ago = utcnow - timedelta(days=11)

--- a/tests/components/recorder/test_purge.py
+++ b/tests/components/recorder/test_purge.py
@@ -10,7 +10,7 @@ from sqlalchemy.exc import DatabaseError, OperationalError
 from sqlalchemy.orm.session import Session
 
 from homeassistant.components import recorder
-from homeassistant.components.recorder import Recorder
+from homeassistant.components.recorder import Recorder, migration
 from homeassistant.components.recorder.const import (
     SQLITE_MAX_BIND_VARS,
     SupportedDialect,
@@ -1726,6 +1726,18 @@ async def test_purge_can_mix_legacy_and_new_format(
 ) -> None:
     """Test purging with legacy a new events."""
     instance = await async_setup_recorder_instance(hass)
+    await async_wait_recording_done(hass)
+    # New databases are no longer created with the legacy events index
+    assert instance.has_legacy_events_index is False
+
+    def _recreate_legacy_events_index():
+        """Recreate the legacy events index since its no longer created on new instances."""
+        migration._create_index(instance.get_session, "states", "ix_states_event_id")
+        instance.has_legacy_events_index = True
+
+    await instance.async_add_executor_job(_recreate_legacy_events_index)
+    assert instance.has_legacy_events_index is True
+
     utcnow = dt_util.utcnow()
     eleven_days_ago = utcnow - timedelta(days=11)
     with session_scope(hass=hass) as session:

--- a/tests/components/recorder/test_v32_migration.py
+++ b/tests/components/recorder/test_v32_migration.py
@@ -142,7 +142,7 @@ async def test_migrate_times(
             _get_states_index_names
         )
         states_index_names = {index["name"] for index in states_indexes}
-        assert recorder.get_instance(hass).has_legacy_events_index is True
+        assert recorder.get_instance(hass).use_legacy_events_index is True
 
         await hass.async_stop()
         await hass.async_block_till_done()
@@ -213,9 +213,12 @@ async def test_migrate_times(
     )
     states_index_names = {index["name"] for index in states_indexes}
 
-    # sqlite does not support dropping foreign keys
+    # sqlite does not support dropping foreign keys so the
+    # ix_states_event_id index is not dropped in this case
+    # but use_legacy_events_index is still False
     assert "ix_states_event_id" in states_index_names
-    assert recorder.get_instance(hass).has_legacy_events_index is True
+
+    assert recorder.get_instance(hass).use_legacy_events_index is False
 
     await hass.async_stop()
     dt_util.DEFAULT_TIME_ZONE = ORIG_TZ

--- a/tests/components/recorder/test_v32_migration.py
+++ b/tests/components/recorder/test_v32_migration.py
@@ -142,6 +142,7 @@ async def test_migrate_times(
             _get_states_index_names
         )
         states_index_names = {index["name"] for index in states_indexes}
+        assert recorder.get_instance(hass).has_legacy_events_index is True
 
         await hass.async_stop()
         await hass.async_block_till_done()
@@ -213,6 +214,7 @@ async def test_migrate_times(
     states_index_names = {index["name"] for index in states_indexes}
 
     assert "ix_states_event_id" not in states_index_names
+    assert recorder.get_instance(hass).has_legacy_events_index is False
 
     await hass.async_stop()
     dt_util.DEFAULT_TIME_ZONE = ORIG_TZ

--- a/tests/components/recorder/test_v32_migration.py
+++ b/tests/components/recorder/test_v32_migration.py
@@ -213,8 +213,9 @@ async def test_migrate_times(
     )
     states_index_names = {index["name"] for index in states_indexes}
 
-    assert "ix_states_event_id" not in states_index_names
-    assert recorder.get_instance(hass).has_legacy_events_index is False
+    # sqlite does not support dropping foreign keys
+    assert "ix_states_event_id" in states_index_names
+    assert recorder.get_instance(hass).has_legacy_events_index is True
 
     await hass.async_stop()
     dt_util.DEFAULT_TIME_ZONE = ORIG_TZ


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
We now remove the the index of of event ids on the states table when its all NULLs to save space via #89901. The purge path needs to avoid checking for legacy rows to purge if the index has been removed since it will result in a full table scan each purge cycle that will always find no legacy rows to purge. Additionally we need to skip removing the index on sqlite since we cannot drop the foreign keys as sqlite does not support this.

This regressed yesterday in #89901 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
