### PR TITLE
Restore state for ZHA OnOff binary sensors

### DIFF
--- a/homeassistant/components/zha/binary_sensor.py
+++ b/homeassistant/components/zha/binary_sensor.py
@@ -120,7 +120,7 @@ class Occupancy(BinarySensor):
 
 @STRICT_MATCH(channel_names=CHANNEL_ON_OFF)
 class Opening(BinarySensor):
-    """ZHA BinarySensor."""
+    """ZHA OnOff BinarySensor."""
 
     SENSOR_ATTR = "on_off"
     _attr_device_class: BinarySensorDeviceClass = BinarySensorDeviceClass.OPENING
@@ -154,10 +154,9 @@ class BinaryInput(BinarySensor):
     manufacturers="Philips",
     models={"SML001", "SML002"},
 )
-class Motion(BinarySensor):
-    """ZHA BinarySensor."""
+class Motion(Opening):
+    """ZHA OnOff BinarySensor with motion device class."""
 
-    SENSOR_ATTR = "on_off"
     _attr_device_class: BinarySensorDeviceClass = BinarySensorDeviceClass.MOTION
 
 

--- a/homeassistant/components/zha/binary_sensor.py
+++ b/homeassistant/components/zha/binary_sensor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import functools
 from typing import Any
 
+import zigpy.types as t
 from zigpy.zcl.clusters.general import OnOff
 from zigpy.zcl.clusters.security import IasZone
 
@@ -125,13 +126,14 @@ class Opening(BinarySensor):
     SENSOR_ATTR = "on_off"
     _attr_device_class: BinarySensorDeviceClass = BinarySensorDeviceClass.OPENING
 
-    # this isn't stored in the zigpy database, so we need to restore the last state for now
+    # Client/out cluster attributes aren't stored in the zigpy database, but are properly stored in the runtime cache.
+    # We need to manually restore the last state from the sensor state to the runtime cache for now.
     @callback
     def async_restore_last_state(self, last_state):
-        """Restore previous state."""
+        """Restore previous state to zigpy cache."""
         self._channel.cluster.update_attribute(
             OnOff.attributes_by_name[self.SENSOR_ATTR].id,
-            last_state.state == STATE_ON,
+            t.Bool.true if last_state.state == STATE_ON else t.Bool.false,
         )
 
 

--- a/homeassistant/components/zha/binary_sensor.py
+++ b/homeassistant/components/zha/binary_sensor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import functools
 from typing import Any
 
+from zigpy.zcl.clusters.general import OnOff
 from zigpy.zcl.clusters.security import IasZone
 
 from homeassistant.components.binary_sensor import (
@@ -123,6 +124,15 @@ class Opening(BinarySensor):
 
     SENSOR_ATTR = "on_off"
     _attr_device_class: BinarySensorDeviceClass = BinarySensorDeviceClass.OPENING
+
+    # this isn't stored in the zigpy database, so we need to restore the last state for now
+    @callback
+    def async_restore_last_state(self, last_state):
+        """Restore previous state."""
+        self._channel.cluster.update_attribute(
+            OnOff.attributes_by_name[self.SENSOR_ATTR].id,
+            last_state.state == STATE_ON,
+        )
 
 
 @MULTI_MATCH(channel_names=CHANNEL_BINARY_INPUT)


### PR DESCRIPTION
## Proposed change
Zigpy doesn't cache attributes on "out" clusters at the moment. With the refactor in #89481, this breaks `OnOff` binary sensors.
This fixes https://github.com/home-assistant/core/issues/90663 by updating "the local/runtime attribute cache" once from the last state on ZHA startup.

This "easy way" of doing it is possible because the OnOff attribute can only be true/false and the "local/runtime attribute cache" correctly persists the attribute (and it's only the database that doesn't).

An alternative approach would be this: https://github.com/TheJulianJES/core/commit/a648d01ad9cf9827fd2f017df55339205534fc94
With that, we don't rely on zigpy attribute cache at all.
With the current approach in this PR, we rely on the local zigpy attribute cache and just populate it with the last value on startup.

A test was also added to verify that ZHA just restores the last HA state for OnOff binary sensors.

### Zigpy stuff:

Zigpy only registers the listener that saves the attribute to the database for input clusters in [`add_input_cluster` here](https://github.com/zigpy/zigpy/blob/14696fe2a999eaef2b5120938cf59f7d8aeb7b22/zigpy/endpoint.py#L106-L110).
It's not done in `add_output_cluster` below.

[`_update_attribute` always updates the "local attribute cache" `_attr_cache`](https://github.com/zigpy/zigpy/blob/14696fe2a999eaef2b5120938cf59f7d8aeb7b22/zigpy/zcl/__init__.py#L764-L766) which is stored per cluster instance.
The `_update_attribute` method is always called (regardless of cluster type) [when an attribute report is received](https://github.com/zigpy/zigpy/blob/14696fe2a999eaef2b5120938cf59f7d8aeb7b22/zigpy/zcl/__init__.py#L425).

This PR also calls that method on ZHA startup to populate `_attr_cache` with what the attribute should be.
(This needs to be done, as zigpy does not call `attribute_updated`/`_save_attribute` for "out" clusters [here](https://github.com/zigpy/zigpy/blob/14696fe2a999eaef2b5120938cf59f7d8aeb7b22/zigpy/appdb.py#L270-L280), as the listener isn't registered for "out" clusters as stated above.)

From my limited point of view, I'd say that zigpy should probably also persistently cache "out" cluster attributes, so this can be removed and binary sensors (like normal sensors) can just be a representation of zigpy attribute cache.
The current behavior where zigpy only caches the attributes at runtime can be a bit confusing IMO.
(note: if implementing, the cluster type would need to be specified in a new "attributes cache" schema)


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #90663
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
