### PR TITLE
Add switch tests to vesync

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1383,7 +1383,6 @@ omit =
     homeassistant/components/vesync/fan.py
     homeassistant/components/vesync/light.py
     homeassistant/components/vesync/sensor.py
-    homeassistant/components/vesync/switch.py
     homeassistant/components/viaggiatreno/sensor.py
     homeassistant/components/vicare/__init__.py
     homeassistant/components/vicare/binary_sensor.py

--- a/tests/components/vesync/common.py
+++ b/tests/components/vesync/common.py
@@ -1,7 +1,28 @@
 """Common methods used across tests for VeSync."""
 import json
 
-from tests.common import load_fixture
+import requests_mock
+
+from tests.common import load_fixture, load_json_object_fixture
+
+ALL_DEVICES = load_json_object_fixture("vesync/vesync_api_call__devices.json")
+ALL_DEVICE_NAMES: list[str] = [
+    dev["deviceName"] for dev in ALL_DEVICES["result"]["list"]
+]
+
+
+def mock_devices_response(
+    requests_mock: requests_mock.Mocker, device_name: str
+) -> None:
+    """Build a response for the Helpers.call_api method."""
+    device_list = []
+    for device in ALL_DEVICES["result"]["list"]:
+        if device["deviceName"] == device_name:
+            device_list.append(device)
+    requests_mock.post(
+        "https://smartapi.vesync.com/cloud/v1/deviceManaged/devices",
+        json={"code": 0, "result": {"list": device_list}},
+    )
 
 
 def call_api_side_effect__no_devices(*args, **kwargs):

--- a/tests/components/vesync/fixtures/vesync_api_call__devices.json
+++ b/tests/components/vesync/fixtures/vesync_api_call__devices.json
@@ -1,0 +1,104 @@
+{
+  "code": 0,
+  "result": {
+    "list": [
+      {
+        "cid": "200s-humidifier",
+        "deviceType": "Classic200S",
+        "deviceName": "Humidifier 200s",
+        "subDeviceNo": null,
+        "deviceStatus": "on",
+        "connectionStatus": "online",
+        "uuid": "00000000-1111-2222-3333-444444444444"
+      },
+      {
+        "cid": "600s-humidifier",
+        "deviceType": "LUH-A602S-WUS",
+        "deviceName": "Humidifier 600S",
+        "subDeviceNo": null,
+        "deviceStatus": "off",
+        "connectionStatus": "online",
+        "uuid": "00000000-1111-2222-3333-555555555555",
+        "deviceImg": "https://image.vesync.com/defaultImages/LV_600S_Series/icon_lv600s_humidifier_160.png",
+        "configModule": "WFON_AHM_LUH-A602S-WUS_US",
+        "currentFirmVersion": null,
+        "subDeviceType": null
+      },
+      {
+        "cid": "air-purifier",
+        "deviceType": "LV-PUR131S",
+        "deviceName": "Air Purifier 131s",
+        "subDeviceNo": null,
+        "deviceStatus": "on",
+        "connectionStatus": "online"
+      },
+      {
+        "cid": "asd_sdfKIHG7IJHGwJGJ7GJ_ag5h3G55",
+        "deviceType": "Core200S",
+        "deviceName": "Air Purifier 200s",
+        "subDeviceNo": null,
+        "deviceStatus": "on",
+        "type": "wifi-air",
+        "connectionStatus": "online"
+      },
+      {
+        "cid": "400s-purifier",
+        "deviceType": "LAP-C401S-WJP",
+        "deviceName": "Air Purifier 400s",
+        "subDeviceNo": null,
+        "deviceStatus": "on",
+        "type": "wifi-air",
+        "connectionStatus": "online"
+      },
+      {
+        "cid": "600s-purifier",
+        "deviceType": "LAP-C601S-WUS",
+        "deviceName": "Air Purifier 600s",
+        "subDeviceNo": null,
+        "type": "wifi-air",
+        "deviceStatus": "on",
+        "connectionStatus": "online"
+      },
+      {
+        "cid": "dimmable-bulb",
+        "deviceType": "ESL100",
+        "deviceName": "Dimmable Light",
+        "subDeviceNo": null,
+        "deviceStatus": "on",
+        "connectionStatus": "online"
+      },
+      {
+        "cid": "tunable-bulb",
+        "deviceType": "ESL100CW",
+        "deviceName": "Temperature Light",
+        "subDeviceNo": null,
+        "deviceStatus": "on",
+        "connectionStatus": "online"
+      },
+      {
+        "cid": "outlet",
+        "deviceType": "wifi-switch-1.3",
+        "deviceName": "Outlet",
+        "subDeviceNo": null,
+        "deviceStatus": "on",
+        "connectionStatus": "online"
+      },
+      {
+        "cid": "switch",
+        "deviceType": "ESWL01",
+        "deviceName": "Wall Switch",
+        "subDeviceNo": null,
+        "deviceStatus": "on",
+        "connectionStatus": "online"
+      },
+      {
+        "cid": "dimmable-switch",
+        "deviceType": "ESWD16",
+        "deviceName": "Dimmer Switch",
+        "subDeviceNo": null,
+        "deviceStatus": "on",
+        "connectionStatus": "online"
+      }
+    ]
+  }
+}

