### PR TITLE
Fix octoprint down every two minutes

### DIFF
--- a/homeassistant/components/octoprint/__init__.py
+++ b/homeassistant/components/octoprint/__init__.py
@@ -23,7 +23,7 @@ from homeassistant.const import (
     CONF_SENSORS,
     CONF_SSL,
     CONF_VERIFY_SSL,
-    EVENT_HOMEASSISTANT_CLOSE,
+    EVENT_HOMEASSISTANT_STOP,
     Platform,
 )
 from homeassistant.core import Event, HomeAssistant, callback
@@ -175,7 +175,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         """Close websession."""
         session.detach()
 
-    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_CLOSE, _async_close_websession)
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _async_close_websession)
 
     client = OctoprintClient(
         host=entry.data[CONF_HOST],

--- a/homeassistant/components/octoprint/__init__.py
+++ b/homeassistant/components/octoprint/__init__.py
@@ -163,14 +163,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         data = {**entry.data, CONF_VERIFY_SSL: True}
         hass.config_entries.async_update_entry(entry, data=data)
 
-    verify_ssl = entry.data[CONF_VERIFY_SSL]
-    websession = async_get_clientsession(hass, verify_ssl=verify_ssl)
     client = OctoprintClient(
-        entry.data[CONF_HOST],
-        websession,
-        entry.data[CONF_PORT],
-        entry.data[CONF_SSL],
-        entry.data[CONF_PATH],
+        host=entry.data[CONF_HOST],
+        port=entry.data[CONF_PORT],
+        ssl=entry.data[CONF_SSL],
+        path=entry.data[CONF_PATH],
     )
 
     client.set_api_key(entry.data[CONF_API_KEY])

--- a/homeassistant/components/octoprint/__init__.py
+++ b/homeassistant/components/octoprint/__init__.py
@@ -27,6 +27,9 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.aiohttp_client import (
+    _async_register_default_clientsession_shutdown,
+)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.typing import ConfigType
@@ -168,6 +171,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         ssl=False if not entry.data[CONF_VERIFY_SSL] else None,
     )
     session = aiohttp.ClientSession(connector=connector)
+    _async_register_default_clientsession_shutdown(hass, session)
 
     client = OctoprintClient(
         host=entry.data[CONF_HOST],

--- a/homeassistant/components/octoprint/config_flow.py
+++ b/homeassistant/components/octoprint/config_flow.py
@@ -23,6 +23,9 @@ from homeassistant.const import (
     CONF_VERIFY_SSL,
 )
 from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers.aiohttp_client import (
+    _async_register_default_clientsession_shutdown,
+)
 import homeassistant.helpers.config_validation as cv
 
 from .const import DOMAIN
@@ -266,6 +269,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             ssl=False if not verify_ssl else None,
         )
         session = aiohttp.ClientSession(connector=connector)
