### PR TITLE
Improve logging for unavailable sonos hosts

### DIFF
--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -365,7 +365,9 @@ class SonosDiscoveryManager:
                     )
 
             else:
-                self.hosts_in_error[ip_addr] = False
+                if self.hosts_in_error.get(ip_addr):
+                    self.hosts_in_error[ip_addr] = False
+                    _LOGGER.info("Connection restablished to Sonos device %s", ip_addr)
                 if new_hosts := {
                     x.ip_address
                     for x in visible_zones

--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -354,7 +354,7 @@ class SonosDiscoveryManager:
                     soco,
                 )
             except (OSError, SoCoException, Timeout) as ex:
-                if self.hosts_in_error.get(ip_addr, False) is False:
+                if not self.hosts_in_error.get(ip_addr):
                     _LOGGER.warning(
                         "Could not get visible Sonos devices from %s: %s", ip_addr, ex
                     )

--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -177,6 +177,7 @@ class SonosDiscoveryManager:
         self.entry = entry
         self.data = data
         self.hosts = set(hosts)
+        self.hosts_in_error: dict[str, bool] = {}
         self.discovery_lock = asyncio.Lock()
         self.creation_lock = asyncio.Lock()
         self._known_invisible: set[SoCo] = set()
@@ -353,10 +354,18 @@ class SonosDiscoveryManager:
                     soco,
                 )
             except (OSError, SoCoException, Timeout) as ex:
-                _LOGGER.warning(
-                    "Could not get visible Sonos devices from %s: %s", ip_addr, ex
-                )
+                if self.hosts_in_error.get(ip_addr, False) is False:
+                    _LOGGER.warning(
+                        "Could not get visible Sonos devices from %s: %s", ip_addr, ex
+                    )
+                    self.hosts_in_error[ip_addr] = True
+                else:
+                    _LOGGER.debug(
+                        "Could not get visible Sonos devices from %s: %s", ip_addr, ex
+                    )
+
             else:
+                self.hosts_in_error[ip_addr] = False
                 if new_hosts := {
                     x.ip_address
                     for x in visible_zones

--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -365,8 +365,7 @@ class SonosDiscoveryManager:
                     )
 
             else:
-                if self.hosts_in_error.get(ip_addr):
-                    self.hosts_in_error[ip_addr] = False
+                if self.hosts_in_error.pop(ip_addr, None):
                     _LOGGER.info("Connection restablished to Sonos device %s", ip_addr)
                 if new_hosts := {
                     x.ip_address

--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -365,8 +365,7 @@ class SonosDiscoveryManager:
                     )
 
             else:
-                if self.hosts_in_error.get(ip_addr):
-                    self.hosts_in_error[ip_addr] = False
+                if self.hosts_in_error.pop(ip_addr):
                     _LOGGER.info("Connection restablished to Sonos device %s", ip_addr)
                 if new_hosts := {
                     x.ip_address

--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -365,7 +365,8 @@ class SonosDiscoveryManager:
                     )
 
             else:
