### PR TITLE
Add sort list service to Shopping List

### DIFF
--- a/homeassistant/components/shopping_list/__init__.py
+++ b/homeassistant/components/shopping_list/__init__.py
@@ -18,8 +18,8 @@ from homeassistant.helpers.typing import ConfigType
 from homeassistant.util.json import JsonArrayType, load_json_array
 
 from .const import (
-    ATTR_SORT_REVERSE,
-    DEFAULT_SORT_REVERSE,
+    ATTR_REVERSE,
+    DEFAULT_REVERSE,
     DOMAIN,
     EVENT_SHOPPING_LIST_UPDATED,
     SERVICE_ADD_ITEM,
@@ -29,7 +29,7 @@ from .const import (
     SERVICE_INCOMPLETE_ALL,
     SERVICE_INCOMPLETE_ITEM,
     SERVICE_REMOVE_ITEM,
-    SERVICE_SORT_LIST,
+    SERVICE_SORT,
 )
 
 ATTR_COMPLETE = "complete"
@@ -42,7 +42,7 @@ PERSISTENCE = ".shopping_list.json"
 SERVICE_ITEM_SCHEMA = vol.Schema({vol.Required(ATTR_NAME): cv.string})
 SERVICE_LIST_SCHEMA = vol.Schema({})
 SERVICE_SORT_SCHEMA = vol.Schema(
-    {vol.Optional(ATTR_SORT_REVERSE, default=DEFAULT_SORT_REVERSE): bool}
+    {vol.Optional(ATTR_REVERSE, default=DEFAULT_REVERSE): bool}
 )
 
 
@@ -119,7 +119,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     async def sort_list_service(call: ServiceCall) -> None:
         """Sort all items by name."""
-        await data.async_sort(call.data[ATTR_SORT_REVERSE])
+        await data.async_sort(call.data[ATTR_REVERSE])
 
     data = hass.data[DOMAIN] = ShoppingData(hass)
     await data.async_load()
@@ -159,7 +159,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     )
     hass.services.async_register(
         DOMAIN,
-        SERVICE_SORT_LIST,
+        SERVICE_SORT,
         sort_list_service,
         schema=SERVICE_SORT_SCHEMA,
     )

--- a/homeassistant/components/shopping_list/__init__.py
+++ b/homeassistant/components/shopping_list/__init__.py
@@ -18,6 +18,8 @@ from homeassistant.helpers.typing import ConfigType
 from homeassistant.util.json import JsonArrayType, load_json_array
 
 from .const import (
+    ATTR_SORT_REVERSE,
+    DEFAULT_SORT_REVERSE,
     DOMAIN,
     EVENT_SHOPPING_LIST_UPDATED,
     SERVICE_ADD_ITEM,
@@ -27,6 +29,7 @@ from .const import (
     SERVICE_INCOMPLETE_ALL,
     SERVICE_INCOMPLETE_ITEM,
     SERVICE_REMOVE_ITEM,
+    SERVICE_SORT_LIST,
 )
 
 ATTR_COMPLETE = "complete"
@@ -38,6 +41,9 @@ PERSISTENCE = ".shopping_list.json"
 
 SERVICE_ITEM_SCHEMA = vol.Schema({vol.Required(ATTR_NAME): cv.string})
 SERVICE_LIST_SCHEMA = vol.Schema({})
+SERVICE_SORT_SCHEMA = vol.Schema(
+    {vol.Optional(ATTR_SORT_REVERSE, default=DEFAULT_SORT_REVERSE): bool}
+)
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
@@ -111,6 +117,10 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         """Clear all completed items from the list."""
         await data.async_clear_completed()
 
+    async def sort_list_service(call: ServiceCall) -> None:
+        """Sort all items by name."""
+        await data.async_sort(call.data[ATTR_SORT_REVERSE])
+
     data = hass.data[DOMAIN] = ShoppingData(hass)
     await data.async_load()
 
@@ -146,6 +156,12 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         SERVICE_CLEAR_COMPLETED_ITEMS,
         clear_completed_items_service,
         schema=SERVICE_LIST_SCHEMA,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SORT_LIST,
+        sort_list_service,
+        schema=SERVICE_SORT_SCHEMA,
     )
 
     hass.http.register_view(ShoppingListView)
@@ -274,6 +290,16 @@ class ShoppingData:
         self.hass.bus.async_fire(
             EVENT_SHOPPING_LIST_UPDATED,
             {"action": "reorder"},
+            context=context,
+        )
+
+    async def async_sort(self, reverse=False, context=None):
+        """Sort items by name."""
+        self.items = sorted(self.items, key=lambda item: item["name"], reverse=reverse)
+        self.hass.async_add_executor_job(self.save)
+        self.hass.bus.async_fire(
+            EVENT_SHOPPING_LIST_UPDATED,
+            {"action": "sorted"},
             context=context,
         )
 

