### PR TITLE
Extract Supla base entity into its own file

### DIFF
--- a/homeassistant/components/supla/__init__.py
+++ b/homeassistant/components/supla/__init__.py
@@ -14,10 +14,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
-    DataUpdateCoordinator,
-)
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -155,58 +152,3 @@ async def discover_devices(hass, hass_config):
     # Load discovered devices
     for component_name, config in component_configs.items():
         await async_load_platform(hass, component_name, DOMAIN, config, hass_config)
-
-
-class SuplaChannel(CoordinatorEntity):
-    """Base class of a Supla Channel (an equivalent of HA's Entity)."""
-
-    def __init__(self, config, server, coordinator):
-        """Init from config, hookup[ server and coordinator."""
-        super().__init__(coordinator)
-        self.server_name = config["server_name"]
-        self.channel_id = config["channel_id"]
-        self.server = server
-
-    @property
-    def channel_data(self):
-        """Return channel data taken from coordinator."""
-        return self.coordinator.data.get(self.channel_id)
-
-    @property
-    def unique_id(self) -> str:
-        """Return a unique ID."""
-        return "supla-{}-{}".format(
-            self.channel_data["iodevice"]["gUIDString"].lower(),
-            self.channel_data["channelNumber"],
-        )
-
-    @property
-    def name(self) -> str | None:
-        """Return the name of the device."""
-        return self.channel_data["caption"]
-
-    @property
-    def available(self) -> bool:
-        """Return True if entity is available."""
-        if self.channel_data is None:
-            return False
-        if (state := self.channel_data.get("state")) is None:
-            return False
-        return state.get("connected")
-
-    async def async_action(self, action, **add_pars):
-        """Run server action.
-
-        Actions are currently hardcoded in components.
-        Supla's API enables autodiscovery
-        """
-        _LOGGER.debug(
-            "Executing action %s on channel %d, params: %s",
-            action,
-            self.channel_data["id"],
-            add_pars,
-        )
-        await self.server.execute_action(self.channel_data["id"], action, **add_pars)
-
-        # Update state
-        await self.coordinator.async_request_refresh()

