### PR TITLE
Add entity name translations to Switchbot

### DIFF
--- a/homeassistant/components/switchbot/binary_sensor.py
+++ b/homeassistant/components/switchbot/binary_sensor.py
@@ -20,50 +20,50 @@ PARALLEL_UPDATES = 0
 BINARY_SENSOR_TYPES: dict[str, BinarySensorEntityDescription] = {
     "calibration": BinarySensorEntityDescription(
         key="calibration",
-        name="Calibration",
+        translation_key="calibration",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     "motion_detected": BinarySensorEntityDescription(
         key="pir_state",
-        name="Motion detected",
+        translation_key="motion",
         device_class=BinarySensorDeviceClass.MOTION,
     ),
     "contact_open": BinarySensorEntityDescription(
         key="contact_open",
-        name="Door open",
+        translation_key="door_open",
         device_class=BinarySensorDeviceClass.DOOR,
     ),
     "contact_timeout": BinarySensorEntityDescription(
         key="contact_timeout",
-        name="Door timeout",
+        translation_key="door_timeout",
         device_class=BinarySensorDeviceClass.PROBLEM,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     "is_light": BinarySensorEntityDescription(
         key="is_light",
-        name="Light",
+        translation_key="light",
         device_class=BinarySensorDeviceClass.LIGHT,
     ),
     "door_open": BinarySensorEntityDescription(
         key="door_status",
-        name="Door status",
+        translation_key="door_open",
         device_class=BinarySensorDeviceClass.DOOR,
     ),
     "unclosed_alarm": BinarySensorEntityDescription(
         key="unclosed_alarm",
-        name="Door unclosed alarm",
+        translation_key="door_unclosed_alarm",
         entity_category=EntityCategory.DIAGNOSTIC,
         device_class=BinarySensorDeviceClass.PROBLEM,
     ),
     "unlocked_alarm": BinarySensorEntityDescription(
         key="unlocked_alarm",
-        name="Door unlocked alarm",
+        translation_key="door_unclosed_alarm",
         entity_category=EntityCategory.DIAGNOSTIC,
         device_class=BinarySensorDeviceClass.PROBLEM,
     ),
     "auto_lock_paused": BinarySensorEntityDescription(
         key="auto_lock_paused",
-        name="Door auto-lock paused",
+        translation_key="door_auto_lock_paused",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
 }

--- a/homeassistant/components/switchbot/sensor.py
+++ b/homeassistant/components/switchbot/sensor.py
@@ -28,7 +28,7 @@ PARALLEL_UPDATES = 0
 SENSOR_TYPES: dict[str, SensorEntityDescription] = {
     "rssi": SensorEntityDescription(
         key="rssi",
-        name="Bluetooth signal strength",
+        translation_key="bluetooth_signal",
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
         device_class=SensorDeviceClass.SIGNAL_STRENGTH,
         state_class=SensorStateClass.MEASUREMENT,
@@ -37,7 +37,7 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
     ),
     "wifi_rssi": SensorEntityDescription(
         key="wifi_rssi",
-        name="Wi-Fi signal strength",
+        translation_key="wifi_signal",
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
         device_class=SensorDeviceClass.SIGNAL_STRENGTH,
         state_class=SensorStateClass.MEASUREMENT,
@@ -46,7 +46,7 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
     ),
     "battery": SensorEntityDescription(
         key="battery",
-        name="Battery",
+        translation_key="battery",
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.BATTERY,
         state_class=SensorStateClass.MEASUREMENT,
@@ -54,27 +54,27 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
     ),
     "lightLevel": SensorEntityDescription(
         key="lightLevel",
-        name="Light level",
+        translation_key="light_level",
         native_unit_of_measurement="Level",
         state_class=SensorStateClass.MEASUREMENT,
     ),
     "humidity": SensorEntityDescription(
         key="humidity",
-        name="Humidity",
+        translation_key="humidity",
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.HUMIDITY,
     ),
     "temperature": SensorEntityDescription(
         key="temperature",
-        name="Temperature",
+        translation_key="temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.TEMPERATURE,
     ),
     "power": SensorEntityDescription(
         key="power",
-        name="Power",
+        translation_key="power",
         native_unit_of_measurement=UnitOfPower.WATT,
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.POWER,

--- a/homeassistant/components/switchbot/strings.json
+++ b/homeassistant/components/switchbot/strings.json
@@ -91,7 +91,7 @@
         "name": "Bluetooth signal"
       },
       "wifi_signal": {
-        "name": "Wi-Fi signal strength"
+        "name": "Wi-Fi signal"
       },
       "battery": {
         "name": "[%key:component::sensor::entity_component::battery::name%]"

--- a/homeassistant/components/switchbot/strings.json
+++ b/homeassistant/components/switchbot/strings.json
@@ -58,5 +58,56 @@
         }
       }
     }
+  },
+  "entity": {
+    "binary_sensor": {
+      "calibration": {
+        "name": "Calibration"
+      },
+      "motion": {
+        "name": "[%key:component::binary_sensor::entity_component::motion::name%]"
+      },
+      "door_open": {
+        "name": "[%key:component::binary_sensor::entity_component::door::name%]"
+      },
+      "door_timeout": {
+        "name": "Door timeout"
+      },
+      "light": {
+        "name": "[%key:component::binary_sensor::entity_component::light::name%]"
+      },
+      "door_unclosed_alarm": {
+        "name": "Door unclosed alarm"
+      },
+      "door_unlocked_alarm": {
+        "name": "Door unlocked alarm"
+      },
+      "door_auto_lock_paused": {
+        "name": "Door auto-lock paused"
+      }
+    },
+    "sensor": {
+      "bluetooth_signal": {
+        "name": "Bluetooth signal strength"
+      },
+      "wifi_signal": {
+        "name": "Wi-Fi signal strength"
+      },
+      "battery": {
+        "name": "[%key:component::sensor::entity_component::battery::name%]"
+      },
+      "light_level": {
+        "name": "Light level"
+      },
+      "humidity": {
+        "name": "[%key:component::sensor::entity_component::humidity::name%]"
+      },
+      "temperature": {
+        "name": "[%key:component::sensor::entity_component::temperature::name%]"
+      },
+      "power": {
+        "name": "[%key:component::sensor::entity_component::power::name%]"
+      }
+    }
   }
 }