--- a/homeassistant/components/shopping_list/const.py
+++ b/homeassistant/components/shopping_list/const.py
@@ -2,9 +2,9 @@
 DOMAIN = "shopping_list"
 EVENT_SHOPPING_LIST_UPDATED = "shopping_list_updated"
 
-ATTR_SORT_REVERSE = "sort_reverse"
+ATTR_REVERSE = "reverse"
 
-DEFAULT_SORT_REVERSE = False
+DEFAULT_REVERSE = False
 
 SERVICE_ADD_ITEM = "add_item"
 SERVICE_REMOVE_ITEM = "remove_item"
@@ -13,4 +13,4 @@ SERVICE_INCOMPLETE_ITEM = "incomplete_item"
 SERVICE_COMPLETE_ALL = "complete_all"
 SERVICE_INCOMPLETE_ALL = "incomplete_all"
 SERVICE_CLEAR_COMPLETED_ITEMS = "clear_completed_items"
-SERVICE_SORT_LIST = "sort_list"
+SERVICE_SORT = "sort"

--- a/homeassistant/components/shopping_list/const.py
+++ b/homeassistant/components/shopping_list/const.py
@@ -2,6 +2,10 @@
 DOMAIN = "shopping_list"
 EVENT_SHOPPING_LIST_UPDATED = "shopping_list_updated"
 
+ATTR_SORT_REVERSE = "sort_reverse"
+
+DEFAULT_SORT_REVERSE = False
+
 SERVICE_ADD_ITEM = "add_item"
 SERVICE_REMOVE_ITEM = "remove_item"
 SERVICE_COMPLETE_ITEM = "complete_item"
@@ -9,3 +13,4 @@ SERVICE_INCOMPLETE_ITEM = "incomplete_item"
 SERVICE_COMPLETE_ALL = "complete_all"
 SERVICE_INCOMPLETE_ALL = "incomplete_all"
 SERVICE_CLEAR_COMPLETED_ITEMS = "clear_completed_items"
+SERVICE_SORT_LIST = "sort_list"

--- a/homeassistant/components/shopping_list/services.yaml
+++ b/homeassistant/components/shopping_list/services.yaml
@@ -57,11 +57,11 @@ clear_completed_items:
   name: Clear completed items
   description: Clear completed items from the shopping list.
 
-sort_list:
+sort:
   name: Sort all items
   description: Sort all items by name in the shopping list.
   fields:
-    sort_reverse:
+    reverse:
       name: Sort reverse
       description: Whether to sort in reverse (descending) order.
       default: false

--- a/homeassistant/components/shopping_list/services.yaml
+++ b/homeassistant/components/shopping_list/services.yaml
@@ -56,3 +56,14 @@ incomplete_all:
 clear_completed_items:
   name: Clear completed items
   description: Clear completed items from the shopping list.
+
+sort_list:
+  name: Sort all items
+  description: Sort all items by name in the shopping list.
+  fields:
+    sort_reverse:
+      name: Sort reverse
+      description: Whether to sort in reverse (descending) order.
+      default: false
+      selector:
+        boolean:

--- a/tests/components/shopping_list/test_init.py
+++ b/tests/components/shopping_list/test_init.py
@@ -751,7 +751,6 @@ async def test_sort_list_service(hass: HomeAssistant, sl_setup) -> None:
     assert len(events) == 1
 
     # sort descending
