### PR TITLE
Strict typing of UniFi integration

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -311,6 +311,7 @@ homeassistant.components.trafikverket_train.*
 homeassistant.components.trafikverket_weatherstation.*
 homeassistant.components.tts.*
 homeassistant.components.twentemilieu.*
+homeassistant.components.unifi
 homeassistant.components.unifi.controller
 homeassistant.components.unifi.update
 homeassistant.components.unifiprotect.*

--- a/.strict-typing
+++ b/.strict-typing
@@ -314,6 +314,7 @@ homeassistant.components.twentemilieu.*
 homeassistant.components.unifi
 homeassistant.components.unifi.config_flow
 homeassistant.components.unifi.controller
+homeassistant.components.unifi.sensor
 homeassistant.components.unifi.switch
 homeassistant.components.unifi.update
 homeassistant.components.unifiprotect.*

--- a/.strict-typing
+++ b/.strict-typing
@@ -314,6 +314,7 @@ homeassistant.components.twentemilieu.*
 homeassistant.components.unifi
 homeassistant.components.unifi.config_flow
 homeassistant.components.unifi.controller
+homeassistant.components.unifi.device_tracker
 homeassistant.components.unifi.sensor
 homeassistant.components.unifi.switch
 homeassistant.components.unifi.update

--- a/.strict-typing
+++ b/.strict-typing
@@ -314,6 +314,7 @@ homeassistant.components.twentemilieu.*
 homeassistant.components.unifi
 homeassistant.components.unifi.config_flow
 homeassistant.components.unifi.controller
+homeassistant.components.unifi.switch
 homeassistant.components.unifi.update
 homeassistant.components.unifiprotect.*
 homeassistant.components.upcloud.*

--- a/.strict-typing
+++ b/.strict-typing
@@ -312,6 +312,7 @@ homeassistant.components.trafikverket_weatherstation.*
 homeassistant.components.tts.*
 homeassistant.components.twentemilieu.*
 homeassistant.components.unifi
+homeassistant.components.unifi.config_flow
 homeassistant.components.unifi.controller
 homeassistant.components.unifi.update
 homeassistant.components.unifiprotect.*

--- a/.strict-typing
+++ b/.strict-typing
@@ -311,6 +311,7 @@ homeassistant.components.trafikverket_train.*
 homeassistant.components.trafikverket_weatherstation.*
 homeassistant.components.tts.*
 homeassistant.components.twentemilieu.*
+homeassistant.components.unifi.controller
 homeassistant.components.unifi.update
 homeassistant.components.unifiprotect.*
 homeassistant.components.upcloud.*

--- a/.strict-typing
+++ b/.strict-typing
@@ -311,13 +311,7 @@ homeassistant.components.trafikverket_train.*
 homeassistant.components.trafikverket_weatherstation.*
 homeassistant.components.tts.*
 homeassistant.components.twentemilieu.*
-homeassistant.components.unifi
-homeassistant.components.unifi.config_flow
-homeassistant.components.unifi.controller
-homeassistant.components.unifi.device_tracker
-homeassistant.components.unifi.sensor
-homeassistant.components.unifi.switch
-homeassistant.components.unifi.update
+homeassistant.components.unifi.*
 homeassistant.components.unifiprotect.*
 homeassistant.components.upcloud.*
 homeassistant.components.update.*

--- a/homeassistant/components/unifi/__init__.py
+++ b/homeassistant/components/unifi/__init__.py
@@ -64,7 +64,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
 async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    controller = hass.data[UNIFI_DOMAIN].pop(config_entry.entry_id)
+    controller: UniFiController = hass.data[UNIFI_DOMAIN].pop(config_entry.entry_id)
 
     if not hass.data[UNIFI_DOMAIN]:
         async_unload_services(hass)

--- a/homeassistant/components/unifi/controller.py
+++ b/homeassistant/components/unifi/controller.py
@@ -141,11 +141,11 @@ class UniFiController:
         # Statistics sensor options
 
         # Config entry option to allow bandwidth sensors.
