### PR TITLE
Add Aqara E1 thermostat entities to ZHA

### DIFF
--- a/homeassistant/components/zha/binary_sensor.py
+++ b/homeassistant/components/zha/binary_sensor.py
@@ -39,6 +39,9 @@ CLASS_MAPPING = {
 
 STRICT_MATCH = functools.partial(ZHA_ENTITIES.strict_match, Platform.BINARY_SENSOR)
 MULTI_MATCH = functools.partial(ZHA_ENTITIES.multipass_match, Platform.BINARY_SENSOR)
+CONFIG_DIAGNOSTIC_MATCH = functools.partial(
+    ZHA_ENTITIES.config_diagnostic_match, Platform.BINARY_SENSOR
+)
 
 
 async def async_setup_entry(
@@ -221,7 +224,7 @@ class AqaraThermostatValveAlarm(BinarySensor, id_suffix="valve_alarm"):
     _attr_name: str = "Valve alarm"
 
 
-@MULTI_MATCH(channel_names="opple_cluster", models={"lumi.airrtc.agl001"})
+@CONFIG_DIAGNOSTIC_MATCH(channel_names="opple_cluster", models={"lumi.airrtc.agl001"})
 class AqaraThermostatCalibrated(BinarySensor, id_suffix="calibrated"):
     """ZHA Aqara thermostat calibrated binary sensor."""
 
@@ -230,7 +233,7 @@ class AqaraThermostatCalibrated(BinarySensor, id_suffix="calibrated"):
     _attr_name: str = "Calibrated"
 
 
-@MULTI_MATCH(channel_names="opple_cluster", models={"lumi.airrtc.agl001"})
+@CONFIG_DIAGNOSTIC_MATCH(channel_names="opple_cluster", models={"lumi.airrtc.agl001"})
 class AqaraThermostatExternalSensor(BinarySensor, id_suffix="sensor"):
     """ZHA Aqara thermostat external sensor binary sensor."""
 

--- a/homeassistant/components/zha/binary_sensor.py
+++ b/homeassistant/components/zha/binary_sensor.py
@@ -201,3 +201,37 @@ class XiaomiPlugConsumerConnected(BinarySensor, id_suffix="consumer_connected"):
     SENSOR_ATTR = "consumer_connected"
     _attr_name: str = "Consumer connected"
     _attr_device_class: BinarySensorDeviceClass = BinarySensorDeviceClass.PLUG
+
+
+@MULTI_MATCH(channel_names="opple_cluster", models={"lumi.airrtc.agl001"})
+class AqaraThermostatWindowOpen(BinarySensor, id_suffix="window_open"):
+    """ZHA Aqara thermostat window open binary sensor."""
+
+    SENSOR_ATTR = "window_open"
+    _attr_device_class: BinarySensorDeviceClass = BinarySensorDeviceClass.WINDOW
+    _attr_name: str = "Window open"
+
+
+@MULTI_MATCH(channel_names="opple_cluster", models={"lumi.airrtc.agl001"})
+class AqaraThermostatValveAlarm(BinarySensor, id_suffix="valve_alarm"):
+    """ZHA Aqara thermostat valve alarm binary sensor."""
+
+    SENSOR_ATTR = "valve_alarm"
+    _attr_device_class: BinarySensorDeviceClass = BinarySensorDeviceClass.PROBLEM
+    _attr_name: str = "Valve alarm"
+
+
+@MULTI_MATCH(channel_names="opple_cluster", models={"lumi.airrtc.agl001"})
+class AqaraThermostatCalibrated(BinarySensor, id_suffix="calibrated"):
+    """ZHA Aqara thermostat calibrated binary sensor."""
+
+    SENSOR_ATTR = "calibrated"
+    _attr_name: str = "Calibrated"
+
+
+@MULTI_MATCH(channel_names="opple_cluster", models={"lumi.airrtc.agl001"})
+class AqaraThermostatExternalSensor(BinarySensor, id_suffix="sensor"):
+    """ZHA Aqara thermostat external sensor binary sensor."""
+
+    SENSOR_ATTR = "sensor"
+    _attr_name: str = "External sensor"

--- a/homeassistant/components/zha/binary_sensor.py
+++ b/homeassistant/components/zha/binary_sensor.py
@@ -8,7 +8,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import Platform
+from homeassistant.const import EntityCategory, Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -226,6 +226,7 @@ class AqaraThermostatCalibrated(BinarySensor, id_suffix="calibrated"):
     """ZHA Aqara thermostat calibrated binary sensor."""
 
     SENSOR_ATTR = "calibrated"
+    _attr_entity_category: EntityCategory = EntityCategory.DIAGNOSTIC
     _attr_name: str = "Calibrated"
 
 
@@ -234,4 +235,5 @@ class AqaraThermostatExternalSensor(BinarySensor, id_suffix="sensor"):
     """ZHA Aqara thermostat external sensor binary sensor."""
 
     SENSOR_ATTR = "sensor"
+    _attr_entity_category: EntityCategory = EntityCategory.DIAGNOSTIC
     _attr_name: str = "External sensor"

--- a/homeassistant/components/zha/button.py
+++ b/homeassistant/components/zha/button.py
@@ -184,12 +184,3 @@ class AqaraPetFeederFeedButton(ZHAAttributeButton, id_suffix="feeding"):
     _attribute_name = "feeding"
     _attr_name = "Feed"
     _attribute_value = 1
-
-
-# @CONFIG_DIAGNOSTIC_MATCH(channel_names="opple_cluster", models={"lumi.airrtc.agl001"})
-# class AqaraThermostatCalibrateButton(ZHAAttributeButton, id_suffix="calibrate"):
-#     """Defines a calibrate button for the Aqara E1 thermostat."""
-#
-#     _attribute_name = "calibrate"
-#     _attr_name = "Calibrate"
-#     _attribute_value = 1

--- a/homeassistant/components/zha/button.py
+++ b/homeassistant/components/zha/button.py
@@ -184,3 +184,12 @@ class AqaraPetFeederFeedButton(ZHAAttributeButton, id_suffix="feeding"):
     _attribute_name = "feeding"
     _attr_name = "Feed"
     _attribute_value = 1
+
+
+# @CONFIG_DIAGNOSTIC_MATCH(channel_names="opple_cluster", models={"lumi.airrtc.agl001"})
+# class AqaraThermostatCalibrateButton(ZHAAttributeButton, id_suffix="calibrate"):
+#     """Defines a calibrate button for the Aqara E1 thermostat."""
+#
+#     _attribute_name = "calibrate"
+#     _attr_name = "Calibrate"
+#     _attribute_value = 1

--- a/homeassistant/components/zha/core/channels/manufacturerspecific.py
+++ b/homeassistant/components/zha/core/channels/manufacturerspecific.py
@@ -138,6 +138,20 @@ class OppleRemote(ZigbeeChannel):
                 "serving_size": True,
                 "portion_weight": True,
             }
+        elif self.cluster.endpoint.model == "lumi.airrtc.agl001":
+            self.ZCL_INIT_ATTRS = {
+                "system_mode": True,
+                "preset": True,
+                "window_detection": True,
+                "valve_detection": True,
+                "valve_alarm": True,
+                "child_lock": True,
+                "away_preset_temperature": True,
+                "window_open": True,
+                "calibrated": True,
+                "schedule": True,
+                "sensor": True,
+            }
 
     async def async_initialize_channel_specific(self, from_cache: bool) -> None:
         """Initialize channel specific."""

--- a/homeassistant/components/zha/number.py
+++ b/homeassistant/components/zha/number.py
@@ -375,7 +375,7 @@ class ZHANumberConfigurationEntity(ZhaEntity, NumberEntity):
 
     _attr_entity_category = EntityCategory.CONFIG
     _attr_native_step: float = 1.0
-    _attr_multiplier: float = 1.0
+    _attr_multiplier: float = 1
     _zcl_attribute: str
 
     @classmethod

--- a/homeassistant/components/zha/number.py
+++ b/homeassistant/components/zha/number.py
@@ -11,7 +11,7 @@ from zigpy.zcl.foundation import Status
 
 from homeassistant.components.number import NumberEntity, NumberMode
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EntityCategory, Platform, UnitOfMass
+from homeassistant.const import EntityCategory, Platform, UnitOfMass, UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -861,3 +861,19 @@ class AqaraPetFeederPortionWeight(
     _attr_mode: NumberMode = NumberMode.BOX
     _attr_native_unit_of_measurement: str = UnitOfMass.GRAMS
     _attr_icon: str = "mdi:weight-gram"
+
+
+@CONFIG_DIAGNOSTIC_MATCH(channel_names="opple_cluster", models={"lumi.airrtc.agl001"})
+class AqaraThermostatAwayTemp(
+    ZHANumberConfigurationEntity, id_suffix="away_preset_temperature"
+):
+    """Aqara away preset temperature configuration entity."""
+
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_native_min_value: float = 500
+    _attr_native_max_value: float = 3000
+    _zcl_attribute: str = "away_preset_temperature"
+    _attr_name: str = "Away preset temperature"
+    _attr_mode: NumberMode = NumberMode.SLIDER
+    _attr_native_unit_of_measurement: str = UnitOfTemperature.CELSIUS
+    _attr_icon: str = ICONS[0]

--- a/homeassistant/components/zha/number.py
+++ b/homeassistant/components/zha/number.py
@@ -375,6 +375,7 @@ class ZHANumberConfigurationEntity(ZhaEntity, NumberEntity):
 
     _attr_entity_category = EntityCategory.CONFIG
     _attr_native_step: float = 1.0
+    _attr_multiplier: float = 1.0
     _zcl_attribute: str
 
     @classmethod
@@ -417,13 +418,13 @@ class ZHANumberConfigurationEntity(ZhaEntity, NumberEntity):
     @property
     def native_value(self) -> float:
         """Return the current value."""
-        return self._channel.cluster.get(self._zcl_attribute)
+        return self._channel.cluster.get(self._zcl_attribute) * self._attr_multiplier
 
     async def async_set_native_value(self, value: float) -> None:
         """Update the current value from HA."""
         try:
             res = await self._channel.cluster.write_attributes(
-                {self._zcl_attribute: int(value)}
+                {self._zcl_attribute: int(value / self._attr_multiplier)}
             )
         except zigpy.exceptions.ZigbeeException as ex:
             self.error("Could not set value: %s", ex)
@@ -870,8 +871,9 @@ class AqaraThermostatAwayTemp(
     """Aqara away preset temperature configuration entity."""
 
     _attr_entity_category = EntityCategory.CONFIG
-    _attr_native_min_value: float = 500
-    _attr_native_max_value: float = 3000
+    _attr_native_min_value: float = 5
+    _attr_native_max_value: float = 30
+    _attr_multiplier: float = 0.01
     _zcl_attribute: str = "away_preset_temperature"
     _attr_name: str = "Away preset temperature"
     _attr_mode: NumberMode = NumberMode.SLIDER

--- a/homeassistant/components/zha/select.py
+++ b/homeassistant/components/zha/select.py
@@ -503,3 +503,20 @@ class AqaraPetFeederMode(ZCLEnumSelectEntity, id_suffix="feeding_mode"):
     _enum = AqaraFeedingMode
     _attr_name = "Mode"
     _attr_icon: str = "mdi:wrench-clock"
+
+
+class AqaraThermostatPresetMode(types.enum8):
+    """Thermostat preset mode."""
+
+    Manual = 0x00
+    Auto = 0x01
+    Away = 0x02
+
+
+@CONFIG_DIAGNOSTIC_MATCH(channel_names="opple_cluster", models={"lumi.airrtc.agl001"})
+class AqaraThermostatPreset(ZCLEnumSelectEntity, id_suffix="preset"):
+    """Representation of an Aqara thermostat preset configuration entity."""
+
+    _select_attr = "preset"
+    _enum = AqaraThermostatPresetMode
+    _attr_name = "Preset"

--- a/homeassistant/components/zha/switch.py
+++ b/homeassistant/components/zha/switch.py
@@ -477,3 +477,32 @@ class TuyaChildLockSwitch(ZHASwitchConfigurationEntity, id_suffix="child_lock"):
     _zcl_attribute: str = "child_lock"
     _attr_name = "Child lock"
     _attr_icon: str = "mdi:account-lock"
+
+
+@CONFIG_DIAGNOSTIC_MATCH(channel_names="opple_cluster", models={"lumi.airrtc.agl001"})
+class AqaraThermostatWindowDetection(
+    ZHASwitchConfigurationEntity, id_suffix="window_detection"
+):
+    """Representation of an Aqara thermostat window detection configuration entity."""
+
+    _zcl_attribute: str = "window_detection"
+    _attr_name = "Window detection"
+
+
+@CONFIG_DIAGNOSTIC_MATCH(channel_names="opple_cluster", models={"lumi.airrtc.agl001"})
+class AqaraThermostatValveDetection(
+    ZHASwitchConfigurationEntity, id_suffix="valve_detection"
+):
+    """Representation of an Aqara thermostat valve detection configuration entity."""
+
+    _zcl_attribute: str = "valve_detection"
+    _attr_name = "Valve detection"
+
+
+@CONFIG_DIAGNOSTIC_MATCH(channel_names="opple_cluster", models={"lumi.airrtc.agl001"})
+class AqaraThermostatChildLock(ZHASwitchConfigurationEntity, id_suffix="child_lock"):
+    """Representation of an Aqara thermostat child lock configuration entity."""
+
+    _zcl_attribute: str = "child_lock"
+    _attr_name = "Child lock"
+    _attr_icon: str = "mdi:account-lock"


### PR DESCRIPTION
### Needed to work completely:
- https://github.com/zigpy/zha-device-handlers/pull/2238
- https://github.com/home-assistant/core/pull/90435

## Proposed change
Adds custom entities for the Aqara E1 thermostat.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/zigpy/zha-device-handlers/issues/1757
- Link to documentation pull request: 

## Checklist

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