-    events = async_capture_events(hass, EVENT_SHOPPING_LIST_UPDATED)
     await hass.services.async_call(
         DOMAIN,
         SERVICE_SORT,
@@ -762,4 +761,4 @@ async def test_sort_list_service(hass: HomeAssistant, sl_setup) -> None:
     assert hass.data[DOMAIN].items[0][ATTR_NAME] == "zzz"
     assert hass.data[DOMAIN].items[1][ATTR_NAME] == "ddd"
     assert hass.data[DOMAIN].items[2][ATTR_NAME] == "aaa"
-    assert len(events) == 1
+    assert len(events) == 2

--- a/tests/components/shopping_list/test_init.py
+++ b/tests/components/shopping_list/test_init.py
@@ -5,14 +5,14 @@ import pytest
 
 from homeassistant.components.shopping_list import NoMatchingShoppingListItem
 from homeassistant.components.shopping_list.const import (
-    ATTR_SORT_REVERSE,
+    ATTR_REVERSE,
     DOMAIN,
     EVENT_SHOPPING_LIST_UPDATED,
     SERVICE_ADD_ITEM,
     SERVICE_CLEAR_COMPLETED_ITEMS,
     SERVICE_COMPLETE_ITEM,
     SERVICE_REMOVE_ITEM,
-    SERVICE_SORT_LIST,
+    SERVICE_SORT,
 )
 from homeassistant.components.websocket_api.const import (
     ERR_INVALID_FORMAT,
@@ -751,8 +751,8 @@ async def test_sort_list_service(hass: HomeAssistant, sl_setup) -> None:
     events = async_capture_events(hass, EVENT_SHOPPING_LIST_UPDATED)
     await hass.services.async_call(
         DOMAIN,
-        SERVICE_SORT_LIST,
-        {ATTR_SORT_REVERSE: False},
+        SERVICE_SORT,
+        {ATTR_REVERSE: False},
         blocking=True,
     )
     await hass.async_block_till_done()
@@ -766,8 +766,8 @@ async def test_sort_list_service(hass: HomeAssistant, sl_setup) -> None:
     events = async_capture_events(hass, EVENT_SHOPPING_LIST_UPDATED)
     await hass.services.async_call(
         DOMAIN,
-        SERVICE_SORT_LIST,
-        {ATTR_SORT_REVERSE: True},
+        SERVICE_SORT,
+        {ATTR_REVERSE: True},
         blocking=True,
     )
     await hass.async_block_till_done()

--- a/tests/components/shopping_list/test_init.py
+++ b/tests/components/shopping_list/test_init.py
@@ -659,8 +659,6 @@ async def test_add_item_service(hass: HomeAssistant, sl_setup) -> None:
         {ATTR_NAME: "beer"},
         blocking=True,
     )
-    await hass.async_block_till_done()
-
     assert len(hass.data[DOMAIN].items) == 1
     assert len(events) == 1
 
@@ -674,15 +672,12 @@ async def test_remove_item_service(hass: HomeAssistant, sl_setup) -> None:
         {ATTR_NAME: "beer"},
         blocking=True,
     )
-    await hass.async_block_till_done()
     await hass.services.async_call(
         DOMAIN,
         SERVICE_ADD_ITEM,
         {ATTR_NAME: "cheese"},
         blocking=True,
     )
-    await hass.async_block_till_done()
-
     assert len(hass.data[DOMAIN].items) == 2
     assert len(events) == 2
 
@@ -692,8 +687,6 @@ async def test_remove_item_service(hass: HomeAssistant, sl_setup) -> None:
         {ATTR_NAME: "beer"},
         blocking=True,
     )
-    await hass.async_block_till_done()
-
     assert len(hass.data[DOMAIN].items) == 1
     assert hass.data[DOMAIN].items[0]["name"] == "cheese"
     assert len(events) == 3
@@ -708,7 +701,6 @@ async def test_clear_completed_items_service(hass: HomeAssistant, sl_setup) -> N
         {ATTR_NAME: "beer"},
         blocking=True,
     )
-    await hass.async_block_till_done()
     assert len(hass.data[DOMAIN].items) == 1
     assert len(events) == 1
 
@@ -719,7 +711,6 @@ async def test_clear_completed_items_service(hass: HomeAssistant, sl_setup) -> N
         {ATTR_NAME: "beer"},
         blocking=True,
     )
-    await hass.async_block_till_done()
     assert len(hass.data[DOMAIN].items) == 1
     assert len(events) == 1
 
@@ -730,7 +721,6 @@ async def test_clear_completed_items_service(hass: HomeAssistant, sl_setup) -> N
         {},
         blocking=True,
     )
-    await hass.async_block_till_done()
     assert len(hass.data[DOMAIN].items) == 0
     assert len(events) == 1
 
@@ -745,7 +735,6 @@ async def test_sort_list_service(hass: HomeAssistant, sl_setup) -> None:
             {ATTR_NAME: name},
             blocking=True,
         )
-    await hass.async_block_till_done()
 
     # sort ascending
     events = async_capture_events(hass, EVENT_SHOPPING_LIST_UPDATED)
@@ -755,7 +744,6 @@ async def test_sort_list_service(hass: HomeAssistant, sl_setup) -> None:
         {ATTR_REVERSE: False},
         blocking=True,
     )
-    await hass.async_block_till_done()
 
     assert hass.data[DOMAIN].items[0][ATTR_NAME] == "aaa"
     assert hass.data[DOMAIN].items[1][ATTR_NAME] == "ddd"
@@ -770,7 +758,6 @@ async def test_sort_list_service(hass: HomeAssistant, sl_setup) -> None:
         {ATTR_REVERSE: True},
         blocking=True,
     )
-    await hass.async_block_till_done()
 
     assert hass.data[DOMAIN].items[0][ATTR_NAME] == "zzz"
     assert hass.data[DOMAIN].items[1][ATTR_NAME] == "ddd"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This service allows to sort the shopping list by name. It is also possible to sort in reverse order (_descending_).
Frontend integration (_thus also the websocket_) should be done in a separate PR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/26839

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
