### PR TITLE
Reduce bond fallback polling interval when BPUP is alive

### DIFF
--- a/homeassistant/components/bond/entity.py
+++ b/homeassistant/components/bond/entity.py
@@ -17,9 +17,9 @@ from homeassistant.const import (
     ATTR_SW_VERSION,
     ATTR_VIA_DEVICE,
 )
-from homeassistant.core import callback
+from homeassistant.core import CALLBACK_TYPE, callback
 from homeassistant.helpers.entity import DeviceInfo, Entity
-from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.helpers.event import async_call_later
 
 from .const import DOMAIN
 from .utils import BondDevice, BondHub
@@ -27,6 +27,7 @@ from .utils import BondDevice, BondHub
 _LOGGER = logging.getLogger(__name__)
 
 _FALLBACK_SCAN_INTERVAL = timedelta(seconds=10)
+_BPUP_ALIVE_SCAN_INTERVAL = timedelta(seconds=60)
 
 
 class BondEntity(Entity):
@@ -65,6 +66,7 @@ class BondEntity(Entity):
             self._attr_name = device.name
         self._attr_assumed_state = self._hub.is_bridge and not self._device.trust_state
         self._apply_state()
+        self._bpup_polling_fallback: CALLBACK_TYPE | None = None
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -106,6 +108,7 @@ class BondEntity(Entity):
     @callback
     def _async_update_if_bpup_not_alive(self, now: datetime) -> None:
         """Fetch via the API if BPUP is not alive."""