--- a/homeassistant/components/supla/cover.py
+++ b/homeassistant/components/supla/cover.py
@@ -10,7 +10,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import DOMAIN, SUPLA_COORDINATORS, SUPLA_SERVERS, SuplaChannel
+from . import DOMAIN, SUPLA_COORDINATORS, SUPLA_SERVERS, SuplaEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -38,16 +38,16 @@ async def async_setup_platform(
 
         if device_name == SUPLA_SHUTTER:
             entities.append(
-                SuplaCover(
+                SuplaCoverEntity(
                     device,
                     hass.data[DOMAIN][SUPLA_SERVERS][server_name],
                     hass.data[DOMAIN][SUPLA_COORDINATORS][server_name],
                 )
             )
 
-        elif device_name in {SUPLA_GATE, SUPLA_GARAGE_DOOR}:
+        elif device_name == SUPLA_GATE or device_name == SUPLA_GARAGE_DOOR:
             entities.append(
-                SuplaDoor(
+                SuplaDoorEntity(
                     device,
                     hass.data[DOMAIN][SUPLA_SERVERS][server_name],
                     hass.data[DOMAIN][SUPLA_COORDINATORS][server_name],
@@ -57,7 +57,7 @@ async def async_setup_platform(
     async_add_entities(entities)
 
 
-class SuplaCover(SuplaChannel, CoverEntity):
+class SuplaCoverEntity(SuplaEntity, CoverEntity):
     """Representation of a Supla Cover."""
 
     @property
@@ -91,7 +91,7 @@ class SuplaCover(SuplaChannel, CoverEntity):
         await self.async_action("STOP")
 
 
-class SuplaDoor(SuplaChannel, CoverEntity):
+class SuplaDoorEntity(SuplaEntity, CoverEntity):
     """Representation of a Supla door."""
 
     @property

--- a/homeassistant/components/supla/cover.py
+++ b/homeassistant/components/supla/cover.py
@@ -10,7 +10,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import DOMAIN, SUPLA_COORDINATORS, SUPLA_SERVERS, SuplaEntity
+from . import DOMAIN, SUPLA_COORDINATORS, SUPLA_SERVERS
+from .entity import SuplaEntity
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/supla/cover.py
+++ b/homeassistant/components/supla/cover.py
@@ -46,7 +46,7 @@ async def async_setup_platform(
                 )
             )
 
-        elif device_name == SUPLA_GATE or device_name == SUPLA_GARAGE_DOOR:
+        elif device_name in {SUPLA_GATE, SUPLA_GARAGE_DOOR}:
             entities.append(
                 SuplaDoorEntity(
                     device,

--- a/homeassistant/components/supla/entity.py
+++ b/homeassistant/components/supla/entity.py
@@ -46,8 +46,7 @@ class SuplaEntity(CoordinatorEntity):
         return state.get("connected")
 
     async def async_action(self, action, **add_pars):
-        """
-        Run server action.
+        """Run server action.
 
         Actions are currently hardcoded in components.
         Supla's API enables autodiscovery

--- a/homeassistant/components/supla/entity.py
+++ b/homeassistant/components/supla/entity.py
@@ -7,6 +7,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 _LOGGER = logging.getLogger(__name__)
 
+
 class SuplaEntity(CoordinatorEntity):
     """Base class of a Supla Channel (an equivalent of HA's Entity)."""
 
@@ -45,7 +46,8 @@ class SuplaEntity(CoordinatorEntity):
         return state.get("connected")
 
     async def async_action(self, action, **add_pars):
-        """Run server action.
+        """
+        Run server action.
 
         Actions are currently hardcoded in components.
         Supla's API enables autodiscovery

--- a/homeassistant/components/supla/entity.py
+++ b/homeassistant/components/supla/entity.py
@@ -1,0 +1,62 @@
+"""Base class for Supla channels."""
+from __future__ import annotations
+
+import logging
+
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+class SuplaEntity(CoordinatorEntity):
+    """Base class of a Supla Channel (an equivalent of HA's Entity)."""
+
+    def __init__(self, config, server, coordinator):
+        """Init from config, hookup[ server and coordinator."""
+        super().__init__(coordinator)
+        self.server_name = config["server_name"]
+        self.channel_id = config["channel_id"]
+        self.server = server
+
+    @property
+    def channel_data(self):
+        """Return channel data taken from coordinator."""
+        return self.coordinator.data.get(self.channel_id)
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        return "supla-{}-{}".format(
+            self.channel_data["iodevice"]["gUIDString"].lower(),
+            self.channel_data["channelNumber"],
+        )
+
+    @property
+    def name(self) -> str | None:
+        """Return the name of the device."""
+        return self.channel_data["caption"]
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        if self.channel_data is None:
+            return False
+        if (state := self.channel_data.get("state")) is None:
+            return False
+        return state.get("connected")
+
+    async def async_action(self, action, **add_pars):
+        """Run server action.
+
+        Actions are currently hardcoded in components.
+        Supla's API enables autodiscovery
+        """
+        _LOGGER.debug(
+            "Executing action %s on channel %d, params: %s",
+            action,
+            self.channel_data["id"],
+            add_pars,
+        )
+        await self.server.execute_action(self.channel_data["id"], action, **add_pars)
+
+        # Update state
+        await self.coordinator.async_request_refresh()

--- a/homeassistant/components/supla/switch.py
+++ b/homeassistant/components/supla/switch.py
@@ -10,7 +10,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import DOMAIN, SUPLA_COORDINATORS, SUPLA_SERVERS, SuplaChannel
+from . import DOMAIN, SUPLA_COORDINATORS, SUPLA_SERVERS
+from .entity import SuplaEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -32,7 +33,7 @@ async def async_setup_platform(
         server_name = device["server_name"]
 
         entities.append(
-            SuplaSwitch(
+            SuplaSwitchEntity(
                 device,
                 hass.data[DOMAIN][SUPLA_SERVERS][server_name],
                 hass.data[DOMAIN][SUPLA_COORDINATORS][server_name],
@@ -42,7 +43,7 @@ async def async_setup_platform(
     async_add_entities(entities)
 
 
-class SuplaSwitch(SuplaChannel, SwitchEntity):
+class SuplaSwitchEntity(SuplaEntity, SwitchEntity):
     """Representation of a Supla Switch."""
 
     async def async_turn_on(self, **kwargs: Any) -> None:


### PR DESCRIPTION
## Proposed change 
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As suggested by this [comment](https://github.com/home-assistant/core/pull/90593#issuecomment-1494188592), base Supla entity is renamed and extracted into its own file.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
