### PR TITLE
2023.3.6

### DIFF
--- a/homeassistant/components/august/manifest.json
+++ b/homeassistant/components/august/manifest.json
@@ -28,5 +28,5 @@
   "documentation": "https://www.home-assistant.io/integrations/august",
   "iot_class": "cloud_push",
   "loggers": ["pubnub", "yalexs"],
-  "requirements": ["yalexs==1.2.7", "yalexs_ble==2.0.4"]
+  "requirements": ["yalexs==1.2.7", "yalexs_ble==2.1.0"]
 }

--- a/homeassistant/components/august/manifest.json
+++ b/homeassistant/components/august/manifest.json
@@ -28,5 +28,5 @@
   "documentation": "https://www.home-assistant.io/integrations/august",
   "iot_class": "cloud_push",
   "loggers": ["pubnub", "yalexs"],
-  "requirements": ["yalexs==1.2.7", "yalexs_ble==2.1.0"]
+  "requirements": ["yalexs==1.2.7", "yalexs-ble==2.1.1"]
 }

--- a/homeassistant/components/easyenergy/manifest.json
+++ b/homeassistant/components/easyenergy/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/easyenergy",
   "iot_class": "cloud_polling",
   "quality_scale": "platinum",
-  "requirements": ["easyenergy==0.2.1"]
+  "requirements": ["easyenergy==0.2.2"]
 }

--- a/homeassistant/components/easyenergy/manifest.json
+++ b/homeassistant/components/easyenergy/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/easyenergy",
   "iot_class": "cloud_polling",
   "quality_scale": "platinum",
-  "requirements": ["easyenergy==0.1.2"]
+  "requirements": ["easyenergy==0.2.1"]
 }

--- a/homeassistant/components/esphome/entry_data.py
+++ b/homeassistant/components/esphome/entry_data.py
@@ -130,10 +130,15 @@ class RuntimeEntryData:
         )
         self.ble_connections_free = free
         self.ble_connections_limit = limit
-        if free:
-            for fut in self._ble_connection_free_futures:
+        if not free:
+            return
+        for fut in self._ble_connection_free_futures:
+            # If wait_for_ble_connections_free gets cancelled, it will
+            # leave a future in the list. We need to check if it's done
+            # before setting the result.
+            if not fut.done():
                 fut.set_result(free)
-            self._ble_connection_free_futures.clear()
+        self._ble_connection_free_futures.clear()
 
     async def wait_for_ble_connections_free(self) -> int:
         """Wait until there are free BLE connections."""

--- a/homeassistant/components/freebox/config_flow.py
+++ b/homeassistant/components/freebox/config_flow.py
@@ -77,7 +77,6 @@ class FreeboxFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             # Check permissions
             await fbx.system.get_config()
             await fbx.lan.get_hosts_list()
-            await self.hass.async_block_till_done()
 
             # Close connection
             await fbx.close()

--- a/homeassistant/components/harmony/manifest.json
+++ b/homeassistant/components/harmony/manifest.json
@@ -13,7 +13,7 @@
   "documentation": "https://www.home-assistant.io/integrations/harmony",
   "iot_class": "local_push",
   "loggers": ["aioharmony", "slixmpp"],
