### PR TITLE
Add media search

### DIFF
--- a/homeassistant/components/demo/media_player.py
+++ b/homeassistant/components/demo/media_player.py
@@ -12,16 +12,10 @@ from homeassistant.components.media_player import (
     MediaPlayerEntityFeature,
     MediaPlayerState,
     MediaType,
+    MediaClass,
     RepeatMode,
 )
-from homeassistant.components.media_player.const import (
-    MEDIA_CLASS_EPISODE,
-    MEDIA_CLASS_SEASON,
-    MEDIA_CLASS_TRACK,
-    MEDIA_TYPE_ALBUM,
-    MEDIA_TYPE_EPISODE,
-    MEDIA_TYPE_MUSIC,
-)
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -381,9 +375,9 @@ class DemoMusicPlayer(AbstractDemoPlayer):
                 children.append(
                     BrowseMedia(
                         title=item_name,
-                        media_class=MEDIA_CLASS_TRACK,
+                        media_class=MediaClass.TRACK,
                         media_content_id=str(count),
-                        media_content_type=MEDIA_TYPE_MUSIC,
+                        media_content_type=MediaType.MUSIC,
                         can_play=True,
                         can_expand=False,
                     )
@@ -392,10 +386,10 @@ class DemoMusicPlayer(AbstractDemoPlayer):
 
         return BrowseMedia(
             title=self._attr_media_album_name,
-            media_class=MEDIA_TYPE_ALBUM,
-            children_media_class=MEDIA_CLASS_TRACK,
+            media_class=MediaType.ALBUM,
+            children_media_class=MediaClass.TRACK,
             media_content_id=search_id,
-            media_content_type=MEDIA_TYPE_ALBUM,
+            media_content_type=MediaType.ALBUM,
             can_play=True,
             can_expand=False,
             children=children,
@@ -473,9 +467,9 @@ class DemoTVShowPlayer(AbstractDemoPlayer):
             children.append(
                 BrowseMedia(
                     title="Chapter " + str(episode),
-                    media_class=MEDIA_CLASS_EPISODE,
+                    media_class=MediaClass.EPISODE,
                     media_content_id=str(episode),
-                    media_content_type=MEDIA_TYPE_EPISODE,
+                    media_content_type=MediaType.EPISODE,
                     can_play=True,
                     can_expand=False,
                 )
@@ -484,10 +478,10 @@ class DemoTVShowPlayer(AbstractDemoPlayer):
 
         return BrowseMedia(
             title=self._attr_media_series_title,
-            media_class=MEDIA_CLASS_SEASON,
-            children_media_class=MEDIA_CLASS_EPISODE,
+            media_class=MediaClass.SEASON,
+            children_media_class=MediaClass.EPISODE,
             media_content_id=str(1),
-            media_content_type=MEDIA_TYPE_EPISODE,
+            media_content_type=MediaType.EPISODE,
             can_play=True,
             can_expand=False,
             children=children,

--- a/homeassistant/components/demo/media_player.py
+++ b/homeassistant/components/demo/media_player.py
@@ -2,9 +2,11 @@
 from __future__ import annotations
 
 from datetime import datetime
+from fnmatch import fnmatch
 from typing import Any
 
 from homeassistant.components.media_player import (
+    BrowseMedia,
     MediaPlayerDeviceClass,
     MediaPlayerEntity,
     MediaPlayerEntityFeature,
@@ -12,22 +14,20 @@ from homeassistant.components.media_player import (
     MediaType,
     RepeatMode,
 )
+from homeassistant.components.media_player.const import (
+    MEDIA_CLASS_EPISODE,
+    MEDIA_CLASS_SEASON,
+    MEDIA_CLASS_TRACK,
+    MEDIA_TYPE_ALBUM,
+    MEDIA_TYPE_EPISODE,
+    MEDIA_TYPE_MUSIC,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 import homeassistant.util.dt as dt_util
 
-from homeassistant.components.media_player.const import (
-    MEDIA_CLASS_TRACK,
-    MEDIA_CLASS_SEASON,
-    MEDIA_CLASS_EPISODE,
-    MEDIA_TYPE_EPISODE,
-    MEDIA_TYPE_MUSIC,
-    MEDIA_TYPE_ALBUM,
-)
-from homeassistant.components.media_player import BrowseMedia
-from fnmatch import fnmatch
 
 async def async_setup_platform(
     hass: HomeAssistant,
@@ -368,9 +368,11 @@ class DemoMusicPlayer(AbstractDemoPlayer):
     ) -> BrowseMedia:
         """Implement the websocket media browsing helper."""
         search_id = media_content_id
-        if not search_id: search_id = " "
-        is_filter = ("*" in search_id)
-        if is_filter: query = search_id.lower()
+        if not search_id:
+            search_id = " "
+        is_filter = "*" in search_id
+        if is_filter:
+            query = search_id.lower()
         children = []
         count = 0
         for item in self.tracks:
@@ -398,9 +400,10 @@ class DemoMusicPlayer(AbstractDemoPlayer):
             can_expand=False,
             children=children,
             thumbnail=self._attr_media_image_url,
-            not_shown = count - len(children),
+            not_shown=count - len(children),
             can_search=True,
         )
+
 
 class DemoTVShowPlayer(AbstractDemoPlayer):
     """A Demo media player that only supports Netflix."""
@@ -466,7 +469,7 @@ class DemoTVShowPlayer(AbstractDemoPlayer):
         """Implement the websocket media browsing helper."""
         children = []
         count = 0
-        for episode in range(1,self._episode_count):
+        for episode in range(1, self._episode_count):
             children.append(
                 BrowseMedia(
                     title="Chapter " + str(episode),
@@ -490,4 +493,3 @@ class DemoTVShowPlayer(AbstractDemoPlayer):
             children=children,
             thumbnail=self._attr_media_image_url,
         )
-

--- a/homeassistant/components/demo/media_player.py
+++ b/homeassistant/components/demo/media_player.py
@@ -18,6 +18,16 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 import homeassistant.util.dt as dt_util
 
+from homeassistant.components.media_player.const import (
+    MEDIA_CLASS_TRACK,
+    MEDIA_CLASS_SEASON,
+    MEDIA_CLASS_EPISODE,
+    MEDIA_TYPE_EPISODE,
+    MEDIA_TYPE_MUSIC,
+    MEDIA_TYPE_ALBUM,
+)
+from homeassistant.components.media_player import BrowseMedia
+from fnmatch import fnmatch
 
 async def async_setup_platform(
     hass: HomeAssistant,
@@ -86,6 +96,8 @@ MUSIC_PLAYER_SUPPORT = (
     | MediaPlayerEntityFeature.NEXT_TRACK
     | MediaPlayerEntityFeature.SELECT_SOUND_MODE
     | MediaPlayerEntityFeature.STOP
+    | MediaPlayerEntityFeature.BROWSE_MEDIA
+    | MediaPlayerEntityFeature.PLAY_MEDIA
 )
 
 NETFLIX_PLAYER_SUPPORT = (
@@ -99,6 +111,8 @@ NETFLIX_PLAYER_SUPPORT = (
     | MediaPlayerEntityFeature.NEXT_TRACK
     | MediaPlayerEntityFeature.SELECT_SOUND_MODE
     | MediaPlayerEntityFeature.STOP
+    | MediaPlayerEntityFeature.BROWSE_MEDIA
+    | MediaPlayerEntityFeature.PLAY_MEDIA
 )
 
 
@@ -339,6 +353,54 @@ class DemoMusicPlayer(AbstractDemoPlayer):
         self._attr_group_members = []
         self.schedule_update_ha_state()
 
+    async def async_play_media(
+        self, media_type: MediaType | str, media_id: str, **kwargs: Any
+    ) -> None:
+        """Play a piece of media."""
+        try:
+            self._cur_track = int(media_id)
+        except ValueError:
+            self._cur_track = 0
+        self.schedule_update_ha_state()
+
+    async def async_browse_media(
+        self, media_content_type: str | None = None, media_content_id: str | None = None
+    ) -> BrowseMedia:
+        """Implement the websocket media browsing helper."""
+        search_id = media_content_id
+        if not search_id: search_id = " "
+        is_filter = ("*" in search_id)
+        if is_filter: query = search_id.lower()
+        children = []
+        count = 0
+        for item in self.tracks:
+            item_name = item[0] + " - " + item[1]
+            if not is_filter or fnmatch(item_name.lower(), query):
+                children.append(
+                    BrowseMedia(
+                        title=item_name,
+                        media_class=MEDIA_CLASS_TRACK,
+                        media_content_id=str(count),
+                        media_content_type=MEDIA_TYPE_MUSIC,
+                        can_play=True,
+                        can_expand=False,
+                    )
+                )
+            count += 1
+
+        return BrowseMedia(
+            title=self._attr_media_album_name,
+            media_class=MEDIA_TYPE_ALBUM,
+            children_media_class=MEDIA_CLASS_TRACK,
+            media_content_id=search_id,
+            media_content_type=MEDIA_TYPE_ALBUM,
+            can_play=True,
+            can_expand=False,
+            children=children,
+            thumbnail=self._attr_media_image_url,
+            not_shown = count - len(children),
+            can_search=True,
+        )
 
 class DemoTVShowPlayer(AbstractDemoPlayer):
     """A Demo media player that only supports Netflix."""
@@ -390,3 +452,42 @@ class DemoTVShowPlayer(AbstractDemoPlayer):
         """Set the input source."""
         self._attr_source = source
         self.schedule_update_ha_state()
+
+    async def async_play_media(
+        self, media_type: MediaType | str, media_id: str, **kwargs: Any
+    ) -> None:
+        """Play a piece of media."""
+        self._cur_episode = int(media_id)
+        self.schedule_update_ha_state()
+
+    async def async_browse_media(
+        self, media_content_type: str | None = None, media_content_id: str | None = None
+    ) -> BrowseMedia:
+        """Implement the websocket media browsing helper."""
+        children = []
+        count = 0
+        for episode in range(1,self._episode_count):
+            children.append(
+                BrowseMedia(
+                    title="Chapter " + str(episode),
+                    media_class=MEDIA_CLASS_EPISODE,
+                    media_content_id=str(episode),
+                    media_content_type=MEDIA_TYPE_EPISODE,
+                    can_play=True,
+                    can_expand=False,
+                )
+            )
+            count += 1
+
+        return BrowseMedia(
+            title=self._attr_media_series_title,
+            media_class=MEDIA_CLASS_SEASON,
+            children_media_class=MEDIA_CLASS_EPISODE,
+            media_content_id=str(1),
+            media_content_type=MEDIA_TYPE_EPISODE,
+            can_play=True,
+            can_expand=False,
+            children=children,
+            thumbnail=self._attr_media_image_url,
+        )
+

--- a/homeassistant/components/media_player/browse_media.py
+++ b/homeassistant/components/media_player/browse_media.py
@@ -103,6 +103,7 @@ class BrowseMedia:
         children_media_class: MediaClass | str | None = None,
         thumbnail: str | None = None,
         not_shown: int = 0,
+        can_search: bool = False,
     ) -> None:
         """Initialize browse media item."""
         self.media_class = media_class
@@ -115,6 +116,7 @@ class BrowseMedia:
         self.children_media_class = children_media_class
         self.thumbnail = thumbnail
         self.not_shown = not_shown
+        self.can_search = can_search
 
     def as_dict(self, *, parent: bool = True) -> dict[str, Any]:
         """Convert Media class to browse media dictionary."""
@@ -136,6 +138,7 @@ class BrowseMedia:
             return response
 
         response["not_shown"] = self.not_shown
+        response["can_search"] = self.can_search
 
         if self.children:
             response["children"] = [

--- a/homeassistant/components/squeezebox/browse_media.py
+++ b/homeassistant/components/squeezebox/browse_media.py
@@ -71,6 +71,8 @@ async def build_item_response(entity, player, payload):
 
     media_class = CONTENT_TYPE_MEDIA_CLASS[search_type]
 
+    """For wildcard searches, search_id is the query as `*<query>*`.
+         search_type is the origional media_type"""
     if "*" in search_id:
         items = await player._lms.async_query_category(
             MEDIA_TYPE_TO_SQUEEZEBOX[search_type],
@@ -139,7 +141,9 @@ async def build_item_response(entity, player, payload):
         can_play=True,
         children=children,
         can_expand=True,
-        can_search=(search_type in SEARCHABLE_TYPES),
+        can_search=(
+            search_type in SEARCHABLE_TYPES
+        ),  #  can_search enables the search button on frontend
     )
 
 

--- a/homeassistant/components/squeezebox/browse_media.py
+++ b/homeassistant/components/squeezebox/browse_media.py
@@ -73,7 +73,7 @@ async def build_item_response(entity, player, payload):
 
     """For wildcard searches, search_id is the query as `*<query>*`.
          search_type is the origional media_type"""
-    if "*" in search_id:
+    if search_id.startswith("*") and search_id.endswith("*"):
         items = await player._lms.async_query_category(
             MEDIA_TYPE_TO_SQUEEZEBOX[search_type],
             limit=BROWSE_LIMIT,

--- a/tests/components/media_player/test_init.py
+++ b/tests/components/media_player/test_init.py
@@ -188,6 +188,7 @@ async def test_media_browse(
         "media_content_id": "mock-id",
         "can_play": False,
         "can_expand": True,
+        "can_search": False,
         "children_media_class": None,
         "thumbnail": None,
         "not_shown": 0,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This is back-end support for adding a Search function to Media Browser filtering content.  It is particularly targeted for media_player integrations with large media libraries that support search functionality as part of the API

Adds `can_search` to BrowseMedia function so the Search button can be enabled where support is applicable.

See matching [front-end PR ](https://github.com/home-assistant/frontend/pull/15867) for 'ha-media-search-button' support in the media browse panel and dialog, and further details

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

The opens up additional functionality for existing media_player entities

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

Code examples are included in the Demo integration. 

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
