### PR TITLE
Fix httpx client creating a new ssl context with each client (memory leak)

### DIFF
--- a/homeassistant/helpers/aiohttp_client.py
+++ b/homeassistant/helpers/aiohttp_client.py
@@ -273,7 +273,7 @@ def _async_get_connector(
     if verify_ssl:
         ssl_context: bool | SSLContext = ssl_util.get_default_context()
     else:
-        ssl_context = False
+        ssl_context = ssl_util.get_default_no_verify_context()
 
     connector = aiohttp.TCPConnector(
         enable_cleanup_closed=True,

--- a/homeassistant/helpers/httpx_client.py
+++ b/homeassistant/helpers/httpx_client.py
@@ -65,8 +65,13 @@ def create_async_httpx_client(
 
     This method must be run in the event loop.
     """
+    ssl_context = (
+        ssl_util.get_default_context()
+        if verify_ssl
+        else ssl_util.get_default_no_verify_context()
+    )
     client = HassHttpXAsyncClient(
-        verify=ssl_util.get_default_context() if verify_ssl else False,
+        verify=ssl_context,
         headers={USER_AGENT: SERVER_SOFTWARE},
         **kwargs,
     )

--- a/homeassistant/helpers/httpx_client.py
+++ b/homeassistant/helpers/httpx_client.py
@@ -11,7 +11,7 @@ from typing_extensions import Self
 from homeassistant.const import APPLICATION_NAME, EVENT_HOMEASSISTANT_CLOSE, __version__
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.loader import bind_hass
-from homeassistant.util import ssl as ssl_util
+from homeassistant.util.ssl import get_default_context, get_default_no_verify_context
 
 from .frame import warn_use
 
@@ -66,9 +66,7 @@ def create_async_httpx_client(
     This method must be run in the event loop.
     """
     ssl_context = (
-        ssl_util.get_default_context()
-        if verify_ssl
-        else ssl_util.get_default_no_verify_context()
+        get_default_context() if verify_ssl else get_default_no_verify_context()
     )
     client = HassHttpXAsyncClient(
         verify=ssl_context,

--- a/homeassistant/util/ssl.py
+++ b/homeassistant/util/ssl.py
@@ -1,8 +1,29 @@
 """Helper to create SSL contexts."""
+import contextlib
 from os import environ
 import ssl
 
 import certifi
+
+
+def create_no_verify_ssl_context() -> ssl.SSLContext:
+    """Return an SSL context that does not verify the server certificate.
+
+    This is a copy of aiohttp's create_default_context() function, with the
+    ssl verify turned off.
+
+    https://github.com/aio-libs/aiohttp/blob/33953f110e97eecc707e1402daa8d543f38a189b/aiohttp/connector.py#L911
+    """
+    sslcontext = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    sslcontext.options |= ssl.OP_NO_SSLv2
+    sslcontext.options |= ssl.OP_NO_SSLv3
+    sslcontext.check_hostname = False
+    sslcontext.verify_mode = ssl.CERT_NONE
+    with contextlib.suppress(AttributeError):
+        # This only works for OpenSSL >= 1.0.0
+        sslcontext.options |= ssl.OP_NO_COMPRESSION
+    sslcontext.set_default_verify_paths()
+    return sslcontext
 
 
 def client_context() -> ssl.SSLContext:
@@ -18,11 +39,17 @@ def client_context() -> ssl.SSLContext:
 
 # Create this only once and reuse it
 _DEFAULT_SSL_CONTEXT = client_context()
+_DEFAULT_NO_VERIFY_SSL_CONTEXT = create_no_verify_ssl_context()
 
 
 def get_default_context() -> ssl.SSLContext:
     """Return the default SSL context."""
     return _DEFAULT_SSL_CONTEXT
+
+
+def get_default_no_verify_context() -> ssl.SSLContext:
+    """Return the default SSL context that does not verify the server certificate."""
+    return _DEFAULT_NO_VERIFY_SSL_CONTEXT
 
 
 def server_context_modern() -> ssl.SSLContext:


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
While working on https://github.com/home-assistant/core/issues/83524 it was discovered that each new httpx client creates a new ssl context even when ssl verify is disabled.

https://github.com/encode/httpx/blob/f1157dbc4102ac8e227a0a0bb12a877f592eff58/httpx/_transports/default.py#L261

If an ssl context is passed in creating a new one is avoided here

https://github.com/encode/httpx/blob/f1157dbc4102ac8e227a0a0bb12a877f592eff58/httpx/_config.py#L110

This change makes httpx ssl no-verify behavior match aiohttp ssl no-verify behavior

https://github.com/aio-libs/aiohttp/blob/6da04694fd87a39af9c3856048c9ff23ca815f88/aiohttp/connector.py#L892

aiohttp solved this by wrapping the code that generates the ssl context in an lru_cache

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
