### PR TITLE
Refactor vicare config_flow tests

### DIFF
--- a/tests/components/vicare/__init__.py
+++ b/tests/components/vicare/__init__.py
@@ -6,6 +6,8 @@ from typing import Final
 from homeassistant.components.vicare.const import CONF_HEATING_TYPE
 from homeassistant.const import CONF_CLIENT_ID, CONF_PASSWORD, CONF_USERNAME
 
+MODULE = "homeassistant.components.vicare"
+
 ENTRY_CONFIG: Final[dict[str, str]] = {
     CONF_USERNAME: "foo@bar.com",
     CONF_PASSWORD: "1234",

--- a/tests/components/vicare/__init__.py
+++ b/tests/components/vicare/__init__.py
@@ -1,18 +1,6 @@
 """Test for ViCare."""
 from __future__ import annotations
 
-from typing import Final
-
-from homeassistant.components.vicare.const import CONF_HEATING_TYPE
-from homeassistant.const import CONF_CLIENT_ID, CONF_PASSWORD, CONF_USERNAME
-
 MODULE = "homeassistant.components.vicare"
-
-ENTRY_CONFIG: Final[dict[str, str]] = {
-    CONF_USERNAME: "foo@bar.com",
-    CONF_PASSWORD: "1234",
-    CONF_CLIENT_ID: "5678",
-    CONF_HEATING_TYPE: "auto",
-}
 
 MOCK_MAC = "B874241B7B9"

--- a/tests/components/vicare/conftest.py
+++ b/tests/components/vicare/conftest.py
@@ -1,0 +1,16 @@
+"""Fixtures for ViCare integration tests."""
+from __future__ import annotations
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from . import MODULE
+
+
+@pytest.fixture
+async def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+    """Mock setting up a config entry."""
+    with patch(f"{MODULE}.async_setup_entry", return_value=True) as mock_setup_entry:
+        yield mock_setup_entry

--- a/tests/components/vicare/conftest.py
+++ b/tests/components/vicare/conftest.py
@@ -10,7 +10,7 @@ from . import MODULE
 
 
 @pytest.fixture
-async def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock, None, None]:
     """Mock setting up a config entry."""
     with patch(f"{MODULE}.async_setup_entry", return_value=True) as mock_setup_entry:
         yield mock_setup_entry

--- a/tests/components/vicare/snapshots/test_config_flow.ambr
+++ b/tests/components/vicare/snapshots/test_config_flow.ambr
@@ -1,0 +1,17 @@
+# serializer version: 1
+# name: test_form_dhcp
+  dict({
+    'client_id': '5678',
+    'heating_type': 'auto',
+    'password': '1234',
+    'username': 'foo@bar.com',
+  })
+# ---
+# name: test_user_create_entry
+  dict({
+    'client_id': '5678',
+    'heating_type': 'auto',
+    'password': '1234',
+    'username': 'foo@bar.com',
+  })
+# ---

