### PR TITLE
Adjust pylint plugin for components fixtures

### DIFF
--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -104,7 +104,7 @@ _TEST_FIXTURES: dict[str, list[str] | str] = {
     "enable_statistics": "bool",
     "enable_schema_validation": "bool",
     "entity_registry": "EntityRegistry",
-    "entity_registry_enabled_by_default": "Mock",
+    "entity_registry_enabled_by_default": "MagicMock",
     "freezer": "FrozenDateTimeFactory",
     "hass_access_token": "str",
     "hass_admin_credential": "Credentials",

--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -104,6 +104,7 @@ _TEST_FIXTURES: dict[str, list[str] | str] = {
     "enable_statistics": "bool",
     "enable_schema_validation": "bool",
     "entity_registry": "EntityRegistry",
+    "entity_registry_enabled_by_default": "Mock",
     "freezer": "FrozenDateTimeFactory",
     "hass_access_token": "str",
     "hass_admin_credential": "Credentials",

--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -104,7 +104,7 @@ _TEST_FIXTURES: dict[str, list[str] | str] = {
     "enable_statistics": "bool",
     "enable_schema_validation": "bool",
     "entity_registry": "EntityRegistry",
-    "entity_registry_enabled_by_default": "MagicMock",
+    "entity_registry_enabled_by_default": "None",
     "freezer": "FrozenDateTimeFactory",
     "hass_access_token": "str",
     "hass_admin_credential": "Credentials",

--- a/tests/components/airzone/test_sensor.py
+++ b/tests/components/airzone/test_sensor.py
@@ -1,5 +1,5 @@
 """The sensor tests for the Airzone platform."""
-from unittest.mock import Mock
+from unittest.mock import MagicMock
 
 from homeassistant.core import HomeAssistant
 
@@ -7,7 +7,7 @@ from .util import async_init_integration
 
 
 async def test_airzone_create_sensors(
-    hass: HomeAssistant, entity_registry_enabled_by_default: Mock
+    hass: HomeAssistant, entity_registry_enabled_by_default: MagicMock
 ) -> None:
     """Test creation of sensors."""
 

--- a/tests/components/airzone/test_sensor.py
+++ b/tests/components/airzone/test_sensor.py
@@ -1,6 +1,5 @@
 """The sensor tests for the Airzone platform."""
-
-from unittest.mock import AsyncMock
+from unittest.mock import Mock
 
 from homeassistant.core import HomeAssistant
 
@@ -8,7 +7,7 @@ from .util import async_init_integration
 
 
 async def test_airzone_create_sensors(
-    hass: HomeAssistant, entity_registry_enabled_by_default: AsyncMock
+    hass: HomeAssistant, entity_registry_enabled_by_default: Mock
 ) -> None:
     """Test creation of sensors."""
 

--- a/tests/components/airzone/test_sensor.py
+++ b/tests/components/airzone/test_sensor.py
@@ -1,5 +1,4 @@
 """The sensor tests for the Airzone platform."""
-from unittest.mock import MagicMock
 
 from homeassistant.core import HomeAssistant
 
@@ -7,7 +6,7 @@ from .util import async_init_integration
 
 
 async def test_airzone_create_sensors(
-    hass: HomeAssistant, entity_registry_enabled_by_default: MagicMock
+    hass: HomeAssistant, entity_registry_enabled_by_default: None
 ) -> None:
     """Test creation of sensors."""
 

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -1,6 +1,6 @@
 """Fixtures for component testing."""
 from collections.abc import Generator
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -25,10 +25,10 @@ def prevent_io() -> Generator[None, None, None]:
 
 
 @pytest.fixture
-def entity_registry_enabled_by_default() -> Generator[MagicMock, None, None]:
+def entity_registry_enabled_by_default() -> Generator[None, None, None]:
     """Test fixture that ensures all entities are enabled in the registry."""
     with patch(
         "homeassistant.helpers.entity.Entity.entity_registry_enabled_default",
         return_value=True,
-    ) as mock_entity_registry_enabled_by_default:
-        yield mock_entity_registry_enabled_by_default
+    ):
+        yield

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -1,12 +1,12 @@
 """Fixtures for component testing."""
 from collections.abc import Generator
-from unittest.mock import AsyncMock, patch
+from unittest.mock import Mock, patch
 
 import pytest
 
 
 @pytest.fixture(scope="session", autouse=True)
-def patch_zeroconf_multiple_catcher():
+def patch_zeroconf_multiple_catcher() -> Generator[None, None, None]:
     """Patch zeroconf wrapper that detects if multiple instances are used."""
     with patch(
         "homeassistant.components.zeroconf.install_multiple_zeroconf_catcher",
@@ -16,7 +16,7 @@ def patch_zeroconf_multiple_catcher():
 
 
 @pytest.fixture(autouse=True)
-def prevent_io():
+def prevent_io() -> Generator[None, None, None]:
     """Fixture to prevent certain I/O from happening."""
     with patch(
         "homeassistant.components.http.ban.load_yaml_config_file",
@@ -25,7 +25,7 @@ def prevent_io():
 
 
 @pytest.fixture
-def entity_registry_enabled_by_default() -> Generator[AsyncMock, None, None]:
+def entity_registry_enabled_by_default() -> Generator[Mock, None, None]:
     """Test fixture that ensures all entities are enabled in the registry."""
     with patch(
         "homeassistant.helpers.entity.Entity.entity_registry_enabled_default",

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -1,6 +1,6 @@
 """Fixtures for component testing."""
 from collections.abc import Generator
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -25,7 +25,7 @@ def prevent_io() -> Generator[None, None, None]:
 
 
 @pytest.fixture
-def entity_registry_enabled_by_default() -> Generator[Mock, None, None]:
+def entity_registry_enabled_by_default() -> Generator[MagicMock, None, None]:
     """Test fixture that ensures all entities are enabled in the registry."""
     with patch(
         "homeassistant.helpers.entity.Entity.entity_registry_enabled_default",

--- a/tests/components/goalzero/test_sensor.py
+++ b/tests/components/goalzero/test_sensor.py
@@ -1,5 +1,5 @@
 """Sensor tests for the Goalzero integration."""
-from unittest.mock import Mock
+from unittest.mock import MagicMock
 
 from homeassistant.components.goalzero.const import DEFAULT_NAME
 from homeassistant.components.sensor import (
@@ -29,7 +29,7 @@ from tests.test_util.aiohttp import AiohttpClientMocker
 async def test_sensors(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
-    entity_registry_enabled_by_default: Mock,
+    entity_registry_enabled_by_default: MagicMock,
 ) -> None:
     """Test we get sensor data."""
     await async_init_integration(hass, aioclient_mock)

--- a/tests/components/goalzero/test_sensor.py
+++ b/tests/components/goalzero/test_sensor.py
@@ -1,5 +1,4 @@
 """Sensor tests for the Goalzero integration."""
-from unittest.mock import MagicMock
 
 from homeassistant.components.goalzero.const import DEFAULT_NAME
 from homeassistant.components.sensor import (
@@ -29,7 +28,7 @@ from tests.test_util.aiohttp import AiohttpClientMocker
 async def test_sensors(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
-    entity_registry_enabled_by_default: MagicMock,
+    entity_registry_enabled_by_default: None,
 ) -> None:
     """Test we get sensor data."""
     await async_init_integration(hass, aioclient_mock)

--- a/tests/components/goalzero/test_sensor.py
+++ b/tests/components/goalzero/test_sensor.py
@@ -1,5 +1,5 @@
 """Sensor tests for the Goalzero integration."""
-from unittest.mock import AsyncMock
+from unittest.mock import Mock
 
 from homeassistant.components.goalzero.const import DEFAULT_NAME
 from homeassistant.components.sensor import (
@@ -29,7 +29,7 @@ from tests.test_util.aiohttp import AiohttpClientMocker
 async def test_sensors(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
-    entity_registry_enabled_by_default: AsyncMock,
+    entity_registry_enabled_by_default: Mock,
 ) -> None:
     """Test we get sensor data."""
     await async_init_integration(hass, aioclient_mock)

--- a/tests/components/gree/test_switch.py
+++ b/tests/components/gree/test_switch.py
@@ -1,5 +1,5 @@
 """Tests for gree component."""
-from unittest.mock import Mock
+from unittest.mock import MagicMock
 
 from greeclimate.exceptions import DeviceTimeoutError
 import pytest
@@ -56,7 +56,7 @@ async def test_health_mode_disabled_by_default(hass):
     ],
 )
 async def test_send_switch_on(
-    hass: HomeAssistant, entity, entity_registry_enabled_by_default: Mock
+    hass: HomeAssistant, entity, entity_registry_enabled_by_default: MagicMock
 ) -> None:
     """Test for sending power on command to the device."""
     await async_setup_gree(hass)
@@ -84,7 +84,7 @@ async def test_send_switch_on(
     ],
 )
 async def test_send_switch_on_device_timeout(
-    hass: HomeAssistant, device, entity, entity_registry_enabled_by_default: Mock
+    hass: HomeAssistant, device, entity, entity_registry_enabled_by_default: MagicMock
 ) -> None:
     """Test for sending power on command to the device with a device timeout."""
     device().push_state_update.side_effect = DeviceTimeoutError
@@ -114,7 +114,7 @@ async def test_send_switch_on_device_timeout(
     ],
 )
 async def test_send_switch_off(
-    hass: HomeAssistant, entity, entity_registry_enabled_by_default: Mock
+    hass: HomeAssistant, entity, entity_registry_enabled_by_default: MagicMock
 ) -> None:
     """Test for sending power on command to the device."""
     await async_setup_gree(hass)
@@ -142,7 +142,7 @@ async def test_send_switch_off(
     ],
 )
 async def test_send_switch_toggle(
-    hass: HomeAssistant, entity, entity_registry_enabled_by_default: Mock
+    hass: HomeAssistant, entity, entity_registry_enabled_by_default: MagicMock
 ) -> None:
     """Test for sending power on command to the device."""
     await async_setup_gree(hass)
@@ -195,7 +195,7 @@ async def test_send_switch_toggle(
     ],
 )
 async def test_entity_name(
-    hass: HomeAssistant, entity, name, entity_registry_enabled_by_default: Mock
+    hass: HomeAssistant, entity, name, entity_registry_enabled_by_default: MagicMock
 ) -> None:
     """Test for name property."""
     await async_setup_gree(hass)

--- a/tests/components/gree/test_switch.py
+++ b/tests/components/gree/test_switch.py
@@ -1,4 +1,6 @@
 """Tests for gree component."""
+from unittest.mock import Mock
+
 from greeclimate.exceptions import DeviceTimeoutError
 import pytest
 
@@ -54,7 +56,7 @@ async def test_health_mode_disabled_by_default(hass):
     ],
 )
 async def test_send_switch_on(
-    hass: HomeAssistant, entity, entity_registry_enabled_by_default
+    hass: HomeAssistant, entity, entity_registry_enabled_by_default: Mock
 ) -> None:
     """Test for sending power on command to the device."""
     await async_setup_gree(hass)
@@ -82,7 +84,7 @@ async def test_send_switch_on(
     ],
 )
 async def test_send_switch_on_device_timeout(
-    hass: HomeAssistant, device, entity, entity_registry_enabled_by_default
+    hass: HomeAssistant, device, entity, entity_registry_enabled_by_default: Mock
 ) -> None:
     """Test for sending power on command to the device with a device timeout."""
     device().push_state_update.side_effect = DeviceTimeoutError
