### PR TITLE
Fix goodwe export limit unit on single phase DT inverters

### DIFF
--- a/homeassistant/components/goodwe/manifest.json
+++ b/homeassistant/components/goodwe/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/goodwe",
   "iot_class": "local_polling",
   "loggers": ["goodwe"],
-  "requirements": ["goodwe==0.2.25"]
+  "requirements": ["goodwe==0.2.29"]
 }

--- a/homeassistant/components/goodwe/number.py
+++ b/homeassistant/components/goodwe/number.py
@@ -39,8 +39,13 @@ class GoodweNumberEntityDescription(
     """Class describing Goodwe number entities."""
 
 
+def _get_setting_unit(inverter: Inverter, setting: str) -> str:
+    """Answer unit of an inverter setting of specified name."""
+    return next((s.unit for s in inverter.settings() if s.id_ == setting), "")
+
+
 NUMBERS = (
-    # non DT inverters (limit in W)
+    # Export limit in W
     GoodweNumberEntityDescription(
         key="grid_export_limit",
         name="Grid export limit",
@@ -53,9 +58,9 @@ NUMBERS = (
         native_max_value=10000,
         getter=lambda inv: inv.get_grid_export_limit(),
         setter=lambda inv, val: inv.set_grid_export_limit(val),
-        filter=lambda inv: type(inv).__name__ != "DT",
+        filter=lambda inv: _get_setting_unit(inv, "grid_export_limit") != "%",
     ),
-    # DT inverters (limit is in %)
+    # Export limit in %
     GoodweNumberEntityDescription(
         key="grid_export_limit",
         name="Grid export limit",
@@ -67,7 +72,7 @@ NUMBERS = (
         native_max_value=100,
         getter=lambda inv: inv.get_grid_export_limit(),
         setter=lambda inv, val: inv.set_grid_export_limit(val),
-        filter=lambda inv: type(inv).__name__ == "DT",
+        filter=lambda inv: _get_setting_unit(inv, "grid_export_limit") == "%",
     ),
     GoodweNumberEntityDescription(
         key="battery_discharge_depth",

--- a/homeassistant/components/goodwe/number.py
+++ b/homeassistant/components/goodwe/number.py
@@ -40,7 +40,7 @@ class GoodweNumberEntityDescription(
 
 
 def _get_setting_unit(inverter: Inverter, setting: str) -> str:
-    """Answer unit of an inverter setting of specified name."""
+    """Return the unit of an inverter setting."""
     return next((s.unit for s in inverter.settings() if s.id_ == setting), "")
 
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -798,7 +798,7 @@ glances_api==0.4.1
 goalzero==0.2.1
 
 # homeassistant.components.goodwe
-goodwe==0.2.25
+goodwe==0.2.29
 
 # homeassistant.components.google_mail
 google-api-python-client==2.71.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -614,7 +614,7 @@ glances_api==0.4.1
 goalzero==0.2.1
 
 # homeassistant.components.goodwe
-goodwe==0.2.25
+goodwe==0.2.29
 
 # homeassistant.components.google_mail
 google-api-python-client==2.71.0


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Single phase inverters of DT protocol family (D-NS, XS) use Watts as grid export limit value 
(in contrast to % of nominal power for 3 phase inverters). 
This fix corrects the improper behavior of using always % and actually forcing limit to be just 100 Watts.
Code was fixed both in HA number descriptor detection and also
in the underlying library https://github.com/marcelblijleven/goodwe/releases/tag/v0.2.29

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #89859
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
