### PR TITLE
Add "stream" to default_config

### DIFF
--- a/homeassistant/components/default_config/__init__.py
+++ b/homeassistant/components/default_config/__init__.py
@@ -11,3 +11,5 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Initialize default configuration."""
     if not is_hassio(hass):
         await async_setup_component(hass, "backup", config)
+
+    return True

--- a/homeassistant/components/default_config/__init__.py
+++ b/homeassistant/components/default_config/__init__.py
@@ -1,10 +1,4 @@
 """Component providing default configuration for new users."""
-
-try:
-    import av
-except ImportError:
-    av = None
-
 from homeassistant.components.hassio import is_hassio
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.typing import ConfigType
@@ -17,8 +11,3 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Initialize default configuration."""
     if not is_hassio(hass):
         await async_setup_component(hass, "backup", config)
-
-    if av is None:
-        return True
-
-    return await async_setup_component(hass, "stream", config)

--- a/homeassistant/components/default_config/manifest.json
+++ b/homeassistant/components/default_config/manifest.json
@@ -33,6 +33,7 @@
     "schedule",
     "script",
     "ssdp",
+    "stream",
     "sun",
     "system_health",
     "tag",

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -1,5 +1,6 @@
 PyJWT==2.6.0
 PyNaCl==1.5.0
+PyTurboJPEG==1.6.7
 aiodiscover==1.4.14
 aiohttp==3.8.4
 aiohttp_cors==0.7.0
@@ -20,6 +21,7 @@ ciso8601==2.3.0
 cryptography==39.0.1
 dbus-fast==1.84.2
 fnvhash==0.1.0
+ha-av==10.0.0
 hass-nabucasa==0.62.0
 hassil==1.0.6
 home-assistant-bluetooth==1.9.3


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This last PR (https://github.com/home-assistant/core/pull/89969) got locked, and I'm not sure my last comment was seen about the `av` `8.0.0` release before that happened.  Re-opening, and adding the context again here:

We do not try to install the `av` package on startup when resolving the dependencies of the default config. It seems like this is an artifact from before `av` used binary wheels and had a more difficult manual installation process. I see that line in `default_config/__init__.py` was written in 2019, and `av` was updated in 2020 to use binary wheels so can now be easily installed with `pip`

> Due to the complexity of the dependencies, PyAV is not always the easiest Python package to install from source. Since release 8.0.0 binary wheels are provided on [PyPI](https://pypi.org/project/av) for Linux, Mac and Windows linked against a modern FFmpeg. You can install these wheels by running:

```
pip install av
```
(https://pypi.org/project/av/#description)


It took some digging to figure this out for me when adding a generic camera did not work.

The UI showed "unknown error"; the logs showed that it was because `stream` was not set up, which was ultimately because `av` was not installed, and it did not get auto-installed on startup when reading the config.

I think it is safe now to make this change since `av` `8.0.0` release and `stream` should get set up correctly including the install of `av`.

If you would like to keep it this way for a manual install, I could instead update the documentation here:
https://www.home-assistant.io/integrations/stream/

Maybe with a troubleshooting section or a note about installing `av` manually?

Let me know your thoughts.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #64675
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
