### PR TITLE
Avoid sorting domain/all states in templates

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -13,7 +13,7 @@ from functools import cache, lru_cache, partial, wraps
 import json
 import logging
 import math
-from operator import attrgetter, contains
+from operator import contains
 import pathlib
 import random
 import re
@@ -983,7 +983,7 @@ def _state_generator(
     hass: HomeAssistant, domain: str | None
 ) -> Generator[TemplateState, None, None]:
     """State generator for a domain or all states."""
-    for state in sorted(hass.states.async_all(domain), key=attrgetter("entity_id")):
+    for state in hass.states.async_all(domain):
         yield _template_state_no_collect(hass, state)
 
 
@@ -1097,7 +1097,7 @@ def expand(hass: HomeAssistant, *args: Any) -> Iterable[State]:
             _collect_state(hass, entity_id)
             found[entity_id] = entity
 
-    return sorted(found.values(), key=lambda a: a.entity_id)
+    return list(found.values())
 
 
 def device_entities(hass: HomeAssistant, _device_id: str) -> Iterable[str]:

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -3043,7 +3043,9 @@ async def test_async_track_template_result_multiple_templates_mixing_domain(
     template_1 = Template("{{ states.switch.test.state == 'on' }}")
     template_2 = Template("{{ states.switch.test.state == 'on' }}")
     template_3 = Template("{{ states.switch.test.state == 'off' }}")
-    template_4 = Template("{{ states.switch | map(attribute='entity_id') | list }}")
+    template_4 = Template(
+        "{{ states.switch | sort(attribute='entity_id') | map(attribute='entity_id') | list }}"
+    )
 
     refresh_runs = []
 

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -185,7 +185,7 @@ def test_raise_exception_on_error(hass: HomeAssistant) -> None:
 
 def test_iterating_all_states(hass: HomeAssistant) -> None:
     """Test iterating all states."""
-    tmpl_str = "{% for state in states %}{{ state.state }}{% endfor %}"
+    tmpl_str = "{% for state in states | sort(attribute='entity_id') %}{{ state.state }}{% endfor %}"
 
     info = render_to_info(hass, tmpl_str)
     assert_result_info(info, "", all_states=True)
@@ -2511,20 +2511,22 @@ async def test_expand(hass: HomeAssistant) -> None:
     hass.states.async_set("test.object", "happy")
 
     info = render_to_info(
-        hass, "{{ expand('test.object') | map(attribute='entity_id') | join(', ') }}"
+        hass,
+        "{{ expand('test.object') | sort(attribute='entity_id') | map(attribute='entity_id') | join(', ') }}",
     )
     assert_result_info(info, "test.object", ["test.object"])
     assert info.rate_limit is None
 
     info = render_to_info(
         hass,
-        "{{ expand('group.new_group') | map(attribute='entity_id') | join(', ') }}",
+        "{{ expand('group.new_group') | sort(attribute='entity_id') | map(attribute='entity_id') | join(', ') }}",
     )
     assert_result_info(info, "", ["group.new_group"])
     assert info.rate_limit is None
 
     info = render_to_info(
-        hass, "{{ expand(states.group) | map(attribute='entity_id') | join(', ') }}"
+        hass,
+        "{{ expand(states.group) | sort(attribute='entity_id') | map(attribute='entity_id') | join(', ') }}",
     )
     assert_result_info(info, "", [], ["group"])
     assert info.rate_limit == template.DOMAIN_STATES_RATE_LIMIT
@@ -2535,13 +2537,14 @@ async def test_expand(hass: HomeAssistant) -> None:
 
     info = render_to_info(
         hass,
-        "{{ expand('group.new_group') | map(attribute='entity_id') | join(', ') }}",
+        "{{ expand('group.new_group') | sort(attribute='entity_id') | map(attribute='entity_id') | join(', ') }}",
     )
     assert_result_info(info, "test.object", {"group.new_group", "test.object"})
     assert info.rate_limit is None
 
     info = render_to_info(
-        hass, "{{ expand(states.group) | map(attribute='entity_id') | join(', ') }}"
+        hass,
+        "{{ expand(states.group) | sort(attribute='entity_id') | map(attribute='entity_id') | join(', ') }}",
     )
     assert_result_info(info, "test.object", {"test.object"}, ["group"])
     assert info.rate_limit == template.DOMAIN_STATES_RATE_LIMIT
@@ -2550,7 +2553,7 @@ async def test_expand(hass: HomeAssistant) -> None:
         hass,
         (
             "{{ expand('group.new_group', 'test.object')"
-            " | map(attribute='entity_id') | join(', ') }}"
+            " | sort(attribute='entity_id') | map(attribute='entity_id') | join(', ') }}"
         ),
     )
     assert_result_info(info, "test.object", {"test.object", "group.new_group"})
@@ -2559,7 +2562,7 @@ async def test_expand(hass: HomeAssistant) -> None:
         hass,
         (
             "{{ ['group.new_group', 'test.object'] | expand"
-            " | map(attribute='entity_id') | join(', ') }}"
+            " | sort(attribute='entity_id') | map(attribute='entity_id') | join(', ') }}"
         ),
     )
     assert_result_info(info, "test.object", {"test.object", "group.new_group"})
