### PR TITLE
Multi-device support for vicare

### DIFF
--- a/homeassistant/components/vicare/__init__.py
+++ b/homeassistant/components/vicare/__init__.py
@@ -10,19 +10,12 @@ from PyViCare.PyViCareDevice import Device
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_CLIENT_ID, CONF_PASSWORD, CONF_USERNAME
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.storage import STORAGE_DIR
 
-from .const import (
-    CONF_HEATING_TYPE,
-    DEFAULT_SCAN_INTERVAL,
-    DOMAIN,
-    HEATING_TYPE_TO_CREATOR_METHOD,
-    PLATFORMS,
-    VICARE_API,
-    VICARE_DEVICE_CONFIG,
-    HeatingType,
-)
+from .const import DEFAULT_SCAN_INTERVAL, DOMAIN, PLATFORMS, VICARE_DEVICE_CONFIG
+from .helpers import get_unique_device_id
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -42,6 +35,60 @@ class ViCareRequiredKeysMixinWithSet:
     value_setter: Callable[[Device], bool]
 
 
+async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    """Migrate old entry."""
+    _LOGGER.debug("Migrating from version %s", config_entry.version)
+
+    _LOGGER.info("Migration to version %s successful", config_entry.version)
+
+    return True
+
+
+async def _async_migrate_entries(
+    hass: HomeAssistant, config_entry: ConfigEntry
+) -> bool:
+    """Migrate old entry."""
+    _LOGGER.debug("Migrating from version %s", config_entry.version)
+    entity_registry = er.async_get(hass)
+
+    if config_entry.version == 1:
+        devices = hass.data[DOMAIN][config_entry.entry_id][VICARE_DEVICE_CONFIG]
+        if devices is None or len(devices) == 0:
+            return True
+
+        @callback
+        def update_unique_id(entry: er.RegistryEntry) -> dict[str, str] | None:
+            new_unique_id = entry.unique_id.replace(
+                f"{devices[0].getConfig().serial}-",
+                f"{get_unique_device_id(devices[0])}-",
+            )
+            _LOGGER.debug(
+                "Migrating entity '%s' unique_id from '%s' to '%s'",
+                entry.entity_id,
+                entry.unique_id,
+                new_unique_id,
+            )
+            if existing_entity_id := entity_registry.async_get_entity_id(
+                entry.domain, entry.platform, new_unique_id
+            ):
+                _LOGGER.warning(
+                    "Cannot migrate to unique_id '%s', already exists for '%s'",
+                    new_unique_id,
+                    existing_entity_id,
+                )
+                return None
+            return {
+                "new_unique_id": new_unique_id,
+            }
+
+        await er.async_migrate_entries(hass, config_entry.entry_id, update_unique_id)
+        config_entry.version = 2
+
+        return True
+
+    return True
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up from config entry."""
     _LOGGER.debug("Setting up ViCare component")
@@ -50,6 +97,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data[DOMAIN][entry.entry_id] = {}
 
     await hass.async_add_executor_job(setup_vicare_api, hass, entry)
+
+    await _async_migrate_entries(hass, entry)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
@@ -78,13 +127,10 @@ def setup_vicare_api(hass, entry):
             "Found device: %s (online: %s)", device.getModel(), str(device.isOnline())
         )
 
-    # Currently we only support a single device
-    device = vicare_api.devices[0]
-    hass.data[DOMAIN][entry.entry_id][VICARE_DEVICE_CONFIG] = device
-    hass.data[DOMAIN][entry.entry_id][VICARE_API] = getattr(
-        device,
-        HEATING_TYPE_TO_CREATOR_METHOD[HeatingType(entry.data[CONF_HEATING_TYPE])],
-    )()
+    # Readjust scan interval: each device has its own API endpoint
+    vicare_api.setCacheDuration(DEFAULT_SCAN_INTERVAL * len(vicare_api.devices))
+
+    hass.data[DOMAIN][entry.entry_id][VICARE_DEVICE_CONFIG] = vicare_api.devices
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/vicare/binary_sensor.py
+++ b/homeassistant/components/vicare/binary_sensor.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 import logging
 
 from PyViCare.PyViCareUtils import (
+    PyViCareInternalServerError,
     PyViCareInvalidDataError,
     PyViCareNotSupportedFeatureError,
     PyViCareRateLimitError,
@@ -23,7 +24,8 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import ViCareRequiredKeysMixin
-from .const import DOMAIN, VICARE_API, VICARE_DEVICE_CONFIG, VICARE_NAME
+from .const import DOMAIN, VICARE_DEVICE_CONFIG, VICARE_NAME
+from .helpers import get_device_name, get_unique_device_id, get_unique_id
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -101,6 +103,11 @@ def _build_entity(name, vicare_api, device_config, sensor):
     try:
         sensor.value_getter(vicare_api)
         _LOGGER.debug("Found entity %s", name)
+    except PyViCareInternalServerError as server_error:
+        _LOGGER.info(
+            "Server error ( %s): Not creating entity %s", server_error.message, name
+        )
+        return None
     except PyViCareNotSupportedFeatureError:
         _LOGGER.info("Feature not supported %s", name)
         return None
@@ -116,8 +123,8 @@ def _build_entity(name, vicare_api, device_config, sensor):
     )
 
 
-async def _entities_from_descriptions(
-    hass, name, entities, sensor_descriptions, iterables, config_entry
+def _entities_from_descriptions(
+    hass, name, entities, sensor_descriptions, iterables, config_entry, device
 ):
     """Create entities from descriptions and list of burners/circuits."""
     for description in sensor_descriptions:
@@ -125,11 +132,10 @@ async def _entities_from_descriptions(
             suffix = ""
             if len(iterables) > 1:
                 suffix = f" {current.id}"
-            entity = await hass.async_add_executor_job(
-                _build_entity,
+            entity = _build_entity(
                 f"{name} {description.name}{suffix}",
                 current,
-                hass.data[DOMAIN][config_entry.entry_id][VICARE_DEVICE_CONFIG],
+                device,
                 description,
             )
             if entity is not None:
@@ -142,44 +148,58 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Create the ViCare binary sensor devices."""
-    name = VICARE_NAME
-    api = hass.data[DOMAIN][config_entry.entry_id][VICARE_API]
-
-    entities = []
-
-    for description in GLOBAL_SENSORS:
-        entity = await hass.async_add_executor_job(
-            _build_entity,
-            f"{name} {description.name}",
-            api,
-            hass.data[DOMAIN][config_entry.entry_id][VICARE_DEVICE_CONFIG],
-            description,
-        )
-        if entity is not None:
-            entities.append(entity)
-
-    try:
-        await _entities_from_descriptions(
-            hass, name, entities, CIRCUIT_SENSORS, api.circuits, config_entry
-        )
-    except PyViCareNotSupportedFeatureError:
-        _LOGGER.info("No circuits found")
-
-    try:
-        await _entities_from_descriptions(
-            hass, name, entities, BURNER_SENSORS, api.burners, config_entry
-        )
-    except PyViCareNotSupportedFeatureError:
-        _LOGGER.info("No burners found")
-
-    try:
-        await _entities_from_descriptions(
-            hass, name, entities, COMPRESSOR_SENSORS, api.compressors, config_entry
-        )
-    except PyViCareNotSupportedFeatureError:
-        _LOGGER.info("No compressors found")
-
+    entities = await hass.async_add_executor_job(
+        create_all_entities, hass, config_entry
+    )
     async_add_entities(entities)
+
+
+def create_all_entities(hass: HomeAssistant, config_entry: ConfigEntry):
+    """Create entities for all devices and their circuits, burners or compressors if applicable."""
+    name = VICARE_NAME
+    entities: list[ViCareBinarySensor] = []
+
+    for device in hass.data[DOMAIN][config_entry.entry_id][VICARE_DEVICE_CONFIG]:
+        api = device.asAutoDetectDevice()
+
+        _entities_from_descriptions(
+            hass, name, entities, GLOBAL_SENSORS, [api], config_entry, device
+        )
+
+        try:
+            _entities_from_descriptions(
+                hass,
+                name,
+                entities,
+                CIRCUIT_SENSORS,
+                api.circuits,
+                config_entry,
+                device,
+            )
+        except PyViCareNotSupportedFeatureError:
+            _LOGGER.info("No circuits found")
+
+        try:
+            _entities_from_descriptions(
+                hass, name, entities, BURNER_SENSORS, api.burners, config_entry, device
+            )
+        except PyViCareNotSupportedFeatureError:
+            _LOGGER.info("No burners found")
+
+        try:
+            _entities_from_descriptions(
+                hass,
+                name,
+                entities,
+                COMPRESSOR_SENSORS,
+                api.compressors,
+                config_entry,
+                device,
+            )
+        except PyViCareNotSupportedFeatureError:
+            _LOGGER.info("No compressors found")
+
+    return entities
 
 
 class ViCareBinarySensor(BinarySensorEntity):