--- a/tests/components/vicare/test_config_flow.py
+++ b/tests/components/vicare/test_config_flow.py
@@ -104,9 +104,7 @@ async def test_form_dhcp(
     mock_setup_entry.assert_called_once()
 
 
-async def test_dhcp_single_instance_allowed(
-    hass: HomeAssistant, mock_setup_entry: AsyncMock
-) -> None:
+async def test_dhcp_single_instance_allowed(hass: HomeAssistant) -> None:
     """Test that configuring more than one instance is rejected."""
     mock_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -123,9 +121,7 @@ async def test_dhcp_single_instance_allowed(
     assert result["reason"] == "single_instance_allowed"
 
 
-async def test_user_input_single_instance_allowed(
-    hass: HomeAssistant, mock_setup_entry: AsyncMock
-) -> None:
+async def test_user_input_single_instance_allowed(hass: HomeAssistant) -> None:
     """Test that configuring more than one instance is rejected."""
     mock_entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/vicare/test_config_flow.py
+++ b/tests/components/vicare/test_config_flow.py
@@ -3,112 +3,105 @@ from unittest.mock import AsyncMock, patch
 
 from PyViCare.PyViCareUtils import PyViCareInvalidCredentialsError
 import pytest
+from syrupy.assertion import SnapshotAssertion
 
-from homeassistant import config_entries, data_entry_flow
 from homeassistant.components import dhcp
 from homeassistant.components.vicare.const import DOMAIN
+from homeassistant.config_entries import SOURCE_DHCP, SOURCE_USER
 from homeassistant.const import CONF_CLIENT_ID, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
 
-from . import ENTRY_CONFIG, MOCK_MAC
+from . import MOCK_MAC, MODULE
 
 from tests.common import MockConfigEntry
 
 pytestmark = pytest.mark.usefixtures("mock_setup_entry")
 
+VALID_CONFIG = {
+    CONF_USERNAME: "foo@bar.com",
+    CONF_PASSWORD: "1234",
+    CONF_CLIENT_ID: "5678",
+}
 
-async def test_form(hass: HomeAssistant, mock_setup_entry: AsyncMock):
-    """Test we get the form."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert len(result["errors"]) == 0
-
-    with patch(
-        "homeassistant.components.vicare.config_flow.vicare_login",
-        return_value=None,
-    ) as mock_setup_entry:
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                CONF_USERNAME: "foo@bar.com",
-                CONF_PASSWORD: "1234",
-                CONF_CLIENT_ID: "5678",
-            },
-        )
-        await hass.async_block_till_done()
-
-    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
-    assert result2["title"] == "ViCare"
-    assert result2["data"] == ENTRY_CONFIG
-    assert len(mock_setup_entry.mock_calls) == 1
+DHCP_INFO = dhcp.DhcpServiceInfo(
+    ip="1.1.1.1",
+    hostname="mock_hostname",
+    macaddress=MOCK_MAC,
+)
 
 
-async def test_invalid_login(
-    hass: HomeAssistant,
-    mock_setup_entry: AsyncMock,
+async def test_user_create_entry(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock, snapshot: SnapshotAssertion
 ) -> None:
-    """Test a flow with an invalid Vicare login."""
-
+    """Test that the user step works."""
+    # start user flow
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": SOURCE_USER}
     )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+
+    # test PyViCareInvalidCredentialsError
     with patch(
-        "homeassistant.components.vicare.config_flow.vicare_login",
+        f"{MODULE}.config_flow.vicare_login",
         side_effect=PyViCareInvalidCredentialsError,
     ):
-        result2 = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            {
-                CONF_USERNAME: "foo@bar.com",
-                CONF_PASSWORD: "1234",
-                CONF_CLIENT_ID: "5678",
-            },
+            VALID_CONFIG,
         )
         await hass.async_block_till_done()
-    await hass.async_block_till_done()
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "invalid_auth"}
 
-    assert result2["type"] == data_entry_flow.FlowResultType.FORM
-    assert result2["step_id"] == "user"
-    assert result2["errors"] == {"base": "invalid_auth"}
-    assert len(mock_setup_entry.mock_calls) == 0
+    # test success
+    with patch(
+        f"{MODULE}.config_flow.vicare_login",
+        return_value=None,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            VALID_CONFIG,
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == "ViCare"
+    assert result["data"] == snapshot
+    mock_setup_entry.assert_called_once()
 
 
-async def test_form_dhcp(hass: HomeAssistant, mock_setup_entry: AsyncMock):
+async def test_form_dhcp(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock, snapshot: SnapshotAssertion
+) -> None:
     """Test we can setup from dhcp."""
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
-        context={"source": config_entries.SOURCE_DHCP},
-        data=dhcp.DhcpServiceInfo(
-            ip="1.1.1.1",
-            hostname="mock_hostname",
-            macaddress=MOCK_MAC,
-        ),
+        context={"source": SOURCE_DHCP},
+        data=DHCP_INFO,
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {}
 
     with patch(
-        "homeassistant.components.vicare.config_flow.vicare_login",
+        f"{MODULE}.config_flow.vicare_login",
         return_value=None,
     ):
-        result2 = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            {
-                CONF_USERNAME: "foo@bar.com",
-                CONF_PASSWORD: "1234",
-                CONF_CLIENT_ID: "5678",
-            },
+            VALID_CONFIG,
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
-    assert result2["title"] == "ViCare"
-    assert result2["data"] == ENTRY_CONFIG
-    assert len(mock_setup_entry.mock_calls) == 1
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == "ViCare"
+    assert result["data"] == snapshot
+    mock_setup_entry.assert_called_once()
 
 
 async def test_dhcp_single_instance_allowed(
@@ -117,22 +110,17 @@ async def test_dhcp_single_instance_allowed(
     """Test that configuring more than one instance is rejected."""
     mock_entry = MockConfigEntry(
         domain=DOMAIN,
-        data=ENTRY_CONFIG,
+        data=VALID_CONFIG,
     )
     mock_entry.add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
-        context={"source": config_entries.SOURCE_DHCP},
-        data=dhcp.DhcpServiceInfo(
-            ip="1.1.1.1",
-            hostname="mock_hostname",
-            macaddress=MOCK_MAC,
-        ),
+        context={"source": SOURCE_DHCP},
+        data=DHCP_INFO,
     )
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"
-    assert len(mock_setup_entry.mock_calls) == 0
 
 
 async def test_user_input_single_instance_allowed(
@@ -142,13 +130,12 @@ async def test_user_input_single_instance_allowed(
     mock_entry = MockConfigEntry(
         domain=DOMAIN,
         unique_id="ViCare",
-        data=ENTRY_CONFIG,
+        data=VALID_CONFIG,
     )
     mock_entry.add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"
-    assert len(mock_setup_entry.mock_calls) == 0


### PR DESCRIPTION
## Proposed change
As a preparation for https://github.com/home-assistant/core/pull/90347 this PR refactors the config flow tests to use a mock_setup_entry fixture in all config_flow_tests


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