--- a/tests/components/vesync/snapshots/test_switch.ambr
+++ b/tests/components/vesync/snapshots/test_switch.ambr
@@ -1,0 +1,394 @@
+# serializer version: 1
+# name: test_switch_state[Air Purifier 131s]
+  list([
+    DeviceRegistryEntrySnapshot({
+      'area_id': None,
+      'config_entries': <ANY>,
+      'configuration_url': None,
+      'connections': set({
+      }),
+      'disabled_by': None,
+      'entry_type': None,
+      'hw_version': None,
+      'id': <ANY>,
+      'identifiers': set({
+        tuple(
+          'vesync',
+          'air-purifier',
+        ),
+      }),
+      'is_new': False,
+      'manufacturer': 'VeSync',
+      'model': 'LV-PUR131S',
+      'name': 'Air Purifier 131s',
+      'name_by_user': None,
+      'suggested_area': None,
+      'sw_version': None,
+      'via_device_id': None,
+    }),
+  ])
+# ---
+# name: test_switch_state[Air Purifier 131s].1
+  list([
+  ])
+# ---
+# name: test_switch_state[Air Purifier 200s]
+  list([
+    DeviceRegistryEntrySnapshot({
+      'area_id': None,
+      'config_entries': <ANY>,
+      'configuration_url': None,
+      'connections': set({
+      }),
+      'disabled_by': None,
+      'entry_type': None,
+      'hw_version': None,
+      'id': <ANY>,
+      'identifiers': set({
+        tuple(
+          'vesync',
+          'asd_sdfKIHG7IJHGwJGJ7GJ_ag5h3G55',
+        ),
+      }),
+      'is_new': False,
+      'manufacturer': 'VeSync',
+      'model': 'Core200S',
+      'name': 'Air Purifier 200s',
+      'name_by_user': None,
+      'suggested_area': None,
+      'sw_version': None,
+      'via_device_id': None,
+    }),
+  ])
+# ---
+# name: test_switch_state[Air Purifier 200s].1
+  list([
+  ])
+# ---
+# name: test_switch_state[Air Purifier 400s]
+  list([
+    DeviceRegistryEntrySnapshot({
+      'area_id': None,
+      'config_entries': <ANY>,
+      'configuration_url': None,
+      'connections': set({
+      }),
+      'disabled_by': None,
+      'entry_type': None,
+      'hw_version': None,
+      'id': <ANY>,
+      'identifiers': set({
+        tuple(
+          'vesync',
+          '400s-purifier',
+        ),
+      }),
+      'is_new': False,
+      'manufacturer': 'VeSync',
+      'model': 'LAP-C401S-WJP',
+      'name': 'Air Purifier 400s',
+      'name_by_user': None,
+      'suggested_area': None,
+      'sw_version': None,
+      'via_device_id': None,
+    }),
+  ])
+# ---
+# name: test_switch_state[Air Purifier 400s].1
+  list([
+  ])
+# ---
+# name: test_switch_state[Air Purifier 600s]
+  list([
+    DeviceRegistryEntrySnapshot({
+      'area_id': None,
+      'config_entries': <ANY>,
+      'configuration_url': None,
+      'connections': set({
+      }),
+      'disabled_by': None,
+      'entry_type': None,
+      'hw_version': None,
+      'id': <ANY>,
+      'identifiers': set({
+        tuple(
+          'vesync',
+          '600s-purifier',
+        ),
+      }),
+      'is_new': False,
+      'manufacturer': 'VeSync',
+      'model': 'LAP-C601S-WUS',
+      'name': 'Air Purifier 600s',
+      'name_by_user': None,
+      'suggested_area': None,
+      'sw_version': None,
+      'via_device_id': None,
+    }),
+  ])
+# ---
+# name: test_switch_state[Air Purifier 600s].1
+  list([
+  ])
+# ---
+# name: test_switch_state[Dimmable Light]
+  list([
+    DeviceRegistryEntrySnapshot({
+      'area_id': None,
+      'config_entries': <ANY>,
+      'configuration_url': None,
+      'connections': set({
+      }),
+      'disabled_by': None,
+      'entry_type': None,
+      'hw_version': None,
+      'id': <ANY>,
+      'identifiers': set({
+        tuple(
+          'vesync',
+          'dimmable-bulb',
+        ),
+      }),
+      'is_new': False,
+      'manufacturer': 'VeSync',
+      'model': 'ESL100',
+      'name': 'Dimmable Light',
+      'name_by_user': None,
+      'suggested_area': None,
+      'sw_version': None,
+      'via_device_id': None,
+    }),
+  ])
+# ---
+# name: test_switch_state[Dimmable Light].1
+  list([
+  ])
+# ---
+# name: test_switch_state[Dimmer Switch]
+  list([
+    DeviceRegistryEntrySnapshot({
+      'area_id': None,
+      'config_entries': <ANY>,
+      'configuration_url': None,
+      'connections': set({
+      }),
+      'disabled_by': None,
+      'entry_type': None,
+      'hw_version': None,
+      'id': <ANY>,
+      'identifiers': set({
+        tuple(
+          'vesync',
+          'dimmable-switch',
+        ),
+      }),
+      'is_new': False,
+      'manufacturer': 'VeSync',
+      'model': 'ESWD16',
+      'name': 'Dimmer Switch',
+      'name_by_user': None,
+      'suggested_area': None,
+      'sw_version': None,
+      'via_device_id': None,
+    }),
+  ])
+# ---
+# name: test_switch_state[Dimmer Switch].1
+  list([
+  ])
+# ---
+# name: test_switch_state[Humidifier 200s]
+  list([
+  ])
+# ---
+# name: test_switch_state[Humidifier 200s].1
+  list([
+  ])
+# ---
+# name: test_switch_state[Humidifier 600S]
+  list([
+  ])
+# ---
+# name: test_switch_state[Humidifier 600S].1
+  list([
+  ])
+# ---
+# name: test_switch_state[Outlet]
+  list([
+    DeviceRegistryEntrySnapshot({
+      'area_id': None,
+      'config_entries': <ANY>,
+      'configuration_url': None,
+      'connections': set({
+      }),
+      'disabled_by': None,
+      'entry_type': None,
+      'hw_version': None,
+      'id': <ANY>,
+      'identifiers': set({
+        tuple(
+          'vesync',
+          'outlet',
+        ),
+      }),
+      'is_new': False,
+      'manufacturer': 'VeSync',
+      'model': 'wifi-switch-1.3',
+      'name': 'Outlet',
+      'name_by_user': None,
+      'suggested_area': None,
+      'sw_version': None,
+      'via_device_id': None,
+    }),
+  ])
+# ---
+# name: test_switch_state[Outlet].1
+  list([
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'switch',
+      'entity_category': None,
+      'entity_id': 'switch.outlet',
+      'has_entity_name': False,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': None,
+      'original_name': 'Outlet',
+      'platform': 'vesync',
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'outlet',
+      'unit_of_measurement': None,
+    }),
+  ])
+# ---
+# name: test_switch_state[Outlet][switch.outlet]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Outlet',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.outlet',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switch_state[Temperature Light]
+  list([
+    DeviceRegistryEntrySnapshot({
+      'area_id': None,
+      'config_entries': <ANY>,
+      'configuration_url': None,
+      'connections': set({
+      }),
+      'disabled_by': None,
+      'entry_type': None,
+      'hw_version': None,
+      'id': <ANY>,
+      'identifiers': set({
+        tuple(
+          'vesync',
+          'tunable-bulb',
+        ),
+      }),
+      'is_new': False,
+      'manufacturer': 'VeSync',
+      'model': 'ESL100CW',
+      'name': 'Temperature Light',
+      'name_by_user': None,
+      'suggested_area': None,
+      'sw_version': None,
+      'via_device_id': None,
+    }),
+  ])
+# ---
+# name: test_switch_state[Temperature Light].1
+  list([
+  ])
+# ---
+# name: test_switch_state[Wall Switch]
+  list([
+    DeviceRegistryEntrySnapshot({
+      'area_id': None,
+      'config_entries': <ANY>,
+      'configuration_url': None,
+      'connections': set({
+      }),
+      'disabled_by': None,
+      'entry_type': None,
+      'hw_version': None,
+      'id': <ANY>,
+      'identifiers': set({
+        tuple(
+          'vesync',
+          'switch',
+        ),
+      }),
+      'is_new': False,
+      'manufacturer': 'VeSync',
+      'model': 'ESWL01',
+      'name': 'Wall Switch',
+      'name_by_user': None,
+      'suggested_area': None,
+      'sw_version': None,
+      'via_device_id': None,
+    }),
+  ])
+# ---
+# name: test_switch_state[Wall Switch].1
+  list([
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'switch',
+      'entity_category': None,
+      'entity_id': 'switch.wall_switch',
+      'has_entity_name': False,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': None,
+      'original_name': 'Wall Switch',
+      'platform': 'vesync',
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'switch',
+      'unit_of_measurement': None,
+    }),
+  ])
+# ---
+# name: test_switch_state[Wall Switch][switch.wall_switch]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Wall Switch',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.wall_switch',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---

