### PR TITLE
Reolink improve config flow login

### DIFF
--- a/homeassistant/components/reolink/config_flow.py
+++ b/homeassistant/components/reolink/config_flow.py
@@ -127,11 +127,7 @@ class ReolinkFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 placeholders["error"] = str(err)
                 errors[CONF_HOST] = "api_error"
             except (ReolinkError, ReolinkException) as err:
-                placeholders["error"] = (
-                    f"{str(err)}\nCheck the IP address of the camera and see the"
-                    " [troubleshooting steps](https://www.home-assistant.io/integrations/reolink/#troubleshooting)"
-                    " to resolve this issue"
-                )
+                placeholders["error"] = str(err)
                 errors[CONF_HOST] = "cannot_connect"
             except Exception as err:  # pylint: disable=broad-except
                 _LOGGER.exception("Unexpected exception")

--- a/homeassistant/components/reolink/config_flow.py
+++ b/homeassistant/components/reolink/config_flow.py
@@ -127,7 +127,11 @@ class ReolinkFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 placeholders["error"] = str(err)
                 errors[CONF_HOST] = "api_error"
             except (ReolinkError, ReolinkException) as err:
-                placeholders["error"] = f"{str(err)}\nCheck the IP adress of the camera and see the [troubleshooting steps](https://www.home-assistant.io/integrations/reolink/#troubleshooting) to resolve this issue" 
+                placeholders["error"] = (
+                    f"{str(err)}\nCheck the IP address of the camera and see the"
+                    " [troubleshooting steps](https://www.home-assistant.io/integrations/reolink/#troubleshooting)"
+                    " to resolve this issue"
+                )
                 errors[CONF_HOST] = "cannot_connect"
             except Exception as err:  # pylint: disable=broad-except
                 _LOGGER.exception("Unexpected exception")

--- a/homeassistant/components/reolink/config_flow.py
+++ b/homeassistant/components/reolink/config_flow.py
@@ -108,7 +108,10 @@ class ReolinkFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> FlowResult:
         """Handle the initial step."""
         errors = {}
-        placeholders = {"error": "", "troubleshooting_link": "https://www.home-assistant.io/integrations/reolink/#troubleshooting"}
+        placeholders = {
+            "error": "",
+            "troubleshooting_link": "https://www.home-assistant.io/integrations/reolink/#troubleshooting",
+        }
 
         if user_input is not None:
             if CONF_HOST not in user_input:

--- a/homeassistant/components/reolink/config_flow.py
+++ b/homeassistant/components/reolink/config_flow.py
@@ -127,7 +127,7 @@ class ReolinkFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 placeholders["error"] = str(err)
                 errors[CONF_HOST] = "api_error"
             except (ReolinkError, ReolinkException) as err:
-                placeholders["error"] = str(err)
+                placeholders["error"] = f"{str(err)}\nCheck the IP adress of the camera and see the [troubleshooting steps](https://www.home-assistant.io/integrations/reolink/#troubleshooting) to resolve this issue" 
                 errors[CONF_HOST] = "cannot_connect"
             except Exception as err:  # pylint: disable=broad-except
                 _LOGGER.exception("Unexpected exception")

--- a/homeassistant/components/reolink/config_flow.py
+++ b/homeassistant/components/reolink/config_flow.py
@@ -108,7 +108,7 @@ class ReolinkFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> FlowResult:
         """Handle the initial step."""
         errors = {}
-        placeholders = {"error": ""}
+        placeholders = {"error": "", "troubleshooting_link": "https://www.home-assistant.io/integrations/reolink/#troubleshooting"}
 
         if user_input is not None:
             if CONF_HOST not in user_input:

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -80,9 +80,15 @@ class ReolinkHost:
                 f"'{self._api.user_level}', only admin users can change camera settings"
             )
 
+        enable_rtsp = None
         enable_onvif = None
         enable_rtmp = None
-        enable_rtsp = None
+
+        if not self._api.rtsp_enabled:
+            _LOGGER.debug(
+                "RTSP is disabled on %s, trying to enable it", self._api.nvr_name
+            )
+            enable_rtsp = True
 
         if not self._api.onvif_enabled:
             _LOGGER.debug(
@@ -95,11 +101,6 @@ class ReolinkHost:
                 "RTMP is disabled on %s, trying to enable it", self._api.nvr_name
             )
             enable_rtmp = True
-        elif not self._api.rtsp_enabled and self._api.protocol == "rtsp":
-            _LOGGER.debug(
-                "RTSP is disabled on %s, trying to enable it", self._api.nvr_name
-            )
-            enable_rtsp = True
 
         if enable_onvif or enable_rtmp or enable_rtsp:
             try:
