### PR TITLE
Add "enqueue" parameter to spotify integration

### DIFF
--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -369,7 +369,7 @@ class SpotifyMediaPlayer(MediaPlayerEntity):
             MediaType.MUSIC,
         }:
             return self.data.client.add_to_queue(media_id, kwargs.get("device_id"))
-            
+
         self.data.client.start_playback(**kwargs)
 
     @spotify_exception_handler

--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -1,26 +1,22 @@
 """Support for interacting with Spotify Connect."""
 from __future__ import annotations
 
-from asyncio import run_coroutine_threadsafe
 import datetime as dt
-from datetime import timedelta
 import logging
+from asyncio import run_coroutine_threadsafe
+from datetime import timedelta
 from typing import Any
 
 import requests
-from spotipy import SpotifyException
 from yarl import URL
 
-from homeassistant.components.media_player import (
-    BrowseMedia,
-    MediaPlayerEntity,
-    MediaPlayerEntityFeature,
-    MediaPlayerState,
-    MediaType,
-    RepeatMode,
-    ATTR_MEDIA_ENQUEUE,
-    MediaPlayerEnqueue,
-)
+from homeassistant.components.media_player import (ATTR_MEDIA_ENQUEUE,
+                                                   BrowseMedia,
+                                                   MediaPlayerEnqueue,
+                                                   MediaPlayerEntity,
+                                                   MediaPlayerEntityFeature,
+                                                   MediaPlayerState, MediaType,
+                                                   RepeatMode)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ID
 from homeassistant.core import HomeAssistant, callback
@@ -29,10 +25,12 @@ from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util.dt import utc_from_timestamp
+from spotipy import SpotifyException
 
 from . import HomeAssistantSpotifyData
 from .browse_media import async_browse_media_internal
-from .const import DOMAIN, MEDIA_PLAYER_PREFIX, PLAYABLE_MEDIA_TYPES, SPOTIFY_SCOPES
+from .const import (DOMAIN, MEDIA_PLAYER_PREFIX, PLAYABLE_MEDIA_TYPES,
+                    SPOTIFY_SCOPES)
 from .util import fetch_image_url
 
 _LOGGER = logging.getLogger(__name__)
@@ -363,11 +361,16 @@ class SpotifyMediaPlayer(MediaPlayerEntity):
         ):
             kwargs["device_id"] = self.data.devices.data[0].get("id")
 
-        if enqueue == MediaPlayerEnqueue.ADD and media_type in {
-            MediaType.TRACK,
-            MediaType.EPISODE,
-            MediaType.MUSIC,
-        }:
+        if enqueue == MediaPlayerEnqueue.ADD:
+            if media_type not in {
+                MediaType.TRACK,
+                MediaType.EPISODE,
+                MediaType.MUSIC,
+            }:
+                _LOGGER.error(
+                    "Media type %s is not supported when enqueue is ADD", media_type
+                )
+                return
             return self.data.client.add_to_queue(media_id, kwargs.get("device_id"))
 
         self.data.client.start_playback(**kwargs)

--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -10,13 +10,16 @@ from typing import Any
 import requests
 from yarl import URL
 
-from homeassistant.components.media_player import (ATTR_MEDIA_ENQUEUE,
-                                                   BrowseMedia,
-                                                   MediaPlayerEnqueue,
-                                                   MediaPlayerEntity,
-                                                   MediaPlayerEntityFeature,
-                                                   MediaPlayerState, MediaType,
-                                                   RepeatMode)
+from homeassistant.components.media_player import (
+    ATTR_MEDIA_ENQUEUE,
+    BrowseMedia,
+    MediaPlayerEnqueue,
+    MediaPlayerEntity,
+    MediaPlayerEntityFeature,
+    MediaPlayerState,
+    MediaType,
+    RepeatMode,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ID
 from homeassistant.core import HomeAssistant, callback
@@ -29,8 +32,7 @@ from spotipy import SpotifyException
 
 from . import HomeAssistantSpotifyData
 from .browse_media import async_browse_media_internal
-from .const import (DOMAIN, MEDIA_PLAYER_PREFIX, PLAYABLE_MEDIA_TYPES,
-                    SPOTIFY_SCOPES)
+from .const import DOMAIN, MEDIA_PLAYER_PREFIX, PLAYABLE_MEDIA_TYPES, SPOTIFY_SCOPES
 from .util import fetch_image_url
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -369,10 +369,9 @@ class SpotifyMediaPlayer(MediaPlayerEntity):
                 MediaType.EPISODE,
                 MediaType.MUSIC,
             }:
-                _LOGGER.error(
-                    "Media type %s is not supported when enqueue is ADD", media_type
+                raise ValueError(
+                    f"Media type {media_type} is not supported when enqueue is ADD"
                 )
-                return
             return self.data.client.add_to_queue(media_id, kwargs.get("device_id"))
 
         self.data.client.start_playback(**kwargs)

--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -18,6 +18,8 @@ from homeassistant.components.media_player import (
     MediaPlayerState,
     MediaType,
     RepeatMode,
+    ATTR_MEDIA_ENQUEUE,
+    MediaPlayerEnqueue,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ID
@@ -336,6 +338,10 @@ class SpotifyMediaPlayer(MediaPlayerEntity):
         """Play media."""
         media_type = media_type.removeprefix(MEDIA_PLAYER_PREFIX)
 
+        enqueue: MediaPlayerEnqueue = kwargs.get(
+            ATTR_MEDIA_ENQUEUE, MediaPlayerEnqueue.REPLACE
+        )
+
         kwargs = {}
 
         # Spotify can't handle URI's with query strings or anchors
@@ -357,6 +363,13 @@ class SpotifyMediaPlayer(MediaPlayerEntity):
         ):
             kwargs["device_id"] = self.data.devices.data[0].get("id")
 
+        if enqueue == MediaPlayerEnqueue.ADD and media_type in {
+            MediaType.TRACK,
+            MediaType.EPISODE,
+            MediaType.MUSIC,
+        }:
+            return self.data.client.add_to_queue(media_id, kwargs.get("device_id"))
+            
         self.data.client.start_playback(**kwargs)
 
     @spotify_exception_handler

--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -1,13 +1,14 @@
 """Support for interacting with Spotify Connect."""
 from __future__ import annotations
 
-import datetime as dt
-import logging
 from asyncio import run_coroutine_threadsafe
+import datetime as dt
 from datetime import timedelta
+import logging
 from typing import Any
 
 import requests
+from spotipy import SpotifyException
 from yarl import URL
 
 from homeassistant.components.media_player import (
@@ -28,7 +29,6 @@ from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util.dt import utc_from_timestamp
-from spotipy import SpotifyException
 
 from . import HomeAssistantSpotifyData
 from .browse_media import async_browse_media_internal


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Makes it possible to add a song last in queue to Spotify using the "enqueue" data argument:
```yaml
service: media_player.play_media
target:
  entity_id: media_player.spotify
data:
  media_content_type: track
  media_content_id: https://open.spotify.com/track/6Hmj7SrLRbreLVfVS7mV1S
  enqueue: add
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #63731

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