@@ -202,8 +222,13 @@ class ViCareBinarySensor(BinarySensorEntity):
     def device_info(self) -> DeviceInfo:
         """Return device info for this device."""
         return DeviceInfo(
-            identifiers={(DOMAIN, self._device_config.getConfig().serial)},
-            name=self._device_config.getModel(),
+            identifiers={
+                (
+                    DOMAIN,
+                    get_unique_device_id(self._device_config),
+                )
+            },
+            name=get_device_name(self._device_config),
             manufacturer="Viessmann",
             model=self._device_config.getModel(),
             configuration_url="https://developer.viessmann.com/",
@@ -217,12 +242,9 @@ class ViCareBinarySensor(BinarySensorEntity):
     @property
     def unique_id(self) -> str:
         """Return unique ID for this device."""
-        tmp_id = (
-            f"{self._device_config.getConfig().serial}-{self.entity_description.key}"
+        return get_unique_id(
+            self._api, self._device_config, self.entity_description.key
         )
-        if hasattr(self._api, "id"):
-            return f"{tmp_id}-{self._api.id}"
-        return tmp_id
 
     @property
     def is_on(self):

--- a/homeassistant/components/vicare/climate.py
+++ b/homeassistant/components/vicare/climate.py
@@ -36,13 +36,8 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import (
-    CONF_HEATING_TYPE,
-    DOMAIN,
-    VICARE_API,
-    VICARE_DEVICE_CONFIG,
-    VICARE_NAME,
-)
+from .const import DOMAIN, VICARE_DEVICE_CONFIG, VICARE_NAME
+from .helpers import get_device_name, get_unique_device_id, get_unique_id
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -113,22 +108,23 @@ async def async_setup_entry(
     """Set up the ViCare climate platform."""
     name = VICARE_NAME
     entities = []
-    api = hass.data[DOMAIN][config_entry.entry_id][VICARE_API]
-    circuits = await hass.async_add_executor_job(_get_circuits, api)
 
-    for circuit in circuits:
-        suffix = ""
-        if len(circuits) > 1:
-            suffix = f" {circuit.id}"
+    for device in hass.data[DOMAIN][config_entry.entry_id][VICARE_DEVICE_CONFIG]:
+        api = device.asAutoDetectDevice()
 
-        entity = ViCareClimate(
-            f"{name} Heating{suffix}",
-            api,
-            circuit,
-            hass.data[DOMAIN][config_entry.entry_id][VICARE_DEVICE_CONFIG],
-            config_entry.data[CONF_HEATING_TYPE],
-        )
-        entities.append(entity)
+        circuits = await hass.async_add_executor_job(_get_circuits, api)
+        for circuit in circuits:
+            suffix = ""
+            if len(circuits) > 1:
+                suffix = f" {circuit.id}"
+
+            entity = ViCareClimate(
+                f"{name} Heating{suffix}",
+                api,
+                circuit,
+                device,
+            )
+            entities.append(entity)
 
     platform = entity_platform.async_get_current_platform()
 
@@ -150,7 +146,7 @@ class ViCareClimate(ClimateEntity):
     )
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
 
-    def __init__(self, name, api, circuit, device_config, heating_type):
+    def __init__(self, name, api, circuit, device_config):
         """Initialize the climate device."""
         self._name = name
         self._state = None
@@ -162,20 +158,24 @@ class ViCareClimate(ClimateEntity):
         self._current_mode = None
         self._current_temperature = None
         self._current_program = None
-        self._heating_type = heating_type
         self._current_action = None
 
     @property
     def unique_id(self) -> str:
         """Return unique ID for this device."""
-        return f"{self._device_config.getConfig().serial}-{self._circuit.id}"
+        return get_unique_id(self._api, self._device_config, self._circuit.id)
 
     @property
     def device_info(self) -> DeviceInfo:
         """Return device info for this device."""
         return DeviceInfo(
-            identifiers={(DOMAIN, self._device_config.getConfig().serial)},
-            name=self._device_config.getModel(),
+            identifiers={
+                (
+                    DOMAIN,
+                    get_unique_device_id(self._device_config),
+                )
+            },
+            name=get_device_name(self._device_config),
             manufacturer="Viessmann",
             model=self._device_config.getModel(),
             configuration_url="https://developer.viessmann.com/",

--- a/homeassistant/components/vicare/config_flow.py
+++ b/homeassistant/components/vicare/config_flow.py
@@ -15,13 +15,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.device_registry import format_mac
 
 from . import vicare_login
-from .const import (
-    CONF_HEATING_TYPE,
-    DEFAULT_HEATING_TYPE,
-    DOMAIN,
-    VICARE_NAME,
-    HeatingType,
-)
+from .const import DOMAIN, VICARE_NAME
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,7 +23,7 @@ _LOGGER = logging.getLogger(__name__)
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for ViCare."""
 
-    VERSION = 1
+    VERSION = 2
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -42,9 +36,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             vol.Required(CONF_USERNAME): cv.string,
             vol.Required(CONF_PASSWORD): cv.string,
             vol.Required(CONF_CLIENT_ID): cv.string,
-            vol.Required(CONF_HEATING_TYPE, default=DEFAULT_HEATING_TYPE.value): vol.In(
-                [e.value for e in HeatingType]
-            ),
         }
         errors: dict[str, str] = {}
 
@@ -53,9 +44,13 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 await self.hass.async_add_executor_job(
                     vicare_login, self.hass, user_input
                 )
+                _LOGGER.info("XXX ok")
             except PyViCareInvalidCredentialsError:
                 errors["base"] = "invalid_auth"
+                _LOGGER.info("XXX abort")
+                return self.async_abort(reason="invalid_auth")
             else:
+                _LOGGER.info("XXX else")
                 return self.async_create_entry(title=VICARE_NAME, data=user_input)
 
         return self.async_show_form(

--- a/homeassistant/components/vicare/config_flow.py
+++ b/homeassistant/components/vicare/config_flow.py
@@ -49,9 +49,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors["base"] = "invalid_auth"
                 _LOGGER.info("XXX abort")
                 return self.async_abort(reason="invalid_auth")
-            else:
-                _LOGGER.info("XXX else")
-                return self.async_create_entry(title=VICARE_NAME, data=user_input)
+            _LOGGER.info("XXX else")
+            return self.async_create_entry(title=VICARE_NAME, data=user_input)
 
         return self.async_show_form(
             step_id="user",

--- a/homeassistant/components/vicare/const.py
+++ b/homeassistant/components/vicare/const.py
@@ -1,6 +1,7 @@
 """Constants for the ViCare integration."""
 import enum
 
+from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.const import Platform, UnitOfEnergy, UnitOfVolume
 
 DOMAIN = "vicare"
@@ -18,13 +19,16 @@ VICARE_API = "api"
 VICARE_NAME = "ViCare"
 
 CONF_CIRCUIT = "circuit"
-CONF_HEATING_TYPE = "heating_type"
 
 DEFAULT_SCAN_INTERVAL = 60
 
 VICARE_CUBIC_METER = "cubicMeter"
 VICARE_KWH = "kilowattHour"
 
+VICARE_UNIT_TO_DEVICE_CLASS = {
+    VICARE_KWH: SensorDeviceClass.ENERGY,
+    VICARE_CUBIC_METER: SensorDeviceClass.GAS,
+}
 
 VICARE_UNIT_TO_UNIT_OF_MEASUREMENT = {
     VICARE_KWH: UnitOfEnergy.KILO_WATT_HOUR,
@@ -45,13 +49,3 @@ class HeatingType(enum.Enum):
 
 
 DEFAULT_HEATING_TYPE = HeatingType.auto
-
-HEATING_TYPE_TO_CREATOR_METHOD = {
-    HeatingType.auto: "asAutoDetectDevice",
-    HeatingType.gas: "asGazBoiler",
-    HeatingType.fuelcell: "asFuelCell",
-    HeatingType.heatpump: "asHeatPump",
-    HeatingType.oil: "asOilBoiler",
-    HeatingType.pellets: "asPelletsBoiler",
-    HeatingType.hybrid: "asHybridDevice",
-}

--- a/homeassistant/components/vicare/diagnostics.py
+++ b/homeassistant/components/vicare/diagnostics.py
@@ -10,6 +10,7 @@ from homeassistant.const import CONF_CLIENT_ID, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN, VICARE_DEVICE_CONFIG
+from .helpers import get_unique_device_id
 
 TO_REDACT = {CONF_CLIENT_ID, CONF_PASSWORD, CONF_USERNAME}
 
@@ -18,12 +19,18 @@ async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, entry: ConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    # Currently we only support a single device
-    device = hass.data[DOMAIN][entry.entry_id][VICARE_DEVICE_CONFIG]
-    data: dict[str, Any] = json.loads(
-        await hass.async_add_executor_job(device.dump_secure)
-    )
+    device_dumps = await hass.async_add_executor_job(dump_device_state, hass, entry)
+
     return {
         "entry": async_redact_data(entry.as_dict(), TO_REDACT),
-        "data": data,
+        "data": device_dumps,
     }
+
+
+def dump_device_state(hass: HomeAssistant, entry: ConfigEntry):
+    """Dump devices state to dict."""
+    devices = hass.data[DOMAIN][entry.entry_id][VICARE_DEVICE_CONFIG]
+    device_dumps = dict[str, Any]()
+    for device in devices:
+        device_dumps[get_unique_device_id(device)] = json.loads(device.dump_secure())
+    return device_dumps

--- a/homeassistant/components/vicare/helpers.py
+++ b/homeassistant/components/vicare/helpers.py
@@ -1,0 +1,19 @@
+"""Helpers for ViCare."""
+
+
+def get_unique_id(api, device_config, entity_id) -> str:
+    """Return unique ID for this entity."""
+    tmp_id = f"{get_unique_device_id(device_config)}-{entity_id}"
+    if hasattr(api, "id"):
+        return f"{tmp_id}-{api.id}"
+    return tmp_id
+
+
+def get_unique_device_id(device_config) -> str:
+    """Return unique ID for this device."""
+    return f"{device_config.getConfig().id}-{device_config.getConfig().serial}-{device_config.getConfig().device_id}"
+
+
+def get_device_name(device_config) -> str:
+    """Return name for this device."""
+    return f"{device_config.getModel()}-{device_config.getConfig().id}-{device_config.getConfig().device_id}"

--- a/homeassistant/components/vicare/manifest.json
+++ b/homeassistant/components/vicare/manifest.json
@@ -11,5 +11,5 @@
   "documentation": "https://www.home-assistant.io/integrations/vicare",
   "iot_class": "cloud_polling",
   "loggers": ["PyViCare"],
-  "requirements": ["PyViCare==2.21.0"]
+  "requirements": ["PyViCare==2.25.0"]
 }

--- a/homeassistant/components/vicare/sensor.py
+++ b/homeassistant/components/vicare/sensor.py
@@ -8,6 +8,7 @@ import logging
 
 from PyViCare.PyViCareDevice import Device
 from PyViCare.PyViCareUtils import (
+    PyViCareInternalServerError,
     PyViCareInvalidDataError,
     PyViCareNotSupportedFeatureError,
     PyViCareRateLimitError,
@@ -36,20 +37,14 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from . import ViCareRequiredKeysMixin
 from .const import (
     DOMAIN,
-    VICARE_API,
-    VICARE_CUBIC_METER,
     VICARE_DEVICE_CONFIG,
-    VICARE_KWH,
     VICARE_NAME,
+    VICARE_UNIT_TO_DEVICE_CLASS,
     VICARE_UNIT_TO_UNIT_OF_MEASUREMENT,
 )
+from .helpers import get_device_name, get_unique_device_id, get_unique_id
 
 _LOGGER = logging.getLogger(__name__)
-
-VICARE_UNIT_TO_DEVICE_CLASS = {
-    VICARE_KWH: SensorDeviceClass.ENERGY,
-    VICARE_CUBIC_METER: SensorDeviceClass.GAS,
-}
 
 
 @dataclass
@@ -454,7 +449,7 @@ GLOBAL_SENSORS: tuple[ViCareSensorEntityDescription, ...] = (
     ),
     ViCareSensorEntityDescription(
         key="buffer top temperature",
-        name="Buffer top temperature",
+        name="Buffer Top Temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         value_getter=lambda api: api.getBufferTopTemperature(),
         device_class=SensorDeviceClass.TEMPERATURE,
@@ -462,7 +457,7 @@ GLOBAL_SENSORS: tuple[ViCareSensorEntityDescription, ...] = (
     ),
     ViCareSensorEntityDescription(
         key="buffer main temperature",
-        name="Buffer main temperature",
+        name="Buffer Main Temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         value_getter=lambda api: api.getBufferMainTemperature(),
         device_class=SensorDeviceClass.TEMPERATURE,
@@ -568,10 +563,14 @@ COMPRESSOR_SENSORS: tuple[ViCareSensorEntityDescription, ...] = (
 
 def _build_entity(name, vicare_api, device_config, sensor):
     """Create a ViCare sensor entity."""
-    _LOGGER.debug("Found device %s", name)
     try:
         sensor.value_getter(vicare_api)
         _LOGGER.debug("Found entity %s", name)
+    except PyViCareInternalServerError as server_error:
+        _LOGGER.info(
+            "Server error ( %s): Not creating entity %s", server_error.message, name
+        )
+        return None
     except PyViCareNotSupportedFeatureError:
         _LOGGER.info("Feature not supported %s", name)
         return None
@@ -587,8 +586,8 @@ def _build_entity(name, vicare_api, device_config, sensor):
     )
 
 
-async def _entities_from_descriptions(
-    hass, name, entities, sensor_descriptions, iterables, config_entry
+def _entities_from_descriptions(
+    hass, name, entities, sensor_descriptions, iterables, config_entry, device
 ):
     """Create entities from descriptions and list of burners/circuits."""
     for description in sensor_descriptions:
@@ -596,11 +595,10 @@ async def _entities_from_descriptions(
             suffix = ""
             if len(iterables) > 1:
                 suffix = f" {current.id}"
-            entity = await hass.async_add_executor_job(
-                _build_entity,
+            entity = _build_entity(
                 f"{name} {description.name}{suffix}",
                 current,
-                hass.data[DOMAIN][config_entry.entry_id][VICARE_DEVICE_CONFIG],
+                device,
                 description,
             )
             if entity is not None:
@@ -613,43 +611,58 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Create the ViCare sensor devices."""
-    name = VICARE_NAME
-    api = hass.data[DOMAIN][config_entry.entry_id][VICARE_API]
-
-    entities = []
-    for description in GLOBAL_SENSORS:
-        entity = await hass.async_add_executor_job(
-            _build_entity,
-            f"{name} {description.name}",
-            api,
-            hass.data[DOMAIN][config_entry.entry_id][VICARE_DEVICE_CONFIG],
-            description,
-        )
-        if entity is not None:
-            entities.append(entity)
-
-    try:
-        await _entities_from_descriptions(
-            hass, name, entities, CIRCUIT_SENSORS, api.circuits, config_entry
-        )
-    except PyViCareNotSupportedFeatureError:
-        _LOGGER.info("No circuits found")
-
-    try:
-        await _entities_from_descriptions(
-            hass, name, entities, BURNER_SENSORS, api.burners, config_entry
-        )
-    except PyViCareNotSupportedFeatureError:
-        _LOGGER.info("No burners found")
-
-    try:
-        await _entities_from_descriptions(
-            hass, name, entities, COMPRESSOR_SENSORS, api.compressors, config_entry
-        )
-    except PyViCareNotSupportedFeatureError:
-        _LOGGER.info("No compressors found")
-
+    entities = await hass.async_add_executor_job(
+        create_all_entities, hass, config_entry
+    )
     async_add_entities(entities)
+
+
+def create_all_entities(hass: HomeAssistant, config_entry: ConfigEntry):
+    """Create entities for all devices and their circuits, burners or compressors if applicable."""
+    name = VICARE_NAME
+    entities: list[ViCareSensor] = []
+
+    for device in hass.data[DOMAIN][config_entry.entry_id][VICARE_DEVICE_CONFIG]:
+        api = device.asAutoDetectDevice()
+
+        _entities_from_descriptions(
+            hass, name, entities, GLOBAL_SENSORS, [api], config_entry, device
+        )
+
+        try:
+            _entities_from_descriptions(
+                hass,
+                name,
+                entities,
+                CIRCUIT_SENSORS,
+                api.circuits,
+                config_entry,
+                device,
+            )
+        except PyViCareNotSupportedFeatureError:
+            _LOGGER.info("No circuits found")
+
+        try:
+            _entities_from_descriptions(
+                hass, name, entities, BURNER_SENSORS, api.burners, config_entry, device
+            )
+        except PyViCareNotSupportedFeatureError:
+            _LOGGER.info("No burners found")
+
+        try:
+            _entities_from_descriptions(
+                hass,
+                name,
+                entities,
+                COMPRESSOR_SENSORS,
+                api.compressors,
+                config_entry,
+                device,
+            )
+        except PyViCareNotSupportedFeatureError:
+            _LOGGER.info("No compressors found")
+
+    return entities
 
 
 class ViCareSensor(SensorEntity):
@@ -671,8 +684,13 @@ class ViCareSensor(SensorEntity):
     def device_info(self) -> DeviceInfo:
         """Return device info for this device."""
         return DeviceInfo(
-            identifiers={(DOMAIN, self._device_config.getConfig().serial)},
-            name=self._device_config.getModel(),
+            identifiers={
+                (
+                    DOMAIN,
+                    get_unique_device_id(self._device_config),
+                )
+            },
+            name=get_device_name(self._device_config),
             manufacturer="Viessmann",
             model=self._device_config.getModel(),
             configuration_url="https://developer.viessmann.com/",
@@ -686,12 +704,9 @@ class ViCareSensor(SensorEntity):
     @property
     def unique_id(self) -> str:
         """Return unique ID for this device."""
-        tmp_id = (
-            f"{self._device_config.getConfig().serial}-{self.entity_description.key}"
+        return get_unique_id(
+            self._api, self._device_config, self.entity_description.key
         )
-        if hasattr(self._api, "id"):
-            return f"{tmp_id}-{self._api.id}"
-        return tmp_id
 
     @property
     def native_value(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -50,7 +50,7 @@ PyTransportNSW==0.1.1
 PyTurboJPEG==1.6.7
 
 # homeassistant.components.vicare
-PyViCare==2.21.0
+PyViCare==2.25.0
 
 # homeassistant.components.xiaomi_aqara
 PyXiaomiGateway==0.14.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -46,7 +46,7 @@ PyTransportNSW==0.1.1
 PyTurboJPEG==1.6.7
 
 # homeassistant.components.vicare
-PyViCare==2.21.0
+PyViCare==2.25.0
 
 # homeassistant.components.xiaomi_aqara
 PyXiaomiGateway==0.14.3

--- a/tests/components/vicare/__init__.py
+++ b/tests/components/vicare/__init__.py
@@ -3,14 +3,20 @@ from __future__ import annotations
 
 from typing import Final
 
-from homeassistant.components.vicare.const import CONF_HEATING_TYPE
 from homeassistant.const import CONF_CLIENT_ID, CONF_PASSWORD, CONF_USERNAME
+
+# When running tests with HA Core ViCare:
+MODULE = "homeassistant.components.vicare"
+
+# When running tests with Custom ViCare Integration:
+# MODULE = "custom_components.vicare"
+# sys.modules["tests.common"] = pytest_homeassistant_custom_component.common
+
 
 ENTRY_CONFIG: Final[dict[str, str]] = {
     CONF_USERNAME: "foo@bar.com",
     CONF_PASSWORD: "1234",
     CONF_CLIENT_ID: "5678",
-    CONF_HEATING_TYPE: "auto",
 }
 
 MOCK_MAC = "B874241B7B9"

--- a/tests/components/vicare/conftest.py
+++ b/tests/components/vicare/conftest.py
@@ -28,7 +28,7 @@ from tests.common import MockConfigEntry
 @pytest.fixture(autouse=True)
 def auto_enable_custom_integrations(enable_custom_integrations):
     """Automatically enable loading custom integrations in all tests."""
-    yield
+    return
 
 
 # This fixture is used to prevent HomeAssistant from attempting to create and dismiss persistent
@@ -109,7 +109,6 @@ class ViCareServiceMock:
         """Read a property from a json dump."""
         entities = self.testData["data"]
         value = readFeature(entities, property_name)
-        print("Read: ", property_name, value)
         return value
 
     def setProperty(self, property_name, action, data):

--- a/tests/components/vicare/conftest.py
+++ b/tests/components/vicare/conftest.py
@@ -1,0 +1,204 @@
+"""Fixtures for LaMetric integration tests."""
+from __future__ import annotations
+
+from collections.abc import Generator
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+from PyViCare.PyViCareDeviceConfig import PyViCareDeviceConfig
+from PyViCare.PyViCareService import (
+    ViCareDeviceAccessor,
+    buildSetPropertyUrl,
+    readFeature,
+)
+from PyViCare.PyViCareUtils import PyViCareInvalidCredentialsError
+import pytest
+
+from homeassistant.components.vicare.const import DOMAIN
+from homeassistant.core import HomeAssistant
+
+from . import ENTRY_CONFIG, MODULE
+
+from tests.common import MockConfigEntry
+
+
+# This fixture enables loading custom integrations in all tests.
+# Remove to enable selective use of this fixture
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations(enable_custom_integrations):
+    """Automatically enable loading custom integrations in all tests."""
+    yield
+
+
+# This fixture is used to prevent HomeAssistant from attempting to create and dismiss persistent
+# notifications. These calls would fail without this fixture since the persistent_notification
+# integration is never loaded during a test.
+@pytest.fixture(name="skip_notifications", autouse=True)
+def skip_notifications_fixture():
+    """Skip notification calls."""
+    with patch("homeassistant.components.persistent_notification.async_create"), patch(
+        "homeassistant.components.persistent_notification.async_dismiss"
+    ):
+        yield
+
+
+@pytest.fixture(name="entity_registry_enabled_by_default", autouse=True)
+def entity_registry_enabled_by_default():
+    """Test fixture that ensures all entities are enabled in the registry."""
+    with patch(
+        "homeassistant.helpers.entity.Entity.entity_registry_enabled_default",
+        return_value=True,
+    ) as mock_entity_registry_enabled_by_default:
+        yield mock_entity_registry_enabled_by_default
+
+
+def readJson(fileName):
+    """Read filte to json."""
+    test_filename = os.path.join(os.path.dirname(__file__), fileName)
+    with open(test_filename, mode="rb") as json_file:
+        return json.load(json_file)
+
+
+class MockPyViCare:
+    """Mocked PyVicare class based on a json dump."""
+
+    def setCacheDuration(self, cache_duration):
+        """Set cache duration to limit # of requests."""
+        self.cacheDuration = int(cache_duration)
+
+    def __init__(self, fixtures) -> None:
+        """Init a single device from json dump."""
+        self.devices = []
+        for idx, fixture in enumerate(fixtures):
+            self.devices.append(
+                PyViCareDeviceConfig(
+                    ViCareServiceMock(
+                        fixture,
+                        f"installationId{idx}",
+                        f"serial{idx}",
+                        f"deviceId{idx}",
+                        ["type:boiler"],
+                    ),
+                    f"deviceId{idx}",
+                    f"model{idx}",
+                    f"online{idx}",
+                )
+            )
+
+    def initWithCredentials(
+        self, username: str, password: str, client_id: str, token_file: str
+    ):
+        """Stub oauth login."""
+        None
+
+
+class ViCareServiceMock:
+    """PyVicareService mock using a json dump."""
+
+    def __init__(self, fixture, inst_id, serial, device_id, roles):
+        """Initialize the mock from a json dump."""
+        testData = readJson(fixture)
+        self.testData = testData
+
+        self.accessor = ViCareDeviceAccessor(inst_id, serial, device_id)
+        self.setPropertyData = []
+        self.roles = roles
+
+    def getProperty(self, property_name):
+        """Read a property from a json dump."""
+        entities = self.testData["data"]
+        value = readFeature(entities, property_name)
+        print("Read: ", property_name, value)
+        return value
+
+    def setProperty(self, property_name, action, data):
+        """Set a property to its internal data structure."""
+        self.setPropertyData.append(
+            {
+                "url": buildSetPropertyUrl(self.accessor, property_name, action),
+                "property_name": property_name,
+                "action": action,
+                "data": data,
+            }
+        )
+
+    def hasRoles(self, requested_roles) -> bool:
+        """Return true if requested roles are supported."""
+        return len(requested_roles) > 0 and set(requested_roles).issubset(
+            set(self.roles)
+        )
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Return the default mocked config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="ViCare",
+        data=ENTRY_CONFIG,
+    )
+
+
+@pytest.fixture
+async def init_integration(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> MockConfigEntry:
+    """Set up the ViCare integration for testing."""
+    mock_config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    return mock_config_entry
+
+
+@pytest.fixture
+async def mock_vicare_gas_boiler() -> Generator[MagicMock, None, None]:
+    """Return a mocked ViCare API representing a single gas boiler device."""
+    fixtures = ["fixtures/Vitodens300W.json"]
+    with patch(
+        f"{MODULE}.vicare_login",
+        return_value=MockPyViCare(fixtures),
+    ) as vicare_mock:
+        vicare = vicare_mock.return_value
+        yield vicare
+
+
+@pytest.fixture
+async def mock_vicare_2_gas_boilers() -> Generator[MagicMock, None, None]:
+    """Return a mocked ViCare API representing two gas boiler devices."""
+    fixtures = ["fixtures/Vitodens300W.json", "fixtures/Vitodens300W.json"]
+    with patch(
+        f"{MODULE}.vicare_login",
+        return_value=MockPyViCare(fixtures),
+    ) as vicare_mock:
+        vicare = vicare_mock.return_value
+        yield vicare
+
+
+@pytest.fixture
+async def mock_vicare_login_config_flow():
+    """Return a mocked ViCare API representing a gas boiler device."""
+    fixtures = ["fixtures/Vitodens300W.json", "fixtures/Vitodens300W.json"]
+    with patch(
+        f"{MODULE}.config_flow.vicare_login", return_value=MockPyViCare(fixtures)
+    ) as mock_vicare_login_config_flow:
+        yield mock_vicare_login_config_flow
+
+
+@pytest.fixture
+async def mock_vicare_login_invalid_credentials_config_flow():
+    """Throw PyViCareInvalidCredentialsError when logging in."""
+    with patch(
+        f"{MODULE}.config_flow.vicare_login",
+        side_effect=PyViCareInvalidCredentialsError(),
+    ) as mock_vicare_login_config_flow:
+        yield mock_vicare_login_config_flow
+
+
+@pytest.fixture
+async def mock_setup_entry() -> bool:
+    """Return a mocked ViCare API representing a gas boiler device."""
+    with patch(f"{MODULE}.async_setup_entry", return_value=True) as mock_setup_entry:
+        yield mock_setup_entry

--- a/tests/components/vicare/fixtures/Vitodens300W.json
+++ b/tests/components/vicare/fixtures/Vitodens300W.json
@@ -1,0 +1,3885 @@
+{
+  "data": [
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.buffer.charging.level.total",
+      "gatewayId": "################",
+      "feature": "heating.buffer.charging.level.total",
+      "timestamp": "2021-08-25T03:29:47.707Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["bottom", "middle", "top", "total"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.buffer.charging.level",
+      "gatewayId": "################",
+      "feature": "heating.buffer.charging.level",
+      "timestamp": "2021-08-25T03:29:46.401Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.solar.pumps.circuit",
+      "gatewayId": "################",
+      "feature": "heating.solar.pumps.circuit",
+      "timestamp": "2021-08-25T03:29:47.713Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "hours": {
+          "type": "number",
+          "value": 18726.3,
+          "unit": ""
+        },
+        "starts": {
+          "type": "number",
+          "value": 14315,
+          "unit": ""
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.burners.0.statistics",
+      "gatewayId": "################",
+      "feature": "heating.burners.0.statistics",
+      "timestamp": "2021-08-25T14:23:17.238Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heating",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.operating.modes.heating",
+      "timestamp": "2021-08-25T03:29:46.971Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/device",
+      "gatewayId": "################",
+      "feature": "device",
+      "timestamp": "2021-08-25T03:29:46.401Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule",
+      "gatewayId": "################",
+      "feature": "heating.dhw.pumps.circulation.schedule",
+      "timestamp": "2021-08-25T03:29:47.694Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "status": {
+          "type": "string",
+          "value": "off"
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.circulation.pump",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.circulation.pump",
+      "timestamp": "2021-08-25T03:29:47.639Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["pump"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.circulation",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.circulation",
+      "timestamp": "2021-08-25T03:29:46.400Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.heating.schedule",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.heating.schedule",
+      "timestamp": "2021-08-25T03:29:46.922Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.supply",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.sensors.temperature.supply",
+      "timestamp": "2021-08-25T03:29:47.572Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.solar.sensors.temperature.collector",
+      "gatewayId": "################",
+      "feature": "heating.solar.sensors.temperature.collector",
+      "timestamp": "2021-08-25T03:29:47.700Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.active",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.operating.modes.active",
+      "timestamp": "2021-08-25T03:29:47.677Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "active": {
+          "type": "boolean",
+          "value": false
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.burner",
+      "gatewayId": "################",
+      "feature": "heating.burner",
+      "timestamp": "2021-08-25T14:16:46.543Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs.holiday",
+      "gatewayId": "################",
+      "feature": "heating.operating.programs.holiday",
+      "timestamp": "2021-08-25T03:29:47.714Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.buffer.charging.level.bottom",
+      "gatewayId": "################",
+      "feature": "heating.buffer.charging.level.bottom",
+      "timestamp": "2021-08-25T03:29:47.711Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "unit": {
+          "value": "celsius",
+          "type": "string"
+        },
+        "value": {
+          "type": "number",
+          "value": 63,
+          "unit": "celsius"
+        },
+        "status": {
+          "type": "string",
+          "value": "connected"
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.supply",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.sensors.temperature.supply",
+      "timestamp": "2021-08-25T15:13:19.679Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.dhw",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.operating.modes.dhw",
+      "timestamp": "2021-08-25T03:29:46.955Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "value": {
+          "value": "dhw",
+          "type": "string"
+        }
+      },
+      "commands": {
+        "setMode": {
+          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active/commands/setMode",
+          "name": "setMode",
+          "isExecutable": true,
+          "params": {
+            "mode": {
+              "type": "string",
+              "required": true,
+              "constraints": {
+                "enum": [
+                  "standby",
+                  "dhw",
+                  "dhwAndHeating",
+                  "forcedReduced",
+                  "forcedNormal"
+                ]
+              }
+            }
+          }
+        }
+      },
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.operating.modes.active",
+      "timestamp": "2021-08-25T03:29:47.654Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "active": {
+          "value": false,
+          "type": "boolean"
+        },
+        "demand": {
+          "value": "unknown",
+          "type": "string"
+        },
+        "temperature": {
+          "value": 22,
+          "unit": "",
+          "type": "number"
+        }
+      },
+      "commands": {
+        "setTemperature": {
+          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/setTemperature",
+          "name": "setTemperature",
+          "isExecutable": true,
+          "params": {
+            "targetTemperature": {
+              "type": "number",
+              "required": true,
+              "constraints": {
+                "min": 4,
+                "max": 37,
+                "stepping": 1
+              }
+            }
+          }
+        },
+        "activate": {
+          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/activate",
+          "name": "activate",
+          "isExecutable": true,
+          "params": {
+            "temperature": {
+              "type": "number",
+              "required": false,
+              "constraints": {
+                "min": 4,
+                "max": 37,
+                "stepping": 1
+              }
+            }
+          }
+        },
+        "deactivate": {
+          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/deactivate",
+          "name": "deactivate",
+          "isExecutable": false,
+          "params": {}
+        }
+      },
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.operating.programs.comfort",
+      "timestamp": "2021-08-25T03:29:46.825Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["operating"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/ventilation",
+      "gatewayId": "################",
+      "feature": "ventilation",
+      "timestamp": "2021-08-25T03:29:47.717Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "shift": {
+          "type": "number",
+          "unit": "",
+          "value": 7
+        },
+        "slope": {
+          "type": "number",
+          "unit": "",
+          "value": 1.1
+        }
+      },
+      "commands": {
+        "setCurve": {
+          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.heating.curve/commands/setCurve",
+          "name": "setCurve",
+          "isExecutable": true,
+          "params": {
+            "slope": {
+              "type": "number",
+              "required": true,
+              "constraints": {
+                "min": 0.2,
+                "max": 3.5,
+                "stepping": 0.1
+              }
+            },
+            "shift": {
+              "type": "number",
+              "required": true,
+              "constraints": {
+                "min": -13,
+                "max": 40,
+                "stepping": 1
+              }
+            }
+          }
+        }
+      },
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.heating.curve",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.heating.curve",
+      "timestamp": "2021-08-25T03:29:46.909Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.boiler.sensors.temperature.commonSupply",
+      "gatewayId": "################",
+      "feature": "heating.boiler.sensors.temperature.commonSupply",
+      "timestamp": "2021-08-25T03:29:46.838Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["pump"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.circulation",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.circulation",
+      "timestamp": "2021-08-25T03:29:46.400Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.frostprotection",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.frostprotection",
+      "timestamp": "2021-08-25T03:29:46.903Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [
+        "circulation",
+        "dhw",
+        "frostprotection",
+        "heating",
+        "operating",
+        "sensors"
+      ],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2",
+      "timestamp": "2021-08-25T03:29:46.863Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["pumps", "sensors"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.solar",
+      "gatewayId": "################",
+      "feature": "heating.solar",
+      "timestamp": "2021-08-25T03:29:47.698Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["modes", "programs"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/ventilation.operating",
+      "gatewayId": "################",
+      "feature": "ventilation.operating",
+      "timestamp": "2021-08-25T03:29:46.400Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "active": {
+          "type": "boolean",
+          "value": false
+        }
+      },
+      "commands": {},
+      "components": ["modulation", "statistics"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.burners.0",
+      "gatewayId": "################",
+      "feature": "heating.burners.0",
+      "timestamp": "2021-08-25T14:16:46.550Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["modes", "programs"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.operating",
+      "timestamp": "2021-08-25T03:29:46.400Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.standby",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.operating.programs.standby",
+      "timestamp": "2021-08-25T03:29:47.560Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "active": {
+          "value": false,
+          "type": "boolean"
+        },
+        "start": {
+          "value": "",
+          "type": "string"
+        },
+        "end": {
+          "value": "",
+          "type": "string"
+        }
+      },
+      "commands": {
+        "changeEndDate": {
+          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.holiday/commands/changeEndDate",
+          "name": "changeEndDate",
+          "isExecutable": false,
+          "params": {
+            "end": {
+              "type": "string",
+              "required": true,
+              "constraints": {
+                "regEx": "^[\\d]{4}-[\\d]{2}-[\\d]{2}$",
+                "sameDayAllowed": false
+              }
+            }
+          }
+        },
+        "schedule": {
+          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.holiday/commands/schedule",
+          "name": "schedule",
+          "isExecutable": true,
+          "params": {
+            "start": {
+              "type": "string",
+              "required": true,
+              "constraints": {
+                "regEx": "^[\\d]{4}-[\\d]{2}-[\\d]{2}$"
+              }
+            },
+            "end": {
+              "type": "string",
+              "required": true,
+              "constraints": {
+                "regEx": "^[\\d]{4}-[\\d]{2}-[\\d]{2}$",
+                "sameDayAllowed": false
+              }
+            }
+          }
+        },
+        "unschedule": {
+          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.holiday/commands/unschedule",
+          "name": "unschedule",
+          "isExecutable": true,
+          "params": {}
+        }
+      },
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.holiday",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.operating.programs.holiday",
+      "timestamp": "2021-08-25T03:29:47.541Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/ventilation.operating.modes.standby",
+      "gatewayId": "################",
+      "feature": "ventilation.operating.modes.standby",
+      "timestamp": "2021-08-25T03:29:47.726Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["active", "dhw", "dhwAndHeating", "heating", "standby"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.modes",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.operating.modes",
+      "timestamp": "2021-08-25T03:29:46.401Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "status": {
+          "type": "string",
+          "value": "off"
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.pumps.primary",
+      "gatewayId": "################",
+      "feature": "heating.dhw.pumps.primary",
+      "timestamp": "2021-08-25T14:18:44.841Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/ventilation.operating.programs.holiday",
+      "gatewayId": "################",
+      "feature": "ventilation.operating.programs.holiday",
+      "timestamp": "2021-08-25T03:29:47.722Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "active": {
+          "value": false,
+          "type": "boolean"
+        },
+        "entries": {
+          "value": {
+            "mon": [
+              {
+                "start": "06:00",
+                "end": "22:00",
+                "mode": "normal",
+                "position": 0
+              }
+            ],
+            "tue": [
+              {
+                "start": "06:00",
+                "end": "22:00",
+                "mode": "normal",
+                "position": 0
+              }
+            ],
+            "wed": [
+              {
+                "start": "06:00",
+                "end": "22:00",
+                "mode": "normal",
+                "position": 0
+              }
+            ],
+            "thu": [
+              {
+                "start": "06:00",
+                "end": "22:00",
+                "mode": "normal",
+                "position": 0
+              }
+            ],
+            "fri": [
+              {
+                "start": "06:00",
+                "end": "22:00",
+                "mode": "normal",
+                "position": 0
+              }
+            ],
+            "sat": [
+              {
+                "start": "06:00",
+                "end": "22:00",
+                "mode": "normal",
+                "position": 0
+              }
+            ],
+            "sun": [
+              {
+                "start": "06:00",
+                "end": "22:00",
+                "mode": "normal",
+                "position": 0
+              }
+            ]
+          },
+          "type": "Schedule"
+        }
+      },
+      "commands": {
+        "setSchedule": {
+          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.heating.schedule/commands/setSchedule",
+          "name": "setSchedule",
+          "isExecutable": true,
+          "params": {
+            "newSchedule": {
+              "type": "Schedule",
+              "required": true,
+              "constraints": {
+                "modes": ["normal"],
+                "maxEntries": 4,
+                "resolution": 10,
+                "defaultMode": "reduced",
+                "overlapAllowed": true
+              }
+            }
+          }
+        }
+      },
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.heating.schedule",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.heating.schedule",
+      "timestamp": "2021-08-25T03:29:46.920Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.dhwAndHeating",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.operating.modes.dhwAndHeating",
+      "timestamp": "2021-08-25T03:29:46.967Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "active": {
+          "value": false,
+          "type": "boolean"
+        },
+        "demand": {
+          "value": "unknown",
+          "type": "string"
+        },
+        "temperature": {
+          "value": 18,
+          "unit": "",
+          "type": "number"
+        }
+      },
+      "commands": {
+        "setTemperature": {
+          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reduced/commands/setTemperature",
+          "name": "setTemperature",
+          "isExecutable": true,
+          "params": {
+            "targetTemperature": {
+              "type": "number",
+              "required": true,
+              "constraints": {
+                "min": 3,
+                "max": 37,
+                "stepping": 1
+              }
+            }
+          }
+        }
+      },
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reduced",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.operating.programs.reduced",
+      "timestamp": "2021-08-25T03:29:47.553Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["offset"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.device.time",
+      "gatewayId": "################",
+      "feature": "heating.device.time",
+      "timestamp": "2021-08-25T03:29:46.401Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["curve", "schedule"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.heating",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.heating",
+      "timestamp": "2021-08-25T03:29:46.400Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "active": {
+          "value": false,
+          "type": "boolean"
+        },
+        "start": {
+          "value": "",
+          "type": "string"
+        },
+        "end": {
+          "value": "",
+          "type": "string"
+        }
+      },
+      "commands": {
+        "changeEndDate": {
+          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.holiday/commands/changeEndDate",
+          "name": "changeEndDate",
+          "isExecutable": false,
+          "params": {
+            "end": {
+              "type": "string",
+              "required": true,
+              "constraints": {
+                "regEx": "^[\\d]{4}-[\\d]{2}-[\\d]{2}$",
+                "sameDayAllowed": false
+              }
+            }
+          }
+        },
+        "schedule": {
+          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.holiday/commands/schedule",
+          "name": "schedule",
+          "isExecutable": true,
+          "params": {
+            "start": {
+              "type": "string",
+              "required": true,
+              "constraints": {
+                "regEx": "^[\\d]{4}-[\\d]{2}-[\\d]{2}$"
+              }
+            },
+            "end": {
+              "type": "string",
+              "required": true,
+              "constraints": {
+                "regEx": "^[\\d]{4}-[\\d]{2}-[\\d]{2}$",
+                "sameDayAllowed": false
+              }
+            }
+          }
+        },
+        "unschedule": {
+          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.holiday/commands/unschedule",
+          "name": "unschedule",
+          "isExecutable": true,
+          "params": {}
+        }
+      },
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.holiday",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.operating.programs.holiday",
+      "timestamp": "2021-08-25T03:29:47.543Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "value": {
+          "value": "dhw",
+          "type": "string"
+        }
+      },
+      "commands": {
+        "setMode": {
+          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.active/commands/setMode",
+          "name": "setMode",
+          "isExecutable": true,
+          "params": {
+            "mode": {
+              "type": "string",
+              "required": true,
+              "constraints": {
+                "enum": [
+                  "standby",
+                  "dhw",
+                  "dhwAndHeating",
+                  "forcedReduced",
+                  "forcedNormal"
+                ]
+              }
+            }
+          }
+        }
+      },
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.active",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.operating.modes.active",
+      "timestamp": "2021-08-25T03:29:47.666Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "active": {
+          "value": false,
+          "type": "boolean"
+        },
+        "entries": {
+          "value": {
+            "mon": [
+              {
+                "start": "06:00",
+                "end": "22:00",
+                "mode": "normal",
+                "position": 0
+              }
+            ],
+            "tue": [
+              {
+                "start": "06:00",
+                "end": "22:00",
+                "mode": "normal",
+                "position": 0
+              }
+            ],
+            "wed": [
+              {
+                "start": "06:00",
+                "end": "22:00",
+                "mode": "normal",
+                "position": 0
+              }
+            ],
+            "thu": [
+              {
+                "start": "06:00",
+                "end": "22:00",
+                "mode": "normal",
+                "position": 0
+              }
+            ],
+            "fri": [
+              {
+                "start": "06:00",
+                "end": "22:00",
+                "mode": "normal",
+                "position": 0
+              }
+            ],
+            "sat": [
+              {
+                "start": "06:00",
+                "end": "22:00",
+                "mode": "normal",
+                "position": 0
+              }
+            ],
+            "sun": [
+              {
+                "start": "06:00",
+                "end": "22:00",
+                "mode": "normal",
+                "position": 0
+              }
+            ]
+          },
+          "type": "Schedule"
+        }
+      },
+      "commands": {
+        "setSchedule": {
+          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule/commands/setSchedule",
+          "name": "setSchedule",
+          "isExecutable": true,
+          "params": {
+            "newSchedule": {
+              "type": "Schedule",
+              "required": true,
+              "constraints": {
+                "modes": ["normal"],
+                "maxEntries": 4,
+                "resolution": 10,
+                "defaultMode": "reduced",
+                "overlapAllowed": true
+              }
+            }
+          }
+        }
+      },
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.heating.schedule",
+      "timestamp": "2021-08-25T03:29:46.918Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "value": {
+          "type": "string",
+          "value": "################"
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.controller.serial",
+      "gatewayId": "################",
+      "feature": "heating.controller.serial",
+      "timestamp": "2021-08-25T03:29:47.574Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "active": {
+          "value": false,
+          "type": "boolean"
+        },
+        "temperature": {
+          "value": 0,
+          "unit": "",
+          "type": "number"
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.external",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.operating.programs.external",
+      "timestamp": "2021-08-25T03:29:47.536Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "active": {
+          "value": true,
+          "type": "boolean"
+        },
+        "name": {
+          "value": "",
+          "type": "string"
+        },
+        "type": {
+          "value": "heatingCircuit",
+          "type": "string"
+        }
+      },
+      "commands": {
+        "setName": {
+          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0/commands/setName",
+          "name": "setName",
+          "isExecutable": true,
+          "params": {
+            "name": {
+              "type": "string",
+              "required": true,
+              "constraints": {
+                "minLength": 1,
+                "maxLength": 20
+              }
+            }
+          }
+        }
+      },
+      "components": [
+        "circulation",
+        "dhw",
+        "frostprotection",
+        "heating",
+        "operating",
+        "sensors"
+      ],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0",
+      "timestamp": "2021-08-25T03:29:46.859Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "active": {
+          "type": "boolean",
+          "value": true
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.dhw",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.operating.modes.dhw",
+      "timestamp": "2021-08-25T03:29:46.939Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["schedule"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.dhw.pumps.circulation",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.dhw.pumps.circulation",
+      "timestamp": "2021-08-25T03:29:46.400Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [
+        "active",
+        "comfort",
+        "eco",
+        "external",
+        "holiday",
+        "normal",
+        "reduced",
+        "standby"
+      ],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.programs",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.operating.programs",
+      "timestamp": "2021-08-25T03:29:46.400Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["room", "supply"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.sensors.temperature",
+      "timestamp": "2021-08-25T03:29:46.401Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "status": {
+          "type": "string",
+          "value": "off"
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.frostprotection",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.frostprotection",
+      "timestamp": "2021-08-25T03:29:46.894Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "active": {
+          "type": "boolean",
+          "value": false
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhwAndHeating",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.operating.modes.dhwAndHeating",
+      "timestamp": "2021-08-25T03:29:46.958Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["programs"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating",
+      "gatewayId": "################",
+      "feature": "heating.operating",
+      "timestamp": "2021-08-25T03:29:46.400Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [
+        "boiler",
+        "buffer",
+        "burner",
+        "burners",
+        "circuits",
+        "configuration",
+        "device",
+        "dhw",
+        "operating",
+        "sensors",
+        "solar"
+      ],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating",
+      "gatewayId": "################",
+      "feature": "heating",
+      "timestamp": "2021-08-25T03:29:46.400Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["0"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.burners",
+      "gatewayId": "################",
+      "feature": "heating.burners",
+      "timestamp": "2021-08-25T03:29:46.401Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["schedule"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.dhw.pumps.circulation",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.dhw.pumps.circulation",
+      "timestamp": "2021-08-25T03:29:46.400Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["circuit"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.solar.pumps",
+      "gatewayId": "################",
+      "feature": "heating.solar.pumps",
+      "timestamp": "2021-08-25T03:29:46.401Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.buffer.charging.level.top",
+      "gatewayId": "################",
+      "feature": "heating.buffer.charging.level.top",
+      "timestamp": "2021-08-25T03:29:47.708Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["temperature"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.solar.sensors",
+      "gatewayId": "################",
+      "feature": "heating.solar.sensors",
+      "timestamp": "2021-08-25T03:29:46.401Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["sensors", "serial", "temperature"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.boiler",
+      "gatewayId": "################",
+      "feature": "heating.boiler",
+      "timestamp": "2021-08-25T03:29:46.401Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.holiday",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.operating.programs.holiday",
+      "timestamp": "2021-08-25T03:29:47.545Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "unit": {
+          "value": "celsius",
+          "type": "string"
+        },
+        "value": {
+          "type": "number",
+          "value": 20.8,
+          "unit": "celsius"
+        },
+        "status": {
+          "type": "string",
+          "value": "connected"
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.sensors.temperature.outside",
+      "gatewayId": "################",
+      "feature": "heating.sensors.temperature.outside",
+      "timestamp": "2021-08-25T15:07:33.251Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.room",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.sensors.temperature.room",
+      "timestamp": "2021-08-25T03:29:47.566Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["modes", "programs"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.operating",
+      "timestamp": "2021-08-25T03:29:46.400Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "unit": {
+          "value": "kilowattHour",
+          "type": "string"
+        },
+        "day": {
+          "type": "array",
+          "value": [0.219, 0.316, 0.32, 0.325, 0.311, 0.317, 0.312, 0.313]
+        },
+        "week": {
+          "type": "array",
+          "value": [
+            0.829, 2.241, 2.22, 2.233, 2.23, 2.23, 2.227, 2.008, 2.198, 2.236,
+            2.159, 2.255, 2.497, 6.849, 7.213, 6.749, 7.994, 7.958, 8.397,
+            8.728, 8.743, 7.453, 8.386, 8.839, 8.763, 8.678, 7.896, 8.783,
+            9.821, 8.683, 9, 8.738, 9.027, 8.974, 8.882, 8.286, 8.448, 8.785,
+            8.704, 8.053, 7.304, 7.078, 7.251, 6.839, 6.902, 7.042, 6.864,
+            6.818, 3.938, 2.308, 2.283, 2.246, 2.269
+          ]
+        },
+        "month": {
+          "type": "array",
+          "value": [
+            7.843, 9.661, 9.472, 31.747, 35.805, 37.785, 35.183, 39.583, 37.998,
+            31.939, 30.552, 13.375, 9.734
+          ]
+        },
+        "year": {
+          "type": "array",
+          "value": [207.106, 311.579, 320.275]
+        },
+        "dayValueReadAt": {
+          "type": "string",
+          "value": "2021-08-25T15:10:12.179Z"
+        },
+        "weekValueReadAt": {
+          "type": "string",
+          "value": "2021-08-25T13:22:51.623Z"
+        },
+        "monthValueReadAt": {
+          "type": "string",
+          "value": "2021-08-25T13:22:54.009Z"
+        },
+        "yearValueReadAt": {
+          "type": "string",
+          "value": "2021-08-25T15:13:33.507Z"
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.power.consumption.total",
+      "gatewayId": "################",
+      "feature": "heating.power.consumption.total",
+      "timestamp": "2021-08-25T15:13:35.950Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["pumps", "schedule"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.dhw",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.dhw",
+      "timestamp": "2021-08-25T03:29:46.400Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/ventilation.operating.modes.active",
+      "gatewayId": "################",
+      "feature": "ventilation.operating.modes.active",
+      "timestamp": "2021-08-25T03:29:47.724Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "active": {
+          "value": true,
+          "type": "boolean"
+        },
+        "name": {
+          "value": "",
+          "type": "string"
+        },
+        "type": {
+          "value": "heatingCircuit",
+          "type": "string"
+        }
+      },
+      "commands": {
+        "setName": {
+          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1/commands/setName",
+          "name": "setName",
+          "isExecutable": true,
+          "params": {
+            "name": {
+              "type": "string",
+              "required": true,
+              "constraints": {
+                "minLength": 1,
+                "maxLength": 20
+              }
+            }
+          }
+        }
+      },
+      "components": [
+        "circulation",
+        "dhw",
+        "frostprotection",
+        "heating",
+        "operating",
+        "sensors"
+      ],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1",
+      "timestamp": "2021-08-25T03:29:46.861Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "unit": {
+          "value": "kilowattHour",
+          "type": "string"
+        },
+        "day": {
+          "type": "array",
+          "value": [0, 0, 0, 0, 0, 0, 0, 0]
+        },
+        "week": {
+          "type": "array",
+          "value": [
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 24, 544, 806, 636, 1153, 1081,
+            1275, 1582, 1594, 888, 1353, 1678, 1588, 1507, 1093, 1687, 2679,
+            1647, 1916, 1668, 1870, 1877, 1785, 1325, 1351, 1718, 1597, 1220,
+            706, 562, 653, 429, 442, 629, 435, 414, 149, 0, 0, 0, 0
+          ]
+        },
+        "month": {
+          "type": "array",
+          "value": [
+            0, 0, 0, 3508, 5710, 6491, 7106, 8131, 6728, 3438, 2113, 336, 0
+          ]
+        },
+        "year": {
+          "type": "array",
+          "value": [30946, 32288, 37266]
+        },
+        "dayValueReadAt": {
+          "type": "string",
+          "value": "2021-08-18T21:22:37.198Z"
+        },
+        "weekValueReadAt": {
+          "type": "string",
+          "value": "2021-08-23T01:22:41.933Z"
+        },
+        "monthValueReadAt": {
+          "type": "string",
+          "value": "2021-08-18T21:22:42.956Z"
+        },
+        "yearValueReadAt": {
+          "type": "string",
+          "value": "2021-08-18T21:22:38.203Z"
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.gas.consumption.heating",
+      "gatewayId": "################",
+      "feature": "heating.gas.consumption.heating",
+      "timestamp": "2021-08-25T03:29:47.627Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reduced",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.operating.programs.reduced",
+      "timestamp": "2021-08-25T03:29:47.556Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "active": {
+          "value": true,
+          "type": "boolean"
+        },
+        "entries": {
+          "value": {
+            "mon": [
+              {
+                "start": "04:30",
+                "end": "20:00",
+                "mode": "on",
+                "position": 0
+              }
+            ],
+            "tue": [
+              {
+                "start": "04:30",
+                "end": "20:00",
+                "mode": "on",
+                "position": 0
+              }
+            ],
+            "wed": [
+              {
+                "start": "04:30",
+                "end": "20:00",
+                "mode": "on",
+                "position": 0
+              }
+            ],
+            "thu": [
+              {
+                "start": "04:30",
+                "end": "20:00",
+                "mode": "on",
+                "position": 0
+              }
+            ],
+            "fri": [
+              {
+                "start": "04:30",
+                "end": "20:00",
+                "mode": "on",
+                "position": 0
+              }
+            ],
+            "sat": [
+              {
+                "start": "04:30",
+                "end": "20:00",
+                "mode": "on",
+                "position": 0
+              }
+            ],
+            "sun": [
+              {
+                "start": "04:30",
+                "end": "20:00",
+                "mode": "on",
+                "position": 0
+              }
+            ]
+          },
+          "type": "Schedule"
+        }
+      },
+      "commands": {
+        "setSchedule": {
+          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.dhw.pumps.circulation.schedule/commands/setSchedule",
+          "name": "setSchedule",
+          "isExecutable": true,
+          "params": {
+            "newSchedule": {
+              "type": "Schedule",
+              "required": true,
+              "constraints": {
+                "modes": ["on"],
+                "maxEntries": 4,
+                "resolution": 10,
+                "defaultMode": "off",
+                "overlapAllowed": true
+              }
+            }
+          }
+        }
+      },
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.dhw.pumps.circulation.schedule",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.dhw.pumps.circulation.schedule",
+      "timestamp": "2021-08-25T03:29:46.866Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/ventilation.operating.programs.standard",
+      "gatewayId": "################",
+      "feature": "ventilation.operating.programs.standard",
+      "timestamp": "2021-08-25T03:29:47.719Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["schedule"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.dhw.pumps.circulation",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.dhw.pumps.circulation",
+      "timestamp": "2021-08-25T03:29:46.400Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "active": {
+          "value": true,
+          "type": "boolean"
+        },
+        "entries": {
+          "value": {
+            "mon": [
+              {
+                "start": "04:30",
+                "end": "10:00",
+                "mode": "on",
+                "position": 0
+              },
+              {
+                "start": "16:30",
+                "end": "24:00",
+                "mode": "on",
+                "position": 1
+              }
+            ],
+            "tue": [
+              {
+                "start": "04:30",
+                "end": "10:00",
+                "mode": "on",
+                "position": 0
+              },
+              {
+                "start": "16:30",
+                "end": "24:00",
+                "mode": "on",
+                "position": 1
+              }
+            ],
+            "wed": [
+              {
+                "start": "04:30",
+                "end": "10:00",
+                "mode": "on",
+                "position": 0
+              },
+              {
+                "start": "16:30",
+                "end": "24:00",
+                "mode": "on",
+                "position": 1
+              }
+            ],
+            "thu": [
+              {
+                "start": "04:30",
+                "end": "10:00",
+                "mode": "on",
+                "position": 0
+              },
+              {
+                "start": "16:30",
+                "end": "24:00",
+                "mode": "on",
+                "position": 1
+              }
+            ],
+            "fri": [
+              {
+                "start": "04:30",
+                "end": "10:00",
+                "mode": "on",
+                "position": 0
+              },
+              {
+                "start": "16:30",
+                "end": "24:00",
+                "mode": "on",
+                "position": 1
+              }
+            ],
+            "sat": [
+              {
+                "start": "06:30",
+                "end": "24:00",
+                "mode": "on",
+                "position": 0
+              }
+            ],
+            "sun": [
+              {
+                "start": "06:30",
+                "end": "24:00",
+                "mode": "on",
+                "position": 0
+              }
+            ]
+          },
+          "type": "Schedule"
+        }
+      },
+      "commands": {
+        "setSchedule": {
+          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.dhw.schedule/commands/setSchedule",
+          "name": "setSchedule",
+          "isExecutable": true,
+          "params": {
+            "newSchedule": {
+              "type": "Schedule",
+              "required": true,
+              "constraints": {
+                "modes": ["on"],
+                "maxEntries": 4,
+                "resolution": 10,
+                "defaultMode": "off",
+                "overlapAllowed": true
+              }
+            }
+          }
+        }
+      },
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.dhw.schedule",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.dhw.schedule",
+      "timestamp": "2021-08-25T03:29:46.883Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["circulation"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.dhw.pumps",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.dhw.pumps",
+      "timestamp": "2021-08-25T03:29:46.400Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.external",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.operating.programs.external",
+      "timestamp": "2021-08-25T03:29:47.540Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["multiFamilyHouse"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.configuration",
+      "gatewayId": "################",
+      "feature": "heating.configuration",
+      "timestamp": "2021-08-25T03:29:46.401Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["pumps", "schedule"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.dhw",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.dhw",
+      "timestamp": "2021-08-25T03:29:46.400Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/ventilation.operating.programs.eco",
+      "gatewayId": "################",
+      "feature": "ventilation.operating.programs.eco",
+      "timestamp": "2021-08-25T03:29:47.720Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "unit": {
+          "value": "celsius",
+          "type": "string"
+        },
+        "value": {
+          "type": "number",
+          "value": 5,
+          "unit": "celsius"
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.boiler.temperature",
+      "gatewayId": "################",
+      "feature": "heating.boiler.temperature",
+      "timestamp": "2021-08-25T14:16:46.376Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "value": {
+          "type": "string",
+          "value": "################"
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.boiler.serial",
+      "gatewayId": "################",
+      "feature": "heating.boiler.serial",
+      "timestamp": "2021-08-25T03:29:46.840Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["curve", "schedule"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.heating",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.heating",
+      "timestamp": "2021-08-25T03:29:46.400Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "status": {
+          "type": "string",
+          "value": "on"
+        }
+      },
+      "commands": {},
+      "components": ["schedule"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.pumps.circulation",
+      "gatewayId": "################",
+      "feature": "heating.dhw.pumps.circulation",
+      "timestamp": "2021-08-25T03:29:47.609Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "active": {
+          "type": "boolean",
+          "value": true
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.configuration.multiFamilyHouse",
+      "gatewayId": "################",
+      "feature": "heating.configuration.multiFamilyHouse",
+      "timestamp": "2021-08-25T03:29:47.693Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [
+        "active",
+        "comfort",
+        "eco",
+        "external",
+        "holiday",
+        "normal",
+        "reduced",
+        "standby"
+      ],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.operating.programs",
+      "timestamp": "2021-08-25T03:29:46.400Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["modes", "programs"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.operating",
+      "timestamp": "2021-08-25T03:29:46.400Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.standby",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.operating.modes.standby",
+      "timestamp": "2021-08-25T03:29:47.533Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "active": {
+          "value": true,
+          "type": "boolean"
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.standby",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.operating.programs.standby",
+      "timestamp": "2021-08-25T03:29:47.558Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/ventilation.operating.modes.ventilation",
+      "gatewayId": "################",
+      "feature": "ventilation.operating.modes.ventilation",
+      "timestamp": "2021-08-25T03:29:47.729Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["curve", "schedule"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.heating",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.heating",
+      "timestamp": "2021-08-25T03:29:46.400Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.dhw.pumps.circulation.schedule",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.dhw.pumps.circulation.schedule",
+      "timestamp": "2021-08-25T03:29:46.876Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "active": {
+          "value": false,
+          "type": "boolean"
+        },
+        "demand": {
+          "value": "unknown",
+          "type": "string"
+        },
+        "temperature": {
+          "value": 23,
+          "unit": "",
+          "type": "number"
+        }
+      },
+      "commands": {
+        "setTemperature": {
+          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normal/commands/setTemperature",
+          "name": "setTemperature",
+          "isExecutable": true,
+          "params": {
+            "targetTemperature": {
+              "type": "number",
+              "required": true,
+              "constraints": {
+                "min": 3,
+                "max": 37,
+                "stepping": 1
+              }
+            }
+          }
+        }
+      },
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normal",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.operating.programs.normal",
+      "timestamp": "2021-08-25T03:29:47.548Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "active": {
+          "value": false,
+          "type": "boolean"
+        },
+        "demand": {
+          "value": "unknown",
+          "type": "string"
+        },
+        "temperature": {
+          "value": 21,
+          "unit": "",
+          "type": "number"
+        }
+      },
+      "commands": {
+        "setTemperature": {
+          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal/commands/setTemperature",
+          "name": "setTemperature",
+          "isExecutable": true,
+          "params": {
+            "targetTemperature": {
+              "type": "number",
+              "required": true,
+              "constraints": {
+                "min": 3,
+                "max": 37,
+                "stepping": 1
+              }
+            }
+          }
+        }
+      },
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.operating.programs.normal",
+      "timestamp": "2021-08-25T03:29:47.546Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "active": {
+          "type": "boolean",
+          "value": false
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.dhwAndHeating",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.operating.modes.dhwAndHeating",
+      "timestamp": "2021-08-25T03:29:46.963Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.active",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.operating.programs.active",
+      "timestamp": "2021-08-25T03:29:47.649Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "active": {
+          "type": "boolean",
+          "value": true
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhw",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.operating.modes.dhw",
+      "timestamp": "2021-08-25T03:29:46.933Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.dhw.schedule",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.dhw.schedule",
+      "timestamp": "2021-08-25T03:29:46.890Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "active": {
+          "value": false,
+          "type": "boolean"
+        },
+        "demand": {
+          "value": "unknown",
+          "type": "string"
+        },
+        "temperature": {
+          "value": 24,
+          "unit": "",
+          "type": "number"
+        }
+      },
+      "commands": {
+        "setTemperature": {
+          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort/commands/setTemperature",
+          "name": "setTemperature",
+          "isExecutable": true,
+          "params": {
+            "targetTemperature": {
+              "type": "number",
+              "required": true,
+              "constraints": {
+                "min": 4,
+                "max": 37,
+                "stepping": 1
+              }
+            }
+          }
+        },
+        "activate": {
+          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort/commands/activate",
+          "name": "activate",
+          "isExecutable": true,
+          "params": {
+            "temperature": {
+              "type": "number",
+              "required": false,
+              "constraints": {
+                "min": 4,
+                "max": 37,
+                "stepping": 1
+              }
+            }
+          }
+        },
+        "deactivate": {
+          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort/commands/deactivate",
+          "name": "deactivate",
+          "isExecutable": false,
+          "params": {}
+        }
+      },
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.operating.programs.comfort",
+      "timestamp": "2021-08-25T03:29:46.827Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "active": {
+          "value": true,
+          "type": "boolean"
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.standby",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.operating.programs.standby",
+      "timestamp": "2021-08-25T03:29:47.559Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "shift": {
+          "type": "number",
+          "unit": "",
+          "value": 9
+        },
+        "slope": {
+          "type": "number",
+          "unit": "",
+          "value": 1.4
+        }
+      },
+      "commands": {
+        "setCurve": {
+          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.heating.curve/commands/setCurve",
+          "name": "setCurve",
+          "isExecutable": true,
+          "params": {
+            "slope": {
+              "type": "number",
+              "required": true,
+              "constraints": {
+                "min": 0.2,
+                "max": 3.5,
+                "stepping": 0.1
+              }
+            },
+            "shift": {
+              "type": "number",
+              "required": true,
+              "constraints": {
+                "min": -13,
+                "max": 40,
+                "stepping": 1
+              }
+            }
+          }
+        }
+      },
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.heating.curve",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.heating.curve",
+      "timestamp": "2021-08-25T03:29:46.906Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.eco",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.operating.programs.eco",
+      "timestamp": "2021-08-25T03:29:47.552Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "unit": {
+          "value": "kilowattHour",
+          "type": "string"
+        },
+        "day": {
+          "type": "array",
+          "value": [22, 33, 32, 34, 32, 32, 32, 32]
+        },
+        "week": {
+          "type": "array",
+          "value": [
+            84, 232, 226, 230, 230, 226, 229, 214, 229, 229, 220, 229, 229, 250,
+            244, 247, 266, 268, 268, 255, 248, 247, 242, 244, 248, 250, 238,
+            242, 259, 256, 259, 263, 255, 241, 257, 250, 237, 240, 243, 253,
+            257, 253, 258, 261, 254, 254, 256, 258, 240, 240, 230, 223, 231
+          ]
+        },
+        "month": {
+          "type": "array",
+          "value": [
+            805, 1000, 968, 1115, 1109, 1087, 995, 1124, 1087, 1094, 1136, 1009,
+            966
+          ]
+        },
+        "year": {
+          "type": "array",
+          "value": [8203, 12546, 11741]
+        },
+        "dayValueReadAt": {
+          "type": "string",
+          "value": "2021-08-25T14:16:40.084Z"
+        },
+        "weekValueReadAt": {
+          "type": "string",
+          "value": "2021-08-25T13:22:47.418Z"
+        },
+        "monthValueReadAt": {
+          "type": "string",
+          "value": "2021-08-25T13:22:47.985Z"
+        },
+        "yearValueReadAt": {
+          "type": "string",
+          "value": "2021-08-25T13:22:51.902Z"
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.gas.consumption.dhw",
+      "gatewayId": "################",
+      "feature": "heating.gas.consumption.dhw",
+      "timestamp": "2021-08-25T14:16:41.758Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["temperature"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.sensors",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.sensors",
+      "timestamp": "2021-08-25T03:29:46.401Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "enabled": {
+          "value": ["0", "1"],
+          "type": "array"
+        }
+      },
+      "commands": {},
+      "components": ["0", "1", "2"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits",
+      "gatewayId": "################",
+      "feature": "heating.circuits",
+      "timestamp": "2021-08-25T03:29:46.864Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "value": {
+          "type": "string",
+          "value": "standby"
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.active",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.operating.programs.active",
+      "timestamp": "2021-08-25T03:29:47.643Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.solar.power.production",
+      "gatewayId": "################",
+      "feature": "heating.solar.power.production",
+      "timestamp": "2021-08-25T03:29:47.634Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["temperature"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.sensors",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.sensors",
+      "timestamp": "2021-08-25T03:29:46.401Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "active": {
+          "value": false,
+          "type": "boolean"
+        },
+        "temperature": {
+          "value": 21,
+          "unit": "",
+          "type": "number"
+        }
+      },
+      "commands": {
+        "activate": {
+          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.eco/commands/activate",
+          "name": "activate",
+          "isExecutable": false,
+          "params": {}
+        },
+        "deactivate": {
+          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.eco/commands/deactivate",
+          "name": "deactivate",
+          "isExecutable": false,
+          "params": {}
+        }
+      },
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.eco",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.operating.programs.eco",
+      "timestamp": "2021-08-25T03:29:47.547Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normal",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.operating.programs.normal",
+      "timestamp": "2021-08-25T03:29:47.551Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "active": {
+          "type": "boolean",
+          "value": true
+        },
+        "status": {
+          "type": "string",
+          "value": "on"
+        }
+      },
+      "commands": {},
+      "components": [
+        "charging",
+        "oneTimeCharge",
+        "schedule",
+        "sensors",
+        "temperature"
+      ],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw",
+      "gatewayId": "################",
+      "feature": "heating.dhw",
+      "timestamp": "2021-08-25T03:29:47.650Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.circulation.pump",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.circulation.pump",
+      "timestamp": "2021-08-25T03:29:47.642Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "unit": {
+          "value": "celsius",
+          "type": "string"
+        },
+        "value": {
+          "type": "number",
+          "value": 63,
+          "unit": "celsius"
+        },
+        "status": {
+          "type": "string",
+          "value": "connected"
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.boiler.sensors.temperature.main",
+      "gatewayId": "################",
+      "feature": "heating.boiler.sensors.temperature.main",
+      "timestamp": "2021-08-25T15:13:19.598Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "status": {
+          "type": "string",
+          "value": "off"
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.circulation.pump",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.circulation.pump",
+      "timestamp": "2021-08-25T03:29:47.641Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "active": {
+          "value": false,
+          "type": "boolean"
+        },
+        "temperature": {
+          "value": 23,
+          "unit": "",
+          "type": "number"
+        }
+      },
+      "commands": {
+        "activate": {
+          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.eco/commands/activate",
+          "name": "activate",
+          "isExecutable": false,
+          "params": {}
+        },
+        "deactivate": {
+          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.eco/commands/deactivate",
+          "name": "deactivate",
+          "isExecutable": false,
+          "params": {}
+        }
+      },
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.eco",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.operating.programs.eco",
+      "timestamp": "2021-08-25T03:29:47.549Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "value": {
+          "type": "number",
+          "value": 0,
+          "unit": ""
+        },
+        "top": {
+          "type": "number",
+          "value": 0,
+          "unit": ""
+        },
+        "middle": {
+          "type": "number",
+          "value": 0,
+          "unit": ""
+        },
+        "bottom": {
+          "type": "number",
+          "value": 0,
+          "unit": ""
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.charging.level",
+      "gatewayId": "################",
+      "feature": "heating.dhw.charging.level",
+      "timestamp": "2021-08-25T03:29:47.603Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["pump"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.circulation",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.circulation",
+      "timestamp": "2021-08-25T03:29:46.400Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/ventilation.operating.modes.standard",
+      "gatewayId": "################",
+      "feature": "ventilation.operating.modes.standard",
+      "timestamp": "2021-08-25T03:29:47.728Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["holiday"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs",
+      "gatewayId": "################",
+      "feature": "heating.operating.programs",
+      "timestamp": "2021-08-25T03:29:46.400Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "active": {
+          "value": true,
+          "type": "boolean"
+        },
+        "entries": {
+          "value": {
+            "mon": [
+              {
+                "start": "04:30",
+                "end": "20:00",
+                "mode": "on",
+                "position": 0
+              }
+            ],
+            "tue": [
+              {
+                "start": "04:30",
+                "end": "20:00",
+                "mode": "on",
+                "position": 0
+              }
+            ],
+            "wed": [
+              {
+                "start": "04:30",
+                "end": "20:00",
+                "mode": "on",
+                "position": 0
+              }
+            ],
+            "thu": [
+              {
+                "start": "04:30",
+                "end": "20:00",
+                "mode": "on",
+                "position": 0
+              }
+            ],
+            "fri": [
+              {
+                "start": "04:30",
+                "end": "20:00",
+                "mode": "on",
+                "position": 0
+              }
+            ],
+            "sat": [
+              {
+                "start": "04:30",
+                "end": "20:00",
+                "mode": "on",
+                "position": 0
+              }
+            ],
+            "sun": [
+              {
+                "start": "04:30",
+                "end": "20:00",
+                "mode": "on",
+                "position": 0
+              }
+            ]
+          },
+          "type": "Schedule"
+        }
+      },
+      "commands": {
+        "setSchedule": {
+          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.dhw.schedule/commands/setSchedule",
+          "name": "setSchedule",
+          "isExecutable": true,
+          "params": {
+            "newSchedule": {
+              "type": "Schedule",
+              "required": true,
+              "constraints": {
+                "modes": ["on"],
+                "maxEntries": 4,
+                "resolution": 10,
+                "defaultMode": "off",
+                "overlapAllowed": true
+              }
+            }
+          }
+        }
+      },
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.dhw.schedule",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.dhw.schedule",
+      "timestamp": "2021-08-25T03:29:46.880Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["eco", "holiday", "standard"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/ventilation.operating.programs",
+      "gatewayId": "################",
+      "feature": "ventilation.operating.programs",
+      "timestamp": "2021-08-25T03:29:46.400Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "active": {
+          "value": true,
+          "type": "boolean"
+        },
+        "entries": {
+          "value": {
+            "mon": [
+              {
+                "start": "05:30",
+                "end": "20:00",
+                "mode": "on",
+                "position": 0
+              }
+            ],
+            "tue": [
+              {
+                "start": "04:30",
+                "end": "20:00",
+                "mode": "on",
+                "position": 0
+              }
+            ],
+            "wed": [
+              {
+                "start": "04:30",
+                "end": "20:00",
+                "mode": "on",
+                "position": 0
+              }
+            ],
+            "thu": [
+              {
+                "start": "04:30",
+                "end": "20:00",
+                "mode": "on",
+                "position": 0
+              }
+            ],
+            "fri": [
+              {
+                "start": "04:30",
+                "end": "20:00",
+                "mode": "on",
+                "position": 0
+              }
+            ],
+            "sat": [
+              {
+                "start": "05:30",
+                "end": "20:00",
+                "mode": "on",
+                "position": 0
+              }
+            ],
+            "sun": [
+              {
+                "start": "06:30",
+                "end": "20:00",
+                "mode": "on",
+                "position": 0
+              }
+            ]
+          },
+          "type": "Schedule"
+        }
+      },
+      "commands": {
+        "setSchedule": {
+          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.dhw.pumps.circulation.schedule/commands/setSchedule",
+          "name": "setSchedule",
+          "isExecutable": true,
+          "params": {
+            "newSchedule": {
+              "type": "Schedule",
+              "required": true,
+              "constraints": {
+                "modes": ["on"],
+                "maxEntries": 4,
+                "resolution": 10,
+                "defaultMode": "off",
+                "overlapAllowed": true
+              }
+            }
+          }
+        }
+      },
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.dhw.pumps.circulation.schedule",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.dhw.pumps.circulation.schedule",
+      "timestamp": "2021-08-25T03:29:46.871Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["room", "supply"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.sensors.temperature",
+      "timestamp": "2021-08-25T03:29:46.401Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.buffer.charging.level.middle",
+      "gatewayId": "################",
+      "feature": "heating.buffer.charging.level.middle",
+      "timestamp": "2021-08-25T03:29:47.710Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "active": {
+          "type": "boolean",
+          "value": false
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.standby",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.operating.modes.standby",
+      "timestamp": "2021-08-25T03:29:47.508Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "value": {
+          "value": 58,
+          "unit": "",
+          "type": "number"
+        }
+      },
+      "commands": {
+        "setTargetTemperature": {
+          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.temperature.main/commands/setTargetTemperature",
+          "name": "setTargetTemperature",
+          "isExecutable": true,
+          "params": {
+            "temperature": {
+              "type": "number",
+              "required": true,
+              "constraints": {
+                "min": 10,
+                "efficientLowerBorder": 10,
+                "efficientUpperBorder": 60,
+                "max": 60,
+                "stepping": 1
+              }
+            }
+          }
+        }
+      },
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.temperature.main",
+      "gatewayId": "################",
+      "feature": "heating.dhw.temperature.main",
+      "timestamp": "2021-08-25T03:29:46.819Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "active": {
+          "value": false,
+          "type": "boolean"
+        }
+      },
+      "commands": {
+        "activate": {
+          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/activate",
+          "name": "activate",
+          "isExecutable": true,
+          "params": {}
+        },
+        "deactivate": {
+          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/deactivate",
+          "name": "deactivate",
+          "isExecutable": false,
+          "params": {}
+        }
+      },
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge",
+      "gatewayId": "################",
+      "feature": "heating.dhw.oneTimeCharge",
+      "timestamp": "2021-08-25T03:29:47.607Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "unit": {
+          "value": "kilowattHour",
+          "type": "string"
+        },
+        "day": {
+          "type": "array",
+          "value": [22, 33, 32, 34, 32, 32, 32, 32]
+        },
+        "week": {
+          "type": "array",
+          "value": [
+            84, 232, 226, 230, 230, 226, 229, 214, 229, 229, 220, 229, 253, 794,
+            1050, 883, 1419, 1349, 1543, 1837, 1842, 1135, 1595, 1922, 1836,
+            1757, 1331, 1929, 2938, 1903, 2175, 1931, 2125, 2118, 2042, 1575,
+            1588, 1958, 1840, 1473, 963, 815, 911, 690, 696, 883, 691, 672, 389,
+            240, 230, 223, 231
+          ]
+        },
+        "month": {
+          "type": "array",
+          "value": [
+            805, 1000, 968, 4623, 6819, 7578, 8101, 9255, 7815, 4532, 3249,
+            1345, 966
+          ]
+        },
+        "year": {
+          "type": "array",
+          "value": [39149, 44834, 49007]
+        },
+        "dayValueReadAt": {
+          "type": "string",
+          "value": "2021-08-18T21:22:37.198Z"
+        },
+        "weekValueReadAt": {
+          "type": "string",
+          "value": "2021-08-23T01:22:41.933Z"
+        },
+        "monthValueReadAt": {
+          "type": "string",
+          "value": "2021-08-18T21:22:42.956Z"
+        },
+        "yearValueReadAt": {
+          "type": "string",
+          "value": "2021-08-18T21:22:38.203Z"
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.gas.consumption.total",
+      "gatewayId": "################",
+      "feature": "heating.gas.consumption.total",
+      "timestamp": "2021-08-25T14:16:41.785Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["temperature"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.sensors",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.sensors",
+      "timestamp": "2021-08-25T03:29:46.401Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "unit": {
+          "value": "percent",
+          "type": "string"
+        },
+        "value": {
+          "type": "number",
+          "value": 0,
+          "unit": "percent"
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.burners.0.modulation",
+      "gatewayId": "################",
+      "feature": "heating.burners.0.modulation",
+      "timestamp": "2021-08-25T14:16:46.499Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["total"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.power.consumption",
+      "gatewayId": "################",
+      "feature": "heating.power.consumption",
+      "timestamp": "2021-08-25T03:29:46.401Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "active": {
+          "value": false,
+          "type": "boolean"
+        },
+        "demand": {
+          "value": "unknown",
+          "type": "string"
+        },
+        "temperature": {
+          "value": 21,
+          "unit": "",
+          "type": "number"
+        }
+      },
+      "commands": {
+        "setTemperature": {
+          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reduced/commands/setTemperature",
+          "name": "setTemperature",
+          "isExecutable": true,
+          "params": {
+            "targetTemperature": {
+              "type": "number",
+              "required": true,
+              "constraints": {
+                "min": 3,
+                "max": 37,
+                "stepping": 1
+              }
+            }
+          }
+        }
+      },
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reduced",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.operating.programs.reduced",
+      "timestamp": "2021-08-25T03:29:47.555Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["outside"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.sensors.temperature",
+      "gatewayId": "################",
+      "feature": "heating.sensors.temperature",
+      "timestamp": "2021-08-25T03:29:46.401Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.room",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.sensors.temperature.room",
+      "timestamp": "2021-08-25T03:29:47.564Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.boiler.sensors",
+      "gatewayId": "################",
+      "feature": "heating.boiler.sensors",
+      "timestamp": "2021-08-25T03:29:46.401Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["collector", "dhw"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.solar.sensors.temperature",
+      "gatewayId": "################",
+      "feature": "heating.solar.sensors.temperature",
+      "timestamp": "2021-08-25T03:29:46.401Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "active": {
+          "type": "boolean",
+          "value": false
+        }
+      },
+      "commands": {},
+      "components": ["level"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.charging",
+      "gatewayId": "################",
+      "feature": "heating.dhw.charging",
+      "timestamp": "2021-08-25T14:16:41.453Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "active": {
+          "type": "boolean",
+          "value": false
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.standby",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.operating.modes.standby",
+      "timestamp": "2021-08-25T03:29:47.524Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["charging"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.buffer",
+      "gatewayId": "################",
+      "feature": "heating.buffer",
+      "timestamp": "2021-08-25T03:29:46.401Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["main"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.temperature",
+      "gatewayId": "################",
+      "feature": "heating.dhw.temperature",
+      "timestamp": "2021-08-25T03:29:46.400Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "value": {
+          "type": "string",
+          "value": "standby"
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.active",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.operating.programs.active",
+      "timestamp": "2021-08-25T03:29:47.645Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.schedule",
+      "gatewayId": "################",
+      "feature": "heating.dhw.schedule",
+      "timestamp": "2021-08-25T03:29:47.695Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["level"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.buffer.charging",
+      "gatewayId": "################",
+      "feature": "heating.buffer.charging",
+      "timestamp": "2021-08-25T03:29:46.401Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfort",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.operating.programs.comfort",
+      "timestamp": "2021-08-25T03:29:46.830Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["active", "dhw", "dhwAndHeating", "heating", "standby"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.modes",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.operating.modes",
+      "timestamp": "2021-08-25T03:29:46.401Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["active", "standard", "standby", "ventilation"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/ventilation.operating.modes",
+      "gatewayId": "################",
+      "feature": "ventilation.operating.modes",
+      "timestamp": "2021-08-25T03:29:46.400Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["circulation"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.dhw.pumps",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.dhw.pumps",
+      "timestamp": "2021-08-25T03:29:46.400Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [
+        "active",
+        "comfort",
+        "eco",
+        "external",
+        "holiday",
+        "normal",
+        "reduced",
+        "standby"
+      ],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.operating.programs",
+      "timestamp": "2021-08-25T03:29:46.400Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.heating",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.operating.modes.heating",
+      "timestamp": "2021-08-25T03:29:46.978Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["room", "supply"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.sensors.temperature",
+      "timestamp": "2021-08-25T03:29:46.401Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.sensors",
+      "gatewayId": "################",
+      "feature": "heating.dhw.sensors",
+      "timestamp": "2021-08-25T03:29:46.401Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "unit": {
+          "value": "celsius",
+          "type": "string"
+        },
+        "status": {
+          "type": "string",
+          "value": "error"
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.outlet",
+      "gatewayId": "################",
+      "feature": "heating.dhw.sensors.temperature.outlet",
+      "timestamp": "2021-08-25T03:29:47.637Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["time"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.device",
+      "gatewayId": "################",
+      "feature": "heating.device",
+      "timestamp": "2021-08-25T03:29:46.401Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["temperature"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.sensors",
+      "gatewayId": "################",
+      "feature": "heating.sensors",
+      "timestamp": "2021-08-25T03:29:46.401Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "value": {
+          "type": "number",
+          "value": 96,
+          "unit": ""
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.device.time.offset",
+      "gatewayId": "################",
+      "feature": "heating.device.time.offset",
+      "timestamp": "2021-08-25T03:29:47.575Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.room",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.sensors.temperature.room",
+      "timestamp": "2021-08-25T03:29:47.562Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["circulation"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.dhw.pumps",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.dhw.pumps",
+      "timestamp": "2021-08-25T03:29:46.400Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "status": {
+          "type": "string",
+          "value": "off"
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.frostprotection",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.frostprotection",
+      "timestamp": "2021-08-25T03:29:46.900Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.solar.sensors.temperature.dhw",
+      "gatewayId": "################",
+      "feature": "heating.solar.sensors.temperature.dhw",
+      "timestamp": "2021-08-25T03:29:47.633Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["pumps", "schedule"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.dhw",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.dhw",
+      "timestamp": "2021-08-25T03:29:46.400Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "shift": {
+          "type": "number",
+          "unit": "",
+          "value": 0
+        },
+        "slope": {
+          "type": "number",
+          "unit": "",
+          "value": 1.4
+        }
+      },
+      "commands": {
+        "setCurve": {
+          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.heating.curve/commands/setCurve",
+          "name": "setCurve",
+          "isExecutable": true,
+          "params": {
+            "slope": {
+              "type": "number",
+              "required": true,
+              "constraints": {
+                "min": 0.2,
+                "max": 3.5,
+                "stepping": 0.1
+              }
+            },
+            "shift": {
+              "type": "number",
+              "required": true,
+              "constraints": {
+                "min": -13,
+                "max": 40,
+                "stepping": 1
+              }
+            }
+          }
+        }
+      },
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.heating.curve",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.heating.curve",
+      "timestamp": "2021-08-25T03:29:46.910Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.heating",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.operating.modes.heating",
+      "timestamp": "2021-08-25T03:29:46.975Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "active": {
+          "value": false,
+          "type": "boolean"
+        },
+        "temperature": {
+          "value": 0,
+          "unit": "",
+          "type": "number"
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.external",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.operating.programs.external",
+      "timestamp": "2021-08-25T03:29:47.538Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "unit": {
+          "value": "celsius",
+          "type": "string"
+        },
+        "value": {
+          "type": "number",
+          "value": 58.6,
+          "unit": "celsius"
+        },
+        "status": {
+          "type": "string",
+          "value": "connected"
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage",
+      "gatewayId": "################",
+      "feature": "heating.dhw.sensors.temperature.hotWaterStorage",
+      "timestamp": "2021-08-25T15:02:49.557Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "unit": {
+          "value": "celsius",
+          "type": "string"
+        },
+        "value": {
+          "type": "number",
+          "value": 25.5,
+          "unit": "celsius"
+        },
+        "status": {
+          "type": "string",
+          "value": "connected"
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.supply",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.sensors.temperature.supply",
+      "timestamp": "2021-08-25T11:03:00.515Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["active", "dhw", "dhwAndHeating", "heating", "standby"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.modes",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.operating.modes",
+      "timestamp": "2021-08-25T03:29:46.401Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    }
+  ]
+}