--- a/tests/components/vesync/test_switch.py
+++ b/tests/components/vesync/test_switch.py
@@ -4,10 +4,8 @@ import requests_mock
 from syrupy import SnapshotAssertion
 
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
-from homeassistant.components.vesync import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
-from homeassistant.setup import async_setup_component
 
 from .common import ALL_DEVICE_NAMES, mock_devices_response
 
@@ -31,7 +29,7 @@ async def test_switch_state(
     )
     mock_devices_response(requests_mock, device_name)
 
-    assert await async_setup_component(hass, DOMAIN, {})
+    await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
     assert (

--- a/tests/components/vesync/test_switch.py
+++ b/tests/components/vesync/test_switch.py
@@ -1,0 +1,52 @@
+"""Tests for the switch module."""
+import pytest
+import requests_mock
+from syrupy import SnapshotAssertion
+
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.components.vesync import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.setup import async_setup_component
+
+from .common import ALL_DEVICE_NAMES, mock_devices_response
+
+from tests.common import MockConfigEntry, load_json_object_fixture
+
+
+@pytest.mark.parametrize("device_name", ALL_DEVICE_NAMES)
+async def test_switch_state(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    config_entry: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    requests_mock: requests_mock.Mocker,
+    device_name: str,
+) -> None:
+    """Test the resulting setup state is as expected for the platform."""
+    requests_mock.post(
+        "https://smartapi.vesync.com/cloud/v1/user/login",
+        json=load_json_object_fixture("vesync/vesync_api_call__login.json"),
+    )
+    mock_devices_response(requests_mock, device_name)
+
+    assert await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+
+    assert (
+        dr.async_entries_for_config_entry(device_registry, config_entry.entry_id)
+        == snapshot
+    )
+
+    entities = [
+        entity
+        for entity in er.async_entries_for_config_entry(
+            entity_registry, config_entry.entry_id
+        )
+        if entity.domain == SWITCH_DOMAIN
+    ]
+    assert entities == snapshot
+
+    for entity in entities:
+        assert hass.states.get(entity.entity_id) == snapshot(name=entity.entity_id)

--- a/tests/components/vesync/test_switch.py
+++ b/tests/components/vesync/test_switch.py
@@ -32,11 +32,11 @@ async def test_switch_state(
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert (
-        dr.async_entries_for_config_entry(device_registry, config_entry.entry_id)
-        == snapshot
-    )
+    # Check device registry
+    devices = dr.async_entries_for_config_entry(device_registry, config_entry.entry_id)
+    assert devices == snapshot
 
+    # Check entity registry
     entities = [
         entity
         for entity in er.async_entries_for_config_entry(
@@ -46,5 +46,6 @@ async def test_switch_state(
     ]
     assert entities == snapshot
 
+    # Check states
     for entity in entities:
         assert hass.states.get(entity.entity_id) == snapshot(name=entity.entity_id)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Based on discussions with @chuckdeal97 on https://github.com/home-assistant/core/pull/90466#discussion_r1153067128

For each device in the devices file, we test:
- the device registry
- the entity registry
- the state machine

Even devices that do not have have switches are tested - they just test that switches are not created.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
