### PR TITLE
Fix memory churn in state templates

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -239,6 +239,7 @@ async def load_registries(hass: core.HomeAssistant) -> None:
 
     # Load the registries and cache the result of platform.uname().processor
     entity.async_setup(hass)
+    template.async_setup(hass)
     await asyncio.gather(
         area_registry.async_load(hass),
         device_registry.async_load(hass),
@@ -292,7 +293,6 @@ async def async_from_config_dict(
         )
         return None
 
-    _async_setup_template_engine(hass)
     await _async_set_up_integrations(hass, config)
 
     stop = monotonic()
@@ -330,16 +330,6 @@ async def async_from_config_dict(
         )
 
     return hass
-
-
-@core.callback
-def _async_setup_template_engine(hass: core.HomeAssistant) -> None:
-    """Set up the template engine."""
-    from .helpers.template import (  # pylint: disable=import-outside-toplevel
-        async_setup as async_setup_template,
-    )
-
-    async_setup_template(hass)
 
 
 @core.callback

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -292,6 +292,7 @@ async def async_from_config_dict(
         )
         return None
 
+    _async_setup_template_engine(hass)
     await _async_set_up_integrations(hass, config)
 
     stop = monotonic()
@@ -329,6 +330,16 @@ async def async_from_config_dict(
         )
 
     return hass
+
+
+@core.callback
+def _async_setup_template_engine(hass: core.HomeAssistant) -> None:
+    """Set up the template engine."""
+    from .helpers.template import (  # pylint: disable=import-outside-toplevel
+        async_setup as async_setup_template,
+    )
+
+    async_setup_template(hass)
 
 
 @core.callback

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -138,6 +138,7 @@ CACHED_TEMPLATE_LRU: MutableMapping[State, TemplateState] = LRU(CACHED_TEMPLATE_
 CACHED_TEMPLATE_NO_COLLECT_LRU: MutableMapping[State, TemplateState] = LRU(
     CACHED_TEMPLATE_STATES
 )
+ENTITY_COUNT_GROWTH_FACTOR = 1.2
 
 
 def _template_state_no_collect(hass: HomeAssistant, state: State) -> TemplateState:
@@ -164,7 +165,9 @@ def async_setup(hass: HomeAssistant) -> bool:
     @callback
     def _async_adjust_lru_sizes(_: Any) -> None:
         """Adjust the lru cache sizes."""
-        new_size = int(hass.states.async_entity_ids_count() * 1.2)
+        new_size = int(
+            round(hass.states.async_entity_ids_count() * ENTITY_COUNT_GROWTH_FACTOR)
+        )
         for lru in (CACHED_TEMPLATE_LRU, CACHED_TEMPLATE_NO_COLLECT_LRU):
             # There is no typing for LRU
             current_size = lru.get_size()  # type: ignore[attr-defined]

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -131,8 +131,8 @@ template_cv: ContextVar[tuple[str, str] | None] = ContextVar(
 #
 # If the cache is too small we will end up creating and destroying
 # TemplateState objects too often which will cause a lot of GC activity
-# and slow down the system. For systems with a lot of entities, and
-# templates this can reach 100000s of object creations and destructions
+# and slow down the system. For systems with a lot of entities and
+# templates, this can reach 100000s of object creations and destructions
 # per minute.
 #
 # Since entity counts may grow over time, we will increase

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1040,9 +1040,12 @@ def _state_generator(
     states = hass.states
     # If domain is None, we want to iterate over all states, but making
     # a copy of the dict is expensive. So we iterate over the protected
-    # _states dict instead. This is safe because we're not modifying it.
+    # _states dict instead. This is safe because we're not modifying it
+    # and everything is happening in the same thread (MainThread).
+    #
     # We do not want to expose this method in the public API though to
     # ensure it does not get misused.
+    #
     container: Iterable[State]
     if domain is None:
         container = states._states.values()  # pylint: disable=protected-access

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -124,10 +124,19 @@ template_cv: ContextVar[tuple[str, str] | None] = ContextVar(
     "template_cv", default=None
 )
 
-# This should match the maximum number of states that we expect to be
-# stored in the state machine. If the cache is too small we will end
-# up creating and destroying TemplateState objects too often which
-# will cause a lot of GC activity and slow down the system.
+#
+# CACHED_TEMPLATE_STATES is a rough estimate of the number of entities
+# on a typical system. It is used as the initial size of the LRU cache
+# for TemplateState objects.
+#
+# If the cache is too small we will end up creating and destroying
+# TemplateState objects too often which will cause a lot of GC activity
+# and slow down the system.
+#
+# Since entity counts have grown over time, we will increase
+# the size if the number of entities grows via _async_adjust_lru_sizes
+# at the start of the system and every 10 minutes if needed.
+#
 CACHED_TEMPLATE_STATES = 512
 
 EVAL_CACHE_SIZE = 512

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -164,7 +164,7 @@ def async_setup(hass: HomeAssistant) -> bool:
     @callback
     def _async_adjust_lru_sizes(_: Any) -> None:
         """Adjust the lru cache sizes."""
-        new_size = hass.states.async_entity_ids_count()
+        new_size = int(hass.states.async_entity_ids_count() * 1.2)
         for lru in (CACHED_TEMPLATE_LRU, CACHED_TEMPLATE_NO_COLLECT_LRU):
             # There is no typing for LRU
             current_size = lru.get_size()  # type: ignore[attr-defined]

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -133,7 +133,7 @@ template_cv: ContextVar[tuple[str, str] | None] = ContextVar(
 # TemplateState objects too often which will cause a lot of GC activity
 # and slow down the system.
 #
-# Since entity counts have grown over time, we will increase
+# Since entity counts may grow over time, we will increase
 # the size if the number of entities grows via _async_adjust_lru_sizes
 # at the start of the system and every 10 minutes if needed.
 #

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -131,7 +131,9 @@ template_cv: ContextVar[tuple[str, str] | None] = ContextVar(
 #
 # If the cache is too small we will end up creating and destroying
 # TemplateState objects too often which will cause a lot of GC activity
-# and slow down the system.
+# and slow down the system. For systems with a lot of entities, and
+# templates this can reach 100000s of object creations and destructions
+# per minute.
 #
 # Since entity counts may grow over time, we will increase
 # the size if the number of entities grows via _async_adjust_lru_sizes

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -140,7 +140,6 @@ template_cv: ContextVar[tuple[str, str] | None] = ContextVar(
 # at the start of the system and every 10 minutes if needed.
 #
 CACHED_TEMPLATE_STATES = 512
-
 EVAL_CACHE_SIZE = 512
 
 MAX_CUSTOM_TEMPLATE_SIZE = 5 * 1024 * 1024

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -43,7 +43,7 @@ from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 from homeassistant.util.unit_system import UnitSystem
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 
 def _set_up_units(hass: HomeAssistant) -> None:
@@ -4497,3 +4497,29 @@ async def test_render_to_info_with_exception(hass: HomeAssistant) -> None:
 
     assert info.all_states is False
     assert info.entities == {"test_domain.object"}
+
+
+async def test_lru_increases_with_many_entities(hass: HomeAssistant) -> None:
+    """Test that the template internal LRU cache increases with many entities."""
+    # We do not actually want to record 4096 entities so we mock the entity count
+    mock_entity_count = 4096
+
+    assert template.CACHED_TEMPLATE_LRU.get_size() == template.CACHED_TEMPLATE_STATES
+    assert (
+        template.CACHED_TEMPLATE_NO_COLLECT_LRU.get_size()
+        == template.CACHED_TEMPLATE_STATES
+    )
+
+    template.async_setup(hass)
+    with patch.object(
+        hass.states, "async_entity_ids_count", return_value=mock_entity_count
+    ):
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=10))
+        await hass.async_block_till_done()
+
+    assert template.CACHED_TEMPLATE_LRU.get_size() == int(
+        round(mock_entity_count * template.ENTITY_COUNT_GROWTH_FACTOR)
+    )
+    assert template.CACHED_TEMPLATE_NO_COLLECT_LRU.get_size() == int(
+        round(mock_entity_count * template.ENTITY_COUNT_GROWTH_FACTOR)
+    )

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -4523,3 +4523,15 @@ async def test_lru_increases_with_many_entities(hass: HomeAssistant) -> None:
     assert template.CACHED_TEMPLATE_NO_COLLECT_LRU.get_size() == int(
         round(mock_entity_count * template.ENTITY_COUNT_GROWTH_FACTOR)
     )
+
+    await hass.async_stop()
+    with patch.object(hass.states, "async_entity_ids_count", return_value=8192):
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=20))
+        await hass.async_block_till_done()
+
+    assert template.CACHED_TEMPLATE_LRU.get_size() == int(
+        round(mock_entity_count * template.ENTITY_COUNT_GROWTH_FACTOR)
+    )
+    assert template.CACHED_TEMPLATE_NO_COLLECT_LRU.get_size() == int(
+        round(mock_entity_count * template.ENTITY_COUNT_GROWTH_FACTOR)
+    )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Dynamically adjust the template LRUs based on the number of states in the state machine.

The LRU for state templates was limited to 512 states. As soon as it was exhausted, system performance would tank if there were templates that enumerated all states as each template that iterated all states or a large domain would have to create and eventually GC any state > 512.  In profiles provided, the GC cycle was 23% of the non-idle event loop run time (41% of the event loop run active time in total) since it was creating and destroying ~275000 `TemplateState` objects per minute.

Sample YAML to trigger the issue when the system has > 512 entities

```yaml
sensor:
  - platform: template
    sensors:
      unavailable_entities:
        friendly_name: Unavailable Entities
        unit_of_measurement: items
        value_template: {{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}
```

![state_generator_misses](https://user-images.githubusercontent.com/663432/229382936-7ed25df1-979c-4306-a3c8-fe0c6da84dc8.png)
![gc_cycles](https://user-images.githubusercontent.com/663432/229382942-ac1f75ed-4766-41e5-9095-95521b2724a9.png)

After the changes it scales much better even with millions of states being examined and it no longer triggers frequent GCs

<img width="475" alt="Screenshot 2023-04-02 at 2 10 36 PM" src="https://user-images.githubusercontent.com/663432/229386639-e3e7720a-1a48-4f0b-aeae-de6840d53b50.png">


Testing.  Paste the following into the template editor
```
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  
{{states|selectattr('state', 'in', ['unavailable','unknown','none']) |list|length}}  

```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
