### PR TITLE
Add reauth to frontier_silicon config flow

### DIFF
--- a/homeassistant/components/frontier_silicon/config_flow.py
+++ b/homeassistant/components/frontier_silicon/config_flow.py
@@ -1,6 +1,7 @@
 """Config flow for Frontier Silicon Media Player integration."""
 from __future__ import annotations
 
+from collections.abc import Mapping
 import logging
 from typing import Any
 from urllib.parse import urlparse
@@ -53,6 +54,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     _name: str
     _webfsapi_url: str
+    _reauth_entry: config_entries.ConfigEntry | None = None  # Only used in reauth flows
 
     async def async_step_import(self, import_info: dict[str, Any]) -> FlowResult:
         """Handle the import of legacy configuration.yaml entries."""
@@ -190,6 +192,19 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._set_confirm_only()
         return self.async_show_form(step_id="confirm")
 
+    async def async_step_reauth(self, config: Mapping[str, Any]) -> FlowResult:
+        """Perform reauth upon an API authentication error."""
+        self._webfsapi_url = config[CONF_WEBFSAPI_URL]
+
+        self._reauth_entry = self.hass.config_entries.async_get_entry(
+            self.context["entry_id"]
+        )
+
+        assert self._reauth_entry
+
+        self.context["title_placeholders"] = {"name": self._reauth_entry.title}
+        return await self.async_step_device_config()
+
     async def async_step_device_config(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
@@ -218,6 +233,17 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             _LOGGER.exception(exception)
             errors["base"] = "unknown"
         else:
+            if self._reauth_entry:
+                self.hass.config_entries.async_update_entry(
+                    self._reauth_entry,
+                    data={
+                        CONF_WEBFSAPI_URL: self._webfsapi_url,
+                        CONF_PIN: user_input[CONF_PIN],
+                    },
+                )
+                await self.hass.config_entries.async_reload(self._reauth_entry.entry_id)
+                return self.async_abort(reason="reauth_successful")
+
             unique_id = await afsapi.get_radio_id()
             await self.async_set_unique_id(unique_id, raise_on_progress=False)
             self._abort_if_unique_id_configured()

--- a/homeassistant/components/frontier_silicon/config_flow.py
+++ b/homeassistant/components/frontier_silicon/config_flow.py
@@ -200,9 +200,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self.context["entry_id"]
         )
 
