### PR TITLE
Prepare MQTT platform tests part6

### DIFF
--- a/tests/components/mqtt/test_mixins.py
+++ b/tests/components/mqtt/test_mixins.py
@@ -2,28 +2,19 @@
 
 from unittest.mock import patch
 
+import pytest
+
 from homeassistant.components import mqtt, sensor
 from homeassistant.const import EVENT_STATE_CHANGED, Platform
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.setup import async_setup_component
 
 from tests.common import async_fire_mqtt_message
 from tests.typing import MqttMockHAClientGenerator
 
 
-@patch("homeassistant.components.mqtt.PLATFORMS", [Platform.SENSOR])
-async def test_availability_with_shared_state_topic(
-    hass: HomeAssistant,
-    mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator,
-) -> None:
-    """Test the state is not changed twice.
-
-    When an entity with a shared state_topic and availability_topic becomes available
-    The state should only change once.
-    """
-    assert await async_setup_component(
-        hass,
-        mqtt.DOMAIN,
+@pytest.mark.parametrize(
+    "hass_config",
+    [
         {
             mqtt.DOMAIN: {
                 sensor.DOMAIN: {
@@ -36,10 +27,20 @@ async def test_availability_with_shared_state_topic(
                     "availability_template": "{{ value != '0' }}",
                 }
             }
-        },
-    )
-    await hass.async_block_till_done()
-    await mqtt_mock_entry_with_yaml_config()
+        }
+    ],
+)
+@patch("homeassistant.components.mqtt.PLATFORMS", [Platform.SENSOR])
+async def test_availability_with_shared_state_topic(
+    hass: HomeAssistant,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
+) -> None:
+    """Test the state is not changed twice.
+
+    When an entity with a shared state_topic and availability_topic becomes available
+    The state should only change once.
+    """
+    await mqtt_mock_entry_no_yaml_config()
 
     events = []
 