-  "requirements": ["aioharmony==0.2.9"],
+  "requirements": ["aioharmony==0.2.10"],
   "ssdp": [
     {
       "manufacturer": "Logitech",

--- a/homeassistant/components/http/auth.py
+++ b/homeassistant/components/http/auth.py
@@ -60,9 +60,7 @@ def async_sign_path(
 
     url = URL(path)
     now = dt_util.utcnow()
-    params = dict(sorted(url.query.items()))
-    for param in SAFE_QUERY_PARAMS:
-        params.pop(param, None)
+    params = [itm for itm in url.query.items() if itm[0] not in SAFE_QUERY_PARAMS]
     encoded = jwt.encode(
         {
             "iss": refresh_token_id,
@@ -75,7 +73,7 @@ def async_sign_path(
         algorithm="HS256",
     )
 
-    params[SIGN_QUERY_PARAM] = encoded
+    params.append((SIGN_QUERY_PARAM, encoded))
     url = url.with_query(params)
     return f"{url.path}?{url.query_string}"
 
@@ -184,10 +182,11 @@ async def async_setup_auth(hass: HomeAssistant, app: Application) -> None:
         if claims["path"] != request.path:
             return False
 
-        params = dict(sorted(request.query.items()))
-        del params[SIGN_QUERY_PARAM]
-        for param in SAFE_QUERY_PARAMS:
-            params.pop(param, None)
+        params = [
+            list(itm)  # claims stores tuples as lists
+            for itm in request.query.items()
+            if itm[0] not in SAFE_QUERY_PARAMS and itm[0] != SIGN_QUERY_PARAM
+        ]
         if claims["params"] != params:
             return False
 

--- a/homeassistant/components/imap_email_content/sensor.py
+++ b/homeassistant/components/imap_email_content/sensor.py
@@ -95,8 +95,24 @@ class EmailReader:
         self._folder = folder
         self._verify_ssl = verify_ssl
         self._last_id = None
+        self._last_message = None
         self._unread_ids = deque([])
         self.connection = None
+
+    @property
+    def last_id(self) -> int | None:
+        """Return last email uid that was processed."""
+        return self._last_id
+
+    @property
+    def last_unread_id(self) -> int | None:
+        """Return last email uid received."""
+        # We assume the last id in the list is the last unread id
+        # We cannot know if that is the newest one, because it could arrive later
+        # https://stackoverflow.com/questions/12409862/python-imap-the-order-of-uids
+        if self._unread_ids:
+            return int(self._unread_ids[-1])
+        return self._last_id
 
     def connect(self):
         """Login and setup the connection."""
@@ -128,21 +144,21 @@ class EmailReader:
         try:
             self.connection.select(self._folder, readonly=True)
 
-            if not self._unread_ids:
-                search = f"SINCE {datetime.date.today():%d-%b-%Y}"
-                if self._last_id is not None:
-                    search = f"UID {self._last_id}:*"
+            if self._last_id is None:
+                # search for today and yesterday
+                time_from = datetime.datetime.now() - datetime.timedelta(days=1)
+                search = f"SINCE {time_from:%d-%b-%Y}"
+            else:
+                search = f"UID {self._last_id}:*"
 
-                _, data = self.connection.uid("search", None, search)
-                self._unread_ids = deque(data[0].split())
-
+            _, data = self.connection.uid("search", None, search)
+            self._unread_ids = deque(data[0].split())
             while self._unread_ids:
                 message_uid = self._unread_ids.popleft()
                 if self._last_id is None or int(message_uid) > self._last_id:
                     self._last_id = int(message_uid)
-                    return self._fetch_message(message_uid)
-
-            return self._fetch_message(str(self._last_id))
+                    self._last_message = self._fetch_message(message_uid)
+                    return self._last_message
 
         except imaplib.IMAP4.error:
             _LOGGER.info("Connection to %s lost, attempting to reconnect", self._server)
@@ -254,22 +270,30 @@ class EmailContentSensor(SensorEntity):
     def update(self) -> None:
         """Read emails and publish state change."""
         email_message = self._email_reader.read_next()
+        while (
+            self._last_id is None or self._last_id != self._email_reader.last_unread_id
+        ):
+            if email_message is None:
+                self._message = None
+                self._state_attributes = {}
+                return
 
-        if email_message is None:
-            self._message = None
-            self._state_attributes = {}
-            return
+            self._last_id = self._email_reader.last_id
 
-        if self.sender_allowed(email_message):
-            message = EmailContentSensor.get_msg_subject(email_message)
+            if self.sender_allowed(email_message):
+                message = EmailContentSensor.get_msg_subject(email_message)
 
-            if self._value_template is not None:
-                message = self.render_template(email_message)
+                if self._value_template is not None:
+                    message = self.render_template(email_message)
 
-            self._message = message
-            self._state_attributes = {
-                ATTR_FROM: EmailContentSensor.get_msg_sender(email_message),
-                ATTR_SUBJECT: EmailContentSensor.get_msg_subject(email_message),
-                ATTR_DATE: email_message["Date"],
-                ATTR_BODY: EmailContentSensor.get_msg_text(email_message),
-            }
+                self._message = message
+                self._state_attributes = {
+                    ATTR_FROM: EmailContentSensor.get_msg_sender(email_message),
+                    ATTR_SUBJECT: EmailContentSensor.get_msg_subject(email_message),
+                    ATTR_DATE: email_message["Date"],
+                    ATTR_BODY: EmailContentSensor.get_msg_text(email_message),
+                }
+
+            if self._last_id == self._email_reader.last_unread_id:
+                break
+            email_message = self._email_reader.read_next()

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -706,7 +706,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             for component in PLATFORMS
         )
     )
-    await hass.async_block_till_done()
+    await asyncio.sleep(0)
     # Unsubscribe reload dispatchers
     while reload_dispatchers := mqtt_data.reload_dispatchers:
         reload_dispatchers.pop()()

--- a/homeassistant/components/nibe_heatpump/__init__.py
+++ b/homeassistant/components/nibe_heatpump/__init__.py
@@ -62,13 +62,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Nibe Heat Pump from a config entry."""
 
     heatpump = HeatPump(Model[entry.data[CONF_MODEL]])
+    heatpump.word_swap = entry.data.get(CONF_WORD_SWAP, True)
     await heatpump.initialize()
 
     connection: Connection
     connection_type = entry.data[CONF_CONNECTION_TYPE]
 
     if connection_type == CONF_CONNECTION_TYPE_NIBEGW:
-        heatpump.word_swap = entry.data[CONF_WORD_SWAP]
         connection = NibeGW(
             heatpump,
             entry.data[CONF_IP_ADDRESS],

--- a/homeassistant/components/oralb/manifest.json
+++ b/homeassistant/components/oralb/manifest.json
@@ -11,5 +11,6 @@
   "dependencies": ["bluetooth_adapters"],
   "documentation": "https://www.home-assistant.io/integrations/oralb",
   "iot_class": "local_push",
-  "requirements": ["oralb-ble==0.17.5"]
+  "loggers": ["oralb-ble"],
+  "requirements": ["oralb-ble==0.17.6"]
 }

--- a/homeassistant/components/switchbot/manifest.json
+++ b/homeassistant/components/switchbot/manifest.json
@@ -40,5 +40,5 @@
   "documentation": "https://www.home-assistant.io/integrations/switchbot",
   "iot_class": "local_push",
   "loggers": ["switchbot"],
-  "requirements": ["PySwitchbot==0.37.3"]
+  "requirements": ["PySwitchbot==0.37.4"]
 }

--- a/homeassistant/components/yalexs_ble/manifest.json
+++ b/homeassistant/components/yalexs_ble/manifest.json
@@ -12,5 +12,5 @@
   "dependencies": ["bluetooth_adapters"],
   "documentation": "https://www.home-assistant.io/integrations/yalexs_ble",
   "iot_class": "local_push",
-  "requirements": ["yalexs-ble==2.0.4"]
+  "requirements": ["yalexs-ble==2.1.0"]
 }

--- a/homeassistant/components/yalexs_ble/manifest.json
+++ b/homeassistant/components/yalexs_ble/manifest.json
@@ -12,5 +12,5 @@
   "dependencies": ["bluetooth_adapters"],
   "documentation": "https://www.home-assistant.io/integrations/yalexs_ble",
   "iot_class": "local_push",
-  "requirements": ["yalexs-ble==2.1.0"]
+  "requirements": ["yalexs-ble==2.1.1"]
 }

--- a/homeassistant/components/yamaha_musiccast/manifest.json
+++ b/homeassistant/components/yamaha_musiccast/manifest.json
@@ -7,7 +7,7 @@
   "documentation": "https://www.home-assistant.io/integrations/yamaha_musiccast",
   "iot_class": "local_push",
   "loggers": ["aiomusiccast"],
-  "requirements": ["aiomusiccast==0.14.7"],
+  "requirements": ["aiomusiccast==0.14.8"],
   "ssdp": [
     {
       "manufacturer": "Yamaha Corporation"

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -8,7 +8,7 @@ from .backports.enum import StrEnum
 APPLICATION_NAME: Final = "HomeAssistant"
 MAJOR_VERSION: Final = 2023
 MINOR_VERSION: Final = 3
-PATCH_VERSION: Final = "5"
+PATCH_VERSION: Final = "6"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 10, 0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name        = "homeassistant"
-version     = "2023.3.5"
+version     = "2023.3.6"
 license     = {text = "Apache-2.0"}
 description = "Open-source home automation platform running on Python 3."
 readme      = "README.rst"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2670,13 +2670,13 @@ xs1-api-client==3.0.0
 yalesmartalarmclient==0.3.9
 
 # homeassistant.components.yalexs_ble
-yalexs-ble==2.0.4
+yalexs-ble==2.1.0
 
 # homeassistant.components.august
 yalexs==1.2.7
 
 # homeassistant.components.august
-yalexs_ble==2.0.4
+yalexs_ble==2.1.0
 
 # homeassistant.components.yeelight
 yeelight==0.7.10

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -171,7 +171,7 @@ aiogithubapi==22.10.1
 aioguardian==2022.07.0
 
 # homeassistant.components.harmony
-aioharmony==0.2.9
+aioharmony==0.2.10
 
 # homeassistant.components.homekit_controller
 aiohomekit==2.6.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -625,7 +625,7 @@ dynalite_devices==0.1.47
 eagle100==0.1.1
 
 # homeassistant.components.easyenergy
-easyenergy==0.1.2
+easyenergy==0.2.1
 
 # homeassistant.components.ebusd
 ebusdpy==0.0.17

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -40,7 +40,7 @@ PyRMVtransport==0.3.3
 PySocks==1.7.1
 
 # homeassistant.components.switchbot
-PySwitchbot==0.37.3
+PySwitchbot==0.37.4
 
 # homeassistant.components.transport_nsw
 PyTransportNSW==0.1.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -214,7 +214,7 @@ aiolyric==1.0.9
 aiomodernforms==0.1.8
 
 # homeassistant.components.yamaha_musiccast
-aiomusiccast==0.14.7
+aiomusiccast==0.14.8
 
 # homeassistant.components.nanoleaf
 aionanoleaf==0.2.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1299,7 +1299,7 @@ openwrt-luci-rpc==1.1.11
 openwrt-ubus-rpc==0.0.2
 
 # homeassistant.components.oralb
-oralb-ble==0.17.5
+oralb-ble==0.17.6
 
 # homeassistant.components.oru
 oru==0.1.11

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2669,14 +2669,12 @@ xs1-api-client==3.0.0
 # homeassistant.components.yale_smart_alarm
 yalesmartalarmclient==0.3.9
 
+# homeassistant.components.august
 # homeassistant.components.yalexs_ble
-yalexs-ble==2.1.0
+yalexs-ble==2.1.1
 
 # homeassistant.components.august
 yalexs==1.2.7
-
-# homeassistant.components.august
-yalexs_ble==2.1.0
 
 # homeassistant.components.yeelight
 yeelight==0.7.10

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -625,7 +625,7 @@ dynalite_devices==0.1.47
 eagle100==0.1.1
 
 # homeassistant.components.easyenergy
-easyenergy==0.2.1
+easyenergy==0.2.2
 
 # homeassistant.components.ebusd
 ebusdpy==0.0.17

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -947,7 +947,7 @@ openai==0.26.2
 openerz-api==0.2.0
 
 # homeassistant.components.oralb
-oralb-ble==0.17.5
+oralb-ble==0.17.6
 
 # homeassistant.components.ovo_energy
 ovoenergy==1.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -36,7 +36,7 @@ PyRMVtransport==0.3.3
 PySocks==1.7.1
 
 # homeassistant.components.switchbot
-PySwitchbot==0.37.3
+PySwitchbot==0.37.4
 
 # homeassistant.components.transport_nsw
 PyTransportNSW==0.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -155,7 +155,7 @@ aiogithubapi==22.10.1
 aioguardian==2022.07.0
 
 # homeassistant.components.harmony
-aioharmony==0.2.9
+aioharmony==0.2.10
 
 # homeassistant.components.homekit_controller
 aiohomekit==2.6.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1894,14 +1894,12 @@ xmltodict==0.13.0
 # homeassistant.components.yale_smart_alarm
 yalesmartalarmclient==0.3.9
 
+# homeassistant.components.august
 # homeassistant.components.yalexs_ble
-yalexs-ble==2.1.0
+yalexs-ble==2.1.1
 
 # homeassistant.components.august
 yalexs==1.2.7
-
-# homeassistant.components.august
-yalexs_ble==2.1.0
 
 # homeassistant.components.yeelight
 yeelight==0.7.10

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -195,7 +195,7 @@ aiolyric==1.0.9
 aiomodernforms==0.1.8
 
 # homeassistant.components.yamaha_musiccast
-aiomusiccast==0.14.7
+aiomusiccast==0.14.8
 
 # homeassistant.components.nanoleaf
 aionanoleaf==0.2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -490,7 +490,7 @@ dynalite_devices==0.1.47
 eagle100==0.1.1
 
 # homeassistant.components.easyenergy
-easyenergy==0.2.1
+easyenergy==0.2.2
 
 # homeassistant.components.elgato
 elgato==4.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -490,7 +490,7 @@ dynalite_devices==0.1.47
 eagle100==0.1.1
 
 # homeassistant.components.easyenergy
-easyenergy==0.1.2
+easyenergy==0.2.1
 
 # homeassistant.components.elgato
 elgato==4.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1895,13 +1895,13 @@ xmltodict==0.13.0
 yalesmartalarmclient==0.3.9
 
 # homeassistant.components.yalexs_ble
-yalexs-ble==2.0.4
+yalexs-ble==2.1.0
 
 # homeassistant.components.august
 yalexs==1.2.7
 
 # homeassistant.components.august
-yalexs_ble==2.0.4
+yalexs_ble==2.1.0
 
 # homeassistant.components.yeelight
 yeelight==0.7.10

--- a/tests/components/imap_email_content/test_sensor.py
+++ b/tests/components/imap_email_content/test_sensor.py
@@ -14,9 +14,16 @@ from homeassistant.helpers.template import Template
 class FakeEMailReader:
     """A test class for sending test emails."""
 
-    def __init__(self, messages):
+    def __init__(self, messages) -> None:
         """Set up the fake email reader."""
         self._messages = messages
+        self.last_id = 0
+        self.last_unread_id = len(messages)
+
+    def add_test_message(self, message):
+        """Add a new message."""
+        self.last_unread_id += 1
+        self._messages.append(message)
 
     def connect(self):
         """Stay always Connected."""
@@ -26,6 +33,7 @@ class FakeEMailReader:
         """Get the next email."""
         if len(self._messages) == 0:
             return None
+        self.last_id += 1
         return self._messages.popleft()
 
 
@@ -146,7 +154,7 @@ async def test_multi_part_only_other_text(hass: HomeAssistant) -> None:
 
 
 async def test_multiple_emails(hass: HomeAssistant) -> None:
-    """Test multiple emails."""
+    """Test multiple emails, discarding stale states."""
     states = []
 
     test_message1 = email.message.Message()
@@ -158,8 +166,14 @@ async def test_multiple_emails(hass: HomeAssistant) -> None:
     test_message2 = email.message.Message()
     test_message2["From"] = "sender@test.com"
     test_message2["Subject"] = "Test 2"
-    test_message2["Date"] = datetime.datetime(2016, 1, 1, 12, 44, 57)
+    test_message2["Date"] = datetime.datetime(2016, 1, 1, 12, 44, 58)
     test_message2.set_payload("Test Message 2")
+
+    test_message3 = email.message.Message()
+    test_message3["From"] = "sender@test.com"
+    test_message3["Subject"] = "Test 3"
+    test_message3["Date"] = datetime.datetime(2016, 1, 1, 12, 50, 1)
+    test_message3.set_payload("Test Message 2")
 
     def state_changed_listener(entity_id, from_s, to_s):
         states.append(to_s)
@@ -178,11 +192,13 @@ async def test_multiple_emails(hass: HomeAssistant) -> None:
 
     sensor.async_schedule_update_ha_state(True)
     await hass.async_block_till_done()
+    # Fake a new received message
+    sensor._email_reader.add_test_message(test_message3)
     sensor.async_schedule_update_ha_state(True)
     await hass.async_block_till_done()
 
-    assert states[0].state == "Test"
-    assert states[1].state == "Test 2"
+    assert states[0].state == "Test 2"
+    assert states[1].state == "Test 3"
 
     assert sensor.extra_state_attributes["body"] == "Test Message 2"
 


### PR DESCRIPTION
- Fix imap_email_content unknown status and replaying stale states ([@jbouwh] - [#89563]) ([imap_email_content docs])
- Bump aioharmony to 0.2.10 ([@bdraco] - [#89831]) ([harmony docs])
- Correct missing wordswap for S series nibe ([@elupus] - [#89866]) ([nibe_heatpump docs])
- Fix blocking MQTT entry unload ([@jbouwh] - [#89922]) ([mqtt docs])
- Remove async_block_till_done in freebox ([@bdraco] - [#89928]) ([freebox docs])
- Bump aiomusiccast to 0.14.8 ([@micha91] - [#89978]) ([yamaha_musiccast docs])
- Handle cancelation of wait_for_ble_connections_free in esphome bluetooth ([@bdraco] - [#90014]) ([esphome docs])
- Bump yalexs_ble to 2.1.0 ([@bdraco] - [#89772]) ([august docs]) ([yalexs_ble docs])
- Bump yalexs-ble to 2.1.1 ([@bdraco] - [#90015]) ([yalexs_ble docs])
- Bump easyEnergy to v0.2.1 ([@klaasnicolaas] - [#89630]) ([easyenergy docs])
- Bump easyEnergy to v0.2.2 ([@klaasnicolaas] - [#90080]) ([easyenergy docs])
- Bump to oralb-ble 0.17.6 ([@Lash-L] - [#90081]) ([oralb docs])
- Bump PySwitchbot to 0.37.4 ([@bdraco] - [#90146]) ([switchbot docs])
- Always enforce URL param ordering for signed URLs ([@balloob] - [#90148]) ([http docs])

[#88979]: https://github.com/home-assistant/core/pull/88979
[#89059]: https://github.com/home-assistant/core/pull/89059
[#89381]: https://github.com/home-assistant/core/pull/89381
[#89459]: https://github.com/home-assistant/core/pull/89459
[#89563]: https://github.com/home-assistant/core/pull/89563
[#89630]: https://github.com/home-assistant/core/pull/89630
[#89647]: https://github.com/home-assistant/core/pull/89647
[#89772]: https://github.com/home-assistant/core/pull/89772
[#89814]: https://github.com/home-assistant/core/pull/89814
[#89831]: https://github.com/home-assistant/core/pull/89831
[#89866]: https://github.com/home-assistant/core/pull/89866
[#89922]: https://github.com/home-assistant/core/pull/89922
[#89928]: https://github.com/home-assistant/core/pull/89928
[#89978]: https://github.com/home-assistant/core/pull/89978
[#90014]: https://github.com/home-assistant/core/pull/90014
[#90015]: https://github.com/home-assistant/core/pull/90015
[#90080]: https://github.com/home-assistant/core/pull/90080
[#90081]: https://github.com/home-assistant/core/pull/90081
[#90146]: https://github.com/home-assistant/core/pull/90146
[#90148]: https://github.com/home-assistant/core/pull/90148
[@Lash-L]: https://github.com/Lash-L
[@balloob]: https://github.com/balloob
[@bdraco]: https://github.com/bdraco
[@elupus]: https://github.com/elupus
[@frenck]: https://github.com/frenck
[@jbouwh]: https://github.com/jbouwh
[@klaasnicolaas]: https://github.com/klaasnicolaas
[@micha91]: https://github.com/micha91
[abode docs]: https://www.home-assistant.io/integrations/abode/
[august docs]: https://www.home-assistant.io/integrations/august/
[dormakaba_dkey docs]: https://www.home-assistant.io/integrations/dormakaba_dkey/
[easyenergy docs]: https://www.home-assistant.io/integrations/easyenergy/
[esphome docs]: https://www.home-assistant.io/integrations/esphome/
[freebox docs]: https://www.home-assistant.io/integrations/freebox/
[frontend docs]: https://www.home-assistant.io/integrations/frontend/
[harmony docs]: https://www.home-assistant.io/integrations/harmony/
[http docs]: https://www.home-assistant.io/integrations/http/
[imap_email_content docs]: https://www.home-assistant.io/integrations/imap_email_content/
[knx docs]: https://www.home-assistant.io/integrations/knx/
[mqtt docs]: https://www.home-assistant.io/integrations/mqtt/
[nibe_heatpump docs]: https://www.home-assistant.io/integrations/nibe_heatpump/
[oralb docs]: https://www.home-assistant.io/integrations/oralb/
[sensor docs]: https://www.home-assistant.io/integrations/sensor/
[switchbot docs]: https://www.home-assistant.io/integrations/switchbot/
[tibber docs]: https://www.home-assistant.io/integrations/tibber/
[yalexs_ble docs]: https://www.home-assistant.io/integrations/yalexs_ble/
[yamaha_musiccast docs]: https://www.home-assistant.io/integrations/yamaha_musiccast/