-        assert self._reauth_entry
-
-        self.context["title_placeholders"] = {"name": self._reauth_entry.title}
         return await self.async_step_device_config()
 
     async def async_step_device_config(

--- a/homeassistant/components/frontier_silicon/config_flow.py
+++ b/homeassistant/components/frontier_silicon/config_flow.py
@@ -236,10 +236,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             if self._reauth_entry:
                 self.hass.config_entries.async_update_entry(
                     self._reauth_entry,
-                    data={
-                        CONF_WEBFSAPI_URL: self._webfsapi_url,
-                        CONF_PIN: user_input[CONF_PIN],
-                    },
+                    data={CONF_PIN: user_input[CONF_PIN]},
                 )
                 await self.hass.config_entries.async_reload(self._reauth_entry.entry_id)
                 return self.async_abort(reason="reauth_successful")

--- a/homeassistant/components/frontier_silicon/strings.json
+++ b/homeassistant/components/frontier_silicon/strings.json
@@ -21,7 +21,8 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     }
   },
   "issues": {

--- a/tests/components/frontier_silicon/test_config_flow.py
+++ b/tests/components/frontier_silicon/test_config_flow.py
@@ -444,7 +444,7 @@ async def test_reauth_flow(hass: HomeAssistant, config_entry: MockConfigEntry) -
 
 
 @pytest.mark.parametrize(
-    ("friendly_name_error", "result_error"),
+    ("exception", "reason"),
     [
         (ConnectionError, "cannot_connect"),
         (InvalidPinException, "invalid_auth"),
@@ -453,8 +453,8 @@ async def test_reauth_flow(hass: HomeAssistant, config_entry: MockConfigEntry) -
 )
 async def test_reauth_flow_friendly_name_error(
     hass: HomeAssistant,
-    friendly_name_error: Exception,
-    result_error: str,
+    exception: Exception,
+    reason: str,
     config_entry: MockConfigEntry,
 ) -> None:
     """Test reauth flow with failures."""
@@ -475,7 +475,7 @@ async def test_reauth_flow_friendly_name_error(
 
     with patch(
         "homeassistant.components.frontier_silicon.config_flow.AFSAPI.get_friendly_name",
-        side_effect=friendly_name_error,
+        side_effect=exception,
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -485,7 +485,7 @@ async def test_reauth_flow_friendly_name_error(
 
     assert result2["type"] == FlowResultType.FORM
     assert result2["step_id"] == "device_config"
-    assert result2["errors"] == {"base": result_error}
+    assert result2["errors"] == {"base": reason}
 
     result3 = await hass.config_entries.flow.async_configure(
         result["flow_id"],

--- a/tests/components/frontier_silicon/test_config_flow.py
+++ b/tests/components/frontier_silicon/test_config_flow.py
@@ -420,6 +420,7 @@ async def test_ssdp_nondefault_pin(hass: HomeAssistant) -> None:
 async def test_reauth_flow(hass: HomeAssistant, config_entry: MockConfigEntry) -> None:
     """Test reauth flow."""
     config_entry.add_to_hass(hass)
+    assert config_entry.data[CONF_PIN] == "1234"
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -458,6 +459,7 @@ async def test_reauth_flow_friendly_name_error(
 ) -> None:
     """Test reauth flow with failures."""
     config_entry.add_to_hass(hass)
+    assert config_entry.data[CONF_PIN] == "1234"
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,

--- a/tests/components/frontier_silicon/test_config_flow.py
+++ b/tests/components/frontier_silicon/test_config_flow.py
@@ -472,7 +472,7 @@ async def test_reauth_flow_friendly_name_error(
     assert result["step_id"] == "device_config"
 
     with patch(
-        "afsapi.AFSAPI.get_friendly_name",
+        "homeassistant.components.frontier_silicon.config_flow.AFSAPI.get_friendly_name",
         side_effect=friendly_name_error,
     ):
         result2 = await hass.config_entries.flow.async_configure(

--- a/tests/components/frontier_silicon/test_config_flow.py
+++ b/tests/components/frontier_silicon/test_config_flow.py
@@ -415,3 +415,80 @@ async def test_ssdp_nondefault_pin(hass: HomeAssistant) -> None:
 
     assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "invalid_auth"
+
+
+async def test_reauth_flow(hass: HomeAssistant, config_entry: MockConfigEntry) -> None:
+    """Test reauth flow."""
+    config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": config_entries.SOURCE_REAUTH,
+            "unique_id": config_entry.unique_id,
+            "entry_id": config_entry.entry_id,
+        },
+        data=config_entry.data,
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "device_config"
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_PIN: "4242"},
+    )
+    assert result2["type"] == FlowResultType.ABORT
+    assert result2["reason"] == "reauth_successful"
+    assert config_entry.data[CONF_PIN] == "4242"
+
+
+@pytest.mark.parametrize(
+    ("friendly_name_error", "result_error"),
+    [
+        (ConnectionError, "cannot_connect"),
+        (InvalidPinException, "invalid_auth"),
+        (ValueError, "unknown"),
+    ],
+)
+async def test_reauth_flow_friendly_name_error(
+    hass: HomeAssistant,
+    friendly_name_error: Exception,
+    result_error: str,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test reauth flow with failures."""
+    config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": config_entries.SOURCE_REAUTH,
+            "unique_id": config_entry.unique_id,
+            "entry_id": config_entry.entry_id,
+        },
+        data=config_entry.data,
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "device_config"
+
+    with patch(
+        "afsapi.AFSAPI.get_friendly_name",
+        side_effect=friendly_name_error,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_PIN: "4321"},
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["step_id"] == "device_config"
+    assert result2["errors"] == {"base": result_error}
+
+    result3 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_PIN: "4242"},
+    )
+    assert result3["type"] == FlowResultType.ABORT
+    assert result3["reason"] == "reauth_successful"
+    assert config_entry.data[CONF_PIN] == "4242"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds reauth flow to frontier_silicon integration

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
