### PR TITLE
Update calendar to always request start/end dates in local time rather than UTC

### DIFF
--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -523,7 +523,7 @@ class CalendarEventView(http.HomeAssistantView):
 
         try:
             calendar_event_list = await entity.async_get_events(
-                request.app["hass"], start_date, end_date
+                request.app["hass"], dt.as_local(start_date), dt.as_local(end_date)
             )
         except HomeAssistantError as err:
             _LOGGER.debug("Error reading events: %s", err)

--- a/homeassistant/components/google/calendar.py
+++ b/homeassistant/components/google/calendar.py
@@ -283,8 +283,8 @@ class CalendarSyncUpdateCoordinator(DataUpdateCoordinator[Timeline]):
                 "Unable to get events: Sync from server has not completed"
             )
         return self.data.overlapping(
-            dt_util.as_local(start_date),
-            dt_util.as_local(end_date),
+            start_date,
+            end_date,
         )
 
     @property

--- a/homeassistant/components/local_calendar/calendar.py
+++ b/homeassistant/components/local_calendar/calendar.py
@@ -85,17 +85,16 @@ class LocalCalendarEntity(CalendarEntity):
         self, hass: HomeAssistant, start_date: datetime, end_date: datetime
     ) -> list[CalendarEvent]:
         """Get all events in a specific time frame."""
-        events = self._calendar.timeline_tz(dt_util.DEFAULT_TIME_ZONE).overlapping(
-            dt_util.as_local(start_date),
-            dt_util.as_local(end_date),
+        events = self._calendar.timeline_tz(start_date.tzinfo).overlapping(
+            start_date,
+            end_date,
         )
         return [_get_calendar_event(event) for event in events]
 
     async def async_update(self) -> None:
         """Update entity state with the next upcoming event."""
-        events = self._calendar.timeline_tz(dt_util.DEFAULT_TIME_ZONE).active_after(
-            dt_util.now()
-        )
+        now = dt_util.now()
+        events = self._calendar.timeline_tz(now.tzinfo).active_after(now)
         if event := next(events, None):
             self._event = _get_calendar_event(event)
         else:

--- a/tests/components/local_calendar/test_calendar.py
+++ b/tests/components/local_calendar/test_calendar.py
@@ -37,10 +37,27 @@ async def test_empty_calendar(
     }
 
 
+@pytest.mark.parametrize(
+    ("dtstart", "dtend"),
+    [
+        ("1997-07-14T18:00:00+01:00", "1997-07-15T05:00:00+01:00"),
+        ("1997-07-14T17:00:00+00:00", "1997-07-15T04:00:00+00:00"),
+        ("1997-07-14T11:00:00-06:00", "1997-07-14T22:00:00-06:00"),
+        ("1997-07-14T10:00:00-07:00", "1997-07-14T21:00:00-07:00"),
+    ],
+)
 async def test_api_date_time_event(
-    ws_client: ClientFixture, setup_integration: None, get_events: GetEventsFn
+    ws_client: ClientFixture,
+    setup_integration: None,
+    get_events: GetEventsFn,
+    dtstart: str,
+    dtend: str,
 ) -> None:
-    """Test an event with a start/end date time."""
+    """Test an event with a start/end date time.
+
+    Events created in various timezones are ultimately returned relative
+    to local home assistant timezone.
+    """
     client = await ws_client()
     await client.cmd_result(
         "create",
@@ -48,8 +65,8 @@ async def test_api_date_time_event(
             "entity_id": TEST_ENTITY,
             "event": {
                 "summary": "Bastille Day Party",
-                "dtstart": "1997-07-14T17:00:00+00:00",
-                "dtend": "1997-07-15T04:00:00+00:00",
+                "dtstart": dtstart,
+                "dtend": dtend,
             },
         },
     )
@@ -63,6 +80,8 @@ async def test_api_date_time_event(
         }
     ]
 
+    # Query events in UTC
+
     # Time range before event
     events = await get_events("1997-07-13T00:00:00Z", "1997-07-14T16:00:00Z")
     assert len(events) == 0
@@ -75,6 +94,12 @@ async def test_api_date_time_event(
     assert len(events) == 1
     # Overlap with event end
     events = await get_events("1997-07-15T03:00:00Z", "1997-07-15T06:00:00Z")
+    assert len(events) == 1
+
+    # Query events overlapping with start and end but in another timezone
+    events = await get_events("1997-07-12T23:00:00-01:00", "1997-07-14T17:00:00-01:00")
+    assert len(events) == 1
+    events = await get_events("1997-07-15T02:00:00-01:00", "1997-07-15T05:00:00-01:00")
     assert len(events) == 1
 
 

--- a/tests/components/todoist/test_calendar.py
+++ b/tests/components/todoist/test_calendar.py
@@ -1,5 +1,5 @@
 """Unit tests for the Todoist calendar platform."""
-from datetime import datetime, timedelta
+from datetime import timedelta
 from http import HTTPStatus
 from unittest.mock import AsyncMock, patch
 import urllib
@@ -30,9 +30,7 @@ def mock_task() -> Task:
         created_at="2021-10-01T00:00:00",
         creator_id="1",
         description="A task",
-        due=Due(
-            is_recurring=False, date=datetime.now().strftime("%Y-%m-%d"), string="today"
-        ),
+        due=Due(is_recurring=False, date=dt.now().strftime("%Y-%m-%d"), string="today"),
         id="1",
         labels=["Label1"],
         order=1,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Implement the proposal in https://github.com/home-assistant/architecture/discussions/853 to have calendar request events in local time, clarifying that integrations must take into account the local timezone to correctly implement all day queries.

When adding this i noticed the `todoist` tests required updating. This is because the existing todoist integration is broken for all day events e.g. https://github.com/home-assistant/core/issues/89717 which was filed by a user which I was able to reproduce. This PR does not fix the broken all day event comparison behavior, and it will be addressed in a followup that adds additional tests for todoists


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
