### PR TITLE
Add charging modes and profiles to bmw_connected_drive

### DIFF
--- a/homeassistant/components/bmw_connected_drive/button.py
+++ b/homeassistant/components/bmw_connected_drive/button.py
@@ -64,13 +64,17 @@ BUTTON_TYPES: tuple[BMWButtonEntityDescription, ...] = (
         key="toggle_immediate_charging_profile",
         icon="mdi:car-electric",
         name="Toggle immediate charging profile",
-        remote_function=lambda vehicle: vehicle.remote_services.trigger_charging_profile_update(ChargingMode.IMMEDIATE_CHARGING),
+        remote_function=lambda vehicle: vehicle.remote_services.trigger_charging_profile_update(
+            ChargingMode.IMMEDIATE_CHARGING
+        ),
     ),
     BMWButtonEntityDescription(
         key="toggle_delayed_charging_charging_profile",
         icon="mdi:car-clock",
         name="Toggle delayed charging profile",
-        remote_function=lambda vehicle: vehicle.remote_services.trigger_charging_profile_update(ChargingMode.DELAYED_CHARGING),
+        remote_function=lambda vehicle: vehicle.remote_services.trigger_charging_profile_update(
+            ChargingMode.DELAYED_CHARGING
+        ),
     ),
     BMWButtonEntityDescription(
         key="find_vehicle",

--- a/homeassistant/components/bmw_connected_drive/button.py
+++ b/homeassistant/components/bmw_connected_drive/button.py
@@ -7,6 +7,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from bimmer_connected.vehicle import MyBMWVehicle
+from bimmer_connected.vehicle.charging_profile import ChargingMode
 from bimmer_connected.vehicle.remote_services import RemoteServiceStatus
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
@@ -58,6 +59,18 @@ BUTTON_TYPES: tuple[BMWButtonEntityDescription, ...] = (
         icon="mdi:hvac-off",
         name="Deactivate air conditioning",
         remote_function=lambda vehicle: vehicle.remote_services.trigger_remote_air_conditioning_stop(),
+    ),
+    BMWButtonEntityDescription(
+        key="toggle_immediate_charging_profile",
+        icon="mdi:car-electric",
+        name="Toggle immediate charging profile",
+        remote_function=lambda vehicle: vehicle.remote_services.trigger_charging_profile_update(ChargingMode.IMMEDIATE_CHARGING),
+    ),
+    BMWButtonEntityDescription(
+        key="toggle_delayed_charging_charging_profile",
+        icon="mdi:car-clock",
+        name="Toggle delayed charging profile",
+        remote_function=lambda vehicle: vehicle.remote_services.trigger_charging_profile_update(ChargingMode.DELAYED_CHARGING),
     ),
     BMWButtonEntityDescription(
         key="find_vehicle",

--- a/homeassistant/components/bmw_connected_drive/sensor.py
+++ b/homeassistant/components/bmw_connected_drive/sensor.py
@@ -66,6 +66,13 @@ SENSOR_TYPES: dict[str, BMWSensorEntityDescription] = {
         key_class="fuel_and_battery",
         device_class=SensorDeviceClass.TIMESTAMP,
     ),
+    "charging_mode": BMWSensorEntityDescription(
+        key="charging_mode",
+        name="Charging mode",
+        key_class="charging_profile",
+        icon="mdi:ev-station",
+        value=lambda x, y: x.value,
+    ),
     "charging_status": BMWSensorEntityDescription(
         key="charging_status",
         name="Charging status",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Added 2 buttons and 1 sensor charging modes/profiles in bmw_connected_drive.
All these were already available in `bimmer_connected==0.13.0` (which is the version currently used by HA).

- Buttons:
    - Toggle immediate charging profile
        - `vehicle.remote_services.trigger_charging_profile_update(ChargingMode.IMMEDIATE_CHARGING)`
    - Toggle delayed charging profile
        - `vehicle.remote_services.trigger_charging_profile_update(ChargingMode.DELAYED_CHARGING)`
- Sensor:
    - Charging mode
        - `charging_profile.charging_mode`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

none

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] ~~Tests have been added to verify that the new code works.~~

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
