### PR TITLE
Deprecate imap_content_sensor

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -519,6 +519,7 @@ omit =
     homeassistant/components/iglo/light.py
     homeassistant/components/ihc/*
     homeassistant/components/imap_email_content/sensor.py
+    homeassistant/components/imap_email_content/repairs.py
     homeassistant/components/incomfort/*
     homeassistant/components/insteon/binary_sensor.py
     homeassistant/components/insteon/climate.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -519,7 +519,6 @@ omit =
     homeassistant/components/iglo/light.py
     homeassistant/components/ihc/*
     homeassistant/components/imap_email_content/sensor.py
-    homeassistant/components/imap_email_content/repairs.py
     homeassistant/components/incomfort/*
     homeassistant/components/insteon/binary_sensor.py
     homeassistant/components/insteon/climate.py

--- a/homeassistant/components/imap/config_flow.py
+++ b/homeassistant/components/imap/config_flow.py
@@ -9,7 +9,7 @@ from aioimaplib import AioImapException
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.const import CONF_PASSWORD, CONF_PORT, CONF_USERNAME
+from homeassistant.const import CONF_NAME, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import AbortFlow, FlowResult
 from homeassistant.helpers import config_validation as cv
@@ -76,6 +76,31 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
     _reauth_entry: config_entries.ConfigEntry | None
+
+    async def async_step_import(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle the import from imap_email_content integration."""
+        assert user_input is not None
+        data = STEP_USER_DATA_SCHEMA(
+            {
+                CONF_SERVER: user_input[CONF_SERVER],
+                CONF_PORT: user_input[CONF_PORT],
+                CONF_USERNAME: user_input[CONF_USERNAME],
+                CONF_PASSWORD: user_input[CONF_PASSWORD],
+                CONF_FOLDER: user_input[CONF_FOLDER],
+            }
+        )
+        self._async_abort_entries_match(
+            {
+                key: data[key]
+                for key in (CONF_USERNAME, CONF_SERVER, CONF_FOLDER, CONF_SEARCH)
+            }
+        )
+        title = user_input[CONF_NAME]
+        if await validate_input(user_input):
+            raise AbortFlow("cannot_connect")
+        return self.async_create_entry(title=title, data=data)
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None

--- a/homeassistant/components/imap/config_flow.py
+++ b/homeassistant/components/imap/config_flow.py
@@ -25,7 +25,7 @@ from .const import (
 from .coordinator import connect_to_server
 from .errors import InvalidAuth, InvalidFolder
 
-STEP_USER_DATA_SCHEMA = vol.Schema(
+CONFIG_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_USERNAME): str,
         vol.Required(CONF_PASSWORD): str,
@@ -77,12 +77,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
     _reauth_entry: config_entries.ConfigEntry | None
 
-    async def async_step_import(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    async def async_step_import(self, user_input: dict[str, Any]) -> FlowResult:
         """Handle the import from imap_email_content integration."""
-        assert user_input is not None
-        data = STEP_USER_DATA_SCHEMA(
+        data = CONFIG_SCHEMA(
             {
                 CONF_SERVER: user_input[CONF_SERVER],
                 CONF_PORT: user_input[CONF_PORT],
@@ -98,7 +95,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             }
         )
         title = user_input[CONF_NAME]
-        if await validate_input(user_input):
+        if await validate_input(data):
             raise AbortFlow("cannot_connect")
         return self.async_create_entry(title=title, data=data)
 
@@ -107,9 +104,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> FlowResult:
         """Handle the initial step."""
         if user_input is None:
-            return self.async_show_form(
-                step_id="user", data_schema=STEP_USER_DATA_SCHEMA
-            )
+            return self.async_show_form(step_id="user", data_schema=CONFIG_SCHEMA)
 
         self._async_abort_entries_match(
             {
@@ -123,7 +118,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             return self.async_create_entry(title=title, data=user_input)
 
-        schema = self.add_suggested_values_to_schema(STEP_USER_DATA_SCHEMA, user_input)
+        schema = self.add_suggested_values_to_schema(CONFIG_SCHEMA, user_input)
         return self.async_show_form(step_id="user", data_schema=schema, errors=errors)
 
     async def async_step_reauth(self, entry_data: Mapping[str, Any]) -> FlowResult:

--- a/homeassistant/components/imap_email_content/__init__.py
+++ b/homeassistant/components/imap_email_content/__init__.py
@@ -1,1 +1,12 @@
 """The imap_email_content component."""
+
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import ConfigType
+
+PLATFORMS = [Platform.SENSOR]
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up imap_email_content."""
+    return True

--- a/homeassistant/components/imap_email_content/const.py
+++ b/homeassistant/components/imap_email_content/const.py
@@ -1,0 +1,13 @@
+"""Constants for the imap email content integration."""
+
+DOMAIN = "imap_email_content"
+
+CONF_SERVER = "server"
+CONF_SENDERS = "senders"
+CONF_FOLDER = "folder"
+
+ATTR_FROM = "from"
+ATTR_BODY = "body"
+ATTR_SUBJECT = "subject"
+
+DEFAULT_PORT = 993

--- a/homeassistant/components/imap_email_content/manifest.json
+++ b/homeassistant/components/imap_email_content/manifest.json
@@ -2,6 +2,7 @@
   "domain": "imap_email_content",
   "name": "IMAP Email Content",
   "codeowners": [],
+  "dependencies": ["imap"],
   "documentation": "https://www.home-assistant.io/integrations/imap_email_content",
   "iot_class": "cloud_push"
 }

--- a/homeassistant/components/imap_email_content/repairs.py
+++ b/homeassistant/components/imap_email_content/repairs.py
@@ -1,0 +1,211 @@
+"""Repair flow for imap email content integration."""
+
+from typing import Any
+
+import voluptuous as vol
+import yaml
+
+from homeassistant import data_entry_flow
+from homeassistant.components.imap import DOMAIN as IMAP_DOMAIN
+from homeassistant.components.imap.config_flow import STEP_USER_DATA_SCHEMA
+from homeassistant.components.repairs import RepairsFlow
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.const import (
+    CONF_NAME,
+    CONF_PASSWORD,
+    CONF_PORT,
+    CONF_USERNAME,
+    CONF_VALUE_TEMPLATE,
+)
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import issue_registry as ir
+from homeassistant.helpers.typing import ConfigType
+
+from .const import CONF_FOLDER, CONF_SENDERS, CONF_SERVER, DOMAIN
+
+
+@callback
+def process_issue(hass: HomeAssistant, config: ConfigType) -> None:
+    """Register an issue and suggest new config."""
+
+    name: str = config.get(CONF_NAME) or config[CONF_USERNAME]
+
+    issue_id = (
+        f"{name}_{config[CONF_USERNAME]}_{config[CONF_SERVER]}_{config[CONF_FOLDER]}"
+    )
+
+    if CONF_VALUE_TEMPLATE in config:
+        template: str = config[CONF_VALUE_TEMPLATE].template
+        template = template.replace("subject", 'trigger.event.data["subject"]')
+        template = template.replace("from", 'trigger.event.data["sender"]')
+        template = template.replace("date", 'trigger.event.data["date"]')
+        template = template.replace("body", 'trigger.event.data["text"]')
+    else:
+        template = '{{ trigger.event.data["subject"] }}'
+    data = config.copy()
+    data[CONF_VALUE_TEMPLATE] = template
+    data[CONF_NAME] = name
+
+    template_sensor_config: ConfigType = {
+        "template": [
+            {
+                "trigger": [
+                    {
+                        "id": "custom_event",
+                        "platform": "event",
+                        "event_type": "imap_content",
+                        "event_data": {"sender": config[CONF_SENDERS][0]},
+                    }
+                ],
+                "sensor": [
+                    {
+                        "state": template,
+                        "name": name,
+                    }
+                ],
+            }
+        ]
+    }
+
+    hass.data.setdefault(
+        DOMAIN,
+        {
+            "unique_id": issue_id,
+            "config": config,
+            "yaml_example": yaml.dump(template_sensor_config),
+        },
+    )
+
+    placeholders = {"yaml_example": yaml.dump(template_sensor_config)}
+    placeholders.update(data)
+
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        issue_id,
+        breaks_in_ha_version="2023.10.0",
+        is_fixable=True,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key="deprecation",
+        translation_placeholders=placeholders,
+        learn_more_url="https://www.home-assistant.io/integrations/imap/#using-events",
+        data=data,
+    )
+
+
+class DeprecationRepairFlow(RepairsFlow):
+    """Handler for an issue fixing flow."""
+
+    def __init__(self, issue_id: str, config: ConfigType) -> None:
+        """Create flow."""
+        self._name: str = config[CONF_NAME]
+        self._config: dict[str, Any] = STEP_USER_DATA_SCHEMA(
+            {
+                CONF_SERVER: config[CONF_SERVER],
+                CONF_PORT: config[CONF_PORT],
+                CONF_USERNAME: config[CONF_USERNAME],
+                CONF_PASSWORD: config[CONF_PASSWORD],
+                CONF_FOLDER: config[CONF_FOLDER],
+            }
+        )
+        self._issue_id = issue_id
+        super().__init__()
+
+    async def async_step_init(
+        self, user_input: dict[str, str] | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Handle the first step of a fix flow."""
+        if self._async_abort_entries_match(self._config):
+            return await self.async_step_deprecation()
+        return await self.async_step_start()
+
+    @callback
+    def _async_get_placeholders(self) -> dict[str, str] | None:
+        issue_registry = ir.async_get(self.hass)
+        description_placeholders = None
+        if issue := issue_registry.async_get_issue(self.handler, self.issue_id):
+            description_placeholders = issue.translation_placeholders
+
+        return description_placeholders
+
+    def _async_abort_entries_match(
+        self, match_dict: dict[str, Any] | None
+    ) -> dict[str, str]:
+        """Validate the user input against other config entries."""
+        if match_dict is None:
+            return {}
+
+        errors: dict[str, str] = {}
+        for entry in list(self.hass.config_entries.async_entries(IMAP_DOMAIN)):
+            if all(item in entry.data.items() for item in match_dict.items()):
+                errors["base"] = "already_configured"
+                break
+        return errors
+
+    async def async_step_start(
+        self, user_input: dict[str, str] | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Wait for the user to start the config migration."""
+        placeholders = self._async_get_placeholders()
+        if user_input is None:
+            return self.async_show_form(
+                step_id="start",
+                data_schema=vol.Schema({}),
+                description_placeholders=placeholders,
+            )
+
+        return self.async_show_form(
+            step_id="confirm",
+            data_schema=vol.Schema({}),
+            description_placeholders=placeholders,
+        )
+
+    async def async_step_confirm(
+        self, user_input: dict[str, str] | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Handle the confirm step of a fix flow."""
+        if user_input is not None:
+            entry = ConfigEntry(
+                version=1,
+                domain=IMAP_DOMAIN,
+                title=self._name,
+                data=self._config,
+                source=SOURCE_IMPORT,
+            )
+            await self.hass.config_entries.async_add(entry)
+            return self.async_create_entry(
+                title="",
+                data={},
+            )
+
+        return self.async_show_form(
+            step_id="confirm",
+            data_schema=vol.Schema({}),
+            description_placeholders=self._config,
+        )
+
+    async def async_step_deprecation(
+        self, user_input: dict[str, str] | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Show deprecation warning."""
+        placeholders = self._async_get_placeholders()
+        if user_input is None:
+            return self.async_show_form(
+                step_id="deprecation",
+                data_schema=vol.Schema({}),
+                description_placeholders=placeholders,
+            )
+
+        return self.async_create_entry(
+            title="",
+            data={},
+        )
+
+
+async def async_create_fix_flow(
+    hass: HomeAssistant,
+    issue_id: str,
+    data: dict[str, str | int | float | None],
+) -> RepairsFlow:
+    """Create flow."""
+    return DeprecationRepairFlow(issue_id, data)

--- a/homeassistant/components/imap_email_content/repairs.py
+++ b/homeassistant/components/imap_email_content/repairs.py
@@ -125,39 +125,42 @@ class DeprecationRepairFlow(RepairsFlow):
                 description_placeholders=placeholders,
             )
 
+        return await self.async_step_confirm()
+
+    async def async_step_confirm(
+        self, user_input: dict[str, str] | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Handle the confirm step of a fix flow."""
+        placeholders = self._async_get_placeholders()
+        if user_input is not None:
+            user_input[CONF_NAME] = self._name
+            result = await self.hass.config_entries.flow.async_init(
+                IMAP_DOMAIN, context={"source": SOURCE_IMPORT}, data=self._config
+            )
+            if result["type"] == FlowResultType.ABORT:
+                ir.async_delete_issue(self.hass, DOMAIN, self._issue_id)
+                ir.async_create_issue(
+                    self.hass,
+                    DOMAIN,
+                    self._issue_id,
+                    breaks_in_ha_version="2023.10.0",
+                    is_fixable=False,
+                    severity=ir.IssueSeverity.WARNING,
+                    translation_key="deprecation",
+                    translation_placeholders=placeholders,
+                    data=self._config,
+                    learn_more_url="https://www.home-assistant.io/integrations/imap/#using-events",
+                )
+                return self.async_abort(reason=result["reason"])
+            return self.async_create_entry(
+                title="",
+                data={},
+            )
+
         return self.async_show_form(
             step_id="confirm",
             data_schema=vol.Schema({}),
             description_placeholders=placeholders,
-        )
-
-    async def async_step_confirm(
-        self, user_input: dict[str, str]
-    ) -> data_entry_flow.FlowResult:
-        """Handle the confirm step of a fix flow."""
-        placeholders = self._async_get_placeholders()
-        user_input[CONF_NAME] = self._name
-        result = await self.hass.config_entries.flow.async_init(
-            IMAP_DOMAIN, context={"source": SOURCE_IMPORT}, data=self._config
-        )
-        if result["type"] == FlowResultType.ABORT:
-            ir.async_delete_issue(self.hass, DOMAIN, self._issue_id)
-            ir.async_create_issue(
-                self.hass,
-                DOMAIN,
-                self._issue_id,
-                breaks_in_ha_version="2023.10.0",
-                is_fixable=False,
-                severity=ir.IssueSeverity.WARNING,
-                translation_key="deprecation",
-                translation_placeholders=placeholders,
-                data=self._config,
-                learn_more_url="https://www.home-assistant.io/integrations/imap/#using-events",
-            )
-            return self.async_abort(reason=result["reason"])
-        return self.async_create_entry(
-            title="",
-            data={},
         )
 
 

--- a/homeassistant/components/imap_email_content/sensor.py
+++ b/homeassistant/components/imap_email_content/sensor.py
@@ -8,7 +8,6 @@ import imaplib
 import logging
 
 import voluptuous as vol
-import yaml
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA, SensorEntity
 from homeassistant.const import (
@@ -22,25 +21,23 @@ from homeassistant.const import (
     CONTENT_TYPE_TEXT_PLAIN,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import issue_registry as ir
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util.ssl import client_context
 
+from .const import (
+    ATTR_BODY,
+    ATTR_FROM,
+    ATTR_SUBJECT,
+    CONF_FOLDER,
+    CONF_SENDERS,
+    CONF_SERVER,
+    DEFAULT_PORT,
+)
+from .repairs import process_issue
+
 _LOGGER = logging.getLogger(__name__)
-
-DOMAIN = "imap_email_content"
-
-CONF_SERVER = "server"
-CONF_SENDERS = "senders"
-CONF_FOLDER = "folder"
-
-ATTR_FROM = "from"
-ATTR_BODY = "body"
-ATTR_SUBJECT = "subject"
-
-DEFAULT_PORT = 993
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
@@ -55,60 +52,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_VERIFY_SSL, default=True): cv.boolean,
     }
 )
-
-
-def register_issue(hass: HomeAssistant, config: ConfigType) -> None:
-    """Register an issue and suggest new config."""
-
-    name: str = config.get(CONF_NAME) or config[CONF_USERNAME]
-
-    issue_id = (
-        f"{name}_{config[CONF_USERNAME]}_{config[CONF_SERVER]}_{config[CONF_FOLDER]}"
-    )
-
-    if CONF_VALUE_TEMPLATE in config:
-        template: str = config[CONF_VALUE_TEMPLATE].template
-        template = template.replace("subject", 'trigger.event.data["subject"]')
-        template = template.replace("from", 'trigger.event.data["sender"]')
-        template = template.replace("date", 'trigger.event.data["date"]')
-        template = template.replace("body", 'trigger.event.data["text"]')
-    else:
-        template = '{{ trigger.event.data["subject"] }}'
-
-    template_sensor_config: ConfigType = {
-        "template": [
-            {
-                "trigger": [
-                    {
-                        "id": "custom_event",
-                        "platform": "event",
-                        "event_type": "imap_content",
-                        "event_data": {"sender": config[CONF_SENDERS][0]},
-                    }
-                ],
-                "sensor": [
-                    {
-                        "state": template,
-                        "name": name,
-                    }
-                ],
-            }
-        ]
-    }
-
-    ir.async_create_issue(
-        hass,
-        DOMAIN,
-        issue_id,
-        breaks_in_ha_version="2023.10.0",
-        is_fixable=False,
-        severity=ir.IssueSeverity.WARNING,
-        translation_key="deprecation",
-        translation_placeholders={
-            "yaml_example": yaml.dump(template_sensor_config),
-        },
-        learn_more_url="https://www.home-assistant.io/integrations/imap/#using-events",
-    )
 
 
 async def async_setup_platform(
@@ -137,7 +80,7 @@ async def async_setup_platform(
         value_template,
     )
 
-    register_issue(hass, config)
+    process_issue(hass, config)
 
     if sensor.connected:
         add_entities([sensor], True)

--- a/homeassistant/components/imap_email_content/sensor.py
+++ b/homeassistant/components/imap_email_content/sensor.py
@@ -35,7 +35,7 @@ from .const import (
     CONF_SERVER,
     DEFAULT_PORT,
 )
-from .repairs import process_issue
+from .repairs import async_process_issue
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -54,7 +54,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 )
 
 
-async def async_setup_platform(
+def setup_platform(
     hass: HomeAssistant,
     config: ConfigType,
     add_entities: AddEntitiesCallback,
@@ -80,7 +80,7 @@ async def async_setup_platform(
         value_template,
     )
 
-    process_issue(hass, config)
+    hass.add_job(async_process_issue, hass, config)
 
     if sensor.connected:
         add_entities([sensor], True)

--- a/homeassistant/components/imap_email_content/sensor.py
+++ b/homeassistant/components/imap_email_content/sensor.py
@@ -62,7 +62,7 @@ def register_issue(hass: HomeAssistant, config: ConfigType) -> None:
 
     name: str = config.get(CONF_NAME) or config[CONF_USERNAME]
 
-    unique_id = (
+    issue_id = (
         f"{name}_{config[CONF_USERNAME]}_{config[CONF_SERVER]}_{config[CONF_FOLDER]}"
     )
 
@@ -99,7 +99,7 @@ def register_issue(hass: HomeAssistant, config: ConfigType) -> None:
     ir.async_create_issue(
         hass,
         DOMAIN,
-        unique_id,
+        issue_id,
         breaks_in_ha_version="2023.10.0",
         is_fixable=False,
         severity=ir.IssueSeverity.WARNING,

--- a/homeassistant/components/imap_email_content/strings.json
+++ b/homeassistant/components/imap_email_content/strings.json
@@ -2,19 +2,19 @@
   "issues": {
     "deprecation": {
       "title": "The IMAP email content integration is deprecated",
+      "description": "The IMAP email content integration is deprecated. Your IMAP server configuration was already migrated to to the [imap integration](https://my.home-assistant.io/redirect/config_flow_start?domain=imap). To set up a sensor for the IMAP email content, set up a template sensor with the config:\n\n```yaml\n{yaml_example}```\n\n Remove the deprecated `imap_email_plaform` sensor configuration from your `configuration.yaml`. Note that the event filter only filters on the the first of allowed sender, customize the filter if needed\n\nYou can skip this step if you have already set up a template sensor.\n\nSubmit to finish."
+    },
+    "migration": {
+      "title": "The IMAP email content integration needs attention",
       "fix_flow": {
         "step": {
           "start": {
             "title": "Migrate your IMAP email configuration",
-            "description": "The IMAP email content integration is deprecated. You IMAP configuration can be migrated automatically to the [imap integration](https://my.home-assistant.io/redirect/config_flow_start?domain=imap), this will enable using an `imap` custom event. To achieve a sensor that has an IMAP content state, set up a template sensor remove the `imap_email_plaform` sensor configuration from your `configuration.yaml`. To set up the template sensor you can copy the configuration below and place this in your `configuration.yaml`. Note that only the first of allowed sender, as only one is shown, customize this if needed:\n\n```yaml\n{yaml_example}```\n\nSubmit to start migration of your IMAP server configuration to the `imap` integration."
-          },
-          "deprecation": {
-            "title": "Remove your IMAP email content configuration",
-            "description": "The IMAP email content integration is deprecated. Your IMAP configuration was migrated for you to the [imap integration](https://my.home-assistant.io/redirect/config_flow_start?domain=imap), this enabled using an `imap` custom event. You still need to remove your `imap_email_content` sensor configuration from your configuration.yaml. To achieve a sensor that has an IMAP content state, set up a template sensor remove the `imap_email_plaform` sensor configuration from your `configuration.yaml`. To set up the template sensor you can copy the configuration below and place this in your `configuration.yaml`. Note that only the first of allowed sender, as only one is shown, customize this if needed:\n\n```yaml\n{yaml_example}```\n\nYou can skip this step if you have already set up a template sensor.\n\nSubmit to finish."
+            "description": "The IMAP email content integration is deprecated. Your IMAP server configuration can be migrated automatically to the [imap integration](https://my.home-assistant.io/redirect/config_flow_start?domain=imap), this will enable using a custom `imap` event trigger. To set up a sensor that has an IMAP content state, a template sensor can be used. Remove the `imap_email_plaform` sensor configuration from your `configuration.yaml` after migration.\n\nSubmit to start migration of your IMAP server configuration to the `imap` integration."
           },
           "confirm": {
             "title": "Your IMAP server settings will be migrated",
-            "description": "An `imap` config entry will be set up with configuration:\n\n```text\nServer\t{server}\nPort\t{port}\nUsername\t{username}\nPassword\t*****\nFolder\t{folder}\n```\n\nSee also: (https://www.home-assistant.io/integrations/imap/)\n\nFitering configuration on `sender` is part of the template sensor config that can be placed in `configuration.yaml.\n\n```yaml\n{yaml_example}```\nDo not forget to cleanup the your `configuration.yaml`.\n\nSubmit to migrate the entry."
+            "description": "In this step an `imap` config entry will be set up with the following configuration:\n\n```text\nServer\t{server}\nPort\t{port}\nUsername\t{username}\nPassword\t*****\nFolder\t{folder}\n```\n\nSee also: (https://www.home-assistant.io/integrations/imap/)\n\nFitering configuration on allowed `sender` is part of the template sensor config that can copied and placed in your `configuration.yaml.\n\nNote that the event filter only filters on the the first of allowed sender, customize the filter if needed\n\n```yaml\n{yaml_example}```\nDo not forget to cleanup the your `configuration.yaml` after migration.\n\nSubmit to migrate your IMAP server configuration to an `imap` configuration entry."
           }
         }
       }

--- a/homeassistant/components/imap_email_content/strings.json
+++ b/homeassistant/components/imap_email_content/strings.json
@@ -2,7 +2,7 @@
   "issues": {
     "deprecation": {
       "title": "The IMAP email content integration is deprecated",
-      "description": "The IMAP email content integration is deprecated. Your IMAP server configuration was already migrated to to the [imap integration](https://my.home-assistant.io/redirect/config_flow_start?domain=imap). To set up a sensor for the IMAP email content, set up a template sensor with the config:\n\n```yaml\n{yaml_example}```\n\nPlease remove the deprecated `imap_email_plaform` sensor configuration from your `configuration.yaml`.\n\nNote that the event filter only filters on the the first of the configured allowed senders, customize the filter if needed.\n\nYou can skip this part if you have already set up a template sensor."
+      "description": "The IMAP email content integration is deprecated. Your IMAP server configuration was already migrated to to the [imap integration](https://my.home-assistant.io/redirect/config_flow_start?domain=imap). To set up a sensor for the IMAP email content, set up a template sensor with the config:\n\n```yaml\n{yaml_example}```\n\nPlease remove the deprecated `imap_email_plaform` sensor configuration from your `configuration.yaml`.\n\nNote that the event filter only filters on the first of the configured allowed senders, customize the filter if needed.\n\nYou can skip this part if you have already set up a template sensor."
     },
     "migration": {
       "title": "The IMAP email content integration needs attention",

--- a/homeassistant/components/imap_email_content/strings.json
+++ b/homeassistant/components/imap_email_content/strings.json
@@ -2,7 +2,7 @@
   "issues": {
     "deprecation": {
       "title": "The IMAP email content integration is deprecated",
-      "description": "The IMAP email content integration is deprecated. Your IMAP server configuration was already migrated to to the [imap integration](https://my.home-assistant.io/redirect/config_flow_start?domain=imap). To set up a sensor for the IMAP email content, set up a template sensor with the config:\n\n```yaml\n{yaml_example}```\n\n Remove the deprecated `imap_email_plaform` sensor configuration from your `configuration.yaml`. Note that the event filter only filters on the the first of allowed sender, customize the filter if needed\n\nYou can skip this step if you have already set up a template sensor.\n\nSubmit to finish."
+      "description": "The IMAP email content integration is deprecated. Your IMAP server configuration was already migrated to to the [imap integration](https://my.home-assistant.io/redirect/config_flow_start?domain=imap). To set up a sensor for the IMAP email content, set up a template sensor with the config:\n\n```yaml\n{yaml_example}```\n\nPlease remove the deprecated `imap_email_plaform` sensor configuration from your `configuration.yaml`.\n\nNote that the event filter only filters on the the first of the configured allowed senders, customize the filter if needed.\n\nYou can skip this part if you have already set up a template sensor."
     },
     "migration": {
       "title": "The IMAP email content integration needs attention",
@@ -14,7 +14,7 @@
           },
           "confirm": {
             "title": "Your IMAP server settings will be migrated",
-            "description": "In this step an `imap` config entry will be set up with the following configuration:\n\n```text\nServer\t{server}\nPort\t{port}\nUsername\t{username}\nPassword\t*****\nFolder\t{folder}\n```\n\nSee also: (https://www.home-assistant.io/integrations/imap/)\n\nFitering configuration on allowed `sender` is part of the template sensor config that can copied and placed in your `configuration.yaml.\n\nNote that the event filter only filters on the the first of allowed sender, customize the filter if needed\n\n```yaml\n{yaml_example}```\nDo not forget to cleanup the your `configuration.yaml` after migration.\n\nSubmit to migrate your IMAP server configuration to an `imap` configuration entry."
+            "description": "In this step an `imap` config entry will be set up with the following configuration:\n\n```text\nServer\t{server}\nPort\t{port}\nUsername\t{username}\nPassword\t*****\nFolder\t{folder}\n```\n\nSee also: (https://www.home-assistant.io/integrations/imap/)\n\nFitering configuration on allowed `sender` is part of the template sensor config that can copied and placed in your `configuration.yaml.\n\nNote that the event filter only filters on the the first of the configured allowed senders, customize the filter if needed.\n\n```yaml\n{yaml_example}```\nDo not forget to cleanup the your `configuration.yaml` after migration.\n\nSubmit to migrate your IMAP server configuration to an `imap` configuration entry."
           }
         }
       }

--- a/homeassistant/components/imap_email_content/strings.json
+++ b/homeassistant/components/imap_email_content/strings.json
@@ -2,7 +2,22 @@
   "issues": {
     "deprecation": {
       "title": "The IMAP email content integration is deprecated",
-      "description": "Please setup an entry for the [imap integration](https://my.home-assistant.io/redirect/config_flow_start?domain=imap) use a `imap` custom event with a template sensor instead and remove the `imap_email_plaform` sensor configuration from your `configuration.yaml`. A sample configuration is shown below (note that only the first of allowed sender is shown):\n\n```yaml\n{yaml_example}```\n"
+      "fix_flow": {
+        "step": {
+          "start": {
+            "title": "Migrate your IMAP email configuration",
+            "description": "The IMAP email content integration is deprecated. You IMAP configuration can be migrated automatically to the [imap integration](https://my.home-assistant.io/redirect/config_flow_start?domain=imap), this will enable using an `imap` custom event. To achieve a sensor that has an IMAP content state, set up a template sensor remove the `imap_email_plaform` sensor configuration from your `configuration.yaml`. To set up the template sensor you can copy the configuration below and place this in your `configuration.yaml`. Note that only the first of allowed sender, as only one is shown, customize this if needed:\n\n```yaml\n{yaml_example}```\n\nSubmit to start migration of your IMAP server configuration to the `imap` integration."
+          },
+          "deprecation": {
+            "title": "Remove your IMAP email content configuration",
+            "description": "The IMAP email content integration is deprecated. Your IMAP configuration was migrated for you to the [imap integration](https://my.home-assistant.io/redirect/config_flow_start?domain=imap), this enabled using an `imap` custom event. You still need to remove your `imap_email_content` sensor configuration from your configuration.yaml. To achieve a sensor that has an IMAP content state, set up a template sensor remove the `imap_email_plaform` sensor configuration from your `configuration.yaml`. To set up the template sensor you can copy the configuration below and place this in your `configuration.yaml`. Note that only the first of allowed sender, as only one is shown, customize this if needed:\n\n```yaml\n{yaml_example}```\n\nYou can skip this step if you have already set up a template sensor.\n\nSubmit to finish."
+          },
+          "confirm": {
+            "title": "Your IMAP server settings will be migrated",
+            "description": "An `imap` config entry will be set up with configuration:\n\n```text\nServer\t{server}\nPort\t{port}\nUsername\t{username}\nPassword\t*****\nFolder\t{folder}\n```\n\nSee also: (https://www.home-assistant.io/integrations/imap/)\n\nFitering configuration on `sender` is part of the template sensor config that can be placed in `configuration.yaml.\n\n```yaml\n{yaml_example}```\nDo not forget to cleanup the your `configuration.yaml`.\n\nSubmit to migrate the entry."
+          }
+        }
+      }
     }
   }
 }

--- a/homeassistant/components/imap_email_content/strings.json
+++ b/homeassistant/components/imap_email_content/strings.json
@@ -1,0 +1,8 @@
+{
+  "issues": {
+    "deprecation": {
+      "title": "The IMAP email content integration is deprecated",
+      "description": "Please setup an entry for the [imap integration](https://my.home-assistant.io/redirect/config_flow_start?domain=imap) use a `imap` custom event with a template sensor instead and remove the `imap_email_plaform` sensor configuration from your `configuration.yaml`. A sample configuration is shown below (note that only the first of allowed sender is shown):\n\n```yaml\n{yaml_example}```\n"
+    }
+  }
+}

--- a/homeassistant/components/imap_email_content/strings.json
+++ b/homeassistant/components/imap_email_content/strings.json
@@ -14,8 +14,12 @@
           },
           "confirm": {
             "title": "Your IMAP server settings will be migrated",
-            "description": "In this step an `imap` config entry will be set up with the following configuration:\n\n```text\nServer\t{server}\nPort\t{port}\nUsername\t{username}\nPassword\t*****\nFolder\t{folder}\n```\n\nSee also: (https://www.home-assistant.io/integrations/imap/)\n\nFitering configuration on allowed `sender` is part of the template sensor config that can copied and placed in your `configuration.yaml.\n\nNote that the event filter only filters on the the first of the configured allowed senders, customize the filter if needed.\n\n```yaml\n{yaml_example}```\nDo not forget to cleanup the your `configuration.yaml` after migration.\n\nSubmit to migrate your IMAP server configuration to an `imap` configuration entry."
+            "description": "In this step an `imap` config entry will be set up with the following configuration:\n\n```text\nServer\t{server}\nPort\t{port}\nUsername\t{username}\nPassword\t*****\nFolder\t{folder}\n```\n\nSee also: (https://www.home-assistant.io/integrations/imap/)\n\nFitering configuration on allowed `sender` is part of the template sensor config that can copied and placed in your `configuration.yaml.\n\nNote that the event filter only filters on the first of the configured allowed senders, customize the filter if needed.\n\n```yaml\n{yaml_example}```\nDo not forget to cleanup the your `configuration.yaml` after migration.\n\nSubmit to migrate your IMAP server configuration to an `imap` configuration entry."
           }
+        },
+        "abort": {
+          "already_configured": "The IMAP server config was already migrated to the imap integration. Remove the `imap_email_plaform` sensor configuration from your `configuration.yaml`.",
+          "cannot_connect": "Migration failed. Failed to connect to the IMAP server. Perform a manual migration."
         }
       }
     }

--- a/tests/components/imap/test_config_flow.py
+++ b/tests/components/imap/test_config_flow.py
@@ -388,3 +388,70 @@ async def test_key_options_in_options_form(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
     assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] == {"base": "already_configured"}
+
+
+async def test_import_flow_success(hass: HomeAssistant) -> None:
+    """Test a successful import of yaml."""
+    with patch(
+        "homeassistant.components.imap.config_flow.connect_to_server"
+    ) as mock_client, patch(
+        "homeassistant.components.imap.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        mock_client.return_value.search.return_value = (
+            "OK",
+            [b""],
+        )
+        result2 = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_IMPORT},
+            data={
+                "name": "IMAP",
+                "username": "email@email.com",
+                "password": "password",
+                "server": "imap.server.com",
+                "port": 993,
+                "folder": "INBOX",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["title"] == "IMAP"
+    assert result2["data"] == {
+        "username": "email@email.com",
+        "password": "password",
+        "server": "imap.server.com",
+        "port": 993,
+        "charset": "utf-8",
+        "folder": "INBOX",
+        "search": "UnSeen UnDeleted",
+    }
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_import_flow_connection_error(hass: HomeAssistant) -> None:
+    """Test a successful import of yaml."""
+    with patch(
+        "homeassistant.components.imap.config_flow.validate_input",
+        return_value={"base": "cannot_connect"},
+    ), patch(
+        "homeassistant.components.imap.async_setup_entry",
+        return_value=True,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_IMPORT},
+            data={
+                "name": "IMAP",
+                "username": "email@email.com",
+                "password": "password",
+                "server": "imap.server.com",
+                "port": 993,
+                "folder": "INBOX",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "cannot_connect"

--- a/tests/components/imap/test_config_flow.py
+++ b/tests/components/imap/test_config_flow.py
@@ -433,8 +433,8 @@ async def test_import_flow_success(hass: HomeAssistant) -> None:
 async def test_import_flow_connection_error(hass: HomeAssistant) -> None:
     """Test a successful import of yaml."""
     with patch(
-        "homeassistant.components.imap.config_flow.validate_input",
-        return_value={"base": "cannot_connect"},
+        "homeassistant.components.imap.config_flow.connect_to_server",
+        side_effect=AioImapException("Unexpected error"),
     ), patch(
         "homeassistant.components.imap.async_setup_entry",
         return_value=True,

--- a/tests/components/imap_email_content/test_repairs.py
+++ b/tests/components/imap_email_content/test_repairs.py
@@ -1,0 +1,302 @@
+"""Test repairs for imap_email_content."""
+
+from collections.abc import Generator
+from http import HTTPStatus
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from homeassistant.components.repairs.issue_handler import (
+    async_process_repairs_platforms,
+)
+from homeassistant.components.repairs.websocket_api import (
+    RepairsFlowIndexView,
+    RepairsFlowResourceView,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry
+from tests.typing import ClientSessionGenerator, WebSocketGenerator
+
+
+@pytest.fixture
+def mock_client() -> Generator[MagicMock, None, None]:
+    """Mock the imap client."""
+    with patch(
+        "homeassistant.components.imap_email_content.sensor.EmailReader.read_next",
+        return_value=None,
+    ), patch("imaplib.IMAP4_SSL") as mock_imap_client:
+        yield mock_imap_client
+
+
+CONFIG = {
+    "platform": "imap_email_content",
+    "name": "Notifications",
+    "server": "imap.example.com",
+    "port": 993,
+    "username": "john.doe@example.com",
+    "password": "**SECRET**",
+    "folder": "INBOX.Notifications",
+    "value_template": "{{ body }}",
+    "senders": ["company@example.com"],
+}
+DESCRIPTION_PLACEHOLDERS = {
+    "yaml_example": ""
+    "template:\n"
+    "- sensor:\n"
+    "  - name: Notifications\n"
+    "    state: '{{ trigger.event.data[\"text\"] }}'\n"
+    "  trigger:\n  - event_data:\n"
+    "      sender: company@example.com\n"
+    "    event_type: imap_content\n"
+    "    id: custom_event\n"
+    "    platform: event\n",
+    "server": "imap.example.com",
+    "port": 993,
+    "username": "john.doe@example.com",
+    "password": "**SECRET**",
+    "folder": "INBOX.Notifications",
+    "value_template": '{{ trigger.event.data["text"] }}',
+    "name": "Notifications",
+}
+
+CONFIG_DEFAULT = {
+    "platform": "imap_email_content",
+    "name": "Notifications",
+    "server": "imap.example.com",
+    "port": 993,
+    "username": "john.doe@example.com",
+    "password": "**SECRET**",
+    "folder": "INBOX.Notifications",
+    "senders": ["company@example.com"],
+}
+DESCRIPTION_PLACEHOLDERS_DEFAULT = {
+    "yaml_example": ""
+    "template:\n"
+    "- sensor:\n"
+    "  - name: Notifications\n"
+    "    state: '{{ trigger.event.data[\"subject\"] }}'\n"
+    "  trigger:\n  - event_data:\n"
+    "      sender: company@example.com\n"
+    "    event_type: imap_content\n"
+    "    id: custom_event\n"
+    "    platform: event\n",
+    "server": "imap.example.com",
+    "port": 993,
+    "username": "john.doe@example.com",
+    "password": "**SECRET**",
+    "folder": "INBOX.Notifications",
+    "value_template": '{{ trigger.event.data["subject"] }}',
+    "name": "Notifications",
+}
+
+
+@pytest.mark.parametrize(
+    ("config", "description_placeholders"),
+    [
+        (CONFIG, DESCRIPTION_PLACEHOLDERS),
+        (CONFIG_DEFAULT, DESCRIPTION_PLACEHOLDERS_DEFAULT),
+    ],
+    ids=["with_value_template", "default_subject"],
+)
+async def test_deprecation_repair_flow(
+    hass: HomeAssistant,
+    mock_client: MagicMock,
+    hass_client: ClientSessionGenerator,
+    hass_ws_client: WebSocketGenerator,
+    config: str | None,
+    description_placeholders: str,
+) -> None:
+    """Test the deprecation repair flow."""
+    # setup config
+    await async_setup_component(hass, "sensor", {"sensor": config})
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.notifications")
+    assert state is not None
+
+    await async_process_repairs_platforms(hass)
+    ws_client = await hass_ws_client(hass)
+    client = await hass_client()
+
+    await ws_client.send_json({"id": 1, "type": "repairs/list_issues"})
+
+    msg = await ws_client.receive_json()
+
+    assert msg["success"]
+    assert len(msg["result"]["issues"]) > 0
+    issue = None
+    for i in msg["result"]["issues"]:
+        if i["domain"] == "imap_email_content":
+            issue = i
+    assert issue is not None
+    assert (
+        issue["issue_id"]
+        == "Notifications_john.doe@example.com_imap.example.com_INBOX.Notifications"
+    )
+    assert issue["is_fixable"]
+    url = RepairsFlowIndexView.url
+    resp = await client.post(
+        url, json={"handler": "imap_email_content", "issue_id": issue["issue_id"]}
+    )
+    assert resp.status == HTTPStatus.OK
+    data = await resp.json()
+
+    flow_id = data["flow_id"]
+    assert data["description_placeholders"] == description_placeholders
+    assert data["step_id"] == "start"
+
+    # Apply fix
+    url = RepairsFlowResourceView.url.format(flow_id=flow_id)
+    resp = await client.post(url)
+    assert resp.status == HTTPStatus.OK
+    data = await resp.json()
+
+    flow_id = data["flow_id"]
+    assert data["description_placeholders"] == description_placeholders
+    assert data["step_id"] == "confirm"
+
+    url = RepairsFlowResourceView.url.format(flow_id=flow_id)
+
+    with patch(
+        "homeassistant.components.imap.config_flow.connect_to_server"
+    ) as mock_client, patch(
+        "homeassistant.components.imap.async_setup_entry",
+        return_value=True,
+    ):
+        mock_client.return_value.search.return_value = (
+            "OK",
+            [b""],
+        )
+        resp = await client.post(url)
+
+    assert resp.status == HTTPStatus.OK
+    data = await resp.json()
+
+    assert data["type"] == "create_entry"
+
+    # Assert the issue is resolved
+    await ws_client.send_json({"id": 2, "type": "repairs/list_issues"})
+    msg = await ws_client.receive_json()
+    assert msg["success"]
+    assert len(msg["result"]["issues"]) == 0
+
+
+@pytest.mark.parametrize(
+    ("config", "description_placeholders"),
+    [
+        (CONFIG, DESCRIPTION_PLACEHOLDERS),
+        (CONFIG_DEFAULT, DESCRIPTION_PLACEHOLDERS_DEFAULT),
+    ],
+    ids=["with_value_template", "default_subject"],
+)
+async def test_repair_flow_where_entry_already_exists(
+    hass: HomeAssistant,
+    mock_client: MagicMock,
+    hass_client: ClientSessionGenerator,
+    hass_ws_client: WebSocketGenerator,
+    config: str | None,
+    description_placeholders: str,
+) -> None:
+    """Test the deprecation repair flow and an entry already exists."""
+
+    await async_setup_component(hass, "sensor", {"sensor": config})
+    await hass.async_block_till_done()
+    state = hass.states.get("sensor.notifications")
+    assert state is not None
+
+    existing_imap_entry_config = {
+        "username": "john.doe@example.com",
+        "password": "password",
+        "server": "imap.example.com",
+        "port": 993,
+        "charset": "utf-8",
+        "folder": "INBOX.Notifications",
+        "search": "UnSeen UnDeleted",
+    }
+
+    with patch("homeassistant.components.imap.async_setup_entry", return_value=True):
+        imap_entry = MockConfigEntry(domain="imap", data=existing_imap_entry_config)
+        imap_entry.add_to_hass(hass)
+        await imap_entry.async_setup(hass)
+
+    await async_process_repairs_platforms(hass)
+    ws_client = await hass_ws_client(hass)
+    client = await hass_client()
+
+    await ws_client.send_json({"id": 1, "type": "repairs/list_issues"})
+
+    msg = await ws_client.receive_json()
+
+    assert msg["success"]
+    assert len(msg["result"]["issues"]) > 0
+    issue = None
+    for i in msg["result"]["issues"]:
+        if i["domain"] == "imap_email_content":
+            issue = i
+    assert issue is not None
+    assert (
+        issue["issue_id"]
+        == "Notifications_john.doe@example.com_imap.example.com_INBOX.Notifications"
+    )
+    assert issue["is_fixable"]
+    assert issue["translation_key"] == "migration"
+
+    url = RepairsFlowIndexView.url
+    resp = await client.post(
+        url, json={"handler": "imap_email_content", "issue_id": issue["issue_id"]}
+    )
+    assert resp.status == HTTPStatus.OK
+    data = await resp.json()
+
+    flow_id = data["flow_id"]
+    assert data["description_placeholders"] == description_placeholders
+    assert data["step_id"] == "start"
+
+    url = RepairsFlowResourceView.url.format(flow_id=flow_id)
+    resp = await client.post(url)
+    assert resp.status == HTTPStatus.OK
+    data = await resp.json()
+
+    flow_id = data["flow_id"]
+    assert data["description_placeholders"] == description_placeholders
+    assert data["step_id"] == "confirm"
+
+    url = RepairsFlowResourceView.url.format(flow_id=flow_id)
+
+    with patch(
+        "homeassistant.components.imap.config_flow.connect_to_server"
+    ) as mock_client, patch(
+        "homeassistant.components.imap.async_setup_entry",
+        return_value=True,
+    ):
+        mock_client.return_value.search.return_value = (
+            "OK",
+            [b""],
+        )
+        resp = await client.post(url)
+
+    assert resp.status == HTTPStatus.OK
+    data = await resp.json()
+
+    assert data["type"] == "abort"
+    assert data["reason"] == "already_configured"
+
+    # We should now have a non_fixable issue left since there is still
+    # a config in configuration.yaml
+    await ws_client.send_json({"id": 2, "type": "repairs/list_issues"})
+    msg = await ws_client.receive_json()
+    assert msg["success"]
+    assert len(msg["result"]["issues"]) > 0
+    issue = None
+    for i in msg["result"]["issues"]:
+        if i["domain"] == "imap_email_content":
+            issue = i
+    assert issue is not None
+    assert (
+        issue["issue_id"]
+        == "Notifications_john.doe@example.com_imap.example.com_INBOX.Notifications"
+    )
+    assert not issue["is_fixable"]
+    assert issue["translation_key"] == "deprecation"

--- a/tests/components/imap_email_content/test_repairs.py
+++ b/tests/components/imap_email_content/test_repairs.py
@@ -6,9 +6,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from homeassistant.components.repairs.issue_handler import (
-    async_process_repairs_platforms,
-)
 from homeassistant.components.repairs.websocket_api import (
     RepairsFlowIndexView,
     RepairsFlowResourceView,
@@ -116,7 +113,6 @@ async def test_deprecation_repair_flow(
     state = hass.states.get("sensor.notifications")
     assert state is not None
 
-    await async_process_repairs_platforms(hass)
     ws_client = await hass_ws_client(hass)
     client = await hass_client()
 
@@ -219,9 +215,7 @@ async def test_repair_flow_where_entry_already_exists(
     with patch("homeassistant.components.imap.async_setup_entry", return_value=True):
         imap_entry = MockConfigEntry(domain="imap", data=existing_imap_entry_config)
         imap_entry.add_to_hass(hass)
-        await imap_entry.async_setup(hass)
-
-    await async_process_repairs_platforms(hass)
+        await hass.config_entries.async_setup(imap_entry.entry_id)
     ws_client = await hass_ws_client(hass)
     client = await hass_client()
 

--- a/tests/components/imap_email_content/test_sensor.py
+++ b/tests/components/imap_email_content/test_sensor.py
@@ -9,6 +9,7 @@ from homeassistant.components.imap_email_content import sensor as imap_email_con
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.event import async_track_state_change
 from homeassistant.helpers.template import Template
+from homeassistant.setup import async_setup_component
 
 
 class FakeEMailReader:
@@ -35,6 +36,11 @@ class FakeEMailReader:
             return None
         self.last_id += 1
         return self._messages.popleft()
+
+
+async def test_integration_setup_(hass: HomeAssistant) -> None:
+    """Test the integration component setup is successful."""
+    assert await async_setup_component(hass, "imap_email_content", {})
 
 
 async def test_allowed_sender(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Deprecate the `imap_email_content_integrations`. The IMAP server config can be migrated to the `imap` integration with a repair flow. A `yaml` configuration  is generated to set up a template sensor and is shown in the flow to allow the user to copy and past the config into `configuration.yaml`.

Base on the original configuration:
```yaml
sensor:
  - platform: imap_email_content
    name: Notifications
    server: imap.example.com
    port: 993
    username: user@example.com
    password: LdH0@gv!
    folder: INBOX.Notification
    value_template: "{{ subject }}"
```

The repair flow will look like:
![afbeelding](https://user-images.githubusercontent.com/7188918/228658107-56f1719b-8a4e-4c2c-a965-65f95ad7035b.png)

The next step:
![afbeelding](https://user-images.githubusercontent.com/7188918/228661245-a22be718-4c4d-4db3-a734-65931e30fadd.png)

If the IMAP config is migrated but the user has not removed the `imap_email_content` configuration from `configuration.yaml` the next time Home Assistant is started, then a non fixable issue is created.
With that warning again is shown how to setup a template sensor with together with the `imap` config entry.

![afbeelding](https://user-images.githubusercontent.com/7188918/228661483-a6fe8a88-3dea-4df6-980b-de3af403d954.png)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/26792

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
