### PR TITLE
Adjust IntFlag handling in syrupy

### DIFF
--- a/.core_files.yaml
+++ b/.core_files.yaml
@@ -125,6 +125,7 @@ tests: &tests
   - tests/mock/**
   - tests/pylint/**
   - tests/scripts/**
+  - tests/syrupy.py
   - tests/test_util/**
   - tests/testing_config/**
   - tests/util/**

--- a/tests/components/elgato/snapshots/test_light.ambr
+++ b/tests/components/elgato/snapshots/test_light.ambr
@@ -23,7 +23,7 @@
       'supported_color_modes': list([
         <ColorMode.COLOR_TEMP: 'color_temp'>,
       ]),
-      'supported_features': 0,
+      'supported_features': <LightEntityFeature: 0>,
       'xy_color': tuple(
         0.465,
         0.376,
@@ -130,7 +130,7 @@
         <ColorMode.COLOR_TEMP: 'color_temp'>,
         <ColorMode.HS: 'hs'>,
       ]),
-      'supported_features': 0,
+      'supported_features': <LightEntityFeature: 0>,
       'xy_color': tuple(
         0.465,
         0.376,
@@ -236,7 +236,7 @@
         <ColorMode.COLOR_TEMP: 'color_temp'>,
         <ColorMode.HS: 'hs'>,
       ]),
-      'supported_features': 0,
+      'supported_features': <LightEntityFeature: 0>,
       'xy_color': tuple(
         0.34,
         0.327,

--- a/tests/syrupy.py
+++ b/tests/syrupy.py
@@ -111,10 +111,10 @@ class HomeAssistantSnapshotSerializer(AmberDataSerializer):
             serializable_data = cls._serializable_config_entry(data)
         elif dataclasses.is_dataclass(data):
             serializable_data = dataclasses.asdict(data)
-        elif isinstance(data, IntFlag) and data == 0:
+        elif isinstance(data, IntFlag):
             # The repr of an enum.IntFlag has changed between Python 3.10 and 3.11
-            # This only concerns the 0 case, which we normalize here
-            serializable_data = 0
+            # so we normalize it here.
+            serializable_data = type(data), data.value
         else:
             serializable_data = data
             with suppress(TypeError):

--- a/tests/syrupy.py
+++ b/tests/syrupy.py
@@ -114,7 +114,7 @@ class HomeAssistantSnapshotSerializer(AmberDataSerializer):
         elif isinstance(data, IntFlag):
             # The repr of an enum.IntFlag has changed between Python 3.10 and 3.11
             # so we normalize it here.
-            serializable_data = type(data), data.value
+            serializable_data = _IntFlagWrapper(data)
         else:
             serializable_data = data
             with suppress(TypeError):
@@ -199,6 +199,17 @@ class HomeAssistantSnapshotSerializer(AmberDataSerializer):
                 "last_updated": ANY,
             }
         )
+
+
+class _IntFlagWrapper:
+    def __init__(self, flag: IntFlag) -> None:
+        self._flag = flag
+
+    def __repr__(self) -> str:
+        # 3.10: <ClimateEntityFeature.SWING_MODE|PRESET_MODE|FAN_MODE|TARGET_TEMPERATURE: 57>
+        # 3.11: <ClimateEntityFeature.TARGET_TEMPERATURE|FAN_MODE|PRESET_MODE|SWING_MODE: 57>
+        # Syrupy: <ClimateEntityFeature: 57>
+        return f"<{self._flag.__class__.__name__}: {self._flag.value}>"
 
 
 class HomeAssistantSnapshotExtension(AmberSnapshotExtension):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adjust `IntFlag` handling in syrupy.
Fixes discrepency between python 3.10 and python 3.11, which on top of zero-handling also sorts the values differently.
Spotted in https://github.com/home-assistant/core/actions/runs/4509488261/jobs/7939351801?pr=90222

```console
  -     'supported_features': <ClimateEntityFeature.SWING_MODE|PRESET_MODE|FAN_MODE|TARGET_TEMPERATURE: 57>,
  +     'supported_features': <ClimateEntityFeature.TARGET_TEMPERATURE|FAN_MODE|PRESET_MODE|SWING_MODE: 57>,
```
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
