### PR TITLE
Refactor Gree switch to use EntityDescription

### DIFF
--- a/homeassistant/components/gree/switch.py
+++ b/homeassistant/components/gree/switch.py
@@ -51,6 +51,7 @@ GREE_SWITCHES: tuple[GreeSwitchEntityDescription, ...] = (
         name="Health mode",
         key="health_mode",
         property=Props.ANION,
+        entity_registry_enabled_default=False,
     ),
 )
 

--- a/homeassistant/components/gree/switch.py
+++ b/homeassistant/components/gree/switch.py
@@ -1,9 +1,12 @@
 """Support for interface with a Gree climate systems."""
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any
 
-from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
+from greeclimate.device import Props
+
+from homeassistant.components.switch import SwitchEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -11,6 +14,45 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import COORDINATORS, DISPATCH_DEVICE_DISCOVERED, DISPATCHERS, DOMAIN
 from .entity import GreeEntity
+
+
+@dataclass
+class GreeSwitchRequiredKeysMixin:
+    """Mixin for require keys."""
+
+    property: Props
+
+
+@dataclass
+class GreeSwitchEntityDescription(SwitchEntityDescription, GreeSwitchRequiredKeysMixin):
+    """Describes a switch entity."""
+
+
+GREE_SWITCHES: tuple[GreeSwitchEntityDescription, ...] = (
+    GreeSwitchEntityDescription(
+        icon="mdi:lightbulb",
+        name="Panel Light",
+        key="panel_light",
+        property=Props.LIGHT,
+    ),
+    GreeSwitchEntityDescription(
+        name="Quiet",
+        key="quiet",
+        property=Props.QUIET,
+    ),
+    GreeSwitchEntityDescription(
+        name="Fresh Air",
+        key="fresh_air",
+        property=Props.FRESH_AIR,
+    ),
+    GreeSwitchEntityDescription(name="XFan", key="xfan", property=Props.XFAN),
+    GreeSwitchEntityDescription(
+        icon="mdi:pine-tree",
+        name="Health mode",
+        key="health_mode",
+        property=Props.ANION,
+    ),
+)
 
 
 async def async_setup_entry(
@@ -23,14 +65,10 @@ async def async_setup_entry(
     @callback
     def init_device(coordinator):
         """Register the device."""
+
         async_add_entities(
-            [
-                GreePanelLightSwitchEntity(coordinator),
-                GreeHealthModeSwitchEntity(coordinator),
-                GreeQuietModeSwitchEntity(coordinator),
-                GreeFreshAirSwitchEntity(coordinator),
-                GreeXFanSwitchEntity(coordinator),
-            ]
+            GreeSwitch(coordinator=coordinator, description=description)
+            for description in GREE_SWITCHES
         )
 
     for coordinator in hass.data[DOMAIN][COORDINATORS]:
@@ -41,162 +79,31 @@ async def async_setup_entry(
     )
 
 
-class GreePanelLightSwitchEntity(GreeEntity, SwitchEntity):
-    """Representation of the front panel light on the device."""
+class GreeSwitch(GreeSwitchEntityDescription, GreeEntity):
+    """Generic Gree entity to use with a modern style configuration."""
 
-    def __init__(self, coordinator):
+    entity_description: GreeSwitchEntityDescription
+
+    def __init__(self, coordinator, description: GreeSwitchEntityDescription) -> None:
         """Initialize the Gree device."""
-        super().__init__(coordinator, "Panel Light")
+        self.entity_description = description
 
-    @property
-    def icon(self) -> str | None:
-        """Return the icon for the device."""
-        return "mdi:lightbulb"
-
-    @property
-    def device_class(self):
-        """Return the class of this device, from component DEVICE_CLASSES."""
-        return SwitchDeviceClass.SWITCH
-
-    @property
-    def is_on(self) -> bool:
-        """Return if the light is turned on."""
-        return self.coordinator.device.light
-
-    async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn the entity on."""
-        self.coordinator.device.light = True
-        await self.coordinator.push_state_update()
-        self.async_write_ha_state()
-
-    async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn the entity off."""
-        self.coordinator.device.light = False
-        await self.coordinator.push_state_update()
-        self.async_write_ha_state()
-
-
-class GreeHealthModeSwitchEntity(GreeEntity, SwitchEntity):
-    """Representation of the health mode on the device."""
-
-    def __init__(self, coordinator):
-        """Initialize the Gree device."""
-        super().__init__(coordinator, "Health mode")
-        self._attr_entity_registry_enabled_default = False
-
-    @property
-    def icon(self) -> str | None:
-        """Return the icon for the device."""
-        return "mdi:pine-tree"
-
-    @property
-    def device_class(self):
-        """Return the class of this device, from component DEVICE_CLASSES."""
-        return SwitchDeviceClass.SWITCH
-
-    @property
-    def is_on(self) -> bool:
-        """Return if the health mode is turned on."""
-        return self.coordinator.device.anion
-
-    async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn the entity on."""
-        self.coordinator.device.anion = True
-        await self.coordinator.push_state_update()
-        self.async_write_ha_state()
-
-    async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn the entity off."""
-        self.coordinator.device.anion = False
-        await self.coordinator.push_state_update()
-        self.async_write_ha_state()
-
-
-class GreeQuietModeSwitchEntity(GreeEntity, SwitchEntity):
-    """Representation of the quiet mode state of the device."""
-
-    def __init__(self, coordinator):
-        """Initialize the Gree device."""
-        super().__init__(coordinator, "Quiet")
-
-    @property
-    def device_class(self):
-        """Return the class of this device, from component DEVICE_CLASSES."""
-        return SwitchDeviceClass.SWITCH
+        if name := self.entity_description.name:
+            super().__init__(coordinator, name)
 
     @property
     def is_on(self) -> bool:
         """Return if the state is turned on."""
-        return self.coordinator.device.quiet
+        return self.coordinator.device.get_property(self.entity_description.property)
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
-        self.coordinator.device.quiet = True
+        self.coordinator.device.set_property(self.entity_description.property, 1)
         await self.coordinator.push_state_update()
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
-        self.coordinator.device.quiet = False
-        await self.coordinator.push_state_update()
-        self.async_write_ha_state()
-
-
-class GreeFreshAirSwitchEntity(GreeEntity, SwitchEntity):
-    """Representation of the fresh air mode state of the device."""
-
-    def __init__(self, coordinator):
-        """Initialize the Gree device."""
-        super().__init__(coordinator, "Fresh Air")
-
-    @property
-    def device_class(self):
-        """Return the class of this device, from component DEVICE_CLASSES."""
-        return SwitchDeviceClass.SWITCH
-
-    @property
-    def is_on(self) -> bool:
-        """Return if the state is turned on."""
-        return self.coordinator.device.fresh_air
-
-    async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn the entity on."""
-        self.coordinator.device.fresh_air = True
-        await self.coordinator.push_state_update()
-        self.async_write_ha_state()
-
-    async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn the entity off."""
-        self.coordinator.device.fresh_air = False
-        await self.coordinator.push_state_update()
-        self.async_write_ha_state()
-
-
-class GreeXFanSwitchEntity(GreeEntity, SwitchEntity):
-    """Representation of the extra fan mode state of the device."""
-
-    def __init__(self, coordinator):
-        """Initialize the Gree device."""
-        super().__init__(coordinator, "XFan")
-
-    @property
-    def device_class(self):
-        """Return the class of this device, from component DEVICE_CLASSES."""
-        return SwitchDeviceClass.SWITCH
-
-    @property
-    def is_on(self) -> bool:
-        """Return if the state is turned on."""
-        return self.coordinator.device.xfan
-
-    async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn the entity on."""
-        self.coordinator.device.xfan = True
-        await self.coordinator.push_state_update()
-        self.async_write_ha_state()
-
-    async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn the entity off."""
-        self.coordinator.device.xfan = False
+        self.coordinator.device.set_property(self.entity_description.property, 0)
         await self.coordinator.push_state_update()
         self.async_write_ha_state()

--- a/homeassistant/components/gree/switch.py
+++ b/homeassistant/components/gree/switch.py
@@ -89,8 +89,7 @@ class GreeSwitch(GreeSwitchEntityDescription, GreeEntity):
         """Initialize the Gree device."""
         self.entity_description = description
 
-        if name := self.entity_description.name:
-            super().__init__(coordinator, name)
+        super().__init__(coordinator, cast(str, description.name))
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/gree/switch.py
+++ b/homeassistant/components/gree/switch.py
@@ -20,7 +20,7 @@ GREE_SWITCHES: tuple[SwitchEntityDescription, ...] = (
     SwitchEntityDescription(
         icon="mdi:lightbulb",
         name="Panel light",
-        key="panel_light",
+        key="light",
     ),
     SwitchEntityDescription(
         name="Quiet",

--- a/homeassistant/components/gree/switch.py
+++ b/homeassistant/components/gree/switch.py
@@ -19,7 +19,7 @@ from .entity import GreeEntity
 GREE_SWITCHES: tuple[SwitchEntityDescription, ...] = (
     SwitchEntityDescription(
         icon="mdi:lightbulb",
-        name="Panel light",
+        name="Panel Light",
         key="light",
     ),
     SwitchEntityDescription(

--- a/homeassistant/components/gree/switch.py
+++ b/homeassistant/components/gree/switch.py
@@ -1,7 +1,6 @@
 """Support for interface with a Gree climate systems."""
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import Any, cast
 
 from homeassistant.components.switch import (
@@ -17,28 +16,22 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import COORDINATORS, DISPATCH_DEVICE_DISCOVERED, DISPATCHERS, DOMAIN
 from .entity import GreeEntity
 
-
-@dataclass
-class GreeSwitchEntityDescription(SwitchEntityDescription):
-    """Describes a switch entity."""
-
-
-GREE_SWITCHES: tuple[GreeSwitchEntityDescription, ...] = (
-    GreeSwitchEntityDescription(
+GREE_SWITCHES: tuple[SwitchEntityDescription, ...] = (
+    SwitchEntityDescription(
         icon="mdi:lightbulb",
         name="Panel light",
         key="panel_light",
     ),
-    GreeSwitchEntityDescription(
+    SwitchEntityDescription(
         name="Quiet",
         key="quiet",
     ),
-    GreeSwitchEntityDescription(
+    SwitchEntityDescription(
         name="Fresh air",
         key="fresh_air",
     ),
-    GreeSwitchEntityDescription(name="XFan", key="xfan"),
-    GreeSwitchEntityDescription(
+    SwitchEntityDescription(name="XFan", key="xfan"),
+    SwitchEntityDescription(
         icon="mdi:pine-tree",
         name="Health mode",
         key="health_mode",
@@ -75,9 +68,9 @@ class GreeSwitch(GreeEntity, SwitchEntity):
     """Generic Gree entity to use with a modern style configuration."""
 
     _attr_device_class = SwitchDeviceClass.SWITCH
-    entity_description: GreeSwitchEntityDescription
+    entity_description: SwitchEntityDescription
 
-    def __init__(self, coordinator, description: GreeSwitchEntityDescription) -> None:
+    def __init__(self, coordinator, description: SwitchEntityDescription) -> None:
         """Initialize the Gree device."""
         self.entity_description = description
 

--- a/homeassistant/components/gree/switch.py
+++ b/homeassistant/components/gree/switch.py
@@ -34,7 +34,7 @@ GREE_SWITCHES: tuple[SwitchEntityDescription, ...] = (
     SwitchEntityDescription(
         icon="mdi:pine-tree",
         name="Health mode",
-        key="health_mode",
+        key="anion",
         entity_registry_enabled_default=False,
     ),
 )

--- a/homeassistant/components/gree/switch.py
+++ b/homeassistant/components/gree/switch.py
@@ -2,11 +2,15 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, cast
 
 from greeclimate.device import Props
 
-from homeassistant.components.switch import SwitchEntityDescription
+from homeassistant.components.switch import (
+    SwitchDeviceClass,
+    SwitchEntity,
+    SwitchEntityDescription,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -31,7 +35,7 @@ class GreeSwitchEntityDescription(SwitchEntityDescription, GreeSwitchRequiredKey
 GREE_SWITCHES: tuple[GreeSwitchEntityDescription, ...] = (
     GreeSwitchEntityDescription(
         icon="mdi:lightbulb",
-        name="Panel Light",
+        name="Panel light",
         key="panel_light",
         property=Props.LIGHT,
     ),
@@ -41,7 +45,7 @@ GREE_SWITCHES: tuple[GreeSwitchEntityDescription, ...] = (
         property=Props.QUIET,
     ),
     GreeSwitchEntityDescription(
-        name="Fresh Air",
+        name="Fresh air",
         key="fresh_air",
         property=Props.FRESH_AIR,
     ),

--- a/homeassistant/components/gree/switch.py
+++ b/homeassistant/components/gree/switch.py
@@ -95,7 +95,7 @@ class GreeSwitch(GreeEntity, SwitchEntity):
     @property
     def is_on(self) -> bool:
         """Return if the state is turned on."""
-        return self.coordinator.device.get_property(self.entity_description.property)
+        return getattr(self.coordinator.device, self.entity_description.key)
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""

--- a/homeassistant/components/gree/switch.py
+++ b/homeassistant/components/gree/switch.py
@@ -105,6 +105,6 @@ class GreeSwitch(GreeEntity, SwitchEntity):
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
-        self.coordinator.device.set_property(self.entity_description.property, 0)
+        setattr(self.coordinator.device, self.entity_description.key, False)
         await self.coordinator.push_state_update()
         self.async_write_ha_state()

--- a/homeassistant/components/gree/switch.py
+++ b/homeassistant/components/gree/switch.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, cast
 
-from greeclimate.device import Props
-
 from homeassistant.components.switch import (
     SwitchDeviceClass,
     SwitchEntity,
@@ -21,14 +19,7 @@ from .entity import GreeEntity
 
 
 @dataclass
-class GreeSwitchRequiredKeysMixin:
-    """Mixin for require keys."""
-
-    property: Props
-
-
-@dataclass
-class GreeSwitchEntityDescription(SwitchEntityDescription, GreeSwitchRequiredKeysMixin):
+class GreeSwitchEntityDescription(SwitchEntityDescription):
     """Describes a switch entity."""
 
 
@@ -37,24 +28,20 @@ GREE_SWITCHES: tuple[GreeSwitchEntityDescription, ...] = (
         icon="mdi:lightbulb",
         name="Panel light",
         key="panel_light",
-        property=Props.LIGHT,
     ),
     GreeSwitchEntityDescription(
         name="Quiet",
         key="quiet",
-        property=Props.QUIET,
     ),
     GreeSwitchEntityDescription(
         name="Fresh air",
         key="fresh_air",
-        property=Props.FRESH_AIR,
     ),
-    GreeSwitchEntityDescription(name="XFan", key="xfan", property=Props.XFAN),
+    GreeSwitchEntityDescription(name="XFan", key="xfan"),
     GreeSwitchEntityDescription(
         icon="mdi:pine-tree",
         name="Health mode",
         key="health_mode",
-        property=Props.ANION,
         entity_registry_enabled_default=False,
     ),
 )

--- a/homeassistant/components/gree/switch.py
+++ b/homeassistant/components/gree/switch.py
@@ -98,7 +98,7 @@ class GreeSwitch(GreeEntity, SwitchEntity):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
-        self.coordinator.device.set_property(self.entity_description.property, 1)
+        setattr(self.coordinator.device, self.entity_description.key, True)
         await self.coordinator.push_state_update()
         self.async_write_ha_state()
 

--- a/homeassistant/components/gree/switch.py
+++ b/homeassistant/components/gree/switch.py
@@ -83,6 +83,7 @@ async def async_setup_entry(
 class GreeSwitch(GreeEntity, SwitchEntity):
     """Generic Gree entity to use with a modern style configuration."""
 
+    _attr_device_class = SwitchDeviceClass.SWITCH
     entity_description: GreeSwitchEntityDescription
 
     def __init__(self, coordinator, description: GreeSwitchEntityDescription) -> None:

--- a/homeassistant/components/gree/switch.py
+++ b/homeassistant/components/gree/switch.py
@@ -80,7 +80,7 @@ async def async_setup_entry(
     )
 
 
-class GreeSwitch(GreeSwitchEntityDescription, GreeEntity):
+class GreeSwitch(GreeEntity, SwitchEntity):
     """Generic Gree entity to use with a modern style configuration."""
 
     entity_description: GreeSwitchEntityDescription

--- a/homeassistant/components/gree/switch.py
+++ b/homeassistant/components/gree/switch.py
@@ -65,7 +65,7 @@ async def async_setup_entry(
 
 
 class GreeSwitch(GreeEntity, SwitchEntity):
-    """Generic Gree entity to use with a modern style configuration."""
+    """Generic Gree switch entity."""
 
     _attr_device_class = SwitchDeviceClass.SWITCH
 

--- a/homeassistant/components/gree/switch.py
+++ b/homeassistant/components/gree/switch.py
@@ -68,7 +68,6 @@ class GreeSwitch(GreeEntity, SwitchEntity):
     """Generic Gree entity to use with a modern style configuration."""
 
     _attr_device_class = SwitchDeviceClass.SWITCH
-    entity_description: SwitchEntityDescription
 
     def __init__(self, coordinator, description: SwitchEntityDescription) -> None:
         """Initialize the Gree device."""

--- a/homeassistant/components/gree/switch.py
+++ b/homeassistant/components/gree/switch.py
@@ -27,7 +27,7 @@ GREE_SWITCHES: tuple[SwitchEntityDescription, ...] = (
         key="quiet",
     ),
     SwitchEntityDescription(
-        name="Fresh air",
+        name="Fresh Air",
         key="fresh_air",
     ),
     SwitchEntityDescription(name="XFan", key="xfan"),

--- a/tests/components/gree/test_switch.py
+++ b/tests/components/gree/test_switch.py
@@ -185,7 +185,7 @@ async def test_send_switch_toggle(
 @pytest.mark.parametrize(
     ("entity", "name"),
     [
-        (ENTITY_ID_LIGHT_PANEL, "Panel light"),
+        (ENTITY_ID_LIGHT_PANEL, "Panel Light"),
         (ENTITY_ID_HEALTH_MODE, "Health mode"),
         (ENTITY_ID_QUIET, "Quiet"),
         (ENTITY_ID_FRESH_AIR, "Fresh Air"),

--- a/tests/components/gree/test_switch.py
+++ b/tests/components/gree/test_switch.py
@@ -188,7 +188,7 @@ async def test_send_switch_toggle(
         (ENTITY_ID_LIGHT_PANEL, "Panel light"),
         (ENTITY_ID_HEALTH_MODE, "Health mode"),
         (ENTITY_ID_QUIET, "Quiet"),
-        (ENTITY_ID_FRESH_AIR, "Fresh air"),
+        (ENTITY_ID_FRESH_AIR, "Fresh Air"),
         (ENTITY_ID_XFAN, "XFan"),
     ],
 )

--- a/tests/components/gree/test_switch.py
+++ b/tests/components/gree/test_switch.py
@@ -185,10 +185,10 @@ async def test_send_switch_toggle(
 @pytest.mark.parametrize(
     ("entity", "name"),
     [
-        (ENTITY_ID_LIGHT_PANEL, "Panel Light"),
+        (ENTITY_ID_LIGHT_PANEL, "Panel light"),
         (ENTITY_ID_HEALTH_MODE, "Health mode"),
         (ENTITY_ID_QUIET, "Quiet"),
-        (ENTITY_ID_FRESH_AIR, "Fresh Air"),
+        (ENTITY_ID_FRESH_AIR, "Fresh air"),
         (ENTITY_ID_XFAN, "XFan"),
     ],
 )


### PR DESCRIPTION
## Proposed change

I was browsing the code and noticed the current way Gree switches were being implemented was not up to standard practices. I don't have a Gree device but I migrated the switch construction to "modern style"

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
