### PR TITLE
Add Aqara smoke sensor entities to ZHA

### DIFF
--- a/homeassistant/components/zha/binary_sensor.py
+++ b/homeassistant/components/zha/binary_sensor.py
@@ -240,3 +240,11 @@ class AqaraThermostatExternalSensor(BinarySensor, id_suffix="sensor"):
     SENSOR_ATTR = "sensor"
     _attr_entity_category: EntityCategory = EntityCategory.DIAGNOSTIC
     _attr_name: str = "External sensor"
+
+
+@MULTI_MATCH(channel_names="opple_cluster", models={"lumi.sensor_smoke.acn03"})
+class AqaraLinkageAlarmState(BinarySensor, id_suffix="linkage_alarm_state"):
+    """ZHA Aqara linkage alarm state binary sensor."""
+
+    SENSOR_ATTR = "linkage_alarm_state"
+    _attr_name: str = "Linkage alarm state"

--- a/homeassistant/components/zha/binary_sensor.py
+++ b/homeassistant/components/zha/binary_sensor.py
@@ -248,3 +248,4 @@ class AqaraLinkageAlarmState(BinarySensor, id_suffix="linkage_alarm_state"):
 
     SENSOR_ATTR = "linkage_alarm_state"
     _attr_name: str = "Linkage alarm state"
+    _attr_device_class: BinarySensorDeviceClass = BinarySensorDeviceClass.SMOKE

--- a/homeassistant/components/zha/button.py
+++ b/homeassistant/components/zha/button.py
@@ -177,18 +177,6 @@ class NoPresenceStatusResetButton(
     _attr_entity_category = EntityCategory.CONFIG
 
 
-@CONFIG_DIAGNOSTIC_MATCH(
-    channel_names="opple_cluster", models={"lumi.sensor_smoke.acn03"}
-)
-class AqaraSelftestButton(ZHAAttributeButton, id_suffix="selftest"):
-    """Defines a ZHA self-test button for Aqara smoke sensors."""
-
-    _attribute_name = "selftest"
-    _attr_name = "Self-test"
-    _attribute_value = True
-    _attr_entity_category = EntityCategory.CONFIG
-
-
 @MULTI_MATCH(channel_names="opple_cluster", models={"aqara.feeder.acn001"})
 class AqaraPetFeederFeedButton(ZHAAttributeButton, id_suffix="feeding"):
     """Defines a feed button for the aqara c1 pet feeder."""
@@ -196,3 +184,15 @@ class AqaraPetFeederFeedButton(ZHAAttributeButton, id_suffix="feeding"):
     _attribute_name = "feeding"
     _attr_name = "Feed"
     _attribute_value = 1
+
+
+@CONFIG_DIAGNOSTIC_MATCH(
+    channel_names="opple_cluster", models={"lumi.sensor_smoke.acn03"}
+)
+class AqaraSelfTestButton(ZHAAttributeButton, id_suffix="self_test"):
+    """Defines a ZHA self-test button for Aqara smoke sensors."""
+
+    _attribute_name = "self_test"
+    _attr_name = "Self-test"
+    _attribute_value = 1
+    _attr_entity_category = EntityCategory.CONFIG

--- a/homeassistant/components/zha/button.py
+++ b/homeassistant/components/zha/button.py
@@ -177,6 +177,18 @@ class NoPresenceStatusResetButton(
     _attr_entity_category = EntityCategory.CONFIG
 
 
+@CONFIG_DIAGNOSTIC_MATCH(
+    channel_names="opple_cluster", models={"lumi.sensor_smoke.acn03"}
+)
+class AqaraSelftestButton(ZHAAttributeButton, id_suffix="selftest"):
+    """Defines a ZHA self-test button for Aqara smoke sensors."""
+
+    _attribute_name = "selftest"
+    _attr_name = "Self-test"
+    _attribute_value = True
+    _attr_entity_category = EntityCategory.CONFIG
+
+
 @MULTI_MATCH(channel_names="opple_cluster", models={"aqara.feeder.acn001"})
 class AqaraPetFeederFeedButton(ZHAAttributeButton, id_suffix="feeding"):
     """Defines a feed button for the aqara c1 pet feeder."""

--- a/homeassistant/components/zha/core/channels/manufacturerspecific.py
+++ b/homeassistant/components/zha/core/channels/manufacturerspecific.py
@@ -159,7 +159,9 @@ class OppleRemote(ZigbeeChannel):
                 "smoke_density": True,
                 "heartbeat_indicator": True,
                 "buzzer_manual_alarm": True,
+                "buzzer": True,
                 "linkage_alarm": True,
+                "linkage_alarm_state": True,
             }
 
     async def async_initialize_channel_specific(self, from_cache: bool) -> None:

--- a/homeassistant/components/zha/core/channels/manufacturerspecific.py
+++ b/homeassistant/components/zha/core/channels/manufacturerspecific.py
@@ -155,13 +155,11 @@ class OppleRemote(ZigbeeChannel):
         elif self.cluster.endpoint.model == "lumi.sensor_smoke.acn03":
             self.ZCL_INIT_ATTRS = {
                 "buzzer_manual_mute": True,
-                "selftest": True,
                 "smoke_density": True,
                 "heartbeat_indicator": True,
                 "buzzer_manual_alarm": True,
                 "buzzer": True,
                 "linkage_alarm": True,
-                "linkage_alarm_state": True,
             }
 
     async def async_initialize_channel_specific(self, from_cache: bool) -> None:

--- a/homeassistant/components/zha/core/channels/manufacturerspecific.py
+++ b/homeassistant/components/zha/core/channels/manufacturerspecific.py
@@ -152,6 +152,15 @@ class OppleRemote(ZigbeeChannel):
                 "schedule": True,
                 "sensor": True,
             }
