### PR TITLE
Allow setting an entity's name by its device class

### DIFF
--- a/homeassistant/components/aranet/sensor.py
+++ b/homeassistant/components/aranet/sensor.py
@@ -107,6 +107,9 @@ def sensor_update_to_bluetooth_data_update(
     """Convert a sensor update to a Bluetooth data update."""
     entity_names: dict[PassiveBluetoothEntityKey, str | None] = {}
     for key, desc in SENSOR_DESCRIPTIONS.items():
+        # PassiveBluetoothDataUpdate does not support DEVICE_CLASS_NAME
+        # the assert satisfies the type checker and will catch attempts
+        # to use DEVICE_CLASS_NAME in the entity descriptions.
         assert desc.name is not DEVICE_CLASS_NAME
         entity_names[_device_key_to_bluetooth_entity_key(adv.device, key)] = desc.name
     return PassiveBluetoothDataUpdate(

--- a/homeassistant/components/aranet/sensor.py
+++ b/homeassistant/components/aranet/sensor.py
@@ -28,7 +28,7 @@ from homeassistant.const import (
     UnitOfTime,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity import DEVICE_CLASS_NAME, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
@@ -105,6 +105,10 @@ def sensor_update_to_bluetooth_data_update(
     adv: Aranet4Advertisement,
 ) -> PassiveBluetoothDataUpdate:
     """Convert a sensor update to a Bluetooth data update."""
+    entity_names: dict[PassiveBluetoothEntityKey, str | None] = {}
+    for key, desc in SENSOR_DESCRIPTIONS.items():
+        assert desc.name is not DEVICE_CLASS_NAME
+        entity_names[_device_key_to_bluetooth_entity_key(adv.device, key)] = desc.name
     return PassiveBluetoothDataUpdate(
         devices={adv.device.address: _sensor_device_info_to_hass(adv)},
         entity_descriptions={
@@ -117,10 +121,7 @@ def sensor_update_to_bluetooth_data_update(
             )
             for key in SENSOR_DESCRIPTIONS
         },
-        entity_names={
-            _device_key_to_bluetooth_entity_key(adv.device, key): desc.name
-            for key, desc in SENSOR_DESCRIPTIONS.items()
-        },
+        entity_names=entity_names,
     )
 
 

--- a/homeassistant/components/balboa/entity.py
+++ b/homeassistant/components/balboa/entity.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from pybalboa import EVENT_UPDATE, SpaClient
 
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
-from homeassistant.helpers.entity import DeviceInfo, Entity
+from homeassistant.helpers.entity import DeviceClassName, DeviceInfo, Entity
 
 from .const import DOMAIN
 
@@ -12,7 +12,9 @@ from .const import DOMAIN
 class BalboaBaseEntity(Entity):
     """Balboa base entity."""
 
-    def __init__(self, client: SpaClient, name: str | None = None) -> None:
+    def __init__(
+        self, client: SpaClient, name: str | DeviceClassName | None = None
+    ) -> None:
         """Initialize the control."""
         mac = client.mac_address
         model = client.model

--- a/homeassistant/components/bond/button.py
+++ b/homeassistant/components/bond/button.py
@@ -35,6 +35,8 @@ class BondButtonEntityDescription(
 ):
     """Class to describe a Bond Button entity."""
 
+    name: str | None = None
+
 
 STOP_BUTTON = BondButtonEntityDescription(
     key=Action.STOP,

--- a/homeassistant/components/bond/button.py
+++ b/homeassistant/components/bond/button.py
@@ -35,6 +35,9 @@ class BondButtonEntityDescription(
 ):
     """Class to describe a Bond Button entity."""
 
+    # BondEntity does not support DEVICE_CLASS_NAME
+    # Restrict the type to satisfy the type checker and catch attempts
+    # to use DEVICE_CLASS_NAME in the entity descriptions.
     name: str | None = None
 
 

--- a/homeassistant/components/brunt/cover.py
+++ b/homeassistant/components/brunt/cover.py
@@ -88,7 +88,7 @@ class BruntDevice(
         self._attr_attribution = ATTRIBUTION
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._attr_unique_id)},  # type: ignore[arg-type]
-            name=self._attr_name,
+            name=self._thing.name,
             via_device=(DOMAIN, self._entry_id),
             manufacturer="Brunt",
             sw_version=self._thing.fw_version,

--- a/homeassistant/components/freebox/home_base.py
+++ b/homeassistant/components/freebox/home_base.py
@@ -30,8 +30,8 @@ class FreeboxHomeEntity(Entity):
         self._node = node
         self._sub_node = sub_node
         self._id = node["id"]
-        self._attr_name = node["label"].strip()
-        self._device_name = self._attr_name
+        self._device_name = node["label"].strip()
+        self._attr_name = self._device_name
         self._attr_unique_id = f"{self._router.mac}-node_{self._id}"
 
         if sub_node is not None:

--- a/homeassistant/components/incomfort/sensor.py
+++ b/homeassistant/components/incomfort/sensor.py
@@ -28,6 +28,7 @@ class IncomfortSensorEntityDescription(SensorEntityDescription):
     """Describes Incomfort sensor entity."""
 
     extra_key: str | None = None
+    name: str | None = None
 
 
 SENSOR_TYPES: tuple[IncomfortSensorEntityDescription, ...] = (

--- a/homeassistant/components/incomfort/sensor.py
+++ b/homeassistant/components/incomfort/sensor.py
@@ -28,6 +28,9 @@ class IncomfortSensorEntityDescription(SensorEntityDescription):
     """Describes Incomfort sensor entity."""
 
     extra_key: str | None = None
+    # IncomfortSensor does not support DEVICE_CLASS_NAME
+    # Restrict the type to satisfy the type checker and catch attempts
+    # to use DEVICE_CLASS_NAME in the entity descriptions.
     name: str | None = None
 
 

--- a/homeassistant/components/modbus/binary_sensor.py
+++ b/homeassistant/components/modbus/binary_sensor.py
@@ -14,6 +14,7 @@ from homeassistant.const import (
     STATE_ON,
 )
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity import DEVICE_CLASS_NAME
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
@@ -73,6 +74,7 @@ class ModbusBinarySensor(BasePlatform, RestoreEntity, BinarySensorEntity):
         # this ensures that idx = bit position of value in result
         # polling is done with the base class
         name = self._attr_name if self._attr_name else "modbus_sensor"
+        assert name is not DEVICE_CLASS_NAME
         self._coordinator = DataUpdateCoordinator(
             hass,
             _LOGGER,

--- a/homeassistant/components/modbus/binary_sensor.py
+++ b/homeassistant/components/modbus/binary_sensor.py
@@ -74,6 +74,10 @@ class ModbusBinarySensor(BasePlatform, RestoreEntity, BinarySensorEntity):
         # this ensures that idx = bit position of value in result
         # polling is done with the base class
         name = self._attr_name if self._attr_name else "modbus_sensor"
+
+        # DataUpdateCoordinator does not support DEVICE_CLASS_NAME
+        # the assert satisfies the type checker and will catch attempts
+        # to use DEVICE_CLASS_NAME in _attr_name.
         assert name is not DEVICE_CLASS_NAME
         self._coordinator = DataUpdateCoordinator(
             hass,

--- a/homeassistant/components/modbus/sensor.py
+++ b/homeassistant/components/modbus/sensor.py
@@ -17,6 +17,7 @@ from homeassistant.const import (
     CONF_UNIT_OF_MEASUREMENT,
 )
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity import DEVICE_CLASS_NAME
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.helpers.update_coordinator import (
@@ -79,6 +80,7 @@ class ModbusRegisterSensor(BaseStructPlatform, RestoreSensor, SensorEntity):
         # this ensures that idx = bit position of value in result
         # polling is done with the base class
         name = self._attr_name if self._attr_name else "modbus_sensor"
+        assert name is not DEVICE_CLASS_NAME
         self._coordinator = DataUpdateCoordinator(
             hass,
             _LOGGER,

--- a/homeassistant/components/modbus/sensor.py
+++ b/homeassistant/components/modbus/sensor.py
@@ -80,6 +80,10 @@ class ModbusRegisterSensor(BaseStructPlatform, RestoreSensor, SensorEntity):
         # this ensures that idx = bit position of value in result
         # polling is done with the base class
         name = self._attr_name if self._attr_name else "modbus_sensor"
+
+        # DataUpdateCoordinator does not support DEVICE_CLASS_NAME
+        # the assert satisfies the type checker and will catch attempts
+        # to use DEVICE_CLASS_NAME in _attr_name.
         assert name is not DEVICE_CLASS_NAME
         self._coordinator = DataUpdateCoordinator(
             hass,

--- a/homeassistant/components/point/alarm_control_panel.py
+++ b/homeassistant/components/point/alarm_control_panel.py
@@ -67,7 +67,7 @@ class MinutPointAlarmControl(AlarmControlPanelEntity):
         self._attr_device_info = DeviceInfo(
             identifiers={(POINT_DOMAIN, home_id)},
             manufacturer="Minut",
-            name=self._attr_name,
+            name=self._home["name"],
         )
 
     async def async_added_to_hass(self) -> None:

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -19,6 +19,7 @@ from homeassistant.helpers.device_registry import (
     async_get as dr_async_get,
     format_mac,
 )
+from homeassistant.helpers.entity import DEVICE_CLASS_NAME, DeviceClassName
 from homeassistant.helpers.entity_registry import async_get as er_async_get
 from homeassistant.helpers.typing import EventType
 from homeassistant.util.dt import utcnow
@@ -72,12 +73,13 @@ def get_number_of_channels(device: BlockDevice, block: Block) -> int:
 def get_block_entity_name(
     device: BlockDevice,
     block: Block | None,
-    description: str | None = None,
+    description: str | DeviceClassName | None = None,
 ) -> str:
     """Naming for block based switch and sensors."""
     channel_name = get_block_channel_name(device, block)
 
     if description:
+        assert description is not DEVICE_CLASS_NAME
         return f"{channel_name} {description.lower()}"
 
     return channel_name
@@ -301,12 +303,13 @@ def get_rpc_channel_name(device: RpcDevice, key: str) -> str:
 
 
 def get_rpc_entity_name(
-    device: RpcDevice, key: str, description: str | None = None
+    device: RpcDevice, key: str, description: str | DeviceClassName | None = None
 ) -> str:
     """Naming for RPC based switch and sensors."""
     channel_name = get_rpc_channel_name(device, key)
 
     if description:
+        assert description is not DEVICE_CLASS_NAME
         return f"{channel_name} {description.lower()}"
 
     return channel_name

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -79,6 +79,9 @@ def get_block_entity_name(
     channel_name = get_block_channel_name(device, block)
 
     if description:
+        # It's not possible to do string manipulations on DEVICE_CLASS_NAME
+        # the assert satisfies the type checker and will catch attempts
+        # to use DEVICE_CLASS_NAME as description.
         assert description is not DEVICE_CLASS_NAME
         return f"{channel_name} {description.lower()}"
 
@@ -309,6 +312,9 @@ def get_rpc_entity_name(
     channel_name = get_rpc_channel_name(device, key)
 
     if description:
+        # It's not possible to do string manipulations on DEVICE_CLASS_NAME
+        # the assert satisfies the type checker and will catch attempts
+        # to use DEVICE_CLASS_NAME as description.
         assert description is not DEVICE_CLASS_NAME
         return f"{channel_name} {description.lower()}"
 

--- a/homeassistant/components/system_bridge/__init__.py
+++ b/homeassistant/components/system_bridge/__init__.py
@@ -286,6 +286,9 @@ class SystemBridgeEntity(CoordinatorEntity[SystemBridgeDataUpdateCoordinator]):
 
         self._hostname = coordinator.data.system.hostname
         self._key = f"{self._hostname}_{key}"
+        # It's not possible to do string manipulations on DEVICE_CLASS_NAME
+        # the assert satisfies the type checker and will catch attempts
+        # to use DEVICE_CLASS_NAME as name.
         assert name is not DEVICE_CLASS_NAME
         self._name = f"{self._hostname} {name}"
         self._configuration_url = (

--- a/homeassistant/components/system_bridge/__init__.py
+++ b/homeassistant/components/system_bridge/__init__.py
@@ -30,7 +30,7 @@ from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity import DEVICE_CLASS_NAME, DeviceClassName, DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, MODULES
@@ -279,13 +279,14 @@ class SystemBridgeEntity(CoordinatorEntity[SystemBridgeDataUpdateCoordinator]):
         coordinator: SystemBridgeDataUpdateCoordinator,
         api_port: int,
         key: str,
-        name: str | None,
+        name: str | DeviceClassName | None,
     ) -> None:
         """Initialize the System Bridge entity."""
         super().__init__(coordinator)
 
         self._hostname = coordinator.data.system.hostname
         self._key = f"{self._hostname}_{key}"
+        assert name is not DEVICE_CLASS_NAME
         self._name = f"{self._hostname} {name}"
         self._configuration_url = (
             f"http://{self._hostname}:{api_port}/app/settings.html"

--- a/homeassistant/components/tomorrowio/sensor.py
+++ b/homeassistant/components/tomorrowio/sensor.py
@@ -350,6 +350,9 @@ class BaseTomorrowioSensorEntity(TomorrowioEntity, SensorEntity):
         """Initialize Tomorrow.io Sensor Entity."""
         super().__init__(config_entry, coordinator, api_version)
         self.entity_description = description
+        # It's not possible to do string manipulations on DEVICE_CLASS_NAME
+        # the assert satisfies the type checker and will catch attempts
+        # to use DEVICE_CLASS_NAME in the entity descriptions.
         assert description.name is not DEVICE_CLASS_NAME
         self._attr_name = f"{self._config_entry.data[CONF_NAME]} - {description.name}"
         self._attr_unique_id = (

--- a/homeassistant/components/tomorrowio/sensor.py
+++ b/homeassistant/components/tomorrowio/sensor.py
@@ -32,6 +32,7 @@ from homeassistant.const import (
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DEVICE_CLASS_NAME
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util import slugify
 from homeassistant.util.unit_conversion import DistanceConverter, SpeedConverter
@@ -349,6 +350,7 @@ class BaseTomorrowioSensorEntity(TomorrowioEntity, SensorEntity):
         """Initialize Tomorrow.io Sensor Entity."""
         super().__init__(config_entry, coordinator, api_version)
         self.entity_description = description
+        assert description.name is not DEVICE_CLASS_NAME
         self._attr_name = f"{self._config_entry.data[CONF_NAME]} - {description.name}"
         self._attr_unique_id = (
             f"{self._config_entry.unique_id}_{slugify(description.name)}"

--- a/homeassistant/components/unifiprotect/entity.py
+++ b/homeassistant/components/unifiprotect/entity.py
@@ -204,6 +204,9 @@ class ProtectDeviceEntity(Entity):
             self.entity_description = description
             self._attr_unique_id = f"{self.device.mac}_{description.key}"
             name = description.name or ""
+            # It's not possible to do string manipulations on DEVICE_CLASS_NAME
+            # the assert satisfies the type checker and will catch attempts
+            # to use DEVICE_CLASS_NAME in the entity descriptions.
             assert name is not DEVICE_CLASS_NAME
             self._attr_name = f"{self.device.display_name} {name.title()}"
 

--- a/homeassistant/components/unifiprotect/entity.py
+++ b/homeassistant/components/unifiprotect/entity.py
@@ -22,7 +22,12 @@ from pyunifiprotect.data import (
 
 from homeassistant.core import callback
 import homeassistant.helpers.device_registry as dr
-from homeassistant.helpers.entity import DeviceInfo, Entity, EntityDescription
+from homeassistant.helpers.entity import (
+    DEVICE_CLASS_NAME,
+    DeviceInfo,
+    Entity,
+    EntityDescription,
+)
 
 from .const import (
     ATTR_EVENT_ID,
@@ -199,6 +204,7 @@ class ProtectDeviceEntity(Entity):
             self.entity_description = description
             self._attr_unique_id = f"{self.device.mac}_{description.key}"
             name = description.name or ""
+            assert name is not DEVICE_CLASS_NAME
             self._attr_name = f"{self.device.display_name} {name.title()}"
 
         self._attr_attribution = DEFAULT_ATTRIBUTION

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -131,6 +131,8 @@ async def async_setup_entry(
 class VizioDevice(MediaPlayerEntity):
     """Media Player implementation which performs REST requests to device."""
 
+    _attr_name: str
+
     def __init__(
         self,
         config_entry: ConfigEntry,

--- a/homeassistant/components/wemo/sensor.py
+++ b/homeassistant/components/wemo/sensor.py
@@ -28,6 +28,7 @@ from .wemo_device import DeviceCoordinator
 class AttributeSensorDescription(SensorEntityDescription):
     """SensorEntityDescription for WeMo AttributeSensor entities."""
 
+    name: str | None = None
     state_conversion: Callable[[StateType], StateType] | None = None
     unique_id_suffix: str | None = None
 

--- a/homeassistant/components/wemo/sensor.py
+++ b/homeassistant/components/wemo/sensor.py
@@ -28,6 +28,9 @@ from .wemo_device import DeviceCoordinator
 class AttributeSensorDescription(SensorEntityDescription):
     """SensorEntityDescription for WeMo AttributeSensor entities."""
 
+    # AttributeSensor does not support DEVICE_CLASS_NAME
+    # the assert satisfies the type checker and will catch attempts
+    # to use DEVICE_CLASS_NAME in the entity descriptions.
     name: str | None = None
     state_conversion: Callable[[StateType], StateType] | None = None
     unique_id_suffix: str | None = None

--- a/homeassistant/components/zwave_js/entity.py
+++ b/homeassistant/components/zwave_js/entity.py
@@ -136,6 +136,9 @@ class ZWaveBaseEntity(Entity):
             and self.entity_description
             and self.entity_description.name
         ):
+            # It's not possible to do string manipulations on DEVICE_CLASS_NAME
+            # the assert satisfies the type checker and will catch attempts
+            # to use DEVICE_CLASS_NAME in the entity descriptions.
             assert self.entity_description.name is not DEVICE_CLASS_NAME
             name = self.entity_description.name
 

--- a/homeassistant/components/zwave_js/entity.py
+++ b/homeassistant/components/zwave_js/entity.py
@@ -8,7 +8,7 @@ from zwave_js_server.model.value import Value as ZwaveValue, get_value_id_str
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.entity import DeviceInfo, Entity
+from homeassistant.helpers.entity import DEVICE_CLASS_NAME, DeviceInfo, Entity
 
 from .const import DOMAIN, LOGGER
 from .discovery import ZwaveDiscoveryInfo
@@ -136,6 +136,7 @@ class ZWaveBaseEntity(Entity):
             and self.entity_description
             and self.entity_description.name
         ):
+            assert self.entity_description.name is not DEVICE_CLASS_NAME
             name = self.entity_description.name
 
         if name_prefix:

--- a/homeassistant/components/zwave_me/__init__.py
+++ b/homeassistant/components/zwave_me/__init__.py
@@ -115,7 +115,7 @@ async def async_setup_platforms(
 class ZWaveMeEntity(Entity):
     """Representation of a ZWaveMe device."""
 
-    def __init__(self, controller, device):
+    def __init__(self, controller: ZWaveMeController, device: ZWaveMeData) -> None:
         """Initialize the device."""
         self.controller = controller
         self.device = device
@@ -124,13 +124,9 @@ class ZWaveMeEntity(Entity):
             f"{self.controller.config.unique_id}-{self.device.id}"
         )
         self._attr_should_poll = False
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return device specific attributes."""
-        return DeviceInfo(
+        self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self.device.deviceIdentifier)},
-            name=self._attr_name,
+            name=device.title,
             manufacturer=self.device.manufacturer,
             sw_version=self.device.firmware,
             suggested_area=self.device.locationName,

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -52,6 +52,16 @@ DATA_ENTITY_SOURCE = "entity_info"
 SOURCE_CONFIG_ENTRY = "config_entry"
 SOURCE_PLATFORM_CONFIG = "platform_config"
 
+
+class DeviceClassName(Enum):
+    """Singleton to use device class name."""
+
+    _singleton = 0
+
+
+DEVICE_CLASS_NAME = DeviceClassName._singleton  # pylint: disable=protected-access
+
+
 # Used when converting float states to string: limit precision according to machine
 # epsilon to make the string representation readable
 FLOAT_PRECISION = abs(int(math.floor(math.log10(abs(sys.float_info.epsilon))))) - 1
@@ -219,7 +229,7 @@ class EntityDescription:
     force_update: bool = False
     icon: str | None = None
     has_entity_name: bool = False
-    name: str | None = None
+    name: str | DeviceClassName | None = None
     translation_key: str | None = None
     unit_of_measurement: str | None = None
 
@@ -288,7 +298,7 @@ class Entity(ABC):
     _attr_extra_state_attributes: MutableMapping[str, Any]
     _attr_force_update: bool
     _attr_icon: str | None
-    _attr_name: str | None
+    _attr_name: str | DeviceClassName | None
     _attr_should_poll: bool = True
     _attr_state: StateType = STATE_UNKNOWN
     _attr_supported_features: int | None = None
@@ -318,10 +328,24 @@ class Entity(ABC):
             return self.entity_description.has_entity_name
         return False
 
+    def _device_class_name(self) -> str | None:
+        """Return a translated name of the entity based on its device class."""
+        assert self.platform
+        if not self.has_entity_name:
+            return None
+        device_class_key = self.device_class or "_"
+        name_translation_key = (
+            f"component.{self.platform.domain}.entity_component."
+            f"{device_class_key}.name"
+        )
+        return self.platform.component_translations.get(name_translation_key)
+
     @property
     def name(self) -> str | None:
         """Return the name of the entity."""
         if hasattr(self, "_attr_name"):
+            if self._attr_name is DEVICE_CLASS_NAME:
+                return self._device_class_name()
             return self._attr_name
         if self.translation_key is not None and self.has_entity_name:
             assert self.platform
@@ -329,10 +353,12 @@ class Entity(ABC):
                 f"component.{self.platform.platform_name}.entity.{self.platform.domain}"
                 f".{self.translation_key}.name"
             )
-            if name_translation_key in self.platform.entity_translations:
-                name: str = self.platform.entity_translations[name_translation_key]
+            if name_translation_key in self.platform.platform_translations:
+                name: str = self.platform.platform_translations[name_translation_key]
                 return name
         if hasattr(self, "entity_description"):
+            if self.entity_description.name is DEVICE_CLASS_NAME:
+                return self._device_class_name()
             return self.entity_description.name
         return None
 

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -125,7 +125,8 @@ class EntityPlatform:
         self.entity_namespace = entity_namespace
         self.config_entry: config_entries.ConfigEntry | None = None
         self.entities: dict[str, Entity] = {}
-        self.entity_translations: dict[str, Any] = {}
+        self.component_translations: dict[str, Any] = {}
+        self.platform_translations: dict[str, Any] = {}
         self._tasks: list[asyncio.Task[None]] = []
         # Stop tracking tasks after setup is completed
         self._setup_complete = False
@@ -279,7 +280,15 @@ class EntityPlatform:
         full_name = f"{self.domain}.{self.platform_name}"
 
         try:
-            self.entity_translations = await translation.async_get_translations(
+            self.component_translations = await translation.async_get_translations(
+                hass, hass.config.language, "entity_component", {self.domain}
+            )
+        except Exception as err:  # pylint: disable=broad-exception-caught
+            _LOGGER.debug(
+                "Could not load translations for %s", self.domain, exc_info=err
+            )
+        try:
+            self.platform_translations = await translation.async_get_translations(
                 hass, hass.config.language, "entity", {self.platform_name}
             )
         except Exception as err:  # pylint: disable=broad-exception-caught

--- a/homeassistant/helpers/template_entity.py
+++ b/homeassistant/helpers/template_entity.py
@@ -171,6 +171,8 @@ class _TemplateAttribute:
 class TemplateEntity(Entity):
     """Entity that uses templates to calculate attributes."""
 
+    _attr_name: str
+
     _attr_available = True
     _attr_entity_picture = None
     _attr_icon = None
@@ -222,7 +224,8 @@ class TemplateEntity(Entity):
         variables = {"this": DummyState()}
 
         # Try to render the name as it can influence the entity ID
-        self._attr_name = fallback_name
+        if fallback_name is not None:
+            self._attr_name = fallback_name
         if self._friendly_name_template:
             self._friendly_name_template.hass = hass
             with contextlib.suppress(TemplateError):

--- a/homeassistant/helpers/template_entity.py
+++ b/homeassistant/helpers/template_entity.py
@@ -171,7 +171,7 @@ class _TemplateAttribute:
 class TemplateEntity(Entity):
     """Entity that uses templates to calculate attributes."""
 
-    _attr_name: str
+    _attr_name: str | None
 
     _attr_available = True
     _attr_entity_picture = None
@@ -224,8 +224,7 @@ class TemplateEntity(Entity):
         variables = {"this": DummyState()}
 
         # Try to render the name as it can influence the entity ID
-        if fallback_name is not None:
-            self._attr_name = fallback_name
+        self._attr_name = fallback_name
         if self._friendly_name_template:
             self._friendly_name_template.hass = hass
             with contextlib.suppress(TemplateError):

--- a/tests/components/esphome/conftest.py
+++ b/tests/components/esphome/conftest.py
@@ -1,9 +1,10 @@
 """esphome session fixtures."""
 from __future__ import annotations
 
+from asyncio import Event
 from unittest.mock import AsyncMock, Mock, patch
 
-from aioesphomeapi import APIClient, APIVersion, DeviceInfo
+from aioesphomeapi import APIClient, APIVersion, DeviceInfo, ReconnectLogic
 import pytest
 from zeroconf import Zeroconf
 
@@ -158,10 +159,18 @@ async def mock_voice_assistant_v1_entry(
     mock_client.device_info = AsyncMock(return_value=device_info)
     mock_client.subscribe_voice_assistant = AsyncMock(return_value=Mock())
 
-    await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
+    try_connect_done = Event()
+    real_try_connect = ReconnectLogic._try_connect
+
+    async def mock_try_connect(self):
+        """Set an event when ReconnectLogic._try_connect has been awaited."""
+        result = await real_try_connect(self)
+        try_connect_done.set()
+        return result
+
+    with patch.object(ReconnectLogic, "_try_connect", mock_try_connect):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await try_connect_done.wait()
 
     return entry
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow setting an entity's name automatically by its device class by setting `Entity._attr_name` or `EntityDescription.name` to `DEVICE_CLASS_NAME`.
The name is looked up in the entity component's translations by `Entity.name`.

The purpose is to make it easier to use translated device class names to name entities since there's no longer a need to set a `translation_key` and reference the entity component's name in `strings.json`.

It's a somewhat common pattern for integrations to use `Entity._attr_name` or `EntityDescription.name` not as input to `Entity.name` but for other purposes. To make those cases pass type checking, they've in most cases been fixed by adding `assert name is not DEVICE_CLASS_NAME`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