-        self.option_allow_bandwidth_sensors = options.get(
+        self.option_allow_bandwidth_sensors: bool = options.get(
             CONF_ALLOW_BANDWIDTH_SENSORS, DEFAULT_ALLOW_BANDWIDTH_SENSORS
         )
         # Config entry option to allow uptime sensors.
-        self.option_allow_uptime_sensors = options.get(
+        self.option_allow_uptime_sensors: bool = options.get(
             CONF_ALLOW_UPTIME_SENSORS, DEFAULT_ALLOW_UPTIME_SENSORS
         )
 

--- a/homeassistant/components/unifi/controller.py
+++ b/homeassistant/components/unifi/controller.py
@@ -22,7 +22,7 @@ from homeassistant.const import (
     CONF_VERIFY_SSL,
     Platform,
 )
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant, callback
 from homeassistant.helpers import (
     aiohttp_client,
     device_registry as dr,
@@ -75,7 +75,9 @@ CHECK_HEARTBEAT_INTERVAL = timedelta(seconds=1)
 class UniFiController:
     """Manages a single UniFi Network instance."""
 
-    def __init__(self, hass, config_entry, api):
+    def __init__(
+        self, hass: HomeAssistant, config_entry: ConfigEntry, api: aiounifi.Controller
+    ) -> None:
         """Initialize the system."""
         self.hass = hass
         self.config_entry = config_entry
@@ -87,19 +89,18 @@ class UniFiController:
         self.wireless_clients = hass.data[UNIFI_WIRELESS_CLIENTS]
 
         self.site_id: str = ""
-        self._site_name = None
-        self._site_role = None
+        self._site_name: str | None = None
+        self._site_role: str | None = None
 
-        self._cancel_heartbeat_check = None
-        self._heartbeat_dispatch = {}
-        self._heartbeat_time = {}
+        self._cancel_heartbeat_check: CALLBACK_TYPE | None = None
+        self._heartbeat_time: dict[str, datetime] = {}
 
         self.load_config_entry_options()
 
-        self.entities = {}
+        self.entities: dict[str, str] = {}
         self.known_objects: set[tuple[str, str]] = set()
 
-    def load_config_entry_options(self):
+    def load_config_entry_options(self) -> None:
         """Store attributes to avoid property call overhead since they are called frequently."""
         options = self.config_entry.options
 
@@ -149,27 +150,29 @@ class UniFiController:
         )
 
     @property
-    def host(self):
+    def host(self) -> str:
         """Return the host of this controller."""
-        return self.config_entry.data[CONF_HOST]
+        host: str = self.config_entry.data[CONF_HOST]
+        return host
 
     @property
-    def site(self):
+    def site(self) -> str:
         """Return the site of this config entry."""
-        return self.config_entry.data[CONF_SITE_ID]
+        site_id: str = self.config_entry.data[CONF_SITE_ID]
+        return site_id
 
     @property
-    def site_name(self):
+    def site_name(self) -> str | None:
         """Return the nice name of site."""
         return self._site_name
 
     @property
-    def site_role(self):
+    def site_role(self) -> str | None:
         """Return the site user role of this controller."""
         return self._site_role
 
     @property
-    def mac(self):
+    def mac(self) -> str | None:
         """Return the mac address of this controller."""
         for client in self.api.clients.values():
             if self.host == client.ip:
@@ -227,7 +230,9 @@ class UniFiController:
             async_load_entities(description)
 
     @callback
-    def async_unifi_signalling_callback(self, signal, data):
+    def async_unifi_signalling_callback(
+        self, signal: WebsocketSignal, data: WebsocketState
+    ) -> None:
         """Handle messages back from UniFi library."""
         if signal == WebsocketSignal.CONNECTION_STATE:
             if data == WebsocketState.DISCONNECTED and self.available:
@@ -259,7 +264,7 @@ class UniFiController:
         """Event specific per UniFi device tracker to signal new heartbeat missed."""
         return "unifi-heartbeat-missed"
 
-    async def initialize(self):
+    async def initialize(self) -> None:
         """Set up a UniFi Network instance."""
         await self.api.initialize()
 
@@ -291,7 +296,7 @@ class UniFiController:
                 continue
 
             client = self.api.clients_all[mac]
-            self.api.clients.process_raw([client.raw])
+            self.api.clients.process_raw([dict(client.raw)])
             LOGGER.debug(
                 "Restore disconnected client %s (%s)",
                 entry.entity_id,
@@ -319,7 +324,7 @@ class UniFiController:
             del self._heartbeat_time[unique_id]
 
     @callback
-    def _async_check_for_stale(self, *_) -> None:
+    def _async_check_for_stale(self, *_: datetime) -> None:
         """Check for any devices scheduled to be marked disconnected."""
         now = dt_util.utcnow()
 
@@ -365,7 +370,7 @@ class UniFiController:
         async_dispatcher_send(hass, controller.signal_options_update)
 
     @callback
-    def reconnect(self, log=False) -> None:
+    def reconnect(self, log: bool = False) -> None:
         """Prepare to reconnect UniFi session."""
         if log:
             LOGGER.info("Will try to reconnect to UniFi Network")
@@ -387,14 +392,14 @@ class UniFiController:
             self.hass.loop.call_later(RETRY_TIMER, self.reconnect)
 
     @callback
-    def shutdown(self, event) -> None:
+    def shutdown(self, event: Event) -> None:
         """Wrap the call to unifi.close.
 
         Used as an argument to EventBus.async_listen_once.
         """
         self.api.stop_websocket()
 
-    async def async_reset(self):
+    async def async_reset(self) -> bool:
         """Reset this controller to default state.
 
         Will cancel any scheduled setup retry and will unload
@@ -421,15 +426,15 @@ async def get_unifi_controller(
     config: MappingProxyType[str, Any],
 ) -> aiounifi.Controller:
     """Create a controller object and verify authentication."""
-    ssl_context = False
+    ssl_context: ssl.SSLContext | bool = False
 
-    if verify_ssl := bool(config.get(CONF_VERIFY_SSL)):
+    if verify_ssl := config.get(CONF_VERIFY_SSL):
         session = aiohttp_client.async_get_clientsession(hass)
         if isinstance(verify_ssl, str):
             ssl_context = ssl.create_default_context(cafile=verify_ssl)
     else:
         session = aiohttp_client.async_create_clientsession(
-            hass, verify_ssl=verify_ssl, cookie_jar=CookieJar(unsafe=True)
+            hass, verify_ssl=False, cookie_jar=CookieJar(unsafe=True)
         )
 
     controller = aiounifi.Controller(

--- a/homeassistant/components/unifi/controller.py
+++ b/homeassistant/components/unifi/controller.py
@@ -134,7 +134,7 @@ class UniFiController:
         # Config entry option with list of clients to control network access.
         self.option_block_clients = options.get(CONF_BLOCK_CLIENT, [])
         # Config entry option to control DPI restriction groups.
-        self.option_dpi_restrictions = options.get(
+        self.option_dpi_restrictions: bool = options.get(
             CONF_DPI_RESTRICTIONS, DEFAULT_DPI_RESTRICTIONS
         )
 

--- a/homeassistant/components/unifi/controller.py
+++ b/homeassistant/components/unifi/controller.py
@@ -115,7 +115,7 @@ class UniFiController:
             CONF_TRACK_WIRED_CLIENTS, DEFAULT_TRACK_WIRED_CLIENTS
         )
         # Config entry option to not track devices.
-        self.option_track_devices = options.get(
+        self.option_track_devices: bool = options.get(
             CONF_TRACK_DEVICES, DEFAULT_TRACK_DEVICES
         )
         # Config entry option listing what SSIDs are being used to track clients.

--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -19,7 +19,7 @@ from aiounifi.models.event import Event, EventKey
 
 from homeassistant.components.device_tracker import ScannerEntity, SourceType
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import Event as core_Event, HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 import homeassistant.util.dt as dt_util
@@ -268,7 +268,7 @@ class UnifiScannerEntity(UnifiEntity[HandlerT, ApiItemT], ScannerEntity):
         return self._attr_unique_id
 
     @callback
-    def _make_disconnected(self, *_) -> None:
+    def _make_disconnected(self, *_: core_Event) -> None:
         """No heart beat by device."""
         self._is_connected = False
         self.async_write_ha_state()

--- a/homeassistant/components/unifi/manifest.json
+++ b/homeassistant/components/unifi/manifest.json
@@ -8,7 +8,7 @@
   "iot_class": "local_push",
   "loggers": ["aiounifi"],
   "quality_scale": "platinum",
-  "requirements": ["aiounifi==45"],
+  "requirements": ["aiounifi==46"],
   "ssdp": [
     {
       "manufacturer": "Ubiquiti Networks",

--- a/homeassistant/components/unifi/switch.py
+++ b/homeassistant/components/unifi/switch.py
@@ -247,8 +247,9 @@ async def async_setup_entry(
 
     for mac in controller.option_block_clients:
         if mac not in controller.api.clients and mac in controller.api.clients_all:
-            client = controller.api.clients_all[mac]
-            controller.api.clients.process_raw([client.raw])
+            controller.api.clients.process_raw(
+                [dict(controller.api.clients_all[mac].raw)]
+            )
 
     controller.register_platform_add_entities(
         UnifiSwitchEntity, ENTITY_DESCRIPTIONS, async_add_entities

--- a/mypy.ini
+++ b/mypy.ini
@@ -2903,6 +2903,16 @@ disallow_untyped_defs = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.unifi.switch]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.unifi.update]
 check_untyped_defs = true
 disallow_incomplete_defs = true

--- a/mypy.ini
+++ b/mypy.ini
@@ -2873,6 +2873,16 @@ disallow_untyped_defs = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.unifi.controller]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.unifi.update]
 check_untyped_defs = true
 disallow_incomplete_defs = true

--- a/mypy.ini
+++ b/mypy.ini
@@ -2903,6 +2903,16 @@ disallow_untyped_defs = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.unifi.device_tracker]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.unifi.sensor]
 check_untyped_defs = true
 disallow_incomplete_defs = true

--- a/mypy.ini
+++ b/mypy.ini
@@ -2873,6 +2873,16 @@ disallow_untyped_defs = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.unifi]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.unifi.controller]
 check_untyped_defs = true
 disallow_incomplete_defs = true

--- a/mypy.ini
+++ b/mypy.ini
@@ -2883,6 +2883,16 @@ disallow_untyped_defs = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.unifi.config_flow]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.unifi.controller]
 check_untyped_defs = true
 disallow_incomplete_defs = true

--- a/mypy.ini
+++ b/mypy.ini
@@ -2873,67 +2873,7 @@ disallow_untyped_defs = true
 warn_return_any = true
 warn_unreachable = true
 
-[mypy-homeassistant.components.unifi]
-check_untyped_defs = true
-disallow_incomplete_defs = true
-disallow_subclassing_any = true
-disallow_untyped_calls = true
-disallow_untyped_decorators = true
-disallow_untyped_defs = true
-warn_return_any = true
-warn_unreachable = true
-
-[mypy-homeassistant.components.unifi.config_flow]
-check_untyped_defs = true
-disallow_incomplete_defs = true
-disallow_subclassing_any = true
-disallow_untyped_calls = true
-disallow_untyped_decorators = true
-disallow_untyped_defs = true
-warn_return_any = true
-warn_unreachable = true
-
-[mypy-homeassistant.components.unifi.controller]
-check_untyped_defs = true
-disallow_incomplete_defs = true
-disallow_subclassing_any = true
-disallow_untyped_calls = true
-disallow_untyped_decorators = true
-disallow_untyped_defs = true
-warn_return_any = true
-warn_unreachable = true
-
-[mypy-homeassistant.components.unifi.device_tracker]
-check_untyped_defs = true
-disallow_incomplete_defs = true
-disallow_subclassing_any = true
-disallow_untyped_calls = true
-disallow_untyped_decorators = true
-disallow_untyped_defs = true
-warn_return_any = true
-warn_unreachable = true
-
-[mypy-homeassistant.components.unifi.sensor]
-check_untyped_defs = true
-disallow_incomplete_defs = true
-disallow_subclassing_any = true
-disallow_untyped_calls = true
-disallow_untyped_decorators = true
-disallow_untyped_defs = true
-warn_return_any = true
-warn_unreachable = true
-
-[mypy-homeassistant.components.unifi.switch]
-check_untyped_defs = true
-disallow_incomplete_defs = true
-disallow_subclassing_any = true
-disallow_untyped_calls = true
-disallow_untyped_decorators = true
-disallow_untyped_defs = true
-warn_return_any = true
-warn_unreachable = true
-
-[mypy-homeassistant.components.unifi.update]
+[mypy-homeassistant.components.unifi.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true
 disallow_subclassing_any = true

--- a/mypy.ini
+++ b/mypy.ini
@@ -2903,6 +2903,16 @@ disallow_untyped_defs = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.unifi.sensor]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.unifi.switch]
 check_untyped_defs = true
 disallow_incomplete_defs = true

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -291,7 +291,7 @@ aiosyncthing==0.5.1
 aiotractive==0.5.5
 
 # homeassistant.components.unifi
-aiounifi==45
+aiounifi==46
 
 # homeassistant.components.vlc_telnet
 aiovlc==0.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -272,7 +272,7 @@ aiosyncthing==0.5.1
 aiotractive==0.5.5
 
 # homeassistant.components.unifi
-aiounifi==45
+aiounifi==46
 
 # homeassistant.components.vlc_telnet
 aiovlc==0.1.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
After 6 months of work and finally it can be strictly typed 🎉 , not many lines of code has been left untouched in neither library nor integration.
Most changes are spread out in minor areas as main brunt of typing has been handled be earlier refactoring.

Library change is only about simplifying typing of websocket state callback.
https://github.com/Kane610/aiounifi/compare/v45...v46


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
