### PR TITLE
Add connected relayer region to system health

### DIFF
--- a/homeassistant/components/cloud/client.py
+++ b/homeassistant/components/cloud/client.py
@@ -47,6 +47,7 @@ class CloudClient(Interface):
         self._google_config: google_config.CloudGoogleConfig | None = None
         self._alexa_config_init_lock = asyncio.Lock()
         self._google_config_init_lock = asyncio.Lock()
+        self._relayer_region: str | None = None
 
     @property
     def base_path(self) -> Path:
@@ -83,6 +84,11 @@ class CloudClient(Interface):
     def remote_autostart(self) -> bool:
         """Return true if we want start a remote connection."""
         return self._prefs.remote_enabled
+
+    @property
+    def relayer_region(self) -> str | None:
+        """Return the connected relayer region."""
+        return self._relayer_region
 
     async def get_alexa_config(self) -> alexa_config.CloudAlexaConfig:
         """Return Alexa config."""
@@ -255,6 +261,11 @@ class CloudClient(Interface):
             "status": response_dict["status"],
             "headers": {"Content-Type": response.content_type},
         }
+
+    async def async_system_message(self, payload: dict[Any, Any] | None) -> None:
+        """Handle system messages."""
+        if payload and (region := payload.get("region")):
+            self._relayer_region = region
 
     async def async_cloudhooks_update(self, data: dict[str, dict[str, str]]) -> None:
         """Update local list of cloudhooks."""

--- a/homeassistant/components/cloud/manifest.json
+++ b/homeassistant/components/cloud/manifest.json
@@ -8,5 +8,5 @@
   "integration_type": "system",
   "iot_class": "cloud_push",
   "loggers": ["hass_nabucasa"],
-  "requirements": ["hass-nabucasa==0.62.0"]
+  "requirements": ["hass-nabucasa==0.63.1"]
 }

--- a/homeassistant/components/cloud/strings.json
+++ b/homeassistant/components/cloud/strings.json
@@ -5,6 +5,7 @@
       "can_reach_cloud": "Reach Home Assistant Cloud",
       "can_reach_cloud_auth": "Reach Authentication Server",
       "relayer_connected": "Relayer Connected",
+      "relayer_region": "Relayer Region",
       "remote_connected": "Remote Connected",
       "remote_enabled": "Remote Enabled",
       "remote_server": "Remote Server",

--- a/homeassistant/components/cloud/system_health.py
+++ b/homeassistant/components/cloud/system_health.py
@@ -28,6 +28,7 @@ async def system_health_info(hass):
     if cloud.is_logged_in:
         data["subscription_expiration"] = cloud.expiration_date
         data["relayer_connected"] = cloud.is_connected
+        data["relayer_region"] = client.relayer_region
         data["remote_enabled"] = client.prefs.remote_enabled
         data["remote_connected"] = cloud.remote.is_connected
         data["alexa_enabled"] = client.prefs.alexa_enabled

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -22,7 +22,7 @@ cryptography==40.0.1
 dbus-fast==1.84.2
 fnvhash==0.1.0
 ha-av==10.0.0
-hass-nabucasa==0.62.0
+hass-nabucasa==0.63.1
 hassil==1.0.6
 home-assistant-bluetooth==1.9.3
 home-assistant-frontend==20230309.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -868,7 +868,7 @@ ha-philipsjs==3.0.0
 habitipy==0.2.0
 
 # homeassistant.components.cloud
-hass-nabucasa==0.62.0
+hass-nabucasa==0.63.1
 
 # homeassistant.components.splunk
 hass_splunk==0.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -666,7 +666,7 @@ ha-philipsjs==3.0.0
 habitipy==0.2.0
 
 # homeassistant.components.cloud
-hass-nabucasa==0.62.0
+hass-nabucasa==0.63.1
 
 # homeassistant.components.conversation
 hassil==1.0.6

--- a/tests/components/cloud/test_client.py
+++ b/tests/components/cloud/test_client.py
@@ -312,3 +312,22 @@ async def test_login_recovers_bad_internet(
     await hass.async_block_till_done()
 
     assert len(client._alexa_config.async_enable_proactive_mode.mock_calls) == 2
+
+
+async def test_system_msg(hass: HomeAssistant) -> None:
+    """Test system msg."""
+    with patch("hass_nabucasa.Cloud.initialize"):
+        setup = await async_setup_component(hass, "cloud", {"cloud": {}})
+        assert setup
+    cloud = hass.data["cloud"]
+
+    assert cloud.client.relayer_region is None
+
+    response = await cloud.client.async_system_message(
+        {
+            "region": "xx-earth-616",
+        }
+    )
+
+    assert response is None
+    assert cloud.client.relayer_region == "xx-earth-616"

--- a/tests/components/cloud/test_system_health.py
+++ b/tests/components/cloud/test_system_health.py
@@ -36,11 +36,12 @@ async def test_cloud_system_health(
         expiration_date=now,
         is_connected=True,
         client=Mock(
+            relayer_region="xx-earth-616",
             prefs=Mock(
                 remote_enabled=True,
                 alexa_enabled=True,
                 google_enabled=False,
-            )
+            ),
         ),
     )
 
@@ -54,6 +55,7 @@ async def test_cloud_system_health(
         "logged_in": True,
         "subscription_expiration": now,
         "relayer_connected": True,
+        "relayer_region": "xx-earth-616",
         "remote_enabled": True,
         "remote_connected": False,
         "remote_server": "us-west-1",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This will add the region which hosts the connected relayer to the system health response of the cloud integration.
While this is mainly a new feature, it is also a dependency bump, but as that bump introduces the new `abstractmethod` that needed to be added while bumping, and with how little extra around I figured it was OK to merge these 2 things in one PR.


Dependency changes <https://github.com/NabuCasa/hass-nabucasa/compare/0.62.0...0.63.1>


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