@@ -110,13 +111,14 @@ class ReolinkHost:
                 )
             except ReolinkError:
                 ports = ""
+                if enable_rtsp:
+                    ports += "RTSP "
+
                 if enable_onvif:
                     ports += "ONVIF "
 
                 if enable_rtmp:
                     ports += "RTMP "
-                elif enable_rtsp:
-                    ports += "RTSP "
 
                 ir.async_create_issue(
                     self._hass,

--- a/homeassistant/components/reolink/strings.json
+++ b/homeassistant/components/reolink/strings.json
@@ -3,7 +3,7 @@
     "flow_title": "{hostname} ({ip_address})",
     "step": {
       "user": {
-        "description": "See the [troubleshooting steps](https://www.home-assistant.io/integrations/reolink/#troubleshooting) if you encounter problems. {error}",
+      "description": "See the [troubleshooting steps]({troubleshooting_link}) if you encounter problems. {error}",
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
           "port": "[%key:common::config_flow::data::port%]",

--- a/homeassistant/components/reolink/strings.json
+++ b/homeassistant/components/reolink/strings.json
@@ -3,7 +3,7 @@
     "flow_title": "{hostname} ({ip_address})",
     "step": {
       "user": {
-        "description": "{error}",
+        "description": "See the [troubleshooting steps](https://www.home-assistant.io/integrations/reolink/#troubleshooting) if you encounter problems {error}",
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
           "port": "[%key:common::config_flow::data::port%]",
@@ -19,7 +19,7 @@
     },
     "error": {
       "api_error": "API error occurred",
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%], Check the IP address of the camera and see the [troubleshooting steps](https://www.home-assistant.io/integrations/reolink/#troubleshooting) to resolve this issue",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%], check the IP address of the camera and see the troubleshooting steps in the documentation",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "not_admin": "User needs to be admin, user ''{username}'' has authorisation level ''{userlevel}''",
       "unknown": "[%key:common::config_flow::error::unknown%]"

--- a/homeassistant/components/reolink/strings.json
+++ b/homeassistant/components/reolink/strings.json
@@ -3,7 +3,7 @@
     "flow_title": "{hostname} ({ip_address})",
     "step": {
       "user": {
-      "description": "See the [troubleshooting steps]({troubleshooting_link}) if you encounter problems. {error}",
+        "description": "See the [troubleshooting steps]({troubleshooting_link}) if you encounter problems. {error}",
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
           "port": "[%key:common::config_flow::data::port%]",

--- a/homeassistant/components/reolink/strings.json
+++ b/homeassistant/components/reolink/strings.json
@@ -19,7 +19,7 @@
     },
     "error": {
       "api_error": "API error occurred",
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%], Check the IP address of the camera and see the [troubleshooting steps](https://www.home-assistant.io/integrations/reolink/#troubleshooting) to resolve this issue",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "not_admin": "User needs to be admin, user ''{username}'' has authorisation level ''{userlevel}''",
       "unknown": "[%key:common::config_flow::error::unknown%]"

--- a/homeassistant/components/reolink/strings.json
+++ b/homeassistant/components/reolink/strings.json
@@ -3,7 +3,7 @@
     "flow_title": "{hostname} ({ip_address})",
     "step": {
       "user": {
-        "description": "See the [troubleshooting steps](https://www.home-assistant.io/integrations/reolink/#troubleshooting) if you encounter problems {error}",
+        "description": "See the [troubleshooting steps](https://www.home-assistant.io/integrations/reolink/#troubleshooting) if you encounter problems. {error}",
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
           "port": "[%key:common::config_flow::data::port%]",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Always enable the RTSP port and make sure to first enable RTSP and then ONVIF port.
This because most camera's require the RTSP port to be enabled in order for the ONVIF port to be enabled.
(This did not cause many issues because the default protocol upon setup is RTSP, so the RTSP port would already be enabled by default).

Include a link to the troubleshooting steps when an connection error ocurs during the config flow.
Specifically, some camera's like the "Reolink TrackMix PoE" require the RTMP port to be enabled in order for the HTTP(S) port to work. The HTTPS port is enabled by default in the firmware but the RTMP port is disabled by default in the firmware, so the user will need to enable this port through the Reolink client before setting up the Reolink integration. Only on some models this is the case, and it appears to be a firmware bug that I will report to the Reolink firmware engineers since HTTPS port schould be independend of the RTMP port.

![afbeelding](https://user-images.githubusercontent.com/14811189/228375616-b526aaff-69b6-4968-9d3a-c03fd5d5ffb1.png)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/26677

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
