### PR TITLE
Bump pychromecast to 13.0.6

### DIFF
--- a/homeassistant/components/cast/manifest.json
+++ b/homeassistant/components/cast/manifest.json
@@ -14,6 +14,6 @@
   "documentation": "https://www.home-assistant.io/integrations/cast",
   "iot_class": "local_polling",
   "loggers": ["casttube", "pychromecast"],
-  "requirements": ["pychromecast==13.0.4"],
+  "requirements": ["pychromecast==13.0.6"],
   "zeroconf": ["_googlecast._tcp.local."]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1540,7 +1540,7 @@ pycfdns==2.0.1
 pychannels==1.2.3
 
 # homeassistant.components.cast
-pychromecast==13.0.4
+pychromecast==13.0.6
 
 # homeassistant.components.pocketcasts
 pycketcasts==1.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1128,7 +1128,7 @@ pybravia==0.3.2
 pycfdns==2.0.1
 
 # homeassistant.components.cast
-pychromecast==13.0.4
+pychromecast==13.0.6
 
 # homeassistant.components.comfoconnect
 pycomfoconnect==0.5.1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump pychromecast from 13.0.4 to 13.0.6
### 13.0.6
- Fix socket leak (https://github.com/home-assistant-libs/pychromecast/pull/718) @emontnemery
- Don't call launch callback on error (https://github.com/home-assistant-libs/pychromecast/pull/715) @emontnemery
- Wait for response when stopping app (https://github.com/home-assistant-libs/pychromecast/pull/714) @emontnemery
- Simplify request callback handling (https://github.com/home-assistant-libs/pychromecast/pull/712) @emontnemery
- Make sure handler is unregistered after quickplay (https://github.com/home-assistant-libs/pychromecast/pull/713) @emontnemery

### 13.0.5
- Fix lint issues (https://github.com/home-assistant-libs/pychromecast/pull/710) @MartinHjelmare
- Add SVS Pro SoundBase (https://github.com/home-assistant-libs/pychromecast/pull/704) @kaechele
- Add JBL Link 10, 20, 300, 500 (https://github.com/home-assistant-libs/pychromecast/pull/701) @caraar12345
- Fix poll/select for Windows (https://github.com/home-assistant-libs/pychromecast/pull/690) @strunker
- Add Smart Soundbar 10 (https://github.com/home-assistant-libs/pychromecast/pull/700) @balloob

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
