### PR TITLE
Turn AVM FRITZ!Box Tools sensors into coordinator entities 

### DIFF
--- a/homeassistant/components/fritz/common.py
+++ b/homeassistant/components/fritz/common.py
@@ -1028,6 +1028,7 @@ class FritzBoxBaseCoordinatorEntity(update_coordinator.CoordinatorEntity):
 
     coordinator: AvmWrapper
     entity_description: FritzEntityDescription
+    _attr_has_entity_name = True
 
     def __init__(
         self,
@@ -1042,7 +1043,6 @@ class FritzBoxBaseCoordinatorEntity(update_coordinator.CoordinatorEntity):
         )
         self.entity_description = description
         self._device_name = device_name
-        self._attr_has_entity_name = True
         self._attr_name = description.name
         self._attr_unique_id = f"{avm_wrapper.unique_id}-{description.key}"
 

--- a/homeassistant/components/fritz/common.py
+++ b/homeassistant/components/fritz/common.py
@@ -1029,17 +1029,22 @@ class FritzBoxBaseCoordinatorEntity(update_coordinator.CoordinatorEntity):
     coordinator: AvmWrapper
     entity_description: FritzEntityDescription
 
-    def __init__(self, avm_wrapper: AvmWrapper, device_name: str) -> None:
+    def __init__(
+        self,
+        avm_wrapper: AvmWrapper,
+        device_name: str,
+        description: FritzEntityDescription,
+    ) -> None:
         """Init device info class."""
         super().__init__(avm_wrapper)
         self.async_on_remove(
-            avm_wrapper.register_entity_updates(
-                self.entity_description.key, self.entity_description.value_fn
-            )
+            avm_wrapper.register_entity_updates(description.key, description.value_fn)
         )
+        self.entity_description = description
         self._device_name = device_name
