### PR TITLE
Bump PyJWT to 2.6.0

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -1,4 +1,4 @@
-PyJWT==2.5.0
+PyJWT==2.6.0
 PyNaCl==1.5.0
 aiodiscover==1.4.14
 aiohttp==3.8.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies    = [
     "ifaddr==0.1.7",
     "jinja2==3.1.2",
     "lru-dict==1.1.8",
-    "PyJWT==2.5.0",
+    "PyJWT==2.6.0",
     # PyJWT has loose dependency. We want the latest one.
     "cryptography==39.0.1",
     # pyOpenSSL 23.0.0 is required to work with cryptography 39+

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ home-assistant-bluetooth==1.9.3
 ifaddr==0.1.7
 jinja2==3.1.2
 lru-dict==1.1.8
-PyJWT==2.5.0
+PyJWT==2.6.0
 cryptography==39.0.1
 pyOpenSSL==23.0.0
 orjson==3.8.7

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -1,7 +1,6 @@
 """Test for smart home alexa support."""
 from unittest.mock import patch
 
-from freezegun import freeze_time
 import pytest
 
 from homeassistant.components.alexa import messages, smart_home
@@ -158,7 +157,7 @@ def assert_endpoint_capabilities(endpoint, *interfaces):
     return capabilities
 
 
-@freeze_time("2022-04-19 07:53:05")
+@pytest.mark.freeze_time("2022-04-19 07:53:05")
 async def test_switch(hass: HomeAssistant, events: list[Event]) -> None:
     """Test switch discovery."""
     device = ("switch.test", "on", {"friendly_name": "Test switch"})
@@ -212,7 +211,7 @@ async def test_outlet(hass: HomeAssistant, events: list[Event]) -> None:
     )
 
 
-@freeze_time("2022-04-19 07:53:05")
+@pytest.mark.freeze_time("2022-04-19 07:53:05")
 async def test_light(hass: HomeAssistant) -> None:
     """Test light discovery."""
     device = ("light.test_1", "on", {"friendly_name": "Test light 1"})
@@ -308,7 +307,7 @@ async def test_color_light(
     # tests
 
 
-@freeze_time("2022-04-19 07:53:05")
+@pytest.mark.freeze_time("2022-04-19 07:53:05")
 async def test_script(hass: HomeAssistant) -> None:
     """Test script discovery."""
     device = ("script.test", "off", {"friendly_name": "Test script"})
@@ -329,7 +328,7 @@ async def test_script(hass: HomeAssistant) -> None:
     )
 
 
-@freeze_time("2022-04-19 07:53:05")
+@pytest.mark.freeze_time("2022-04-19 07:53:05")
 async def test_input_boolean(hass: HomeAssistant) -> None:
     """Test input boolean discovery."""
     device = ("input_boolean.test", "off", {"friendly_name": "Test input boolean"})
@@ -366,7 +365,7 @@ async def test_input_boolean(hass: HomeAssistant) -> None:
     assert {"name": "detectionState"} in properties["supported"]
 
 
-@freeze_time("2022-04-19 07:53:05")
+@pytest.mark.freeze_time("2022-04-19 07:53:05")
 async def test_scene(hass: HomeAssistant) -> None:
     """Test scene discovery."""
     device = ("scene.test", "off", {"friendly_name": "Test scene"})
@@ -387,7 +386,7 @@ async def test_scene(hass: HomeAssistant) -> None:
     )
 
 
-@freeze_time("2022-04-19 07:53:05")
+@pytest.mark.freeze_time("2022-04-19 07:53:05")
 async def test_fan(hass: HomeAssistant) -> None:
     """Test fan discovery."""
     device = ("fan.test_1", "off", {"friendly_name": "Test fan 1"})