--- a/tests/components/mqtt/test_number.py
+++ b/tests/components/mqtt/test_number.py
@@ -30,7 +30,6 @@ from homeassistant.const import (
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant, State
-from homeassistant.setup import async_setup_component
 
 from .test_common import (
     help_test_availability_when_connection_lost,
@@ -76,31 +75,30 @@ def number_platform_only():
         yield
 
 
-async def test_run_number_setup(
-    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
-) -> None:
-    """Test that it fetches the given payload."""
-    topic = "test/number"
-    await async_setup_component(
-        hass,
-        mqtt.DOMAIN,
+@pytest.mark.parametrize(
+    "hass_config",
+    [
         {
             mqtt.DOMAIN: {
                 number.DOMAIN: {
-                    "state_topic": topic,
-                    "command_topic": topic,
+                    "state_topic": "test/state_number",
+                    "command_topic": "test/cmd_number",
                     "name": "Test Number",
                     "device_class": "temperature",
-                    "unit_of_measurement": UnitOfTemperature.FAHRENHEIT,
+                    "unit_of_measurement": UnitOfTemperature.FAHRENHEIT.value,
                     "payload_reset": "reset!",
                 }
             }
-        },
-    )
-    await hass.async_block_till_done()
-    await mqtt_mock_entry_with_yaml_config()
+        }
+    ],
+)
+async def test_run_number_setup(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator
+) -> None:
+    """Test that it fetches the given payload."""
+    await mqtt_mock_entry_no_yaml_config()
 
-    async_fire_mqtt_message(hass, topic, "10")
+    async_fire_mqtt_message(hass, "test/state_number", "10")
 
     await hass.async_block_till_done()
 
@@ -109,7 +107,7 @@ async def test_run_number_setup(
     assert state.attributes.get(ATTR_DEVICE_CLASS) == NumberDeviceClass.TEMPERATURE
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == "°C"
 
-    async_fire_mqtt_message(hass, topic, "20.5")
+    async_fire_mqtt_message(hass, "test/state_number", "20.5")
 
     await hass.async_block_till_done()
 
@@ -118,7 +116,7 @@ async def test_run_number_setup(
     assert state.attributes.get(ATTR_DEVICE_CLASS) == NumberDeviceClass.TEMPERATURE
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == "°C"
 
-    async_fire_mqtt_message(hass, topic, "reset!")
+    async_fire_mqtt_message(hass, "test/state_number", "reset!")
 
     await hass.async_block_till_done()
 
@@ -128,27 +126,27 @@ async def test_run_number_setup(
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == "°C"
 
 
-async def test_value_template(
-    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
-) -> None:
-    """Test that it fetches the given payload with a template."""
-    topic = "test/number"
-    await async_setup_component(
-        hass,
-        mqtt.DOMAIN,
+@pytest.mark.parametrize(
+    "hass_config",
+    [
         {
             mqtt.DOMAIN: {
                 number.DOMAIN: {
-                    "state_topic": topic,
-                    "command_topic": topic,
+                    "state_topic": "test/state_number",
+                    "command_topic": "test/cmd_number",
                     "name": "Test Number",
                     "value_template": "{{ value_json.val }}",
                 }
             }
-        },
-    )
-    await hass.async_block_till_done()
-    await mqtt_mock_entry_with_yaml_config()
+        }
+    ],
+)
+async def test_value_template(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator
+) -> None:
+    """Test that it fetches the given payload with a template."""
+    topic = "test/state_number"
+    await mqtt_mock_entry_no_yaml_config()
 
     async_fire_mqtt_message(hass, topic, '{"val":10}')
 
@@ -172,11 +170,25 @@ async def test_value_template(
     assert state.state == "unknown"
 
 
+@pytest.mark.parametrize(
+    "hass_config",
+    [
+        {
+            mqtt.DOMAIN: {
+                number.DOMAIN: {
+                    "command_topic": "test/number",
+                    "device_class": "temperature",
+                    "unit_of_measurement": UnitOfTemperature.FAHRENHEIT.value,
+                    "name": "Test Number",
+                }
+            }
+        }
+    ],
+)
 async def test_restore_native_value(
-    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator
 ) -> None:
     """Test that the stored native_value is restored."""
-    topic = "test/number"
 
     RESTORE_DATA = {
         "native_max_value": None,  # Ignored by MQTT number
@@ -189,30 +201,28 @@ async def test_restore_native_value(
     mock_restore_cache_with_extra_data(
         hass, ((State("number.test_number", "abc"), RESTORE_DATA),)
     )
-    assert await async_setup_component(
-        hass,
-        mqtt.DOMAIN,
-        {
-            mqtt.DOMAIN: {
-                number.DOMAIN: {
-                    "command_topic": topic,
-                    "device_class": "temperature",
-                    "unit_of_measurement": UnitOfTemperature.FAHRENHEIT,
-                    "name": "Test Number",
-                }
-            }
-        },
-    )
-    await hass.async_block_till_done()
-    await mqtt_mock_entry_with_yaml_config()
+    await mqtt_mock_entry_no_yaml_config()
 
     state = hass.states.get("number.test_number")
     assert state.state == "37.8"
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
 
+@pytest.mark.parametrize(
+    "hass_config",
+    [
+        {
+            mqtt.DOMAIN: {
+                number.DOMAIN: {
+                    "command_topic": "test/number",
+                    "name": "Test Number",
+                }
+            }
+        }
+    ],
+)
 async def test_run_number_service_optimistic(
-    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator
 ) -> None:
     """Test that set_value service works in optimistic mode."""
     topic = "test/number"
@@ -228,20 +238,8 @@ async def test_run_number_service_optimistic(
     mock_restore_cache_with_extra_data(
         hass, ((State("number.test_number", "abc"), RESTORE_DATA),)
     )
-    assert await async_setup_component(
-        hass,
-        mqtt.DOMAIN,
-        {
-            mqtt.DOMAIN: {
-                number.DOMAIN: {
-                    "command_topic": topic,
-                    "name": "Test Number",
-                }
-            }
-        },
-    )
-    await hass.async_block_till_done()
-    mqtt_mock = await mqtt_mock_entry_with_yaml_config()
+
+    mqtt_mock = await mqtt_mock_entry_no_yaml_config()
 
     state = hass.states.get("number.test_number")
     assert state.state == "3"
@@ -287,8 +285,22 @@ async def test_run_number_service_optimistic(
     assert state.state == "42.1"
 
 
+@pytest.mark.parametrize(
+    "hass_config",
+    [
+        {
+            mqtt.DOMAIN: {
+                number.DOMAIN: {
+                    "command_topic": "test/number",
+                    "name": "Test Number",
+                    "command_template": '{"number": {{ value }} }',
+                }
+            }
+        }
+    ],
+)
 async def test_run_number_service_optimistic_with_command_template(
-    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator
 ) -> None:
     """Test that set_value service works in optimistic mode and with a command_template."""
     topic = "test/number"
@@ -304,21 +316,7 @@ async def test_run_number_service_optimistic_with_command_template(
     mock_restore_cache_with_extra_data(
         hass, ((State("number.test_number", "abc"), RESTORE_DATA),)
     )
-    assert await async_setup_component(
-        hass,
-        mqtt.DOMAIN,
-        {
-            mqtt.DOMAIN: {
-                number.DOMAIN: {
-                    "command_topic": topic,
-                    "name": "Test Number",
-                    "command_template": '{"number": {{ value }} }',
-                }
-            }
-        },
-    )
-    await hass.async_block_till_done()
-    mqtt_mock = await mqtt_mock_entry_with_yaml_config()
+    mqtt_mock = await mqtt_mock_entry_no_yaml_config()
 
     state = hass.states.get("number.test_number")
     assert state.state == "3"
@@ -366,28 +364,28 @@ async def test_run_number_service_optimistic_with_command_template(
     assert state.state == "42.1"
 
 
+@pytest.mark.parametrize(
+    "hass_config",
+    [
+        {
+            mqtt.DOMAIN: {
+                number.DOMAIN: {
+                    "command_topic": "test/number/set",
+                    "state_topic": "test/number",
+                    "name": "Test Number",
+                }
+            }
+        }
+    ],
+)
 async def test_run_number_service(
-    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator
 ) -> None:
     """Test that set_value service works in non optimistic mode."""
     cmd_topic = "test/number/set"
     state_topic = "test/number"
 
-    assert await async_setup_component(
-        hass,
-        mqtt.DOMAIN,
-        {
-            mqtt.DOMAIN: {
-                number.DOMAIN: {
-                    "command_topic": cmd_topic,
-                    "state_topic": state_topic,
-                    "name": "Test Number",
-                }
-            }
-        },
-    )
-    await hass.async_block_till_done()
-    mqtt_mock = await mqtt_mock_entry_with_yaml_config()
+    mqtt_mock = await mqtt_mock_entry_no_yaml_config()
 
     async_fire_mqtt_message(hass, state_topic, "32")
     state = hass.states.get("number.test_number")
@@ -404,29 +402,29 @@ async def test_run_number_service(
     assert state.state == "32"
 
 
+@pytest.mark.parametrize(
+    "hass_config",
+    [
+        {
+            mqtt.DOMAIN: {
+                number.DOMAIN: {
+                    "command_topic": "test/number/set",
+                    "state_topic": "test/number",
+                    "name": "Test Number",
+                    "command_template": '{"number": {{ value }} }',
+                }
+            }
+        }
+    ],
+)
 async def test_run_number_service_with_command_template(
-    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator
 ) -> None:
     """Test that set_value service works in non optimistic mode and with a command_template."""
     cmd_topic = "test/number/set"
     state_topic = "test/number"
 
-    assert await async_setup_component(
-        hass,
-        mqtt.DOMAIN,
-        {
-            mqtt.DOMAIN: {
-                number.DOMAIN: {
-                    "command_topic": cmd_topic,
-                    "state_topic": state_topic,
-                    "name": "Test Number",
-                    "command_template": '{"number": {{ value }} }',
-                }
-            }
-        },
-    )
-    await hass.async_block_till_done()
-    mqtt_mock = await mqtt_mock_entry_with_yaml_config()
+    mqtt_mock = await mqtt_mock_entry_no_yaml_config()
 
     async_fire_mqtt_message(hass, state_topic, "32")
     state = hass.states.get("number.test_number")
@@ -732,29 +730,28 @@ async def test_entity_debug_info_message(
     )
 
 
-async def test_min_max_step_attributes(
-    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
-) -> None:
-    """Test min/max/step attributes."""
-    topic = "test/number"
-    await async_setup_component(
-        hass,
-        mqtt.DOMAIN,
+@pytest.mark.parametrize(
+    "hass_config",
+    [
         {
             mqtt.DOMAIN: {
                 number.DOMAIN: {
-                    "state_topic": topic,
-                    "command_topic": topic,
+                    "state_topic": "test/state_number",
+                    "command_topic": "test/cmd_number",
                     "name": "Test Number",
                     "min": 5,
                     "max": 110,
                     "step": 20,
                 }
             }
-        },
-    )
-    await hass.async_block_till_done()
-    await mqtt_mock_entry_with_yaml_config()
+        }
+    ],
+)
+async def test_min_max_step_attributes(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator
+) -> None:
+    """Test min/max/step attributes."""
+    await mqtt_mock_entry_no_yaml_config()
 
     state = hass.states.get("number.test_number")
     assert state.attributes.get(ATTR_MIN) == 5
@@ -762,129 +759,180 @@ async def test_min_max_step_attributes(
     assert state.attributes.get(ATTR_STEP) == 20
 
 
-async def test_invalid_min_max_attributes(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
-) -> None:
-    """Test invalid min/max attributes."""
-    topic = "test/number"
-    assert not await async_setup_component(
-        hass,
-        mqtt.DOMAIN,
+@pytest.mark.parametrize(
+    "hass_config",
+    [
         {
             mqtt.DOMAIN: {
                 number.DOMAIN: {
-                    "state_topic": topic,
-                    "command_topic": topic,
+                    "state_topic": "test/state_number",
+                    "command_topic": "test/cmd_number",
                     "name": "Test Number",
                     "min": 35,
                     "max": 10,
                 }
             }
-        },
-    )
-
+        }
+    ],
+)
+async def test_invalid_min_max_attributes(
+    hass: HomeAssistant,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test invalid min/max attributes."""
+    with pytest.raises(AssertionError):
+        await mqtt_mock_entry_no_yaml_config()
     assert f"'{CONF_MAX}' must be > '{CONF_MIN}'" in caplog.text
 
 
-async def test_default_mode(
-    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
-) -> None:
-    """Test default mode."""
-    topic = "test/number"
-    await async_setup_component(
-        hass,
-        mqtt.DOMAIN,
+@pytest.mark.parametrize(
+    "hass_config",
+    [
         {
             mqtt.DOMAIN: {
                 number.DOMAIN: {
-                    "state_topic": topic,
-                    "command_topic": topic,
+                    "state_topic": "test/state_number",
+                    "command_topic": "test/cmd_number",
                     "name": "Test Number",
                 }
             }
-        },
-    )
-    await hass.async_block_till_done()
-    await mqtt_mock_entry_with_yaml_config()
+        }
+    ],
+)
+async def test_default_mode(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator
+) -> None:
+    """Test default mode."""
+    await mqtt_mock_entry_no_yaml_config()
 
     state = hass.states.get("number.test_number")
     assert state.attributes.get(ATTR_MODE) == "auto"
 
 
-@pytest.mark.parametrize("mode", ("auto", "box", "slider"))
+@pytest.mark.parametrize(
+    ("hass_config", "mode"),
+    [
+        (
+            {
+                mqtt.DOMAIN: {
+                    number.DOMAIN: {
+                        "state_topic": "test/state_number",
+                        "command_topic": "test/cmd_number",
+                        "name": "Test Number",
+                        "mode": "auto",
+                    }
+                }
+            },
+            "auto",
+        ),
+        (
+            {
+                mqtt.DOMAIN: {
+                    number.DOMAIN: {
+                        "state_topic": "test/state_number",
+                        "command_topic": "test/cmd_number",
+                        "name": "Test Number",
+                        "mode": "box",
+                    }
+                }
+            },
+            "box",
+        ),
+        (
+            {
+                mqtt.DOMAIN: {
+                    number.DOMAIN: {
+                        "state_topic": "test/state_number",
+                        "command_topic": "test/cmd_number",
+                        "name": "Test Number",
+                        "mode": "slider",
+                    }
+                }
+            },
+            "slider",
+        ),
+    ],
+)
 async def test_mode(
     hass: HomeAssistant,
-    mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
     mode,
 ) -> None:
     """Test mode."""
-    topic = "test/number"
-    await async_setup_component(
-        hass,
-        mqtt.DOMAIN,
-        {
-            mqtt.DOMAIN: {
-                number.DOMAIN: {
-                    "state_topic": topic,
-                    "command_topic": topic,
-                    "name": "Test Number",
-                    "mode": mode,
-                }
-            }
-        },
-    )
-    await hass.async_block_till_done()
-    await mqtt_mock_entry_with_yaml_config()
+    await mqtt_mock_entry_no_yaml_config()
 
     state = hass.states.get("number.test_number")
     assert state.attributes.get(ATTR_MODE) == mode
 
 
-@pytest.mark.parametrize(("mode", "valid"), [("bleh", False), ("auto", True)])
-async def test_invalid_mode(hass: HomeAssistant, mode, valid) -> None:
-    """Test invalid mode."""
-    topic = "test/number"
-    assert (
-        await async_setup_component(
-            hass,
-            mqtt.DOMAIN,
+@pytest.mark.parametrize(
+    ("hass_config", "valid"),
+    [
+        (
             {
                 mqtt.DOMAIN: {
                     number.DOMAIN: {
-                        "state_topic": topic,
-                        "command_topic": topic,
+                        "state_topic": "test/state_number",
+                        "command_topic": "test/cmd_number",
                         "name": "Test Number",
-                        "mode": mode,
+                        "mode": "bleh",
                     }
                 }
             },
-        )
-        is valid
-    )
-
-
-async def test_mqtt_payload_not_a_number_warning(
+            False,
+        ),
+        (
+            {
+                mqtt.DOMAIN: {
+                    number.DOMAIN: {
+                        "state_topic": "test/state_number",
+                        "command_topic": "test/cmd_number",
+                        "name": "Test Number",
+                        "mode": "auto",
+                    }
+                }
+            },
+            True,
+        ),
+    ],
+)
+async def test_invalid_mode(
     hass: HomeAssistant,
-    caplog: pytest.LogCaptureFixture,
-    mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
+    valid: bool,
 ) -> None:
-    """Test warning for MQTT payload which is not a number."""
-    topic = "test/number"
-    assert await async_setup_component(
-        hass,
-        mqtt.DOMAIN,
+    """Test invalid mode."""
+    if valid:
+        await mqtt_mock_entry_no_yaml_config()
+        return
+    with pytest.raises(AssertionError):
+        await mqtt_mock_entry_no_yaml_config()
+
+
+@pytest.mark.parametrize(
+    "hass_config",
+    [
         {
             mqtt.DOMAIN: {
                 number.DOMAIN: {
-                    "state_topic": topic,
-                    "command_topic": topic,
+                    "state_topic": "test/state_number",
+                    "command_topic": "test/cmd_number",
                     "name": "Test Number",
                 }
             }
-        },
-    )
-    await hass.async_block_till_done()
-    await mqtt_mock_entry_with_yaml_config()
+        }
+    ],
+)
+async def test_mqtt_payload_not_a_number_warning(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
+) -> None:
+    """Test warning for MQTT payload which is not a number."""
+    topic = "test/state_number"
+
+    await mqtt_mock_entry_no_yaml_config()
 
     async_fire_mqtt_message(hass, topic, "not_a_number")
 
@@ -893,30 +941,32 @@ async def test_mqtt_payload_not_a_number_warning(
     assert "Payload 'not_a_number' is not a Number" in caplog.text
 
 
-async def test_mqtt_payload_out_of_range_error(
-    hass: HomeAssistant,
-    caplog: pytest.LogCaptureFixture,
-    mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator,
-) -> None:
-    """Test error when MQTT payload is out of min/max range."""
-    topic = "test/number"
-    await async_setup_component(
-        hass,
-        mqtt.DOMAIN,
+@pytest.mark.parametrize(
+    "hass_config",
+    [
         {
             mqtt.DOMAIN: {
                 number.DOMAIN: {
-                    "state_topic": topic,
-                    "command_topic": topic,
+                    "state_topic": "test/state_number",
+                    "command_topic": "test/cmd_number",
                     "name": "Test Number",
                     "min": 5,
                     "max": 110,
                 }
             }
-        },
-    )
+        }
+    ],
+)
+async def test_mqtt_payload_out_of_range_error(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator,
+) -> None:
+    """Test error when MQTT payload is out of min/max range."""
+    topic = "test/state_number"
+
     await hass.async_block_till_done()
-    await mqtt_mock_entry_with_yaml_config()
+    await mqtt_mock_entry_no_yaml_config()
 
     async_fire_mqtt_message(hass, topic, "115.5")
 

--- a/tests/components/mqtt/test_scene.py
+++ b/tests/components/mqtt/test_scene.py
@@ -7,7 +7,6 @@ import pytest
 from homeassistant.components import mqtt, scene
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_ON, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant, State
-from homeassistant.setup import async_setup_component
 
 from .test_common import (
     help_test_availability_when_connection_lost,
@@ -44,16 +43,9 @@ def scene_platform_only():
         yield
 
 
-async def test_sending_mqtt_commands(
-    hass: HomeAssistant, mqtt_mock_entry_with_yaml_config: MqttMockHAClientGenerator
-) -> None:
-    """Test the sending MQTT commands."""
-    fake_state = State("scene.test", STATE_UNKNOWN)
-    mock_restore_cache(hass, (fake_state,))
-
-    assert await async_setup_component(
-        hass,
-        mqtt.DOMAIN,
+@pytest.mark.parametrize(
+    "hass_config",
+    [
         {
             mqtt.DOMAIN: {
                 scene.DOMAIN: {
@@ -62,10 +54,17 @@ async def test_sending_mqtt_commands(
                     "payload_on": "beer on",
                 },
             }
-        },
-    )
-    await hass.async_block_till_done()
-    mqtt_mock = await mqtt_mock_entry_with_yaml_config()
+        }
+    ],
+)
+async def test_sending_mqtt_commands(
+    hass: HomeAssistant, mqtt_mock_entry_no_yaml_config: MqttMockHAClientGenerator
+) -> None:
+    """Test the sending MQTT commands."""
+    fake_state = State("scene.test", STATE_UNKNOWN)
+    mock_restore_cache(hass, (fake_state,))
+
+    mqtt_mock = await mqtt_mock_entry_no_yaml_config()
 
     state = hass.states.get("scene.test")
     assert state.state == STATE_UNKNOWN


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update MQTT (platform) tests for:
- `lock`
- `mixins`
- `number`
- `scene`

this PR is part of splitting up tests as preparation for #87987

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
