### PR TITLE
Redact secret zwave values in diagnostics

### DIFF
--- a/homeassistant/components/zwave_js/diagnostics.py
+++ b/homeassistant/components/zwave_js/diagnostics.py
@@ -34,16 +34,23 @@ VALUES_TO_REDACT = (
 )
 
 
-def redact_value_of_zwave_value(zwave_value: ValueDataType) -> ValueDataType:
-    """Redact value of a Z-Wave value."""
+def _redacted_value(zwave_value: ValueDataType) -> ValueDataType:
+    """Return redacted value of a Z-Wave value."""
+    redacted_value: ValueDataType = deepcopy(zwave_value)
+    redacted_value["value"] = REDACTED
+    return redacted_value
+
+
+def optionally_redact_value_of_zwave_value(zwave_value: ValueDataType) -> ValueDataType:
+    """Redact value of a Z-Wave value if it matches criteria to redact."""
     # If the value has no value, there is nothing to redact
     if zwave_value.get("value") in (None, ""):
         return zwave_value
+    if zwave_value.get("metadata", {}).get("secret"):
+        return _redacted_value(zwave_value)
     for value_to_redact in VALUES_TO_REDACT:
         if value_matches_matcher(value_to_redact, zwave_value):
-            redacted_value: ValueDataType = deepcopy(zwave_value)
-            redacted_value["value"] = REDACTED
-            return redacted_value
+            return _redacted_value(zwave_value)
     return zwave_value
 
 
@@ -51,7 +58,8 @@ def redact_node_state(node_state: NodeDataType) -> NodeDataType:
     """Redact node state."""
     redacted_state: NodeDataType = deepcopy(node_state)
     redacted_state["values"] = [
-        redact_value_of_zwave_value(zwave_value) for zwave_value in node_state["values"]
+        optionally_redact_value_of_zwave_value(zwave_value)
+        for zwave_value in node_state["values"]
     ]
     return redacted_state
 

--- a/tests/components/zwave_js/test_diagnostics.py
+++ b/tests/components/zwave_js/test_diagnostics.py
@@ -195,8 +195,8 @@ async def test_device_diagnostics_secret_value(
 ) -> None:
     """Test that secret value in device level diagnostics gets redacted."""
 
-    def _find_val(data: dict) -> dict:
-        """Find specific value in data."""
+    def _find_ultraviolet_val(data: dict) -> dict:
+        """Find ultraviolet property value in data."""
         return next(
             val
             for val in data["values"]
@@ -206,7 +206,7 @@ async def test_device_diagnostics_secret_value(
 
     node_state = copy.deepcopy(multisensor_6_state)
     # Force a value to be secret so we can check if it gets redacted
-    secret_value = _find_val(node_state)
+    secret_value = _find_ultraviolet_val(node_state)
     secret_value["metadata"]["secret"] = True
     node = Node(client, node_state)
     client.driver.controller.nodes[node.node_id] = node
@@ -219,5 +219,5 @@ async def test_device_diagnostics_secret_value(
     diagnostics_data = await get_diagnostics_for_device(
         hass, hass_client, integration, device
     )
-    test_value = _find_val(diagnostics_data["state"])
+    test_value = _find_ultraviolet_val(diagnostics_data["state"])
     assert test_value["value"] == REDACTED

--- a/tests/components/zwave_js/test_diagnostics.py
+++ b/tests/components/zwave_js/test_diagnostics.py
@@ -1,10 +1,14 @@
 """Test the Z-Wave JS diagnostics."""
+import copy
 from unittest.mock import patch
 
 import pytest
+from zwave_js_server.const import CommandClass
 from zwave_js_server.event import Event
+from zwave_js_server.model.node import Node
 
 from homeassistant.components.zwave_js.diagnostics import (
+    REDACTED,
     ZwaveValueMatcher,
     async_get_device_diagnostics,
 )
@@ -179,3 +183,41 @@ async def test_device_diagnostics_missing_primary_value(
 
     assert air_entity["value_id"] == value.value_id
     assert air_entity["primary_value"] is None
+
+
+async def test_device_diagnostics_secret_value(
+    hass: HomeAssistant,
+    client,
+    multisensor_6_state,
+    integration,
+    hass_client: ClientSessionGenerator,
+    version_state,
+) -> None:
+    """Test that secret value in device level diagnostics gets redacted."""
+    node_state = copy.deepcopy(multisensor_6_state)
+    # Force a value to be secret so we can check if it gets redacted
+    secret_value = next(
+        val
+        for val in node_state["values"]
+        if val["commandClass"] == CommandClass.SENSOR_MULTILEVEL
+        and val["property"] == PROPERTY_ULTRAVIOLET
+    )
+    secret_value["metadata"]["secret"] = True
+    node = Node(client, node_state)
+    client.driver.controller.nodes[node.node_id] = node
+    client.driver.controller.emit("node added", {"node": node})
+    await hass.async_block_till_done()
+    dev_reg = async_get_dev_reg(hass)
+    device = dev_reg.async_get_device({get_device_id(client.driver, node)})
+    assert device
+
+    diagnostics_data = await get_diagnostics_for_device(
+        hass, hass_client, integration, device
+    )
+    test_value = next(
+        val
+        for val in diagnostics_data["state"]["values"]
+        if val["commandClass"] == CommandClass.SENSOR_MULTILEVEL
+        and val["property"] == PROPERTY_ULTRAVIOLET
+    )
+    assert test_value["value"] == REDACTED


### PR DESCRIPTION
## Proposed change
`zwave-js` introduced a new `secret` metadata property in [v10.11](https://github.com/zwave-js/node-zwave-js/releases/tag/v10.11.0). According to the [PR](https://github.com/zwave-js/node-zwave-js/pull/5467), secret values should be obfuscated in the logs. There may be some actual logging we need to fix, but in the meantime, this will redact these secret values in the diagnostics dumps.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
