### PR TITLE
Fix Notify Group payload data mis-merge

### DIFF
--- a/homeassistant/components/group/notify.py
+++ b/homeassistant/components/group/notify.py
@@ -32,14 +32,16 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 )
 
 
-def add_defaults(input_data: dict[str, Any], default_data: dict[str, Any]) -> dict[str, Any]:
+def add_defaults(
+    input_data: dict[str, Any], default_data: dict[str, Any]
+) -> dict[str, Any]:
     """Deep update a dictionary with default values."""
     for key, val in default_data.items():
         if isinstance(val, Mapping):
-            input_dict[key] = add_defaults(input_data.get(key, {}), val)  # type: ignore[arg-type]
+            input_data[key] = add_defaults(input_data.get(key, {}), val)  # type: ignore[arg-type]
         elif key not in input_data:
             input_data[key] = val
-    return input_dict
+    return input_data
 
 
 async def async_get_service(

--- a/homeassistant/components/group/notify.py
+++ b/homeassistant/components/group/notify.py
@@ -41,8 +41,8 @@ def update(input_dict: dict[str, Any], update_source: dict[str, Any]) -> dict[st
         if isinstance(val, Mapping):
             recurse = update(input_dict.get(key, {}), val)  # type: ignore[arg-type]
             input_dict[key] = recurse
-        else:
-            input_dict[key] = update_source[key]
+        elif key not in input_dict:
+            input_dict[key] = val
     return input_dict
 
 
@@ -72,7 +72,7 @@ class GroupNotifyPlatform(BaseNotificationService):
         for entity in self.entities:
             sending_payload = deepcopy(payload.copy())
             if (data := entity.get(ATTR_DATA)) is not None:
-                update(data, sending_payload)
+                update(sending_payload, data)
             tasks.append(
                 asyncio.create_task(
                     self.hass.services.async_call(

--- a/homeassistant/components/group/notify.py
+++ b/homeassistant/components/group/notify.py
@@ -72,7 +72,7 @@ class GroupNotifyPlatform(BaseNotificationService):
         for entity in self.entities:
             sending_payload = deepcopy(payload.copy())
             if (data := entity.get(ATTR_DATA)) is not None:
-                update(sending_payload, data)
+                update(data, sending_payload)
             tasks.append(
                 asyncio.create_task(
                     self.hass.services.async_call(

--- a/homeassistant/components/group/notify.py
+++ b/homeassistant/components/group/notify.py
@@ -32,17 +32,13 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 )
 
 
-def update(input_dict: dict[str, Any], update_source: dict[str, Any]) -> dict[str, Any]:
-    """Deep update a dictionary.
-
-    Async friendly.
-    """
-    for key, val in update_source.items():
+def add_defaults(input_data: dict[str, Any], default_data: dict[str, Any]) -> dict[str, Any]:
+    """Deep update a dictionary with default values."""
+    for key, val in default_data.items():
         if isinstance(val, Mapping):
-            recurse = update(input_dict.get(key, {}), val)  # type: ignore[arg-type]
-            input_dict[key] = recurse
-        elif key not in input_dict:
-            input_dict[key] = val
+            input_dict[key] = add_defaults(input_data.get(key, {}), val)  # type: ignore[arg-type]
+        elif key not in input_data:
+            input_data[key] = val
     return input_dict
 
 
@@ -71,8 +67,8 @@ class GroupNotifyPlatform(BaseNotificationService):
         tasks: list[asyncio.Task[bool | None]] = []
         for entity in self.entities:
             sending_payload = deepcopy(payload.copy())
-            if (data := entity.get(ATTR_DATA)) is not None:
-                update(sending_payload, data)
+            if (default_data := entity.get(ATTR_DATA)) is not None:
+                add_defaults(sending_payload, default_data)
             tasks.append(
                 asyncio.create_task(
                     self.hass.services.async_call(

--- a/tests/components/group/test_notify.py
+++ b/tests/components/group/test_notify.py
@@ -54,14 +54,14 @@ async def test_send_message_with_data(hass: HomeAssistant) -> None:
                     "service": "demo2",
                     "data": {
                         "target": "unnamed device",
-                        "data": {"test": "message"},
+                        "data": {"test": "message", "default": "default"},
                     },
                 },
             ]
         },
     )
 
-    """Test sending a message with to a notify group."""
+    """Test sending a message to a notify group."""
     await service.async_send_message(
         "Hello", title="Test notification", data={"hello": "world"}
     )
@@ -77,7 +77,28 @@ async def test_send_message_with_data(hass: HomeAssistant) -> None:
     assert service2.send_message.mock_calls[0][2] == {
         "target": ["unnamed device"],
         "title": "Test notification",
-        "data": {"hello": "world", "test": "message"},
+        "data": {"hello": "world", "test": "message", "default": "default"},
+    }
+
+    """Test sending a message which overrides service defaults to a notify group."""
+    await service.async_send_message(
+        "Hello",
+        title="Test notification",
+        data={"hello": "world", "default": "override"},
+    )
+
+    await hass.async_block_till_done()
+
+    assert service1.send_message.mock_calls[1][1][0] == "Hello"
+    assert service1.send_message.mock_calls[1][2] == {
+        "title": "Test notification",
+        "data": {"hello": "world", "default": "override"},
+    }
+    assert service2.send_message.mock_calls[1][1][0] == "Hello"
+    assert service2.send_message.mock_calls[1][2] == {
+        "target": ["unnamed device"],
+        "title": "Test notification",
+        "data": {"hello": "world", "test": "message", "default": "override"},
     }
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Current behaviour: `data` mappings configured in the **service** override mappings configured in the **action**
New behaviour: `data` mappings configured in the **action** override mappings configured in the **service**

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The Notify Group component allows a [set of data mappings](https://www.home-assistant.io/integrations/group/#data) to be configured and used as the default payload for the notification. Currently, these mappings _override_ what is configured in the action itself.

### Example:
```yaml
notify:
  - name: ios_group
    platform: group
    services:
      - service: mobile_app_a
        data:
          data:
            push:
              sound: 'sound-DEFAULT.wav'

automation:
  - alias: automation with default
    trigger: ~
    condition: ~
    action:
      - service: notify.ios_group
        data:
          message: "test - default sound"

  - alias: automation with override
    trigger: ~
    condition: ~
    action:
      - service: notify.ios_group
        data:
          message: "test - override sound"
          data:
            push:
              sound: "sound-OVERRIDE.wav"
```

Expected behaviour would be that the first automation inherits the data mappings from the service and pushes `sound-DEFAULT.wav` to the device; whereas the second automation has its own key for the sound mapping, the expectation is taht key will override what is in the service and `sound-OVERRIDE.wav` will be pushed to the device.

This is not the current behaviour. Instead, the mappings configured in the service stomp on whatever is passed from the action. This corrects the behaviour so that the action overrides the service configuration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- https://github.com/home-assistant/home-assistant.io/pull/26715

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