-        self._attr_name = f"{device_name} {self.entity_description.name}"
-        self._attr_unique_id = f"{avm_wrapper.unique_id}-{self.entity_description.key}"
+        self._attr_has_entity_name = True
+        self._attr_name = description.name
+        self._attr_unique_id = f"{avm_wrapper.unique_id}-{description.key}"
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/homeassistant/components/fritz/common.py
+++ b/homeassistant/components/fritz/common.py
@@ -35,7 +35,8 @@ from homeassistant.helpers import (
     update_coordinator,
 )
 from homeassistant.helpers.dispatcher import async_dispatcher_send
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity import DeviceInfo, EntityDescription
+from homeassistant.helpers.typing import StateType
 from homeassistant.util import dt as dt_util
 
 from .const import (
@@ -136,7 +137,9 @@ class HostInfo(TypedDict):
     status: bool
 
 
-class FritzBoxTools(update_coordinator.DataUpdateCoordinator[None]):
+class FritzBoxTools(
+    update_coordinator.DataUpdateCoordinator[dict[str, bool | StateType]]
+):
     """FritzBoxTools class."""
 
     def __init__(
@@ -175,6 +178,9 @@ class FritzBoxTools(update_coordinator.DataUpdateCoordinator[None]):
         self._latest_firmware: str | None = None
         self._update_available: bool = False
         self._release_url: str | None = None
+        self._entity_update_functions: dict[
+            str, Callable[[FritzStatus, StateType], Any]
+        ] = {}
 
     async def async_setup(
         self, options: MappingProxyType[str, Any] | None = None
@@ -237,12 +243,36 @@ class FritzBoxTools(update_coordinator.DataUpdateCoordinator[None]):
             )
             self.device_is_router = self.fritz_status.has_wan_enabled
 
-    async def _async_update_data(self) -> None:
+    def register_entity_updates(
+        self, key: str, update_fn: Callable[[FritzStatus, StateType], Any]
+    ) -> Callable[[], None]:
+        """Register an entity to be updated by coordinator."""
+
+        def unregister_entity_updates() -> None:
+            """Unregister an entity to be updated by coordinator."""
+            if key in self._entity_update_functions:
+                _LOGGER.debug("unregister entity %s from updates", key)
+                self._entity_update_functions.pop(key)
+
+        if key not in self._entity_update_functions:
+            _LOGGER.debug("register entity %s for updates", key)
+            self._entity_update_functions[key] = update_fn
+        return unregister_entity_updates
+
+    async def _async_update_data(self) -> dict[str, bool | StateType]:
         """Update FritzboxTools data."""
+        enity_data: dict[str, bool | StateType] = {}
         try:
             await self.async_scan_devices()
+            for key, update_fn in self._entity_update_functions.items():
+                _LOGGER.debug("update entity %s", key)
+                enity_data[key] = await self.hass.async_add_executor_job(
+                    update_fn, self.fritz_status, self.data.get(key)
+                )
         except FRITZ_EXCEPTIONS as ex:
             raise update_coordinator.UpdateFailed(ex) from ex
+        _LOGGER.debug("enity_data: %s", enity_data)
+        return enity_data
 
     @property
     def unique_id(self) -> str:
@@ -978,6 +1008,50 @@ class FritzBoxBaseEntity:
             model=self._avm_wrapper.model,
             name=self._device_name,
             sw_version=self._avm_wrapper.current_firmware,
+        )
+
+
+@dataclass
+class FritzRequireKeysMixin:
+    """Fritz entity description mix in."""
+
+    value_fn: Callable[[FritzStatus, Any], Any]
+
+
+@dataclass
+class FritzEntityDescription(EntityDescription, FritzRequireKeysMixin):
+    """Fritz entity base description."""
+
+
+class FritzBoxBaseCoordinatorEntity(update_coordinator.CoordinatorEntity):
+    """Fritz host coordinator entity base class."""
+
+    coordinator: AvmWrapper
+    entity_description: FritzEntityDescription
+
+    def __init__(self, avm_wrapper: AvmWrapper, device_name: str) -> None:
+        """Init device info class."""
+        super().__init__(avm_wrapper)
+        self.async_on_remove(
+            avm_wrapper.register_entity_updates(
+                self.entity_description.key, self.entity_description.value_fn
+            )
+        )
+        self._device_name = device_name
+        self._attr_name = f"{device_name} {self.entity_description.name}"
+        self._attr_unique_id = f"{avm_wrapper.unique_id}-{self.entity_description.key}"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device information."""
+        return DeviceInfo(
+            configuration_url=f"http://{self.coordinator.host}",
+            connections={(dr.CONNECTION_NETWORK_MAC, self.coordinator.mac)},
+            identifiers={(DOMAIN, self.coordinator.unique_id)},
+            manufacturer="AVM",
+            model=self.coordinator.model,
+            name=self._device_name,
+            sw_version=self.coordinator.current_firmware,
         )
 
 

--- a/homeassistant/components/fritz/sensor.py
+++ b/homeassistant/components/fritz/sensor.py
@@ -5,9 +5,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 import logging
-from typing import Any
 
-from fritzconnection.core.exceptions import FritzConnectionException
 from fritzconnection.lib.fritzstatus import FritzStatus
 
 from homeassistant.components.sensor import (
@@ -25,9 +23,15 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import StateType
 from homeassistant.util.dt import utcnow
 
-from .common import AvmWrapper, ConnectionInfo, FritzBoxBaseEntity
+from .common import (
+    AvmWrapper,
+    ConnectionInfo,
+    FritzBoxBaseCoordinatorEntity,
+    FritzEntityDescription,
+)
 from .const import DOMAIN, DSL_CONNECTION, UPTIME_DEVIATION
 
 _LOGGER = logging.getLogger(__name__)
@@ -139,14 +143,7 @@ def _retrieve_link_attenuation_received_state(
 
 
 @dataclass
-class FritzRequireKeysMixin:
-    """Fritz sensor data class."""
-
-    value_fn: Callable[[FritzStatus, Any], Any]
-
-
-@dataclass
-class FritzSensorEntityDescription(SensorEntityDescription, FritzRequireKeysMixin):
+class FritzSensorEntityDescription(SensorEntityDescription, FritzEntityDescription):
     """Describes Fritz sensor entity."""
 
     is_suitable: Callable[[ConnectionInfo], bool] = lambda info: info.wan_enabled
@@ -304,7 +301,7 @@ async def async_setup_entry(
     async_add_entities(entities, True)
 
 
-class FritzBoxSensor(FritzBoxBaseEntity, SensorEntity):
+class FritzBoxSensor(FritzBoxBaseCoordinatorEntity, SensorEntity):
     """Define FRITZ!Box connectivity class."""
 
     entity_description: FritzSensorEntityDescription
@@ -317,23 +314,9 @@ class FritzBoxSensor(FritzBoxBaseEntity, SensorEntity):
     ) -> None:
         """Init FRITZ!Box connectivity class."""
         self.entity_description = description
-        self._last_device_value: str | None = None
-        self._attr_available = True
-        self._attr_name = f"{device_friendly_name} {description.name}"
-        self._attr_unique_id = f"{avm_wrapper.unique_id}-{description.key}"
         super().__init__(avm_wrapper, device_friendly_name)
 
-    def update(self) -> None:
-        """Update data."""
-        _LOGGER.debug("Updating FRITZ!Box sensors")
-
-        status: FritzStatus = self._avm_wrapper.fritz_status
-        try:
-            self._attr_native_value = (
-                self._last_device_value
-            ) = self.entity_description.value_fn(status, self._last_device_value)
-        except FritzConnectionException:
-            _LOGGER.error("Error getting the state from the FRITZ!Box", exc_info=True)
-            self._attr_available = False
-            return
-        self._attr_available = True
+    @property
+    def native_value(self) -> StateType:
+        """Return the value reported by the sensor."""
+        return self.coordinator.data.get(self.entity_description.key)

--- a/homeassistant/components/fritz/sensor.py
+++ b/homeassistant/components/fritz/sensor.py
@@ -306,16 +306,6 @@ class FritzBoxSensor(FritzBoxBaseCoordinatorEntity, SensorEntity):
 
     entity_description: FritzSensorEntityDescription
 
-    def __init__(
-        self,
-        avm_wrapper: AvmWrapper,
-        device_friendly_name: str,
-        description: FritzSensorEntityDescription,
-    ) -> None:
-        """Init FRITZ!Box connectivity class."""
-        self.entity_description = description
-        super().__init__(avm_wrapper, device_friendly_name)
-
     @property
     def native_value(self) -> StateType:
         """Return the value reported by the sensor."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The AVM FRITZ!Box Tools already uses a data update coordinator, but did not implement real coordinator entities.
This is the first PR (_starting with sensor platform_) to turn all entities into coordinator entities.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
