### PR TITLE
Bump reolink-aio to 0.5.6

### DIFF
--- a/homeassistant/components/reolink/manifest.json
+++ b/homeassistant/components/reolink/manifest.json
@@ -18,5 +18,5 @@
   "documentation": "https://www.home-assistant.io/integrations/reolink",
   "iot_class": "local_push",
   "loggers": ["reolink_aio"],
-  "requirements": ["reolink-aio==0.5.5"]
+  "requirements": ["reolink-aio==0.5.6"]
 }

--- a/homeassistant/components/reolink/number.py
+++ b/homeassistant/components/reolink/number.py
@@ -63,7 +63,7 @@ NUMBER_ENTITIES = (
         native_step=1,
         get_min_value=lambda api, ch: api.zoom_range(ch)["focus"]["pos"]["min"],
         get_max_value=lambda api, ch: api.zoom_range(ch)["focus"]["pos"]["max"],
-        supported=lambda api, ch: api.supported(ch, "zoom"),
+        supported=lambda api, ch: api.supported(ch, "focus"),
         value=lambda api, ch: api.get_focus(ch),
         method=lambda api, ch, value: api.set_focus(ch, int(value)),
     ),

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2237,7 +2237,7 @@ regenmaschine==2022.11.0
 renault-api==0.1.12
 
 # homeassistant.components.reolink
-reolink-aio==0.5.5
+reolink-aio==0.5.6
 
 # homeassistant.components.python_script
 restrictedpython==6.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1594,7 +1594,7 @@ regenmaschine==2022.11.0
 renault-api==0.1.12
 
 # homeassistant.components.reolink
-reolink-aio==0.5.5
+reolink-aio==0.5.6
 
 # homeassistant.components.python_script
 restrictedpython==6.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump reolink-aio to 0.5.6:
https://github.com/starkillerOG/reolink_aio/compare/0.5.5...0.5.6

New features:
- [Add auto track stop/disapear time](https://github.com/starkillerOG/reolink_aio/commit/71cf67405e688de80127baeec10c29787961be31)
- [Add auto track method](https://github.com/starkillerOG/reolink_aio/commit/0273200b01bf72736894d6d5933125f8872bbb5c)
- [Add auto tracking limits](https://github.com/starkillerOG/reolink_aio/commit/bb582ec41471808de9c7234477b7143a5865f424)

Fixes / improvements:
- [Fix doorbell status led](https://github.com/starkillerOG/reolink_aio/commit/2ec960475335ded43fa6471f73cf8f5da0d23803)
- [Improve AI polling when ONVIF push does not include AI](https://github.com/starkillerOG/reolink_aio/commit/2362257923badb708543643a2f1e3c7bcb07cdb5)
- [Add RLC-81MA to dual lens models](https://github.com/starkillerOG/reolink_aio/commit/12eea6017beaa882caeda4bc6a9999906a09e523)
- [Add minimum firmware versions](https://github.com/starkillerOG/reolink_aio/commit/a81e117f6682708282d79bbb250d29d872315797)
- [Fix floodlight not supported for TrackMix](https://github.com/starkillerOG/reolink_aio/commit/1ab4c89fa6985c273a72389c963195839d1a9a77)
- [Mark zoom supported if DigitalZoom supported](https://github.com/starkillerOG/reolink_aio/commit/8dac4491b4860916f621378931ab1e14ce327b13)
- [Check supportAutoTrackStream flag](https://github.com/starkillerOG/reolink_aio/commit/923312bf0b1ab804e30c5cc4a3907d260ccc65de)

Cleanup:
- [Depricate ptz_supported, zoom_supported and pan_tilt_supported](https://github.com/starkillerOG/reolink_aio/commit/278824e5a41f0533bb139dd02b68d34e26abc5d9)
- [Cleanup request_vod_files method](https://github.com/starkillerOG/reolink_aio/commit/4fa3a87ecb71be99b50c38ec9d250e7d9eb0ea2e)
- [Cleanup get_vod_source method](https://github.com/starkillerOG/reolink_aio/commit/80affcd0abb6a6ea3ee921ed861503d48d9f6b23)

Note:
The supported(ch, "zoom") and supported(ch, "focus") has been split out in reolink-aio 0.5.6 since the Reolink TrackMix PoE does not support hardware zoom, but does support digital zooming using two fixed lenses (wide angle and telephoto lenses). Therefore the TrackMix does support zoom but does not support focus.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
