### PR TITLE
Make abort_entries_match available in options flow

### DIFF
--- a/homeassistant/components/imap/config_flow.py
+++ b/homeassistant/components/imap/config_flow.py
@@ -148,24 +148,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 class OptionsFlow(config_entries.OptionsFlowWithConfigEntry):
     """Option flow handler."""
 
-    def _async_abort_entries_match(
-        self, match_dict: dict[str, Any] | None
-    ) -> dict[str, str]:
-        """Validate the user input against other config entries."""
-        if match_dict is None:
-            return {}
-
-        errors: dict[str, str] = {}
-        for entry in [
-            entry
-            for entry in self.hass.config_entries.async_entries(DOMAIN)
-            if entry is not self.config_entry
-        ]:
-            if all(item in entry.data.items() for item in match_dict.items()):
-                errors["base"] = "already_configured"
-                break
-        return errors
-
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1891,7 +1891,7 @@ class OptionsFlowWithConfigEntry(OptionsFlow):
             for entry in self.hass.config_entries.async_entries(
                 self.config_entry.domain
             )
-            if entry is not self.config_entry
+            if entry is not self.config_entry and entry.source != SOURCE_IGNORE
         ]:
             if all(
                 item

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1861,7 +1861,7 @@ class OptionsFlow(data_entry_flow.FlowHandler):
     @callback
     def _async_abort_entries_match(
         self, match_dict: dict[str, Any] | None = None
-    ) -> dict[str, str]:
+    ) -> None:
         """Validate the user input against other config entries."""
         if match_dict is None:
             match_dict = {}  # Match any entry
@@ -1869,7 +1869,6 @@ class OptionsFlow(data_entry_flow.FlowHandler):
         config_entry = cast(
             ConfigEntry, self.hass.config_entries.async_get_entry(self.handler)
         )
-        errors: dict[str, str] = {}
         for entry in [
             entry
             for entry in self.hass.config_entries.async_entries(config_entry.domain)
@@ -1883,9 +1882,7 @@ class OptionsFlow(data_entry_flow.FlowHandler):
                 ).items()
                 for item in match_dict.items()
             ):
-                errors["base"] = "already_configured"
-                break
-        return errors
+                raise data_entry_flow.AbortFlow("already_configured")
 
 
 class OptionsFlowWithConfigEntry(OptionsFlow):

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1468,6 +1468,28 @@ async def _old_conf_migrator(old_config: dict[str, Any]) -> dict[str, Any]:
     return {"entries": old_config}
 
 
+@callback
+def _async_abort_entries_match(
+    other_entries: list[ConfigEntry], match_dict: dict[str, Any] | None = None
+) -> None:
+    """Abort if current entries match all data.
+
+    Requires `already_configured` in strings.json in user visible flows.
+    """
+    if match_dict is None:
+        match_dict = {}  # Match any entry
+    for entry in other_entries:
+        if all(
+            item
+            in ChainMap(
+                entry.options,  # type: ignore[arg-type]
+                entry.data,  # type: ignore[arg-type]
+            ).items()
+            for item in match_dict.items()
+        ):
+            raise data_entry_flow.AbortFlow("already_configured")
+
+
 class ConfigFlow(data_entry_flow.FlowHandler):
     """Base class for config flows with some helpers."""
 
