### PR TITLE
Add entity name translations to prusalink entities

### DIFF
--- a/homeassistant/components/prusalink/button.py
+++ b/homeassistant/components/prusalink/button.py
@@ -38,7 +38,7 @@ BUTTONS: dict[str, tuple[PrusaLinkButtonEntityDescription, ...]] = {
     "printer": (
         PrusaLinkButtonEntityDescription[PrinterInfo](
             key="printer.cancel_job",
-            name="Cancel Job",
+            translation_key="cancel_job",
             icon="mdi:cancel",
             press_fn=lambda api: cast(Coroutine, api.cancel_job()),
             available_fn=lambda data: any(
@@ -48,7 +48,7 @@ BUTTONS: dict[str, tuple[PrusaLinkButtonEntityDescription, ...]] = {
         ),
         PrusaLinkButtonEntityDescription[PrinterInfo](
             key="job.pause_job",
-            name="Pause Job",
+            translation_key="pause_job",
             icon="mdi:pause",
             press_fn=lambda api: cast(Coroutine, api.pause_job()),
             available_fn=lambda data: (
@@ -58,7 +58,7 @@ BUTTONS: dict[str, tuple[PrusaLinkButtonEntityDescription, ...]] = {
         ),
         PrusaLinkButtonEntityDescription[PrinterInfo](
             key="job.resume_job",
-            name="Resume Job",
+            translation_key="resume_job",
             icon="mdi:play",
             press_fn=lambda api: cast(Coroutine, api.resume_job()),
             available_fn=lambda data: cast(bool, data["state"]["flags"]["paused"]),

--- a/homeassistant/components/prusalink/camera.py
+++ b/homeassistant/components/prusalink/camera.py
@@ -24,7 +24,7 @@ class PrusaLinkJobPreviewEntity(PrusaLinkEntity, Camera):
 
     last_path = ""
     last_image: bytes
-    _attr_name = "Job Preview"
+    _attr_translation_key = "job_preview"
 
     def __init__(self, coordinator: JobUpdateCoordinator) -> None:
         """Initialize a PrusaLink camera entity."""

--- a/homeassistant/components/prusalink/sensor.py
+++ b/homeassistant/components/prusalink/sensor.py
@@ -65,7 +65,7 @@ SENSORS: dict[str, tuple[PrusaLinkSensorEntityDescription, ...]] = {
         ),
         PrusaLinkSensorEntityDescription[PrinterInfo](
             key="printer.telemetry.temp-bed",
-            name="Heatbed",
+            translation_key="heatbed_temperature",
             native_unit_of_measurement=UnitOfTemperature.CELSIUS,
             device_class=SensorDeviceClass.TEMPERATURE,
             state_class=SensorStateClass.MEASUREMENT,
@@ -74,7 +74,7 @@ SENSORS: dict[str, tuple[PrusaLinkSensorEntityDescription, ...]] = {
         ),
         PrusaLinkSensorEntityDescription[PrinterInfo](
             key="printer.telemetry.temp-nozzle",
-            name="Nozzle Temperature",
+            translation_key="nozzle_temperature",
             native_unit_of_measurement=UnitOfTemperature.CELSIUS,
             device_class=SensorDeviceClass.TEMPERATURE,
             state_class=SensorStateClass.MEASUREMENT,
@@ -85,7 +85,7 @@ SENSORS: dict[str, tuple[PrusaLinkSensorEntityDescription, ...]] = {
     "job": (
         PrusaLinkSensorEntityDescription[JobInfo](
             key="job.progress",
-            name="Progress",
+            translation_key="progress",
             icon="mdi:progress-clock",
             native_unit_of_measurement=PERCENTAGE,
             value_fn=lambda data: cast(float, data["progress"]["completion"]) * 100,
@@ -93,14 +93,14 @@ SENSORS: dict[str, tuple[PrusaLinkSensorEntityDescription, ...]] = {
         ),
         PrusaLinkSensorEntityDescription[JobInfo](
             key="job.filename",
-            name="Filename",
+            translation_key="filename",
             icon="mdi:file-image-outline",
             value_fn=lambda data: cast(str, data["job"]["file"]["display"]),
             available_fn=lambda data: data.get("job") is not None,
         ),
         PrusaLinkSensorEntityDescription[JobInfo](
             key="job.start",
-            name="Print Start",
+            translation_key="print_start",
             device_class=SensorDeviceClass.TIMESTAMP,
             icon="mdi:clock-start",
             value_fn=ignore_variance(
@@ -113,7 +113,7 @@ SENSORS: dict[str, tuple[PrusaLinkSensorEntityDescription, ...]] = {
         ),
         PrusaLinkSensorEntityDescription[JobInfo](
             key="job.finish",
-            name="Print Finish",
+            translation_key="print_finish",
             icon="mdi:clock-end",
             device_class=SensorDeviceClass.TIMESTAMP,
             value_fn=ignore_variance(

--- a/homeassistant/components/prusalink/strings.json
+++ b/homeassistant/components/prusalink/strings.json
@@ -25,6 +25,40 @@
           "pausing": "Pausing",
           "printing": "Printing"
         }
+      },
+      "heatbed_temperature": {
+        "name": "Heatbed temperature"
+      },
+      "nozzle_temperature": {
+        "name": "Nozzle temperature"
+      },
+      "progress": {
+        "name": "Progress"
+      },
+      "filename": {
+        "name": "Filename"
+      },
+      "print_start": {
+        "name": "Print start"
+      },
+      "print_finish": {
+        "name": "Print finish"
+      }
+    },
+    "button": {
+      "cancel_job": {
+        "name": "Cancel job"
+      },
+      "pause_job": {
+        "name": "Pause job"
+      },
+      "resume_job": {
+        "name": "Resume job"
+      }
+    },
+    "camera": {
+      "job_preview": {
+        "name": "Preview"
       }
     }
   }

--- a/tests/components/prusalink/test_camera.py
+++ b/tests/components/prusalink/test_camera.py
@@ -25,12 +25,12 @@ async def test_camera_no_job(
 ) -> None:
     """Test camera while no job active."""
     assert await async_setup_component(hass, "prusalink", {})
-    state = hass.states.get("camera.mock_title_job_preview")
+    state = hass.states.get("camera.mock_title_preview")
     assert state is not None
     assert state.state == "unavailable"
 
     client = await hass_client()
-    resp = await client.get("/api/camera_proxy/camera.mock_title_job_preview")
+    resp = await client.get("/api/camera_proxy/camera.mock_title_preview")
     assert resp.status == 500
 
 
@@ -43,19 +43,19 @@ async def test_camera_active_job(
 ) -> None:
     """Test camera while job active."""
     assert await async_setup_component(hass, "prusalink", {})
-    state = hass.states.get("camera.mock_title_job_preview")
+    state = hass.states.get("camera.mock_title_preview")
     assert state is not None
     assert state.state == "idle"
 
     client = await hass_client()
 
     with patch("pyprusalink.PrusaLink.get_large_thumbnail", return_value=b"hello"):
-        resp = await client.get("/api/camera_proxy/camera.mock_title_job_preview")
+        resp = await client.get("/api/camera_proxy/camera.mock_title_preview")
         assert resp.status == 200
         assert await resp.read() == b"hello"
 
     # Make sure we hit cached value.
     with patch("pyprusalink.PrusaLink.get_large_thumbnail", side_effect=ValueError):
-        resp = await client.get("/api/camera_proxy/camera.mock_title_job_preview")
+        resp = await client.get("/api/camera_proxy/camera.mock_title_preview")
         assert resp.status == 200
         assert await resp.read() == b"hello"

--- a/tests/components/prusalink/test_sensor.py
+++ b/tests/components/prusalink/test_sensor.py
@@ -49,7 +49,7 @@ async def test_sensors_no_job(hass: HomeAssistant, mock_config_entry, mock_api) 
         "printing",
     ]
 
-    state = hass.states.get("sensor.mock_title_heatbed")
+    state = hass.states.get("sensor.mock_title_heatbed_temperature")
     assert state is not None
     assert state.state == "41.9"
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfTemperature.CELSIUS


### PR DESCRIPTION
## Proposed change

Add entity name translations to prusalink entities

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
