### PR TITLE
Isolate the sql integration with a separate query cache

### DIFF
--- a/homeassistant/components/sql/sensor.py
+++ b/homeassistant/components/sql/sensor.py
@@ -6,9 +6,12 @@ import decimal
 import logging
 
 import sqlalchemy
+from sqlalchemy import TextClause, lambda_stmt
 from sqlalchemy.engine import Result
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session, scoped_session, sessionmaker
+from sqlalchemy.sql.lambdas import StatementLambdaElement
+from sqlalchemy.util import LRUCache
 
 from homeassistant.components.recorder import CONF_DB_URL, get_instance
 from homeassistant.components.sensor import (
@@ -37,6 +40,8 @@ from .const import CONF_COLUMN_NAME, CONF_QUERY, DB_URL_RE, DOMAIN
 from .util import resolve_db_url
 
 _LOGGER = logging.getLogger(__name__)
+
+_SQL_LAMBDA_CACHE: LRUCache = LRUCache(1000)
 
 
 def redact_credentials(data: str) -> str:
@@ -201,6 +206,11 @@ def _validate_and_get_session_maker_for_db_url(db_url: str) -> scoped_session | 
             sess.close()
 
 
+def _generate_lambda_stmt(text: TextClause) -> StatementLambdaElement:
+    """Generate the lambda statement."""
+    return lambda_stmt(lambda: text, lambda_cache=_SQL_LAMBDA_CACHE)
+
+
 class SQLSensor(SensorEntity):
     """Representation of an SQL sensor."""
 
@@ -233,6 +243,7 @@ class SQLSensor(SensorEntity):
         self._attr_extra_state_attributes = {}
         self._attr_unique_id = unique_id
         self._use_database_executor = use_database_executor
+        self._lambda_stmt = _generate_lambda_stmt(sqlalchemy.text(query))
         if not yaml and unique_id:
             self._attr_device_info = DeviceInfo(
                 entry_type=DeviceEntryType.SERVICE,
@@ -254,7 +265,7 @@ class SQLSensor(SensorEntity):
         self._attr_extra_state_attributes = {}
         sess: scoped_session = self.sessionmaker()
         try:
-            result: Result = sess.execute(sqlalchemy.text(self._query))
+            result: Result = sess.execute(self._lambda_stmt)
         except SQLAlchemyError as err:
             _LOGGER.error(
                 "Error executing query %s: %s",

--- a/homeassistant/components/sql/sensor.py
+++ b/homeassistant/components/sql/sensor.py
@@ -244,6 +244,7 @@ class SQLSensor(SensorEntity):
         self._attr_extra_state_attributes = {}
         self._attr_unique_id = unique_id
         self._use_database_executor = use_database_executor
+        self._lambda_stmt = _generate_lambda_stmt(query)
         if not yaml and unique_id:
             self._attr_device_info = DeviceInfo(
                 entry_type=DeviceEntryType.SERVICE,
@@ -265,7 +266,7 @@ class SQLSensor(SensorEntity):
         self._attr_extra_state_attributes = {}
         sess: scoped_session = self.sessionmaker()
         try:
-            result: Result = sess.execute(_generate_lambda_stmt(self._query))
+            result: Result = sess.execute(self._lambda_stmt)
         except SQLAlchemyError as err:
             _LOGGER.error(
                 "Error executing query %s: %s",

--- a/homeassistant/components/sql/sensor.py
+++ b/homeassistant/components/sql/sensor.py
@@ -6,7 +6,7 @@ import decimal
 import logging
 
 import sqlalchemy
-from sqlalchemy import TextClause, lambda_stmt
+from sqlalchemy import lambda_stmt
 from sqlalchemy.engine import Result
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session, scoped_session, sessionmaker
@@ -206,8 +206,9 @@ def _validate_and_get_session_maker_for_db_url(db_url: str) -> scoped_session | 
             sess.close()
 
 
-def _generate_lambda_stmt(text: TextClause) -> StatementLambdaElement:
+def _generate_lambda_stmt(query: str) -> StatementLambdaElement:
     """Generate the lambda statement."""
+    text = sqlalchemy.text(query)
     return lambda_stmt(lambda: text, lambda_cache=_SQL_LAMBDA_CACHE)
 
 
@@ -243,7 +244,7 @@ class SQLSensor(SensorEntity):
         self._attr_extra_state_attributes = {}
         self._attr_unique_id = unique_id
         self._use_database_executor = use_database_executor
-        self._lambda_stmt = _generate_lambda_stmt(sqlalchemy.text(query))
+        self._lambda_stmt = _generate_lambda_stmt(query)
         if not yaml and unique_id:
             self._attr_device_info = DeviceInfo(
                 entry_type=DeviceEntryType.SERVICE,

--- a/homeassistant/components/sql/sensor.py
+++ b/homeassistant/components/sql/sensor.py
@@ -244,7 +244,6 @@ class SQLSensor(SensorEntity):
         self._attr_extra_state_attributes = {}
         self._attr_unique_id = unique_id
         self._use_database_executor = use_database_executor
-        self._lambda_stmt = _generate_lambda_stmt(query)
         if not yaml and unique_id:
             self._attr_device_info = DeviceInfo(
                 entry_type=DeviceEntryType.SERVICE,
@@ -266,7 +265,7 @@ class SQLSensor(SensorEntity):
         self._attr_extra_state_attributes = {}
         sess: scoped_session = self.sessionmaker()
         try:
-            result: Result = sess.execute(self._lambda_stmt)
+            result: Result = sess.execute(_generate_lambda_stmt(self._query))
         except SQLAlchemyError as err:
             _LOGGER.error(
                 "Error executing query %s: %s",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If there were a lot of sql integrations they affect the performance of the recorder/logbook/history since some of the queries were sharing the same LRU and since the sql sensor updates frequently it would evict the recorder queries from the LRU.

LRU in eviction in sqlalchemy has some outstanding issues that have yet to be solved (the same lru implementation is used for lambda, the transparent query cache, and likely the legacy bakeries).  This should prevent the problem from happening.

https://github.com/sqlalchemy/sqlalchemy/issues/9461#issuecomment-1462867521

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