-                if self.hosts_in_error.pop(ip_addr):
+                if self.hosts_in_error.get(ip_addr):
+                    self.hosts_in_error[ip_addr] = False
                     _LOGGER.info("Connection restablished to Sonos device %s", ip_addr)
                 if new_hosts := {
                     x.ip_address

--- a/tests/components/sonos/test_init.py
+++ b/tests/components/sonos/test_init.py
@@ -110,9 +110,9 @@ async def test_async_poll_manual_hosts_warnings(
         assert record.levelname == "DEBUG"
         assert "Could not get visible Sonos devices from" in record.message
 
+        # Third call succeeds, it should log an info message
         caplog.clear()
         await manager.async_poll_manual_hosts()
-        # Success in the call, should clear the host from the error list, and log an info message
         assert len(caplog.messages) == 1
         record = caplog.records[0]
         assert record.levelname == "INFO"

--- a/tests/components/sonos/test_init.py
+++ b/tests/components/sonos/test_init.py
@@ -93,6 +93,7 @@ async def test_async_poll_manual_hosts_warnings(
             OSError(),
             OSError(),
             [],
+            [],
             OSError(),
         ]
         caplog.clear()
@@ -116,6 +117,11 @@ async def test_async_poll_manual_hosts_warnings(
         record = caplog.records[0]
         assert record.levelname == "INFO"
         assert "Connection restablished to Sonos device" in record.message
+
+        caplog.clear()
+        await manager.async_poll_manual_hosts()
+        # Success in the call, no message should be logged since not clearing error state
+        assert len(caplog.messages) == 0
 
         mock_async_add_executor_job.side_effect = OSError()
         caplog.clear()

--- a/tests/components/sonos/test_init.py
+++ b/tests/components/sonos/test_init.py
@@ -119,9 +119,9 @@ async def test_async_poll_manual_hosts_warnings(
         assert record.levelname == "INFO"
         assert "Connection restablished to Sonos device" in record.message
 
+        # Fourth call succeeds again, no need to log
         caplog.clear()
         await manager.async_poll_manual_hosts()
-        # Success in the call, no message should be logged since not clearing error state
         assert len(caplog.messages) == 0
 
         mock_async_add_executor_job.side_effect = OSError()

--- a/tests/components/sonos/test_init.py
+++ b/tests/components/sonos/test_init.py
@@ -129,6 +129,5 @@ async def test_async_poll_manual_hosts_warnings(
         await manager.async_poll_manual_hosts()
         assert len(caplog.messages) == 1
         record = caplog.records[0]
-        # Warning should be logged again.
         assert record.levelname == "WARNING"
         assert "Could not get visible Sonos devices from" in record.message

--- a/tests/components/sonos/test_init.py
+++ b/tests/components/sonos/test_init.py
@@ -103,7 +103,7 @@ async def test_async_poll_manual_hosts_warnings(
         record = caplog.records[0]
         assert record.levelname == "WARNING"
         assert "Could not get visible Sonos devices from" in record.message
-        # On second call it should be logged as a DEBUG message
+        # Second call fails again, it should be logged as a DEBUG message
         caplog.clear()
         await manager.async_poll_manual_hosts()
         assert len(caplog.messages) == 1

--- a/tests/components/sonos/test_init.py
+++ b/tests/components/sonos/test_init.py
@@ -111,8 +111,11 @@ async def test_async_poll_manual_hosts_warnings(
 
         caplog.clear()
         await manager.async_poll_manual_hosts()
-        # Success in the call, should clear the host from the error list
-        assert len(caplog.messages) == 0
+        # Success in the call, should clear the host from the error list, and log an info message
+        assert len(caplog.messages) == 1
+        record = caplog.records[0]
+        assert record.levelname == "INFO"
+        assert "Connection restablished to Sonos device" in record.message
 
         mock_async_add_executor_job.side_effect = OSError()
         caplog.clear()

--- a/tests/components/sonos/test_init.py
+++ b/tests/components/sonos/test_init.py
@@ -96,6 +96,7 @@ async def test_async_poll_manual_hosts_warnings(
             [],
             OSError(),
         ]
+        # First call fails, it should be logged as a WARNING message
         caplog.clear()
         await manager.async_poll_manual_hosts()
         assert len(caplog.messages) == 1

--- a/tests/components/sonos/test_init.py
+++ b/tests/components/sonos/test_init.py
@@ -1,8 +1,13 @@
 """Tests for the Sonos config flow."""
-from unittest.mock import patch
+import logging
+from unittest.mock import AsyncMock, patch
+
+import pytest
 
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components import sonos, zeroconf
+from homeassistant.components.sonos import SonosDiscoveryManager
+from homeassistant.components.sonos.const import DATA_SONOS_DISCOVERY_MANAGER
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -63,3 +68,57 @@ async def test_not_configuring_sonos_not_creates_entry(hass: HomeAssistant) -> N
         await hass.async_block_till_done()
 
     assert len(mock_setup.mock_calls) == 0
+
+
+async def test_async_poll_manual_hosts_warnings(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that host warnings are not logged repeatedly."""
+    await async_setup_component(
+        hass,
+        sonos.DOMAIN,
+        {"sonos": {"media_player": {"interface_addr": "127.0.0.1"}}},
+    )
+    await hass.async_block_till_done()
+    manager: SonosDiscoveryManager = hass.data[DATA_SONOS_DISCOVERY_MANAGER]
+    manager.hosts.add("10.10.10.10")
+    with caplog.at_level(logging.DEBUG), patch.object(
+        manager, "_async_handle_discovery_message"
+    ), patch("homeassistant.components.sonos.async_call_later"), patch(
+        "homeassistant.components.sonos.async_dispatcher_send"
+    ), patch.object(
+        hass, "async_add_executor_job", new=AsyncMock()
+    ) as mock_async_add_executor_job:
+        mock_async_add_executor_job.side_effect = [
+            OSError(),
+            OSError(),
+            [],
+            OSError(),
+        ]
+        caplog.clear()
+        await manager.async_poll_manual_hosts()
+        assert len(caplog.messages) == 1
+        record = caplog.records[0]
+        assert record.levelname == "WARNING"
+        assert "Could not get visible Sonos devices from" in record.message
+        # On second call it should be logged as a DEBUG message
+        caplog.clear()
+        await manager.async_poll_manual_hosts()
+        assert len(caplog.messages) == 1
+        record = caplog.records[0]
+        assert record.levelname == "DEBUG"
+        assert "Could not get visible Sonos devices from" in record.message
+
+        caplog.clear()
+        await manager.async_poll_manual_hosts()
+        # Success in the call, should clear the host from the error list
+        assert len(caplog.messages) == 0
+
+        mock_async_add_executor_job.side_effect = OSError()
+        caplog.clear()
+        await manager.async_poll_manual_hosts()
+        assert len(caplog.messages) == 1
+        record = caplog.records[0]
+        # Warning should be logged again.
+        assert record.levelname == "WARNING"
+        assert "Could not get visible Sonos devices from" in record.message

--- a/tests/components/sonos/test_init.py
+++ b/tests/components/sonos/test_init.py
@@ -103,6 +103,7 @@ async def test_async_poll_manual_hosts_warnings(
         record = caplog.records[0]
         assert record.levelname == "WARNING"
         assert "Could not get visible Sonos devices from" in record.message
+
         # Second call fails again, it should be logged as a DEBUG message
         caplog.clear()
         await manager.async_poll_manual_hosts()
@@ -124,7 +125,7 @@ async def test_async_poll_manual_hosts_warnings(
         await manager.async_poll_manual_hosts()
         assert len(caplog.messages) == 0
 
-        mock_async_add_executor_job.side_effect = OSError()
+        # Fifth call fail again again, should be logged as a WARNING message
         caplog.clear()
         await manager.async_poll_manual_hosts()
         assert len(caplog.messages) == 1


### PR DESCRIPTION
Sonos logs warning messages every 1 minute 12 seconds for hosts that are not on-line.  This fixes the issue and the warning will be logged the first time, and subsequent logs messages will be at DEBUG level

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Don't log warnings continuously when a host is unavailable. 
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #90171 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
