### PR TITLE
Use async_timeout instead of asyncio.wait_for

### DIFF
--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -2,13 +2,13 @@
 from __future__ import annotations
 
 import asyncio
-import async_timeout
 from collections.abc import Mapping
 import logging
 from typing import Any
 
 import aiohttp
 from aiohttp.web import Request
+import async_timeout
 from reolink_aio.api import Host
 from reolink_aio.exceptions import ReolinkError, SubscriptionError
 

--- a/tests/components/reolink/conftest.py
+++ b/tests/components/reolink/conftest.py
@@ -40,8 +40,6 @@ def reolink_connect(mock_get_source_ip: None) -> Generator[MagicMock, None, None
         "homeassistant.components.reolink.host.webhook.async_register",
         return_value=True,
     ), patch(
-        "homeassistant.components.reolink.host.asyncio.Event.wait", AsyncMock()
-    ), patch(
         "homeassistant.components.reolink.host.Host", autospec=True
     ) as host_mock_class:
         host_mock = host_mock_class.return_value
@@ -63,6 +61,13 @@ def reolink_connect(mock_get_source_ip: None) -> Generator[MagicMock, None, None
         host_mock.timeout = 60
         host_mock.renewtimer = 600
         yield host_mock
+
+
+@pytest.fixture
+def reolink_ONVIF_wait(mock_get_source_ip: None) -> Generator[MagicMock, None, None]:
+    """Mock reolink connection."""
+    with patch("homeassistant.components.reolink.host.asyncio.Event.wait", AsyncMock()):
+        yield
 
 
 @pytest.fixture

--- a/tests/components/reolink/conftest.py
+++ b/tests/components/reolink/conftest.py
@@ -64,7 +64,7 @@ def reolink_connect(mock_get_source_ip: None) -> Generator[MagicMock, None, None
 
 
 @pytest.fixture
-def reolink_ONVIF_wait(mock_get_source_ip: None) -> Generator[None, None, None]:
+def reolink_ONVIF_wait() -> Generator[None, None, None]:
     """Mock reolink connection."""
     with patch("homeassistant.components.reolink.host.asyncio.Event.wait", AsyncMock()):
         yield

--- a/tests/components/reolink/conftest.py
+++ b/tests/components/reolink/conftest.py
@@ -64,7 +64,7 @@ def reolink_connect(mock_get_source_ip: None) -> Generator[MagicMock, None, None
 
 
 @pytest.fixture
-def reolink_ONVIF_wait(mock_get_source_ip: None) -> Generator[MagicMock, None, None]:
+def reolink_ONVIF_wait(mock_get_source_ip: None) -> Generator[None, None, None]:
     """Mock reolink connection."""
     with patch("homeassistant.components.reolink.host.asyncio.Event.wait", AsyncMock()):
         yield

--- a/tests/components/reolink/test_config_flow.py
+++ b/tests/components/reolink/test_config_flow.py
@@ -28,7 +28,9 @@ from .conftest import (
 
 from tests.common import MockConfigEntry
 
-pytestmark = pytest.mark.usefixtures("mock_setup_entry", "reolink_connect")
+pytestmark = pytest.mark.usefixtures(
+    "mock_setup_entry", "reolink_connect", "reolink_ONVIF_wait"
+)
 
 
 async def test_config_flow_manual_success(hass: HomeAssistant) -> None:

--- a/tests/components/reolink/test_init.py
+++ b/tests/components/reolink/test_init.py
@@ -54,6 +54,7 @@ pytestmark = pytest.mark.usefixtures("reolink_connect", "reolink_platforms")
 async def test_failures_parametrized(
     hass: HomeAssistant,
     reolink_connect: MagicMock,
+    reolink_ONVIF_wait: MagicMock,
     config_entry: MockConfigEntry,
     attr: str,
     value: Any,
@@ -70,7 +71,10 @@ async def test_failures_parametrized(
 
 
 async def test_entry_reloading(
-    hass: HomeAssistant, config_entry: MockConfigEntry, reolink_connect: MagicMock
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    reolink_connect: MagicMock,
+    reolink_ONVIF_wait: MagicMock,
 ) -> None:
     """Test the entry is reloaded correctly when settings change."""
     assert await hass.config_entries.async_setup(config_entry.entry_id)
@@ -87,7 +91,7 @@ async def test_entry_reloading(
 
 
 async def test_no_repair_issue(
-    hass: HomeAssistant, config_entry: MockConfigEntry
+    hass: HomeAssistant, config_entry: MockConfigEntry, reolink_ONVIF_wait: MagicMock
 ) -> None:
     """Test no repairs issue is raised when http local url is used."""
     await async_process_ha_core_config(
@@ -105,7 +109,7 @@ async def test_no_repair_issue(
 
 
 async def test_https_repair_issue(
-    hass: HomeAssistant, config_entry: MockConfigEntry
+    hass: HomeAssistant, config_entry: MockConfigEntry, reolink_ONVIF_wait: MagicMock
 ) -> None:
     """Test repairs issue is raised when https local url is used."""
     await async_process_ha_core_config(
@@ -124,6 +128,7 @@ async def test_port_repair_issue(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
     reolink_connect: MagicMock,
+    reolink_ONVIF_wait: MagicMock,
     protocol: str,
 ) -> None:
     """Test repairs issue is raised when auto enable of ports fails."""
@@ -152,7 +157,10 @@ async def test_webhook_repair_issue(
 
 
 async def test_firmware_repair_issue(
-    hass: HomeAssistant, config_entry: MockConfigEntry, reolink_connect: MagicMock
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    reolink_connect: MagicMock,
+    reolink_ONVIF_wait: MagicMock,
 ) -> None:
     """Test firmware issue is raised when too old firmware is used."""
     reolink_connect.sw_version_update_required = True

--- a/tests/components/reolink/test_init.py
+++ b/tests/components/reolink/test_init.py
@@ -144,10 +144,7 @@ async def test_webhook_repair_issue(
     hass: HomeAssistant, config_entry: MockConfigEntry
 ) -> None:
     """Test repairs issue is raised when the webhook url is unreachable."""
-    with patch(
-        "homeassistant.components.reolink.host.asyncio.Event.wait",
-        AsyncMock(side_effect=asyncio.TimeoutError()),
-    ):
+    with patch("homeassistant.components.reolink.host.FIRST_ONVIF_TIMEOUT", new=0):
         assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 

--- a/tests/components/reolink/test_init.py
+++ b/tests/components/reolink/test_init.py
@@ -1,5 +1,4 @@
 """Test the Reolink init."""
-import asyncio
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adresses review comments from @MartinHjelmare from PR https://github.com/home-assistant/core/pull/89585#pullrequestreview-1362208591

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
