### PR TITLE
Add config for Landis+Gyr power supply

### DIFF
--- a/homeassistant/components/landisgyr_heat_meter/__init__.py
+++ b/homeassistant/components/landisgyr_heat_meter/__init__.py
@@ -10,7 +10,7 @@ from homeassistant.const import CONF_DEVICE, Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_registry import async_migrate_entries
 
-from .const import DOMAIN
+from .const import CONF_BATTERY_POWERED, DOMAIN
 from .coordinator import UltraheatCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -25,7 +25,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     reader = ultraheat_api.UltraheatReader(entry.data[CONF_DEVICE])
     api = ultraheat_api.HeatMeterService(reader)
 
-    coordinator = UltraheatCoordinator(hass, api)
+    try:
+        battery_powered = entry.data[CONF_BATTERY_POWERED]
+    except KeyError:
+        # If the key is not present, we assume battery powered
+        battery_powered = True
+    coordinator = UltraheatCoordinator(hass, api, battery_powered)
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
 

--- a/homeassistant/components/landisgyr_heat_meter/const.py
+++ b/homeassistant/components/landisgyr_heat_meter/const.py
@@ -4,5 +4,10 @@ from datetime import timedelta
 
 DOMAIN = "landisgyr_heat_meter"
 
+CONF_BATTERY_POWERED = "battery_powered"
+
 ULTRAHEAT_TIMEOUT = 30  # reading the IR port can take some time
-POLLING_INTERVAL = timedelta(days=1)  # Polling is only daily to prevent battery drain.
+POLLING_INTERVAL_BATTERY = timedelta(
+    days=1
+)  # Polling is only daily to prevent battery drain.
+POLLING_INTERVAL_MAINS = timedelta(hours=1)

--- a/homeassistant/components/landisgyr_heat_meter/coordinator.py
+++ b/homeassistant/components/landisgyr_heat_meter/coordinator.py
@@ -10,7 +10,7 @@ from ultraheat_api.service import HeatMeterService
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import POLLING_INTERVAL, ULTRAHEAT_TIMEOUT
+from .const import POLLING_INTERVAL_BATTERY, POLLING_INTERVAL_MAINS, ULTRAHEAT_TIMEOUT
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -18,13 +18,18 @@ _LOGGER = logging.getLogger(__name__)
 class UltraheatCoordinator(DataUpdateCoordinator[HeatMeterResponse]):
     """Coordinator for getting data from the ultraheat api."""
 
-    def __init__(self, hass: HomeAssistant, api: HeatMeterService) -> None:
+    def __init__(
+        self, hass: HomeAssistant, api: HeatMeterService, battery_powered: bool
+    ) -> None:
         """Initialize my coordinator."""
+        polling_interval = (
+            POLLING_INTERVAL_BATTERY if battery_powered else POLLING_INTERVAL_MAINS
+        )
         super().__init__(
             hass,
             _LOGGER,
             name="ultraheat",
-            update_interval=POLLING_INTERVAL,
+            update_interval=polling_interval,
         )
         self.api = api
 

--- a/homeassistant/components/landisgyr_heat_meter/strings.json
+++ b/homeassistant/components/landisgyr_heat_meter/strings.json
@@ -10,6 +10,13 @@
         "data": {
           "device": "[%key:common::config_flow::data::usb_path%]"
         }
+      },
+      "battery_powered": {
+        "title": "Battery or mains",
+        "description": "If the Landis+Gyr is on batteries make sure this is checked and polling will be once daily. Only uncheck this if the device is mains powered and polling will be every hour. Polling can be further customized using automation, if required.",
+        "data": {
+          "battery_powered": "The Landis+Gyr Heat Meter is battery operated"
+        }
       }
     },
     "abort": {

--- a/tests/components/landisgyr_heat_meter/test_config_flow.py
+++ b/tests/components/landisgyr_heat_meter/test_config_flow.py
@@ -64,9 +64,18 @@ async def test_manual_entry(mock_heat_meter, hass: HomeAssistant) -> None:
         result["flow_id"], {"device": "/dev/ttyUSB0"}
     )
 
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "battery_powered"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"battery_powered": True}
+    )
+
     assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["title"] == "LUGCUH50"
     assert result["data"] == {
+        "battery_powered": True,
         "device": "/dev/ttyUSB0",
         "model": "LUGCUH50",
         "device_number": "123456789",
@@ -91,9 +100,19 @@ async def test_list_entry(mock_port, mock_heat_meter, hass: HomeAssistant) -> No
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"device": port.device}
     )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "battery_powered"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"battery_powered": False}