--- a/homeassistant/components/switchbot/strings.json
+++ b/homeassistant/components/switchbot/strings.json
@@ -71,24 +71,24 @@
         "name": "[%key:component::binary_sensor::entity_component::door::name%]"
       },
       "door_timeout": {
-        "name": "Door timeout"
+        "name": "Timeout"
       },
       "light": {
         "name": "[%key:component::binary_sensor::entity_component::light::name%]"
       },
       "door_unclosed_alarm": {
-        "name": "Door unclosed alarm"
+        "name": "Unclosed alarm"
       },
       "door_unlocked_alarm": {
-        "name": "Door unlocked alarm"
+        "name": "Unlocked alarm"
       },
       "door_auto_lock_paused": {
-        "name": "Door auto-lock paused"
+        "name": "Auto-lock paused"
       }
     },
     "sensor": {
       "bluetooth_signal": {
-        "name": "Bluetooth signal strength"
+        "name": "Bluetooth signal"
       },
       "wifi_signal": {
         "name": "Wi-Fi signal strength"

--- a/tests/components/switchbot/test_sensor.py
+++ b/tests/components/switchbot/test_sensor.py
@@ -50,12 +50,10 @@ async def test_sensors(
     assert battery_sensor_attrs[ATTR_UNIT_OF_MEASUREMENT] == "%"
     assert battery_sensor_attrs[ATTR_STATE_CLASS] == "measurement"
 
-    rssi_sensor = hass.states.get("sensor.test_name_bluetooth_signal_strength")
+    rssi_sensor = hass.states.get("sensor.test_name_bluetooth_signal")
     rssi_sensor_attrs = rssi_sensor.attributes
     assert rssi_sensor.state == "-60"
-    assert (
-        rssi_sensor_attrs[ATTR_FRIENDLY_NAME] == "test-name Bluetooth signal strength"
-    )
+    assert rssi_sensor_attrs[ATTR_FRIENDLY_NAME] == "test-name Bluetooth signal"
     assert rssi_sensor_attrs[ATTR_UNIT_OF_MEASUREMENT] == "dBm"
 
     assert await hass.config_entries.async_unload(entry.entry_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add entity name translations for Switchbot integrations.
The same is used for contact sensor and door sensor because these are two separate devices and name should not conflict.
I used two separate for Wi-fi and Bluetooth signal because all Switchbot devices are used with BLE in HA but both signals coexist.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
