### PR TITLE
Use metric units internally in Accuweather integration

### DIFF
--- a/homeassistant/components/accuweather/__init__.py
+++ b/homeassistant/components/accuweather/__init__.py
@@ -17,7 +17,6 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
-from homeassistant.util.unit_system import METRIC_SYSTEM
 
 from .const import ATTR_FORECAST, CONF_FORECAST, DOMAIN, MANUFACTURER
 
@@ -116,11 +115,7 @@ class AccuWeatherDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             async with timeout(10):
                 current = await self.accuweather.async_get_current_conditions()
                 forecast = (
-                    await self.accuweather.async_get_forecast(
-                        metric=self.hass.config.units is METRIC_SYSTEM
-                    )
-                    if self.forecast
-                    else {}
+                    await self.accuweather.async_get_forecast() if self.forecast else {}
                 )
         except (
             ApiError,

--- a/homeassistant/components/accuweather/const.py
+++ b/homeassistant/components/accuweather/const.py
@@ -20,7 +20,6 @@ from homeassistant.components.weather import (
     ATTR_CONDITION_WINDY,
 )
 
-API_IMPERIAL: Final = "Imperial"
 API_METRIC: Final = "Metric"
 ATTRIBUTION: Final = "Data provided by AccuWeather"
 ATTR_CATEGORY: Final = "Category"

--- a/homeassistant/components/accuweather/sensor.py
+++ b/homeassistant/components/accuweather/sensor.py
@@ -26,6 +26,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
 from . import AccuWeatherDataUpdateCoordinator
 from .const import (
@@ -406,6 +407,21 @@ class AccuWeatherSensor(
             return self.entity_description.attr_fn(self._sensor_data)
 
         return self.entity_description.attr_fn(self.coordinator.data)
+
+    @property
+    def suggested_unit_of_measurement(self) -> str | None:
+        """Return the unit which should be used for the sensor's state.
+
+        Entity units with device_class WIND_SPEED are not automatically converted for
+        the US CUSTOMARY unit system, so we return the suggested unit for them.
+        """
+        if (
+            self.entity_description.device_class == SensorDeviceClass.WIND_SPEED
+            and self.hass.config.units == US_CUSTOMARY_SYSTEM
+        ):
+            return UnitOfSpeed.MILES_PER_HOUR
+
+        return None
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/homeassistant/components/accuweather/sensor.py
+++ b/homeassistant/components/accuweather/sensor.py
@@ -394,9 +394,11 @@ class AccuWeatherSensor(
             )
         self._attr_device_info = coordinator.device_info
         self.forecast_day = forecast_day
-        self._attr_suggested_unit_of_measurement = self._get_suggested_unit(
-            description.device_class
-        )
+        if (
+            description.device_class == SensorDeviceClass.WIND_SPEED
+            and coordinator.hass.config.units == US_CUSTOMARY_SYSTEM
+        ):
+            self._attr_suggested_unit_of_measurement = UnitOfSpeed.MILES_PER_HOUR
 
     @property
     def native_value(self) -> StateType:
@@ -418,20 +420,6 @@ class AccuWeatherSensor(
             self.coordinator.data, self.entity_description.key, self.forecast_day
         )
         self.async_write_ha_state()
-
-    def _get_suggested_unit(self, device_class: str | None) -> str | None:
-        """Return the unit which should be used for the sensor's state.
-
-        Entity units with device_class WIND_SPEED are not automatically converted for
-        the US CUSTOMARY unit system, so we return the suggested unit for them.
-        """
-        if (
-            device_class == SensorDeviceClass.WIND_SPEED
-            and self.coordinator.hass.config.units == US_CUSTOMARY_SYSTEM
-        ):
-            return UnitOfSpeed.MILES_PER_HOUR
-
-        return None
 
 
 def _get_sensor_data(

--- a/homeassistant/components/accuweather/sensor.py
+++ b/homeassistant/components/accuweather/sensor.py
@@ -392,8 +392,7 @@ class AccuWeatherSensor(
                 f"{coordinator.location_key}-{description.key}".lower()
             )
         self._attr_device_info = coordinator.device_info
-        if forecast_day is not None:
-            self.forecast_day = forecast_day
+        self.forecast_day = forecast_day
 
     @property
     def native_value(self) -> StateType:
@@ -409,7 +408,7 @@ class AccuWeatherSensor(
     def _handle_coordinator_update(self) -> None:
         """Handle data update."""
         self._sensor_data = _get_sensor_data(
-            self.coordinator.data, self.entity_description.key
+            self.coordinator.data, self.entity_description.key, self.forecast_day
         )
         self.async_write_ha_state()
 
@@ -436,11 +435,3 @@ class AccuWeatherForecastSensor(AccuWeatherSensor):
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes."""
         return self.entity_description.attr_fn(self._sensor_data)
-
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        """Handle data update."""
-        self._sensor_data = _get_sensor_data(
-            self.coordinator.data, self.entity_description.key, self.forecast_day
-        )
-        self.async_write_ha_state()

--- a/homeassistant/components/accuweather/sensor.py
+++ b/homeassistant/components/accuweather/sensor.py
@@ -352,7 +352,7 @@ async def async_setup_entry(
         # Some air quality/allergy sensors are only available for certain
         # locations.
         sensors.extend(
-            AccuWeatherForecastSensor(coordinator, description, forecast_day=day)
+            AccuWeatherSensor(coordinator, description, forecast_day=day)
             for day in range(MAX_FORECAST_DAYS + 1)
             for description in FORECAST_SENSOR_TYPES
             if description.key in coordinator.data[ATTR_FORECAST][0]
@@ -402,6 +402,9 @@ class AccuWeatherSensor(
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes."""
+        if self.forecast_day is not None:
+            return self.entity_description.attr_fn(self._sensor_data)
+
         return self.entity_description.attr_fn(self.coordinator.data)
 
     @callback
@@ -426,12 +429,3 @@ def _get_sensor_data(
         return sensors["PrecipitationSummary"]["PastHour"]
 
     return sensors[kind]
-
-
-class AccuWeatherForecastSensor(AccuWeatherSensor):
-    """Define an AccuWeather forecast entity."""
-
-    @property
-    def extra_state_attributes(self) -> dict[str, Any]:
-        """Return the state attributes."""
-        return self.entity_description.attr_fn(self._sensor_data)

--- a/homeassistant/components/accuweather/sensor.py
+++ b/homeassistant/components/accuweather/sensor.py
@@ -26,7 +26,6 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
 from . import AccuWeatherDataUpdateCoordinator
 from .const import (
@@ -394,11 +393,6 @@ class AccuWeatherSensor(
             )
         self._attr_device_info = coordinator.device_info
         self.forecast_day = forecast_day
-        if (
-            description.device_class == SensorDeviceClass.WIND_SPEED
-            and coordinator.hass.config.units == US_CUSTOMARY_SYSTEM
-        ):
-            self._attr_suggested_unit_of_measurement = UnitOfSpeed.MILES_PER_HOUR
 
     @property
     def native_value(self) -> StateType:

--- a/homeassistant/components/accuweather/sensor.py
+++ b/homeassistant/components/accuweather/sensor.py
@@ -26,11 +26,9 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.util.unit_system import METRIC_SYSTEM
 
 from . import AccuWeatherDataUpdateCoordinator
 from .const import (
-    API_IMPERIAL,
     API_METRIC,
     ATTR_CATEGORY,
     ATTR_DIRECTION,
@@ -51,7 +49,7 @@ PARALLEL_UPDATES = 1
 class AccuWeatherSensorDescriptionMixin:
     """Mixin for AccuWeather sensor."""
 
-    value_fn: Callable[[dict[str, Any], str], StateType]
+    value_fn: Callable[[dict[str, Any]], StateType]
 
 
 @dataclass
@@ -61,8 +59,6 @@ class AccuWeatherSensorDescription(
     """Class describing AccuWeather sensor entities."""
 
     attr_fn: Callable[[dict[str, Any]], dict[str, StateType]] = lambda _: {}
-    metric_unit: str | None = None
-    us_customary_unit: str | None = None
 
 
 FORECAST_SENSOR_TYPES: tuple[AccuWeatherSensorDescription, ...] = (
@@ -72,7 +68,7 @@ FORECAST_SENSOR_TYPES: tuple[AccuWeatherSensorDescription, ...] = (
         name="Cloud cover day",
         entity_registry_enabled_default=False,
         native_unit_of_measurement=PERCENTAGE,
-        value_fn=lambda data, _: cast(int, data),
+        value_fn=lambda data: cast(int, data),
     ),
     AccuWeatherSensorDescription(
         key="CloudCoverNight",
@@ -80,7 +76,7 @@ FORECAST_SENSOR_TYPES: tuple[AccuWeatherSensorDescription, ...] = (
         name="Cloud cover night",
         entity_registry_enabled_default=False,
         native_unit_of_measurement=PERCENTAGE,
-        value_fn=lambda data, _: cast(int, data),
+        value_fn=lambda data: cast(int, data),
     ),
     AccuWeatherSensorDescription(
         key="Grass",
@@ -88,7 +84,7 @@ FORECAST_SENSOR_TYPES: tuple[AccuWeatherSensorDescription, ...] = (
         name="Grass pollen",
         entity_registry_enabled_default=False,
         native_unit_of_measurement=CONCENTRATION_PARTS_PER_CUBIC_METER,
-        value_fn=lambda data, _: cast(int, data[ATTR_VALUE]),
+        value_fn=lambda data: cast(int, data[ATTR_VALUE]),
         attr_fn=lambda data: {ATTR_LEVEL: data[ATTR_CATEGORY]},
     ),
     AccuWeatherSensorDescription(
@@ -96,7 +92,7 @@ FORECAST_SENSOR_TYPES: tuple[AccuWeatherSensorDescription, ...] = (
         icon="mdi:weather-partly-cloudy",
         name="Hours of sun",
         native_unit_of_measurement=UnitOfTime.HOURS,
-        value_fn=lambda data, _: cast(float, data),
+        value_fn=lambda data: cast(float, data),
     ),
     AccuWeatherSensorDescription(
         key="Mold",
@@ -104,7 +100,7 @@ FORECAST_SENSOR_TYPES: tuple[AccuWeatherSensorDescription, ...] = (
         name="Mold pollen",
         entity_registry_enabled_default=False,
         native_unit_of_measurement=CONCENTRATION_PARTS_PER_CUBIC_METER,
-        value_fn=lambda data, _: cast(int, data[ATTR_VALUE]),
+        value_fn=lambda data: cast(int, data[ATTR_VALUE]),
         attr_fn=lambda data: {ATTR_LEVEL: data[ATTR_CATEGORY]},
     ),
     AccuWeatherSensorDescription(
@@ -112,7 +108,7 @@ FORECAST_SENSOR_TYPES: tuple[AccuWeatherSensorDescription, ...] = (
         icon="mdi:vector-triangle",
         name="Ozone",
         entity_registry_enabled_default=False,
-        value_fn=lambda data, _: cast(int, data[ATTR_VALUE]),
+        value_fn=lambda data: cast(int, data[ATTR_VALUE]),
         attr_fn=lambda data: {ATTR_LEVEL: data[ATTR_CATEGORY]},
     ),
     AccuWeatherSensorDescription(
@@ -121,56 +117,52 @@ FORECAST_SENSOR_TYPES: tuple[AccuWeatherSensorDescription, ...] = (
         name="Ragweed pollen",
         native_unit_of_measurement=CONCENTRATION_PARTS_PER_CUBIC_METER,
         entity_registry_enabled_default=False,
-        value_fn=lambda data, _: cast(int, data[ATTR_VALUE]),
+        value_fn=lambda data: cast(int, data[ATTR_VALUE]),
         attr_fn=lambda data: {ATTR_LEVEL: data[ATTR_CATEGORY]},
     ),
     AccuWeatherSensorDescription(
         key="RealFeelTemperatureMax",
         device_class=SensorDeviceClass.TEMPERATURE,
         name="RealFeel temperature max",
-        metric_unit=UnitOfTemperature.CELSIUS,
-        us_customary_unit=UnitOfTemperature.FAHRENHEIT,
-        value_fn=lambda data, _: cast(float, data[ATTR_VALUE]),
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        value_fn=lambda data: cast(float, data[ATTR_VALUE]),
     ),
     AccuWeatherSensorDescription(
         key="RealFeelTemperatureMin",
         device_class=SensorDeviceClass.TEMPERATURE,
         name="RealFeel temperature min",
-        metric_unit=UnitOfTemperature.CELSIUS,
-        us_customary_unit=UnitOfTemperature.FAHRENHEIT,
-        value_fn=lambda data, _: cast(float, data[ATTR_VALUE]),
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        value_fn=lambda data: cast(float, data[ATTR_VALUE]),
     ),
     AccuWeatherSensorDescription(
         key="RealFeelTemperatureShadeMax",
         device_class=SensorDeviceClass.TEMPERATURE,
         name="RealFeel temperature shade max",
         entity_registry_enabled_default=False,
-        metric_unit=UnitOfTemperature.CELSIUS,
-        us_customary_unit=UnitOfTemperature.FAHRENHEIT,
-        value_fn=lambda data, _: cast(float, data[ATTR_VALUE]),
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        value_fn=lambda data: cast(float, data[ATTR_VALUE]),
     ),
     AccuWeatherSensorDescription(
         key="RealFeelTemperatureShadeMin",
         device_class=SensorDeviceClass.TEMPERATURE,
         name="RealFeel temperature shade min",
         entity_registry_enabled_default=False,
-        metric_unit=UnitOfTemperature.CELSIUS,
-        us_customary_unit=UnitOfTemperature.FAHRENHEIT,
-        value_fn=lambda data, _: cast(float, data[ATTR_VALUE]),
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        value_fn=lambda data: cast(float, data[ATTR_VALUE]),
     ),
     AccuWeatherSensorDescription(
         key="ThunderstormProbabilityDay",
         icon="mdi:weather-lightning",
         name="Thunderstorm probability day",
         native_unit_of_measurement=PERCENTAGE,
-        value_fn=lambda data, _: cast(int, data),
+        value_fn=lambda data: cast(int, data),
     ),
     AccuWeatherSensorDescription(
         key="ThunderstormProbabilityNight",
         icon="mdi:weather-lightning",
         name="Thunderstorm probability night",
         native_unit_of_measurement=PERCENTAGE,
-        value_fn=lambda data, _: cast(int, data),
+        value_fn=lambda data: cast(int, data),
     ),
     AccuWeatherSensorDescription(
         key="Tree",
@@ -178,7 +170,7 @@ FORECAST_SENSOR_TYPES: tuple[AccuWeatherSensorDescription, ...] = (
         name="Tree pollen",
         native_unit_of_measurement=CONCENTRATION_PARTS_PER_CUBIC_METER,
         entity_registry_enabled_default=False,
-        value_fn=lambda data, _: cast(int, data[ATTR_VALUE]),
+        value_fn=lambda data: cast(int, data[ATTR_VALUE]),
         attr_fn=lambda data: {ATTR_LEVEL: data[ATTR_CATEGORY]},
     ),
     AccuWeatherSensorDescription(
@@ -186,7 +178,7 @@ FORECAST_SENSOR_TYPES: tuple[AccuWeatherSensorDescription, ...] = (
         icon="mdi:weather-sunny",
         name="UV index",
         native_unit_of_measurement=UV_INDEX,
-        value_fn=lambda data, _: cast(int, data[ATTR_VALUE]),
+        value_fn=lambda data: cast(int, data[ATTR_VALUE]),
         attr_fn=lambda data: {ATTR_LEVEL: data[ATTR_CATEGORY]},
     ),
     AccuWeatherSensorDescription(
@@ -194,9 +186,8 @@ FORECAST_SENSOR_TYPES: tuple[AccuWeatherSensorDescription, ...] = (
         device_class=SensorDeviceClass.WIND_SPEED,
         name="Wind gust day",
         entity_registry_enabled_default=False,
-        metric_unit=UnitOfSpeed.KILOMETERS_PER_HOUR,
-        us_customary_unit=UnitOfSpeed.MILES_PER_HOUR,
-        value_fn=lambda data, _: cast(float, data[ATTR_SPEED][ATTR_VALUE]),
+        native_unit_of_measurement=UnitOfSpeed.KILOMETERS_PER_HOUR,
+        value_fn=lambda data: cast(float, data[ATTR_SPEED][ATTR_VALUE]),
         attr_fn=lambda data: {"direction": data[ATTR_DIRECTION][ATTR_ENGLISH]},
     ),
     AccuWeatherSensorDescription(
@@ -204,27 +195,24 @@ FORECAST_SENSOR_TYPES: tuple[AccuWeatherSensorDescription, ...] = (
         device_class=SensorDeviceClass.WIND_SPEED,
         name="Wind gust night",
         entity_registry_enabled_default=False,
-        metric_unit=UnitOfSpeed.KILOMETERS_PER_HOUR,
-        us_customary_unit=UnitOfSpeed.MILES_PER_HOUR,
-        value_fn=lambda data, _: cast(float, data[ATTR_SPEED][ATTR_VALUE]),
+        native_unit_of_measurement=UnitOfSpeed.KILOMETERS_PER_HOUR,
+        value_fn=lambda data: cast(float, data[ATTR_SPEED][ATTR_VALUE]),
         attr_fn=lambda data: {"direction": data[ATTR_DIRECTION][ATTR_ENGLISH]},
     ),
     AccuWeatherSensorDescription(
         key="WindDay",
         device_class=SensorDeviceClass.WIND_SPEED,
         name="Wind day",
-        metric_unit=UnitOfSpeed.KILOMETERS_PER_HOUR,
-        us_customary_unit=UnitOfSpeed.MILES_PER_HOUR,
-        value_fn=lambda data, _: cast(float, data[ATTR_SPEED][ATTR_VALUE]),
+        native_unit_of_measurement=UnitOfSpeed.KILOMETERS_PER_HOUR,
+        value_fn=lambda data: cast(float, data[ATTR_SPEED][ATTR_VALUE]),
         attr_fn=lambda data: {"direction": data[ATTR_DIRECTION][ATTR_ENGLISH]},
     ),
     AccuWeatherSensorDescription(
         key="WindNight",
         device_class=SensorDeviceClass.WIND_SPEED,
         name="Wind night",
-        metric_unit=UnitOfSpeed.KILOMETERS_PER_HOUR,
-        us_customary_unit=UnitOfSpeed.MILES_PER_HOUR,
-        value_fn=lambda data, _: cast(float, data[ATTR_SPEED][ATTR_VALUE]),
+        native_unit_of_measurement=UnitOfSpeed.KILOMETERS_PER_HOUR,
+        value_fn=lambda data: cast(float, data[ATTR_SPEED][ATTR_VALUE]),
         attr_fn=lambda data: {"direction": data[ATTR_DIRECTION][ATTR_ENGLISH]},
     ),
 )
@@ -236,9 +224,8 @@ SENSOR_TYPES: tuple[AccuWeatherSensorDescription, ...] = (
         name="Apparent temperature",
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.MEASUREMENT,
-        metric_unit=UnitOfTemperature.CELSIUS,
-        us_customary_unit=UnitOfTemperature.FAHRENHEIT,
-        value_fn=lambda data, unit: cast(float, data[unit][ATTR_VALUE]),
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        value_fn=lambda data: cast(float, data[API_METRIC][ATTR_VALUE]),
     ),
     AccuWeatherSensorDescription(
         key="Ceiling",
@@ -246,9 +233,8 @@ SENSOR_TYPES: tuple[AccuWeatherSensorDescription, ...] = (
         icon="mdi:weather-fog",
         name="Cloud ceiling",
         state_class=SensorStateClass.MEASUREMENT,
-        metric_unit=UnitOfLength.METERS,
-        us_customary_unit=UnitOfLength.FEET,
-        value_fn=lambda data, unit: cast(float, data[unit][ATTR_VALUE]),
+        native_unit_of_measurement=UnitOfLength.METERS,
+        value_fn=lambda data: cast(float, data[API_METRIC][ATTR_VALUE]),
         suggested_display_precision=0,
     ),
     AccuWeatherSensorDescription(
@@ -258,7 +244,7 @@ SENSOR_TYPES: tuple[AccuWeatherSensorDescription, ...] = (
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=PERCENTAGE,
-        value_fn=lambda data, _: cast(int, data),
+        value_fn=lambda data: cast(int, data),
     ),
     AccuWeatherSensorDescription(
         key="DewPoint",
@@ -266,18 +252,16 @@ SENSOR_TYPES: tuple[AccuWeatherSensorDescription, ...] = (
         name="Dew point",
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.MEASUREMENT,
-        metric_unit=UnitOfTemperature.CELSIUS,
-        us_customary_unit=UnitOfTemperature.FAHRENHEIT,
-        value_fn=lambda data, unit: cast(float, data[unit][ATTR_VALUE]),
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        value_fn=lambda data: cast(float, data[API_METRIC][ATTR_VALUE]),
     ),
     AccuWeatherSensorDescription(
         key="RealFeelTemperature",
         device_class=SensorDeviceClass.TEMPERATURE,
         name="RealFeel temperature",
         state_class=SensorStateClass.MEASUREMENT,
-        metric_unit=UnitOfTemperature.CELSIUS,
-        us_customary_unit=UnitOfTemperature.FAHRENHEIT,
-        value_fn=lambda data, unit: cast(float, data[unit][ATTR_VALUE]),
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        value_fn=lambda data: cast(float, data[API_METRIC][ATTR_VALUE]),
     ),
     AccuWeatherSensorDescription(
         key="RealFeelTemperatureShade",
@@ -285,18 +269,16 @@ SENSOR_TYPES: tuple[AccuWeatherSensorDescription, ...] = (
         name="RealFeel temperature shade",
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.MEASUREMENT,
-        metric_unit=UnitOfTemperature.CELSIUS,
-        us_customary_unit=UnitOfTemperature.FAHRENHEIT,
-        value_fn=lambda data, unit: cast(float, data[unit][ATTR_VALUE]),
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        value_fn=lambda data: cast(float, data[API_METRIC][ATTR_VALUE]),
     ),
     AccuWeatherSensorDescription(
         key="Precipitation",
         device_class=SensorDeviceClass.PRECIPITATION_INTENSITY,
         name="Precipitation",
         state_class=SensorStateClass.MEASUREMENT,
-        metric_unit=UnitOfVolumetricFlux.MILLIMETERS_PER_HOUR,
-        us_customary_unit=UnitOfVolumetricFlux.INCHES_PER_HOUR,
-        value_fn=lambda data, unit: cast(float, data[unit][ATTR_VALUE]),
+        native_unit_of_measurement=UnitOfVolumetricFlux.MILLIMETERS_PER_HOUR,
+        value_fn=lambda data: cast(float, data[API_METRIC][ATTR_VALUE]),
         attr_fn=lambda data: {"type": data["PrecipitationType"]},
     ),
     AccuWeatherSensorDescription(
@@ -306,7 +288,7 @@ SENSOR_TYPES: tuple[AccuWeatherSensorDescription, ...] = (
         name="Pressure tendency",
         options=["falling", "rising", "steady"],
         translation_key="pressure_tendency",
-        value_fn=lambda data, _: cast(str, data["LocalizedText"]).lower(),
+        value_fn=lambda data: cast(str, data["LocalizedText"]).lower(),
     ),
     AccuWeatherSensorDescription(
         key="UVIndex",
@@ -314,7 +296,7 @@ SENSOR_TYPES: tuple[AccuWeatherSensorDescription, ...] = (
         name="UV index",
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UV_INDEX,
-        value_fn=lambda data, _: cast(int, data),
+        value_fn=lambda data: cast(int, data),
         attr_fn=lambda data: {ATTR_LEVEL: data["UVIndexText"]},
     ),
     AccuWeatherSensorDescription(
@@ -323,9 +305,8 @@ SENSOR_TYPES: tuple[AccuWeatherSensorDescription, ...] = (
         name="Wet bulb temperature",
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.MEASUREMENT,
-        metric_unit=UnitOfTemperature.CELSIUS,
-        us_customary_unit=UnitOfTemperature.FAHRENHEIT,
-        value_fn=lambda data, unit: cast(float, data[unit][ATTR_VALUE]),
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        value_fn=lambda data: cast(float, data[API_METRIC][ATTR_VALUE]),
     ),
     AccuWeatherSensorDescription(
         key="WindChillTemperature",
@@ -333,18 +314,16 @@ SENSOR_TYPES: tuple[AccuWeatherSensorDescription, ...] = (
         name="Wind chill temperature",
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.MEASUREMENT,
-        metric_unit=UnitOfTemperature.CELSIUS,
-        us_customary_unit=UnitOfTemperature.FAHRENHEIT,
-        value_fn=lambda data, unit: cast(float, data[unit][ATTR_VALUE]),
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        value_fn=lambda data: cast(float, data[API_METRIC][ATTR_VALUE]),
     ),
     AccuWeatherSensorDescription(
         key="Wind",
         device_class=SensorDeviceClass.WIND_SPEED,
         name="Wind",
         state_class=SensorStateClass.MEASUREMENT,
-        metric_unit=UnitOfSpeed.KILOMETERS_PER_HOUR,
-        us_customary_unit=UnitOfSpeed.MILES_PER_HOUR,
-        value_fn=lambda data, unit: cast(float, data[ATTR_SPEED][unit][ATTR_VALUE]),
+        native_unit_of_measurement=UnitOfSpeed.KILOMETERS_PER_HOUR,
+        value_fn=lambda data: cast(float, data[ATTR_SPEED][API_METRIC][ATTR_VALUE]),
     ),
     AccuWeatherSensorDescription(
         key="WindGust",
@@ -352,9 +331,8 @@ SENSOR_TYPES: tuple[AccuWeatherSensorDescription, ...] = (
         name="Wind gust",
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.MEASUREMENT,
-        metric_unit=UnitOfSpeed.KILOMETERS_PER_HOUR,
-        us_customary_unit=UnitOfSpeed.MILES_PER_HOUR,
-        value_fn=lambda data, unit: cast(float, data[ATTR_SPEED][unit][ATTR_VALUE]),
+        native_unit_of_measurement=UnitOfSpeed.KILOMETERS_PER_HOUR,
+        value_fn=lambda data: cast(float, data[ATTR_SPEED][API_METRIC][ATTR_VALUE]),
     ),
 )
 
@@ -414,14 +392,6 @@ class AccuWeatherSensor(
                 f"{coordinator.location_key}-{description.key}".lower()
             )
         self._attr_native_unit_of_measurement = description.native_unit_of_measurement
-        if self.coordinator.hass.config.units is METRIC_SYSTEM:
-            self._unit_system = API_METRIC
-            if metric_unit := description.metric_unit:
-                self._attr_native_unit_of_measurement = metric_unit
-        else:
-            self._unit_system = API_IMPERIAL
-            if us_customary_unit := description.us_customary_unit:
-                self._attr_native_unit_of_measurement = us_customary_unit
         self._attr_device_info = coordinator.device_info
         if forecast_day is not None:
             self.forecast_day = forecast_day
@@ -429,7 +399,7 @@ class AccuWeatherSensor(
     @property
     def native_value(self) -> StateType:
         """Return the state."""
-        return self.entity_description.value_fn(self._sensor_data, self._unit_system)
+        return self.entity_description.value_fn(self._sensor_data)
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:

--- a/homeassistant/components/accuweather/sensor.py
+++ b/homeassistant/components/accuweather/sensor.py
@@ -391,7 +391,6 @@ class AccuWeatherSensor(
             self._attr_unique_id = (
                 f"{coordinator.location_key}-{description.key}".lower()
             )
-        self._attr_native_unit_of_measurement = description.native_unit_of_measurement
         self._attr_device_info = coordinator.device_info
         if forecast_day is not None:
             self.forecast_day = forecast_day

--- a/homeassistant/components/accuweather/weather.py
+++ b/homeassistant/components/accuweather/weather.py
@@ -28,17 +28,9 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util.dt import utc_from_timestamp
-from homeassistant.util.unit_system import METRIC_SYSTEM
 
 from . import AccuWeatherDataUpdateCoordinator
-from .const import (
-    API_IMPERIAL,
-    API_METRIC,
-    ATTR_FORECAST,
-    ATTRIBUTION,
-    CONDITION_CLASSES,
-    DOMAIN,
-)
+from .const import API_METRIC, ATTR_FORECAST, ATTRIBUTION, CONDITION_CLASSES, DOMAIN
 
 PARALLEL_UPDATES = 1
 
@@ -66,20 +58,11 @@ class AccuWeatherEntity(
         # Coordinator data is used also for sensors which don't have units automatically
         # converted, hence the weather entity's native units follow the configured unit
         # system
-        if coordinator.hass.config.units is METRIC_SYSTEM:
-            self._attr_native_precipitation_unit = UnitOfPrecipitationDepth.MILLIMETERS
-            self._attr_native_pressure_unit = UnitOfPressure.HPA
-            self._attr_native_temperature_unit = UnitOfTemperature.CELSIUS
-            self._attr_native_visibility_unit = UnitOfLength.KILOMETERS
-            self._attr_native_wind_speed_unit = UnitOfSpeed.KILOMETERS_PER_HOUR
-            self._unit_system = API_METRIC
-        else:
-            self._unit_system = API_IMPERIAL
-            self._attr_native_precipitation_unit = UnitOfPrecipitationDepth.INCHES
-            self._attr_native_pressure_unit = UnitOfPressure.INHG
-            self._attr_native_temperature_unit = UnitOfTemperature.FAHRENHEIT
-            self._attr_native_visibility_unit = UnitOfLength.MILES
-            self._attr_native_wind_speed_unit = UnitOfSpeed.MILES_PER_HOUR
+        self._attr_native_precipitation_unit = UnitOfPrecipitationDepth.MILLIMETERS
+        self._attr_native_pressure_unit = UnitOfPressure.HPA
+        self._attr_native_temperature_unit = UnitOfTemperature.CELSIUS
+        self._attr_native_visibility_unit = UnitOfLength.KILOMETERS
+        self._attr_native_wind_speed_unit = UnitOfSpeed.KILOMETERS_PER_HOUR
         self._attr_unique_id = coordinator.location_key
         self._attr_attribution = ATTRIBUTION
         self._attr_device_info = coordinator.device_info
@@ -99,16 +82,12 @@ class AccuWeatherEntity(
     @property
     def native_temperature(self) -> float:
         """Return the temperature."""
-        return cast(
-            float, self.coordinator.data["Temperature"][self._unit_system]["Value"]
-        )
+        return cast(float, self.coordinator.data["Temperature"][API_METRIC]["Value"])
 
     @property
     def native_pressure(self) -> float:
         """Return the pressure."""
-        return cast(
-            float, self.coordinator.data["Pressure"][self._unit_system]["Value"]
-        )
+        return cast(float, self.coordinator.data["Pressure"][API_METRIC]["Value"])
 
     @property
     def humidity(self) -> int:
@@ -118,9 +97,7 @@ class AccuWeatherEntity(
     @property
     def native_wind_speed(self) -> float:
         """Return the wind speed."""
-        return cast(
-            float, self.coordinator.data["Wind"]["Speed"][self._unit_system]["Value"]
-        )
+        return cast(float, self.coordinator.data["Wind"]["Speed"][API_METRIC]["Value"])
 
     @property
     def wind_bearing(self) -> int:
@@ -130,9 +107,7 @@ class AccuWeatherEntity(
     @property
     def native_visibility(self) -> float:
         """Return the visibility."""
-        return cast(
-            float, self.coordinator.data["Visibility"][self._unit_system]["Value"]
-        )
+        return cast(float, self.coordinator.data["Visibility"][API_METRIC]["Value"])
 
     @property
     def ozone(self) -> int | None:

--- a/tests/components/accuweather/test_sensor.py
+++ b/tests/components/accuweather/test_sensor.py
@@ -748,7 +748,7 @@ async def test_sensor_imperial_units(hass: HomeAssistant) -> None:
 
     state = hass.states.get("sensor.home_wind")
     assert state
-    assert state.state == "9.009882"
+    assert state.state == "9.0"
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfSpeed.MILES_PER_HOUR
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT

--- a/tests/components/accuweather/test_sensor.py
+++ b/tests/components/accuweather/test_sensor.py
@@ -741,10 +741,28 @@ async def test_sensor_imperial_units(hass: HomeAssistant) -> None:
 
     state = hass.states.get("sensor.home_cloud_ceiling")
     assert state
-    assert state.state == "10500.0"
+    assert state.state == "10498.687664042"
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
     assert state.attributes.get(ATTR_ICON) == "mdi:weather-fog"
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfLength.FEET
+
+    state = hass.states.get("sensor.home_wind")
+    assert state
+    assert state.state == "14.5"
+    assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
+    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfSpeed.MILES_PER_HOUR
+    assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
+    assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.WIND_SPEED
+
+    state = hass.states.get("sensor.home_realfeel_temperature")
+    assert state
+    assert state.state == "77.2"
+    assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
+    assert (
+        state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfTemperature.FAHRENHEIT
+    )
+    assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.TEMPERATURE
+    assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
 
 
 async def test_state_update(hass: HomeAssistant) -> None:

--- a/tests/components/accuweather/test_sensor.py
+++ b/tests/components/accuweather/test_sensor.py
@@ -742,27 +742,19 @@ async def test_sensor_imperial_units(hass: HomeAssistant) -> None:
     state = hass.states.get("sensor.home_cloud_ceiling")
     assert state
     assert state.state == "10498.687664042"
-    assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
-    assert state.attributes.get(ATTR_ICON) == "mdi:weather-fog"
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfLength.FEET
 
     state = hass.states.get("sensor.home_wind")
     assert state
     assert state.state == "9.0"
-    assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfSpeed.MILES_PER_HOUR
-    assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
-    assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.WIND_SPEED
 
     state = hass.states.get("sensor.home_realfeel_temperature")
     assert state
     assert state.state == "77.2"
-    assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
     assert (
         state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfTemperature.FAHRENHEIT
     )
-    assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.TEMPERATURE
-    assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
 
 
 async def test_state_update(hass: HomeAssistant) -> None:

--- a/tests/components/accuweather/test_sensor.py
+++ b/tests/components/accuweather/test_sensor.py
@@ -748,7 +748,7 @@ async def test_sensor_imperial_units(hass: HomeAssistant) -> None:
 
     state = hass.states.get("sensor.home_wind")
     assert state
-    assert state.state == "14.5"
+    assert state.state == "9.009882"
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfSpeed.MILES_PER_HOUR
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
With this change, the integration will only use metric units internally. For entities with device class `wind_speed`, <strike>the suggested unit `mph` will return if imperial units are required (units of entities with this device class are not automatically converted).</strike>
I also made a small change in the sensor entity classes so that one of the classes can be removed.

The PR is waiting for #90504

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