+        _async_register_default_clientsession_shutdown(hass, session)
 
         return OctoprintClient(
             host=user_input[CONF_HOST],

--- a/homeassistant/components/octoprint/config_flow.py
+++ b/homeassistant/components/octoprint/config_flow.py
@@ -23,10 +23,10 @@ from homeassistant.const import (
     CONF_VERIFY_SSL,
     EVENT_HOMEASSISTANT_STOP,
 )
+from homeassistant.core import Event, callback
 from homeassistant.data_entry_flow import FlowResult
 import homeassistant.helpers.config_validation as cv
 
-from homeassistant.core import Event, callback
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/octoprint/config_flow.py
+++ b/homeassistant/components/octoprint/config_flow.py
@@ -26,7 +26,7 @@ from homeassistant.const import (
 from homeassistant.data_entry_flow import FlowResult
 import homeassistant.helpers.config_validation as cv
 
-from ...core import Event, callback
+from homeassistant.core import Event, callback
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/octoprint/config_flow.py
+++ b/homeassistant/components/octoprint/config_flow.py
@@ -21,9 +21,7 @@ from homeassistant.const import (
     CONF_SSL,
     CONF_USERNAME,
     CONF_VERIFY_SSL,
-    EVENT_HOMEASSISTANT_STOP,
 )
-from homeassistant.core import Event, callback
 from homeassistant.data_entry_flow import FlowResult
 import homeassistant.helpers.config_validation as cv
 

--- a/homeassistant/components/octoprint/config_flow.py
+++ b/homeassistant/components/octoprint/config_flow.py
@@ -258,9 +258,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     def _get_octoprint_client(self, user_input: dict) -> OctoprintClient:
         """Build an octoprint client from the user_input."""
+        verify_ssl = user_input.get(CONF_VERIFY_SSL, True)
+
         connector = aiohttp.TCPConnector(
             force_close=True,
-            ssl=False if not user_input[CONF_VERIFY_SSL] else None,
+            ssl=False if not verify_ssl else None,
         )
         session = aiohttp.ClientSession(connector=connector)
 

--- a/homeassistant/components/octoprint/config_flow.py
+++ b/homeassistant/components/octoprint/config_flow.py
@@ -259,14 +259,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     def _get_octoprint_client(self, user_input: dict) -> OctoprintClient:
         """Build an octoprint client from the user_input."""
-        verify_ssl = user_input.get(CONF_VERIFY_SSL, True)
-        session = async_get_clientsession(self.hass, verify_ssl=verify_ssl)
         return OctoprintClient(
-            user_input[CONF_HOST],
-            session,
-            user_input[CONF_PORT],
-            user_input[CONF_SSL],
-            user_input[CONF_PATH],
+            host=user_input[CONF_HOST],
+            port=user_input[CONF_PORT],
+            ssl=user_input[CONF_SSL],
+            path=user_input[CONF_PATH],
         )
 
 

--- a/homeassistant/components/octoprint/config_flow.py
+++ b/homeassistant/components/octoprint/config_flow.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Mapping
 import logging
-from typing import Any, List
+from typing import Any
 
 import aiohttp
 from pyoctoprintapi import ApiError, OctoprintClient, OctoprintException
@@ -58,7 +58,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle a config flow for OctoPrint."""
         self.discovery_schema = None
         self._user_input = None
-        self._sessions: List[aiohttp.ClientSession] = []
+        self._sessions: list[aiohttp.ClientSession] = []
 
     async def async_step_user(self, user_input=None):
         """Handle the initial step."""

--- a/homeassistant/components/octoprint/config_flow.py
+++ b/homeassistant/components/octoprint/config_flow.py
@@ -269,7 +269,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             ssl=False if not verify_ssl else None,
         )
         session = aiohttp.ClientSession(connector=connector)
-        _async_register_default_clientsession_shutdown(hass, session)
+        _async_register_default_clientsession_shutdown(self.hass, session)
 
         return OctoprintClient(
             host=user_input[CONF_HOST],

--- a/homeassistant/components/octoprint/config_flow.py
+++ b/homeassistant/components/octoprint/config_flow.py
@@ -22,7 +22,6 @@ from homeassistant.const import (
     CONF_VERIFY_SSL,
 )
 from homeassistant.data_entry_flow import FlowResult
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 
 from .const import DOMAIN
@@ -259,8 +258,17 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     def _get_octoprint_client(self, user_input: dict) -> OctoprintClient:
         """Build an octoprint client from the user_input."""
+        import aiohttp
+
+        connector = aiohttp.TCPConnector(
+            force_close=True,
+            ssl=False if not user_input[CONF_VERIFY_SSL] else None,
+        )
+        session = aiohttp.ClientSession(connector=connector)
+
         return OctoprintClient(
             host=user_input[CONF_HOST],
+            session=session,
             port=user_input[CONF_PORT],
             ssl=user_input[CONF_SSL],
             path=user_input[CONF_PATH],

--- a/homeassistant/components/octoprint/config_flow.py
+++ b/homeassistant/components/octoprint/config_flow.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping
 import logging
 from typing import Any
 
+import aiohttp
 from pyoctoprintapi import ApiError, OctoprintClient, OctoprintException
 import voluptuous as vol
 from yarl import URL

--- a/homeassistant/components/octoprint/config_flow.py
+++ b/homeassistant/components/octoprint/config_flow.py
@@ -258,8 +258,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     def _get_octoprint_client(self, user_input: dict) -> OctoprintClient:
         """Build an octoprint client from the user_input."""
-        import aiohttp
-
         connector = aiohttp.TCPConnector(
             force_close=True,
             ssl=False if not user_input[CONF_VERIFY_SSL] else None,

--- a/homeassistant/components/octoprint/config_flow.py
+++ b/homeassistant/components/octoprint/config_flow.py
@@ -21,7 +21,7 @@ from homeassistant.const import (
     CONF_SSL,
     CONF_USERNAME,
     CONF_VERIFY_SSL,
-    EVENT_HOMEASSISTANT_CLOSE,
+    EVENT_HOMEASSISTANT_STOP,
 )
 from homeassistant.data_entry_flow import FlowResult
 import homeassistant.helpers.config_validation as cv
@@ -275,7 +275,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             session.detach()
 
         self.hass.bus.async_listen_once(
-            EVENT_HOMEASSISTANT_CLOSE, _async_close_websession
+            EVENT_HOMEASSISTANT_STOP, _async_close_websession
         )
 
         return OctoprintClient(

--- a/homeassistant/components/octoprint/manifest.json
+++ b/homeassistant/components/octoprint/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://www.home-assistant.io/integrations/octoprint",
   "iot_class": "local_polling",
   "loggers": ["pyoctoprintapi"],
-  "requirements": ["pyoctoprintapi==0.1.11"],
+  "requirements": ["pyoctoprintapi==0.1.12"],
   "ssdp": [
     {
       "manufacturer": "The OctoPrint Project",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1871,7 +1871,7 @@ pynzbgetapi==0.2.0
 pyobihai==1.3.2
 
 # homeassistant.components.octoprint
-pyoctoprintapi==0.1.11
+pyoctoprintapi==0.1.12
 
 # homeassistant.components.ombi
 pyombi==0.1.10

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1384,7 +1384,7 @@ pynzbgetapi==0.2.0
 pyobihai==1.3.2
 
 # homeassistant.components.octoprint
-pyoctoprintapi==0.1.11
+pyoctoprintapi==0.1.12
 
 # homeassistant.components.openuv
 pyopenuv==2023.02.0


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Due to issues found in #83624 and https://github.com/OctoPrint/OctoPrint/issues/4764 this PR updates the dependency to `pyoctoprintapi` used for the octoprint integration to fix an issue linked below.

After a conversation in the comments, this PR now additionally proposes to create a custom session instance specifically for the octoprint integration to be able to set the `force_close` parameter on the `TCPConnector` object. Technically the library version bump is not necessary anymore now, but I guess it doesn't hurt to keep this change, since its already implemented.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #83624
- This PR is related to issue: #83624 https://github.com/OctoPrint/OctoPrint/issues/4764
- Link to documentation pull request: N/A
- Link to the new `pyoctoprintapi` release: https://github.com/rfleming71/pyoctoprintapi/releases/tag/v0.1.12

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
