### PR TITLE
Bump locationsharinglib to 5.0.0

### DIFF
--- a/homeassistant/components/google_maps/manifest.json
+++ b/homeassistant/components/google_maps/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "https://www.home-assistant.io/integrations/google_maps",
   "iot_class": "cloud_polling",
   "loggers": ["locationsharinglib"],
-  "requirements": ["locationsharinglib==4.1.5"]
+  "requirements": ["locationsharinglib==5.0.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1069,7 +1069,7 @@ limitlessled==1.1.3
 linode-api==4.1.9b1
 
 # homeassistant.components.google_maps
-locationsharinglib==4.1.5
+locationsharinglib==5.0.0
 
 # homeassistant.components.logi_circle
 logi_circle==0.2.3


### PR DESCRIPTION
## Proposed change
Update Google Maps component to use dependency `locationsharinglib` v5.0.0 as described [here](https://pypi.org/project/locationsharinglib/)
With this change, the author of the package removed the deprecated usage of pickle and added a different cookie validation flow.

Diff:
https://github.com/costastf/locationsharinglib/compare/4.1.5...5.0.0
```
4.1.6 (24-02-2021)
More verbose debug messages (courtesy of Dmitry Katsubo <[dmitry.katsubo@gmail.com](mailto:dmitry.katsubo%40gmail.com)>) and bumped dependencies.

4.1.7 (07-07-2021)
Bumped dependencies.

4.1.8 (07-07-2021)
Pinned Pipfile version to 3.7

4.1.9 (01-03-2023)
Implement default values for cookies.

4.2.0 (01-03-2023)
Expose more details.

5.0.0 (04-04-2023)
Implement better session validation heuristic, checking from cookies. Remove obsolete pickle cookie loading.
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