@@ -1505,18 +1527,9 @@ class ConfigFlow(data_entry_flow.FlowHandler):
 
         Requires `already_configured` in strings.json in user visible flows.
         """
-        if match_dict is None:
-            match_dict = {}  # Match any entry
-        for entry in self._async_current_entries(include_ignore=False):
-            if all(
-                item
-                in ChainMap(
-                    entry.options,  # type: ignore[arg-type]
-                    entry.data,  # type: ignore[arg-type]
-                ).items()
-                for item in match_dict.items()
-            ):
-                raise data_entry_flow.AbortFlow("already_configured")
+        _async_abort_entries_match(
+            self._async_current_entries(include_ignore=False), match_dict
+        )
 
     @callback
     def _abort_if_unique_id_configured(
@@ -1862,27 +1875,22 @@ class OptionsFlow(data_entry_flow.FlowHandler):
     def _async_abort_entries_match(
         self, match_dict: dict[str, Any] | None = None
     ) -> None:
-        """Validate the user input against other config entries."""
-        if match_dict is None:
-            match_dict = {}  # Match any entry
+        """Abort if another current entry matches all data.
+
+        Requires `already_configured` in strings.json in user visible flows.
+        """
 
         config_entry = cast(
             ConfigEntry, self.hass.config_entries.async_get_entry(self.handler)
         )
-        for entry in [
-            entry
-            for entry in self.hass.config_entries.async_entries(config_entry.domain)
-            if entry is not config_entry and entry.source != SOURCE_IGNORE
-        ]:
-            if all(
-                item
-                in ChainMap(
-                    entry.options,  # type: ignore[arg-type]
-                    entry.data,  # type: ignore[arg-type]
-                ).items()
-                for item in match_dict.items()
-            ):
-                raise data_entry_flow.AbortFlow("already_configured")
+        _async_abort_entries_match(
+            [
+                entry
+                for entry in self.hass.config_entries.async_entries(config_entry.domain)
+                if entry is not config_entry and entry.source != SOURCE_IGNORE
+            ],
+            match_dict,
+        )
 
 
 class OptionsFlowWithConfigEntry(OptionsFlow):

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1858,6 +1858,35 @@ class OptionsFlow(data_entry_flow.FlowHandler):
 
     handler: str
 
+    @callback
+    def _async_abort_entries_match(
+        self, match_dict: dict[str, Any] | None = None
+    ) -> dict[str, str]:
+        """Validate the user input against other config entries."""
+        if match_dict is None:
+            match_dict = {}  # Match any entry
+
+        config_entry = cast(
+            ConfigEntry, self.hass.config_entries.async_get_entry(self.handler)
+        )
+        errors: dict[str, str] = {}
+        for entry in [
+            entry
+            for entry in self.hass.config_entries.async_entries(config_entry.domain)
+            if entry is not config_entry and entry.source != SOURCE_IGNORE
+        ]:
+            if all(
+                item
+                in ChainMap(
+                    entry.options,  # type: ignore[arg-type]
+                    entry.data,  # type: ignore[arg-type]
+                ).items()
+                for item in match_dict.items()
+            ):
+                errors["base"] = "already_configured"
+                break
+        return errors
+
 
 class OptionsFlowWithConfigEntry(OptionsFlow):
     """Base class for options flows with config entry and options."""
@@ -1876,34 +1905,6 @@ class OptionsFlowWithConfigEntry(OptionsFlow):
     def options(self) -> dict[str, Any]:
         """Return a mutable copy of the config entry options."""
         return self._options
-
-    @callback
-    def _async_abort_entries_match(
-        self, match_dict: dict[str, Any] | None = None
-    ) -> dict[str, str]:
-        """Validate the user input against other config entries."""
-        if match_dict is None:
-            match_dict = {}  # Match any entry
-
-        errors: dict[str, str] = {}
-        for entry in [
-            entry
-            for entry in self.hass.config_entries.async_entries(
-                self.config_entry.domain
-            )
-            if entry is not self.config_entry and entry.source != SOURCE_IGNORE
-        ]:
-            if all(
-                item
-                in ChainMap(
-                    entry.options,  # type: ignore[arg-type]
-                    entry.data,  # type: ignore[arg-type]
-                ).items()
-                for item in match_dict.items()
-            ):
-                errors["base"] = "already_configured"
-                break
-        return errors
 
 
 class EntityRegistryDisabledHandler:

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -3404,6 +3404,7 @@ async def test__async_abort_entries_match(
         ),
         ({"vendor": "zoo"}, "already_configured"),
         ({"ip": "9.9.9.9"}, "already_configured"),
+        ({"ip": "7.7.7.7"}, "no_match"),  # ignored
         ({"vendor": "data"}, "no_match"),
         (
             {"vendor": "options"},

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -3388,6 +3388,97 @@ async def test__async_abort_entries_match(
     assert result["reason"] == reason
 
 
+@pytest.mark.parametrize(
+    ("matchers", "reason"),
+    [
+        ({}, "already_configured"),
+        ({"host": "3.3.3.3"}, "no_match"),
+        ({"vendor": "no_match"}, "no_match"),
+        ({"host": "3.4.5.6"}, "already_configured"),
+        ({"host": "3.4.5.6", "ip": "3.4.5.6"}, "no_match"),
+        ({"host": "3.4.5.6", "ip": "1.2.3.4"}, "already_configured"),
+        ({"host": "3.4.5.6", "ip": "1.2.3.4", "port": 23}, "already_configured"),
+        (
+            {"host": "9.9.9.9", "ip": "6.6.6.6", "port": 12, "vendor": "zoo"},
+            "already_configured",
+        ),
+        ({"vendor": "zoo"}, "already_configured"),
+        ({"ip": "9.9.9.9"}, "already_configured"),
+        ({"vendor": "data"}, "no_match"),
+        (
+            {"vendor": "options"},
+            "already_configured",
+        ),  # ensure options takes precedence over data
+    ],
+)
+async def test__async_abort_entries_match_options_flow(
+    hass: HomeAssistant,
+    manager: config_entries.ConfigEntries,
+    matchers: dict[str, str],
+    reason: str,
+) -> None:
+    """Test aborting if matching config entries exist."""
+    MockConfigEntry(
+        domain="comp", data={"ip": "1.2.3.4", "host": "4.5.6.7", "port": 23}
+    ).add_to_hass(hass)
+    MockConfigEntry(
+        domain="comp", data={"ip": "9.9.9.9", "host": "4.5.6.7", "port": 23}
+    ).add_to_hass(hass)
+    MockConfigEntry(
+        domain="comp", data={"ip": "1.2.3.4", "host": "3.4.5.6", "port": 23}
+    ).add_to_hass(hass)
+    MockConfigEntry(
+        domain="comp",
+        source=config_entries.SOURCE_IGNORE,
+        data={"ip": "7.7.7.7", "host": "4.5.6.7", "port": 23},
+    ).add_to_hass(hass)
+    MockConfigEntry(
+        domain="comp",
+        data={"ip": "6.6.6.6", "host": "9.9.9.9", "port": 12},
+        options={"vendor": "zoo"},
+    ).add_to_hass(hass)
+    MockConfigEntry(
+        domain="comp",
+        data={"vendor": "data"},
+        options={"vendor": "options"},
+    ).add_to_hass(hass)
+
+    original_entry = MockConfigEntry(domain="comp", data={})
+    original_entry.add_to_hass(hass)
+
+    mock_setup_entry = AsyncMock(return_value=True)
+
+    mock_integration(hass, MockModule("comp", async_setup_entry=mock_setup_entry))
+    mock_entity_platform(hass, "config_flow.comp", None)
+
+    class TestFlow(config_entries.ConfigFlow):
+        """Test flow."""
+
+        @staticmethod
+        @callback
+        def async_get_options_flow(config_entry):
+            """Test options flow."""
+
+            class _OptionsFlow(config_entries.OptionsFlowWithConfigEntry):
+                """Test flow."""
+
+                async def async_step_init(self, user_input=None):
+                    """Test user step."""
+                    if errors := self._async_abort_entries_match(user_input):
+                        return self.async_abort(reason=errors["base"])
+                    return self.async_abort(reason="no_match")
+
+            return _OptionsFlow(config_entry)
+
+    with patch.dict(config_entries.HANDLERS, {"comp": TestFlow, "beer": 5}):
+        result = await hass.config_entries.options.async_init(
+            original_entry.entry_id, data=matchers
+        )
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == reason
+
+
 async def test_loading_old_data(
     hass: HomeAssistant, hass_storage: dict[str, Any]
 ) -> None:

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -40,6 +40,7 @@ from .common import (
     MockModule,
     MockPlatform,
     async_fire_time_changed,
+    mock_config_flow,
     mock_coro,
     mock_entity_platform,
     mock_integration,
@@ -3420,37 +3421,37 @@ async def test__async_abort_entries_match_options_flow(
 ) -> None:
     """Test aborting if matching config entries exist."""
     MockConfigEntry(
-        domain="comp", data={"ip": "1.2.3.4", "host": "4.5.6.7", "port": 23}
+        domain="test_abort", data={"ip": "1.2.3.4", "host": "4.5.6.7", "port": 23}
     ).add_to_hass(hass)
     MockConfigEntry(
-        domain="comp", data={"ip": "9.9.9.9", "host": "4.5.6.7", "port": 23}
+        domain="test_abort", data={"ip": "9.9.9.9", "host": "4.5.6.7", "port": 23}
     ).add_to_hass(hass)
     MockConfigEntry(
-        domain="comp", data={"ip": "1.2.3.4", "host": "3.4.5.6", "port": 23}
+        domain="test_abort", data={"ip": "1.2.3.4", "host": "3.4.5.6", "port": 23}
     ).add_to_hass(hass)
     MockConfigEntry(
-        domain="comp",
+        domain="test_abort",
         source=config_entries.SOURCE_IGNORE,
         data={"ip": "7.7.7.7", "host": "4.5.6.7", "port": 23},
     ).add_to_hass(hass)
     MockConfigEntry(
-        domain="comp",
+        domain="test_abort",
         data={"ip": "6.6.6.6", "host": "9.9.9.9", "port": 12},
         options={"vendor": "zoo"},
     ).add_to_hass(hass)
     MockConfigEntry(
-        domain="comp",
+        domain="test_abort",
         data={"vendor": "data"},
         options={"vendor": "options"},
     ).add_to_hass(hass)
 
-    original_entry = MockConfigEntry(domain="comp", data={})
+    original_entry = MockConfigEntry(domain="test_abort", data={})
     original_entry.add_to_hass(hass)
 
     mock_setup_entry = AsyncMock(return_value=True)
 
-    mock_integration(hass, MockModule("comp", async_setup_entry=mock_setup_entry))
-    mock_entity_platform(hass, "config_flow.comp", None)
+    mock_integration(hass, MockModule("test_abort", async_setup_entry=mock_setup_entry))
+    mock_entity_platform(hass, "config_flow.test_abort", None)
 
     class TestFlow(config_entries.ConfigFlow):
         """Test flow."""
@@ -3471,7 +3472,7 @@ async def test__async_abort_entries_match_options_flow(
 
             return _OptionsFlow()
 
-    with patch.dict(config_entries.HANDLERS, {"comp": TestFlow, "beer": 5}):
+    with mock_config_flow("test_abort", TestFlow):
         result = await hass.config_entries.options.async_init(
             original_entry.entry_id, data=matchers
         )

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -3460,7 +3460,7 @@ async def test__async_abort_entries_match_options_flow(
         def async_get_options_flow(config_entry):
             """Test options flow."""
 
-            class _OptionsFlow(config_entries.OptionsFlowWithConfigEntry):
+            class _OptionsFlow(config_entries.OptionsFlow):
                 """Test flow."""
 
                 async def async_step_init(self, user_input=None):
@@ -3469,7 +3469,7 @@ async def test__async_abort_entries_match_options_flow(
                         return self.async_abort(reason=errors["base"])
                     return self.async_abort(reason="no_match")
 
-            return _OptionsFlow(config_entry)
+            return _OptionsFlow()
 
     with patch.dict(config_entries.HANDLERS, {"comp": TestFlow, "beer": 5}):
         result = await hass.config_entries.options.async_init(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow-up to #89914
Linked to #72558

cc @MartinHjelmare, @gjohansson-ST, @jbouwh

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
