### PR TITLE
Remove duplicate code in livisi coordinator

### DIFF
--- a/homeassistant/components/livisi/climate.py
+++ b/homeassistant/components/livisi/climate.py
@@ -99,14 +99,15 @@ class LivisiClimate(LivisiEntity, ClimateEntity):
 
         await super().async_added_to_hass()
 
-        target_temperature = await self.coordinator.async_get_vrcc_target_temperature(
-            self._target_temperature_capability
+        target_temperature = await self.coordinator.async_get_device_state(
+            self._target_temperature_capability,
+            "setpointTemperature" if self.coordinator.is_avatar else "pointTemperature",
         )
-        temperature = await self.coordinator.async_get_vrcc_temperature(
-            self._temperature_capability
+        temperature = await self.coordinator.async_get_device_state(
+            self._temperature_capability, "temperature"
         )
-        humidity = await self.coordinator.async_get_vrcc_humidity(
-            self._humidity_capability
+        humidity = await self.coordinator.async_get_device_state(
+            self._humidity_capability, "humidity"
         )
         if temperature is None:
             self._attr_current_temperature = None

--- a/homeassistant/components/livisi/coordinator.py
+++ b/homeassistant/components/livisi/coordinator.py
@@ -58,7 +58,7 @@ class LivisiDataUpdateCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
         except ClientConnectorError as exc:
             raise UpdateFailed("Failed to get LIVISI the devices") from exc
 
-    def _async_dispatcher_send(self, data, event, source):
+    def _async_dispatcher_send(self, event: str, source: str, data: Any):
         if data is not None:
             async_dispatcher_send(self.hass, f"{event}_{source}", data)
 
@@ -107,19 +107,19 @@ class LivisiDataUpdateCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
     def on_data(self, event_data: LivisiEvent) -> None:
         """Define a handler to fire when the data is received."""
         self._async_dispatcher_send(
-            event_data.onState, LIVISI_STATE_CHANGE, event_data.source
+            LIVISI_STATE_CHANGE, event_data.source, event_data.onState
         )
         self._async_dispatcher_send(
-            event_data.vrccData, LIVISI_STATE_CHANGE, event_data.source
+            LIVISI_STATE_CHANGE, event_data.source, event_data.vrccData
         )
         self._async_dispatcher_send(
-            event_data.isReachable, LIVISI_REACHABILITY_CHANGE, event_data.source
+            LIVISI_REACHABILITY_CHANGE, event_data.source, event_data.isReachable
         )
 
     async def on_close(self) -> None:
         """Define a handler to fire when the websocket is closed."""
         for device_id in self.devices:
-            self._async_dispatcher_send(False, LIVISI_REACHABILITY_CHANGE, device_id)
+            self._async_dispatcher_send(LIVISI_REACHABILITY_CHANGE, device_id, False)
 
         await self.websocket.connect(self.on_data, self.on_close, self.port)
 

--- a/homeassistant/components/livisi/coordinator.py
+++ b/homeassistant/components/livisi/coordinator.py
@@ -87,7 +87,7 @@ class LivisiDataUpdateCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
         """Set the discovered devices list."""
         return await self.aiolivisi.async_get_devices()
 
-    async def async_get_device_state(self, capability, key):
+    async def async_get_device_state(self, capability: str, key: str) -> Any | None:
         """Get state from livisi devices."""
         response: dict[str, Any] = await self.aiolivisi.async_get_device_state(
             capability[1:]

--- a/homeassistant/components/livisi/coordinator.py
+++ b/homeassistant/components/livisi/coordinator.py
@@ -58,6 +58,10 @@ class LivisiDataUpdateCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
         except ClientConnectorError as exc:
             raise UpdateFailed("Failed to get LIVISI the devices") from exc
 
+    def _async_dispatcher_send(self, data, event, source):
+        if data is not None:
+            async_dispatcher_send(self.hass, f"{event}_{source}", data)
+
     async def async_setup(self) -> None:
         """Set up the Livisi Smart Home Controller."""
         if not self.aiolivisi.livisi_connection_data:
@@ -83,44 +87,14 @@ class LivisiDataUpdateCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
         """Set the discovered devices list."""
         return await self.aiolivisi.async_get_devices()
 
-    async def async_get_pss_state(self, capability: str) -> bool | None:
-        """Set the PSS state."""
-        response: dict[str, Any] | None = await self.aiolivisi.async_get_device_state(
+    async def async_get_device_state(self, capability, key):
+        """Get state from livisi devices."""
+        response: dict[str, Any] = await self.aiolivisi.async_get_device_state(
             capability[1:]
         )
         if response is None:
             return None
-        on_state = response["onState"]
-        return on_state["value"]
-
-    async def async_get_vrcc_target_temperature(self, capability: str) -> float | None:
-        """Get the target temperature of the climate device."""
-        response: dict[str, Any] | None = await self.aiolivisi.async_get_device_state(
-            capability[1:]
-        )
-        if response is None:
-            return None
-        if self.is_avatar:
-            return response["setpointTemperature"]["value"]
-        return response["pointTemperature"]["value"]
-
-    async def async_get_vrcc_temperature(self, capability: str) -> float | None:
-        """Get the temperature of the climate device."""
-        response: dict[str, Any] | None = await self.aiolivisi.async_get_device_state(
-            capability[1:]
-        )
-        if response is None:
-            return None
-        return response["temperature"]["value"]
-
-    async def async_get_vrcc_humidity(self, capability: str) -> int | None:
-        """Get the humidity of the climate device."""
-        response: dict[str, Any] | None = await self.aiolivisi.async_get_device_state(
-            capability[1:]
-        )
-        if response is None:
-            return None
-        return response["humidity"]["value"]
+        return response.get(key, {}).get("value")
 
     async def async_set_all_rooms(self) -> None:
         """Set the room list."""
@@ -132,34 +106,23 @@ class LivisiDataUpdateCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
 
     def on_data(self, event_data: LivisiEvent) -> None:
         """Define a handler to fire when the data is received."""
-        if event_data.onState is not None:
-            async_dispatcher_send(
-                self.hass,
-                f"{LIVISI_STATE_CHANGE}_{event_data.source}",
-                event_data.onState,
-            )
-        if event_data.vrccData is not None:
-            async_dispatcher_send(
-                self.hass,
-                f"{LIVISI_STATE_CHANGE}_{event_data.source}",
-                event_data.vrccData,
-            )
-        if event_data.isReachable is not None:
-            async_dispatcher_send(
-                self.hass,
-                f"{LIVISI_REACHABILITY_CHANGE}_{event_data.source}",
-                event_data.isReachable,
-            )
+        self._async_dispatcher_send(
+            event_data.isOpen, LIVISI_STATE_CHANGE, event_data.source
+        )
+        self._async_dispatcher_send(
+            event_data.onState, LIVISI_STATE_CHANGE, event_data.source
+        )
+        self._async_dispatcher_send(
+            event_data.vrccData, LIVISI_STATE_CHANGE, event_data.source
+        )
+        self._async_dispatcher_send(
+            event_data.isReachable, LIVISI_REACHABILITY_CHANGE, event_data.source
+        )
 
     async def on_close(self) -> None:
         """Define a handler to fire when the websocket is closed."""
         for device_id in self.devices:
-            is_reachable: bool = False
-            async_dispatcher_send(
-                self.hass,
-                f"{LIVISI_REACHABILITY_CHANGE}_{device_id}",
-                is_reachable,
-            )
+            self._async_dispatcher_send(False, LIVISI_REACHABILITY_CHANGE, device_id)
 
         await self.websocket.connect(self.on_data, self.on_close, self.port)
 

--- a/homeassistant/components/livisi/coordinator.py
+++ b/homeassistant/components/livisi/coordinator.py
@@ -107,9 +107,6 @@ class LivisiDataUpdateCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
     def on_data(self, event_data: LivisiEvent) -> None:
         """Define a handler to fire when the data is received."""
         self._async_dispatcher_send(
-            event_data.isOpen, LIVISI_STATE_CHANGE, event_data.source
-        )
-        self._async_dispatcher_send(
             event_data.onState, LIVISI_STATE_CHANGE, event_data.source
         )
         self._async_dispatcher_send(

--- a/homeassistant/components/livisi/coordinator.py
+++ b/homeassistant/components/livisi/coordinator.py
@@ -58,7 +58,7 @@ class LivisiDataUpdateCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
         except ClientConnectorError as exc:
             raise UpdateFailed("Failed to get LIVISI the devices") from exc
 
-    def _async_dispatcher_send(self, event: str, source: str, data: Any):
+    def _async_dispatcher_send(self, event: str, source: str, data: Any) -> None:
         if data is not None:
             async_dispatcher_send(self.hass, f"{event}_{source}", data)
 

--- a/homeassistant/components/livisi/switch.py
+++ b/homeassistant/components/livisi/switch.py
@@ -81,7 +81,9 @@ class LivisiSwitch(LivisiEntity, SwitchEntity):
         """Register callbacks."""
         await super().async_added_to_hass()
 
-        response = await self.coordinator.async_get_pss_state(self._capability_id)
+        response = await self.coordinator.async_get_device_state(
+            self._capability_id, "onState"
+        )
         if response is None:
             self._attr_is_on = False
             self._attr_available = False


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

As proposed in and as a prerequisite for https://github.com/home-assistant/core/pull/90220 introduce generic helper methods in coordinator and move entity specific details to the entity implementations (which are switch and climate currently).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
