### PR TITLE
Add "volume_step" parameter to media_player.volume_up/volume_down

### DIFF
--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -284,12 +284,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     )
     component.async_register_entity_service(
         SERVICE_TOGGLE,
-        vol.All(
-            cv.make_entity_service_schema(
-                {vol.Required(ATTR_MEDIA_VOLUME_LEVEL): cv.small_float}
-            ),
-            _rename_keys(volume=ATTR_MEDIA_VOLUME_LEVEL),
-        ),
+        {},
         "async_toggle",
         [MediaPlayerEntityFeature.TURN_OFF | MediaPlayerEntityFeature.TURN_ON],
     )

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -93,6 +93,7 @@ from .const import (  # noqa: F401
     ATTR_MEDIA_TITLE,
     ATTR_MEDIA_TRACK,
     ATTR_MEDIA_VOLUME_LEVEL,
+    ATTR_MEDIA_VOLUME_STEP,
     ATTR_MEDIA_VOLUME_MUTED,
     ATTR_SOUND_MODE,
     ATTR_SOUND_MODE_LIST,
@@ -283,19 +284,34 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     )
     component.async_register_entity_service(
         SERVICE_TOGGLE,
-        {},
+        vol.All(
+            cv.make_entity_service_schema(
+                {vol.Required(ATTR_MEDIA_VOLUME_LEVEL): cv.small_float}
+            ),
+            _rename_keys(volume=ATTR_MEDIA_VOLUME_LEVEL),
+        ),
         "async_toggle",
         [MediaPlayerEntityFeature.TURN_OFF | MediaPlayerEntityFeature.TURN_ON],
     )
     component.async_register_entity_service(
         SERVICE_VOLUME_UP,
-        {},
+        vol.All(
+            cv.make_entity_service_schema(
+                {vol.Optional(ATTR_MEDIA_VOLUME_STEP): cv.small_float, default=0.1}
+            ),
+            _rename_keys(step=ATTR_MEDIA_VOLUME_STEP),
+        ),
         "async_volume_up",
         [MediaPlayerEntityFeature.VOLUME_SET, MediaPlayerEntityFeature.VOLUME_STEP],
     )
     component.async_register_entity_service(
         SERVICE_VOLUME_DOWN,
-        {},
+        vol.All(
+            cv.make_entity_service_schema(
+                {vol.Optional(ATTR_MEDIA_VOLUME_STEP): cv.small_float, default=0.1}
+            ),
+            _rename_keys(step=ATTR_MEDIA_VOLUME_STEP),
+        ),
         "async_volume_down",
         [MediaPlayerEntityFeature.VOLUME_SET, MediaPlayerEntityFeature.VOLUME_STEP],
     )
@@ -932,7 +948,7 @@ class MediaPlayerEntity(Entity):
         else:
             await self.async_turn_off()
 
-    async def async_volume_up(self) -> None:
+    async def async_volume_up(self, step: float) -> None:
         """Turn volume up for media player.
 
         This method is a coroutine.
@@ -946,9 +962,9 @@ class MediaPlayerEntity(Entity):
             and self.volume_level < 1
             and self.supported_features & MediaPlayerEntityFeature.VOLUME_SET
         ):
-            await self.async_set_volume_level(min(1, self.volume_level + 0.1))
+            await self.async_set_volume_level(min(1, self.volume_level + step))
 
-    async def async_volume_down(self) -> None:
+    async def async_volume_down(self, step: float) -> None:
         """Turn volume down for media player.
 
         This method is a coroutine.
@@ -962,7 +978,7 @@ class MediaPlayerEntity(Entity):
             and self.volume_level > 0
             and self.supported_features & MediaPlayerEntityFeature.VOLUME_SET
         ):
