### PR TITLE
Retain history when renaming an entity_id

### DIFF
--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.integration_platform import (
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import bind_hass
 
-from . import statistics, websocket_api
+from . import entity_registry, websocket_api
 from .const import (  # noqa: F401
     CONF_DB_INTEGRITY_CHECK,
     DATA_INSTANCE,
@@ -163,8 +163,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     instance.async_register()
     instance.start()
     async_register_services(hass, instance)
-    statistics.async_setup(hass)
     websocket_api.async_setup(hass)
+    entity_registry.async_setup(hass)
     await async_process_integration_platforms(hass, DOMAIN, _process_recorder_platform)
 
     return await instance.async_db_ready

--- a/homeassistant/components/recorder/core.py
+++ b/homeassistant/components/recorder/core.py
@@ -977,8 +977,27 @@ class Recorder(threading.Thread):
     def _process_state_changed_event_into_session(self, event: Event) -> None:
         """Process a state_changed event into the session."""
         state_attributes_manager = self.state_attributes_manager
+        states_meta_manager = self.states_meta_manager
+        states_meta_manager_active = states_meta_manager.active
+        entity_removed = not event.data.get("new_state")
+        entity_id = event.data["entity_id"]
+
         dbstate = States.from_event(event)
-        if (entity_id := dbstate.entity_id) is None or not (
+
+        states_manager = self.states_manager
+        if old_state := states_manager.pop_pending(entity_id):
+            dbstate.old_state = old_state
+        elif old_state_id := states_manager.pop_committed(entity_id):
+            dbstate.old_state_id = old_state_id
+        if entity_removed:
+            dbstate.state = None
+        else:
+            states_manager.add_pending(entity_id, dbstate)
+
+        if states_meta_manager_active:
+            dbstate.entity_id = None
+
+        if entity_id is None or not (
             shared_attrs_bytes := state_attributes_manager.serialize_from_event(event)
         ):
             return
@@ -986,11 +1005,16 @@ class Recorder(threading.Thread):
         assert self.event_session is not None
         session = self.event_session
         # Map the entity_id to the StatesMeta table
-        states_meta_manager = self.states_meta_manager
         if pending_states_meta := states_meta_manager.get_pending(entity_id):
             dbstate.states_meta_rel = pending_states_meta
         elif metadata_id := states_meta_manager.get(entity_id, session, True):
             dbstate.metadata_id = metadata_id
+        elif states_meta_manager_active and entity_removed:
+            # If the entity was removed, we don't need to add it to the
+            # StatesMeta table or record it in the pending commit
+            # if it does not have a metadata_id allocated to it as
+            # it either never existed or was just renamed.
+            return
         else:
             states_meta = StatesMeta(entity_id=entity_id)
             states_meta_manager.add_pending(states_meta)
@@ -1021,19 +1045,6 @@ class Recorder(threading.Thread):
             state_attributes_manager.add_pending(dbstate_attributes)
             session.add(dbstate_attributes)
             dbstate.state_attributes = dbstate_attributes
-
-        states_manager = self.states_manager
-        if old_state := states_manager.pop_pending(entity_id):
-            dbstate.old_state = old_state
-        elif old_state_id := states_manager.pop_committed(entity_id):
-            dbstate.old_state_id = old_state_id
-        if event.data.get("new_state"):
-            states_manager.add_pending(entity_id, dbstate)
-        else:
-            dbstate.state = None
-
-        if states_meta_manager.active:
-            dbstate.entity_id = None
 
         session.add(dbstate)
 

--- a/homeassistant/components/recorder/core.py
+++ b/homeassistant/components/recorder/core.py
@@ -978,7 +978,6 @@ class Recorder(threading.Thread):
         """Process a state_changed event into the session."""
         state_attributes_manager = self.state_attributes_manager
         states_meta_manager = self.states_meta_manager
-        states_meta_manager_active = states_meta_manager.active
         entity_removed = not event.data.get("new_state")
         entity_id = event.data["entity_id"]
 
@@ -994,7 +993,7 @@ class Recorder(threading.Thread):
         else:
             states_manager.add_pending(entity_id, dbstate)
 
-        if states_meta_manager_active:
+        if states_meta_manager.active:
             dbstate.entity_id = None
 
         if entity_id is None or not (
@@ -1009,7 +1008,7 @@ class Recorder(threading.Thread):
             dbstate.states_meta_rel = pending_states_meta
         elif metadata_id := states_meta_manager.get(entity_id, session, True):
             dbstate.metadata_id = metadata_id
-        elif states_meta_manager_active and entity_removed:
+        elif states_meta_manager.active and entity_removed:
             # If the entity was removed, we don't need to add it to the
             # StatesMeta table or record it in the pending commit
             # if it does not have a metadata_id allocated to it as

--- a/homeassistant/components/recorder/core.py
+++ b/homeassistant/components/recorder/core.py
@@ -109,6 +109,7 @@ from .tasks import (
     StatisticsTask,
     StopTask,
     SynchronizeTask,
+    UpdateStatesMetadataTask,
     UpdateStatisticsMetadataTask,
     WaitTask,
 )
@@ -545,6 +546,15 @@ class Recorder(threading.Thread):
                 statistic_id, new_statistic_id, new_unit_of_measurement
             )
         )
+
+    @callback
+    def async_update_states_metadata(
+        self,
+        entity_id: str,
+        new_entity_id: str,
+    ) -> None:
+        """Update states metadata for an entity_id."""
+        self.queue_task(UpdateStatesMetadataTask(entity_id, new_entity_id))
 
     @callback
     def async_change_statistics_unit(

--- a/homeassistant/components/recorder/entity_registry.py
+++ b/homeassistant/components/recorder/entity_registry.py
@@ -11,6 +11,7 @@ from .util import get_instance, session_scope
 _LOGGER = logging.getLogger(__name__)
 
 
+@callback
 def async_setup(hass: HomeAssistant) -> None:
     """Set up the entity hooks."""
 

--- a/homeassistant/components/recorder/entity_registry.py
+++ b/homeassistant/components/recorder/entity_registry.py
@@ -61,9 +61,7 @@ def update_states_metadata(
         return
 
     with session_scope(session=instance.get_session()) as session:
-        if not instance.states_meta_manager.update_metadata(
-            session, entity_id, new_entity_id
-        ):
+        if not states_meta_manager.update_metadata(session, entity_id, new_entity_id):
             _LOGGER.warning(
                 "Cannot migrate history for entity_id `%s` to `%s` "
                 "because the new entity_id is already in use",

--- a/homeassistant/components/recorder/entity_registry.py
+++ b/homeassistant/components/recorder/entity_registry.py
@@ -1,0 +1,50 @@
+"""Entity helper."""
+from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.start import async_at_start
+
+from .core import Recorder
+from .util import get_instance, session_scope
+
+
+def async_setup(hass: HomeAssistant) -> None:
+    """Set up the entity hooks."""
+
+    @callback
+    def _async_entity_id_changed(event: Event) -> None:
+        instance = get_instance(hass)
+        old_entity_id: str = event.data["old_entity_id"]
+        new_entity_id: str = event.data["entity_id"]
+        instance.async_update_statistics_metadata(
+            old_entity_id, new_statistic_id=new_entity_id
+        )
+        instance.async_update_states_metadata(
+            old_entity_id, new_entity_id=new_entity_id
+        )
+
+    @callback
+    def entity_registry_changed_filter(event: Event) -> bool:
+        """Handle entity_id changed filter."""
+        return event.data["action"] == "update" and "old_entity_id" in event.data
+
+    @callback
+    def _setup_entity_registry_event_handler(hass: HomeAssistant) -> None:
+        """Subscribe to event registry events."""
+        hass.bus.async_listen(
+            er.EVENT_ENTITY_REGISTRY_UPDATED,
+            _async_entity_id_changed,
+            event_filter=entity_registry_changed_filter,
+            run_immediately=True,
+        )
+
+    async_at_start(hass, _setup_entity_registry_event_handler)
+
+
+def update_states_metadata(
+    instance: Recorder,
+    entity_id: str,
+    new_entity_id: str,
+) -> None:
+    """Update the states metadata table when an entity is renamed."""
+    with session_scope(session=instance.get_session()) as session:
+        instance.states_meta_manager.update_metadata(session, entity_id, new_entity_id)

--- a/homeassistant/components/recorder/entity_registry.py
+++ b/homeassistant/components/recorder/entity_registry.py
@@ -61,4 +61,12 @@ def update_states_metadata(
         return
 
     with session_scope(session=instance.get_session()) as session:
-        instance.states_meta_manager.update_metadata(session, entity_id, new_entity_id)
+        if not instance.states_meta_manager.update_metadata(
+            session, entity_id, new_entity_id
+        ):
+            _LOGGER.warning(
+                "Cannot migrate history for entity_id `%s` to `%s` "
+                "because the new entity_id is already in use",
+                entity_id,
+                new_entity_id,
+            )

--- a/homeassistant/components/recorder/entity_registry.py
+++ b/homeassistant/components/recorder/entity_registry.py
@@ -1,10 +1,14 @@
-"""Entity helper."""
+"""Recorder entity registry helper."""
+import logging
+
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.start import async_at_start
 
 from .core import Recorder
 from .util import get_instance, session_scope
+
+_LOGGER = logging.getLogger(__name__)
 
 
 def async_setup(hass: HomeAssistant) -> None:
@@ -46,5 +50,15 @@ def update_states_metadata(
     new_entity_id: str,
 ) -> None:
     """Update the states metadata table when an entity is renamed."""
+    states_meta_manager = instance.states_meta_manager
+    if not states_meta_manager.active:
+        _LOGGER.warning(
+            "Cannot rename entity_id `%s` to `%s` "
+            "because the states meta manager is not yet active",
+            entity_id,
+            new_entity_id,
+        )
+        return
+
     with session_scope(session=instance.get_session()) as session:
         instance.states_meta_manager.update_metadata(session, entity_id, new_entity_id)

--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -26,11 +26,9 @@ from sqlalchemy.sql.lambdas import StatementLambdaElement
 import voluptuous as vol
 
 from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT
-from homeassistant.core import Event, HomeAssistant, callback, valid_entity_id
+from homeassistant.core import HomeAssistant, callback, valid_entity_id
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.json import JSONEncoder
-from homeassistant.helpers.start import async_at_start
 from homeassistant.helpers.storage import STORAGE_DIR
 from homeassistant.helpers.typing import UNDEFINED, UndefinedType
 from homeassistant.util import dt as dt_util
@@ -324,35 +322,6 @@ class ValidationIssue:
     def as_dict(self) -> dict:
         """Return dictionary version."""
         return dataclasses.asdict(self)
-
-
-def async_setup(hass: HomeAssistant) -> None:
-    """Set up the history hooks."""
-
-    @callback
-    def _async_entity_id_changed(event: Event) -> None:
-        get_instance(hass).async_update_statistics_metadata(
-            event.data["old_entity_id"], new_statistic_id=event.data["entity_id"]
-        )
-
-    @callback
-    def entity_registry_changed_filter(event: Event) -> bool:
-        """Handle entity_id changed filter."""
-        if event.data["action"] != "update" or "old_entity_id" not in event.data:
-            return False
-
-        return True
-
-    @callback
-    def setup_entity_registry_event_handler(hass: HomeAssistant) -> None:
-        """Subscribe to event registry events."""
-        hass.bus.async_listen(
-            er.EVENT_ENTITY_REGISTRY_UPDATED,
-            _async_entity_id_changed,
-            event_filter=entity_registry_changed_filter,
-        )
-
-    async_at_start(hass, setup_entity_registry_event_handler)
 
 
 def get_start_time() -> datetime:

--- a/homeassistant/components/recorder/table_managers/states_meta.py
+++ b/homeassistant/components/recorder/table_managers/states_meta.py
@@ -152,7 +152,7 @@ class StatesMetaManager(BaseLRUTableManager[StatesMeta]):
         new_entity_id: str,
     ) -> bool:
         """Update states metadata for an entity_id."""
-        if self.get(new_entity_id, session, False) is not None:
+        if self.get(new_entity_id, session, True) is not None:
             # If the new entity id already exists we have
             # a collision and should not update.
             return False

--- a/homeassistant/components/recorder/table_managers/states_meta.py
+++ b/homeassistant/components/recorder/table_managers/states_meta.py
@@ -144,3 +144,29 @@ class StatesMetaManager(BaseLRUTableManager[StatesMeta]):
         """
         for entity_id in entity_ids:
             self._id_map.pop(entity_id, None)
+
+    def update_metadata(
+        self,
+        session: Session,
+        entity_id: str,
+        new_entity_id: str,
+    ) -> None:
+        """Update states metadata for an entity_id."""
+        if (
+            session.query(StatesMeta)
+            .filter(StatesMeta.entity_id == entity_id)
+            .update({StatesMeta.entity_id: new_entity_id})
+            and (old_metadata_id := self._id_map.pop(entity_id, None))
+            and (pending := self._pending.get(entity_id))
+        ):
+            # Purge the cache but do not add the new entity_id
+            # to the cache since we do not know if the session
+            # will be committed in case of a rollback. The next
+            # time the entity_id is recorded, it will be added
+            # to the cache.
+            #
+            # If the new entity id managed to get a pending state
+            # change into the queue before the registry update was seen
+            # we set the metadata_id to the old metadata_id so that
+            # the state change is not lost.
+            pending.metadata_id = old_metadata_id

--- a/homeassistant/components/recorder/tasks.py
+++ b/homeassistant/components/recorder/tasks.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Any
 from homeassistant.core import Event
 from homeassistant.helpers.typing import UndefinedType
 
-from . import purge, statistics
+from . import entity_registry, purge, statistics
 from .const import DOMAIN, EXCLUDE_ATTRIBUTES
 from .db_schema import Statistics, StatisticsShortTerm
 from .models import StatisticData, StatisticMetaData
@@ -80,6 +80,22 @@ class UpdateStatisticsMetadataTask(RecorderTask):
             self.statistic_id,
             self.new_statistic_id,
             self.new_unit_of_measurement,
+        )
+
+
+@dataclass
+class UpdateStatesMetadataTask(RecorderTask):
+    """Task to update states metadata."""
+
+    entity_id: str
+    new_entity_id: str
+
+    def run(self, instance: Recorder) -> None:
+        """Handle the task."""
+        entity_registry.update_states_metadata(
+            instance,
+            self.entity_id,
+            self.new_entity_id,
         )
 
 

--- a/tests/components/recorder/common.py
+++ b/tests/components/recorder/common.py
@@ -39,6 +39,15 @@ class BlockRecorderTask(RecorderTask):
         time.sleep(self.seconds)
 
 
+@dataclass
+class ForceReturnConnectionToPool(RecorderTask):
+    """Force return connection to pool."""
+
+    def run(self, instance: Recorder) -> None:
+        """Handle the task."""
+        instance.event_session.commit()
+
+
 async def async_block_recorder(hass: HomeAssistant, seconds: float) -> None:
     """Block the recorders event loop for testing.
 

--- a/tests/components/recorder/common.py
+++ b/tests/components/recorder/common.py
@@ -4,21 +4,22 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Iterable
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
 import time
 from typing import Any, Literal, cast
+from unittest.mock import patch, sentinel
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm.session import Session
 
 from homeassistant import core as ha
 from homeassistant.components import recorder
-from homeassistant.components.recorder import get_instance, statistics
-from homeassistant.components.recorder.core import Recorder
+from homeassistant.components.recorder import Recorder, get_instance, statistics
 from homeassistant.components.recorder.db_schema import RecorderRuns
 from homeassistant.components.recorder.tasks import RecorderTask, StatisticsTask
+from homeassistant.const import UnitOfTemperature
 from homeassistant.core import Event, HomeAssistant, State
-from homeassistant.util import dt as dt_util
+import homeassistant.util.dt as dt_util
 
 from . import db_schema_0
 
@@ -221,3 +222,77 @@ def assert_dict_of_states_equal_without_context_and_last_changed(
         assert_multiple_states_equal_without_context_and_last_changed(
             state, others[entity_id]
         )
+
+
+def record_states(hass):
+    """Record some test states.
+
+    We inject a bunch of state updates temperature sensors.
+    """
+    mp = "media_player.test"
+    sns1 = "sensor.test1"
+    sns2 = "sensor.test2"
+    sns3 = "sensor.test3"
+    sns4 = "sensor.test4"
+    sns1_attr = {
+        "device_class": "temperature",
+        "state_class": "measurement",
+        "unit_of_measurement": UnitOfTemperature.CELSIUS,
+    }
+    sns2_attr = {
+        "device_class": "humidity",
+        "state_class": "measurement",
+        "unit_of_measurement": "%",
+    }
+    sns3_attr = {"device_class": "temperature"}
+    sns4_attr = {}
+
+    def set_state(entity_id, state, **kwargs):
+        """Set the state."""
+        hass.states.set(entity_id, state, **kwargs)
+        wait_recording_done(hass)
+        return hass.states.get(entity_id)
+
+    zero = dt_util.utcnow()
+    one = zero + timedelta(seconds=1 * 5)
+    two = one + timedelta(seconds=15 * 5)
+    three = two + timedelta(seconds=30 * 5)
+    four = three + timedelta(seconds=15 * 5)
+
+    states = {mp: [], sns1: [], sns2: [], sns3: [], sns4: []}
+    with patch(
+        "homeassistant.components.recorder.core.dt_util.utcnow", return_value=one
+    ):
+        states[mp].append(
+            set_state(mp, "idle", attributes={"media_title": str(sentinel.mt1)})
+        )
+        states[sns1].append(set_state(sns1, "10", attributes=sns1_attr))
+        states[sns2].append(set_state(sns2, "10", attributes=sns2_attr))
+        states[sns3].append(set_state(sns3, "10", attributes=sns3_attr))
+        states[sns4].append(set_state(sns4, "10", attributes=sns4_attr))
+
+    with patch(
+        "homeassistant.components.recorder.core.dt_util.utcnow",
+        return_value=one + timedelta(microseconds=1),
+    ):
+        states[mp].append(
+            set_state(mp, "YouTube", attributes={"media_title": str(sentinel.mt2)})
+        )
+
+    with patch(
+        "homeassistant.components.recorder.core.dt_util.utcnow", return_value=two
+    ):
+        states[sns1].append(set_state(sns1, "15", attributes=sns1_attr))
+        states[sns2].append(set_state(sns2, "15", attributes=sns2_attr))
+        states[sns3].append(set_state(sns3, "15", attributes=sns3_attr))
+        states[sns4].append(set_state(sns4, "15", attributes=sns4_attr))
+
+    with patch(
+        "homeassistant.components.recorder.core.dt_util.utcnow", return_value=three
+    ):
+        states[sns1].append(set_state(sns1, "20", attributes=sns1_attr))
+        states[sns2].append(set_state(sns2, "20", attributes=sns2_attr))
+        states[sns3].append(set_state(sns3, "20", attributes=sns3_attr))
+        states[sns4].append(set_state(sns4, "20", attributes=sns4_attr))
+
+    return zero, four, states

--- a/tests/components/recorder/test_entity_registry.py
+++ b/tests/components/recorder/test_entity_registry.py
@@ -152,8 +152,8 @@ async def test_rename_entity_on_mocked_platform(
 
     assert "sensor.test1" not in hist
     # Make sure the states manager has not leaked the old entity_id
-    assert "sensor.test1" not in instance.states_manager._pending
-    assert "sensor.test1" not in instance.states_manager._last_committed_id
+    assert instance.states_manager.pop_committed("sensor.test1") is None
+    assert instance.states_manager.pop_pending("sensor.test1") is None
 
     hass.states.async_set("sensor.test99", "post_migrate")
     await async_wait_recording_done(hass)

--- a/tests/components/recorder/test_entity_registry.py
+++ b/tests/components/recorder/test_entity_registry.py
@@ -20,7 +20,9 @@ from .common import (
 from tests.common import mock_registry
 
 
-def test_rename_entity(hass_recorder: Callable[..., HomeAssistant]) -> None:
+def test_rename_entity(
+    hass_recorder: Callable[..., HomeAssistant], caplog: pytest.LogCaptureFixture
+) -> None:
     """Test states meta is migrated when entity_id is changed."""
     hass = hass_recorder()
     setup_component(hass, "sensor", {})
@@ -74,6 +76,7 @@ def test_rename_entity(hass_recorder: Callable[..., HomeAssistant]) -> None:
             )
             == 1
         )
+    assert "the new entity_id is already in use" not in caplog.text
 
 
 def test_rename_entity_collision(

--- a/tests/components/recorder/test_entity_registry.py
+++ b/tests/components/recorder/test_entity_registry.py
@@ -92,7 +92,12 @@ async def test_rename_entity_on_mocked_platform(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test states meta is migrated when entity_id is changed."""
+    """Test states meta is migrated when entity_id is changed when using a mocked platform.
+
+    This test will call async_remove on the entity so we can make
+    sure that we do not record the entity as removed in the database
+    when we rename it.
+    """
     instance = await async_setup_recorder_instance(hass)
     entity_reg = er.async_get(hass)
     start = dt_util.utcnow()

--- a/tests/components/recorder/test_entity_registry.py
+++ b/tests/components/recorder/test_entity_registry.py
@@ -227,18 +227,7 @@ def test_rename_entity_collision(
     assert len(hist["sensor.test99"]) == 2
 
     with session_scope(hass=hass) as session:
-        assert (
-            len(
-                list(
-                    session.execute(
-                        select(StatesMeta).filter(
-                            StatesMeta.entity_id == "sensor.test99"
-                        )
-                    )
-                )
-            )
-            == 1
-        )
+        assert _count_entity_id_in_states_meta(hass, session, "sensor.test99") == 1
 
     hass.states.set("sensor.test99", "post_migrate")
     wait_recording_done(hass)
@@ -247,29 +236,7 @@ def test_rename_entity_collision(
     assert len(hist["sensor.test99"]) == 2
 
     with session_scope(hass=hass) as session:
-        assert (
-            len(
-                list(
-                    session.execute(
-                        select(StatesMeta).filter(
-                            StatesMeta.entity_id == "sensor.test99"
-                        )
-                    )
-                )
-            )
-            == 1
-        )
-        assert (
-            len(
-                list(
-                    session.execute(
-                        select(StatesMeta).filter(
-                            StatesMeta.entity_id == "sensor.test1"
-                        )
-                    )
-                )
-            )
-            == 1
-        )
+        assert _count_entity_id_in_states_meta(hass, session, "sensor.test99") == 1
+        assert _count_entity_id_in_states_meta(hass, session, "sensor.test1") == 1
 
     assert "the new entity_id is already in use" in caplog.text

--- a/tests/components/recorder/test_entity_registry.py
+++ b/tests/components/recorder/test_entity_registry.py
@@ -4,7 +4,6 @@ from collections.abc import Callable
 import pytest
 from sqlalchemy import select
 
-from homeassistant.components import recorder
 from homeassistant.components.recorder import history
 from homeassistant.components.recorder.db_schema import StatesMeta
 from homeassistant.components.recorder.util import session_scope
@@ -62,6 +61,7 @@ def test_rename_entity(
     hass.states.set("sensor.test99", "post_migrate")
     wait_recording_done(hass)
     new_hist = history.get_significant_states(hass, zero, dt_util.utcnow())
+    assert not new_hist.get("sensor.test1")
     assert new_hist["sensor.test99"][-1].state == "post_migrate"
 
     with session_scope(hass=hass) as session:
@@ -142,8 +142,8 @@ def test_rename_entity_collision(
             len(
                 list(
                     session.execute(
-                        select(recorder.db_schema.StatesMeta).filter(
-                            recorder.db_schema.StatesMeta.entity_id == "sensor.test99"
+                        select(StatesMeta).filter(
+                            StatesMeta.entity_id == "sensor.test99"
                         )
                     )
                 )

--- a/tests/components/recorder/test_entity_registry.py
+++ b/tests/components/recorder/test_entity_registry.py
@@ -1,0 +1,143 @@
+"""The tests for sensor recorder platform."""
+from collections.abc import Callable
+
+import pytest
+from sqlalchemy import select
+
+from homeassistant.components import recorder
+from homeassistant.components.recorder import history
+from homeassistant.components.recorder.util import session_scope
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.setup import setup_component
+from homeassistant.util import dt as dt_util
+
+from .common import (
+    assert_dict_of_states_equal_without_context_and_last_changed,
+    record_states,
+    wait_recording_done,
+)
+
+from tests.common import mock_registry
+
+
+def test_rename_entity(hass_recorder: Callable[..., HomeAssistant]) -> None:
+    """Test states meta is migrated when entity_id is changed."""
+    hass = hass_recorder()
+    setup_component(hass, "sensor", {})
+
+    entity_reg = mock_registry(hass)
+
+    @callback
+    def add_entry():
+        reg_entry = entity_reg.async_get_or_create(
+            "sensor",
+            "test",
+            "unique_0000",
+            suggested_object_id="test1",
+        )
+        assert reg_entry.entity_id == "sensor.test1"
+
+    hass.add_job(add_entry)
+    hass.block_till_done()
+
+    zero, four, states = record_states(hass)
+    hist = history.get_significant_states(hass, zero, four)
+
+    assert_dict_of_states_equal_without_context_and_last_changed(states, hist)
+
+    @callback
+    def rename_entry():
+        entity_reg.async_update_entity("sensor.test1", new_entity_id="sensor.test99")
+
+    hass.add_job(rename_entry)
+    wait_recording_done(hass)
+
+    hist = history.get_significant_states(hass, zero, four)
+    states["sensor.test99"] = states.pop("sensor.test1")
+    assert_dict_of_states_equal_without_context_and_last_changed(states, hist)
+
+    hass.states.set("sensor.test99", "post_migrate")
+    wait_recording_done(hass)
+    new_hist = history.get_significant_states(hass, zero, dt_util.utcnow())
+    assert new_hist["sensor.test99"][-1].state == "post_migrate"
+
+    with session_scope(hass=hass) as session:
+        assert (
+            len(
+                list(
+                    session.execute(
+                        select(recorder.db_schema.StatesMeta).filter(
+                            recorder.db_schema.StatesMeta.entity_id == "sensor.test99"
+                        )
+                    )
+                )
+            )
+            == 1
+        )
+
+
+def test_rename_entity_collision(
+    hass_recorder: Callable[..., HomeAssistant], caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test states meta is not migrated when there is a collision."""
+    hass = hass_recorder()
+    setup_component(hass, "sensor", {})
+
+    entity_reg = mock_registry(hass)
+
+    @callback
+    def add_entry():
+        reg_entry = entity_reg.async_get_or_create(
+            "sensor",
+            "test",
+            "unique_0000",
+            suggested_object_id="test1",
+        )
+        assert reg_entry.entity_id == "sensor.test1"
+
+    hass.add_job(add_entry)
+    hass.block_till_done()
+
+    zero, four, states = record_states(hass)
+    hist = history.get_significant_states(hass, zero, four)
+    assert_dict_of_states_equal_without_context_and_last_changed(states, hist)
+
+    hass.states.set("sensor.test99", "collision")
+    hass.states.remove("sensor.test99")
+
+    hass.block_till_done()
+
+    # Rename entity sensor.test1 to sensor.test99
+    @callback
+    def rename_entry():
+        entity_reg.async_update_entity("sensor.test1", new_entity_id="sensor.test99")
+
+    hass.add_job(rename_entry)
+    wait_recording_done(hass)
+
+    # History is not migrated on collision
+    hist = history.get_significant_states(hass, zero, four)
+    states["sensor.test99"] = states.pop("sensor.test1")
+
+    assert len(hist["sensor.test99"]) == 2
+
+    hass.states.set("sensor.test99", "post_migrate")
+    wait_recording_done(hass)
+    new_hist = history.get_significant_states(hass, zero, dt_util.utcnow())
+    assert new_hist["sensor.test99"][-1].state == "post_migrate"
+
+    with session_scope(hass=hass) as session:
+        assert (
+            len(
+                list(
+                    session.execute(
+                        select(recorder.db_schema.StatesMeta).filter(
+                            recorder.db_schema.StatesMeta.entity_id == "sensor.test99"
+                        )
+                    )
+                )
+            )
+            == 1
+        )
+
+    assert "the new entity_id is already in use" in caplog.text

--- a/tests/components/recorder/test_entity_registry.py
+++ b/tests/components/recorder/test_entity_registry.py
@@ -151,6 +151,9 @@ async def test_rename_entity_on_mocked_platform(
     )
 
     assert "sensor.test1" not in hist
+    # Make sure the states manager has not leaked the old entity_id
+    assert "sensor.test1" not in instance.states_manager._pending
+    assert "sensor.test1" not in instance.states_manager._last_committed_id
 
     hass.states.async_set("sensor.test99", "post_migrate")
     await async_wait_recording_done(hass)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

History will now be retained when renaming an `entity_id`
https://community.home-assistant.io/t/wth-when-i-rename-an-entity-most-of-the-time-its-history-is-lost/469199/4
https://community.home-assistant.io/t/rename-entities-while-retaining-history/412589
https://community.home-assistant.io/t/rename-of-sensor-loss-of-history/355122/3

This feature requires up to 24 hours for background data migration to complete after installing 2023.4.0 or later. As with earlier versions, entities renamed before the background data migration completes will not retain history. For the avoidance of doubt, if you want to be sure the history will be retained after an entity_id rename, wait 24 hours after the migration message disappears from the persistent notifications after upgrading to 2023.4.0 or later.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