@@ -2579,7 +2582,7 @@ async def test_expand(hass: HomeAssistant) -> None:
         hass,
         (
             "{{ states.group.power_sensors.attributes.entity_id | expand "
-            "| map(attribute='state')|map('float')|sum  }}"
+            "| sort(attribute='entity_id') | map(attribute='state')|map('float')|sum  }}"
         ),
     )
     assert_result_info(
@@ -2607,7 +2610,8 @@ async def test_expand(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     info = render_to_info(
-        hass, "{{ expand('light.grouped') | map(attribute='entity_id') | join(', ') }}"
+        hass,
+        "{{ expand('light.grouped') | sort(attribute='entity_id') | map(attribute='entity_id') | join(', ') }}",
     )
     assert_result_info(
         info,
@@ -2629,7 +2633,8 @@ async def test_expand(hass: HomeAssistant) -> None:
         },
     )
     info = render_to_info(
-        hass, "{{ expand('zone.test') | map(attribute='entity_id') | join(', ') }}"
+        hass,
+        "{{ expand('zone.test') | sort(attribute='entity_id') | map(attribute='entity_id') | join(', ') }}",
     )
     assert_result_info(
         info,
@@ -2644,7 +2649,8 @@ async def test_expand(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     info = render_to_info(
-        hass, "{{ expand('zone.test') | map(attribute='entity_id') | join(', ') }}"
+        hass,
+        "{{ expand('zone.test') | sort(attribute='entity_id') | map(attribute='entity_id') | join(', ') }}",
     )
     assert_result_info(
         info,
@@ -2659,7 +2665,8 @@ async def test_expand(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     info = render_to_info(
-        hass, "{{ expand('zone.test') | map(attribute='entity_id') | join(', ') }}"
+        hass,
+        "{{ expand('zone.test') | sort(attribute='entity_id') | map(attribute='entity_id') | join(', ') }}",
     )
     assert_result_info(
         info,
@@ -2709,7 +2716,7 @@ async def test_device_entities(
         hass,
         (
             f"{{{{ device_entities('{device_entry.id}') | expand "
-            "| map(attribute='entity_id') | join(', ') }}"
+            "| sort(attribute='entity_id') | map(attribute='entity_id') | join(', ') }}"
         ),
     )
     assert_result_info(info, "", ["light.hue_5678"])
@@ -2721,7 +2728,7 @@ async def test_device_entities(
         hass,
         (
             f"{{{{ device_entities('{device_entry.id}') | expand "
-            "| map(attribute='entity_id') | join(', ') }}"
+            "| sort(attribute='entity_id') | map(attribute='entity_id') | join(', ') }}"
         ),
     )
     assert_result_info(info, "light.hue_5678", ["light.hue_5678"])
@@ -2743,7 +2750,7 @@ async def test_device_entities(
         hass,
         (
             f"{{{{ device_entities('{device_entry.id}') | expand "
-            "| map(attribute='entity_id') | join(', ') }}"
+            "| sort(attribute='entity_id') | map(attribute='entity_id') | join(', ') }}"
         ),
     )
     assert_result_info(
@@ -3384,7 +3391,7 @@ def test_async_render_to_info_with_complex_branching(hass: HomeAssistant) -> Non
 {%     elif     states.light.a == "on" %}
   {{ states[domain] | list }}
 {%         elif     states('light.b') == "on" %}
-  {{ states[otherdomain] | map(attribute='entity_id') | list }}
+  {{ states[otherdomain] | sort(attribute='entity_id') | map(attribute='entity_id') | list }}
 {% elif states.light.a == "on" %}
   {{ states["nonexist"] | list }}
 {% else %}
@@ -4205,7 +4212,7 @@ async def test_lights(hass: HomeAssistant) -> None:
     """Test we can sort lights."""
 
     tmpl = """
-          {% set lights_on = states.light|selectattr('state','eq','on')|map(attribute='name')|list %}
+          {% set lights_on = states.light|selectattr('state','eq','on')|sort(attribute='entity_id')|map(attribute='name')|list %}
           {% if lights_on|length == 0 %}
             No lights on. Sleep well..
           {% elif lights_on|length == 1 %}
@@ -4308,7 +4315,7 @@ async def test_unavailable_states(hass: HomeAssistant) -> None:
     tpl = template.Template(
         (
             "{{ states | selectattr('state', 'in', ['unavailable','unknown','none']) "
-            "| map(attribute='entity_id') | list | join(', ') }}"
+            "| sort(attribute='entity_id') | map(attribute='entity_id') | list | join(', ') }}"
         ),
         hass,
     )
@@ -4318,7 +4325,7 @@ async def test_unavailable_states(hass: HomeAssistant) -> None:
         (
             "{{ states.light "
             "| selectattr('state', 'in', ['unavailable','unknown','none']) "
-            "| map(attribute='entity_id') | list "
+            "| sort(attribute='entity_id') | map(attribute='entity_id') | list "
             "| join(', ') }}"
         ),
         hass,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Enumerating states using templates are no longer sorted by `entity_id` by default as it was computationally expensive.

To restore the original behavior a `sort` filter can be added to any existing template using the below example:

`{% for state in states | sort(attribute='entity_id') %}`

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Sorting all the states in the state machine has become quite expensive as the number of entities has increased. When templates match all states or all states in a domain they tend to run with an increased frequency. Sorting the states can quickly lead to a performance problem.  For larger installs with many templates, the sorting was consuming more cpu time than the recording of new states.

I looked through the docs at https://www.home-assistant.io/integrations/template/ and none of the examples should be impacted by this change.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/26822

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
