### PR TITLE
Add Warning in the issue registry if a HTTPS webhook is used for Nuki

### DIFF
--- a/homeassistant/components/nuki/__init__.py
+++ b/homeassistant/components/nuki/__init__.py
@@ -26,7 +26,11 @@ from homeassistant.const import (
 )
 from homeassistant.core import Event, HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers import (
+    device_registry as dr,
+    entity_registry as er,
+    issue_registry as ir,
+)
 from homeassistant.helpers.network import get_url
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
@@ -152,17 +156,36 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass, allow_cloud=False, allow_external=False, allow_ip=True, require_ssl=False
     )
     url = f"{hass_url}{webhook_url}"
-    try:
-        async with async_timeout.timeout(10):
-            await hass.async_add_executor_job(
-                _register_webhook, bridge, entry.entry_id, url
-            )
-    except InvalidCredentialsException as err:
-        webhook.async_unregister(hass, entry.entry_id)
-        raise ConfigEntryNotReady(f"Invalid credentials for Bridge: {err}") from err
-    except RequestException as err:
-        webhook.async_unregister(hass, entry.entry_id)
-        raise ConfigEntryNotReady(f"Error communicating with Bridge: {err}") from err
+
+    if hass_url.startswith("https"):
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            "https_webhook",
+            is_fixable=False,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key="https_webhook",
+            translation_placeholders={
+                "base_url": hass_url,
+                "network_link": "https://my.home-assistant.io/redirect/network/",
+            },
+        )
+    else:
+        ir.async_delete_issue(hass, DOMAIN, "https_webhook")
+
+        try:
+            async with async_timeout.timeout(10):
+                await hass.async_add_executor_job(
+                    _register_webhook, bridge, entry.entry_id, url
+                )
+        except InvalidCredentialsException as err:
+            webhook.async_unregister(hass, entry.entry_id)
+            raise ConfigEntryNotReady(f"Invalid credentials for Bridge: {err}") from err
+        except RequestException as err:
+            webhook.async_unregister(hass, entry.entry_id)
+            raise ConfigEntryNotReady(
+                f"Error communicating with Bridge: {err}"
+            ) from err
 
     async def _stop_nuki(_: Event):
         """Stop and remove the Nuki webhook."""

--- a/homeassistant/components/nuki/strings.json
+++ b/homeassistant/components/nuki/strings.json
@@ -25,5 +25,11 @@
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     }
+  },
+  "issues": {
+    "https_webhook": {
+      "title": "Nuki webhook URL uses HTTPS (SSL)",
+      "description": "The Nuki bridge can not push events to an HTTPS address (SSL), please configure a (local) HTTP address under \"Home Assistant URL\" in the [network settings]({network_link}). The current (local) address is: `{base_url}`, a valid address could, for example, be `http://192.168.1.10:8123` where `192.168.1.10` is the IP of the Home Assistant device"
+    }
   }
 }


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adding a warning into the issue registry if the internal Home Assistant URL uses HTTPS.
Based on the reolink integration:
https://github.com/home-assistant/core/blob/bacbe4aa58e02a25217c07d23c45fccc70325a5e/homeassistant/components/reolink/host.py#L338

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/90640 https://github.com/home-assistant/core/issues/90502
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