+        self._async_schedule_bpup_alive_or_poll()
         if (
             self.hass.is_stopping
             or self._bpup_subs.alive
@@ -172,16 +175,26 @@ class BondEntity(Entity):
         """Subscribe to BPUP and start polling."""
         await super().async_added_to_hass()
         self._bpup_subs.subscribe(self._device_id, self._async_bpup_callback)
-        self.async_on_remove(
-            async_track_time_interval(
-                self.hass,
-                self._async_update_if_bpup_not_alive,
-                _FALLBACK_SCAN_INTERVAL,
-                name=f"Bond {self.entity_id} fallback polling",
-            )
+        self._async_schedule_bpup_alive_or_poll()
+
+    def _async_schedule_bpup_alive_or_poll(self) -> None:
+        """Schedule the BPUP alive or poll."""
+        alive = self._bpup_subs.alive
+        interval = _BPUP_ALIVE_SCAN_INTERVAL if alive else _FALLBACK_SCAN_INTERVAL
+        self._bpup_polling_fallback = async_call_later(
+            self.hass,
+            interval,
+            self._async_update_if_bpup_not_alive,
         )
+
+    def _async_cancel_bpup_alive_or_poll(self) -> None:
+        """Cancel the BPUP alive or poll check."""
+        if self._bpup_polling_fallback:
+            self._bpup_polling_fallback()
+            self._bpup_polling_fallback = None
 
     async def async_will_remove_from_hass(self) -> None:
         """Unsubscribe from BPUP data on remove."""
         await super().async_will_remove_from_hass()
         self._bpup_subs.unsubscribe(self._device_id, self._async_bpup_callback)
+        self._async_cancel_bpup_alive_or_poll()

--- a/homeassistant/components/bond/entity.py
+++ b/homeassistant/components/bond/entity.py
@@ -180,10 +180,9 @@ class BondEntity(Entity):
     def _async_schedule_bpup_alive_or_poll(self) -> None:
         """Schedule the BPUP alive or poll."""
         alive = self._bpup_subs.alive
-        interval = _BPUP_ALIVE_SCAN_INTERVAL if alive else _FALLBACK_SCAN_INTERVAL
         self._bpup_polling_fallback = async_call_later(
             self.hass,
-            interval,
+            _BPUP_ALIVE_SCAN_INTERVAL if alive else _FALLBACK_SCAN_INTERVAL,
             self._async_update_if_bpup_not_alive,
         )
 

--- a/homeassistant/components/bond/entity.py
+++ b/homeassistant/components/bond/entity.py
@@ -177,6 +177,7 @@ class BondEntity(Entity):
         self._bpup_subs.subscribe(self._device_id, self._async_bpup_callback)
         self._async_schedule_bpup_alive_or_poll()
 
+    @callback
     def _async_schedule_bpup_alive_or_poll(self) -> None:
         """Schedule the BPUP alive or poll."""
         alive = self._bpup_subs.alive
@@ -186,14 +187,10 @@ class BondEntity(Entity):
             self._async_update_if_bpup_not_alive,
         )
 
-    def _async_cancel_bpup_alive_or_poll(self) -> None:
-        """Cancel the BPUP alive or poll check."""
-        if self._bpup_polling_fallback:
-            self._bpup_polling_fallback()
-            self._bpup_polling_fallback = None
-
     async def async_will_remove_from_hass(self) -> None:
         """Unsubscribe from BPUP data on remove."""
         await super().async_will_remove_from_hass()
         self._bpup_subs.unsubscribe(self._device_id, self._async_bpup_callback)
-        self._async_cancel_bpup_alive_or_poll()
+        if self._bpup_polling_fallback:
+            self._bpup_polling_fallback()
+            self._bpup_polling_fallback = None

--- a/homeassistant/components/bond/entity.py
+++ b/homeassistant/components/bond/entity.py
@@ -102,7 +102,7 @@ class BondEntity(Entity):
         return device_info
 
     async def async_update(self) -> None:
-        """Fetch assumed state of the cover from the hub using API."""
+        """Perform a manual update from API."""
         await self._async_update_from_api()
 
     @callback

--- a/tests/components/bond/common.py
+++ b/tests/components/bond/common.py
@@ -127,7 +127,12 @@ def patch_bond_version(
         return nullcontext()
 
     if return_value is None:
-        return_value = {"bondid": "ZXXX12345"}
+        return_value = {
+            "bondid": "ZXXX12345",
+            "target": "test-model",
+            "fw_ver": "test-version",
+            "mcu_ver": "test-hw-version",
+        }
 
     return patch(
         "homeassistant.components.bond.Bond.version",

--- a/tests/components/bond/test_diagnostics.py
+++ b/tests/components/bond/test_diagnostics.py
@@ -42,5 +42,12 @@ async def test_diagnostics(
             "data": {"access_token": "**REDACTED**", "host": "some host"},
             "title": "Mock Title",
         },
-        "hub": {"version": {"bondid": "ZXXX12345"}},
+        "hub": {
+            "version": {
+                "bondid": "ZXXX12345",
+                "fw_ver": "test-version",
+                "mcu_ver": "test-hw-version",
+                "target": "test-model",
+            }
+        },
     }

--- a/tests/components/bond/test_fan.py
+++ b/tests/components/bond/test_fan.py
@@ -468,3 +468,30 @@ async def test_fan_available(hass: HomeAssistant) -> None:
     await help_test_entity_available(
         hass, FAN_DOMAIN, ceiling_fan("name-1"), "fan.name_1"
     )
+
+
+async def test_setup_smart_by_bond_fan(hass: HomeAssistant) -> None:
+    """Test setting up a fan without a hub."""
+    await setup_platform(
+        hass,
+        FAN_DOMAIN,
+        ceiling_fan("name-1"),
+        bond_device_id="test-device-id",
+        bond_version={
+            "bondid": "KXXX12345",
+            "target": "test-model",
+            "fw_ver": "test-version",
+            "mcu_ver": "test-hw-version",
+        },
+    )
+    assert hass.states.get("fan.name_1") is not None
+    registry = er.async_get(hass)
+    entry = registry.async_get("fan.name_1")
+    assert entry.device_id is not None
+    device_registry = dr.async_get(hass)
+    device = device_registry.async_get(entry.device_id)
+    assert device is not None
+    assert device.sw_version == "test-version"
+    assert device.manufacturer == "Olibra"
+    assert device.identifiers == {("bond", "KXXX12345", "test-device-id")}
+    assert device.hw_version == "test-hw-version"

--- a/tests/components/bond/test_fan.py
+++ b/tests/components/bond/test_fan.py
@@ -472,7 +472,7 @@ async def test_fan_available(hass: HomeAssistant) -> None:
 
 async def test_setup_smart_by_bond_fan(hass: HomeAssistant) -> None:
     """Test setting up a fan without a hub."""
-    await setup_platform(
+    config_entry = await setup_platform(
         hass,
         FAN_DOMAIN,
         ceiling_fan("name-1"),
@@ -495,11 +495,13 @@ async def test_setup_smart_by_bond_fan(hass: HomeAssistant) -> None:
     assert device.manufacturer == "Olibra"
     assert device.identifiers == {("bond", "KXXX12345", "test-device-id")}
     assert device.hw_version == "test-hw-version"
+    await hass.config_entries.async_unload(config_entry.entry_id)
+    await hass.async_block_till_done()
 
 
 async def test_setup_hub_template_fan(hass: HomeAssistant) -> None:
     """Test setting up a fan on a hub created from a template."""
-    await setup_platform(
+    config_entry = await setup_platform(
         hass,
         FAN_DOMAIN,
         {**ceiling_fan("name-1"), "template": "test-template"},
@@ -524,3 +526,5 @@ async def test_setup_hub_template_fan(hass: HomeAssistant) -> None:
     assert device.manufacturer == "Olibra"
     assert device.identifiers == {("bond", "ZXXX12345", "test-device-id")}
     assert device.hw_version is None
+    await hass.config_entries.async_unload(config_entry.entry_id)
+    await hass.async_block_till_done()

--- a/tests/components/bond/test_fan.py
+++ b/tests/components/bond/test_fan.py
@@ -495,3 +495,32 @@ async def test_setup_smart_by_bond_fan(hass: HomeAssistant) -> None:
     assert device.manufacturer == "Olibra"
     assert device.identifiers == {("bond", "KXXX12345", "test-device-id")}
     assert device.hw_version == "test-hw-version"
+
+
+async def test_setup_hub_template_fan(hass: HomeAssistant) -> None:
+    """Test setting up a fan on a hub created from a template."""
+    await setup_platform(
+        hass,
+        FAN_DOMAIN,
+        {**ceiling_fan("name-1"), "template": "test-template"},
+        bond_device_id="test-device-id",
+        props={"branding_profile": "test-branding-profile"},
+        bond_version={
+            "bondid": "ZXXX12345",
+            "target": "test-model",
+            "fw_ver": "test-version",
+            "mcu_ver": "test-hw-version",
+        },
+    )
+    assert hass.states.get("fan.name_1") is not None
+    registry = er.async_get(hass)
+    entry = registry.async_get("fan.name_1")
+    assert entry.device_id is not None
+    device_registry = dr.async_get(hass)
+    device = device_registry.async_get(entry.device_id)
+    assert device is not None
+    assert device.sw_version is None
+    assert device.model == "test-branding-profile test-template"
+    assert device.manufacturer == "Olibra"
+    assert device.identifiers == {("bond", "ZXXX12345", "test-device-id")}
+    assert device.hw_version is None


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If push updates are alive we should not check every 10 seconds.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
