### PR TITLE
Add entity name translations for devolo Home Network

### DIFF
--- a/homeassistant/components/devolo_home_network/binary_sensor.py
+++ b/homeassistant/components/devolo_home_network/binary_sensor.py
@@ -53,7 +53,6 @@ SENSOR_TYPES: dict[str, DevoloBinarySensorEntityDescription] = {
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
         icon="mdi:router-network",
-        name="Connected to router",
         value_func=_is_connected_to_router,
     ),
 }

--- a/homeassistant/components/devolo_home_network/entity.py
+++ b/homeassistant/components/devolo_home_network/entity.py
@@ -57,4 +57,5 @@ class DevoloEntity(CoordinatorEntity[DataUpdateCoordinator[_DataT]]):
             name=entry.title,
             sw_version=device.firmware_version,
         )
+        self._attr_translation_key = self.entity_description.key
         self._attr_unique_id = f"{device.serial_number}_{self.entity_description.key}"

--- a/homeassistant/components/devolo_home_network/sensor.py
+++ b/homeassistant/components/devolo_home_network/sensor.py
@@ -54,7 +54,6 @@ SENSOR_TYPES: dict[str, DevoloSensorEntityDescription[Any]] = {
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
         icon="mdi:lan",
-        name="Connected PLC devices",
         value_func=lambda data: len(
             {device.mac_address_from for device in data.data_rates}
         ),
@@ -62,7 +61,6 @@ SENSOR_TYPES: dict[str, DevoloSensorEntityDescription[Any]] = {
     CONNECTED_WIFI_CLIENTS: DevoloSensorEntityDescription[list[ConnectedStationInfo]](
         key=CONNECTED_WIFI_CLIENTS,
         icon="mdi:wifi",
-        name="Connected Wifi clients",
         state_class=SensorStateClass.MEASUREMENT,
         value_func=len,
     ),
@@ -71,7 +69,6 @@ SENSOR_TYPES: dict[str, DevoloSensorEntityDescription[Any]] = {
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
         icon="mdi:wifi-marker",
-        name="Neighboring Wifi networks",
         value_func=len,
     ),
 }

--- a/homeassistant/components/devolo_home_network/strings.json
+++ b/homeassistant/components/devolo_home_network/strings.json
@@ -27,5 +27,31 @@
       "home_control": "The devolo Home Control Central Unit does not work with this integration.",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     }
+  },
+  "entity": {
+    "binary_sensor": {
+      "connected_to_router": {
+        "name": "Connected to router"
+      }
+    },
+    "sensor": {
+      "connected_plc_devices": {
+        "name": "Connected PLC devices"
+      },
+      "connected_wifi_clients": {
+        "name": "Connected Wifi clients"
+      },
+      "neighboring_wifi_networks": {
+        "name": "Neighboring Wifi networks"
+      }
+    },
+    "switch": {
+      "switch_guest_wifi": {
+        "name": "Enable guest Wifi"
+      },
+      "switch_leds": {
+        "name": "Enable LEDs"
+      }
+    }
   }
 }

--- a/homeassistant/components/devolo_home_network/switch.py
+++ b/homeassistant/components/devolo_home_network/switch.py
@@ -42,7 +42,6 @@ SWITCH_TYPES: dict[str, DevoloSwitchEntityDescription[Any]] = {
     SWITCH_GUEST_WIFI: DevoloSwitchEntityDescription[WifiGuestAccessGet](
         key=SWITCH_GUEST_WIFI,
         icon="mdi:wifi",
-        name="Enable guest Wifi",
         is_on_func=lambda data: data.enabled is True,
         turn_on_func=lambda device: device.device.async_set_wifi_guest_access(True),  # type: ignore[union-attr]
         turn_off_func=lambda device: device.device.async_set_wifi_guest_access(False),  # type: ignore[union-attr]
@@ -51,7 +50,6 @@ SWITCH_TYPES: dict[str, DevoloSwitchEntityDescription[Any]] = {
         key=SWITCH_LEDS,
         entity_category=EntityCategory.CONFIG,
         icon="mdi:led-off",
-        name="Enable LEDs",
         is_on_func=bool,
         turn_on_func=lambda device: device.device.async_set_led_setting(True),  # type: ignore[union-attr]
         turn_off_func=lambda device: device.device.async_set_led_setting(False),  # type: ignore[union-attr]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add entity name translations for devolo Home Network. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
