### PR TITLE
Migrate old ZHA IasZone sensor state to zigpy cache

### DIFF
--- a/homeassistant/components/zha/binary_sensor.py
+++ b/homeassistant/components/zha/binary_sensor.py
@@ -2,13 +2,16 @@
 from __future__ import annotations
 
 import functools
+from typing import Any
+
+from zigpy.zcl.clusters.security import IasZone
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EntityCategory, Platform
+from homeassistant.const import STATE_ON, EntityCategory, Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -163,6 +166,32 @@ class IASZone(BinarySensor):
     def parse(value: bool | int) -> bool:
         """Parse the raw attribute into a bool state."""
         return BinarySensor.parse(value & 3)  # use only bit 0 and 1 for alarm state
+
+    # temporary code to migrate old IasZone sensors to update attribute cache state once
+    # remove in 2024.4.0
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return state attributes."""
+        return {"migrated_to_cache": True}  # writing new state means we're migrated
+
+    # temporary migration code
+    @callback
+    def async_restore_last_state(self, last_state):
+        """Restore previous state."""
+        # trigger migration if extra state attribute is not present
+        if "migrated_to_cache" not in last_state.attributes:
+            self.migrate_to_zigpy_cache(last_state)
+
+    # temporary migration code
+    @callback
+    def migrate_to_zigpy_cache(self, last_state):
+        """Save old IasZone sensor state to attribute cache."""
+        # previous HA versions did not update the attribute cache for IasZone sensors, so do it once here
+        # this triggers a HA state update and writes the "migrated_to_cache" extra state attribute
+        self._channel.cluster.update_attribute(
+            IasZone.attributes_by_name[self.SENSOR_ATTR].id,
+            last_state.state == STATE_ON,
+        )
 
 
 @MULTI_MATCH(

--- a/homeassistant/components/zha/binary_sensor.py
+++ b/homeassistant/components/zha/binary_sensor.py
@@ -187,10 +187,14 @@ class IASZone(BinarySensor):
     def migrate_to_zigpy_cache(self, last_state):
         """Save old IasZone sensor state to attribute cache."""
         # previous HA versions did not update the attribute cache for IasZone sensors, so do it once here
-        # this triggers a HA state update and writes the "migrated_to_cache" extra state attribute
+        # a HA state write is triggered shortly afterwards and writes the "migrated_to_cache" extra state attribute
+        if last_state.state == STATE_ON:
+            migrated_state = IasZone.ZoneStatus.Alarm_1
+        else:
+            migrated_state = IasZone.ZoneStatus(0)
+
         self._channel.cluster.update_attribute(
-            IasZone.attributes_by_name[self.SENSOR_ATTR].id,
-            last_state.state == STATE_ON,
+            IasZone.attributes_by_name[self.SENSOR_ATTR].id, migrated_state
         )
 
 

--- a/tests/components/zha/test_binary_sensor.py
+++ b/tests/components/zha/test_binary_sensor.py
@@ -8,6 +8,8 @@ import zigpy.zcl.clusters.security as security
 
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import restore_state
+from homeassistant.util import dt as dt_util
 
 from .common import (
     async_enable_traffic,
@@ -120,3 +122,65 @@ async def test_binary_sensor(
     # test rejoin
     await async_test_rejoin(hass, zigpy_device, [cluster], reporting)
     assert hass.states.get(entity_id).state == STATE_OFF
+
+
+@pytest.fixture
+def core_rs(hass_storage):
+    """Core.restore_state fixture."""
+
+    def _storage(entity_id, attributes, state):
+        now = dt_util.utcnow().isoformat()
+
+        hass_storage[restore_state.STORAGE_KEY] = {
+            "version": restore_state.STORAGE_VERSION,
+            "key": restore_state.STORAGE_KEY,
+            "data": [
+                {
+                    "state": {
+                        "entity_id": entity_id,
+                        "state": str(state),
+                        "attributes": attributes,
+                        "last_changed": now,
+                        "last_updated": now,
+                        "context": {
+                            "id": "3c2243ff5f30447eb12e7348cfd5b8ff",
+                            "user_id": None,
+                        },
+                    },
+                    "last_seen": now,
+                }
+            ],
+        }
+        return
+
+    return _storage
+
+
+@pytest.mark.parametrize(
+    "restored_state",
+    [
+        (STATE_ON,),
+        (STATE_OFF,),
+    ],
+)
+async def test_binary_sensor_migration_not_migrated(
+    hass: HomeAssistant,
+    zigpy_device_mock,
+    core_rs,
+    zha_device_restored,
+    restored_state,
+) -> None:
+    """Test temporary ZHA IasZone binary_sensor migration to zigpy cache."""
+
+    entity_id = "binary_sensor.fakemanufacturer_fakemodel_iaszone"
+    core_rs(entity_id, state=restored_state, attributes={})  # migration sensor state
+
+    zigpy_device = zigpy_device_mock(DEVICE_IAS)
+    zha_device = await zha_device_restored(zigpy_device)
+    entity_id = await find_entity_id(Platform.BINARY_SENSOR, zha_device, hass)
+
+    assert entity_id is not None
+    assert hass.states.get(entity_id).state == restored_state
+
+    # confirm migration extra state attribute was set to True
+    assert hass.states.get(entity_id).attributes["migrated_to_cache"]

--- a/tests/components/zha/test_binary_sensor.py
+++ b/tests/components/zha/test_binary_sensor.py
@@ -160,8 +160,8 @@ def core_rs(hass_storage):
 @pytest.mark.parametrize(
     "restored_state",
     [
-        (STATE_ON,),
-        (STATE_OFF,),
+        STATE_ON,
+        STATE_OFF,
     ],
 )
 async def test_binary_sensor_migration_not_migrated(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Previous HA versions did not update the zigpy attribute cache for IasZone sensors.
https://github.com/home-assistant/core/pull/89481 correctly updates attribute cache and migrated ZHA binary sensors to use zigpy attribute cache.

The issue is that upgrading to a newer HA version could cause the IasZone binary sensor state to be wrong until the sensor is toggled once. While this isn't a major issue, it might be nice to not have it in the first place.

This PR introduces a temporary migration where it's checked if the `migrated_to_cache` extra state attribute is present on the last state.
If it's not present, it means we've upgraded from an older HA version to a newer one. The attribute cache is updated once and the extra state attribute gets set with that state write (as an attribute update triggers writing state).
If the extra state attribute is already present when restoring the entity, we don't do anything.

This migration code should be removed in the future. I've added a comment that it should be done a year later in 2024.4.0. Maybe it could also be done earlier, as missing out on the migration doesn't mean your entire ZHA setup breaks.

The only "downside" I can see is that the IasZone binary sensors now have an extra state attribute until the migration code is removed.

I've also added tests to check that the migration happens once and only once.

If it's decided to go with this, it should really still be in 2023.4.0 to make sense.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
