### PR TITLE
Bump bluetooth deps for bleak 0.20

### DIFF
--- a/homeassistant/components/bluetooth/base_scanner.py
+++ b/homeassistant/components/bluetooth/base_scanner.py
@@ -339,7 +339,7 @@ class BaseHaRemoteScanner(BaseHaScanner):
             tx_power=NO_RSSI_VALUE if tx_power is None else tx_power,
             platform_data=(),
         )
-        device = BLEDevice(  # type: ignore[no-untyped-call]
+        device = BLEDevice(
             address=address,
             name=local_name,
             details=self._details | details,

--- a/homeassistant/components/bluetooth/base_scanner.py
+++ b/homeassistant/components/bluetooth/base_scanner.py
@@ -165,13 +165,13 @@ class BaseHaScanner(ABC):
             "monotonic_time": MONOTONIC_TIME(),
             "discovered_devices_and_advertisement_data": [
                 {
-                    "name": device_adv[0].name,
-                    "address": device_adv[0].address,
-                    "rssi": device_adv[0].rssi,
-                    "advertisement_data": device_adv[1],
-                    "details": device_adv[0].details,
+                    "name": device.name,
+                    "address": device.address,
+                    "rssi": advertisement_data.rssi,
+                    "advertisement_data": advertisement_data,
+                    "details": device.details,
                 }
-                for device_adv in device_adv_datas
+                for device, advertisement_data in device_adv_datas
             ],
         }
 

--- a/homeassistant/components/bluetooth/manifest.json
+++ b/homeassistant/components/bluetooth/manifest.json
@@ -17,7 +17,7 @@
   "requirements": [
     "bleak==0.20.0",
     "bleak-retry-connector==3.0.1",
-    "bluetooth-adapters==0.15.2",
+    "bluetooth-adapters==0.15.3",
     "bluetooth-auto-recovery==1.0.3",
     "bluetooth-data-tools==0.3.1",
     "dbus-fast==1.84.2"

--- a/homeassistant/components/bluetooth/manifest.json
+++ b/homeassistant/components/bluetooth/manifest.json
@@ -15,11 +15,11 @@
   ],
   "quality_scale": "internal",
   "requirements": [
-    "bleak==0.19.5",
+    "bleak==0.20.0",
     "bleak-retry-connector==2.13.0",
     "bluetooth-adapters==0.15.2",
     "bluetooth-auto-recovery==1.0.3",
     "bluetooth-data-tools==0.3.1",
-    "dbus-fast==1.84.1"
+    "dbus-fast==1.84.2"
   ]
 }

--- a/homeassistant/components/bluetooth/manifest.json
+++ b/homeassistant/components/bluetooth/manifest.json
@@ -16,7 +16,7 @@
   "quality_scale": "internal",
   "requirements": [
     "bleak==0.20.0",
-    "bleak-retry-connector==2.13.0",
+    "bleak-retry-connector==3.0.1",
     "bluetooth-adapters==0.15.2",
     "bluetooth-auto-recovery==1.0.3",
     "bluetooth-data-tools==0.3.1",

--- a/homeassistant/components/esphome/bluetooth/client.py
+++ b/homeassistant/components/esphome/bluetooth/client.py
@@ -223,7 +223,7 @@ class ESPHomeClient(BaseBleakClient):
     def _async_call_bleak_disconnected_callback(self) -> None:
         """Call the disconnected callback to inform the bleak consumer."""
         if self._disconnected_callback:
-            self._disconnected_callback(self)
+            self._disconnected_callback()
             self._disconnected_callback = None
 
     @api_error_as_bleak_error
@@ -499,8 +499,10 @@ class ESPHomeClient(BaseBleakClient):
         self, char_specifier: BleakGATTCharacteristic | int | str | uuid.UUID
     ) -> BleakGATTCharacteristic:
         """Resolve a characteristic specifier to a BleakGATTCharacteristic object."""
+        if (services := self.services) is None:
+            raise BleakError("Services have not been resolved")
         if not isinstance(char_specifier, BleakGATTCharacteristic):
-            characteristic = self.services.get_characteristic(char_specifier)
+            characteristic = services.get_characteristic(char_specifier)
         else:
             characteristic = char_specifier
         if not characteristic:

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -11,14 +11,14 @@ attrs==22.2.0
 awesomeversion==22.9.0
 bcrypt==4.0.1
 bleak-retry-connector==2.13.0
-bleak==0.19.5
+bleak==0.20.0
 bluetooth-adapters==0.15.2
 bluetooth-auto-recovery==1.0.3
 bluetooth-data-tools==0.3.1
 certifi>=2021.5.30
 ciso8601==2.3.0
 cryptography==39.0.1
-dbus-fast==1.84.1
+dbus-fast==1.84.2
 fnvhash==0.1.0
 hass-nabucasa==0.61.1
 hassil==1.0.6

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -12,7 +12,7 @@ awesomeversion==22.9.0
 bcrypt==4.0.1
 bleak-retry-connector==3.0.1
 bleak==0.20.0
-bluetooth-adapters==0.15.2
+bluetooth-adapters==0.15.3
 bluetooth-auto-recovery==1.0.3
 bluetooth-data-tools==0.3.1
 certifi>=2021.5.30

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -10,7 +10,7 @@ atomicwrites-homeassistant==1.4.1
 attrs==22.2.0
 awesomeversion==22.9.0
 bcrypt==4.0.1
-bleak-retry-connector==2.13.0
+bleak-retry-connector==3.0.1
 bleak==0.20.0
 bluetooth-adapters==0.15.2
 bluetooth-auto-recovery==1.0.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -434,7 +434,7 @@ bizkaibus==0.1.1
 bleak-retry-connector==2.13.0
 
 # homeassistant.components.bluetooth
-bleak==0.19.5
+bleak==0.20.0
 
 # homeassistant.components.blebox
 blebox_uniapi==2.1.4
@@ -563,7 +563,7 @@ datadog==0.15.0
 datapoint==0.9.8
 
 # homeassistant.components.bluetooth
-dbus-fast==1.84.1
+dbus-fast==1.84.2
 
 # homeassistant.components.debugpy
 debugpy==1.6.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -456,7 +456,7 @@ bluemaestro-ble==0.2.3
 # bluepy==1.3.0
 
 # homeassistant.components.bluetooth
-bluetooth-adapters==0.15.2
+bluetooth-adapters==0.15.3
 
 # homeassistant.components.bluetooth
 bluetooth-auto-recovery==1.0.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -431,7 +431,7 @@ bimmer_connected==0.12.1
 bizkaibus==0.1.1
 
 # homeassistant.components.bluetooth
-bleak-retry-connector==2.13.0
+bleak-retry-connector==3.0.1
 
 # homeassistant.components.bluetooth
 bleak==0.20.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -364,7 +364,7 @@ bimmer_connected==0.12.1
 bleak-retry-connector==2.13.0
 
 # homeassistant.components.bluetooth
-bleak==0.19.5
+bleak==0.20.0
 
 # homeassistant.components.blebox
 blebox_uniapi==2.1.4
@@ -449,7 +449,7 @@ datadog==0.15.0
 datapoint==0.9.8
 
 # homeassistant.components.bluetooth
-dbus-fast==1.84.1
+dbus-fast==1.84.2
 
 # homeassistant.components.debugpy
 debugpy==1.6.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -361,7 +361,7 @@ bellows==0.34.10
 bimmer_connected==0.12.1
 
 # homeassistant.components.bluetooth
-bleak-retry-connector==2.13.0
+bleak-retry-connector==3.0.1
 
 # homeassistant.components.bluetooth
 bleak==0.20.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -376,7 +376,7 @@ blinkpy==0.19.2
 bluemaestro-ble==0.2.3
 
 # homeassistant.components.bluetooth
-bluetooth-adapters==0.15.2
+bluetooth-adapters==0.15.3
 
 # homeassistant.components.bluetooth
 bluetooth-auto-recovery==1.0.3

--- a/tests/components/airthings_ble/__init__.py
+++ b/tests/components/airthings_ble/__init__.py
@@ -4,11 +4,10 @@ from __future__ import annotations
 from unittest.mock import patch
 
 from airthings_ble import AirthingsBluetoothDeviceData, AirthingsDevice
-from bleak.backends.device import BLEDevice
 
 from homeassistant.components.bluetooth.models import BluetoothServiceInfoBleak
 
-from tests.components.bluetooth import generate_advertisement_data
+from tests.components.bluetooth import generate_advertisement_data, generate_ble_device
 
 
 def patch_async_setup_entry(return_value=True):