@@ -112,7 +114,7 @@ async def test_send_switch_on_device_timeout(
     ],
 )
 async def test_send_switch_off(
-    hass: HomeAssistant, entity, entity_registry_enabled_by_default
+    hass: HomeAssistant, entity, entity_registry_enabled_by_default: Mock
 ) -> None:
     """Test for sending power on command to the device."""
     await async_setup_gree(hass)
@@ -140,7 +142,7 @@ async def test_send_switch_off(
     ],
 )
 async def test_send_switch_toggle(
-    hass: HomeAssistant, entity, entity_registry_enabled_by_default
+    hass: HomeAssistant, entity, entity_registry_enabled_by_default: Mock
 ) -> None:
     """Test for sending power on command to the device."""
     await async_setup_gree(hass)
@@ -193,7 +195,7 @@ async def test_send_switch_toggle(
     ],
 )
 async def test_entity_name(
-    hass: HomeAssistant, entity, name, entity_registry_enabled_by_default
+    hass: HomeAssistant, entity, name, entity_registry_enabled_by_default: Mock
 ) -> None:
     """Test for name property."""
     await async_setup_gree(hass)

--- a/tests/components/gree/test_switch.py
+++ b/tests/components/gree/test_switch.py
@@ -1,5 +1,4 @@
 """Tests for gree component."""
-from unittest.mock import MagicMock
 
 from greeclimate.exceptions import DeviceTimeoutError
 import pytest
@@ -56,7 +55,7 @@ async def test_health_mode_disabled_by_default(hass):
     ],
 )
 async def test_send_switch_on(
-    hass: HomeAssistant, entity, entity_registry_enabled_by_default: MagicMock
+    hass: HomeAssistant, entity, entity_registry_enabled_by_default: None
 ) -> None:
     """Test for sending power on command to the device."""
     await async_setup_gree(hass)
@@ -84,7 +83,7 @@ async def test_send_switch_on(
     ],
 )
 async def test_send_switch_on_device_timeout(
-    hass: HomeAssistant, device, entity, entity_registry_enabled_by_default: MagicMock
+    hass: HomeAssistant, device, entity, entity_registry_enabled_by_default: None
 ) -> None:
     """Test for sending power on command to the device with a device timeout."""
     device().push_state_update.side_effect = DeviceTimeoutError
@@ -114,7 +113,7 @@ async def test_send_switch_on_device_timeout(
     ],
 )
 async def test_send_switch_off(
-    hass: HomeAssistant, entity, entity_registry_enabled_by_default: MagicMock
+    hass: HomeAssistant, entity, entity_registry_enabled_by_default: None
 ) -> None:
     """Test for sending power on command to the device."""
     await async_setup_gree(hass)
@@ -142,7 +141,7 @@ async def test_send_switch_off(
     ],
 )
 async def test_send_switch_toggle(
-    hass: HomeAssistant, entity, entity_registry_enabled_by_default: MagicMock
+    hass: HomeAssistant, entity, entity_registry_enabled_by_default: None
 ) -> None:
     """Test for sending power on command to the device."""
     await async_setup_gree(hass)