+    )
+
     assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["title"] == "LUGCUH50"
     assert result["data"] == {
+        "battery_powered": False,
         "device": port.device,
         "model": "LUGCUH50",
         "device_number": "123456789",
@@ -126,7 +145,15 @@ async def test_manual_entry_fail(mock_heat_meter, hass: HomeAssistant) -> None:
     )
 
     assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == "setup_serial_manual_path"
+    assert result["step_id"] == "battery_powered"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"battery_powered": False}
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "battery_powered"
     assert result["errors"] == {"base": "cannot_connect"}
 
 
@@ -148,8 +175,17 @@ async def test_list_entry_fail(mock_port, mock_heat_meter, hass: HomeAssistant) 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"device": port.device}
     )
+
     assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == "user"
+    assert result["step_id"] == "battery_powered"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"battery_powered": False}
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "battery_powered"
     assert result["errors"] == {"base": "cannot_connect"}
 
 
@@ -182,6 +218,14 @@ async def test_already_configured(
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"device": port.device}
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "battery_powered"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"battery_powered": False}
     )
 
     assert result["type"] == FlowResultType.ABORT

--- a/tests/components/landisgyr_heat_meter/test_sensor.py
+++ b/tests/components/landisgyr_heat_meter/test_sensor.py
@@ -8,7 +8,10 @@ from syrupy import SnapshotAssertion
 from ultraheat_api.response import HeatMeterResponse
 
 from homeassistant.components.homeassistant import DOMAIN as HA_DOMAIN
-from homeassistant.components.landisgyr_heat_meter.const import DOMAIN, POLLING_INTERVAL
+from homeassistant.components.landisgyr_heat_meter.const import (
+    DOMAIN,
+    POLLING_INTERVAL_BATTERY,
+)
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -148,18 +151,18 @@ async def test_exception_on_polling(mock_heat_meter, hass: HomeAssistant) -> Non
 
     # Now 'disable' the connection and wait for polling and see if it fails
     mock_heat_meter().read.side_effect = serial.serialutil.SerialException
-    async_fire_time_changed(hass, dt_util.utcnow() + POLLING_INTERVAL)
+    async_fire_time_changed(hass, dt_util.utcnow() + POLLING_INTERVAL_BATTERY)
     await hass.async_block_till_done()
     state = hass.states.get("sensor.heat_meter_heat_usage_gj")
     assert state.state == STATE_UNAVAILABLE
 
-    # # Now 'enable' and see if next poll succeeds
+    # Now 'enable' and see if next poll succeeds
     mock_heat_meter_response = HeatMeterResponse(**MOCK_RESPONSE_GJ)
     mock_heat_meter_response.heat_usage_gj += 1
 
     mock_heat_meter().read.return_value = mock_heat_meter_response
     mock_heat_meter().read.side_effect = None
-    async_fire_time_changed(hass, dt_util.utcnow() + POLLING_INTERVAL)
+    async_fire_time_changed(hass, dt_util.utcnow() + POLLING_INTERVAL_BATTERY)
     await hass.async_block_till_done()
     state = hass.states.get("sensor.heat_meter_heat_usage_gj")
     assert state


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Some Landis+Gyr devices are on mains power supply (as opposed to on battery). Users have requested to allow faster polling for these devices. This change will allow the user to choose the type of power supply the device is on. Note: this cannot be determined from the unit type.

I've not chosen for a migration of the config, since this is something the users has to choose explicitly on setup. Old installations will default to battery-polling, just like they did before.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/vpathuis/core/pull/2
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
