### PR TITLE
Adjust scrape sensor validation

### DIFF
--- a/homeassistant/components/scrape/sensor.py
+++ b/homeassistant/components/scrape/sensor.py
@@ -1,10 +1,9 @@
 """Support for getting data from websites with scraping."""
 from __future__ import annotations
 
+from collections.abc import Mapping
 import logging
 from typing import Any, cast
-
-import voluptuous as vol
 
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.components.sensor.helpers import async_parse_date_datetime
@@ -19,10 +18,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.template import Template
-from homeassistant.helpers.template_entity import (
-    TEMPLATE_SENSOR_BASE_SCHEMA,
-    TemplateSensor,
-)
+from homeassistant.helpers.template_entity import TemplateSensor
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -77,12 +73,7 @@ async def async_setup_entry(
     entities: list = []
 
     coordinator: ScrapeCoordinator = hass.data[DOMAIN][entry.entry_id]
-    config = dict(entry.options)
-    for sensor in config["sensor"]:
-        sensor_config: ConfigType = vol.Schema(
-            TEMPLATE_SENSOR_BASE_SCHEMA.schema, extra=vol.ALLOW_EXTRA
-        )(sensor)
-
+    for sensor_config in entry.options["sensor"]:
         name: str = sensor_config[CONF_NAME]
         select: str = sensor_config[CONF_SELECT]
         attr: str | None = sensor_config.get(CONF_ATTRIBUTE)
@@ -117,7 +108,7 @@ class ScrapeSensor(CoordinatorEntity[ScrapeCoordinator], TemplateSensor):
         self,
         hass: HomeAssistant,
         coordinator: ScrapeCoordinator,
-        config: ConfigType,
+        config: Mapping[str, Any],
         name: str,
         unique_id: str | None,
         select: str,

--- a/homeassistant/components/scrape/sensor.py
+++ b/homeassistant/components/scrape/sensor.py
@@ -79,6 +79,7 @@ async def async_setup_entry(
     coordinator: ScrapeCoordinator = hass.data[DOMAIN][entry.entry_id]
     config = dict(entry.options)
     for sensor in config["sensor"]:
+        # We need to ensure templates are correctly initialised
         sensor_config: ConfigType = vol.Schema(
             TEMPLATE_ENTITY_BASE_SCHEMA.schema, extra=vol.ALLOW_EXTRA
         )(sensor)

--- a/homeassistant/helpers/template_entity.py
+++ b/homeassistant/helpers/template_entity.py
@@ -1,7 +1,7 @@
 """TemplateEntity utility class."""
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 import contextlib
 import logging
 from typing import Any
@@ -32,7 +32,6 @@ from .entity import Entity
 from .event import TrackTemplate, TrackTemplateResult, async_track_template_result
 from .script import Script, _VarsType
 from .template import Template, TemplateStateFromEntityId, result_as_boolean
-from .typing import ConfigType
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -168,7 +167,7 @@ class TemplateEntity(Entity):
         icon_template: Template | None = None,
         entity_picture_template: Template | None = None,
         attribute_templates: dict[str, Template] | None = None,
-        config: ConfigType | None = None,
+        config: Mapping[str, Any] | None = None,
         fallback_name: str | None = None,
         unique_id: str | None = None,
     ) -> None:
@@ -428,7 +427,7 @@ class TemplateSensor(TemplateEntity, SensorEntity):
         self,
         hass: HomeAssistant,
         *,
-        config: dict[str, Any],
+        config: Mapping[str, Any],
         fallback_name: str | None,
         unique_id: str | None,
     ) -> None:

--- a/homeassistant/helpers/template_entity.py
+++ b/homeassistant/helpers/template_entity.py
@@ -1,7 +1,7 @@
 """TemplateEntity utility class."""
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping
+from collections.abc import Callable
 import contextlib
 import logging
 from typing import Any
@@ -32,6 +32,7 @@ from .entity import Entity
 from .event import TrackTemplate, TrackTemplateResult, async_track_template_result
 from .script import Script, _VarsType
 from .template import Template, TemplateStateFromEntityId, result_as_boolean
+from .typing import ConfigType
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -167,7 +168,7 @@ class TemplateEntity(Entity):
         icon_template: Template | None = None,
         entity_picture_template: Template | None = None,
         attribute_templates: dict[str, Template] | None = None,
-        config: Mapping[str, Any] | None = None,
+        config: ConfigType | None = None,
         fallback_name: str | None = None,
         unique_id: str | None = None,
     ) -> None:
@@ -427,7 +428,7 @@ class TemplateSensor(TemplateEntity, SensorEntity):
         self,
         hass: HomeAssistant,
         *,
-        config: Mapping[str, Any],
+        config: dict[str, Any],
         fallback_name: str | None,
         unique_id: str | None,
     ) -> None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adjust scrape sensor validation.
We want to allow `None` or empty string in the sensor definition.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
