### PR TITLE
Fix ssl context being recreated frequently in httpx

### DIFF
--- a/homeassistant/helpers/aiohttp_client.py
+++ b/homeassistant/helpers/aiohttp_client.py
@@ -271,7 +271,7 @@ def _async_get_connector(
         return cast(aiohttp.BaseConnector, hass.data[key])
 
     if verify_ssl:
-        ssl_context: bool | SSLContext = ssl_util.client_context()
+        ssl_context: bool | SSLContext = ssl_util.get_default_context()
     else:
         ssl_context = False
 

--- a/homeassistant/helpers/httpx_client.py
+++ b/homeassistant/helpers/httpx_client.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+import ssl
 import sys
 from typing import Any
 
@@ -20,6 +21,7 @@ SERVER_SOFTWARE = "{0}/{1} httpx/{2} Python/{3[0]}.{3[1]}".format(
     APPLICATION_NAME, __version__, httpx.__version__, sys.version_info
 )
 USER_AGENT = "User-Agent"
+_DEFAULT_SSL_CONTEXT = ssl.create_default_context()
 
 
 @callback
@@ -65,7 +67,7 @@ def create_async_httpx_client(
     This method must be run in the event loop.
     """
     client = HassHttpXAsyncClient(
-        verify=verify_ssl,
+        verify=_DEFAULT_SSL_CONTEXT if verify_ssl else False,
         headers={USER_AGENT: SERVER_SOFTWARE},
         **kwargs,
     )

--- a/homeassistant/helpers/httpx_client.py
+++ b/homeassistant/helpers/httpx_client.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-import ssl
 import sys
 from typing import Any
 
@@ -12,6 +11,7 @@ from typing_extensions import Self
 from homeassistant.const import APPLICATION_NAME, EVENT_HOMEASSISTANT_CLOSE, __version__
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.loader import bind_hass
+from homeassistant.util import ssl as ssl_util
 
 from .frame import warn_use
 
@@ -21,7 +21,6 @@ SERVER_SOFTWARE = "{0}/{1} httpx/{2} Python/{3[0]}.{3[1]}".format(
     APPLICATION_NAME, __version__, httpx.__version__, sys.version_info
 )
 USER_AGENT = "User-Agent"
-_DEFAULT_SSL_CONTEXT = ssl.create_default_context()
 
 
 @callback
@@ -67,7 +66,7 @@ def create_async_httpx_client(
     This method must be run in the event loop.
     """
     client = HassHttpXAsyncClient(
-        verify=_DEFAULT_SSL_CONTEXT if verify_ssl else False,
+        verify=ssl_util.get_default_context() if verify_ssl else False,
         headers={USER_AGENT: SERVER_SOFTWARE},
         **kwargs,
     )

--- a/homeassistant/util/ssl.py
+++ b/homeassistant/util/ssl.py
@@ -16,6 +16,15 @@ def client_context() -> ssl.SSLContext:
     return ssl.create_default_context(purpose=ssl.Purpose.SERVER_AUTH, cafile=cafile)
 
 
+# Create this only once and reuse it
+_DEFAULT_SSL_CONTEXT = client_context()
+
+
+def get_default_context() -> ssl.SSLContext:
+    """Return the default SSL context."""
+    return _DEFAULT_SSL_CONTEXT
+
+
 def server_context_modern() -> ssl.SSLContext:
     """Return an SSL context following the Mozilla recommendations.
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The same default `SSLContext` is now shared between the `httpx` and `aiohttp` helper when using the default shared client to reduce the overhead of creating multiple contexts with the same settings.

Creating an ssl context can read the default ssl certs from disk which can do I/O in the event loop.

We should provide an `SSLContext` instead of setting verify to `True`. This can make a substantial difference in `httpx` performance, especially with polling integrations, since previously session resumes were not always possible before https://docs.python.org/3/library/ssl.html#ssl.SSLContext.session_stats

see https://github.com/encode/httpx/pull/2609 https://github.com/encode/httpx/issues/838#issuecomment-1289927214


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