+        elif self.cluster.endpoint.model == "lumi.sensor_smoke.acn03":
+            self.ZCL_INIT_ATTRS = {
+                "buzzer_manual_mute": True,
+                "selftest": True,
+                "smoke_density": True,
+                "heartbeat_indicator": True,
+                "buzzer_manual_alarm": True,
+                "linkage_alarm": True,
+            }
 
     async def async_initialize_channel_specific(self, from_cache: bool) -> None:
         """Initialize channel specific."""

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -955,3 +955,15 @@ class AqaraPetFeederWeightDispensed(Sensor, id_suffix="weight_dispensed"):
     _attr_native_unit_of_measurement = UnitOfMass.GRAMS
     _attr_state_class: SensorStateClass = SensorStateClass.TOTAL_INCREASING
     _attr_icon: str = "mdi:weight-gram"
+
+
+@MULTI_MATCH(channel_names="opple_cluster", models={"lumi.sensor_smoke.acn03"})
+class AqaraSmokeDensityDbm(Sensor, id_suffix="smoke_density_dbm"):
+    """Sensor that displays the smoke density of an Aqara smoke sensor in dB/m."""
+
+    SENSOR_ATTR = "smoke_density_dbm"
+    _attr_name: str = "Smoke density"
+    _attr_native_unit_of_measurement = "dB/m"
+    _attr_state_class: SensorStateClass = SensorStateClass.MEASUREMENT
+    _attr_icon: str = "mdi:google-circles-communities"
+    _attr_suggested_display_precision: int = 3