@@ -195,7 +194,7 @@ async def test_send_switch_toggle(
     ],
 )
 async def test_entity_name(
-    hass: HomeAssistant, entity, name, entity_registry_enabled_by_default: MagicMock
+    hass: HomeAssistant, entity, name, entity_registry_enabled_by_default: None
 ) -> None:
     """Test for name property."""
     await async_setup_gree(hass)

--- a/tests/components/homekit_controller/test_sensor.py
+++ b/tests/components/homekit_controller/test_sensor.py
@@ -1,5 +1,5 @@
 """Basic checks for HomeKit sensor."""
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from aiohomekit.model import Transport
 from aiohomekit.model.characteristics import CharacteristicsTypes
@@ -364,7 +364,7 @@ def test_thread_status_to_str() -> None:
 async def test_rssi_sensor(
     hass: HomeAssistant,
     utcnow,
-    entity_registry_enabled_by_default: MagicMock,
+    entity_registry_enabled_by_default: None,
     enable_bluetooth: None,
 ) -> None:
     """Test an rssi sensor."""
@@ -389,7 +389,7 @@ async def test_rssi_sensor(
 async def test_migrate_rssi_sensor_unique_id(
     hass: HomeAssistant,
     utcnow,
-    entity_registry_enabled_by_default: MagicMock,
+    entity_registry_enabled_by_default: None,
     enable_bluetooth: None,
 ) -> None:
     """Test an rssi sensor unique id migration."""

--- a/tests/components/homekit_controller/test_sensor.py
+++ b/tests/components/homekit_controller/test_sensor.py
@@ -1,5 +1,5 @@
 """Basic checks for HomeKit sensor."""
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, patch
 
 from aiohomekit.model import Transport
 from aiohomekit.model.characteristics import CharacteristicsTypes
@@ -364,7 +364,7 @@ def test_thread_status_to_str() -> None:
 async def test_rssi_sensor(
     hass: HomeAssistant,
     utcnow,
-    entity_registry_enabled_by_default: Mock,
+    entity_registry_enabled_by_default: MagicMock,
     enable_bluetooth: None,
 ) -> None:
     """Test an rssi sensor."""
@@ -389,7 +389,7 @@ async def test_rssi_sensor(
 async def test_migrate_rssi_sensor_unique_id(
     hass: HomeAssistant,
     utcnow,
-    entity_registry_enabled_by_default: Mock,
+    entity_registry_enabled_by_default: MagicMock,
     enable_bluetooth: None,
 ) -> None:
     """Test an rssi sensor unique id migration."""

--- a/tests/components/homekit_controller/test_sensor.py
+++ b/tests/components/homekit_controller/test_sensor.py
@@ -1,5 +1,5 @@
 """Basic checks for HomeKit sensor."""
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from aiohomekit.model import Transport
 from aiohomekit.model.characteristics import CharacteristicsTypes
@@ -364,7 +364,7 @@ def test_thread_status_to_str() -> None:
 async def test_rssi_sensor(
     hass: HomeAssistant,
     utcnow,
-    entity_registry_enabled_by_default,
+    entity_registry_enabled_by_default: Mock,
     enable_bluetooth: None,
 ) -> None:
     """Test an rssi sensor."""
@@ -389,7 +389,7 @@ async def test_rssi_sensor(
 async def test_migrate_rssi_sensor_unique_id(
     hass: HomeAssistant,
     utcnow,
-    entity_registry_enabled_by_default,
+    entity_registry_enabled_by_default: Mock,
     enable_bluetooth: None,
 ) -> None:
     """Test an rssi sensor unique id migration."""

--- a/tests/components/kostal_plenticore/test_number.py
+++ b/tests/components/kostal_plenticore/test_number.py
@@ -1,8 +1,7 @@
 """Test Kostal Plenticore number."""
-
 from collections.abc import Generator
 from datetime import timedelta
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from pykoplenti import ApiClient, SettingsData
 import pytest
@@ -90,7 +89,7 @@ async def test_setup_all_entries(
     mock_config_entry: MockConfigEntry,
     mock_plenticore_client: ApiClient,
     mock_get_setting_values: list,
-    entity_registry_enabled_by_default,
+    entity_registry_enabled_by_default: Mock,
 ) -> None:
     """Test if all available entries are setup."""
 
@@ -109,7 +108,7 @@ async def test_setup_no_entries(
     mock_config_entry: MockConfigEntry,
     mock_plenticore_client: ApiClient,
     mock_get_setting_values: list,
-    entity_registry_enabled_by_default,
+    entity_registry_enabled_by_default: Mock,
 ) -> None:
     """Test that no entries are setup if Plenticore does not provide data."""
 
@@ -130,7 +129,7 @@ async def test_number_has_value(
     mock_config_entry: MockConfigEntry,
     mock_plenticore_client: ApiClient,
     mock_get_setting_values: list,
-    entity_registry_enabled_by_default,
+    entity_registry_enabled_by_default: Mock,
 ) -> None:
     """Test if number has a value if data is provided on update."""
 
@@ -155,7 +154,7 @@ async def test_number_is_unavailable(
     mock_config_entry: MockConfigEntry,
     mock_plenticore_client: ApiClient,
     mock_get_setting_values: list,
-    entity_registry_enabled_by_default,
+    entity_registry_enabled_by_default: Mock,
 ) -> None:
     """Test if number is unavailable if no data is provided on update."""
 
@@ -176,7 +175,7 @@ async def test_set_value(
     mock_config_entry: MockConfigEntry,
     mock_plenticore_client: ApiClient,
     mock_get_setting_values: list,
-    entity_registry_enabled_by_default,
+    entity_registry_enabled_by_default: Mock,
 ) -> None:
     """Test if a new value could be set."""
 

--- a/tests/components/kostal_plenticore/test_number.py
+++ b/tests/components/kostal_plenticore/test_number.py
@@ -1,7 +1,7 @@
 """Test Kostal Plenticore number."""
 from collections.abc import Generator
 from datetime import timedelta
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, patch
 
 from pykoplenti import ApiClient, SettingsData
 import pytest
@@ -89,7 +89,7 @@ async def test_setup_all_entries(
     mock_config_entry: MockConfigEntry,
     mock_plenticore_client: ApiClient,
     mock_get_setting_values: list,
-    entity_registry_enabled_by_default: Mock,
+    entity_registry_enabled_by_default: MagicMock,
 ) -> None:
     """Test if all available entries are setup."""
 
@@ -108,7 +108,7 @@ async def test_setup_no_entries(
     mock_config_entry: MockConfigEntry,
     mock_plenticore_client: ApiClient,
     mock_get_setting_values: list,
-    entity_registry_enabled_by_default: Mock,
+    entity_registry_enabled_by_default: MagicMock,
 ) -> None:
     """Test that no entries are setup if Plenticore does not provide data."""
 
@@ -129,7 +129,7 @@ async def test_number_has_value(
     mock_config_entry: MockConfigEntry,
     mock_plenticore_client: ApiClient,
     mock_get_setting_values: list,
-    entity_registry_enabled_by_default: Mock,
+    entity_registry_enabled_by_default: MagicMock,
 ) -> None:
     """Test if number has a value if data is provided on update."""
 
@@ -154,7 +154,7 @@ async def test_number_is_unavailable(
     mock_config_entry: MockConfigEntry,
     mock_plenticore_client: ApiClient,
     mock_get_setting_values: list,
-    entity_registry_enabled_by_default: Mock,
+    entity_registry_enabled_by_default: MagicMock,
 ) -> None:
     """Test if number is unavailable if no data is provided on update."""
 
@@ -175,7 +175,7 @@ async def test_set_value(
     mock_config_entry: MockConfigEntry,
     mock_plenticore_client: ApiClient,
     mock_get_setting_values: list,
-    entity_registry_enabled_by_default: Mock,
+    entity_registry_enabled_by_default: MagicMock,
 ) -> None:
     """Test if a new value could be set."""
 

--- a/tests/components/kostal_plenticore/test_number.py
+++ b/tests/components/kostal_plenticore/test_number.py
@@ -1,7 +1,7 @@
 """Test Kostal Plenticore number."""
 from collections.abc import Generator
 from datetime import timedelta
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from pykoplenti import ApiClient, SettingsData
 import pytest
@@ -89,7 +89,7 @@ async def test_setup_all_entries(
     mock_config_entry: MockConfigEntry,
     mock_plenticore_client: ApiClient,
     mock_get_setting_values: list,
-    entity_registry_enabled_by_default: MagicMock,
+    entity_registry_enabled_by_default: None,
 ) -> None:
     """Test if all available entries are setup."""
 
@@ -108,7 +108,7 @@ async def test_setup_no_entries(
     mock_config_entry: MockConfigEntry,
     mock_plenticore_client: ApiClient,
     mock_get_setting_values: list,
-    entity_registry_enabled_by_default: MagicMock,
+    entity_registry_enabled_by_default: None,
 ) -> None:
     """Test that no entries are setup if Plenticore does not provide data."""
 
@@ -129,7 +129,7 @@ async def test_number_has_value(
     mock_config_entry: MockConfigEntry,
     mock_plenticore_client: ApiClient,
     mock_get_setting_values: list,
-    entity_registry_enabled_by_default: MagicMock,
+    entity_registry_enabled_by_default: None,
 ) -> None:
     """Test if number has a value if data is provided on update."""
 
@@ -154,7 +154,7 @@ async def test_number_is_unavailable(
     mock_config_entry: MockConfigEntry,
     mock_plenticore_client: ApiClient,
     mock_get_setting_values: list,
-    entity_registry_enabled_by_default: MagicMock,
+    entity_registry_enabled_by_default: None,
 ) -> None:
     """Test if number is unavailable if no data is provided on update."""
 
@@ -175,7 +175,7 @@ async def test_set_value(
     mock_config_entry: MockConfigEntry,
     mock_plenticore_client: ApiClient,
     mock_get_setting_values: list,
-    entity_registry_enabled_by_default: MagicMock,
+    entity_registry_enabled_by_default: None,
 ) -> None:
     """Test if a new value could be set."""
 

--- a/tests/components/litterrobot/test_binary_sensor.py
+++ b/tests/components/litterrobot/test_binary_sensor.py
@@ -17,7 +17,7 @@ from .conftest import setup_integration
 async def test_binary_sensors(
     hass: HomeAssistant,
     mock_account: MagicMock,
-    entity_registry_enabled_by_default: MagicMock,
+    entity_registry_enabled_by_default: None,
 ) -> None:
     """Tests binary sensors."""
     await setup_integration(hass, mock_account, PLATFORM_DOMAIN)

--- a/tests/components/litterrobot/test_binary_sensor.py
+++ b/tests/components/litterrobot/test_binary_sensor.py
@@ -1,5 +1,5 @@
 """Test the Litter-Robot binary sensor entity."""
-from unittest.mock import MagicMock, Mock
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -17,7 +17,7 @@ from .conftest import setup_integration
 async def test_binary_sensors(
     hass: HomeAssistant,
     mock_account: MagicMock,
-    entity_registry_enabled_by_default: Mock,
+    entity_registry_enabled_by_default: MagicMock,
 ) -> None:
     """Tests binary sensors."""
     await setup_integration(hass, mock_account, PLATFORM_DOMAIN)

--- a/tests/components/litterrobot/test_binary_sensor.py
+++ b/tests/components/litterrobot/test_binary_sensor.py
@@ -1,5 +1,5 @@
 """Test the Litter-Robot binary sensor entity."""
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock, Mock
 
 import pytest
 
@@ -17,7 +17,7 @@ from .conftest import setup_integration
 async def test_binary_sensors(
     hass: HomeAssistant,
     mock_account: MagicMock,
-    entity_registry_enabled_by_default: AsyncMock,
+    entity_registry_enabled_by_default: Mock,
 ) -> None:
     """Tests binary sensors."""
     await setup_integration(hass, mock_account, PLATFORM_DOMAIN)

--- a/tests/components/oralb/test_sensor.py
+++ b/tests/components/oralb/test_sensor.py
@@ -1,4 +1,6 @@
 """Test the OralB sensors."""
+from unittest.mock import Mock
+
 from homeassistant.components.oralb.const import DOMAIN
 from homeassistant.const import ATTR_FRIENDLY_NAME
 from homeassistant.core import HomeAssistant
@@ -16,7 +18,9 @@ from tests.components.bluetooth import (
 )
 
 
-async def test_sensors(hass: HomeAssistant, entity_registry_enabled_by_default) -> None:
+async def test_sensors(
+    hass: HomeAssistant, entity_registry_enabled_by_default: Mock
+) -> None:
     """Test setting up creates the sensors."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -47,7 +51,7 @@ async def test_sensors(hass: HomeAssistant, entity_registry_enabled_by_default) 
 
 
 async def test_sensors_io_series_4(
-    hass: HomeAssistant, entity_registry_enabled_by_default
+    hass: HomeAssistant, entity_registry_enabled_by_default: Mock
 ) -> None:
     """Test setting up creates the sensors with an io series 4."""
     entry = MockConfigEntry(

--- a/tests/components/oralb/test_sensor.py
+++ b/tests/components/oralb/test_sensor.py
@@ -1,5 +1,5 @@
 """Test the OralB sensors."""
-from unittest.mock import Mock
+from unittest.mock import MagicMock
 
 from homeassistant.components.oralb.const import DOMAIN
 from homeassistant.const import ATTR_FRIENDLY_NAME
@@ -19,7 +19,7 @@ from tests.components.bluetooth import (
 
 
 async def test_sensors(
-    hass: HomeAssistant, entity_registry_enabled_by_default: Mock
+    hass: HomeAssistant, entity_registry_enabled_by_default: MagicMock
 ) -> None:
     """Test setting up creates the sensors."""
     entry = MockConfigEntry(
@@ -51,7 +51,7 @@ async def test_sensors(
 
 
 async def test_sensors_io_series_4(
-    hass: HomeAssistant, entity_registry_enabled_by_default: Mock
+    hass: HomeAssistant, entity_registry_enabled_by_default: MagicMock
 ) -> None:
     """Test setting up creates the sensors with an io series 4."""
     entry = MockConfigEntry(

--- a/tests/components/oralb/test_sensor.py
+++ b/tests/components/oralb/test_sensor.py
@@ -1,5 +1,4 @@
 """Test the OralB sensors."""
-from unittest.mock import MagicMock
 
 from homeassistant.components.oralb.const import DOMAIN
 from homeassistant.const import ATTR_FRIENDLY_NAME
@@ -19,7 +18,7 @@ from tests.components.bluetooth import (
 
 
 async def test_sensors(
-    hass: HomeAssistant, entity_registry_enabled_by_default: MagicMock
+    hass: HomeAssistant, entity_registry_enabled_by_default: None
 ) -> None:
     """Test setting up creates the sensors."""
     entry = MockConfigEntry(
@@ -51,7 +50,7 @@ async def test_sensors(
 
 
 async def test_sensors_io_series_4(
-    hass: HomeAssistant, entity_registry_enabled_by_default: MagicMock
+    hass: HomeAssistant, entity_registry_enabled_by_default: None
 ) -> None:
     """Test setting up creates the sensors with an io series 4."""
     entry = MockConfigEntry(

--- a/tests/components/powerwall/test_sensor.py
+++ b/tests/components/powerwall/test_sensor.py
@@ -20,7 +20,9 @@ from .mocks import _mock_powerwall_with_fixtures
 from tests.common import MockConfigEntry
 
 
-async def test_sensors(hass: HomeAssistant, entity_registry_enabled_by_default) -> None:
+async def test_sensors(
+    hass: HomeAssistant, entity_registry_enabled_by_default: Mock
+) -> None:
     """Test creation of the sensors."""
 
     mock_powerwall = await _mock_powerwall_with_fixtures(hass)

--- a/tests/components/powerwall/test_sensor.py
+++ b/tests/components/powerwall/test_sensor.py
@@ -1,5 +1,5 @@
 """The sensor tests for the powerwall platform."""
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 from tesla_powerwall.error import MissingAttributeError
 
@@ -21,7 +21,7 @@ from tests.common import MockConfigEntry
 
 
 async def test_sensors(
-    hass: HomeAssistant, entity_registry_enabled_by_default: Mock
+    hass: HomeAssistant, entity_registry_enabled_by_default: MagicMock
 ) -> None:
     """Test creation of the sensors."""
 

--- a/tests/components/powerwall/test_sensor.py
+++ b/tests/components/powerwall/test_sensor.py
@@ -1,5 +1,5 @@
 """The sensor tests for the powerwall platform."""
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import Mock, patch
 
 from tesla_powerwall.error import MissingAttributeError
 
@@ -21,7 +21,7 @@ from tests.common import MockConfigEntry
 
 
 async def test_sensors(
-    hass: HomeAssistant, entity_registry_enabled_by_default: MagicMock
+    hass: HomeAssistant, entity_registry_enabled_by_default: None
 ) -> None:
     """Test creation of the sensors."""
 

--- a/tests/components/qnap_qsw/test_binary_sensor.py
+++ b/tests/components/qnap_qsw/test_binary_sensor.py
@@ -1,5 +1,4 @@
 """The binary sensor tests for the QNAP QSW platform."""
-from unittest.mock import MagicMock
 
 from homeassistant.components.qnap_qsw.const import ATTR_MESSAGE
 from homeassistant.const import STATE_OFF, STATE_ON
@@ -11,7 +10,7 @@ from .util import async_init_integration
 
 async def test_qnap_qsw_create_binary_sensors(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: MagicMock,
+    entity_registry_enabled_by_default: None,
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test creation of binary sensors."""

--- a/tests/components/qnap_qsw/test_binary_sensor.py
+++ b/tests/components/qnap_qsw/test_binary_sensor.py
@@ -1,5 +1,5 @@
 """The binary sensor tests for the QNAP QSW platform."""
-from unittest.mock import Mock
+from unittest.mock import MagicMock
 
 from homeassistant.components.qnap_qsw.const import ATTR_MESSAGE
 from homeassistant.const import STATE_OFF, STATE_ON
@@ -11,7 +11,7 @@ from .util import async_init_integration
 
 async def test_qnap_qsw_create_binary_sensors(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: Mock,
+    entity_registry_enabled_by_default: MagicMock,
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test creation of binary sensors."""

--- a/tests/components/qnap_qsw/test_binary_sensor.py
+++ b/tests/components/qnap_qsw/test_binary_sensor.py
@@ -1,6 +1,5 @@
 """The binary sensor tests for the QNAP QSW platform."""
-
-from unittest.mock import AsyncMock
+from unittest.mock import Mock
 
 from homeassistant.components.qnap_qsw.const import ATTR_MESSAGE
 from homeassistant.const import STATE_OFF, STATE_ON
@@ -12,7 +11,7 @@ from .util import async_init_integration
 
 async def test_qnap_qsw_create_binary_sensors(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: AsyncMock,
+    entity_registry_enabled_by_default: Mock,
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test creation of binary sensors."""

--- a/tests/components/qnap_qsw/test_sensor.py
+++ b/tests/components/qnap_qsw/test_sensor.py
@@ -1,5 +1,4 @@
 """The sensor tests for the QNAP QSW platform."""
-from unittest.mock import MagicMock
 
 from homeassistant.components.qnap_qsw.const import ATTR_MAX
 from homeassistant.core import HomeAssistant
@@ -9,7 +8,7 @@ from .util import async_init_integration
 
 async def test_qnap_qsw_create_sensors(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: MagicMock,
+    entity_registry_enabled_by_default: None,
 ) -> None:
     """Test creation of sensors."""
 

--- a/tests/components/qnap_qsw/test_sensor.py
+++ b/tests/components/qnap_qsw/test_sensor.py
@@ -1,6 +1,5 @@
 """The sensor tests for the QNAP QSW platform."""
-
-from unittest.mock import AsyncMock
+from unittest.mock import Mock
 
 from homeassistant.components.qnap_qsw.const import ATTR_MAX
 from homeassistant.core import HomeAssistant
@@ -10,7 +9,7 @@ from .util import async_init_integration
 
 async def test_qnap_qsw_create_sensors(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: AsyncMock,
+    entity_registry_enabled_by_default: Mock,
 ) -> None:
     """Test creation of sensors."""
 

--- a/tests/components/qnap_qsw/test_sensor.py
+++ b/tests/components/qnap_qsw/test_sensor.py
@@ -1,5 +1,5 @@
 """The sensor tests for the QNAP QSW platform."""
-from unittest.mock import Mock
+from unittest.mock import MagicMock
 
 from homeassistant.components.qnap_qsw.const import ATTR_MAX
 from homeassistant.core import HomeAssistant
@@ -9,7 +9,7 @@ from .util import async_init_integration
 
 async def test_qnap_qsw_create_sensors(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: Mock,
+    entity_registry_enabled_by_default: MagicMock,
 ) -> None:
     """Test creation of sensors."""
 

--- a/tests/components/radarr/test_sensor.py
+++ b/tests/components/radarr/test_sensor.py
@@ -1,5 +1,5 @@
 """The tests for Radarr sensor platform."""
-from unittest.mock import Mock
+from unittest.mock import MagicMock
 
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.const import ATTR_DEVICE_CLASS, ATTR_UNIT_OF_MEASUREMENT
@@ -13,7 +13,7 @@ from tests.test_util.aiohttp import AiohttpClientMocker
 async def test_sensors(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
-    entity_registry_enabled_by_default: Mock,
+    entity_registry_enabled_by_default: MagicMock,
 ) -> None:
     """Test for successfully setting up the Radarr platform."""
     await setup_integration(hass, aioclient_mock)

--- a/tests/components/radarr/test_sensor.py
+++ b/tests/components/radarr/test_sensor.py
@@ -1,5 +1,4 @@
 """The tests for Radarr sensor platform."""
-from unittest.mock import MagicMock
 
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.const import ATTR_DEVICE_CLASS, ATTR_UNIT_OF_MEASUREMENT
@@ -13,7 +12,7 @@ from tests.test_util.aiohttp import AiohttpClientMocker
 async def test_sensors(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
-    entity_registry_enabled_by_default: MagicMock,
+    entity_registry_enabled_by_default: None,
 ) -> None:
     """Test for successfully setting up the Radarr platform."""
     await setup_integration(hass, aioclient_mock)

--- a/tests/components/radarr/test_sensor.py
+++ b/tests/components/radarr/test_sensor.py
@@ -1,5 +1,5 @@
 """The tests for Radarr sensor platform."""
-from unittest.mock import AsyncMock
+from unittest.mock import Mock
 
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.const import ATTR_DEVICE_CLASS, ATTR_UNIT_OF_MEASUREMENT
@@ -13,7 +13,7 @@ from tests.test_util.aiohttp import AiohttpClientMocker
 async def test_sensors(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
-    entity_registry_enabled_by_default: AsyncMock,
+    entity_registry_enabled_by_default: Mock,
 ) -> None:
     """Test for successfully setting up the Radarr platform."""
     await setup_integration(hass, aioclient_mock)

--- a/tests/components/sensibo/test_binary_sensor.py
+++ b/tests/components/sensibo/test_binary_sensor.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, patch
 
 from pysensibo.model import SensiboData
 import pytest
@@ -16,7 +16,7 @@ from tests.common import async_fire_time_changed
 
 async def test_binary_sensor(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: Mock,
+    entity_registry_enabled_by_default: MagicMock,
     load_int: ConfigEntry,
     monkeypatch: pytest.MonkeyPatch,
     get_data: SensiboData,

--- a/tests/components/sensibo/test_binary_sensor.py
+++ b/tests/components/sensibo/test_binary_sensor.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from pysensibo.model import SensiboData
 import pytest
@@ -16,7 +16,7 @@ from tests.common import async_fire_time_changed
 
 async def test_binary_sensor(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: MagicMock,
+    entity_registry_enabled_by_default: None,
     load_int: ConfigEntry,
     monkeypatch: pytest.MonkeyPatch,
     get_data: SensiboData,

--- a/tests/components/sensibo/test_binary_sensor.py
+++ b/tests/components/sensibo/test_binary_sensor.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from unittest.mock import AsyncMock, patch
+from unittest.mock import Mock, patch
 
 from pysensibo.model import SensiboData
 import pytest
@@ -16,7 +16,7 @@ from tests.common import async_fire_time_changed
 
 async def test_binary_sensor(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: AsyncMock,
+    entity_registry_enabled_by_default: Mock,
     load_int: ConfigEntry,
     monkeypatch: pytest.MonkeyPatch,
     get_data: SensiboData,

--- a/tests/components/sensibo/test_climate.py
+++ b/tests/components/sensibo/test_climate.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, patch
 
 from pysensibo.model import SensiboData
 import pytest
@@ -720,7 +720,7 @@ async def test_climate_no_fan_no_swing(
 
 async def test_climate_set_timer(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: Mock,
+    entity_registry_enabled_by_default: MagicMock,
     load_int: ConfigEntry,
     monkeypatch: pytest.MonkeyPatch,
     get_data: SensiboData,
@@ -824,7 +824,7 @@ async def test_climate_set_timer(
 
 async def test_climate_pure_boost(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: Mock,
+    entity_registry_enabled_by_default: MagicMock,
     load_int: ConfigEntry,
     monkeypatch: pytest.MonkeyPatch,
     get_data: SensiboData,
@@ -928,7 +928,7 @@ async def test_climate_pure_boost(
 
 async def test_climate_climate_react(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: Mock,
+    entity_registry_enabled_by_default: MagicMock,
     load_int: ConfigEntry,
     monkeypatch: pytest.MonkeyPatch,
     get_data: SensiboData,
@@ -1091,7 +1091,7 @@ async def test_climate_climate_react(
 
 async def test_climate_climate_react_fahrenheit(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: Mock,
+    entity_registry_enabled_by_default: MagicMock,
     load_int: ConfigEntry,
     monkeypatch: pytest.MonkeyPatch,
     get_data: SensiboData,
@@ -1234,7 +1234,7 @@ async def test_climate_climate_react_fahrenheit(
 
 async def test_climate_full_ac_state(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: Mock,
+    entity_registry_enabled_by_default: MagicMock,
     load_int: ConfigEntry,
     monkeypatch: pytest.MonkeyPatch,
     get_data: SensiboData,

--- a/tests/components/sensibo/test_climate.py
+++ b/tests/components/sensibo/test_climate.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from pysensibo.model import SensiboData
 import pytest
@@ -720,7 +720,7 @@ async def test_climate_no_fan_no_swing(
 
 async def test_climate_set_timer(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: MagicMock,
+    entity_registry_enabled_by_default: None,
     load_int: ConfigEntry,
     monkeypatch: pytest.MonkeyPatch,
     get_data: SensiboData,
@@ -824,7 +824,7 @@ async def test_climate_set_timer(
 
 async def test_climate_pure_boost(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: MagicMock,
+    entity_registry_enabled_by_default: None,
     load_int: ConfigEntry,
     monkeypatch: pytest.MonkeyPatch,
     get_data: SensiboData,
@@ -928,7 +928,7 @@ async def test_climate_pure_boost(
 
 async def test_climate_climate_react(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: MagicMock,
+    entity_registry_enabled_by_default: None,
     load_int: ConfigEntry,
     monkeypatch: pytest.MonkeyPatch,
     get_data: SensiboData,
@@ -1091,7 +1091,7 @@ async def test_climate_climate_react(
 
 async def test_climate_climate_react_fahrenheit(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: MagicMock,
+    entity_registry_enabled_by_default: None,
     load_int: ConfigEntry,
     monkeypatch: pytest.MonkeyPatch,
     get_data: SensiboData,
@@ -1234,7 +1234,7 @@ async def test_climate_climate_react_fahrenheit(
 
 async def test_climate_full_ac_state(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: MagicMock,
+    entity_registry_enabled_by_default: None,
     load_int: ConfigEntry,
     monkeypatch: pytest.MonkeyPatch,
     get_data: SensiboData,

--- a/tests/components/sensibo/test_climate.py
+++ b/tests/components/sensibo/test_climate.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
-from unittest.mock import AsyncMock, patch
+from unittest.mock import Mock, patch
 
 from pysensibo.model import SensiboData
 import pytest
@@ -720,7 +720,7 @@ async def test_climate_no_fan_no_swing(
 
 async def test_climate_set_timer(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: AsyncMock,
+    entity_registry_enabled_by_default: Mock,
     load_int: ConfigEntry,
     monkeypatch: pytest.MonkeyPatch,
     get_data: SensiboData,
@@ -824,7 +824,7 @@ async def test_climate_set_timer(
 
 async def test_climate_pure_boost(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: AsyncMock,
+    entity_registry_enabled_by_default: Mock,
     load_int: ConfigEntry,
     monkeypatch: pytest.MonkeyPatch,
     get_data: SensiboData,
@@ -928,7 +928,7 @@ async def test_climate_pure_boost(
 
 async def test_climate_climate_react(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: AsyncMock,
+    entity_registry_enabled_by_default: Mock,
     load_int: ConfigEntry,
     monkeypatch: pytest.MonkeyPatch,
     get_data: SensiboData,
@@ -1091,7 +1091,7 @@ async def test_climate_climate_react(
 
 async def test_climate_climate_react_fahrenheit(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: AsyncMock,
+    entity_registry_enabled_by_default: Mock,
     load_int: ConfigEntry,
     monkeypatch: pytest.MonkeyPatch,
     get_data: SensiboData,
@@ -1234,7 +1234,7 @@ async def test_climate_climate_react_fahrenheit(
 
 async def test_climate_full_ac_state(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: AsyncMock,
+    entity_registry_enabled_by_default: Mock,
     load_int: ConfigEntry,
     monkeypatch: pytest.MonkeyPatch,
     get_data: SensiboData,

--- a/tests/components/sensibo/test_number.py
+++ b/tests/components/sensibo/test_number.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from unittest.mock import AsyncMock, patch
+from unittest.mock import Mock, patch
 
 from pysensibo.model import SensiboData
 import pytest
@@ -23,7 +23,7 @@ from tests.common import async_fire_time_changed
 
 async def test_number(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: AsyncMock,
+    entity_registry_enabled_by_default: Mock,
     load_int: ConfigEntry,
     monkeypatch: pytest.MonkeyPatch,
     get_data: SensiboData,
@@ -53,7 +53,7 @@ async def test_number(
 
 async def test_number_set_value(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: AsyncMock,
+    entity_registry_enabled_by_default: Mock,
     load_int: ConfigEntry,
     get_data: SensiboData,
 ) -> None:

--- a/tests/components/sensibo/test_number.py
+++ b/tests/components/sensibo/test_number.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, patch
 
 from pysensibo.model import SensiboData
 import pytest
@@ -23,7 +23,7 @@ from tests.common import async_fire_time_changed
 
 async def test_number(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: Mock,
+    entity_registry_enabled_by_default: MagicMock,
     load_int: ConfigEntry,
     monkeypatch: pytest.MonkeyPatch,
     get_data: SensiboData,
@@ -53,7 +53,7 @@ async def test_number(
 
 async def test_number_set_value(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: Mock,
+    entity_registry_enabled_by_default: MagicMock,
     load_int: ConfigEntry,
     get_data: SensiboData,
 ) -> None:

--- a/tests/components/sensibo/test_number.py
+++ b/tests/components/sensibo/test_number.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from pysensibo.model import SensiboData
 import pytest
@@ -23,7 +23,7 @@ from tests.common import async_fire_time_changed
 
 async def test_number(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: MagicMock,
+    entity_registry_enabled_by_default: None,
     load_int: ConfigEntry,
     monkeypatch: pytest.MonkeyPatch,
     get_data: SensiboData,
@@ -53,7 +53,7 @@ async def test_number(
 
 async def test_number_set_value(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: MagicMock,
+    entity_registry_enabled_by_default: None,
     load_int: ConfigEntry,
     get_data: SensiboData,
 ) -> None:

--- a/tests/components/sensibo/test_sensor.py
+++ b/tests/components/sensibo/test_sensor.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from pysensibo.model import SensiboData
 import pytest
@@ -16,7 +16,7 @@ from tests.common import async_fire_time_changed
 
 async def test_sensor(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: MagicMock,
+    entity_registry_enabled_by_default: None,
     load_int: ConfigEntry,
     monkeypatch: pytest.pytest.MonkeyPatch,
     get_data: SensiboData,

--- a/tests/components/sensibo/test_sensor.py
+++ b/tests/components/sensibo/test_sensor.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, patch
 
 from pysensibo.model import SensiboData
 import pytest
@@ -16,7 +16,7 @@ from tests.common import async_fire_time_changed
 
 async def test_sensor(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: Mock,
+    entity_registry_enabled_by_default: MagicMock,
     load_int: ConfigEntry,
     monkeypatch: pytest.pytest.MonkeyPatch,
     get_data: SensiboData,

--- a/tests/components/sensibo/test_sensor.py
+++ b/tests/components/sensibo/test_sensor.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from unittest.mock import AsyncMock, patch
+from unittest.mock import Mock, patch
 
 from pysensibo.model import SensiboData
 import pytest
@@ -16,7 +16,7 @@ from tests.common import async_fire_time_changed
 
 async def test_sensor(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: AsyncMock,
+    entity_registry_enabled_by_default: Mock,
     load_int: ConfigEntry,
     monkeypatch: pytest.pytest.MonkeyPatch,
     get_data: SensiboData,

--- a/tests/components/sonarr/test_sensor.py
+++ b/tests/components/sonarr/test_sensor.py
@@ -25,7 +25,7 @@ async def test_sensors(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_sonarr: MagicMock,
-    entity_registry_enabled_by_default: MagicMock,
+    entity_registry_enabled_by_default: None,
 ) -> None:
     """Test the creation and values of the sensors."""
     registry = er.async_get(hass)

--- a/tests/components/sonarr/test_sensor.py
+++ b/tests/components/sonarr/test_sensor.py
@@ -1,6 +1,6 @@
 """Tests for the Sonarr sensor platform."""
 from datetime import timedelta
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 from aiopyarr import ArrException
 import pytest
@@ -25,7 +25,7 @@ async def test_sensors(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_sonarr: MagicMock,
-    entity_registry_enabled_by_default: AsyncMock,
+    entity_registry_enabled_by_default: Mock,
 ) -> None:
     """Test the creation and values of the sensors."""
     registry = er.async_get(hass)

--- a/tests/components/sonarr/test_sensor.py
+++ b/tests/components/sonarr/test_sensor.py
@@ -1,6 +1,6 @@
 """Tests for the Sonarr sensor platform."""
 from datetime import timedelta
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, patch
 
 from aiopyarr import ArrException
 import pytest
@@ -25,7 +25,7 @@ async def test_sensors(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_sonarr: MagicMock,
-    entity_registry_enabled_by_default: Mock,
+    entity_registry_enabled_by_default: MagicMock,
 ) -> None:
     """Test the creation and values of the sensors."""
     registry = er.async_get(hass)

--- a/tests/components/switchbot/test_sensor.py
+++ b/tests/components/switchbot/test_sensor.py
@@ -1,4 +1,6 @@
 """Test the switchbot sensors."""
+from unittest.mock import Mock
+
 from homeassistant.components.sensor import ATTR_STATE_CLASS
 from homeassistant.components.switchbot.const import DOMAIN
 from homeassistant.const import (
@@ -18,7 +20,9 @@ from tests.common import MockConfigEntry
 from tests.components.bluetooth import inject_bluetooth_service_info
 
 
-async def test_sensors(hass: HomeAssistant, entity_registry_enabled_by_default) -> None:
+async def test_sensors(
+    hass: HomeAssistant, entity_registry_enabled_by_default: Mock
+) -> None:
     """Test setting up creates the sensors."""
     await async_setup_component(hass, DOMAIN, {})
     inject_bluetooth_service_info(hass, WOHAND_SERVICE_INFO)

--- a/tests/components/switchbot/test_sensor.py
+++ b/tests/components/switchbot/test_sensor.py
@@ -1,5 +1,4 @@
 """Test the switchbot sensors."""
-from unittest.mock import MagicMock
 
 from homeassistant.components.sensor import ATTR_STATE_CLASS
 from homeassistant.components.switchbot.const import DOMAIN
@@ -21,7 +20,7 @@ from tests.components.bluetooth import inject_bluetooth_service_info
 
 
 async def test_sensors(
-    hass: HomeAssistant, entity_registry_enabled_by_default: MagicMock
+    hass: HomeAssistant, entity_registry_enabled_by_default: None
 ) -> None:
     """Test setting up creates the sensors."""
     await async_setup_component(hass, DOMAIN, {})

--- a/tests/components/switchbot/test_sensor.py
+++ b/tests/components/switchbot/test_sensor.py
@@ -1,5 +1,5 @@
 """Test the switchbot sensors."""
-from unittest.mock import Mock
+from unittest.mock import MagicMock
 
 from homeassistant.components.sensor import ATTR_STATE_CLASS
 from homeassistant.components.switchbot.const import DOMAIN
@@ -21,7 +21,7 @@ from tests.components.bluetooth import inject_bluetooth_service_info
 
 
 async def test_sensors(
-    hass: HomeAssistant, entity_registry_enabled_by_default: Mock
+    hass: HomeAssistant, entity_registry_enabled_by_default: MagicMock
 ) -> None:
     """Test setting up creates the sensors."""
     await async_setup_component(hass, DOMAIN, {})

--- a/tests/components/unifi/test_sensor.py
+++ b/tests/components/unifi/test_sensor.py
@@ -1,7 +1,7 @@
 """UniFi Network sensor platform tests."""
 from copy import deepcopy
 from datetime import datetime, timedelta
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from aiounifi.models.message import MessageKey
 from aiounifi.websocket import WebsocketState
@@ -210,7 +210,7 @@ async def test_uptime_sensors(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
     mock_unifi_websocket,
-    entity_registry_enabled_by_default,
+    entity_registry_enabled_by_default: Mock,
     initial_uptime,
     event_uptime,
     new_uptime,
@@ -296,7 +296,7 @@ async def test_remove_sensors(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
     mock_unifi_websocket,
-    entity_registry_enabled_by_default,
+    entity_registry_enabled_by_default: Mock,
 ) -> None:
     """Verify removing of clients work as expected."""
     wired_client = {

--- a/tests/components/unifi/test_sensor.py
+++ b/tests/components/unifi/test_sensor.py
@@ -1,7 +1,7 @@
 """UniFi Network sensor platform tests."""
 from copy import deepcopy
 from datetime import datetime, timedelta
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, patch
 
 from aiounifi.models.message import MessageKey
 from aiounifi.websocket import WebsocketState
@@ -210,7 +210,7 @@ async def test_uptime_sensors(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
     mock_unifi_websocket,
-    entity_registry_enabled_by_default: Mock,
+    entity_registry_enabled_by_default: MagicMock,
     initial_uptime,
     event_uptime,
     new_uptime,
@@ -296,7 +296,7 @@ async def test_remove_sensors(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
     mock_unifi_websocket,
-    entity_registry_enabled_by_default: Mock,
+    entity_registry_enabled_by_default: MagicMock,
 ) -> None:
     """Verify removing of clients work as expected."""
     wired_client = {

--- a/tests/components/unifi/test_sensor.py
+++ b/tests/components/unifi/test_sensor.py
@@ -1,7 +1,7 @@
 """UniFi Network sensor platform tests."""
 from copy import deepcopy
 from datetime import datetime, timedelta
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from aiounifi.models.message import MessageKey
 from aiounifi.websocket import WebsocketState
@@ -210,7 +210,7 @@ async def test_uptime_sensors(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
     mock_unifi_websocket,
-    entity_registry_enabled_by_default: MagicMock,
+    entity_registry_enabled_by_default: None,
     initial_uptime,
     event_uptime,
     new_uptime,
@@ -296,7 +296,7 @@ async def test_remove_sensors(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
     mock_unifi_websocket,
-    entity_registry_enabled_by_default: MagicMock,
+    entity_registry_enabled_by_default: None,
 ) -> None:
     """Verify removing of clients work as expected."""
     wired_client = {

--- a/tests/components/unifiprotect/test_sensor.py
+++ b/tests/components/unifiprotect/test_sensor.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock
 
 from pyunifiprotect.data import (
     NVR,
@@ -397,7 +397,7 @@ async def test_sensor_setup_camera(
 
 async def test_sensor_setup_camera_with_last_trip_time(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: Mock,
+    entity_registry_enabled_by_default: MagicMock,
     ufp: MockUFPFixture,
     doorbell: Camera,
     fixed_now: datetime,
@@ -473,7 +473,7 @@ async def test_sensor_update_alarm(
 
 async def test_sensor_update_alarm_with_last_trip_time(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: Mock,
+    entity_registry_enabled_by_default: MagicMock,
     ufp: MockUFPFixture,
     sensor_all: Sensor,
     fixed_now: datetime,

--- a/tests/components/unifiprotect/test_sensor.py
+++ b/tests/components/unifiprotect/test_sensor.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
-from unittest.mock import MagicMock, Mock
+from unittest.mock import Mock
 
 from pyunifiprotect.data import (
     NVR,
@@ -397,7 +397,7 @@ async def test_sensor_setup_camera(
 
 async def test_sensor_setup_camera_with_last_trip_time(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: MagicMock,
+    entity_registry_enabled_by_default: None,
     ufp: MockUFPFixture,
     doorbell: Camera,
     fixed_now: datetime,
@@ -473,7 +473,7 @@ async def test_sensor_update_alarm(
 
 async def test_sensor_update_alarm_with_last_trip_time(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: MagicMock,
+    entity_registry_enabled_by_default: None,
     ufp: MockUFPFixture,
     sensor_all: Sensor,
     fixed_now: datetime,

--- a/tests/components/unifiprotect/test_sensor.py
+++ b/tests/components/unifiprotect/test_sensor.py
@@ -1,9 +1,8 @@
 """Test the UniFi Protect sensor platform."""
-
 from __future__ import annotations
 
 from datetime import datetime, timedelta
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import Mock
 
 from pyunifiprotect.data import (
     NVR,
@@ -398,7 +397,7 @@ async def test_sensor_setup_camera(
 
 async def test_sensor_setup_camera_with_last_trip_time(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: AsyncMock,
+    entity_registry_enabled_by_default: Mock,
     ufp: MockUFPFixture,
     doorbell: Camera,
     fixed_now: datetime,
@@ -474,7 +473,7 @@ async def test_sensor_update_alarm(
 
 async def test_sensor_update_alarm_with_last_trip_time(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: AsyncMock,
+    entity_registry_enabled_by_default: Mock,
     ufp: MockUFPFixture,
     sensor_all: Sensor,
     fixed_now: datetime,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Mainly cleans up `entity_registry_enabled_by_default`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
