### PR TITLE
Add regex validation for the entity id filter

### DIFF
--- a/homeassistant/components/history/__init__.py
+++ b/homeassistant/components/history/__init__.py
@@ -121,7 +121,7 @@ class HistoryPeriodView(HomeAssistantView):
         if entity_ids_str:
             entity_ids = entity_ids_str.lower().split(",")
             for entity_id in entity_ids:
-                if not valid_entity_id(entity_id):
+                if not hass.states.get(entity_id) or not valid_entity_id(entity_id):
                     return self.json_message(
                         "Invalid filter_entity_id", HTTPStatus.BAD_REQUEST
                     )

--- a/homeassistant/components/history/__init__.py
+++ b/homeassistant/components/history/__init__.py
@@ -24,7 +24,7 @@ from homeassistant.components.recorder.filters import (
     sqlalchemy_filter_from_include_exclude_conf,
 )
 from homeassistant.components.recorder.util import session_scope
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, valid_entity_id
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entityfilter import (
     INCLUDE_EXCLUDE_BASE_FILTER_SCHEMA,
@@ -120,6 +120,11 @@ class HistoryPeriodView(HomeAssistantView):
         entity_ids = None
         if entity_ids_str:
             entity_ids = entity_ids_str.lower().split(",")
+            for entity_id in entity_ids:
+                if not valid_entity_id(entity_id):
+                    return self.json_message(
+                        "Invalid filter_entity_id", HTTPStatus.BAD_REQUEST
+                    )
         include_start_time_state = "skip_initial_state" not in request.query
         significant_changes_only = (
             request.query.get("significant_changes_only", "1") != "0"

--- a/homeassistant/components/history/websocket_api.py
+++ b/homeassistant/components/history/websocket_api.py
@@ -138,7 +138,7 @@ async def ws_get_history_during_period(
     entity_ids = msg.get("entity_ids")
     if entity_ids is not None:
         for entity_id in entity_ids:
-            if not valid_entity_id(entity_id):
+            if not hass.states.get(entity_id) or not valid_entity_id(entity_id):
                 connection.send_error(
                     msg["id"], "invalid_entity_ids", "Invalid entity_ids"
                 )
@@ -470,7 +470,7 @@ async def ws_stream(
     entity_ids = msg.get("entity_ids")
     if entity_ids is not None:
         for entity_id in entity_ids:
-            if not valid_entity_id(entity_id):
+            if not hass.states.get(entity_id) or not valid_entity_id(entity_id):
                 connection.send_error(
                     msg["id"], "invalid_entity_ids", "Invalid entity_ids"
                 )

--- a/homeassistant/components/history/websocket_api.py
+++ b/homeassistant/components/history/websocket_api.py
@@ -470,7 +470,7 @@ async def ws_stream(
     entity_ids = msg.get("entity_ids")
     if entity_ids is not None:
         for entity_id in entity_ids:
-            if not hass.states.get(entity_id) or not valid_entity_id(entity_id):
+            if not valid_entity_id(entity_id):
                 connection.send_error(
                     msg["id"], "invalid_entity_ids", "Invalid entity_ids"
                 )

--- a/homeassistant/components/history/websocket_api.py
+++ b/homeassistant/components/history/websocket_api.py
@@ -29,6 +29,7 @@ from homeassistant.core import (
     State,
     callback,
     is_callback,
+    valid_entity_id,
 )
 from homeassistant.helpers.entityfilter import EntityFilter
 from homeassistant.helpers.event import (
@@ -135,6 +136,13 @@ async def ws_get_history_during_period(
         return
 
     entity_ids = msg.get("entity_ids")
+    if entity_ids is not None:
+        for entity_id in entity_ids:
+            if not valid_entity_id(entity_id):
+                connection.send_error(
+                    msg["id"], "invalid_entity_ids", "Invalid entity_ids"
+                )
+                return
     include_start_time_state = msg["include_start_time_state"]
     no_attributes = msg["no_attributes"]
 
@@ -460,6 +468,13 @@ async def ws_stream(
             return
 
     entity_ids = msg.get("entity_ids")
+    if entity_ids is not None:
+        for entity_id in entity_ids:
+            if not valid_entity_id(entity_id):
+                connection.send_error(
+                    msg["id"], "invalid_entity_ids", "Invalid entity_ids"
+                )
+                return
     include_start_time_state = msg["include_start_time_state"]
     significant_changes_only = msg["significant_changes_only"]
     no_attributes = msg["no_attributes"]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This adds regex validation for the filter_entity_id parameter in the history part of the REST API to make sure that the provided entity IDs are valid. Previously the API would just return an empty array instead of an error message, which is (probably) not expected behaviour.

This makes it easier to spot if you made a mistake in your request formatting, as you now get a specific error instead of an empty array which could be confusing.

Also for the WebSocket API

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
