### PR TITLE
DO NOT MERGE: Add descending index for states last updated time

### DIFF
--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -49,6 +49,7 @@ from .db_schema import (
     CONTEXT_ID_BIN_MAX_LENGTH,
     DOUBLE_PRECISION_TYPE_SQL,
     LEGACY_STATES_EVENT_ID_INDEX,
+    METADATA_ID_LAST_UPDATED_INDEX_TS_DESC,
     MYSQL_COLLATE,
     MYSQL_DEFAULT_CHARSET,
     SCHEMA_VERSION,
@@ -1071,6 +1072,8 @@ def _apply_update(  # noqa: C901
     elif new_version == 41:
         _create_index(session_maker, "event_types", "ix_event_types_event_type")
         _create_index(session_maker, "states_meta", "ix_states_meta_entity_id")
+    elif new_version == 42:
+        _create_index(session_maker, "states", METADATA_ID_LAST_UPDATED_INDEX_TS_DESC)
     else:
         raise ValueError(f"No schema migration defined for version {new_version}")
 

--- a/homeassistant/components/sensor/recorder.py
+++ b/homeassistant/components/sensor/recorder.py
@@ -100,7 +100,8 @@ def _time_weighted_average(
     for fstate, state in fstates:
         # The recorder will give us the last known state, which may be well
         # before the requested start time for the statistics
-        start_time = start if state.last_updated < start else state.last_updated
+        last_updated = state.last_updated
+        start_time = start if last_updated < start else last_updated
         if old_start_time is None:
             # Adjust start time, if there was no last known state
             start = start_time

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -2112,15 +2112,10 @@ async def test_connect_args_priority(hass: HomeAssistant, config_url) -> None:
     assert connect_params[0]["charset"] == "utf8mb4"
 
 
-@pytest.mark.parametrize("core_state", [CoreState.starting, CoreState.running])
 async def test_excluding_attributes_by_integration(
-    recorder_mock: Recorder,
-    hass: HomeAssistant,
-    entity_registry: er.EntityRegistry,
-    core_state: CoreState,
+    recorder_mock: Recorder, hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Test that an integration's recorder platform can exclude attributes."""
-    hass.state = core_state
     state = "restoring_from_db"
     attributes = {"test_attr": 5, "excluded": 10}
     mock_platform(
@@ -2136,7 +2131,6 @@ async def test_excluding_attributes_by_integration(
     platform = MockEntityPlatform(hass, platform_name="fake_integration")
     entity_platform = MockEntity(entity_id=entity_id, extra_state_attributes=attributes)
     await platform.async_add_entities([entity_platform])
-    await hass.async_block_till_done()
 
     await async_wait_recording_done(hass)
 

--- a/tests/components/sensor/test_recorder.py
+++ b/tests/components/sensor/test_recorder.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 from datetime import datetime, timedelta
 import math
 from statistics import mean
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import pytest
 
@@ -299,7 +299,7 @@ def test_compile_hourly_statistics_with_some_same_last_updated(
             {
                 "start": process_timestamp(zero).timestamp(),
                 "end": process_timestamp(zero + timedelta(minutes=5)).timestamp(),
-                "mean": pytest.approx(mean),
+                "mean": ANY,  # behavior is undefined when two different states happen at the same microsecond
                 "min": pytest.approx(min),
                 "max": pytest.approx(max),
                 "last_reset": None,
@@ -408,7 +408,7 @@ def test_compile_hourly_statistics_with_all_same_last_updated(
             {
                 "start": process_timestamp(zero).timestamp(),
                 "end": process_timestamp(zero + timedelta(minutes=5)).timestamp(),
-                "mean": pytest.approx(mean),
+                "mean": ANY,  # behavior is undefined when two different states happen at the same microsecond
                 "min": pytest.approx(min),
                 "max": pytest.approx(max),
                 "last_reset": None,


### PR DESCRIPTION
I'm inclined not to fix this because we would need to make everyone carry another index for a single integration that uses this. The downside is that queries can take minutes and overload the system if we don't.

https://www.home-assistant.io/integrations/filter/#window_size

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If the states table is large it can take a long time to find the newest state when searching the an ascending index.

This query is only used by the `filter` integation

`homeassistant/components/filter/sensor.py:                        history.get_last_state_changes,`

Since most of our queries return data in ascending order we still need an ascending index for the ranged queries.
https://github.com/home-assistant/core/blob/f1ec77b8e07eb9c8fd140a32327f6085040ad355/homeassistant/components/recorder/history/modern.py#L428

To find the newest state we need a descending index.

fixes #90113

replaces and closes #90208

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