@@ -45,7 +44,7 @@ WAVE_SERVICE_INFO = BluetoothServiceInfoBleak(
     service_data={},
     service_uuids=["b42e1c08-ade7-11e4-89d3-123b93f75cba"],
     source="local",
-    device=BLEDevice(
+    device=generate_ble_device(
         "cc:cc:cc:cc:cc:cc",
         "cc-cc-cc-cc-cc-cc",
     ),
@@ -65,7 +64,7 @@ UNKNOWN_SERVICE_INFO = BluetoothServiceInfoBleak(
     service_data={},
     service_uuids=[],
     source="local",
-    device=BLEDevice(
+    device=generate_ble_device(
         "cc:cc:cc:cc:cc:cc",
         "unknown",
     ),

--- a/tests/components/aranet/__init__.py
+++ b/tests/components/aranet/__init__.py
@@ -2,10 +2,11 @@
 
 from time import time
 
-from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import AdvertisementData
 
 from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
+
+from tests.components.bluetooth import generate_ble_device
 
 
 def fake_service_info(name, service_uuid, manufacturer_data):
@@ -20,7 +21,7 @@ def fake_service_info(name, service_uuid, manufacturer_data):
         source="local",
         connectable=False,
         time=time(),
-        device=BLEDevice("aa:bb:cc:dd:ee:ff", name=name),
+        device=generate_ble_device("aa:bb:cc:dd:ee:ff", name=name),
         advertisement=AdvertisementData(
             local_name=name,
             manufacturer_data=manufacturer_data,

--- a/tests/components/bluetooth/__init__.py
+++ b/tests/components/bluetooth/__init__.py
@@ -33,6 +33,7 @@ __all__ = (
     "patch_all_discovered_devices",
     "patch_discovered_devices",
     "generate_advertisement_data",
+    "generate_ble_device",
     "MockBleakClient",
 )
 
@@ -46,6 +47,12 @@ ADVERTISEMENT_DATA_DEFAULTS = {
     "tx_power": -127,
 }
 
+BLE_DEVICE_DEFAULTS = {
+    "name": "",
+    "rssi": -127,
+    "details": (),
+}
+
 
 def generate_advertisement_data(**kwargs: Any) -> AdvertisementData:
     """Generate advertisement data with defaults."""
@@ -53,6 +60,14 @@ def generate_advertisement_data(**kwargs: Any) -> AdvertisementData:
     for key, value in ADVERTISEMENT_DATA_DEFAULTS.items():
         new.setdefault(key, value)
     return AdvertisementData(**new)
+
+
+def generate_ble_device(**kwargs: Any) -> BLEDevice:
+    """Generate a BLEDevice with defaults."""
+    new = kwargs.copy()
+    for key, value in BLE_DEVICE_DEFAULTS.items():
+        new.setdefault(key, value)
+    return BLEDevice(**new)
 
 
 def _get_manager() -> BluetoothManager:
@@ -126,7 +141,7 @@ def inject_bluetooth_service_info_bleak(
         service_uuids=info.service_uuids,
         rssi=info.rssi,
     )
-    device = BLEDevice(  # type: ignore[no-untyped-call]
+    device = generate_ble_device(  # type: ignore[no-untyped-call]
         address=info.address,
         name=info.name,
         details={},
@@ -152,7 +167,7 @@ def inject_bluetooth_service_info(
         service_uuids=info.service_uuids,
         rssi=info.rssi,
     )
-    device = BLEDevice(  # type: ignore[no-untyped-call]
+    device = generate_ble_device(  # type: ignore[no-untyped-call]
         address=info.address,
         name=info.name,
         details={},

--- a/tests/components/bluetooth/__init__.py
+++ b/tests/components/bluetooth/__init__.py
@@ -48,7 +48,7 @@ ADVERTISEMENT_DATA_DEFAULTS = {
 }
 
 BLE_DEVICE_DEFAULTS = {
-    "name": "",
+    "name": None,
     "rssi": -127,
     "details": None,
 }

--- a/tests/components/bluetooth/__init__.py
+++ b/tests/components/bluetooth/__init__.py
@@ -62,9 +62,23 @@ def generate_advertisement_data(**kwargs: Any) -> AdvertisementData:
     return AdvertisementData(**new)
 
 
-def generate_ble_device(**kwargs: Any) -> BLEDevice:
+def generate_ble_device(
+    address: str | None = None,
+    name: str | None = None,
+    details: Any | None = None,
+    rssi: int | None = None,
+    **kwargs: Any,
+) -> BLEDevice:
     """Generate a BLEDevice with defaults."""
     new = kwargs.copy()
+    if address is not None:
+        new["address"] = address
+    if name is not None:
+        new["name"] = name
+    if details is not None:
+        new["details"] = details
+    if rssi is not None:
+        new["rssi"] = rssi
     for key, value in BLE_DEVICE_DEFAULTS.items():
         new.setdefault(key, value)
     return BLEDevice(**new)

--- a/tests/components/bluetooth/__init__.py
+++ b/tests/components/bluetooth/__init__.py
@@ -50,7 +50,7 @@ ADVERTISEMENT_DATA_DEFAULTS = {
 BLE_DEVICE_DEFAULTS = {
     "name": "",
     "rssi": -127,
-    "details": (),
+    "details": None,
 }
 
 

--- a/tests/components/bluetooth/test_advertisement_tracker.py
+++ b/tests/components/bluetooth/test_advertisement_tracker.py
@@ -3,7 +3,6 @@ from datetime import timedelta
 import time
 from unittest.mock import patch
 
-from bleak.backends.scanner import BLEDevice
 import pytest
 
 from homeassistant.components.bluetooth import (
@@ -24,6 +23,7 @@ from homeassistant.util import dt as dt_util
 from . import (
     FakeScanner,
     generate_advertisement_data,
+    generate_ble_device,
     inject_advertisement_with_time_and_source,
     inject_advertisement_with_time_and_source_connectable,
 )
@@ -41,7 +41,7 @@ async def test_advertisment_interval_shorter_than_adapter_stack_timeout(
 ) -> None:
     """Test we can determine the advertisement interval."""
     start_monotonic_time = time.monotonic()
-    switchbot_device = BLEDevice("44:44:33:11:23:12", "wohand")
+    switchbot_device = generate_ble_device("44:44:33:11:23:12", "wohand")
     switchbot_adv = generate_advertisement_data(
         local_name="wohand", service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"]
     )
@@ -88,7 +88,7 @@ async def test_advertisment_interval_longer_than_adapter_stack_timeout_connectab
 ) -> None:
     """Test device with a long advertisement interval."""
     start_monotonic_time = time.monotonic()
-    switchbot_device = BLEDevice("44:44:33:11:23:18", "wohand")
+    switchbot_device = generate_ble_device("44:44:33:11:23:18", "wohand")
     switchbot_adv = generate_advertisement_data(
         local_name="wohand", service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"]
     )
@@ -137,7 +137,7 @@ async def test_advertisment_interval_longer_than_adapter_stack_timeout_adapter_c
 ) -> None:
     """Test device with a long advertisement interval with an adapter change."""
     start_monotonic_time = time.monotonic()
-    switchbot_device = BLEDevice("44:44:33:11:23:45", "wohand")
+    switchbot_device = generate_ble_device("44:44:33:11:23:45", "wohand")
     switchbot_adv = generate_advertisement_data(
         local_name="wohand", service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"]
     )
@@ -195,7 +195,7 @@ async def test_advertisment_interval_longer_than_adapter_stack_timeout_not_conne
 ) -> None:
     """Test device with a long advertisement interval that is not connectable not reaching the advertising interval."""
     start_monotonic_time = time.monotonic()
-    switchbot_device = BLEDevice("44:44:33:11:23:45", "wohand")
+    switchbot_device = generate_ble_device("44:44:33:11:23:45", "wohand")
     switchbot_adv = generate_advertisement_data(
         local_name="wohand", service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"]
     )
@@ -247,7 +247,7 @@ async def test_advertisment_interval_shorter_than_adapter_stack_timeout_adapter_
 ) -> None:
     """Test device with a short advertisement interval with an adapter change that is not connectable."""
     start_monotonic_time = time.monotonic()
-    switchbot_device = BLEDevice("44:44:33:11:23:5C", "wohand")
+    switchbot_device = generate_ble_device("44:44:33:11:23:5C", "wohand")
     switchbot_adv = generate_advertisement_data(
         local_name="wohand",
         service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
@@ -315,7 +315,7 @@ async def test_advertisment_interval_longer_than_adapter_stack_timeout_adapter_c
 ) -> None:
     """Test device with a long advertisement interval with an adapter change that is not connectable."""
     start_monotonic_time = time.monotonic()
-    switchbot_device = BLEDevice("44:44:33:11:23:45", "wohand")
+    switchbot_device = generate_ble_device("44:44:33:11:23:45", "wohand")
     switchbot_adv = generate_advertisement_data(
         local_name="wohand",
         service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
@@ -416,7 +416,7 @@ async def test_advertisment_interval_longer_increasing_than_adapter_stack_timeou
 ) -> None:
     """Test device with a increasing advertisement interval with an adapter change that is not connectable."""
     start_monotonic_time = time.monotonic()
-    switchbot_device = BLEDevice("44:44:33:11:23:45", "wohand")
+    switchbot_device = generate_ble_device("44:44:33:11:23:45", "wohand")
     switchbot_adv = generate_advertisement_data(
         local_name="wohand", service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"]
     )

--- a/tests/components/bluetooth/test_api.py
+++ b/tests/components/bluetooth/test_api.py
@@ -8,11 +8,16 @@ from homeassistant.components.bluetooth import (
     HaBluetoothConnector,
     async_scanner_by_source,
     async_scanner_devices_by_address,
-    generate_ble_device,
 )
 from homeassistant.core import HomeAssistant
 
-from . import FakeScanner, MockBleakClient, _get_manager, generate_advertisement_data
+from . import (
+    FakeScanner,
+    MockBleakClient,
+    _get_manager,
+    generate_advertisement_data,
+    generate_ble_device,
+)
 
 
 async def test_scanner_by_source(hass: HomeAssistant, enable_bluetooth: None) -> None:

--- a/tests/components/bluetooth/test_api.py
+++ b/tests/components/bluetooth/test_api.py
@@ -8,6 +8,7 @@ from homeassistant.components.bluetooth import (
     HaBluetoothConnector,
     async_scanner_by_source,
     async_scanner_devices_by_address,
+    generate_ble_device,
 )
 from homeassistant.core import HomeAssistant
 
@@ -56,7 +57,7 @@ async def test_async_scanner_devices_by_address_connectable(
     )
     unsetup = scanner.async_setup()
     cancel = manager.async_register_scanner(scanner, True)
-    switchbot_device = BLEDevice(
+    switchbot_device = generate_ble_device(
         "44:44:33:11:23:45",
         "wohand",
         {},
@@ -89,7 +90,7 @@ async def test_async_scanner_devices_by_address_non_connectable(
 ) -> None:
     """Test getting scanner devices by address with non-connectable devices."""
     manager = _get_manager()
-    switchbot_device = BLEDevice(
+    switchbot_device = generate_ble_device(
         "44:44:33:11:23:45",
         "wohand",
         {},

--- a/tests/components/bluetooth/test_base_scanner.py
+++ b/tests/components/bluetooth/test_base_scanner.py
@@ -29,7 +29,12 @@ from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 from homeassistant.util.json import json_loads
 
-from . import MockBleakClient, _get_manager, generate_advertisement_data
+from . import (
+    MockBleakClient,
+    _get_manager,
+    generate_advertisement_data,
+    generate_ble_device,
+)
 
 from tests.common import async_fire_time_changed, load_fixture
 
@@ -38,7 +43,7 @@ async def test_remote_scanner(hass: HomeAssistant, enable_bluetooth: None) -> No
     """Test the remote scanner base class merges advertisement_data."""
     manager = _get_manager()
 
-    switchbot_device = BLEDevice(
+    switchbot_device = generate_ble_device(
         "44:44:33:11:23:45",
         "wohand",
         {},
@@ -51,7 +56,7 @@ async def test_remote_scanner(hass: HomeAssistant, enable_bluetooth: None) -> No
         manufacturer_data={1: b"\x01"},
         rssi=-100,
     )
-    switchbot_device_2 = BLEDevice(
+    switchbot_device_2 = generate_ble_device(
         "44:44:33:11:23:45",
         "w",
         {},
@@ -126,7 +131,7 @@ async def test_remote_scanner_expires_connectable(
     """Test the remote scanner expires stale connectable data."""
     manager = _get_manager()
 
-    switchbot_device = BLEDevice(
+    switchbot_device = generate_ble_device(
         "44:44:33:11:23:45",
         "wohand",
         {},
@@ -200,7 +205,7 @@ async def test_remote_scanner_expires_non_connectable(
     """Test the remote scanner expires stale non connectable data."""
     manager = _get_manager()
 
-    switchbot_device = BLEDevice(
+    switchbot_device = generate_ble_device(
         "44:44:33:11:23:45",
         "wohand",
         {},
@@ -297,7 +302,7 @@ async def test_base_scanner_connecting_behavior(
     """Test that the default behavior is to mark the scanner as not scanning when connecting."""
     manager = _get_manager()
 
-    switchbot_device = BLEDevice(
+    switchbot_device = generate_ble_device(
         "44:44:33:11:23:45",
         "wohand",
         {},
@@ -420,7 +425,7 @@ async def test_device_with_ten_minute_advertising_interval(
     """Test a device with a 10 minute advertising interval."""
     manager = _get_manager()
 
-    bparasite_device = BLEDevice(
+    bparasite_device = generate_ble_device(
         "44:44:33:11:23:45",
         "bparasite",
         {},

--- a/tests/components/bluetooth/test_diagnostics.py
+++ b/tests/components/bluetooth/test_diagnostics.py
@@ -341,7 +341,7 @@ async def test_diagnostics_macos(
                         ],
                         "device": {
                             "__type": "<class 'bleak.backends.device.BLEDevice'>",
-                            "repr": "generate_ble_device(44:44:33:11:23:45, wohand)",
+                            "repr": "BLEDevice(44:44:33:11:23:45, wohand)",
                         },
                         "connectable": True,
                         "manufacturer_data": {
@@ -369,7 +369,7 @@ async def test_diagnostics_macos(
                         ],
                         "device": {
                             "__type": "<class 'bleak.backends.device.BLEDevice'>",
-                            "repr": "generate_ble_device(44:44:33:11:23:45, wohand)",
+                            "repr": "BLEDevice(44:44:33:11:23:45, wohand)",
                         },
                         "connectable": True,
                         "manufacturer_data": {
@@ -533,7 +533,7 @@ async def test_diagnostics_remote_adapter(
                         "connectable": False,
                         "device": {
                             "__type": "<class 'bleak.backends.device.BLEDevice'>",
-                            "repr": "generate_ble_device(44:44:33:11:23:45, wohand)",
+                            "repr": "BLEDevice(44:44:33:11:23:45, wohand)",
                         },
                         "manufacturer_data": {
                             "1": {"__type": "<class 'bytes'>", "repr": "b'\\x01'"}
@@ -561,7 +561,7 @@ async def test_diagnostics_remote_adapter(
                         "connectable": True,
                         "device": {
                             "__type": "<class 'bleak.backends.device.BLEDevice'>",
-                            "repr": "generate_ble_device(44:44:33:11:23:45, wohand)",
+                            "repr": "BLEDevice(44:44:33:11:23:45, wohand)",
                         },
                         "manufacturer_data": {
                             "1": {"__type": "<class 'bytes'>", "repr": "b'\\x01'"}

--- a/tests/components/bluetooth/test_diagnostics.py
+++ b/tests/components/bluetooth/test_diagnostics.py
@@ -38,7 +38,7 @@ async def test_diagnostics(
         "homeassistant.components.bluetooth.scanner.HaScanner.discovered_devices_and_advertisement_data",
         {
             "44:44:33:11:23:45": (
-                generate_ble_device(name="x", rssi=-60, address="44:44:33:11:23:45"),
+                generate_ble_device(name="x", rssi=-127, address="44:44:33:11:23:45"),
                 generate_advertisement_data(local_name="x"),
             )
         },
@@ -175,7 +175,7 @@ async def test_diagnostics(
                                 ],
                                 "details": None,
                                 "name": "x",
-                                "rssi": -60,
+                                "rssi": -127,
                             }
                         ],
                         "last_detection": ANY,
@@ -202,7 +202,7 @@ async def test_diagnostics(
                                 ],
                                 "details": None,
                                 "name": "x",
-                                "rssi": -60,
+                                "rssi": -127,
                             }
                         ],
                         "last_detection": ANY,
@@ -229,7 +229,7 @@ async def test_diagnostics(
                                 ],
                                 "details": None,
                                 "name": "x",
-                                "rssi": -60,
+                                "rssi": -127,
                             }
                         ],
                         "last_detection": ANY,
@@ -267,7 +267,7 @@ async def test_diagnostics_macos(
         "homeassistant.components.bluetooth.scanner.HaScanner.discovered_devices_and_advertisement_data",
         {
             "44:44:33:11:23:45": (
-                generate_ble_device(name="x", rssi=-60, address="44:44:33:11:23:45"),
+                generate_ble_device(name="x", rssi=-127, address="44:44:33:11:23:45"),
                 switchbot_adv,
             )
         },
@@ -405,7 +405,7 @@ async def test_diagnostics_macos(
                                 ],
                                 "details": None,
                                 "name": "x",
-                                "rssi": -60,
+                                "rssi": -127,
                             }
                         ],
                         "last_detection": ANY,

--- a/tests/components/bluetooth/test_diagnostics.py
+++ b/tests/components/bluetooth/test_diagnostics.py
@@ -12,6 +12,7 @@ from . import (
     MockBleakClient,
     _get_manager,
     generate_advertisement_data,
+    generate_ble_device,
     inject_advertisement,
 )
 
@@ -37,7 +38,7 @@ async def test_diagnostics(
         "homeassistant.components.bluetooth.scanner.HaScanner.discovered_devices_and_advertisement_data",
         {
             "44:44:33:11:23:45": (
-                BLEDevice(name="x", rssi=-60, address="44:44:33:11:23:45"),
+                generate_ble_device(name="x", rssi=-60, address="44:44:33:11:23:45"),
                 generate_advertisement_data(local_name="x"),
             )
         },
@@ -257,7 +258,7 @@ async def test_diagnostics_macos(
     # because we cannot import the scanner class directly without it throwing an
     # error if the test is not running on linux since we won't have the correct
     # deps installed when testing on MacOS.
-    switchbot_device = BLEDevice("44:44:33:11:23:45", "wohand")
+    switchbot_device = generate_ble_device("44:44:33:11:23:45", "wohand")
     switchbot_adv = generate_advertisement_data(
         local_name="wohand", service_uuids=[], manufacturer_data={1: b"\x01"}
     )
@@ -266,7 +267,7 @@ async def test_diagnostics_macos(
         "homeassistant.components.bluetooth.scanner.HaScanner.discovered_devices_and_advertisement_data",
         {
             "44:44:33:11:23:45": (
-                BLEDevice(name="x", rssi=-60, address="44:44:33:11:23:45"),
+                generate_ble_device(name="x", rssi=-60, address="44:44:33:11:23:45"),
                 switchbot_adv,
             )
         },
@@ -340,7 +341,7 @@ async def test_diagnostics_macos(
                         ],
                         "device": {
                             "__type": "<class 'bleak.backends.device.BLEDevice'>",
-                            "repr": "BLEDevice(44:44:33:11:23:45, wohand)",
+                            "repr": "generate_ble_device(44:44:33:11:23:45, wohand)",
                         },
                         "connectable": True,
                         "manufacturer_data": {
@@ -368,7 +369,7 @@ async def test_diagnostics_macos(
                         ],
                         "device": {
                             "__type": "<class 'bleak.backends.device.BLEDevice'>",
-                            "repr": "BLEDevice(44:44:33:11:23:45, wohand)",
+                            "repr": "generate_ble_device(44:44:33:11:23:45, wohand)",
                         },
                         "connectable": True,
                         "manufacturer_data": {
@@ -430,7 +431,7 @@ async def test_diagnostics_remote_adapter(
 ) -> None:
     """Test diagnostics for remote adapter."""
     manager = _get_manager()
-    switchbot_device = BLEDevice("44:44:33:11:23:45", "wohand")
+    switchbot_device = generate_ble_device("44:44:33:11:23:45", "wohand")
     switchbot_adv = generate_advertisement_data(
         local_name="wohand", service_uuids=[], manufacturer_data={1: b"\x01"}
     )
@@ -532,7 +533,7 @@ async def test_diagnostics_remote_adapter(
                         "connectable": False,
                         "device": {
                             "__type": "<class 'bleak.backends.device.BLEDevice'>",
-                            "repr": "BLEDevice(44:44:33:11:23:45, wohand)",
+                            "repr": "generate_ble_device(44:44:33:11:23:45, wohand)",
                         },
                         "manufacturer_data": {
                             "1": {"__type": "<class 'bytes'>", "repr": "b'\\x01'"}
@@ -560,7 +561,7 @@ async def test_diagnostics_remote_adapter(
                         "connectable": True,
                         "device": {
                             "__type": "<class 'bleak.backends.device.BLEDevice'>",
-                            "repr": "BLEDevice(44:44:33:11:23:45, wohand)",
+                            "repr": "generate_ble_device(44:44:33:11:23:45, wohand)",
                         },
                         "manufacturer_data": {
                             "1": {"__type": "<class 'bytes'>", "repr": "b'\\x01'"}

--- a/tests/components/bluetooth/test_init.py
+++ b/tests/components/bluetooth/test_init.py
@@ -49,6 +49,7 @@ from . import (
     _get_manager,
     async_setup_with_default_adapter,
     generate_advertisement_data,
+    generate_ble_device,
     inject_advertisement,
     inject_advertisement_with_time_and_source_connectable,
     patch_discovered_devices,
@@ -354,7 +355,7 @@ async def test_discovery_match_by_service_uuid(
 
         assert len(mock_bleak_scanner_start.mock_calls) == 1
 
-        wrong_device = BLEDevice("44:44:33:11:23:45", "wrong_name")
+        wrong_device = generate_ble_device("44:44:33:11:23:45", "wrong_name")
         wrong_adv = generate_advertisement_data(
             local_name="wrong_name", service_uuids=[]
         )
@@ -364,7 +365,7 @@ async def test_discovery_match_by_service_uuid(
 
         assert len(mock_config_flow.mock_calls) == 0
 
-        switchbot_device = BLEDevice("44:44:33:11:23:45", "wohand")
+        switchbot_device = generate_ble_device("44:44:33:11:23:45", "wohand")
         switchbot_adv = generate_advertisement_data(
             local_name="wohand", service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"]
         )
@@ -401,7 +402,7 @@ async def test_discovery_match_by_service_uuid_connectable(
 
         assert len(mock_bleak_scanner_start.mock_calls) == 1
 
-        wrong_device = BLEDevice("44:44:33:11:23:45", "wrong_name")
+        wrong_device = generate_ble_device("44:44:33:11:23:45", "wrong_name")
         wrong_adv = generate_advertisement_data(
             local_name="wrong_name", service_uuids=[]
         )
@@ -413,7 +414,7 @@ async def test_discovery_match_by_service_uuid_connectable(
 
         assert len(_domains_from_mock_config_flow(mock_config_flow)) == 0
 
-        switchbot_device = BLEDevice("44:44:33:11:23:45", "wohand")
+        switchbot_device = generate_ble_device("44:44:33:11:23:45", "wohand")
         switchbot_adv = generate_advertisement_data(
             local_name="wohand", service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"]
         )
@@ -448,7 +449,7 @@ async def test_discovery_match_by_service_uuid_not_connectable(
 
         assert len(mock_bleak_scanner_start.mock_calls) == 1
 
-        wrong_device = BLEDevice("44:44:33:11:23:45", "wrong_name")
+        wrong_device = generate_ble_device("44:44:33:11:23:45", "wrong_name")
         wrong_adv = generate_advertisement_data(
             local_name="wrong_name", service_uuids=[]
         )
@@ -460,7 +461,7 @@ async def test_discovery_match_by_service_uuid_not_connectable(
 
         assert len(_domains_from_mock_config_flow(mock_config_flow)) == 0
 
-        switchbot_device = BLEDevice("44:44:33:11:23:45", "wohand")
+        switchbot_device = generate_ble_device("44:44:33:11:23:45", "wohand")
         switchbot_adv = generate_advertisement_data(
             local_name="wohand", service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"]
         )
@@ -493,7 +494,7 @@ async def test_discovery_match_by_name_connectable_false(
 
         assert len(mock_bleak_scanner_start.mock_calls) == 1
 
-        wrong_device = BLEDevice("44:44:33:11:23:45", "wrong_name")
+        wrong_device = generate_ble_device("44:44:33:11:23:45", "wrong_name")
         wrong_adv = generate_advertisement_data(
             local_name="wrong_name", service_uuids=[]
         )
@@ -505,7 +506,9 @@ async def test_discovery_match_by_name_connectable_false(
 
         assert len(_domains_from_mock_config_flow(mock_config_flow)) == 0
 
-        qingping_device = BLEDevice("44:44:33:11:23:45", "Qingping Motion & Light")
+        qingping_device = generate_ble_device(
+            "44:44:33:11:23:45", "Qingping Motion & Light"
+        )
         qingping_adv = generate_advertisement_data(
             local_name="Qingping Motion & Light",
             service_data={
@@ -561,7 +564,7 @@ async def test_discovery_match_by_local_name(
 
         assert len(mock_bleak_scanner_start.mock_calls) == 1
 
-        wrong_device = BLEDevice("44:44:33:11:23:45", "wrong_name")
+        wrong_device = generate_ble_device("44:44:33:11:23:45", "wrong_name")
         wrong_adv = generate_advertisement_data(
             local_name="wrong_name", service_uuids=[]
         )
@@ -571,7 +574,7 @@ async def test_discovery_match_by_local_name(
 
         assert len(mock_config_flow.mock_calls) == 0
 
-        switchbot_device = BLEDevice("44:44:33:11:23:45", "wohand")
+        switchbot_device = generate_ble_device("44:44:33:11:23:45", "wohand")
         switchbot_adv = generate_advertisement_data(
             local_name="wohand", service_uuids=[], manufacturer_data={1: b"\x01"}
         )
@@ -605,7 +608,7 @@ async def test_discovery_match_by_manufacturer_id_and_manufacturer_data_start(
 
         assert len(mock_bleak_scanner_start.mock_calls) == 1
 
-        hkc_device = BLEDevice("44:44:33:11:23:45", "lock")
+        hkc_device = generate_ble_device("44:44:33:11:23:45", "lock")
         hkc_adv_no_mfr_data = generate_advertisement_data(
             local_name="lock",
             service_uuids=[],
@@ -639,7 +642,7 @@ async def test_discovery_match_by_manufacturer_id_and_manufacturer_data_start(
         assert len(mock_config_flow.mock_calls) == 0
 
         mock_config_flow.reset_mock()
-        not_hkc_device = BLEDevice("44:44:33:11:23:21", "lock")
+        not_hkc_device = generate_ble_device("44:44:33:11:23:21", "lock")
         not_hkc_adv = generate_advertisement_data(
             local_name="lock", service_uuids=[], manufacturer_data={76: b"\x02"}
         )
@@ -648,7 +651,7 @@ async def test_discovery_match_by_manufacturer_id_and_manufacturer_data_start(
         await hass.async_block_till_done()
 
         assert len(mock_config_flow.mock_calls) == 0
-        not_apple_device = BLEDevice("44:44:33:11:23:23", "lock")
+        not_apple_device = generate_ble_device("44:44:33:11:23:23", "lock")
         not_apple_adv = generate_advertisement_data(
             local_name="lock", service_uuids=[], manufacturer_data={21: b"\x02"}
         )
@@ -688,7 +691,7 @@ async def test_discovery_match_by_service_data_uuid_then_others(
 
         assert len(mock_bleak_scanner_start.mock_calls) == 1
 
-        device = BLEDevice("44:44:33:11:23:45", "lock")
+        device = generate_ble_device("44:44:33:11:23:45", "lock")
         adv_without_service_data_uuid = generate_advertisement_data(
             local_name="lock",
             service_uuids=[],
@@ -838,7 +841,7 @@ async def test_discovery_match_by_service_data_uuid_when_format_changes(
 
         assert len(mock_bleak_scanner_start.mock_calls) == 1
 
-        device = BLEDevice("44:44:33:11:23:45", "lock")
+        device = generate_ble_device("44:44:33:11:23:45", "lock")
         adv_without_service_data_uuid = generate_advertisement_data(
             local_name="Qingping Temp RH M",
             service_uuids=[],
@@ -921,7 +924,7 @@ async def test_discovery_match_first_by_service_uuid_and_then_manufacturer_id(
 
         assert len(mock_bleak_scanner_start.mock_calls) == 1
 
-        device = BLEDevice("44:44:33:11:23:45", "lock")
+        device = generate_ble_device("44:44:33:11:23:45", "lock")
         adv_service_uuids = generate_advertisement_data(
             local_name="lock",
             service_uuids=["0000fd3d-0000-1000-8000-00805f9b34fc"],
@@ -976,7 +979,7 @@ async def test_rediscovery(
 
         assert len(mock_bleak_scanner_start.mock_calls) == 1
 
-        switchbot_device = BLEDevice("44:44:33:11:23:45", "wohand")
+        switchbot_device = generate_ble_device("44:44:33:11:23:45", "wohand")
         switchbot_adv = generate_advertisement_data(
             local_name="wohand", service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"]
         )
@@ -1026,12 +1029,12 @@ async def test_async_discovered_device_api(
 
             assert not bluetooth.async_discovered_service_info(hass)
 
-            wrong_device = BLEDevice("44:44:33:11:23:42", "wrong_name")
+            wrong_device = generate_ble_device("44:44:33:11:23:42", "wrong_name")
             wrong_adv = generate_advertisement_data(
                 local_name="wrong_name", service_uuids=[]
             )
             inject_advertisement(hass, wrong_device, wrong_adv)
-            switchbot_device = BLEDevice("44:44:33:11:23:45", "wohand")
+            switchbot_device = generate_ble_device("44:44:33:11:23:45", "wohand")
             switchbot_adv = generate_advertisement_data(
                 local_name="wohand", service_uuids=[]
             )
@@ -1119,7 +1122,7 @@ async def test_register_callbacks(
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
 
-        seen_switchbot_device = BLEDevice("44:44:33:11:23:46", "wohand")
+        seen_switchbot_device = generate_ble_device("44:44:33:11:23:46", "wohand")
         seen_switchbot_adv = generate_advertisement_data(
             local_name="wohand",
             service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
@@ -1138,7 +1141,7 @@ async def test_register_callbacks(
 
         assert len(mock_bleak_scanner_start.mock_calls) == 1
 
-        switchbot_device = BLEDevice("44:44:33:11:23:45", "wohand")
+        switchbot_device = generate_ble_device("44:44:33:11:23:45", "wohand")
         switchbot_adv = generate_advertisement_data(
             local_name="wohand",
             service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
@@ -1148,13 +1151,13 @@ async def test_register_callbacks(
 
         inject_advertisement(hass, switchbot_device, switchbot_adv)
 
-        empty_device = BLEDevice("11:22:33:44:55:66", "empty")
+        empty_device = generate_ble_device("11:22:33:44:55:66", "empty")
         empty_adv = generate_advertisement_data(local_name="empty")
 
         inject_advertisement(hass, empty_device, empty_adv)
         await hass.async_block_till_done()
 
-        empty_device = BLEDevice("11:22:33:44:55:66", "empty")
+        empty_device = generate_ble_device("11:22:33:44:55:66", "empty")
         empty_adv = generate_advertisement_data(local_name="empty")
 
         inject_advertisement(hass, empty_device, empty_adv)
@@ -1209,7 +1212,7 @@ async def test_register_callbacks_raises_exception(
 
         assert len(mock_bleak_scanner_start.mock_calls) == 1
 
-        switchbot_device = BLEDevice("44:44:33:11:23:45", "wohand")
+        switchbot_device = generate_ble_device("44:44:33:11:23:45", "wohand")
         switchbot_adv = generate_advertisement_data(
             local_name="wohand",
             service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
@@ -1268,7 +1271,7 @@ async def test_register_callback_by_address(
 
         assert len(mock_bleak_scanner_start.mock_calls) == 1
 
-        switchbot_device = BLEDevice("44:44:33:11:23:45", "wohand")
+        switchbot_device = generate_ble_device("44:44:33:11:23:45", "wohand")
         switchbot_adv = generate_advertisement_data(
             local_name="wohand",
             service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
@@ -1278,13 +1281,13 @@ async def test_register_callback_by_address(
 
         inject_advertisement(hass, switchbot_device, switchbot_adv)
 
-        empty_device = BLEDevice("11:22:33:44:55:66", "empty")
+        empty_device = generate_ble_device("11:22:33:44:55:66", "empty")
         empty_adv = generate_advertisement_data(local_name="empty")
 
         inject_advertisement(hass, empty_device, empty_adv)
         await hass.async_block_till_done()
 
-        empty_device = BLEDevice("11:22:33:44:55:66", "empty")
+        empty_device = generate_ble_device("11:22:33:44:55:66", "empty")
         empty_adv = generate_advertisement_data(local_name="empty")
 
         # 3rd callback raises ValueError but is still tracked
@@ -1370,7 +1373,7 @@ async def test_register_callback_by_address_connectable_only(
 
         assert len(mock_bleak_scanner_start.mock_calls) == 1
 
-        switchbot_device = BLEDevice("44:44:33:11:23:45", "wohand")
+        switchbot_device = generate_ble_device("44:44:33:11:23:45", "wohand")
         switchbot_adv = generate_advertisement_data(
             local_name="wohand",
             service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
@@ -1436,7 +1439,7 @@ async def test_register_callback_by_manufacturer_id(
 
         assert len(mock_bleak_scanner_start.mock_calls) == 1
 
-        apple_device = BLEDevice("44:44:33:11:23:45", "rtx")
+        apple_device = generate_ble_device("44:44:33:11:23:45", "rtx")
         apple_adv = generate_advertisement_data(
             local_name="rtx",
             manufacturer_data={21: b"\xd8.\xad\xcd\r\x85"},
@@ -1444,7 +1447,7 @@ async def test_register_callback_by_manufacturer_id(
 
         inject_advertisement(hass, apple_device, apple_adv)
 
-        empty_device = BLEDevice("11:22:33:44:55:66", "empty")
+        empty_device = generate_ble_device("11:22:33:44:55:66", "empty")
         empty_adv = generate_advertisement_data(local_name="empty")
 
         inject_advertisement(hass, empty_device, empty_adv)
@@ -1491,7 +1494,7 @@ async def test_register_callback_by_connectable(
 
         assert len(mock_bleak_scanner_start.mock_calls) == 1
 
-        apple_device = BLEDevice("44:44:33:11:23:45", "rtx")
+        apple_device = generate_ble_device("44:44:33:11:23:45", "rtx")
         apple_adv = generate_advertisement_data(
             local_name="rtx",
             manufacturer_data={7676: b"\xd8.\xad\xcd\r\x85"},
@@ -1499,7 +1502,7 @@ async def test_register_callback_by_connectable(
 
         inject_advertisement(hass, apple_device, apple_adv)
 
-        empty_device = BLEDevice("11:22:33:44:55:66", "empty")
+        empty_device = generate_ble_device("11:22:33:44:55:66", "empty")
         empty_adv = generate_advertisement_data(local_name="empty")
 
         inject_advertisement(hass, empty_device, empty_adv)
@@ -1546,7 +1549,7 @@ async def test_not_filtering_wanted_apple_devices(
 
         assert len(mock_bleak_scanner_start.mock_calls) == 1
 
-        ibeacon_device = BLEDevice("44:44:33:11:23:45", "rtx")
+        ibeacon_device = generate_ble_device("44:44:33:11:23:45", "rtx")
         ibeacon_adv = generate_advertisement_data(
             local_name="ibeacon",
             manufacturer_data={76: b"\x02\x00\x00\x00"},
@@ -1554,7 +1557,7 @@ async def test_not_filtering_wanted_apple_devices(
 
         inject_advertisement(hass, ibeacon_device, ibeacon_adv)
 
-        homekit_device = BLEDevice("44:44:33:11:23:46", "rtx")
+        homekit_device = generate_ble_device("44:44:33:11:23:46", "rtx")
         homekit_adv = generate_advertisement_data(
             local_name="homekit",
             manufacturer_data={76: b"\x06\x00\x00\x00"},
@@ -1562,7 +1565,7 @@ async def test_not_filtering_wanted_apple_devices(
 
         inject_advertisement(hass, homekit_device, homekit_adv)
 
-        apple_device = BLEDevice("44:44:33:11:23:47", "rtx")
+        apple_device = generate_ble_device("44:44:33:11:23:47", "rtx")
         apple_adv = generate_advertisement_data(
             local_name="apple",
             manufacturer_data={76: b"\x10\x00\x00\x00"},
@@ -1606,7 +1609,7 @@ async def test_filtering_noisy_apple_devices(
 
         assert len(mock_bleak_scanner_start.mock_calls) == 1
 
-        apple_device = BLEDevice("44:44:33:11:23:45", "rtx")
+        apple_device = generate_ble_device("44:44:33:11:23:45", "rtx")
         apple_adv = generate_advertisement_data(
             local_name="noisy",
             manufacturer_data={76: b"\xd8.\xad\xcd\r\x85"},
@@ -1614,7 +1617,7 @@ async def test_filtering_noisy_apple_devices(
 
         inject_advertisement(hass, apple_device, apple_adv)
 
-        empty_device = BLEDevice("11:22:33:44:55:66", "empty")
+        empty_device = generate_ble_device("11:22:33:44:55:66", "empty")
         empty_adv = generate_advertisement_data(local_name="empty")
 
         inject_advertisement(hass, empty_device, empty_adv)
@@ -1656,7 +1659,7 @@ async def test_register_callback_by_address_connectable_manufacturer_id(
 
         assert len(mock_bleak_scanner_start.mock_calls) == 1
 
-        apple_device = BLEDevice("44:44:33:11:23:45", "rtx")
+        apple_device = generate_ble_device("44:44:33:11:23:45", "rtx")
         apple_adv = generate_advertisement_data(
             local_name="rtx",
             manufacturer_data={21: b"\xd8.\xad\xcd\r\x85"},
@@ -1664,7 +1667,7 @@ async def test_register_callback_by_address_connectable_manufacturer_id(
 
         inject_advertisement(hass, apple_device, apple_adv)
 
-        apple_device_wrong_address = BLEDevice("44:44:33:11:23:46", "rtx")
+        apple_device_wrong_address = generate_ble_device("44:44:33:11:23:46", "rtx")
 
         inject_advertisement(hass, apple_device_wrong_address, apple_adv)
         await hass.async_block_till_done()
@@ -1710,7 +1713,7 @@ async def test_register_callback_by_manufacturer_id_and_address(
 
         assert len(mock_bleak_scanner_start.mock_calls) == 1
 
-        rtx_device = BLEDevice("44:44:33:11:23:45", "rtx")
+        rtx_device = generate_ble_device("44:44:33:11:23:45", "rtx")
         rtx_adv = generate_advertisement_data(
             local_name="rtx",
             manufacturer_data={21: b"\xd8.\xad\xcd\r\x85"},
@@ -1718,7 +1721,7 @@ async def test_register_callback_by_manufacturer_id_and_address(
 
         inject_advertisement(hass, rtx_device, rtx_adv)
 
-        yale_device = BLEDevice("44:44:33:11:23:45", "apple")
+        yale_device = generate_ble_device("44:44:33:11:23:45", "apple")
         yale_adv = generate_advertisement_data(
             local_name="yale",
             manufacturer_data={465: b"\xd8.\xad\xcd\r\x85"},
@@ -1727,7 +1730,7 @@ async def test_register_callback_by_manufacturer_id_and_address(
         inject_advertisement(hass, yale_device, yale_adv)
         await hass.async_block_till_done()
 
-        other_apple_device = BLEDevice("44:44:33:11:23:22", "apple")
+        other_apple_device = generate_ble_device("44:44:33:11:23:22", "apple")
         other_apple_adv = generate_advertisement_data(
             local_name="apple",
             manufacturer_data={21: b"\xd8.\xad\xcd\r\x85"},
@@ -1778,7 +1781,7 @@ async def test_register_callback_by_service_uuid_and_address(
 
         assert len(mock_bleak_scanner_start.mock_calls) == 1
 
-        switchbot_dev = BLEDevice("44:44:33:11:23:45", "switchbot")
+        switchbot_dev = generate_ble_device("44:44:33:11:23:45", "switchbot")
         switchbot_adv = generate_advertisement_data(
             local_name="switchbot",
             service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
@@ -1786,7 +1789,9 @@ async def test_register_callback_by_service_uuid_and_address(
 
         inject_advertisement(hass, switchbot_dev, switchbot_adv)
 
-        switchbot_missing_service_uuid_dev = BLEDevice("44:44:33:11:23:45", "switchbot")
+        switchbot_missing_service_uuid_dev = generate_ble_device(
+            "44:44:33:11:23:45", "switchbot"
+        )
         switchbot_missing_service_uuid_adv = generate_advertisement_data(
             local_name="switchbot",
         )
@@ -1796,7 +1801,9 @@ async def test_register_callback_by_service_uuid_and_address(
         )
         await hass.async_block_till_done()
 
-        service_uuid_wrong_address_dev = BLEDevice("44:44:33:11:23:22", "switchbot2")
+        service_uuid_wrong_address_dev = generate_ble_device(
+            "44:44:33:11:23:22", "switchbot2"
+        )
         service_uuid_wrong_address_adv = generate_advertisement_data(
             local_name="switchbot2",
             service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
@@ -1847,7 +1854,7 @@ async def test_register_callback_by_service_data_uuid_and_address(
 
         assert len(mock_bleak_scanner_start.mock_calls) == 1
 
-        switchbot_dev = BLEDevice("44:44:33:11:23:45", "switchbot")
+        switchbot_dev = generate_ble_device("44:44:33:11:23:45", "switchbot")
         switchbot_adv = generate_advertisement_data(
             local_name="switchbot",
             service_data={"cba20d00-224d-11e6-9fb8-0002a5d5c51b": b"x"},
@@ -1855,7 +1862,9 @@ async def test_register_callback_by_service_data_uuid_and_address(
 
         inject_advertisement(hass, switchbot_dev, switchbot_adv)
 
-        switchbot_missing_service_uuid_dev = BLEDevice("44:44:33:11:23:45", "switchbot")
+        switchbot_missing_service_uuid_dev = generate_ble_device(
+            "44:44:33:11:23:45", "switchbot"
+        )
         switchbot_missing_service_uuid_adv = generate_advertisement_data(
             local_name="switchbot",
         )
@@ -1865,7 +1874,9 @@ async def test_register_callback_by_service_data_uuid_and_address(
         )
         await hass.async_block_till_done()
 
-        service_uuid_wrong_address_dev = BLEDevice("44:44:33:11:23:22", "switchbot2")
+        service_uuid_wrong_address_dev = generate_ble_device(
+            "44:44:33:11:23:22", "switchbot2"
+        )
         service_uuid_wrong_address_adv = generate_advertisement_data(
             local_name="switchbot2",
             service_data={"cba20d00-224d-11e6-9fb8-0002a5d5c51b": b"x"},
@@ -1913,7 +1924,7 @@ async def test_register_callback_by_local_name(
 
         assert len(mock_bleak_scanner_start.mock_calls) == 1
 
-        rtx_device = BLEDevice("44:44:33:11:23:45", "rtx")
+        rtx_device = generate_ble_device("44:44:33:11:23:45", "rtx")
         rtx_adv = generate_advertisement_data(
             local_name="rtx",
             manufacturer_data={21: b"\xd8.\xad\xcd\r\x85"},
@@ -1921,12 +1932,12 @@ async def test_register_callback_by_local_name(
 
         inject_advertisement(hass, rtx_device, rtx_adv)
 
-        empty_device = BLEDevice("11:22:33:44:55:66", "empty")
+        empty_device = generate_ble_device("11:22:33:44:55:66", "empty")
         empty_adv = generate_advertisement_data(local_name="empty")
 
         inject_advertisement(hass, empty_device, empty_adv)
 
-        rtx_device_2 = BLEDevice("44:44:33:11:23:45", "rtx")
+        rtx_device_2 = generate_ble_device("44:44:33:11:23:45", "rtx")
         rtx_adv_2 = generate_advertisement_data(
             local_name="rtx2",
             manufacturer_data={21: b"\xd8.\xad\xcd\r\x85"},
@@ -2012,7 +2023,7 @@ async def test_register_callback_by_service_data_uuid(
 
         assert len(mock_bleak_scanner_start.mock_calls) == 1
 
-        apple_device = BLEDevice("44:44:33:11:23:45", "xiaomi")
+        apple_device = generate_ble_device("44:44:33:11:23:45", "xiaomi")
         apple_adv = generate_advertisement_data(
             local_name="xiaomi",
             service_data={
@@ -2022,7 +2033,7 @@ async def test_register_callback_by_service_data_uuid(
 
         inject_advertisement(hass, apple_device, apple_adv)
 
-        empty_device = BLEDevice("11:22:33:44:55:66", "empty")
+        empty_device = generate_ble_device("11:22:33:44:55:66", "empty")
         empty_adv = generate_advertisement_data(local_name="empty")
 
         inject_advertisement(hass, empty_device, empty_adv)
@@ -2066,7 +2077,7 @@ async def test_register_callback_survives_reload(
 
     assert len(mock_bleak_scanner_start.mock_calls) == 1
 
-    switchbot_device = BLEDevice("44:44:33:11:23:45", "wohand")
+    switchbot_device = generate_ble_device("44:44:33:11:23:45", "wohand")
     switchbot_adv = generate_advertisement_data(
         local_name="wohand",
         service_uuids=["zba20d00-224d-11e6-9fb8-0002a5d5c51b"],
@@ -2120,7 +2131,7 @@ async def test_process_advertisements_bail_on_good_advertisement(
     )
 
     while not done.done():
-        device = BLEDevice("aa:44:33:11:23:45", "wohand")
+        device = generate_ble_device("aa:44:33:11:23:45", "wohand")
         adv = generate_advertisement_data(
             local_name="wohand",
             service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51a"],
@@ -2145,7 +2156,7 @@ async def test_process_advertisements_ignore_bad_advertisement(
     done = asyncio.Event()
     return_value = asyncio.Event()
 
-    device = BLEDevice("aa:44:33:11:23:45", "wohand")
+    device = generate_ble_device("aa:44:33:11:23:45", "wohand")
     adv = generate_advertisement_data(
         local_name="wohand",
         service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51a"],
@@ -2227,7 +2238,7 @@ async def test_wrapped_instance_with_filter(
             """Handle a detected device."""
             detected.append((device, advertisement_data))
 
-        switchbot_device = BLEDevice("44:44:33:11:23:45", "wohand")
+        switchbot_device = generate_ble_device("44:44:33:11:23:45", "wohand")
         switchbot_adv = generate_advertisement_data(
             local_name="wohand",
             service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
@@ -2240,7 +2251,7 @@ async def test_wrapped_instance_with_filter(
             manufacturer_data={89: b"\xd8.\xad\xcd\r\x84"},
             service_data={"00000d00-0000-1000-8000-00805f9b34fb": b"H\x10c"},
         )
-        empty_device = BLEDevice("11:22:33:44:55:66", "empty")
+        empty_device = generate_ble_device("11:22:33:44:55:66", "empty")
         empty_adv = generate_advertisement_data(local_name="empty")
 
         assert _get_manager() is not None
@@ -2299,7 +2310,7 @@ async def test_wrapped_instance_with_service_uuids(
             """Handle a detected device."""
             detected.append((device, advertisement_data))
 
-        switchbot_device = BLEDevice("44:44:33:11:23:45", "wohand")
+        switchbot_device = generate_ble_device("44:44:33:11:23:45", "wohand")
         switchbot_adv = generate_advertisement_data(
             local_name="wohand",
             service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
@@ -2312,7 +2323,7 @@ async def test_wrapped_instance_with_service_uuids(
             manufacturer_data={89: b"\xd8.\xad\xcd\r\x84"},
             service_data={"00000d00-0000-1000-8000-00805f9b34fb": b"H\x10c"},
         )
-        empty_device = BLEDevice("11:22:33:44:55:66", "empty")
+        empty_device = generate_ble_device("11:22:33:44:55:66", "empty")
         empty_adv = generate_advertisement_data(local_name="empty")
 
         assert _get_manager() is not None
@@ -2357,7 +2368,7 @@ async def test_wrapped_instance_with_broken_callbacks(
                 raise ValueError
             detected.append((device, advertisement_data))
 
-        switchbot_device = BLEDevice("44:44:33:11:23:45", "wohand")
+        switchbot_device = generate_ble_device("44:44:33:11:23:45", "wohand")
         switchbot_adv = generate_advertisement_data(
             local_name="wohand",
             service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
@@ -2398,7 +2409,7 @@ async def test_wrapped_instance_changes_uuids(
             """Handle a detected device."""
             detected.append((device, advertisement_data))
 
-        switchbot_device = BLEDevice("44:44:33:11:23:45", "wohand")
+        switchbot_device = generate_ble_device("44:44:33:11:23:45", "wohand")
         switchbot_adv = generate_advertisement_data(
             local_name="wohand",
             service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
@@ -2411,7 +2422,7 @@ async def test_wrapped_instance_changes_uuids(
             manufacturer_data={89: b"\xd8.\xad\xcd\r\x84"},
             service_data={"00000d00-0000-1000-8000-00805f9b34fb": b"H\x10c"},
         )
-        empty_device = BLEDevice("11:22:33:44:55:66", "empty")
+        empty_device = generate_ble_device("11:22:33:44:55:66", "empty")
         empty_adv = generate_advertisement_data(local_name="empty")
 
         assert _get_manager() is not None
@@ -2453,7 +2464,7 @@ async def test_wrapped_instance_changes_filters(
             """Handle a detected device."""
             detected.append((device, advertisement_data))
 
-        switchbot_device = BLEDevice("44:44:33:11:23:42", "wohand")
+        switchbot_device = generate_ble_device("44:44:33:11:23:42", "wohand")
         switchbot_adv = generate_advertisement_data(
             local_name="wohand",
             service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
@@ -2466,7 +2477,7 @@ async def test_wrapped_instance_changes_filters(
             manufacturer_data={89: b"\xd8.\xad\xcd\r\x84"},
             service_data={"00000d00-0000-1000-8000-00805f9b34fb": b"H\x10c"},
         )
-        empty_device = BLEDevice("11:22:33:44:55:62", "empty")
+        empty_device = generate_ble_device("11:22:33:44:55:62", "empty")
         empty_adv = generate_advertisement_data(local_name="empty")
 
         assert _get_manager() is not None
@@ -2541,7 +2552,7 @@ async def test_async_ble_device_from_address(
 
         assert not bluetooth.async_discovered_service_info(hass)
 
-        switchbot_device = BLEDevice("44:44:33:11:23:45", "wohand")
+        switchbot_device = generate_ble_device("44:44:33:11:23:45", "wohand")
         switchbot_adv = generate_advertisement_data(
             local_name="wohand", service_uuids=[]
         )

--- a/tests/components/bluetooth/test_manager.py
+++ b/tests/components/bluetooth/test_manager.py
@@ -37,6 +37,7 @@ from . import (
     MockBleakClient,
     _get_manager,
     generate_advertisement_data,
+    generate_ble_device,
     inject_advertisement_with_source,
     inject_advertisement_with_time_and_source,
     inject_advertisement_with_time_and_source_connectable,
@@ -73,7 +74,9 @@ async def test_advertisements_do_not_switch_adapters_for_no_reason(
 
     address = "44:44:33:11:23:12"
 
-    switchbot_device_signal_100 = BLEDevice(address, "wohand_signal_100", rssi=-100)
+    switchbot_device_signal_100 = generate_ble_device(
+        address, "wohand_signal_100", rssi=-100
+    )
     switchbot_adv_signal_100 = generate_advertisement_data(
         local_name="wohand_signal_100", service_uuids=[]
     )
@@ -86,7 +89,9 @@ async def test_advertisements_do_not_switch_adapters_for_no_reason(
         is switchbot_device_signal_100
     )
 
-    switchbot_device_signal_99 = BLEDevice(address, "wohand_signal_99", rssi=-99)
+    switchbot_device_signal_99 = generate_ble_device(
+        address, "wohand_signal_99", rssi=-99
+    )
     switchbot_adv_signal_99 = generate_advertisement_data(
         local_name="wohand_signal_99", service_uuids=[]
     )
@@ -99,7 +104,9 @@ async def test_advertisements_do_not_switch_adapters_for_no_reason(
         is switchbot_device_signal_99
     )
 
-    switchbot_device_signal_98 = BLEDevice(address, "wohand_good_signal", rssi=-98)
+    switchbot_device_signal_98 = generate_ble_device(
+        address, "wohand_good_signal", rssi=-98
+    )
     switchbot_adv_signal_98 = generate_advertisement_data(
         local_name="wohand_good_signal", service_uuids=[]
     )
@@ -124,7 +131,7 @@ async def test_switching_adapters_based_on_rssi(
 
     address = "44:44:33:11:23:45"
 
-    switchbot_device_poor_signal = BLEDevice(address, "wohand_poor_signal")
+    switchbot_device_poor_signal = generate_ble_device(address, "wohand_poor_signal")
     switchbot_adv_poor_signal = generate_advertisement_data(
         local_name="wohand_poor_signal", service_uuids=[], rssi=-100
     )
@@ -137,7 +144,7 @@ async def test_switching_adapters_based_on_rssi(
         is switchbot_device_poor_signal
     )
 
-    switchbot_device_good_signal = BLEDevice(address, "wohand_good_signal")
+    switchbot_device_good_signal = generate_ble_device(address, "wohand_good_signal")
     switchbot_adv_good_signal = generate_advertisement_data(
         local_name="wohand_good_signal", service_uuids=[], rssi=-60
     )
@@ -159,7 +166,9 @@ async def test_switching_adapters_based_on_rssi(
     )
 
     # We should not switch adapters unless the signal hits the threshold
-    switchbot_device_similar_signal = BLEDevice(address, "wohand_similar_signal")
+    switchbot_device_similar_signal = generate_ble_device(
+        address, "wohand_similar_signal"
+    )
     switchbot_adv_similar_signal = generate_advertisement_data(
         local_name="wohand_similar_signal", service_uuids=[], rssi=-62
     )
@@ -183,7 +192,7 @@ async def test_switching_adapters_based_on_zero_rssi(
 
     address = "44:44:33:11:23:45"
 
-    switchbot_device_no_rssi = BLEDevice(address, "wohand_poor_signal")
+    switchbot_device_no_rssi = generate_ble_device(address, "wohand_poor_signal")
     switchbot_adv_no_rssi = generate_advertisement_data(
         local_name="wohand_no_rssi", service_uuids=[], rssi=0
     )
@@ -196,7 +205,7 @@ async def test_switching_adapters_based_on_zero_rssi(
         is switchbot_device_no_rssi
     )
 
-    switchbot_device_good_signal = BLEDevice(address, "wohand_good_signal")
+    switchbot_device_good_signal = generate_ble_device(address, "wohand_good_signal")
     switchbot_adv_good_signal = generate_advertisement_data(
         local_name="wohand_good_signal", service_uuids=[], rssi=-60
     )
@@ -218,7 +227,9 @@ async def test_switching_adapters_based_on_zero_rssi(
     )
 
     # We should not switch adapters unless the signal hits the threshold
-    switchbot_device_similar_signal = BLEDevice(address, "wohand_similar_signal")
+    switchbot_device_similar_signal = generate_ble_device(
+        address, "wohand_similar_signal"
+    )
     switchbot_adv_similar_signal = generate_advertisement_data(
         local_name="wohand_similar_signal", service_uuids=[], rssi=-62
     )
@@ -243,7 +254,9 @@ async def test_switching_adapters_based_on_stale(
     address = "44:44:33:11:23:41"
     start_time_monotonic = 50.0
 
-    switchbot_device_poor_signal_hci0 = BLEDevice(address, "wohand_poor_signal_hci0")
+    switchbot_device_poor_signal_hci0 = generate_ble_device(
+        address, "wohand_poor_signal_hci0"
+    )
     switchbot_adv_poor_signal_hci0 = generate_advertisement_data(
         local_name="wohand_poor_signal_hci0", service_uuids=[], rssi=-100
     )
@@ -260,7 +273,9 @@ async def test_switching_adapters_based_on_stale(
         is switchbot_device_poor_signal_hci0
     )
 
-    switchbot_device_poor_signal_hci1 = BLEDevice(address, "wohand_poor_signal_hci1")
+    switchbot_device_poor_signal_hci1 = generate_ble_device(
+        address, "wohand_poor_signal_hci1"
+    )
     switchbot_adv_poor_signal_hci1 = generate_advertisement_data(
         local_name="wohand_poor_signal_hci1", service_uuids=[], rssi=-99
     )
@@ -301,7 +316,7 @@ async def test_restore_history_from_dbus(
     """Test we can restore history from dbus."""
     address = "AA:BB:CC:CC:CC:FF"
 
-    ble_device = BLEDevice(address, "name")
+    ble_device = generate_ble_device(address, "name")
     history = {
         address: AdvertisementHistory(
             ble_device, generate_advertisement_data(local_name="name"), "hci0"
@@ -337,7 +352,7 @@ async def test_restore_history_from_dbus_and_remote_adapters(
     for address in timestamps:
         timestamps[address] = now
 
-    ble_device = BLEDevice(address, "name")
+    ble_device = generate_ble_device(address, "name")
     history = {
         address: AdvertisementHistory(
             ble_device, generate_advertisement_data(local_name="name"), "hci0"
@@ -377,7 +392,7 @@ async def test_restore_history_from_dbus_and_corrupted_remote_adapters(
     for address in timestamps:
         timestamps[address] = now
 
-    ble_device = BLEDevice(address, "name")
+    ble_device = generate_ble_device(address, "name")
     history = {
         address: AdvertisementHistory(
             ble_device, generate_advertisement_data(local_name="name"), "hci0"
@@ -406,7 +421,7 @@ async def test_switching_adapters_based_on_rssi_connectable_to_non_connectable(
 
     address = "44:44:33:11:23:45"
     now = time.monotonic()
-    switchbot_device_poor_signal = BLEDevice(address, "wohand_poor_signal")
+    switchbot_device_poor_signal = generate_ble_device(address, "wohand_poor_signal")
     switchbot_adv_poor_signal = generate_advertisement_data(
         local_name="wohand_poor_signal", service_uuids=[], rssi=-100
     )
@@ -422,7 +437,7 @@ async def test_switching_adapters_based_on_rssi_connectable_to_non_connectable(
         bluetooth.async_ble_device_from_address(hass, address, True)
         is switchbot_device_poor_signal
     )
-    switchbot_device_good_signal = BLEDevice(address, "wohand_good_signal")
+    switchbot_device_good_signal = generate_ble_device(address, "wohand_good_signal")
     switchbot_adv_good_signal = generate_advertisement_data(
         local_name="wohand_good_signal", service_uuids=[], rssi=-60
     )
@@ -459,7 +474,9 @@ async def test_switching_adapters_based_on_rssi_connectable_to_non_connectable(
         bluetooth.async_ble_device_from_address(hass, address, True)
         is switchbot_device_poor_signal
     )
-    switchbot_device_excellent_signal = BLEDevice(address, "wohand_excellent_signal")
+    switchbot_device_excellent_signal = generate_ble_device(
+        address, "wohand_excellent_signal"
+    )
     switchbot_adv_excellent_signal = generate_advertisement_data(
         local_name="wohand_excellent_signal", service_uuids=[], rssi=-25
     )
@@ -496,7 +513,7 @@ async def test_connectable_advertisement_can_be_retrieved_with_best_path_is_non_
 
     address = "44:44:33:11:23:45"
     now = time.monotonic()
-    switchbot_device_good_signal = BLEDevice(address, "wohand_good_signal")
+    switchbot_device_good_signal = generate_ble_device(address, "wohand_good_signal")
     switchbot_adv_good_signal = generate_advertisement_data(
         local_name="wohand_good_signal", service_uuids=[], rssi=-60
     )
@@ -515,7 +532,7 @@ async def test_connectable_advertisement_can_be_retrieved_with_best_path_is_non_
     )
     assert bluetooth.async_ble_device_from_address(hass, address, True) is None
 
-    switchbot_device_poor_signal = BLEDevice(address, "wohand_poor_signal")
+    switchbot_device_poor_signal = generate_ble_device(address, "wohand_poor_signal")
     switchbot_adv_poor_signal = generate_advertisement_data(
         local_name="wohand_poor_signal", service_uuids=[], rssi=-100
     )
@@ -543,7 +560,7 @@ async def test_switching_adapters_when_one_goes_away(
 
     address = "44:44:33:11:23:45"
 
-    switchbot_device_good_signal = BLEDevice(address, "wohand_good_signal")
+    switchbot_device_good_signal = generate_ble_device(address, "wohand_good_signal")
     switchbot_adv_good_signal = generate_advertisement_data(
         local_name="wohand_good_signal", service_uuids=[], rssi=-60
     )
@@ -556,7 +573,7 @@ async def test_switching_adapters_when_one_goes_away(
         is switchbot_device_good_signal
     )
 
-    switchbot_device_poor_signal = BLEDevice(address, "wohand_poor_signal")
+    switchbot_device_poor_signal = generate_ble_device(address, "wohand_poor_signal")
     switchbot_adv_poor_signal = generate_advertisement_data(
         local_name="wohand_poor_signal", service_uuids=[], rssi=-100
     )
@@ -593,7 +610,7 @@ async def test_switching_adapters_when_one_stop_scanning(
 
     address = "44:44:33:11:23:45"
 
-    switchbot_device_good_signal = BLEDevice(address, "wohand_good_signal")
+    switchbot_device_good_signal = generate_ble_device(address, "wohand_good_signal")
     switchbot_adv_good_signal = generate_advertisement_data(
         local_name="wohand_good_signal", service_uuids=[], rssi=-60
     )
@@ -606,7 +623,7 @@ async def test_switching_adapters_when_one_stop_scanning(
         is switchbot_device_good_signal
     )
 
-    switchbot_device_poor_signal = BLEDevice(address, "wohand_poor_signal")
+    switchbot_device_poor_signal = generate_ble_device(address, "wohand_poor_signal")
     switchbot_adv_poor_signal = generate_advertisement_data(
         local_name="wohand_poor_signal", service_uuids=[], rssi=-100
     )
@@ -645,13 +662,13 @@ async def test_goes_unavailable_connectable_only_and_recovers(
 
     assert async_scanner_count(hass, connectable=True) == 0
     assert async_scanner_count(hass, connectable=False) == 0
-    switchbot_device_connectable = BLEDevice(
+    switchbot_device_connectable = generate_ble_device(
         "44:44:33:11:23:45",
         "wohand",
         {},
         rssi=-100,
     )
-    switchbot_device_non_connectable = BLEDevice(
+    switchbot_device_non_connectable = generate_ble_device(
         "44:44:33:11:23:45",
         "wohand",
         {},
@@ -813,7 +830,7 @@ async def test_goes_unavailable_dismisses_discovery(
     await hass.async_block_till_done()
 
     assert async_scanner_count(hass, connectable=False) == 0
-    switchbot_device_non_connectable = BLEDevice(
+    switchbot_device_non_connectable = generate_ble_device(
         "44:44:33:11:23:45",
         "wohand",
         {},

--- a/tests/components/bluetooth/test_models.py
+++ b/tests/components/bluetooth/test_models.py
@@ -24,6 +24,7 @@ from . import (
     MockBleakClient,
     _get_manager,
     generate_advertisement_data,
+    generate_ble_device,
     inject_advertisement,
     inject_advertisement_with_source,
 )
@@ -34,7 +35,7 @@ async def test_wrapped_bleak_scanner(
 ) -> None:
     """Test wrapped bleak scanner dispatches calls as expected."""
     scanner = HaBleakScannerWrapper()
-    switchbot_device = BLEDevice("44:44:33:11:23:45", "wohand")
+    switchbot_device = generate_ble_device("44:44:33:11:23:45", "wohand")
     switchbot_adv = generate_advertisement_data(
         local_name="wohand", service_uuids=[], manufacturer_data={1: b"\x01"}
     )
@@ -47,7 +48,7 @@ async def test_wrapped_bleak_client_raises_device_missing(
     hass: HomeAssistant, enable_bluetooth: None
 ) -> None:
     """Test wrapped bleak client dispatches calls as expected."""
-    switchbot_device = BLEDevice("44:44:33:11:23:45", "wohand")
+    switchbot_device = generate_ble_device("44:44:33:11:23:45", "wohand")
     client = HaBleakClientWrapper(switchbot_device)
     assert client.is_connected is False
     with pytest.raises(bleak.BleakError):
@@ -61,7 +62,7 @@ async def test_wrapped_bleak_client_set_disconnected_callback_before_connected(
     hass: HomeAssistant, enable_bluetooth: None
 ) -> None:
     """Test wrapped bleak client can set a disconnected callback before connected."""
-    switchbot_device = BLEDevice("44:44:33:11:23:45", "wohand")
+    switchbot_device = generate_ble_device("44:44:33:11:23:45", "wohand")
     client = HaBleakClientWrapper(switchbot_device)
     client.set_disconnected_callback(lambda client: None)
 
@@ -72,7 +73,7 @@ async def test_wrapped_bleak_client_local_adapter_only(
     """Test wrapped bleak client with only a local adapter."""
     manager = _get_manager()
 
-    switchbot_device = BLEDevice(
+    switchbot_device = generate_ble_device(
         "44:44:33:11:23:45",
         "wohand",
         {"path": "/org/bluez/hci0/dev_44_44_33_11_23_45"},
@@ -133,7 +134,7 @@ async def test_wrapped_bleak_client_set_disconnected_callback_after_connected(
     """Test wrapped bleak client can set a disconnected callback after connected."""
     manager = _get_manager()
 
-    switchbot_proxy_device_has_connection_slot = BLEDevice(
+    switchbot_proxy_device_has_connection_slot = generate_ble_device(
         "44:44:33:11:23:45",
         "wohand",
         {
@@ -148,7 +149,7 @@ async def test_wrapped_bleak_client_set_disconnected_callback_after_connected(
         manufacturer_data={1: b"\x01"},
         rssi=-40,
     )
-    switchbot_device = BLEDevice(
+    switchbot_device = generate_ble_device(
         "44:44:33:11:23:45",
         "wohand",
         {"path": "/org/bluez/hci0/dev_44_44_33_11_23_45"},
@@ -220,7 +221,7 @@ async def test_ble_device_with_proxy_client_out_of_connections_no_scanners(
     """Test we switch to the next available proxy when one runs out of connections with no scanners."""
     manager = _get_manager()
 
-    switchbot_proxy_device_no_connection_slot = BLEDevice(
+    switchbot_proxy_device_no_connection_slot = generate_ble_device(
         "44:44:33:11:23:45",
         "wohand",
         {
@@ -257,7 +258,7 @@ async def test_ble_device_with_proxy_client_out_of_connections(
     """Test handling all scanners are out of connection slots."""
     manager = _get_manager()
 
-    switchbot_proxy_device_no_connection_slot = BLEDevice(
+    switchbot_proxy_device_no_connection_slot = generate_ble_device(
         "44:44:33:11:23:45",
         "wohand",
         {
@@ -322,7 +323,7 @@ async def test_ble_device_with_proxy_clear_cache(
     """Test we can clear cache on the proxy."""
     manager = _get_manager()
 
-    switchbot_proxy_device_with_connection_slot = BLEDevice(
+    switchbot_proxy_device_with_connection_slot = generate_ble_device(
         "44:44:33:11:23:45",
         "wohand",
         {
@@ -384,7 +385,7 @@ async def test_ble_device_with_proxy_client_out_of_connections_uses_best_availab
     """Test we switch to the next available proxy when one runs out of connections."""
     manager = _get_manager()
 
-    switchbot_proxy_device_no_connection_slot = BLEDevice(
+    switchbot_proxy_device_no_connection_slot = generate_ble_device(
         "44:44:33:11:23:45",
         "wohand",
         {
@@ -398,7 +399,7 @@ async def test_ble_device_with_proxy_client_out_of_connections_uses_best_availab
         manufacturer_data={1: b"\x01"},
         rssi=-30,
     )
-    switchbot_proxy_device_has_connection_slot = BLEDevice(
+    switchbot_proxy_device_has_connection_slot = generate_ble_device(
         "44:44:33:11:23:45",
         "wohand",
         {
@@ -413,7 +414,7 @@ async def test_ble_device_with_proxy_client_out_of_connections_uses_best_availab
         manufacturer_data={1: b"\x01"},
         rssi=-40,
     )
-    switchbot_device = BLEDevice(
+    switchbot_device = generate_ble_device(
         "44:44:33:11:23:45",
         "wohand",
         {"path": "/org/bluez/hci0/dev_44_44_33_11_23_45"},
@@ -493,7 +494,7 @@ async def test_ble_device_with_proxy_client_out_of_connections_uses_best_availab
     """Test we switch to the next available proxy when one runs out of connections on MacOS."""
     manager = _get_manager()
 
-    switchbot_proxy_device_no_connection_slot = BLEDevice(
+    switchbot_proxy_device_no_connection_slot = generate_ble_device(
         "44:44:33:11:23:45",
         "wohand_no_connection_slot",
         {
@@ -509,7 +510,7 @@ async def test_ble_device_with_proxy_client_out_of_connections_uses_best_availab
         manufacturer_data={1: b"\x01"},
         rssi=-30,
     )
-    switchbot_proxy_device_has_connection_slot = BLEDevice(
+    switchbot_proxy_device_has_connection_slot = generate_ble_device(
         "44:44:33:11:23:45",
         "wohand_has_connection_slot",
         {
@@ -525,7 +526,7 @@ async def test_ble_device_with_proxy_client_out_of_connections_uses_best_availab
         rssi=-40,
     )
 
-    switchbot_device = BLEDevice(
+    switchbot_device = generate_ble_device(
         "44:44:33:11:23:45",
         "wohand",
         {},

--- a/tests/components/bluetooth/test_scanner.py
+++ b/tests/components/bluetooth/test_scanner.py
@@ -5,7 +5,7 @@ import time
 from unittest.mock import MagicMock, patch
 
 from bleak import BleakError
-from bleak.backends.scanner import AdvertisementDataCallback, BLEDevice
+from bleak.backends.scanner import AdvertisementDataCallback
 from dbus_fast import InvalidMessageError
 import pytest
 
@@ -20,7 +20,12 @@ from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, EVENT_HOMEASSISTANT
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
-from . import _get_manager, async_setup_with_one_adapter, generate_advertisement_data
+from . import (
+    _get_manager,
+    async_setup_with_one_adapter,
+    generate_advertisement_data,
+    generate_ble_device,
+)
 
 from tests.common import async_fire_time_changed
 
@@ -236,7 +241,7 @@ async def test_recovery_from_dbus_restart(
         return_value=start_time_monotonic,
     ):
         _callback(
-            BLEDevice("44:44:33:11:23:42", "any_name"),
+            generate_ble_device("44:44:33:11:23:42", "any_name"),
             generate_advertisement_data(local_name="any_name"),
         )
 

--- a/tests/components/bluetooth/test_usage.py
+++ b/tests/components/bluetooth/test_usage.py
@@ -2,7 +2,6 @@
 from unittest.mock import patch
 
 import bleak
-from bleak.backends.device import BLEDevice
 import bleak_retry_connector
 import pytest
 
@@ -16,10 +15,14 @@ from homeassistant.components.bluetooth.wrappers import (
 )
 from homeassistant.core import HomeAssistant
 
-from . import _get_manager
+from . import _get_manager, generate_ble_device
 
-MOCK_BLE_DEVICE = BLEDevice(
-    "00:00:00:00:00:00", "any", delegate="", details={"path": "/dev/hci0/device"}
+MOCK_BLE_DEVICE = generate_ble_device(
+    "00:00:00:00:00:00",
+    "any",
+    delegate="",
+    details={"path": "/dev/hci0/device"},
+    rssi=-127,
 )
 
 

--- a/tests/components/bluetooth/test_wrappers.py
+++ b/tests/components/bluetooth/test_wrappers.py
@@ -21,7 +21,7 @@ from homeassistant.components.bluetooth.usage import (
 )
 from homeassistant.core import HomeAssistant
 
-from . import _get_manager, generate_advertisement_data
+from . import _get_manager, generate_advertisement_data, generate_ble_device
 
 
 class FakeScanner(BaseHaRemoteScanner):
@@ -108,7 +108,7 @@ def _generate_ble_device_and_adv_data(
 ) -> tuple[BLEDevice, AdvertisementData]:
     """Generate a BLE device with adv data."""
     return (
-        BLEDevice(
+        generate_ble_device(
             mac,
             "any",
             delegate="",

--- a/tests/components/bluetooth_le_tracker/test_device_tracker.py
+++ b/tests/components/bluetooth_le_tracker/test_device_tracker.py
@@ -4,7 +4,6 @@ from datetime import timedelta
 from unittest.mock import patch
 
 from bleak import BleakError
-from bleak.backends.scanner import BLEDevice
 
 from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
 from homeassistant.components.bluetooth_le_tracker import device_tracker
@@ -24,7 +23,7 @@ from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util, slugify
 
 from tests.common import async_fire_time_changed
-from tests.components.bluetooth import generate_advertisement_data
+from tests.components.bluetooth import generate_advertisement_data, generate_ble_device
 
 
 class MockBleakClient:
@@ -89,7 +88,7 @@ async def test_preserve_new_tracked_device_name(
             service_data={},
             service_uuids=[],
             source="local",
-            device=BLEDevice(address, None),
+            device=generate_ble_device(address, None),
             advertisement=generate_advertisement_data(local_name="empty"),
             time=0,
             connectable=False,
@@ -114,7 +113,7 @@ async def test_preserve_new_tracked_device_name(
             service_data={},
             service_uuids=[],
             source="local",
-            device=BLEDevice(address, None),
+            device=generate_ble_device(address, None),
             advertisement=generate_advertisement_data(local_name="empty"),
             time=0,
             connectable=False,
@@ -159,7 +158,7 @@ async def test_tracking_battery_times_out(
             service_data={},
             service_uuids=[],
             source="local",
-            device=BLEDevice(address, None),
+            device=generate_ble_device(address, None),
             advertisement=generate_advertisement_data(local_name="empty"),
             time=0,
             connectable=False,
@@ -228,7 +227,7 @@ async def test_tracking_battery_fails(
             service_data={},
             service_uuids=[],
             source="local",
-            device=BLEDevice(address, None),
+            device=generate_ble_device(address, None),
             advertisement=generate_advertisement_data(local_name="empty"),
             time=0,
             connectable=False,
@@ -297,7 +296,7 @@ async def test_tracking_battery_successful(
             service_data={},
             service_uuids=[],
             source="local",
-            device=BLEDevice(address, None),
+            device=generate_ble_device(address, None),
             advertisement=generate_advertisement_data(local_name="empty"),
             time=0,
             connectable=True,

--- a/tests/components/bthome/__init__.py
+++ b/tests/components/bthome/__init__.py
@@ -1,15 +1,14 @@
 """Tests for the BTHome integration."""
 
-from bleak.backends.device import BLEDevice
 
 from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
 
-from tests.components.bluetooth import generate_advertisement_data
+from tests.components.bluetooth import generate_advertisement_data, generate_ble_device
 
 TEMP_HUMI_SERVICE_INFO = BluetoothServiceInfoBleak(
     name="ATC 8D18B2",
     address="A4:C1:38:8D:18:B2",
-    device=BLEDevice("A4:C1:38:8D:18:B2", None),
+    device=generate_ble_device("A4:C1:38:8D:18:B2", None),
     rssi=-63,
     manufacturer_data={},
     service_data={
@@ -25,7 +24,7 @@ TEMP_HUMI_SERVICE_INFO = BluetoothServiceInfoBleak(
 TEMP_HUMI_ENCRYPTED_SERVICE_INFO = BluetoothServiceInfoBleak(
     name="TEST DEVICE 8F80A5",
     address="54:48:E6:8F:80:A5",
-    device=BLEDevice("54:48:E6:8F:80:A5", None),
+    device=generate_ble_device("54:48:E6:8F:80:A5", None),
     rssi=-63,
     manufacturer_data={},
     service_data={
@@ -43,7 +42,7 @@ TEMP_HUMI_ENCRYPTED_SERVICE_INFO = BluetoothServiceInfoBleak(
 PRST_SERVICE_INFO = BluetoothServiceInfoBleak(
     name="prst 8F80A5",
     address="54:48:E6:8F:80:A5",
-    device=BLEDevice("54:48:E6:8F:80:A5", None),
+    device=generate_ble_device("54:48:E6:8F:80:A5", None),
     rssi=-63,
     manufacturer_data={},
     service_data={
@@ -61,7 +60,7 @@ PRST_SERVICE_INFO = BluetoothServiceInfoBleak(
 INVALID_PAYLOAD = BluetoothServiceInfoBleak(
     name="ATC 565384",
     address="A4:C1:38:56:53:84",
-    device=BLEDevice("A4:C1:38:56:53:84", None),
+    device=generate_ble_device("A4:C1:38:56:53:84", None),
     rssi=-56,
     manufacturer_data={},
     service_data={
@@ -77,7 +76,7 @@ INVALID_PAYLOAD = BluetoothServiceInfoBleak(
 NOT_BTHOME_SERVICE_INFO = BluetoothServiceInfoBleak(
     name="Not it",
     address="00:00:00:00:00:00",
-    device=BLEDevice("00:00:00:00:00:00", None),
+    device=generate_ble_device("00:00:00:00:00:00", None),
     rssi=-63,
     manufacturer_data={3234: b"\x00\x01"},
     service_data={},
@@ -94,7 +93,7 @@ def make_bthome_v1_adv(address: str, payload: bytes) -> BluetoothServiceInfoBlea
     return BluetoothServiceInfoBleak(
         name="Test Device",
         address=address,
-        device=BLEDevice(address, None),
+        device=generate_ble_device(address, None),
         rssi=-56,
         manufacturer_data={},
         service_data={
@@ -115,7 +114,7 @@ def make_encrypted_bthome_v1_adv(
     return BluetoothServiceInfoBleak(
         name="ATC 8F80A5",
         address=address,
-        device=BLEDevice(address, None),
+        device=generate_ble_device(address, None),
         rssi=-56,
         manufacturer_data={},
         service_data={
@@ -134,7 +133,7 @@ def make_bthome_v2_adv(address: str, payload: bytes) -> BluetoothServiceInfoBlea
     return BluetoothServiceInfoBleak(
         name="Test Device",
         address=address,
-        device=BLEDevice(address, None),
+        device=generate_ble_device(address, None),
         rssi=-56,
         manufacturer_data={},
         service_data={

--- a/tests/components/dormakaba_dkey/__init__.py
+++ b/tests/components/dormakaba_dkey/__init__.py
@@ -1,9 +1,8 @@
 """Tests for the Dormakaba dKey integration."""
-from bleak.backends.device import BLEDevice
 
 from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
 
-from tests.components.bluetooth import generate_advertisement_data
+from tests.components.bluetooth import generate_advertisement_data, generate_ble_device
 
 DKEY_DISCOVERY_INFO = BluetoothServiceInfoBleak(
     name="00123456",
@@ -13,7 +12,7 @@ DKEY_DISCOVERY_INFO = BluetoothServiceInfoBleak(
     service_uuids=["e7a60000-6639-429f-94fd-86de8ea26897"],
     service_data={},
     source="local",
-    device=BLEDevice(address="AA:BB:CC:DD:EE:F0", name="00123456"),
+    device=generate_ble_device(address="AA:BB:CC:DD:EE:F0", name="00123456"),
     advertisement=generate_advertisement_data(
         service_uuids=["e7a60000-6639-429f-94fd-86de8ea26897"]
     ),
@@ -33,7 +32,7 @@ NOT_DKEY_DISCOVERY_INFO = BluetoothServiceInfoBleak(
     service_uuids=[],
     service_data={},
     source="local",
-    device=BLEDevice(address="AA:BB:CC:DD:EE:F2", name="Aug"),
+    device=generate_ble_device(address="AA:BB:CC:DD:EE:F2", name="Aug"),
     advertisement=generate_advertisement_data(),
     time=0,
     connectable=True,

--- a/tests/components/fjaraskupan/__init__.py
+++ b/tests/components/fjaraskupan/__init__.py
@@ -1,11 +1,9 @@
 """Tests for the Fjäråskupan integration."""
 
 
-from bleak.backends.device import BLEDevice
-
 from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
 
-from tests.components.bluetooth import generate_advertisement_data
+from tests.components.bluetooth import generate_advertisement_data, generate_ble_device
 
 COOKER_SERVICE_INFO = BluetoothServiceInfoBleak(
     name="COOKERHOOD_FJAR",
@@ -15,7 +13,7 @@ COOKER_SERVICE_INFO = BluetoothServiceInfoBleak(
     service_uuids=[],
     service_data={},
     source="local",
-    device=BLEDevice(address="AA:BB:CC:DD:EE:FF", name="COOKERHOOD_FJAR"),
+    device=generate_ble_device(address="AA:BB:CC:DD:EE:FF", name="COOKERHOOD_FJAR"),
     advertisement=generate_advertisement_data(),
     time=0,
     connectable=True,

--- a/tests/components/ibeacon/__init__.py
+++ b/tests/components/ibeacon/__init__.py
@@ -1,11 +1,11 @@
 """Tests for the ibeacon integration."""
 from typing import Any
 
-from bleak.backends.device import BLEDevice
-
 from homeassistant.helpers.service_info.bluetooth import BluetoothServiceInfo
 
-BLUECHARM_BLE_DEVICE = BLEDevice(
+from tests.components.bluetooth import generate_ble_device
+
+BLUECHARM_BLE_DEVICE = generate_ble_device(
     address="61DE521B-F0BF-9F44-64D4-75BBE1738105",
     name="BlueCharm_177999",
 )
@@ -71,12 +71,12 @@ TESLA_TRANSIENT = BluetoothServiceInfo(
     service_uuids=[],
     source="hci0",
 )
-TESLA_TRANSIENT_BLE_DEVICE = BLEDevice(
+TESLA_TRANSIENT_BLE_DEVICE = generate_ble_device(
     address="CC:CC:CC:CC:CC:CC",
     name="S6da7c9389bd5452cC",
 )
 
-FEASY_BEACON_BLE_DEVICE = BLEDevice(
+FEASY_BEACON_BLE_DEVICE = generate_ble_device(
     address="AA:BB:CC:DD:EE:FF",
     name="FSC-BP108",
 )

--- a/tests/components/ibeacon/test_coordinator.py
+++ b/tests/components/ibeacon/test_coordinator.py
@@ -2,7 +2,6 @@
 from datetime import timedelta
 import time
 
-from bleak.backends.scanner import BLEDevice
 import pytest
 
 from homeassistant.components.ibeacon.const import ATTR_SOURCE, DOMAIN, UPDATE_INTERVAL
@@ -23,6 +22,7 @@ from . import (
 from tests.common import MockConfigEntry, async_fire_time_changed
 from tests.components.bluetooth import (
     generate_advertisement_data,
+    generate_ble_device,
     inject_advertisement_with_time_and_source_connectable,
     inject_bluetooth_service_info,
     patch_all_discovered_devices,
@@ -276,7 +276,7 @@ async def test_changing_source_attribute(hass: HomeAssistant) -> None:
 
     now = time.monotonic()
     info = BLUECHARM_BEACON_SERVICE_INFO_2
-    device = BLEDevice(
+    device = generate_ble_device(
         address=info.address,
         name=info.name,
         details={},

--- a/tests/components/keymitt_ble/__init__.py
+++ b/tests/components/keymitt_ble/__init__.py
@@ -1,12 +1,10 @@
 """Tests for the MicroBot integration."""
 from unittest.mock import patch
 
-from bleak.backends.device import BLEDevice
-
 from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
 from homeassistant.const import CONF_ADDRESS
 
-from tests.components.bluetooth import generate_advertisement_data
+from tests.components.bluetooth import generate_advertisement_data, generate_ble_device
 
 DOMAIN = "keymitt_ble"
 
@@ -44,7 +42,7 @@ SERVICE_INFO = BluetoothServiceInfoBleak(
         manufacturer_data={},
         service_uuids=["0000abcd-0000-1000-8000-00805f9b34fb"],
     ),
-    device=BLEDevice("aa:bb:cc:dd:ee:ff", "mibp"),
+    device=generate_ble_device("aa:bb:cc:dd:ee:ff", "mibp"),
     time=0,
     connectable=True,
 )

--- a/tests/components/ld2410_ble/__init__.py
+++ b/tests/components/ld2410_ble/__init__.py
@@ -1,9 +1,8 @@
 """Tests for the LD2410 BLE Bluetooth integration."""
-from bleak.backends.device import BLEDevice
 
 from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
 
-from tests.components.bluetooth import generate_advertisement_data
+from tests.components.bluetooth import generate_advertisement_data, generate_ble_device
 
 LD2410_BLE_DISCOVERY_INFO = BluetoothServiceInfoBleak(
     name="HLK-LD2410B_EEFF",
@@ -13,7 +12,7 @@ LD2410_BLE_DISCOVERY_INFO = BluetoothServiceInfoBleak(
     service_uuids=[],
     service_data={},
     source="local",
-    device=BLEDevice(address="AA:BB:CC:DD:EE:FF", name="HLK-LD2410B_EEFF"),
+    device=generate_ble_device(address="AA:BB:CC:DD:EE:FF", name="HLK-LD2410B_EEFF"),
     advertisement=generate_advertisement_data(),
     time=0,
     connectable=True,
@@ -30,7 +29,7 @@ NOT_LD2410_BLE_DISCOVERY_INFO = BluetoothServiceInfoBleak(
     service_uuids=[],
     service_data={},
     source="local",
-    device=BLEDevice(address="AA:BB:CC:DD:EE:FF", name="Aug"),
+    device=generate_ble_device(address="AA:BB:CC:DD:EE:FF", name="Aug"),
     advertisement=generate_advertisement_data(),
     time=0,
     connectable=True,

--- a/tests/components/led_ble/__init__.py
+++ b/tests/components/led_ble/__init__.py
@@ -1,9 +1,8 @@
 """Tests for the LED BLE Bluetooth integration."""
-from bleak.backends.device import BLEDevice
 
 from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
 
-from tests.components.bluetooth import generate_advertisement_data
+from tests.components.bluetooth import generate_advertisement_data, generate_ble_device
 
 LED_BLE_DISCOVERY_INFO = BluetoothServiceInfoBleak(
     name="Triones:F30200000152C",
@@ -13,7 +12,9 @@ LED_BLE_DISCOVERY_INFO = BluetoothServiceInfoBleak(
     service_uuids=[],
     service_data={},
     source="local",
-    device=BLEDevice(address="AA:BB:CC:DD:EE:FF", name="Triones:F30200000152C"),
+    device=generate_ble_device(
+        address="AA:BB:CC:DD:EE:FF", name="Triones:F30200000152C"
+    ),
     advertisement=generate_advertisement_data(),
     time=0,
     connectable=True,
@@ -27,7 +28,9 @@ UNSUPPORTED_LED_BLE_DISCOVERY_INFO = BluetoothServiceInfoBleak(
     service_uuids=[],
     service_data={},
     source="local",
-    device=BLEDevice(address="AA:BB:CC:DD:EE:FF", name="LEDnetWFF30200000152C"),
+    device=generate_ble_device(
+        address="AA:BB:CC:DD:EE:FF", name="LEDnetWFF30200000152C"
+    ),
     advertisement=generate_advertisement_data(),
     time=0,
     connectable=True,
@@ -45,7 +48,7 @@ NOT_LED_BLE_DISCOVERY_INFO = BluetoothServiceInfoBleak(
     service_uuids=[],
     service_data={},
     source="local",
-    device=BLEDevice(address="AA:BB:CC:DD:EE:FF", name="Aug"),
+    device=generate_ble_device(address="AA:BB:CC:DD:EE:FF", name="Aug"),
     advertisement=generate_advertisement_data(),
     time=0,
     connectable=True,

--- a/tests/components/melnor/conftest.py
+++ b/tests/components/melnor/conftest.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
-from bleak.backends.device import BLEDevice
 from melnor_bluetooth.device import Device
 import pytest
 
@@ -14,7 +13,7 @@ from homeassistant.const import CONF_ADDRESS
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
-from tests.components.bluetooth import generate_advertisement_data
+from tests.components.bluetooth import generate_advertisement_data, generate_ble_device
 
 FAKE_ADDRESS_1 = "FAKE-ADDRESS-1"
 FAKE_ADDRESS_2 = "FAKE-ADDRESS-2"
@@ -30,7 +29,7 @@ FAKE_SERVICE_INFO_1 = BluetoothServiceInfoBleak(
     service_uuids=[],
     service_data={},
     source="local",
-    device=BLEDevice(FAKE_ADDRESS_1, None),
+    device=generate_ble_device(FAKE_ADDRESS_1, None),
     advertisement=generate_advertisement_data(local_name=""),
     time=0,
     connectable=True,
@@ -46,7 +45,7 @@ FAKE_SERVICE_INFO_2 = BluetoothServiceInfoBleak(
     service_uuids=[],
     service_data={},
     source="local",
-    device=BLEDevice(FAKE_ADDRESS_2, None),
+    device=generate_ble_device(FAKE_ADDRESS_2, None),
     advertisement=generate_advertisement_data(local_name=""),
     time=0,
     connectable=True,

--- a/tests/components/oralb/__init__.py
+++ b/tests/components/oralb/__init__.py
@@ -1,11 +1,10 @@
 """Tests for the OralB integration."""
 
-from bleak.backends.device import BLEDevice
 from home_assistant_bluetooth import BluetoothServiceInfoBleak
 
 from homeassistant.helpers.service_info.bluetooth import BluetoothServiceInfo
 
-from tests.components.bluetooth import generate_advertisement_data
+from tests.components.bluetooth import generate_advertisement_data, generate_ble_device
 
 NOT_ORALB_SERVICE_INFO = BluetoothServiceInfo(
     name="Not it",
@@ -41,7 +40,7 @@ ORALB_IO_SERIES_4_SERVICE_INFO = BluetoothServiceInfo(
 ORALB_IO_SERIES_6_SERVICE_INFO = BluetoothServiceInfoBleak(
     name="Oral-B Toothbrush",
     address="B0:D2:78:20:1D:CF",
-    device=BLEDevice("B0:D2:78:20:1D:CF", "Oral-B Toothbrush"),
+    device=generate_ble_device("B0:D2:78:20:1D:CF", "Oral-B Toothbrush"),
     rssi=-56,
     manufacturer_data={220: b"\x062k\x02r\x00\x00\x02\x01\x00\x04"},
     service_data={"a0f0ff00-5047-4d53-8208-4f72616c2d42": bytearray(b"1\x00\x00\x00")},

--- a/tests/components/snooz/__init__.py
+++ b/tests/components/snooz/__init__.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from unittest.mock import patch
 
-from bleak import BLEDevice
 from pysnooz.commands import SnoozCommandData
 from pysnooz.testing import MockSnoozDevice
 
@@ -14,6 +13,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.service_info.bluetooth import BluetoothServiceInfo
 
 from tests.common import MockConfigEntry
+from tests.components.bluetooth import generate_ble_device
 
 TEST_ADDRESS = "00:00:00:00:AB:CD"
 TEST_SNOOZ_LOCAL_NAME = "Snooz-ABCD"
@@ -90,7 +90,7 @@ async def create_mock_snooz_config_entry(
         "homeassistant.components.snooz.SnoozDevice", return_value=device
     ), patch(
         "homeassistant.components.snooz.async_ble_device_from_address",
-        return_value=BLEDevice(device.address, device.name),
+        return_value=generate_ble_device(device.address, device.name),
     ):
         entry = MockConfigEntry(
             domain=DOMAIN,

--- a/tests/components/switchbot/__init__.py
+++ b/tests/components/switchbot/__init__.py
@@ -1,14 +1,12 @@
 """Tests for the switchbot integration."""
 from unittest.mock import patch
 
-from bleak.backends.device import BLEDevice
-
 from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
 from homeassistant.const import CONF_ADDRESS
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
-from tests.components.bluetooth import generate_advertisement_data
+from tests.components.bluetooth import generate_advertisement_data, generate_ble_device
 
 DOMAIN = "switchbot"
 
@@ -68,7 +66,7 @@ WOHAND_SERVICE_INFO = BluetoothServiceInfoBleak(
         service_data={"00000d00-0000-1000-8000-00805f9b34fb": b"H\x90\xd9"},
         service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
     ),
-    device=BLEDevice("AA:BB:CC:DD:EE:FF", "WoHand"),
+    device=generate_ble_device("AA:BB:CC:DD:EE:FF", "WoHand"),
     time=0,
     connectable=True,
 )
@@ -88,7 +86,7 @@ WOHAND_SERVICE_INFO_NOT_CONNECTABLE = BluetoothServiceInfoBleak(
         service_data={"00000d00-0000-1000-8000-00805f9b34fb": b"H\x90\xd9"},
         service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
     ),
-    device=BLEDevice("aa:bb:cc:dd:ee:ff", "WoHand"),
+    device=generate_ble_device("aa:bb:cc:dd:ee:ff", "WoHand"),
     time=0,
     connectable=False,
 )
@@ -108,7 +106,7 @@ WOHAND_ENCRYPTED_SERVICE_INFO = BluetoothServiceInfoBleak(
         service_data={"00000d00-0000-1000-8000-00805f9b34fb": b"\xc8\x10\xcf"},
         service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
     ),
-    device=BLEDevice("798A8547-2A3D-C609-55FF-73FA824B923B", "WoHand"),
+    device=generate_ble_device("798A8547-2A3D-C609-55FF-73FA824B923B", "WoHand"),
     time=0,
     connectable=True,
 )
@@ -128,7 +126,7 @@ WOHAND_SERVICE_ALT_ADDRESS_INFO = BluetoothServiceInfoBleak(
         service_data={"00000d00-0000-1000-8000-00805f9b34fb": b"H\x90\xd9"},
         service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
     ),
-    device=BLEDevice("aa:bb:cc:dd:ee:ff", "WoHand"),
+    device=generate_ble_device("aa:bb:cc:dd:ee:ff", "WoHand"),
     time=0,
     connectable=True,
 )
@@ -146,7 +144,7 @@ WOCURTAIN_SERVICE_INFO = BluetoothServiceInfoBleak(
         service_data={"00000d00-0000-1000-8000-00805f9b34fb": b"c\xd0Y\x00\x11\x04"},
         service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
     ),
-    device=BLEDevice("aa:bb:cc:dd:ee:ff", "WoCurtain"),
+    device=generate_ble_device("aa:bb:cc:dd:ee:ff", "WoCurtain"),
     time=0,
     connectable=True,
 )
@@ -163,7 +161,7 @@ WOSENSORTH_SERVICE_INFO = BluetoothServiceInfoBleak(
         manufacturer_data={2409: b"\xda,\x1e\xb1\x86Au\x03\x00\x96\xac"},
         service_data={"0000fd3d-0000-1000-8000-00805f9b34fb": b"T\x00d\x00\x96\xac"},
     ),
-    device=BLEDevice("aa:bb:cc:dd:ee:ff", "WoSensorTH"),
+    device=generate_ble_device("aa:bb:cc:dd:ee:ff", "WoSensorTH"),
     time=0,
     connectable=False,
 )
@@ -183,7 +181,7 @@ WOLOCK_SERVICE_INFO = BluetoothServiceInfoBleak(
         service_data={"0000fd3d-0000-1000-8000-00805f9b34fb": b"o\x80d"},
         service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
     ),
-    device=BLEDevice("aa:bb:cc:dd:ee:ff", "WoLock"),
+    device=generate_ble_device("aa:bb:cc:dd:ee:ff", "WoLock"),
     time=0,
     connectable=True,
 )
@@ -200,7 +198,7 @@ NOT_SWITCHBOT_INFO = BluetoothServiceInfoBleak(
         manufacturer_data={},
         service_data={},
     ),
-    device=BLEDevice("aa:bb:cc:dd:ee:ff", "unknown"),
+    device=generate_ble_device("aa:bb:cc:dd:ee:ff", "unknown"),
     time=0,
     connectable=True,
 )

--- a/tests/components/xiaomi_ble/__init__.py
+++ b/tests/components/xiaomi_ble/__init__.py
@@ -1,15 +1,14 @@
 """Tests for the SensorPush integration."""
 
-from bleak.backends.device import BLEDevice
 
 from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
 
-from tests.components.bluetooth import generate_advertisement_data
+from tests.components.bluetooth import generate_advertisement_data, generate_ble_device
 
 NOT_SENSOR_PUSH_SERVICE_INFO = BluetoothServiceInfoBleak(
     name="Not it",
     address="00:00:00:00:00:00",
-    device=BLEDevice("00:00:00:00:00:00", None),
+    device=generate_ble_device("00:00:00:00:00:00", None),
     rssi=-63,
     manufacturer_data={3234: b"\x00\x01"},
     service_data={},
@@ -23,7 +22,7 @@ NOT_SENSOR_PUSH_SERVICE_INFO = BluetoothServiceInfoBleak(
 LYWSDCGQ_SERVICE_INFO = BluetoothServiceInfoBleak(
     name="LYWSDCGQ",
     address="58:2D:34:35:93:21",
-    device=BLEDevice("00:00:00:00:00:00", None),
+    device=generate_ble_device("00:00:00:00:00:00", None),
     rssi=-63,
     manufacturer_data={},
     service_data={
@@ -41,7 +40,7 @@ LYWSDCGQ_SERVICE_INFO = BluetoothServiceInfoBleak(
 MMC_T201_1_SERVICE_INFO = BluetoothServiceInfoBleak(
     name="MMC_T201_1",
     address="00:81:F9:DD:6F:C1",
-    device=BLEDevice("00:00:00:00:00:00", None),
+    device=generate_ble_device("00:00:00:00:00:00", None),
     rssi=-56,
     manufacturer_data={},
     service_data={
@@ -59,7 +58,7 @@ MMC_T201_1_SERVICE_INFO = BluetoothServiceInfoBleak(
 JTYJGD03MI_SERVICE_INFO = BluetoothServiceInfoBleak(
     name="JTYJGD03MI",
     address="54:EF:44:E3:9C:BC",
-    device=BLEDevice("00:00:00:00:00:00", None),
+    device=generate_ble_device("00:00:00:00:00:00", None),
     rssi=-56,
     manufacturer_data={},
     service_data={
@@ -77,7 +76,7 @@ JTYJGD03MI_SERVICE_INFO = BluetoothServiceInfoBleak(
 YLKG07YL_SERVICE_INFO = BluetoothServiceInfoBleak(
     name="YLKG07YL",
     address="F8:24:41:C5:98:8B",
-    device=BLEDevice("00:00:00:00:00:00", None),
+    device=generate_ble_device("00:00:00:00:00:00", None),
     rssi=-56,
     manufacturer_data={},
     service_data={
@@ -95,7 +94,7 @@ YLKG07YL_SERVICE_INFO = BluetoothServiceInfoBleak(
 HHCCJCY10_SERVICE_INFO = BluetoothServiceInfoBleak(
     name="HHCCJCY10",
     address="DC:23:4D:E5:5B:FC",
-    device=BLEDevice("00:00:00:00:00:00", None),
+    device=generate_ble_device("00:00:00:00:00:00", None),
     rssi=-56,
     manufacturer_data={},
     service_data={"0000fd50-0000-1000-8000-00805f9b34fb": b"\x0e\x00n\x014\xa4(\x00["},
@@ -109,7 +108,7 @@ HHCCJCY10_SERVICE_INFO = BluetoothServiceInfoBleak(
 MISSING_PAYLOAD_ENCRYPTED = BluetoothServiceInfoBleak(
     name="LYWSD02MMC",
     address="A4:C1:38:56:53:84",
-    device=BLEDevice("00:00:00:00:00:00", None),
+    device=generate_ble_device("00:00:00:00:00:00", None),
     rssi=-56,
     manufacturer_data={},
     service_data={
@@ -130,7 +129,7 @@ def make_advertisement(
     return BluetoothServiceInfoBleak(
         name="Test Device",
         address=address,
-        device=BLEDevice(address, None),
+        device=generate_ble_device(address, None),
         rssi=-56,
         manufacturer_data={},
         service_data={

--- a/tests/components/yalexs_ble/__init__.py
+++ b/tests/components/yalexs_ble/__init__.py
@@ -1,9 +1,8 @@
 """Tests for the Yale Access Bluetooth integration."""
-from bleak.backends.device import BLEDevice
 
 from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
 
-from tests.components.bluetooth import generate_advertisement_data
+from tests.components.bluetooth import generate_advertisement_data, generate_ble_device
 
 YALE_ACCESS_LOCK_DISCOVERY_INFO = BluetoothServiceInfoBleak(
     name="M1012LU",
@@ -16,7 +15,7 @@ YALE_ACCESS_LOCK_DISCOVERY_INFO = BluetoothServiceInfoBleak(
     service_uuids=[],
     service_data={},
     source="local",
-    device=BLEDevice(address="AA:BB:CC:DD:EE:FF", name="M1012LU"),
+    device=generate_ble_device(address="AA:BB:CC:DD:EE:FF", name="M1012LU"),
     advertisement=generate_advertisement_data(),
     time=0,
     connectable=True,
@@ -34,7 +33,7 @@ LOCK_DISCOVERY_INFO_UUID_ADDRESS = BluetoothServiceInfoBleak(
     service_uuids=[],
     service_data={},
     source="local",
-    device=BLEDevice(address="AA:BB:CC:DD:EE:FF", name="M1012LU"),
+    device=generate_ble_device(address="AA:BB:CC:DD:EE:FF", name="M1012LU"),
     advertisement=generate_advertisement_data(),
     time=0,
     connectable=True,
@@ -51,7 +50,7 @@ OLD_FIRMWARE_LOCK_DISCOVERY_INFO = BluetoothServiceInfoBleak(
     service_uuids=[],
     service_data={},
     source="local",
-    device=BLEDevice(address="AA:BB:CC:DD:EE:FF", name="Aug"),
+    device=generate_ble_device(address="AA:BB:CC:DD:EE:FF", name="Aug"),
     advertisement=generate_advertisement_data(),
     time=0,
     connectable=True,
@@ -69,7 +68,7 @@ NOT_YALE_DISCOVERY_INFO = BluetoothServiceInfoBleak(
     service_uuids=[],
     service_data={},
     source="local",
-    device=BLEDevice(address="AA:BB:CC:DD:EE:FF", name="Aug"),
+    device=generate_ble_device(address="AA:BB:CC:DD:EE:FF", name="Aug"),
     advertisement=generate_advertisement_data(),
     time=0,
     connectable=True,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bumps dependencies:

* `bleak` to `v0.20.0` [[Compare](https://github.com/hbldh/bleak/compare/v0.19.5...v0.20.0)] [[Release](https://github.com/hbldh/bleak/releases/tag/v0.20.0)]
* `dbus-fast` to `v1.84.2` [[Compare](https://github.com/Bluetooth-Devices/dbus-fast/compare/v1.84.1...v1.84.2)] [[Release](https://github.com/Bluetooth-Devices/dbus-fast/releases/tag/v1.84.2)]
* `bleak-retry-connector` to `v3.0.1` [[Compare]](https://github.com/Bluetooth-Devices/bleak-retry-connector/compare/v2.13.1...v3.0.1) [[Release]](https://github.com/Bluetooth-Devices/bleak-retry-connector/releases/tag/v3.0.1)
* `bluetooth-adapters` https://github.com/Bluetooth-Devices/bluetooth-adapters/compare/v0.15.2...v0.15.3

originally opened by @kiwiz in #89906 (thank you!). Since the work to support 0.20.0 turned out to be substantial I picked this up to finish it.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