-            await self.async_set_volume_level(max(0, self.volume_level - 0.1))
+            await self.async_set_volume_level(max(0, self.volume_level - step))
 
     async def async_media_play_pause(self) -> None:
         """Play or pause the media player."""

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -93,8 +93,8 @@ from .const import (  # noqa: F401
     ATTR_MEDIA_TITLE,
     ATTR_MEDIA_TRACK,
     ATTR_MEDIA_VOLUME_LEVEL,
-    ATTR_MEDIA_VOLUME_STEP,
     ATTR_MEDIA_VOLUME_MUTED,
+    ATTR_MEDIA_VOLUME_STEP,
     ATTR_SOUND_MODE,
     ATTR_SOUND_MODE_LIST,
     CONTENT_AUTH_EXPIRY_TIME,
@@ -292,7 +292,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         SERVICE_VOLUME_UP,
         vol.All(
             cv.make_entity_service_schema(
-                {vol.Optional(ATTR_MEDIA_VOLUME_STEP): cv.small_float, default=0.1}
+                {vol.Optional(ATTR_MEDIA_VOLUME_STEP, default=0.1): cv.small_float}
             ),
             _rename_keys(step=ATTR_MEDIA_VOLUME_STEP),
         ),
@@ -303,7 +303,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         SERVICE_VOLUME_DOWN,
         vol.All(
             cv.make_entity_service_schema(
-                {vol.Optional(ATTR_MEDIA_VOLUME_STEP): cv.small_float, default=0.1}
+                {vol.Optional(ATTR_MEDIA_VOLUME_STEP, default=0.1): cv.small_float}
             ),
             _rename_keys(step=ATTR_MEDIA_VOLUME_STEP),
         ),

--- a/homeassistant/components/media_player/const.py
+++ b/homeassistant/components/media_player/const.py
@@ -35,6 +35,7 @@ ATTR_MEDIA_TITLE = "media_title"
 ATTR_MEDIA_TRACK = "media_track"
 ATTR_MEDIA_VOLUME_LEVEL = "volume_level"
 ATTR_MEDIA_VOLUME_MUTED = "is_volume_muted"
+ATTR_MEDIA_VOLUME_STEP = "volume_step"
 ATTR_SOUND_MODE = "sound_mode"
 ATTR_SOUND_MODE_LIST = "sound_mode_list"
 

--- a/tests/components/media_player/common.py
+++ b/tests/components/media_player/common.py
@@ -11,6 +11,7 @@ from homeassistant.components.media_player import (
     ATTR_MEDIA_SEEK_POSITION,
     ATTR_MEDIA_VOLUME_LEVEL,
     ATTR_MEDIA_VOLUME_MUTED,
+    ATTR_MEDIA_VOLUME_STEP,
     DOMAIN,
     SERVICE_CLEAR_PLAYLIST,
     SERVICE_PLAY_MEDIA,
@@ -73,28 +74,36 @@ def toggle(hass, entity_id=ENTITY_MATCH_ALL):
     hass.add_job(async_toggle, hass, entity_id)
 
 
-async def async_volume_up(hass, entity_id=ENTITY_MATCH_ALL):
+async def async_volume_up(hass, step, entity_id=ENTITY_MATCH_ALL):
     """Send the media player the command for volume up."""
     data = {ATTR_ENTITY_ID: entity_id} if entity_id else {}
+
+    if step:
+        data[ATTR_MEDIA_VOLUME_STEP] = step
+
     await hass.services.async_call(DOMAIN, SERVICE_VOLUME_UP, data, blocking=True)
 
 
 @bind_hass
-def volume_up(hass, entity_id=ENTITY_MATCH_ALL):
+def volume_up(hass, step, entity_id=ENTITY_MATCH_ALL):
     """Send the media player the command for volume up."""
-    hass.add_job(async_volume_up, hass, entity_id)
+    hass.add_job(async_volume_up, hass, step, entity_id)
 
 
-async def async_volume_down(hass, entity_id=ENTITY_MATCH_ALL):
+async def async_volume_down(hass, step, entity_id=ENTITY_MATCH_ALL):
     """Send the media player the command for volume down."""
     data = {ATTR_ENTITY_ID: entity_id} if entity_id else {}
+
+    if step:
+        data[ATTR_MEDIA_VOLUME_STEP] = step
+
     await hass.services.async_call(DOMAIN, SERVICE_VOLUME_DOWN, data, blocking=True)
 
 
 @bind_hass
-def volume_down(hass, entity_id=ENTITY_MATCH_ALL):
+def volume_down(hass, step, entity_id=ENTITY_MATCH_ALL):
     """Send the media player the command for volume down."""
-    hass.add_job(async_volume_down, hass, entity_id)
+    hass.add_job(async_volume_down, hass, step, entity_id)
 
 
 async def async_mute_volume(hass, mute, entity_id=ENTITY_MATCH_ALL):

--- a/tests/components/media_player/test_async_helpers.py
+++ b/tests/components/media_player/test_async_helpers.py
@@ -47,15 +47,15 @@ class ExtendedMediaPlayer(mp.MediaPlayerEntity):
         """Set volume level, range 0..1."""
         self._volume = volume
 
-    def volume_up(self):
+    def volume_up(self, step):
         """Turn volume up for media player."""
         if self.volume_level < 1:
-            self.set_volume_level(min(1, self.volume_level + 0.1))
+            self.set_volume_level(min(1, self.volume_level + step))
 
-    def volume_down(self):
+    def volume_down(self, step):
         """Turn volume down for media player."""
         if self.volume_level > 0:
-            self.set_volume_level(max(0, self.volume_level - 0.1))
+            self.set_volume_level(max(0, self.volume_level - step))
 
     def media_play(self):
         """Play the media player."""
@@ -159,8 +159,8 @@ async def test_volume_up(player) -> None:
     assert player.volume_level == 0
     await player.async_set_volume_level(0.5)
     assert player.volume_level == 0.5
-    await player.async_volume_up()
-    assert player.volume_level == 0.6
+    await player.async_volume_up(0.01)
+    assert player.volume_level == 0.51
 
 
 async def test_volume_down(player) -> None:
@@ -168,8 +168,8 @@ async def test_volume_down(player) -> None:
     assert player.volume_level == 0
     await player.async_set_volume_level(0.5)
     assert player.volume_level == 0.5
-    await player.async_volume_down()
-    assert player.volume_level == 0.4
+    await player.async_volume_down(0.01)
+    assert player.volume_level == 0.39
 
 
 async def test_media_play_pause(player) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change adds the ability to set the volume step amount percentage for media_player.volume_up and media_player.volume_down service calls.

Some media_player entities will have major volume changes with the currently hardcoded 10% value.
This adds some flexibility by allowing it to be customized.

I tested this on a local build in the developer console, with an Anthem AV receiver, that I observed stepping at a lower percentage value than the hardcoded one.

I'll note that it would also need some updates to frontend to add a value slider for the parameter (similar to media_player.volume_set's volume_level parameter)

|Example use|
|-|
|<img width="525" alt="Screenshot 2023-03-25 at 9 32 21 PM" src="https://user-images.githubusercontent.com/379485/227750505-8dc50139-db27-4294-8e0b-49e87507714b.png">|


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Architecture discussion: https://github.com/home-assistant/architecture/discussions/891

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
