### PR TITLE
Improve type hints in calendar trigger tests

### DIFF
--- a/tests/components/calendar/test_trigger.py
+++ b/tests/components/calendar/test_trigger.py
@@ -53,7 +53,7 @@ TEST_UPDATE_INTERVAL = datetime.timedelta(minutes=7)
 class FakeSchedule:
     """Test fixture class for return events in a specific date range."""
 
-    def __init__(self, hass, freezer):
+    def __init__(self, hass: HomeAssistant, freezer: FrozenDateTimeFactory) -> None:
         """Initiailize FakeSchedule."""
         self.hass = hass
         self.freezer = freezer
@@ -62,8 +62,8 @@ class FakeSchedule:
 
     def create_event(
         self,
-        start: datetime.timedelta,
-        end: datetime.timedelta,
+        start: datetime.datetime,
+        end: datetime.datetime,
         summary: str | None = None,
         description: str | None = None,
         location: str | None = None,
@@ -103,7 +103,7 @@ class FakeSchedule:
         async_fire_time_changed(self.hass, trigger_time)
         await self.hass.async_block_till_done()
 
-    async def fire_until(self, end: datetime.timedelta) -> None:
+    async def fire_until(self, end: datetime.datetime) -> None:
         """Simulate the passage of time by firing alarms until the time is reached."""
 
         current_time = dt_util.as_utc(self.freezer())
@@ -120,7 +120,7 @@ class FakeSchedule:
 
 
 @pytest.fixture
-def set_time_zone(hass):
+def set_time_zone(hass: HomeAssistant) -> None:
     """Set the time zone for the tests."""
     # Set our timezone to CST/Regina so we can check calculations
     # This keeps UTC-6 all year round
@@ -128,7 +128,9 @@ def set_time_zone(hass):
 
 
 @pytest.fixture
-def fake_schedule(hass, freezer):
+def fake_schedule(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory
+) -> Generator[FakeSchedule, None, None]:
     """Fixture that tests can use to make fake events."""
 
     # Setup start time for all tests
@@ -173,11 +175,11 @@ async def create_automation(hass: HomeAssistant, event_type: str, offset=None) -
 
 
 @pytest.fixture
-def calls(hass: HomeAssistant) -> Callable[[], list]:
+def calls(hass: HomeAssistant) -> Callable[[], list[dict[str, Any]]]:
     """Fixture to return payload data for automation calls."""
     service_calls = async_mock_service(hass, "test", "automation")
 
-    def get_trigger_data() -> list:
+    def get_trigger_data() -> list[dict[str, Any]]:
         return [c.data for c in service_calls]
 
     return get_trigger_data
@@ -193,7 +195,11 @@ def mock_update_interval() -> Generator[None, None, None]:
         yield
 
 
-async def test_event_start_trigger(hass: HomeAssistant, calls, fake_schedule) -> None:
+async def test_event_start_trigger(
+    hass: HomeAssistant,
+    calls: Callable[[], list[dict[str, Any]]],
+    fake_schedule: FakeSchedule,
+) -> None:
     """Test the a calendar trigger based on start time."""
     event_data = fake_schedule.create_event(
         start=datetime.datetime.fromisoformat("2022-04-19 11:00:00+00:00"),
@@ -222,7 +228,11 @@ async def test_event_start_trigger(hass: HomeAssistant, calls, fake_schedule) ->
     ],
 )
 async def test_event_start_trigger_with_offset(
-    hass: HomeAssistant, calls, fake_schedule, offset_str, offset_delta
+    hass: HomeAssistant,
+    calls: Callable[[], list[dict[str, Any]]],
+    fake_schedule: FakeSchedule,
+    offset_str,
+    offset_delta,
 ) -> None:
     """Test the a calendar trigger based on start time with an offset."""
     event_data = fake_schedule.create_event(
@@ -250,7 +260,11 @@ async def test_event_start_trigger_with_offset(
     ]
 
 
-async def test_event_end_trigger(hass: HomeAssistant, calls, fake_schedule) -> None:
+async def test_event_end_trigger(
+    hass: HomeAssistant,
+    calls: Callable[[], list[dict[str, Any]]],
+    fake_schedule: FakeSchedule,
+) -> None:
     """Test the a calendar trigger based on end time."""
     event_data = fake_schedule.create_event(
         start=datetime.datetime.fromisoformat("2022-04-19 11:00:00+00:00"),
@@ -285,7 +299,11 @@ async def test_event_end_trigger(hass: HomeAssistant, calls, fake_schedule) -> N
     ],
 )
 async def test_event_end_trigger_with_offset(
-    hass: HomeAssistant, calls, fake_schedule, offset_str, offset_delta
+    hass: HomeAssistant,
+    calls: Callable[[], list[dict[str, Any]]],
+    fake_schedule: FakeSchedule,
+    offset_str,
+    offset_delta,
 ) -> None:
     """Test the a calendar trigger based on end time with an offset."""
     event_data = fake_schedule.create_event(
@@ -314,7 +332,9 @@ async def test_event_end_trigger_with_offset(
 
 
 async def test_calendar_trigger_with_no_events(
-    hass: HomeAssistant, calls, fake_schedule
+    hass: HomeAssistant,
+    calls: Callable[[], list[dict[str, Any]]],
+    fake_schedule: FakeSchedule,
 ) -> None:
     """Test a calendar trigger setup  with no events."""
 
@@ -328,7 +348,11 @@ async def test_calendar_trigger_with_no_events(
     assert len(calls()) == 0
 
 
-async def test_multiple_start_events(hass: HomeAssistant, calls, fake_schedule) -> None:
+async def test_multiple_start_events(
+    hass: HomeAssistant,
+    calls: Callable[[], list[dict[str, Any]]],
+    fake_schedule: FakeSchedule,
+) -> None:
     """Test that a trigger fires for multiple events."""
 
     event_data1 = fake_schedule.create_event(
@@ -358,7 +382,11 @@ async def test_multiple_start_events(hass: HomeAssistant, calls, fake_schedule) 
     ]
 
 
-async def test_multiple_end_events(hass: HomeAssistant, calls, fake_schedule) -> None:
+async def test_multiple_end_events(
+    hass: HomeAssistant,
+    calls: Callable[[], list[dict[str, Any]]],
+    fake_schedule: FakeSchedule,
+) -> None:
     """Test that a trigger fires for multiple events."""
 
     event_data1 = fake_schedule.create_event(
@@ -389,7 +417,9 @@ async def test_multiple_end_events(hass: HomeAssistant, calls, fake_schedule) ->
 
 
 async def test_multiple_events_sharing_start_time(
-    hass: HomeAssistant, calls, fake_schedule
+    hass: HomeAssistant,
+    calls: Callable[[], list[dict[str, Any]]],
+    fake_schedule: FakeSchedule,
 ) -> None:
     """Test that a trigger fires for every event sharing a start time."""
 
@@ -420,7 +450,11 @@ async def test_multiple_events_sharing_start_time(
     ]
 
 
-async def test_overlap_events(hass: HomeAssistant, calls, fake_schedule) -> None:
+async def test_overlap_events(
+    hass: HomeAssistant,
+    calls: Callable[[], list[dict[str, Any]]],
+    fake_schedule: FakeSchedule,
+) -> None:
     """Test that a trigger fires for events that overlap."""
 
     event_data1 = fake_schedule.create_event(
@@ -492,7 +526,11 @@ async def test_legacy_entity_type(
     assert "is not a calendar entity" in caplog.text
 
 
-async def test_update_next_event(hass: HomeAssistant, calls, fake_schedule) -> None:
+async def test_update_next_event(
+    hass: HomeAssistant,
+    calls: Callable[[], list[dict[str, Any]]],
+    fake_schedule: FakeSchedule,
+) -> None:
     """Test detection of a new event after initial trigger is setup."""
 
     event_data1 = fake_schedule.create_event(
@@ -531,7 +569,11 @@ async def test_update_next_event(hass: HomeAssistant, calls, fake_schedule) -> N
     ]
 
 
-async def test_update_missed(hass: HomeAssistant, calls, fake_schedule) -> None:
+async def test_update_missed(
+    hass: HomeAssistant,
+    calls: Callable[[], list[dict[str, Any]]],
+    fake_schedule: FakeSchedule,
+) -> None:
     """Test that new events are missed if they arrive outside the update interval."""
 
     event_data1 = fake_schedule.create_event(
@@ -619,9 +661,9 @@ async def test_update_missed(hass: HomeAssistant, calls, fake_schedule) -> None:
 )
 async def test_event_payload(
     hass: HomeAssistant,
-    calls,
-    fake_schedule,
-    set_time_zone,
+    calls: Callable[[], list[dict[str, Any]]],
+    fake_schedule: FakeSchedule,
+    set_time_zone: None,
     create_data,
     fire_time,
     payload_data,
@@ -642,7 +684,10 @@ async def test_event_payload(
 
 
 async def test_trigger_timestamp_window_edge(
-    hass: HomeAssistant, calls, fake_schedule, freezer: FrozenDateTimeFactory
+    hass: HomeAssistant,
+    calls: Callable[[], list[dict[str, Any]]],
+    fake_schedule: FakeSchedule,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test that events in the edge of a scan are included."""
     freezer.move_to("2022-04-19 11:00:00+00:00")
@@ -668,7 +713,10 @@ async def test_trigger_timestamp_window_edge(
 
 
 async def test_event_start_trigger_dst(
-    hass: HomeAssistant, calls, fake_schedule, freezer: FrozenDateTimeFactory
+    hass: HomeAssistant,
+    calls: Callable[[], list[dict[str, Any]]],
+    fake_schedule: FakeSchedule,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test a calendar event trigger happening at the start of daylight savings time."""
     tzinfo = zoneinfo.ZoneInfo("America/Los_Angeles")


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Linked to #89976 - as I am hunting for the root cause of lingering timers in the calendar trigger tests

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