--- a/tests/components/vicare/test_config_entry.py
+++ b/tests/components/vicare/test_config_entry.py
@@ -1,0 +1,25 @@
+"""Test the ViCare config flow."""
+
+from unittest.mock import MagicMock
+
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def test_config_entry_single_device(
+    hass: HomeAssistant,
+    mock_vicare_gas_boiler: MagicMock,
+    init_integration: MockConfigEntry,
+) -> None:
+    """Test default cache duration when using a single device."""
+    assert mock_vicare_gas_boiler.cacheDuration == 60
+
+
+async def test_config_entry_2_devices(
+    hass: HomeAssistant,
+    mock_vicare_2_gas_boilers: MagicMock,
+    init_integration: MockConfigEntry,
+) -> None:
+    """Test increased cache duration when using a multiple devices."""
+    assert mock_vicare_2_gas_boilers.cacheDuration == 120

--- a/tests/components/vicare/test_sensor.py
+++ b/tests/components/vicare/test_sensor.py
@@ -1,0 +1,28 @@
+"""Test the ViCare config flow."""
+
+from unittest.mock import MagicMock
+
+from homeassistant.components.sensor import SensorDeviceClass
+from homeassistant.const import ATTR_DEVICE_CLASS, ATTR_FRIENDLY_NAME
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def test_outside_temperature(
+    hass: HomeAssistant,
+    mock_vicare_2_gas_boilers: MagicMock,
+    init_integration: MockConfigEntry,
+) -> None:
+    """Test Outside temperature sensor."""
+    state = hass.states.get("sensor.vicare_outside_temperature")
+    assert state
+    assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.TEMPERATURE
+    assert state.attributes.get(ATTR_FRIENDLY_NAME) == "ViCare Outside Temperature"
+    # TODO: I don't understand why below assert fails. State is always unknown
+    # assert state.state == "20.8"
+
+    state = hass.states.get("sensor.vicare_outside_temperature_2")
+    assert state
+    assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.TEMPERATURE
+    assert state.attributes.get(ATTR_FRIENDLY_NAME) == "ViCare Outside Temperature"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
Entity IDs will change due to this PR. However all Entities will be migrated to the new format.
The Device ID will not be migrated.

## Proposed change
Support arbitrary numbers of devices.
Before this change the integration was limited to showing the first device only. With increasing complexity of heating systems this limitation turned out to be a major problem for users.

This required new unique ids to be generated for both: entities and devices.
Devices are not migrated since I could not find a way to do this in Home Assistant. This leads to a stale device when the user updates. **Any pointers on how to fix that would be great**

At the same time this change introduces a new type of tests which can use API dumps as jsons as fixture.

An update of the underlying library PyVicare was also necessary:
https://github.com/somm15/PyViCare/compare/2.21.0...2.25.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #87404 #80231
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
