### PR TITLE
EasyEnergy: Add two additional sensors to help pick the best hours

### DIFF
--- a/homeassistant/components/easyenergy/manifest.json
+++ b/homeassistant/components/easyenergy/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/easyenergy",
   "iot_class": "cloud_polling",
   "quality_scale": "platinum",
-  "requirements": ["easyenergy==0.2.3"]
+  "requirements": ["easyenergy==0.3.0"]
 }

--- a/homeassistant/components/easyenergy/sensor.py
+++ b/homeassistant/components/easyenergy/sensor.py
@@ -13,7 +13,13 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CURRENCY_EURO, PERCENTAGE, UnitOfEnergy, UnitOfVolume
+from homeassistant.const import (
+    CURRENCY_EURO,
+    PERCENTAGE,
+    UnitOfEnergy,
+    UnitOfTime,
+    UnitOfVolume,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo
@@ -174,6 +180,22 @@ SENSORS: tuple[EasyEnergySensorEntityDescription, ...] = (
         native_unit_of_measurement=PERCENTAGE,
         icon="mdi:percent",
         value_fn=lambda data: data.energy_today.pct_of_max_return,
+    ),
+    EasyEnergySensorEntityDescription(
+        key="hours_priced_equal_or_lower",
+        name="Hours priced equal or lower than current - today",
+        service_type="today_energy_usage",
+        native_unit_of_measurement=UnitOfTime.HOURS,
+        icon="mdi:clock",
+        value_fn=lambda data: data.energy_today.hours_priced_equal_or_lower_usage,
+    ),
+    EasyEnergySensorEntityDescription(
+        key="hours_priced_equal_or_higher",
+        name="Hours priced equal or higher than current - today",
+        service_type="today_energy_return",
+        native_unit_of_measurement=UnitOfTime.HOURS,
+        icon="mdi:clock",
+        value_fn=lambda data: data.energy_today.hours_priced_equal_or_higher_return,
     ),
 )
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -626,7 +626,7 @@ dynalite_devices==0.1.47
 eagle100==0.1.1
 
 # homeassistant.components.easyenergy
-easyenergy==0.2.3
+easyenergy==0.3.0
 
 # homeassistant.components.ebusd
 ebusdpy==0.0.17

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -497,7 +497,7 @@ dynalite_devices==0.1.47
 eagle100==0.1.1
 
 # homeassistant.components.easyenergy
-easyenergy==0.2.3
+easyenergy==0.3.0
 
 # homeassistant.components.elgato
 elgato==4.0.1

--- a/tests/components/easyenergy/test_sensor.py
+++ b/tests/components/easyenergy/test_sensor.py
@@ -124,6 +124,25 @@ async def test_energy_usage_today(
     assert not device_entry.model
     assert not device_entry.sw_version
 
+    # Usage hours priced equal or lower sensor
+    state = hass.states.get(
+        "sensor.easyenergy_today_energy_usage_hours_priced_equal_or_lower"
+    )
+    entry = entity_registry.async_get(
+        "sensor.easyenergy_today_energy_usage_hours_priced_equal_or_lower"
+    )
+    assert entry
+    assert state
+    assert (
+        entry.unique_id == f"{entry_id}_today_energy_usage_hours_priced_equal_or_lower"
+    )
+    assert state.state == "21"
+    assert (
+        state.attributes.get(ATTR_FRIENDLY_NAME)
+        == "Energy market price - Usage Hours priced equal or lower than current - today"
+    )
+    assert ATTR_DEVICE_CLASS not in state.attributes
+
 
 @pytest.mark.freeze_time("2023-01-19 15:00:00")
 async def test_energy_return_today(
@@ -218,6 +237,26 @@ async def test_energy_return_today(
     assert device_entry.entry_type is dr.DeviceEntryType.SERVICE
     assert not device_entry.model
     assert not device_entry.sw_version
+
+    # Return hours priced equal or higher sensor
+    state = hass.states.get(
+        "sensor.easyenergy_today_energy_return_hours_priced_equal_or_higher"
+    )
+    entry = entity_registry.async_get(
+        "sensor.easyenergy_today_energy_return_hours_priced_equal_or_higher"
+    )
+    assert entry
+    assert state
+    assert (
+        entry.unique_id
+        == f"{entry_id}_today_energy_return_hours_priced_equal_or_higher"
+    )
+    assert state.state == "3"
+    assert (
+        state.attributes.get(ATTR_FRIENDLY_NAME)
+        == "Energy market price - Return Hours priced equal or higher than current - today"
+    )
+    assert ATTR_DEVICE_CLASS not in state.attributes
 
 
 @pytest.mark.freeze_time("2023-01-19 10:00:00")


### PR DESCRIPTION
Depends on:  klaasnicolaas/python-easyenergy#55

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change adds sensors to the easyenergy component to enable
triggers based on the N cheapest hours to consume energy in.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: klaasnicolaas/python-easyenergy#54
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