@@ -945,7 +944,7 @@ async def test_single_preset_mode_fan(
     caplog.clear()
 
 
-@freeze_time("2022-04-19 07:53:05")
+@pytest.mark.freeze_time("2022-04-19 07:53:05")
 async def test_humidifier(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
@@ -1117,7 +1116,7 @@ async def test_lock(hass: HomeAssistant) -> None:
     assert properties["value"] == "UNLOCKED"
 
 
-@freeze_time("2022-04-19 07:53:05")
+@pytest.mark.freeze_time("2022-04-19 07:53:05")
 async def test_media_player(hass: HomeAssistant) -> None:
     """Test media player discovery."""
     device = (
@@ -1729,7 +1728,7 @@ async def test_media_player_seek_error(hass: HomeAssistant) -> None:
         assert msg["payload"]["type"] == "ACTION_NOT_PERMITTED_FOR_CONTENT"
 
 
-@freeze_time("2022-04-19 07:53:05")
+@pytest.mark.freeze_time("2022-04-19 07:53:05")
 async def test_alert(hass: HomeAssistant) -> None:
     """Test alert discovery."""
     device = ("alert.test", "off", {"friendly_name": "Test alert"})
@@ -1747,7 +1746,7 @@ async def test_alert(hass: HomeAssistant) -> None:
     )
 
 
-@freeze_time("2022-04-19 07:53:05")
+@pytest.mark.freeze_time("2022-04-19 07:53:05")
 async def test_automation(hass: HomeAssistant) -> None:
     """Test automation discovery."""
     device = ("automation.test", "off", {"friendly_name": "Test automation"})
@@ -1769,7 +1768,7 @@ async def test_automation(hass: HomeAssistant) -> None:
     )
 
 
-@freeze_time("2022-04-19 07:53:05")
+@pytest.mark.freeze_time("2022-04-19 07:53:05")
 async def test_group(hass: HomeAssistant) -> None:
     """Test group discovery."""
     device = ("group.test", "off", {"friendly_name": "Test group"})
@@ -4183,7 +4182,7 @@ async def test_initialize_camera_stream(
     )
 
 
-@freeze_time("2022-04-19 07:53:05")
+@pytest.mark.freeze_time("2022-04-19 07:53:05")
 @pytest.mark.parametrize(
     "domain",
     ["button", "input_button"],

--- a/tests/components/bmw_connected_drive/test_diagnostics.py
+++ b/tests/components/bmw_connected_drive/test_diagnostics.py
@@ -4,7 +4,7 @@ import json
 import os
 import time
 
-from freezegun import freeze_time
+import pytest
 
 from homeassistant.components.bmw_connected_drive.const import DOMAIN
 from homeassistant.core import HomeAssistant
@@ -20,7 +20,7 @@ from tests.components.diagnostics import (
 from tests.typing import ClientSessionGenerator
 
 
-@freeze_time(datetime.datetime(2022, 7, 10, 11))
+@pytest.mark.freeze_time(datetime.datetime(2022, 7, 10, 11))
 async def test_config_entry_diagnostics(
     hass: HomeAssistant, hass_client: ClientSessionGenerator, bmw_fixture
 ) -> None:
@@ -43,7 +43,7 @@ async def test_config_entry_diagnostics(
     assert diagnostics == diagnostics_fixture
 
 
-@freeze_time(datetime.datetime(2022, 7, 10, 11))
+@pytest.mark.freeze_time(datetime.datetime(2022, 7, 10, 11))
 async def test_device_diagnostics(
     hass: HomeAssistant, hass_client: ClientSessionGenerator, bmw_fixture
 ) -> None:
@@ -72,7 +72,7 @@ async def test_device_diagnostics(
     assert diagnostics == diagnostics_fixture
 
 
-@freeze_time(datetime.datetime(2022, 7, 10, 11))
+@pytest.mark.freeze_time(datetime.datetime(2022, 7, 10, 11))
 async def test_device_diagnostics_vehicle_not_found(
     hass: HomeAssistant, hass_client: ClientSessionGenerator, bmw_fixture
 ) -> None:

--- a/tests/components/ipma/test_weather.py
+++ b/tests/components/ipma/test_weather.py
@@ -2,7 +2,7 @@
 from datetime import datetime
 from unittest.mock import patch
 
-from freezegun import freeze_time
+import pytest
 
 from homeassistant.components.weather import (
     ATTR_FORECAST,
@@ -100,7 +100,7 @@ async def test_daily_forecast(hass: HomeAssistant) -> None:
     assert forecast.get(ATTR_FORECAST_WIND_BEARING) == "S"
 
 
-@freeze_time("2020-01-14 23:00:00")
+@pytest.mark.freeze_time("2020-01-14 23:00:00")
 async def test_hourly_forecast(hass: HomeAssistant) -> None:
     """Test for successfully getting daily forecast."""
     with patch(

--- a/tests/components/local_calendar/test_diagnostics.py
+++ b/tests/components/local_calendar/test_diagnostics.py
@@ -1,16 +1,44 @@
 """Tests for diagnostics platform of local calendar."""
 
+from aiohttp.test_utils import TestClient
+from freezegun import freeze_time
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.auth.models import Credentials
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
-from .conftest import TEST_ENTITY, ClientFixture
+from .conftest import TEST_ENTITY, Client, ClientFixture
 
-from tests.common import MockConfigEntry
+from tests.common import CLIENT_ID, MockConfigEntry, MockUser
 from tests.components.diagnostics import get_diagnostics_for_config_entry
 from tests.typing import ClientSessionGenerator
+
+
+async def generate_new_hass_access_token(
+    hass: HomeAssistant, hass_admin_user: MockUser, hass_admin_credential: Credentials
+) -> str:
+    """Return an access token to access Home Assistant."""
+    await hass.auth.async_link_user(hass_admin_user, hass_admin_credential)
+
+    refresh_token = await hass.auth.async_create_refresh_token(
+        hass_admin_user, CLIENT_ID, credential=hass_admin_credential
+    )
+    return hass.auth.async_create_access_token(refresh_token)
+
+
+def _get_test_client_generator(
+    hass: HomeAssistant, aiohttp_client: ClientSessionGenerator, new_token: str
+):
+    """Return a test client generator.""."""
+
+    async def auth_client() -> TestClient:
+        return await aiohttp_client(
+            hass.http.app, headers={"Authorization": f"Bearer {new_token}"}
+        )
+
+    return auth_client
 
 
 @pytest.fixture(autouse=True)
@@ -19,31 +47,58 @@ async def setup_diag(hass):
     assert await async_setup_component(hass, "diagnostics", {})
 
 
-@pytest.mark.freeze_time("2023-03-13 12:05:00-07:00")
+@freeze_time("2023-03-13 12:05:00-07:00")
 async def test_empty_calendar(
     hass: HomeAssistant,
     setup_integration: None,
-    hass_client: ClientSessionGenerator,
+    hass_admin_user: MockUser,
+    hass_admin_credential: Credentials,
     config_entry: MockConfigEntry,
+    aiohttp_client: ClientSessionGenerator,
+    socket_enabled: None,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test diagnostics against an empty calendar."""
-    data = await get_diagnostics_for_config_entry(hass, hass_client, config_entry)
+    # Since we are freezing time only when we enter this test, we need to
+    # manually create a new token and clients since the token created by
+    # the fixtures would not be valid.
+    #
+    # Ideally we would use pytest.mark.freeze_time before the fixtures, but that does not
+    # work with the ical library and freezegun because
+    # `TypeError: '<' not supported between instances of 'FakeDatetimeMeta' and 'FakeDateMeta'`
+    new_token = await generate_new_hass_access_token(
+        hass, hass_admin_user, hass_admin_credential
+    )
+    data = await get_diagnostics_for_config_entry(
+        hass, _get_test_client_generator(hass, aiohttp_client, new_token), config_entry
+    )
     assert data == snapshot
 
 
-@pytest.mark.freeze_time("2023-03-13 12:05:00-07:00")
+@freeze_time("2023-03-13 12:05:00-07:00")
 async def test_api_date_time_event(
     hass: HomeAssistant,
     setup_integration: None,
+    hass_admin_user: MockUser,
+    hass_admin_credential: Credentials,
     config_entry: MockConfigEntry,
-    hass_client: ClientSessionGenerator,
-    ws_client: ClientFixture,
+    hass_ws_client: ClientFixture,
+    aiohttp_client: ClientSessionGenerator,
+    socket_enabled: None,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test an event with a start/end date time."""
-
-    client = await ws_client()
+    # Since we are freezing time only when we enter this test, we need to
+    # manually create a new token and clients since the token created by
+    # the fixtures would not be valid.
+    #
+    # Ideally we would use pytest.mark.freeze_time before the fixtures, but that does not
+    # work with the ical library and freezegun because
+    # `TypeError: '<' not supported between instances of 'FakeDatetimeMeta' and 'FakeDateMeta'`
+    new_token = await generate_new_hass_access_token(
+        hass, hass_admin_user, hass_admin_credential
+    )
+    client = Client(await hass_ws_client(hass, access_token=new_token))
     await client.cmd_result(
         "create",
         {
@@ -57,5 +112,7 @@ async def test_api_date_time_event(
         },
     )
 
-    data = await get_diagnostics_for_config_entry(hass, hass_client, config_entry)
+    data = await get_diagnostics_for_config_entry(
+        hass, _get_test_client_generator(hass, aiohttp_client, new_token), config_entry
+    )
     assert data == snapshot

--- a/tests/components/local_calendar/test_diagnostics.py
+++ b/tests/components/local_calendar/test_diagnostics.py
@@ -1,6 +1,5 @@
 """Tests for diagnostics platform of local calendar."""
 
-from freezegun import freeze_time
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -20,7 +19,7 @@ async def setup_diag(hass):
     assert await async_setup_component(hass, "diagnostics", {})
 
 
-@freeze_time("2023-03-13 12:05:00-07:00")
+@pytest.mark.freeze_time("2023-03-13 12:05:00-07:00")
 async def test_empty_calendar(
     hass: HomeAssistant,
     setup_integration: None,
@@ -33,7 +32,7 @@ async def test_empty_calendar(
     assert data == snapshot
 
 
-@freeze_time("2023-03-13 12:05:00-07:00")
+@pytest.mark.freeze_time("2023-03-13 12:05:00-07:00")
 async def test_api_date_time_event(
     hass: HomeAssistant,
     setup_integration: None,

--- a/tests/components/metoffice/test_init.py
+++ b/tests/components/metoffice/test_init.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import datetime
 
-from freezegun import freeze_time
 import pytest
 import requests_mock
 
@@ -16,7 +15,9 @@ from .const import DOMAIN, METOFFICE_CONFIG_WAVERTREE, TEST_COORDINATES_WAVERTRE
 from tests.common import MockConfigEntry
 
 
-@freeze_time(datetime.datetime(2020, 4, 25, 12, tzinfo=datetime.timezone.utc))
+@pytest.mark.freeze_time(
+    datetime.datetime(2020, 4, 25, 12, tzinfo=datetime.timezone.utc)
+)
 @pytest.mark.parametrize(
     ("old_unique_id", "new_unique_id", "migration_needed"),
     [

--- a/tests/components/metoffice/test_sensor.py
+++ b/tests/components/metoffice/test_sensor.py
@@ -2,7 +2,7 @@
 import datetime
 import json
 
-from freezegun import freeze_time
+import pytest
 import requests_mock
 
 from homeassistant.components.metoffice.const import ATTRIBUTION, DOMAIN
@@ -24,7 +24,9 @@ from .const import (
 from tests.common import MockConfigEntry, load_fixture
 
 
-@freeze_time(datetime.datetime(2020, 4, 25, 12, tzinfo=datetime.timezone.utc))
+@pytest.mark.freeze_time(
+    datetime.datetime(2020, 4, 25, 12, tzinfo=datetime.timezone.utc)
+)
 async def test_one_sensor_site_running(
     hass: HomeAssistant, requests_mock: requests_mock.Mocker
 ) -> None:
@@ -72,7 +74,9 @@ async def test_one_sensor_site_running(
         assert sensor.attributes.get("attribution") == ATTRIBUTION
 
 
-@freeze_time(datetime.datetime(2020, 4, 25, 12, tzinfo=datetime.timezone.utc))
+@pytest.mark.freeze_time(
+    datetime.datetime(2020, 4, 25, 12, tzinfo=datetime.timezone.utc)
+)
 async def test_two_sensor_sites_running(
     hass: HomeAssistant, requests_mock: requests_mock.Mocker
 ) -> None:

--- a/tests/components/metoffice/test_weather.py
+++ b/tests/components/metoffice/test_weather.py
@@ -3,7 +3,7 @@ import datetime
 from datetime import timedelta
 import json
 
-from freezegun import freeze_time
+import pytest
 import requests_mock
 
 from homeassistant.components.metoffice.const import DOMAIN
@@ -23,7 +23,9 @@ from .const import (
 from tests.common import MockConfigEntry, async_fire_time_changed, load_fixture
 
 
-@freeze_time(datetime.datetime(2020, 4, 25, 12, tzinfo=datetime.timezone.utc))
+@pytest.mark.freeze_time(
+    datetime.datetime(2020, 4, 25, 12, tzinfo=datetime.timezone.utc)
+)
 async def test_site_cannot_connect(
     hass: HomeAssistant, requests_mock: requests_mock.Mocker
 ) -> None:
@@ -52,7 +54,9 @@ async def test_site_cannot_connect(
         assert sensor is None
 
 
-@freeze_time(datetime.datetime(2020, 4, 25, 12, tzinfo=datetime.timezone.utc))
+@pytest.mark.freeze_time(
+    datetime.datetime(2020, 4, 25, 12, tzinfo=datetime.timezone.utc)
+)
 async def test_site_cannot_update(
     hass: HomeAssistant, requests_mock: requests_mock.Mocker
 ) -> None:
@@ -100,7 +104,9 @@ async def test_site_cannot_update(
     assert weather.state == STATE_UNAVAILABLE
 
 
-@freeze_time(datetime.datetime(2020, 4, 25, 12, tzinfo=datetime.timezone.utc))
+@pytest.mark.freeze_time(
+    datetime.datetime(2020, 4, 25, 12, tzinfo=datetime.timezone.utc)
+)
 async def test_one_weather_site_running(
     hass: HomeAssistant, requests_mock: requests_mock.Mocker
 ) -> None:
@@ -183,7 +189,9 @@ async def test_one_weather_site_running(
     assert weather.attributes.get("forecast")[3]["wind_bearing"] == "SE"
 
 
-@freeze_time(datetime.datetime(2020, 4, 25, 12, tzinfo=datetime.timezone.utc))
+@pytest.mark.freeze_time(
+    datetime.datetime(2020, 4, 25, 12, tzinfo=datetime.timezone.utc)
+)
 async def test_two_weather_sites_running(
     hass: HomeAssistant, requests_mock: requests_mock.Mocker
 ) -> None:

--- a/tests/components/recorder/test_util.py
+++ b/tests/components/recorder/test_util.py
@@ -6,7 +6,6 @@ from pathlib import Path
 import sqlite3
 from unittest.mock import MagicMock, Mock, patch
 
-from freezegun import freeze_time
 import py
 import pytest
 from sqlalchemy import text
@@ -934,7 +933,7 @@ def test_execute_stmt_lambda_element(
             assert rows == ["mock_row"]
 
 
-@freeze_time(datetime(2022, 10, 21, 7, 25, tzinfo=timezone.utc))
+@pytest.mark.freeze_time(datetime(2022, 10, 21, 7, 25, tzinfo=timezone.utc))
 async def test_resolve_period(hass: HomeAssistant) -> None:
     """Test statistic_during_period."""
 

--- a/tests/components/recorder/test_websocket_api.py
+++ b/tests/components/recorder/test_websocket_api.py
@@ -217,7 +217,9 @@ async def test_statistics_during_period(
     }
 
 
-@freeze_time(datetime.datetime(2022, 10, 21, 7, 25, tzinfo=datetime.timezone.utc))
+@pytest.mark.freeze_time(
+    datetime.datetime(2022, 10, 21, 7, 25, tzinfo=datetime.timezone.utc)
+)
 @pytest.mark.parametrize("offset", (0, 1, 2))
 async def test_statistic_during_period(
     recorder_mock: Recorder,
@@ -632,7 +634,9 @@ async def test_statistic_during_period(
     }
 
 
-@freeze_time(datetime.datetime(2022, 10, 21, 7, 25, tzinfo=datetime.timezone.utc))
+@pytest.mark.freeze_time(
+    datetime.datetime(2022, 10, 21, 7, 25, tzinfo=datetime.timezone.utc)
+)
 async def test_statistic_during_period_hole(
     recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
@@ -795,7 +799,9 @@ async def test_statistic_during_period_hole(
     }
 
 
-@freeze_time(datetime.datetime(2022, 10, 21, 7, 25, tzinfo=datetime.timezone.utc))
+@pytest.mark.freeze_time(
+    datetime.datetime(2022, 10, 21, 7, 25, tzinfo=datetime.timezone.utc)
+)
 @pytest.mark.parametrize(
     ("calendar_period", "start_time", "end_time"),
     (

--- a/tests/components/repairs/test_init.py
+++ b/tests/components/repairs/test_init.py
@@ -1,7 +1,6 @@
 """Test the repairs websocket API."""
 from unittest.mock import AsyncMock, Mock
 
-from freezegun import freeze_time
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 
@@ -27,7 +26,7 @@ from tests.common import mock_platform
 from tests.typing import WebSocketGenerator
 
 
-@freeze_time("2022-07-19 07:53:05")
+@pytest.mark.freeze_time("2022-07-19 07:53:05")
 async def test_create_update_issue(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
@@ -166,7 +165,7 @@ async def test_create_issue_invalid_version(
     assert msg["result"] == {"issues": []}
 
 
-@freeze_time("2022-07-19 07:53:05")
+@pytest.mark.freeze_time("2022-07-19 07:53:05")
 async def test_ignore_issue(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
@@ -487,7 +486,7 @@ async def test_non_compliant_platform(
     assert list(hass.data[DOMAIN]["platforms"].keys()) == ["fake_integration"]
 
 
-@freeze_time("2022-07-21 08:22:00")
+@pytest.mark.freeze_time("2022-07-21 08:22:00")
 async def test_sync_methods(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,

--- a/tests/components/repairs/test_init.py
+++ b/tests/components/repairs/test_init.py
@@ -334,6 +334,7 @@ async def test_ignore_issue(
     }
 
 
+@pytest.mark.freeze_time("2022-07-19 07:53:05")
 async def test_delete_issue(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,

--- a/tests/components/repairs/test_websocket_api.py
+++ b/tests/components/repairs/test_websocket_api.py
@@ -5,7 +5,6 @@ from http import HTTPStatus
 from typing import Any
 from unittest.mock import ANY, AsyncMock, Mock
 
-from freezegun import freeze_time
 import pytest
 import voluptuous as vol
 
@@ -430,7 +429,7 @@ async def test_step_unauth(
     assert resp.status == HTTPStatus.UNAUTHORIZED
 
 
-@freeze_time("2022-07-19 07:53:05")
+@pytest.mark.freeze_time("2022-07-19 07:53:05")
 async def test_list_issues(
     hass: HomeAssistant, hass_storage: dict[str, Any], hass_ws_client
 ) -> None:

--- a/tests/components/shelly/test_utils.py
+++ b/tests/components/shelly/test_utils.py
@@ -1,5 +1,4 @@
 """Tests for Shelly utils."""
-from freezegun import freeze_time
 import pytest
 
 from homeassistant.components.shelly.utils import (
@@ -150,7 +149,7 @@ async def test_get_block_device_sleep_period(settings, sleep_period) -> None:
     assert get_block_device_sleep_period(settings) == sleep_period
 
 
-@freeze_time("2019-01-10 18:43:00+00:00")
+@pytest.mark.freeze_time("2019-01-10 18:43:00+00:00")
 async def test_get_device_uptime() -> None:
     """Test block test get device uptime."""
     assert get_device_uptime(

--- a/tests/components/tod/test_binary_sensor.py
+++ b/tests/components/tod/test_binary_sensor.py
@@ -1,7 +1,6 @@
 """Test Times of the Day Binary Sensor."""
 from datetime import datetime, timedelta
 
-from freezegun import freeze_time
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 
@@ -67,7 +66,7 @@ async def test_setup_no_sensors(hass: HomeAssistant) -> None:
         )
 
 
-@freeze_time("2019-01-10 18:43:00-08:00")
+@pytest.mark.freeze_time("2019-01-10 18:43:00-08:00")
 async def test_in_period_on_start(hass: HomeAssistant) -> None:
     """Test simple setting."""
     config = {
@@ -87,7 +86,7 @@ async def test_in_period_on_start(hass: HomeAssistant) -> None:
     assert state.state == STATE_ON
 
 
-@freeze_time("2019-01-10 22:30:00-08:00")
+@pytest.mark.freeze_time("2019-01-10 22:30:00-08:00")
 async def test_midnight_turnover_before_midnight_inside_period(
     hass: HomeAssistant,
 ) -> None:
@@ -131,7 +130,7 @@ async def test_midnight_turnover_after_midnight_inside_period(
     assert state.state == STATE_ON
 
 
-@freeze_time("2019-01-10 20:30:00-08:00")
+@pytest.mark.freeze_time("2019-01-10 20:30:00-08:00")
 async def test_midnight_turnover_before_midnight_outside_period(
     hass: HomeAssistant,
 ) -> None:
@@ -148,7 +147,7 @@ async def test_midnight_turnover_before_midnight_outside_period(
     assert state.state == STATE_OFF
 
 
-@freeze_time("2019-01-10 10:00:00-08:00")
+@pytest.mark.freeze_time("2019-01-10 10:00:00-08:00")
 async def test_after_happens_tomorrow(hass: HomeAssistant) -> None:
     """Test when both before and after are in the future, and after is later than before."""
     config = {
@@ -643,7 +642,7 @@ async def test_dst(
     assert state.state == STATE_OFF
 
 
-@freeze_time("2019-01-10 18:43:00")
+@pytest.mark.freeze_time("2019-01-10 18:43:00")
 @pytest.mark.parametrize("hass_time_zone", ("UTC",))
 async def test_simple_before_after_does_not_loop_utc_not_in_range(
     hass: HomeAssistant,
@@ -669,7 +668,7 @@ async def test_simple_before_after_does_not_loop_utc_not_in_range(
     assert state.attributes["next_update"] == "2019-01-10T22:00:00+00:00"
 
 
-@freeze_time("2019-01-10 22:43:00")
+@pytest.mark.freeze_time("2019-01-10 22:43:00")
 @pytest.mark.parametrize("hass_time_zone", ("UTC",))
 async def test_simple_before_after_does_not_loop_utc_in_range(
     hass: HomeAssistant,
@@ -695,7 +694,7 @@ async def test_simple_before_after_does_not_loop_utc_in_range(
     assert state.attributes["next_update"] == "2019-01-11T06:00:00+00:00"
 
 
-@freeze_time("2019-01-11 06:00:00")
+@pytest.mark.freeze_time("2019-01-11 06:00:00")
 @pytest.mark.parametrize("hass_time_zone", ("UTC",))
 async def test_simple_before_after_does_not_loop_utc_fire_at_before(
     hass: HomeAssistant,
@@ -721,7 +720,7 @@ async def test_simple_before_after_does_not_loop_utc_fire_at_before(
     assert state.attributes["next_update"] == "2019-01-11T22:00:00+00:00"
 
 
-@freeze_time("2019-01-10 22:00:00")
+@pytest.mark.freeze_time("2019-01-10 22:00:00")
 @pytest.mark.parametrize("hass_time_zone", ("UTC",))
 async def test_simple_before_after_does_not_loop_utc_fire_at_after(
     hass: HomeAssistant,
@@ -747,7 +746,7 @@ async def test_simple_before_after_does_not_loop_utc_fire_at_after(
     assert state.attributes["next_update"] == "2019-01-11T06:00:00+00:00"
 
 
-@freeze_time("2019-01-10 22:00:00")
+@pytest.mark.freeze_time("2019-01-10 22:00:00")
 @pytest.mark.parametrize("hass_time_zone", ("UTC",))
 async def test_simple_before_after_does_not_loop_utc_both_before_now(
     hass: HomeAssistant,
@@ -773,7 +772,7 @@ async def test_simple_before_after_does_not_loop_utc_both_before_now(
     assert state.attributes["next_update"] == "2019-01-11T00:00:00+00:00"
 
 
-@freeze_time("2019-01-10 17:43:00+01:00")
+@pytest.mark.freeze_time("2019-01-10 17:43:00+01:00")
 @pytest.mark.parametrize("hass_time_zone", ("Europe/Berlin",))
 async def test_simple_before_after_does_not_loop_berlin_not_in_range(
     hass: HomeAssistant,
@@ -799,7 +798,7 @@ async def test_simple_before_after_does_not_loop_berlin_not_in_range(
     assert state.attributes["next_update"] == "2019-01-11T00:00:00+01:00"
 
 
-@freeze_time("2019-01-11 00:43:00+01:00")
+@pytest.mark.freeze_time("2019-01-11 00:43:00+01:00")
 @pytest.mark.parametrize("hass_time_zone", ("Europe/Berlin",))
 async def test_simple_before_after_does_not_loop_berlin_in_range(
     hass: HomeAssistant,

--- a/tests/components/tod/test_config_flow.py
+++ b/tests/components/tod/test_config_flow.py
@@ -1,7 +1,6 @@
 """Test the Times of the Day config flow."""
 from unittest.mock import patch
 
-from freezegun import freeze_time
 import pytest
 
 from homeassistant import config_entries
@@ -66,7 +65,7 @@ def get_suggested(schema, key):
     raise Exception
 
 
-@freeze_time("2022-03-16 17:37:00", tz_offset=-7)
+@pytest.mark.freeze_time("2022-03-16 17:37:00", tz_offset=-7)
 async def test_options(hass: HomeAssistant) -> None:
     """Test reconfiguring."""
     # Setup the config entry

--- a/tests/components/tod/test_init.py
+++ b/tests/components/tod/test_init.py
@@ -1,5 +1,6 @@
 """Test the Times of the Day integration."""
-from freezegun import freeze_time
+
+import pytest
 
 from homeassistant.components.tod.const import DOMAIN
 from homeassistant.core import HomeAssistant
@@ -8,7 +9,7 @@ from homeassistant.helpers import entity_registry as er
 from tests.common import MockConfigEntry
 
 
-@freeze_time("2022-03-16 17:37:00", tz_offset=-7)
+@pytest.mark.freeze_time("2022-03-16 17:37:00", tz_offset=-7)
 async def test_setup_and_remove_config_entry(hass: HomeAssistant) -> None:
     """Test setting up and removing a config entry."""
     registry = er.async_get(hass)

--- a/tests/components/unifiprotect/test_media_source.py
+++ b/tests/components/unifiprotect/test_media_source.py
@@ -4,7 +4,6 @@ from datetime import datetime, timedelta
 from ipaddress import IPv4Address
 from unittest.mock import AsyncMock, Mock, patch
 
-from freezegun import freeze_time
 import pytest
 import pytz
 from pyunifiprotect.data import (
@@ -465,7 +464,7 @@ TWO_MONTH_SIMPLE = (
     ("start", "months"),
     [ONE_MONTH_SIMPLE, TWO_MONTH_SIMPLE],
 )
-@freeze_time("2022-09-15 03:00:00-07:00")
+@pytest.mark.freeze_time("2022-09-15 03:00:00-07:00")
 async def test_browse_media_time(
     hass: HomeAssistant,
     ufp: MockUFPFixture,
@@ -537,7 +536,7 @@ TWO_MONTH_TIMEZONE = (
     ("start", "months"),
     [ONE_MONTH_TIMEZONE, TWO_MONTH_TIMEZONE],
 )
-@freeze_time("2022-08-31 21:00:00-07:00")
+@pytest.mark.freeze_time("2022-08-31 21:00:00-07:00")
 async def test_browse_media_time_timezone(
     hass: HomeAssistant,
     ufp: MockUFPFixture,
@@ -713,7 +712,7 @@ async def test_browse_media_eventthumb(
     assert browse.media_class == MediaClass.IMAGE
 
 
-@freeze_time("2022-09-15 03:00:00-07:00")
+@pytest.mark.freeze_time("2022-09-15 03:00:00-07:00")
 async def test_browse_media_day(
     hass: HomeAssistant, ufp: MockUFPFixture, doorbell: Camera
 ) -> None:

--- a/tests/components/zha/test_button.py
+++ b/tests/components/zha/test_button.py
@@ -1,6 +1,7 @@
 """Test ZHA button."""
 from unittest.mock import call, patch
 
+from freezegun import freeze_time
 import pytest
 from zhaquirks.const import (
     DEVICE_TYPE,
@@ -119,7 +120,7 @@ async def tuya_water_valve(hass, zigpy_device_mock, zha_device_joined_restored):
     return zha_device, zigpy_device.endpoints[1].tuya_manufacturer
 
 
-@pytest.mark.freeze_time("2021-11-04 17:37:00", tz_offset=-1)
+@freeze_time("2021-11-04 17:37:00", tz_offset=-1)
 async def test_button(hass: HomeAssistant, contact_sensor) -> None:
     """Test ZHA button platform."""
 

--- a/tests/components/zha/test_button.py
+++ b/tests/components/zha/test_button.py
@@ -1,7 +1,6 @@
 """Test ZHA button."""
 from unittest.mock import call, patch
 
-from freezegun import freeze_time
 import pytest
 from zhaquirks.const import (
     DEVICE_TYPE,
@@ -120,7 +119,7 @@ async def tuya_water_valve(hass, zigpy_device_mock, zha_device_joined_restored):
     return zha_device, zigpy_device.endpoints[1].tuya_manufacturer
 
 
-@freeze_time("2021-11-04 17:37:00", tz_offset=-1)
+@pytest.mark.freeze_time("2021-11-04 17:37:00", tz_offset=-1)
 async def test_button(hass: HomeAssistant, contact_sensor) -> None:
     """Test ZHA button platform."""
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump PyJWT to 2.6.0

changelog: https://github.com/jpadilla/pyjwt/compare/2.5.0...2.6.0

The tests needed to be updated since some of them where freezing time too late so the access token would get created with a future time and the test would run in the past which with the newly added `iat` check in https://github.com/jpadilla/pyjwt/compare/2.5.0...2.6.0#diff-6893ad4a1c5a36b8af3028db8c8bc3b62418149843fc382faf901eaab008e380R219 the test would fail.

This is good as we are now checking for future tokens

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
