### PR TITLE
Avoid calling the http access logging when logging is disabled

### DIFF
--- a/tests/components/http/test_init.py
+++ b/tests/components/http/test_init.py
@@ -504,10 +504,10 @@ async def test_logging(
     assert "GET /api/states/logging.entity" not in caplog.text
 
 
-async def test_hass_access_logger(
+async def test_hass_access_logger_at_info_level(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Test that the access logger is created."""
+    """Test that logging happens at info level."""
     test_logger = logging.getLogger("test.aiohttp.logger")
     logger = http.HomeAssistantAccessLogger(test_logger)
     mock_request = MagicMock()

--- a/tests/components/http/test_init.py
+++ b/tests/components/http/test_init.py
@@ -514,10 +514,10 @@ async def test_hass_access_logger_at_info_level(
     response = AiohttpClientMockResponse(
         "POST", "http://127.0.0.1", status=HTTPStatus.OK
     )
-    setattr(response, "body_length", 10)
+    setattr(response, "body_length", 42)
     logger.log(mock_request, response, time.time())
-    assert "HTTPStatus.OK 10" in caplog.text
+    assert "42" in caplog.text
     caplog.clear()
     test_logger.setLevel(logging.WARNING)
     logger.log(mock_request, response, time.time())
-    assert "HTTPStatus.OK 10" not in caplog.text
+    assert "42" not in caplog.text


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Avoid calling the http access logging when logging is disabled as its ~12% of the request time for static files.

https://docs.aiohttp.org/en/stable/logging.html
`access_log_class` was introduced in 2.3.0

Noticed this while trying to do some denial of service testing on the webserver
<img width="1304" alt="Screenshot 2023-03-22 at 5 56 05 PM" src="https://user-images.githubusercontent.com/663432/227099005-b57e42d6-0202-4aed-a460-ef5ec8c9b282.png">



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
