### PR TITLE
Update Todoist all day event handling following best practices

### DIFF
--- a/homeassistant/components/todoist/calendar.py
+++ b/homeassistant/components/todoist/calendar.py
@@ -9,7 +9,7 @@ import uuid
 from todoist_api_python.api_async import TodoistAPIAsync
 from todoist_api_python.endpoints import get_sync_url
 from todoist_api_python.headers import create_headers
-from todoist_api_python.models import Label, Task
+from todoist_api_python.models import Due, Label, Task
 import voluptuous as vol
 
 from homeassistant.components.calendar import (
@@ -588,27 +588,21 @@ class TodoistProjectData:
 
         events = []
         for task in project_task_data:
-            if task.due is None:
+            if not task.due:
                 continue
-            due_date = dt.parse_datetime(
-                task.due.datetime if task.due.datetime else task.due.date
+            start = get_start(task.due)
+            if not start:
+                continue
+            event = CalendarEvent(
+                summary=task.content,
+                start=start,
+                end=start + timedelta(days=1),
             )
-            if not due_date:
+            if event.start_datetime_local >= end_date:
                 continue
-            due_date = dt.as_utc(due_date)
-            if start_date < due_date < end_date:
-                due_date_value: datetime | date = due_date
-                midnight = dt.start_of_local_day(due_date)
-                if due_date == midnight:
-                    # If the due date has no time data, return just the date so that it
-                    # will render correctly as an all day event on a calendar.
-                    due_date_value = due_date.date()
-                event = CalendarEvent(
-                    summary=task.content,
-                    start=due_date_value,
-                    end=due_date_value + timedelta(days=1),
-                )
-                events.append(event)
+            if event.end_datetime_local < start_date:
+                continue
+            events.append(event)
         return events
 
     async def async_update(self) -> None:
@@ -663,3 +657,15 @@ class TodoistProjectData:
             return
         self.event = event
         _LOGGER.debug("Updated %s", self._name)
+
+
+def get_start(due: Due) -> datetime | date | None:
+    """Return the task due date as a start date or date time."""
+    if due.datetime:
+        start = dt.parse_datetime(due.datetime)
+        if not start:
+            return None
+        return dt.as_local(start)
+    if due.date:
+        return dt.parse_date(due.date)
+    return None

--- a/homeassistant/components/todoist/calendar.py
+++ b/homeassistant/components/todoist/calendar.py
@@ -588,10 +588,10 @@ class TodoistProjectData:
 
         events = []
         for task in project_task_data:
-            if not task.due:
+            if task.due is None:
                 continue
             start = get_start(task.due)
-            if not start:
+            if start is None:
                 continue
             event = CalendarEvent(
                 summary=task.content,

--- a/tests/components/todoist/test_calendar.py
+++ b/tests/components/todoist/test_calendar.py
@@ -278,6 +278,20 @@ async def test_all_day_event(
     assert await response.json() == expected_response
 
 
+async def test_create_task_service_call(hass: HomeAssistant, api: AsyncMock) -> None:
+    """Test api is called correctly after a new task service call."""
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_NEW_TASK,
+        {ASSIGNEE: "user", CONTENT: "task", LABELS: ["Label1"], PROJECT_NAME: "Name"},
+    )
+    await hass.async_block_till_done()
+
+    api.add_task.assert_called_with(
+        "task", project_id="12345", labels=["Label1"], assignee_id="1"
+    )
+
+
 @pytest.mark.parametrize(
     ("due"),
     [
@@ -373,17 +387,3 @@ async def test_task_due_datetime(
     )
     assert response.status == HTTPStatus.OK
     assert await response.json() == []
-
-
-async def test_create_task_service_call(hass: HomeAssistant, api: AsyncMock) -> None:
-    """Test api is called correctly after a new task service call."""
-    await hass.services.async_call(
-        DOMAIN,
-        SERVICE_NEW_TASK,
-        {ASSIGNEE: "user", CONTENT: "task", LABELS: ["Label1"], PROJECT_NAME: "Name"},
-    )
-    await hass.async_block_till_done()
-
-    api.add_task.assert_called_with(
-        "task", project_id="12345", labels=["Label1"], assignee_id="1"
-    )

--- a/tests/components/todoist/test_calendar.py
+++ b/tests/components/todoist/test_calendar.py
@@ -228,8 +228,39 @@ async def test_calendar_custom_project_unique_id(
             "2023-03-28T00:00:00.000Z",
             "2023-04-01T00:00:00.000Z",
             [get_events_response({"date": "2023-03-30"}, {"date": "2023-03-31"})],
-        )
+        ),
+        (
+            Due(date="2023-03-30", is_recurring=False, string="Mar 30"),
+            "2023-03-30T06:00:00.000Z",
+            "2023-03-31T06:00:00.000Z",
+            [get_events_response({"date": "2023-03-30"}, {"date": "2023-03-31"})],
+        ),
+        (
+            Due(date="2023-03-30", is_recurring=False, string="Mar 30"),
+            "2023-03-29T08:00:00.000Z",
+            "2023-03-30T08:00:00.000Z",
+            [get_events_response({"date": "2023-03-30"}, {"date": "2023-03-31"})],
+        ),
+        (
+            Due(date="2023-03-30", is_recurring=False, string="Mar 30"),
+            "2023-03-30T08:00:00.000Z",
+            "2023-03-31T08:00:00.000Z",
+            [get_events_response({"date": "2023-03-30"}, {"date": "2023-03-31"})],
+        ),
+        (
+            Due(date="2023-03-30", is_recurring=False, string="Mar 30"),
+            "2023-03-31T08:00:00.000Z",
+            "2023-04-01T08:00:00.000Z",
+            [],
+        ),
+        (
+            Due(date="2023-03-30", is_recurring=False, string="Mar 30"),
+            "2023-03-29T06:00:00.000Z",
+            "2023-03-30T06:00:00.000Z",
+            [],
+        ),
     ],
+    ids=("included", "exact", "overlap_start", "overlap_end", "after", "before"),
 )
 async def test_all_day_event(
     hass: HomeAssistant,
@@ -245,6 +276,103 @@ async def test_all_day_event(
     )
     assert response.status == HTTPStatus.OK
     assert await response.json() == expected_response
+
+
+@pytest.mark.parametrize(
+    ("due"),
+    [
+        # These are all equivalent due dates for the same time in different
+        # timezone formats.
+        Due(
+            date="2023-03-30",
+            is_recurring=False,
+            string="Mar 30 6:00 PM",
+            datetime="2023-03-31T00:00:00Z",
+            timezone="America/Regina",
+        ),
+        Due(
+            date="2023-03-30",
+            is_recurring=False,
+            string="Mar 30 7:00 PM",
+            datetime="2023-03-31T00:00:00Z",
+            timezone="America/Los_Angeles",
+        ),
+        Due(
+            date="2023-03-30",
+            is_recurring=False,
+            string="Mar 30 6:00 PM",
+            datetime="2023-03-30T18:00:00",
+        ),
+    ],
+    ids=("in_local_timezone", "in_other_timezone", "floating"),
+)
+async def test_task_due_datetime(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+) -> None:
+    """Test for task due at a specific time, using different time formats."""
+    client = await hass_client()
+
+    has_task_response = [
+        get_events_response(
+            {"dateTime": "2023-03-30T18:00:00-06:00"},
+            {"dateTime": "2023-03-31T18:00:00-06:00"},
+        )
+    ]
+
+    # Completely includes the start/end of the task
+    response = await client.get(
+        get_events_url(
+            "calendar.name", "2023-03-30T08:00:00.000Z", "2023-03-31T08:00:00.000Z"
+        ),
+    )
+    assert response.status == HTTPStatus.OK
+    assert await response.json() == has_task_response
+
+    # Overlap with the start of the event
+    response = await client.get(
+        get_events_url(
+            "calendar.name", "2023-03-29T20:00:00.000Z", "2023-03-31T02:00:00.000Z"
+        ),
+    )
+    assert response.status == HTTPStatus.OK
+    assert await response.json() == has_task_response
+
+    # Overlap with the end of the event
+    response = await client.get(
+        get_events_url(
+            "calendar.name", "2023-03-31T20:00:00.000Z", "2023-04-01T02:00:00.000Z"
+        ),
+    )
+    assert response.status == HTTPStatus.OK
+    assert await response.json() == has_task_response
+
+    # Task is active, but range does not include start/end
+    response = await client.get(
+        get_events_url(
+            "calendar.name", "2023-03-31T10:00:00.000Z", "2023-03-31T11:00:00.000Z"
+        ),
+    )
+    assert response.status == HTTPStatus.OK
+    assert await response.json() == has_task_response
+
+    # Query is before the task starts (no results)
+    response = await client.get(
+        get_events_url(
+            "calendar.name", "2023-03-28T00:00:00.000Z", "2023-03-29T00:00:00.000Z"
+        ),
+    )
+    assert response.status == HTTPStatus.OK
+    assert await response.json() == []
+
+    # Query is after the task ends (no results)
+    response = await client.get(
+        get_events_url(
+            "calendar.name", "2023-04-01T07:00:00.000Z", "2023-04-02T07:00:00.000Z"
+        ),
+    )
+    assert response.status == HTTPStatus.OK
+    assert await response.json() == []
 
 
 async def test_create_task_service_call(hass: HomeAssistant, api: AsyncMock) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update Todoist to follow the time zone handling best practices.  See https://developers.home-assistant.io/blog/2023/03/28/calendar_best_practices for the background.

This fixes an issue where all day TODOs are not displayed. The test setup code has been shared via a new fixture to reduce additional setup for new tests.

Note for reviewer: A todo event currently has a duration of one day, which is odd. By fixing the start/end date selection logic, it makes it more obvious since the event spans the next day e.g. a TODO at 6pm lasts 24 hours until 6pm the following day so now it shows up on the calendar the whole duration. We should consider changing the duration of the TODO, but I consider that a second fix that should be made independent of fixing the date comparison logic to be correct.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #89717
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
