### PR TITLE
Add config flow to Swisscom

### DIFF
--- a/homeassistant/components/swisscom/config_flow.py
+++ b/homeassistant/components/swisscom/config_flow.py
@@ -1,0 +1,139 @@
+"""Config flow to configure the Swisscom integration."""
+from __future__ import annotations
+
+import logging
+from sc_inetbox_adapter import DEFAULT_HOST, DEFAULT_PROTOCOL
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_PASSWORD,
+    CONF_SSL,
+)
+
+from .const import (
+    CONF_CONSIDER_HOME,
+    DEFAULT_CONSIDER_HOME,
+    DEFAULT_NAME,
+    DOMAIN,
+)
+
+from .errors import CannotLoginException
+from .router import get_api
+
+_LOGGER = logging.getLogger(__name__)
+
+def _user_schema_with_defaults(user_input):
+    user_schema = {vol.Optional(CONF_HOST, default=user_input.get(CONF_HOST, "")): str}
+    user_schema.update(_ordered_shared_schema(user_input))
+
+    return vol.Schema(user_schema)
+
+def _ordered_shared_schema(schema_input):
+    return {
+        vol.Required(CONF_PASSWORD, default=schema_input.get(CONF_PASSWORD, "")): str,
+    }
+
+class OptionsFlowHandler(config_entries.OptionsFlow):
+    """Options for the component."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        """Init object."""
+        self.config_entry = config_entry
+
+    async def async_step_init(self, user_input=None):
+        """Manage the options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        settings_schema = vol.Schema(
+            {
+                vol.Optional(
+                    CONF_CONSIDER_HOME,
+                    default=self.config_entry.options.get(
+                        CONF_CONSIDER_HOME, DEFAULT_CONSIDER_HOME.total_seconds()
+                    ),
+                ): int,
+            }
+        )
+
+        return self.async_show_form(step_id="init", data_schema=settings_schema)
+
+class InternetBoxFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow."""
+
+    VERSION = 1
+
+    def __init__(self) -> None:
+        """Initialize the internetbox config flow."""
+        self.placeholders = {
+            CONF_HOST: DEFAULT_HOST,
+            CONF_SSL: False,
+        }
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> OptionsFlowHandler:
+        """Get the options flow."""
+        return OptionsFlowHandler(config_entry)
+
+    async def _show_setup_form(self, user_input=None, errors=None):
+        """Show the setup form to the user."""
+        if not user_input:
+            user_input = {}
+
+        data_schema = _user_schema_with_defaults(user_input)
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=data_schema,
+            errors=errors or {},
+            description_placeholders=self.placeholders,
+        )
+
+
+    async def async_step_user(self, user_input=None):
+        """Handle a flow initiated by the user."""
+        errors = {}
+
+        if user_input is None:
+            return await self._show_setup_form()
+
+        host = user_input.get(CONF_HOST, self.placeholders[CONF_HOST])
+        ssl = self.placeholders[CONF_SSL]
+        password = user_input[CONF_PASSWORD]
+
+        # Open connection and check authentication
+        try:
+            api = await self.hass.async_add_executor_job(
+                get_api, password, host, ssl
+            )
+        except CannotLoginException:
+            errors["base"] = "config"
+
+        if errors:
+            return await self._show_setup_form(user_input, errors)
+
+        config_data = {
+            CONF_PASSWORD: password,
+            CONF_HOST: host,
+            CONF_SSL: api.ssl,
+        }
+
+        # Check if already configured
+        info = await self.hass.async_add_executor_job(api.get_info)
+        await self.async_set_unique_id(info["SerialNumber"], raise_on_progress=False)
+        self._abort_if_unique_id_configured(updates=config_data)
+
+        if info.get("ModelName") is not None and info.get("DeviceName") is not None:
+            name = f"{info['ModelName']} - {info['DeviceName']}"
+        else:
+            name = info.get("ModelName", DEFAULT_NAME)
+
+        return self.async_create_entry(
+            title=name,
+            data=config_data,
+        )

--- a/homeassistant/components/swisscom/config_flow.py
+++ b/homeassistant/components/swisscom/config_flow.py
@@ -124,14 +124,11 @@ class InternetBoxFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         }
 
         # Check if already configured
-        info = await self.hass.async_add_executor_job(api.get_info)
+        info = await self.hass.async_add_executor_job(api.get_device_info)
         await self.async_set_unique_id(info["SerialNumber"], raise_on_progress=False)
         self._abort_if_unique_id_configured(updates=config_data)
 
-        if info.get("ModelName") is not None and info.get("DeviceName") is not None:
-            name = f"{info['ModelName']} - {info['DeviceName']}"
-        else:
-            name = info.get("ModelName", DEFAULT_NAME)
+        name = info["ModelName"]
 
         return self.async_create_entry(
             title=name,

--- a/homeassistant/components/swisscom/device_tracker.py
+++ b/homeassistant/components/swisscom/device_tracker.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 from contextlib import suppress
 import logging
 
-import requests
 import voluptuous as vol
 
 from homeassistant.components.device_tracker import (

--- a/homeassistant/components/swisscom/errors.py
+++ b/homeassistant/components/swisscom/errors.py
@@ -1,0 +1,10 @@
+"""Errors for the Swisscom component."""
+from homeassistant.exceptions import HomeAssistantError
+
+
+class SwisscomException(HomeAssistantError):
+    """Base class for Swisscom exceptions."""
+
+
+class CannotLoginException(SwisscomException):
+    """Unable to login to the router."""

--- a/homeassistant/components/swisscom/manifest.json
+++ b/homeassistant/components/swisscom/manifest.json
@@ -3,5 +3,6 @@
   "name": "Swisscom Internet-Box",
   "codeowners": [],
   "documentation": "https://www.home-assistant.io/integrations/swisscom",
-  "iot_class": "local_polling"
+  "iot_class": "local_polling",
+  "config_flow": true
 }

--- a/homeassistant/components/swisscom/router.py
+++ b/homeassistant/components/swisscom/router.py
@@ -1,0 +1,20 @@
+"""Represent the Swisscom router and its devices."""
+from __future__ import annotations
+
+from sc_inetbox_adapter import InternetboxAdapter
+
+from .errors import CannotLoginException
+
+
+def get_api(
+    password: str,
+    host: str,
+    ssl: bool
+) -> InternetboxAdapter:
+    """Get the Internetbox API and login to it."""
+    api: InternetboxAdapter = InternetboxAdapter(password, ssl, host)
+
+    if api.create_session() != http.HTTPStatus.OK:
+        raise CannotLoginException
+
+    return api


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
This change might break the current Swisscom integration if you're already using it. Reinitializing might be obligatory.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Since the current Swisscom integration doesnt work any more (#87220, #82789) an update is needed.
The old module doesnt support config flow and is not compliant with the new rules regarding the direct calls of external APIs inside HA.
The new Swisscom router firmware uses HTTPS with an subdomain of swisscom.ch. Additionally, authentication is required to get the API calls needed for the device tracker.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #87220
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
