### PR TITLE
Use domain constants in rest tests

### DIFF
--- a/tests/components/rest/test_binary_sensor.py
+++ b/tests/components/rest/test_binary_sensor.py
@@ -9,7 +9,11 @@ import pytest
 import respx
 
 from homeassistant import config as hass_config
-from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+from homeassistant.components.binary_sensor import (
+    DOMAIN as BINARY_SENSOR_DOMAIN,
+    BinarySensorDeviceClass,
+)
+from homeassistant.components.rest import DOMAIN
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_ENTITY_ID,
@@ -18,7 +22,6 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
     STATE_UNAVAILABLE,
-    Platform,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -30,27 +33,27 @@ from tests.common import get_fixture_path
 async def test_setup_missing_basic_config(hass: HomeAssistant) -> None:
     """Test setup with configuration missing required entries."""
     assert await async_setup_component(
-        hass, Platform.BINARY_SENSOR, {"binary_sensor": {"platform": "rest"}}
+        hass, BINARY_SENSOR_DOMAIN, {BINARY_SENSOR_DOMAIN: {"platform": DOMAIN}}
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all("binary_sensor")) == 0
+    assert len(hass.states.async_all(BINARY_SENSOR_DOMAIN)) == 0
 
 
 async def test_setup_missing_config(hass: HomeAssistant) -> None:
     """Test setup with configuration missing required entries."""
     assert await async_setup_component(
         hass,
-        Platform.BINARY_SENSOR,
+        BINARY_SENSOR_DOMAIN,
         {
-            "binary_sensor": {
-                "platform": "rest",
+            BINARY_SENSOR_DOMAIN: {
+                "platform": DOMAIN,
                 "resource": "localhost",
                 "method": "GET",
             }
         },
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all("binary_sensor")) == 0
+    assert len(hass.states.async_all(BINARY_SENSOR_DOMAIN)) == 0
 
 
 @respx.mock
@@ -64,17 +67,17 @@ async def test_setup_failed_connect(
     )
     assert await async_setup_component(
         hass,
-        Platform.BINARY_SENSOR,
+        BINARY_SENSOR_DOMAIN,
         {
-            "binary_sensor": {
-                "platform": "rest",
+            BINARY_SENSOR_DOMAIN: {
+                "platform": DOMAIN,
                 "resource": "http://localhost",
                 "method": "GET",
             }
         },
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all("binary_sensor")) == 0
+    assert len(hass.states.async_all(BINARY_SENSOR_DOMAIN)) == 0
     assert "server offline" in caplog.text
 
 
@@ -84,17 +87,17 @@ async def test_setup_timeout(hass: HomeAssistant) -> None:
     respx.get("http://localhost").mock(side_effect=asyncio.TimeoutError())
     assert await async_setup_component(
         hass,
-        Platform.BINARY_SENSOR,
+        BINARY_SENSOR_DOMAIN,
         {
-            "binary_sensor": {
-                "platform": "rest",
+            BINARY_SENSOR_DOMAIN: {
+                "platform": DOMAIN,
                 "resource": "localhost",
                 "method": "GET",
             }
         },
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all("binary_sensor")) == 0
+    assert len(hass.states.async_all(BINARY_SENSOR_DOMAIN)) == 0
 
 
 @respx.mock
@@ -103,17 +106,17 @@ async def test_setup_minimum(hass: HomeAssistant) -> None:
     respx.get("http://localhost") % HTTPStatus.OK
     assert await async_setup_component(
         hass,
-        Platform.BINARY_SENSOR,
+        BINARY_SENSOR_DOMAIN,
         {
-            "binary_sensor": {
-                "platform": "rest",
+            BINARY_SENSOR_DOMAIN: {
+                "platform": DOMAIN,
                 "resource": "http://localhost",
                 "method": "GET",
             }
         },
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all("binary_sensor")) == 1
+    assert len(hass.states.async_all(BINARY_SENSOR_DOMAIN)) == 1
 
 
 @respx.mock
@@ -122,16 +125,16 @@ async def test_setup_minimum_resource_template(hass: HomeAssistant) -> None:
     respx.get("http://localhost") % HTTPStatus.OK
     assert await async_setup_component(
         hass,
-        Platform.BINARY_SENSOR,
+        BINARY_SENSOR_DOMAIN,
         {
-            "binary_sensor": {
-                "platform": "rest",
+            BINARY_SENSOR_DOMAIN: {
+                "platform": DOMAIN,
                 "resource_template": "{% set url = 'http://localhost' %}{{ url }}",
             }
         },
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all("binary_sensor")) == 1
+    assert len(hass.states.async_all(BINARY_SENSOR_DOMAIN)) == 1
 
 
 @respx.mock
@@ -140,17 +143,17 @@ async def test_setup_duplicate_resource_template(hass: HomeAssistant) -> None:
     respx.get("http://localhost") % HTTPStatus.OK
     assert await async_setup_component(
         hass,
-        Platform.BINARY_SENSOR,
+        BINARY_SENSOR_DOMAIN,
         {
-            "binary_sensor": {
-                "platform": "rest",
+            BINARY_SENSOR_DOMAIN: {
+                "platform": DOMAIN,
                 "resource": "http://localhost",
                 "resource_template": "http://localhost",
             }
         },
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all("binary_sensor")) == 0
+    assert len(hass.states.async_all(BINARY_SENSOR_DOMAIN)) == 0
 
 
 @respx.mock
@@ -159,10 +162,10 @@ async def test_setup_get(hass: HomeAssistant) -> None:
     respx.get("http://localhost").respond(status_code=HTTPStatus.OK, json={})
     assert await async_setup_component(
         hass,
-        "binary_sensor",
+        BINARY_SENSOR_DOMAIN,
         {
-            "binary_sensor": {
-                "platform": "rest",
+            BINARY_SENSOR_DOMAIN: {
+                "platform": DOMAIN,
                 "resource": "http://localhost",
                 "method": "GET",
                 "value_template": "{{ value_json.key }}",
@@ -179,7 +182,7 @@ async def test_setup_get(hass: HomeAssistant) -> None:
     )
 
     await hass.async_block_till_done()
-    assert len(hass.states.async_all("binary_sensor")) == 1
+    assert len(hass.states.async_all(BINARY_SENSOR_DOMAIN)) == 1
 
     state = hass.states.get("binary_sensor.foo")
     assert state.state == STATE_OFF
@@ -195,7 +198,7 @@ async def test_setup_get_template_headers_params(hass: HomeAssistant) -> None:
         "sensor",
         {
             "sensor": {
-                "platform": "rest",
+                "platform": DOMAIN,
                 "resource": "http://localhost",
                 "method": "GET",
                 "value_template": "{{ value_json.key }}",
@@ -227,10 +230,10 @@ async def test_setup_get_digest_auth(hass: HomeAssistant) -> None:
     respx.get("http://localhost").respond(status_code=HTTPStatus.OK, json={})
     assert await async_setup_component(
         hass,
-        "binary_sensor",
+        BINARY_SENSOR_DOMAIN,
         {
-            "binary_sensor": {
-                "platform": "rest",
+            BINARY_SENSOR_DOMAIN: {
+                "platform": DOMAIN,
                 "resource": "http://localhost",
                 "method": "GET",
                 "value_template": "{{ value_json.key }}",
@@ -246,7 +249,7 @@ async def test_setup_get_digest_auth(hass: HomeAssistant) -> None:
     )
 
     await hass.async_block_till_done()
-    assert len(hass.states.async_all("binary_sensor")) == 1
+    assert len(hass.states.async_all(BINARY_SENSOR_DOMAIN)) == 1
 
 
 @respx.mock
@@ -255,10 +258,10 @@ async def test_setup_post(hass: HomeAssistant) -> None:
     respx.post("http://localhost").respond(status_code=HTTPStatus.OK, json={})
     assert await async_setup_component(
         hass,
-        "binary_sensor",
+        BINARY_SENSOR_DOMAIN,
         {
-            "binary_sensor": {
-                "platform": "rest",
+            BINARY_SENSOR_DOMAIN: {
+                "platform": DOMAIN,
                 "resource": "http://localhost",
                 "method": "POST",
                 "value_template": "{{ value_json.key }}",
@@ -274,7 +277,7 @@ async def test_setup_post(hass: HomeAssistant) -> None:
         },
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all("binary_sensor")) == 1
+    assert len(hass.states.async_all(BINARY_SENSOR_DOMAIN)) == 1
 
 
 @respx.mock
@@ -287,10 +290,10 @@ async def test_setup_get_off(hass: HomeAssistant) -> None:
     )
     assert await async_setup_component(
         hass,
-        "binary_sensor",
+        BINARY_SENSOR_DOMAIN,
         {
-            "binary_sensor": {
-                "platform": "rest",
+            BINARY_SENSOR_DOMAIN: {
+                "platform": DOMAIN,
                 "resource": "http://localhost",
                 "method": "GET",
                 "value_template": "{{ value_json.dog }}",
@@ -301,7 +304,7 @@ async def test_setup_get_off(hass: HomeAssistant) -> None:
         },
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all("binary_sensor")) == 1
+    assert len(hass.states.async_all(BINARY_SENSOR_DOMAIN)) == 1
 
     state = hass.states.get("binary_sensor.foo")
     assert state.state == STATE_OFF
@@ -317,10 +320,10 @@ async def test_setup_get_on(hass: HomeAssistant) -> None:
     )
     assert await async_setup_component(
         hass,
-        "binary_sensor",
+        BINARY_SENSOR_DOMAIN,
         {
-            "binary_sensor": {
-                "platform": "rest",
+            BINARY_SENSOR_DOMAIN: {
+                "platform": DOMAIN,
                 "resource": "http://localhost",
                 "method": "GET",
                 "value_template": "{{ value_json.dog }}",
@@ -331,7 +334,7 @@ async def test_setup_get_on(hass: HomeAssistant) -> None:
         },
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all("binary_sensor")) == 1
+    assert len(hass.states.async_all(BINARY_SENSOR_DOMAIN)) == 1
 
     state = hass.states.get("binary_sensor.foo")
     assert state.state == STATE_ON
@@ -343,10 +346,10 @@ async def test_setup_with_exception(hass: HomeAssistant) -> None:
     respx.get("http://localhost").respond(status_code=HTTPStatus.OK, json={})
     assert await async_setup_component(
         hass,
-        "binary_sensor",
+        BINARY_SENSOR_DOMAIN,
         {
-            "binary_sensor": {
-                "platform": "rest",
+            BINARY_SENSOR_DOMAIN: {
+                "platform": DOMAIN,
                 "resource": "http://localhost",
                 "method": "GET",
                 "value_template": "{{ value_json.dog }}",
@@ -357,7 +360,7 @@ async def test_setup_with_exception(hass: HomeAssistant) -> None:
         },
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all("binary_sensor")) == 1
+    assert len(hass.states.async_all(BINARY_SENSOR_DOMAIN)) == 1
 
     state = hass.states.get("binary_sensor.foo")
     assert state.state == STATE_OFF
@@ -387,10 +390,10 @@ async def test_reload(hass: HomeAssistant) -> None:
 
     await async_setup_component(
         hass,
-        "binary_sensor",
+        BINARY_SENSOR_DOMAIN,
         {
-            "binary_sensor": {
-                "platform": "rest",
+            BINARY_SENSOR_DOMAIN: {
+                "platform": DOMAIN,
                 "method": "GET",
                 "name": "mockrest",
                 "resource": "http://localhost",
@@ -401,14 +404,14 @@ async def test_reload(hass: HomeAssistant) -> None:
     await hass.async_start()
     await hass.async_block_till_done()
 
-    assert len(hass.states.async_all("binary_sensor")) == 1
+    assert len(hass.states.async_all(BINARY_SENSOR_DOMAIN)) == 1
 
     assert hass.states.get("binary_sensor.mockrest")
 
-    yaml_path = get_fixture_path("configuration.yaml", "rest")
+    yaml_path = get_fixture_path("configuration.yaml", DOMAIN)
     with patch.object(hass_config, "YAML_CONFIG_FILE", yaml_path):
         await hass.services.async_call(
-            "rest",
+            DOMAIN,
             SERVICE_RELOAD,
             {},
             blocking=True,
@@ -425,10 +428,10 @@ async def test_setup_query_params(hass: HomeAssistant) -> None:
     respx.get("http://localhost", params={"search": "something"}) % HTTPStatus.OK
     assert await async_setup_component(
         hass,
-        Platform.BINARY_SENSOR,
+        BINARY_SENSOR_DOMAIN,
         {
-            "binary_sensor": {
-                "platform": "rest",
+            BINARY_SENSOR_DOMAIN: {
+                "platform": DOMAIN,
                 "resource": "http://localhost",
                 "method": "GET",
                 "params": {"search": "something"},
@@ -436,7 +439,7 @@ async def test_setup_query_params(hass: HomeAssistant) -> None:
         },
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all("binary_sensor")) == 1
+    assert len(hass.states.async_all(BINARY_SENSOR_DOMAIN)) == 1
 
 
 @respx.mock
@@ -444,9 +447,9 @@ async def test_entity_config(hass: HomeAssistant) -> None:
     """Test entity configuration."""
 
     config = {
-        Platform.BINARY_SENSOR: {
+        BINARY_SENSOR_DOMAIN: {
             # REST configuration
-            "platform": "rest",
+            "platform": DOMAIN,
             "method": "GET",
             "resource": "http://localhost",
             # Entity configuration
@@ -458,7 +461,7 @@ async def test_entity_config(hass: HomeAssistant) -> None:
     }
 
     respx.get("http://localhost") % HTTPStatus.OK
-    assert await async_setup_component(hass, Platform.BINARY_SENSOR, config)
+    assert await async_setup_component(hass, BINARY_SENSOR_DOMAIN, config)
     await hass.async_block_till_done()
 
     entity_registry = er.async_get(hass)

--- a/tests/components/rest/test_switch.py
+++ b/tests/components/rest/test_switch.py
@@ -437,7 +437,7 @@ async def test_entity_config(
     config = {
         SWITCH_DOMAIN: {
             # REST configuration
-            CONF_PLATFORM: "rest",
+            CONF_PLATFORM: DOMAIN,
             CONF_METHOD: "POST",
             CONF_RESOURCE: "http://localhost",
             # Entity configuration


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Simply adjust existing use of constants in rest test, and use them in more places.
Linked to #90763

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