--- a/homeassistant/components/zha/switch.py
+++ b/homeassistant/components/zha/switch.py
@@ -518,6 +518,7 @@ class AqaraHeartbeatIndicator(
 
     _zcl_attribute: str = "heartbeat_indicator"
     _attr_name = "Heartbeat indicator"
+    _attr_icon: str = "mdi:heart-flash"
 
 
 @CONFIG_DIAGNOSTIC_MATCH(
@@ -528,6 +529,7 @@ class AqaraLinkageAlarm(ZHASwitchConfigurationEntity, id_suffix="linkage_alarm")
 
     _zcl_attribute: str = "linkage_alarm"
     _attr_name = "Linkage alarm"
+    _attr_icon: str = "mdi:shield-link-variant"
 
 
 @CONFIG_DIAGNOSTIC_MATCH(
@@ -540,6 +542,7 @@ class AqaraBuzzerManualMute(
 
     _zcl_attribute: str = "buzzer_manual_mute"
     _attr_name = "Buzzer manual mute"
+    _attr_icon: str = "mdi:volume-off"
 
 
 @CONFIG_DIAGNOSTIC_MATCH(
@@ -552,13 +555,4 @@ class AqaraBuzzerManualAlarm(
 
     _zcl_attribute: str = "buzzer_manual_alarm"
     _attr_name = "Buzzer manual alarm"
-
-
-@CONFIG_DIAGNOSTIC_MATCH(
-    channel_names="opple_cluster", models={"lumi.sensor_smoke.acn03"}
-)
-class AqaraSelftest(ZHASwitchConfigurationEntity, id_suffix="selftest"):
-    """Representation of a self-test configuration entity for Aqara smoke sensors."""
-
-    _zcl_attribute: str = "selftest"
-    _attr_name = "Self-test"
+    _attr_icon: str = "mdi:bullhorn"

--- a/homeassistant/components/zha/switch.py
+++ b/homeassistant/components/zha/switch.py
@@ -506,3 +506,59 @@ class AqaraThermostatChildLock(ZHASwitchConfigurationEntity, id_suffix="child_lo
     _zcl_attribute: str = "child_lock"
     _attr_name = "Child lock"
     _attr_icon: str = "mdi:account-lock"
+
+
+@CONFIG_DIAGNOSTIC_MATCH(
+    channel_names="opple_cluster", models={"lumi.sensor_smoke.acn03"}
+)
+class AqaraHeartbeatIndicator(
+    ZHASwitchConfigurationEntity, id_suffix="heartbeat_indicator"
+):
+    """Representation of a heartbeat indicator configuration entity for Aqara smoke sensors."""
+
+    _zcl_attribute: str = "heartbeat_indicator"
+    _attr_name = "Heartbeat indicator"
+
+
+@CONFIG_DIAGNOSTIC_MATCH(
+    channel_names="opple_cluster", models={"lumi.sensor_smoke.acn03"}
+)
+class AqaraLinkageAlarm(ZHASwitchConfigurationEntity, id_suffix="linkage_alarm"):
+    """Representation of a linkage alarm configuration entity for Aqara smoke sensors."""
+
+    _zcl_attribute: str = "linkage_alarm"
+    _attr_name = "Linkage alarm"
+
+
+@CONFIG_DIAGNOSTIC_MATCH(
+    channel_names="opple_cluster", models={"lumi.sensor_smoke.acn03"}
+)
+class AqaraBuzzerManualMute(
+    ZHASwitchConfigurationEntity, id_suffix="buzzer_manual_mute"
+):
+    """Representation of a buzzer manual mute configuration entity for Aqara smoke sensors."""
+
+    _zcl_attribute: str = "buzzer_manual_mute"
+    _attr_name = "Buzzer manual mute"
+
+
+@CONFIG_DIAGNOSTIC_MATCH(
+    channel_names="opple_cluster", models={"lumi.sensor_smoke.acn03"}
+)
+class AqaraBuzzerManualAlarm(
+    ZHASwitchConfigurationEntity, id_suffix="buzzer_manual_alarm"
+):
+    """Representation of a buzzer manual mute configuration entity for Aqara smoke sensors."""
+
+    _zcl_attribute: str = "buzzer_manual_alarm"
+    _attr_name = "Buzzer manual alarm"
+
+
+@CONFIG_DIAGNOSTIC_MATCH(
+    channel_names="opple_cluster", models={"lumi.sensor_smoke.acn03"}
+)
+class AqaraSelftest(ZHASwitchConfigurationEntity, id_suffix="selftest"):
+    """Representation of a self-test configuration entity for Aqara smoke sensors."""
+
+    _zcl_attribute: str = "selftest"
+    _attr_name = "Self-test"


### PR DESCRIPTION
### Needed to work completely:
- https://github.com/zigpy/zha-device-handlers/pull/2219
- https://github.com/home-assistant/core/pull/90435

## Proposed change
Adds custom entities for the Aqara smoke sensor (`JY-GZ-01AQ`).

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/zigpy/zha-device-handlers/issues/1828
- Link to documentation pull request: 

## Checklist

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
