### PR TITLE
Add humidifier support to VeSync

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1384,6 +1384,7 @@ omit =
     homeassistant/components/versasense/*
     homeassistant/components/vesync/common.py
     homeassistant/components/vesync/fan.py
+    homeassistant/components/vesync/humidifier.py
     homeassistant/components/vesync/light.py
     homeassistant/components/vesync/sensor.py
     homeassistant/components/vesync/switch.py

--- a/homeassistant/components/vesync/__init__.py
+++ b/homeassistant/components/vesync/__init__.py
@@ -15,13 +15,20 @@ from .const import (
     SERVICE_UPDATE_DEVS,
     VS_DISCOVERY,
     VS_FANS,
+    VS_HUMIDIFIERS,
     VS_LIGHTS,
     VS_MANAGER,
     VS_SENSORS,
     VS_SWITCHES,
 )
 
-PLATFORMS = [Platform.FAN, Platform.LIGHT, Platform.SENSOR, Platform.SWITCH]
+PLATFORMS = [
+    Platform.FAN,
+    Platform.HUMIDIFIER,
+    Platform.LIGHT,
+    Platform.SENSOR,
+    Platform.SWITCH,
+]
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -52,6 +59,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     switches = hass.data[DOMAIN][VS_SWITCHES] = []
     fans = hass.data[DOMAIN][VS_FANS] = []
+    humidifiers = hass.data[DOMAIN][VS_HUMIDIFIERS] = []
     lights = hass.data[DOMAIN][VS_LIGHTS] = []
     sensors = hass.data[DOMAIN][VS_SENSORS] = []
     platforms = []
@@ -63,6 +71,10 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     if device_dict[VS_FANS]:
         fans.extend(device_dict[VS_FANS])
         platforms.append(Platform.FAN)
+
+    if device_dict[VS_HUMIDIFIERS]:
+        humidifiers.extend(device_dict[VS_HUMIDIFIERS])
+        platforms.append(Platform.HUMIDIFIER)
 
     if device_dict[VS_LIGHTS]:
         lights.extend(device_dict[VS_LIGHTS])
@@ -79,12 +91,14 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         manager = hass.data[DOMAIN][VS_MANAGER]
         switches = hass.data[DOMAIN][VS_SWITCHES]
         fans = hass.data[DOMAIN][VS_FANS]
+        humidifiers = hass.data[DOMAIN][VS_HUMIDIFIERS]
         lights = hass.data[DOMAIN][VS_LIGHTS]
         sensors = hass.data[DOMAIN][VS_SENSORS]
 
         dev_dict = await async_process_devices(hass, manager)
         switch_devs = dev_dict.get(VS_SWITCHES, [])
         fan_devs = dev_dict.get(VS_FANS, [])
+        humidifier_devs = dev_dict.get(VS_HUMIDIFIERS, [])
         light_devs = dev_dict.get(VS_LIGHTS, [])
         sensor_devs = dev_dict.get(VS_SENSORS, [])
 
@@ -107,6 +121,18 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         if new_fans and not fans:
             fans.extend(new_fans)
             hass.async_create_task(forward_setup(config_entry, Platform.FAN))
+
+        humidifier_set = set(humidifier_devs)
+        new_humidifiers = list(humidifier_set.difference(humidifiers))
+        if new_humidifiers and humidifiers:
+            humidifiers.extend(new_humidifiers)
+            async_dispatcher_send(
+                hass, VS_DISCOVERY.format(VS_HUMIDIFIERS), new_humidifiers
+            )
+            return
+        if new_humidifiers and not humidifiers:
+            humidifiers.extend(new_humidifiers)
+            hass.async_create_task(forward_setup(config_entry, Platform.HUMIDIFIER))
 
         light_set = set(light_devs)
         new_lights = list(light_set.difference(lights))

--- a/homeassistant/components/vesync/common.py
+++ b/homeassistant/components/vesync/common.py
@@ -6,7 +6,7 @@ from pyvesync.vesyncbasedevice import VeSyncBaseDevice
 
 from homeassistant.helpers.entity import DeviceInfo, Entity, ToggleEntity
 
-from .const import DOMAIN, VS_FANS, VS_LIGHTS, VS_SENSORS, VS_SWITCHES
+from .const import DOMAIN, VS_FANS, VS_HUMIDIFIERS, VS_LIGHTS, VS_SENSORS, VS_SWITCHES
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -16,16 +16,21 @@ async def async_process_devices(hass, manager):
     devices = {}
     devices[VS_SWITCHES] = []
     devices[VS_FANS] = []
+    devices[VS_HUMIDIFIERS] = []
     devices[VS_LIGHTS] = []
     devices[VS_SENSORS] = []
 
     await hass.async_add_executor_job(manager.update)
 
     if manager.fans:
-        devices[VS_FANS].extend(manager.fans)
+        fans = [f for f in manager.fans if not hasattr(f, "humidity")]
+        humidifiers = [f for f in manager.fans if hasattr(f, "humidity")]
+        devices[VS_FANS].extend(fans)
+        devices[VS_HUMIDIFIERS].extend(humidifiers)
         # Expose fan sensors separately
         devices[VS_SENSORS].extend(manager.fans)
-        _LOGGER.info("%d VeSync fans found", len(manager.fans))
+        _LOGGER.info("%d VeSync fans found", len(fans))
+        _LOGGER.info("%d VeSync humidifiers found", len(humidifiers))
 
     if manager.bulbs:
         devices[VS_LIGHTS].extend(manager.bulbs)

--- a/homeassistant/components/vesync/const.py
+++ b/homeassistant/components/vesync/const.py
@@ -6,6 +6,7 @@ SERVICE_UPDATE_DEVS = "update_devices"
 
 VS_SWITCHES = "switches"
 VS_FANS = "fans"
+VS_HUMIDIFIERS = "humidifiers"
 VS_LIGHTS = "lights"
 VS_SENSORS = "sensors"
 VS_MANAGER = "manager"
@@ -36,4 +37,5 @@ SKU_TO_BASE_DEVICE = {
     "LAP-C601S-WUS": "Core600S",  # Alt ID Model Core600S
     "LAP-C601S-WUSR": "Core600S",  # Alt ID Model Core600S
     "LAP-C601S-WEU": "Core600S",  # Alt ID Model Core600S
+    "LUH-A602S-WUS": "LUH-A602S-WUS",
 }

--- a/homeassistant/components/vesync/diagnostics.py
+++ b/homeassistant/components/vesync/diagnostics.py
@@ -23,17 +23,22 @@ async def async_get_config_entry_diagnostics(
     """Return diagnostics for a config entry."""
     manager: VeSync = hass.data[DOMAIN][VS_MANAGER]
 
+    fans = [f for f in manager.fans if not hasattr(f, "humidity")]
+    humidifiers = [f for f in manager.fans if hasattr(f, "humidity")]
+
     data = {
         DOMAIN: {
             "bulb_count": len(manager.bulbs),
-            "fan_count": len(manager.fans),
+            "fan_count": len(fans),
+            "humidifier_count": len(humidifiers),
             "outlets_count": len(manager.outlets),
             "switch_count": len(manager.switches),
             "timezone": manager.time_zone,
         },
         "devices": {
             "bulbs": [_redact_device_values(device) for device in manager.bulbs],
-            "fans": [_redact_device_values(device) for device in manager.fans],
+            "fans": [_redact_device_values(device) for device in fans],
+            "humidifiers": [_redact_device_values(device) for device in humidifiers],
             "outlets": [_redact_device_values(device) for device in manager.outlets],
             "switches": [_redact_device_values(device) for device in manager.switches],
         },

--- a/homeassistant/components/vesync/humidifier.py
+++ b/homeassistant/components/vesync/humidifier.py
@@ -1,0 +1,112 @@
+"""Support for VeSync humidifiers."""
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.humidifier import (
+    HumidifierEntity,
+    HumidifierEntityFeature,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .common import VeSyncDevice
+from .const import DOMAIN, SKU_TO_BASE_DEVICE, VS_DISCOVERY, VS_HUMIDIFIERS
+
+_LOGGER = logging.getLogger(__name__)
+
+DEV_TYPE_TO_HA = {
+    "LUH-A602S-WUS": "humidifier",
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the VeSync humidifier platform."""
+
+    @callback
+    def discover(devices):
+        """Add new devices to platform."""
+        _setup_entities(devices, async_add_entities)
+
+    config_entry.async_on_unload(
+        async_dispatcher_connect(hass, VS_DISCOVERY.format(VS_HUMIDIFIERS), discover)
+    )
+
+    _setup_entities(hass.data[DOMAIN][VS_HUMIDIFIERS], async_add_entities)
+
+
+@callback
+def _setup_entities(devices, async_add_entities):
+    """Check if device is online and add entity."""
+    entities = []
+    for dev in devices:
+        if DEV_TYPE_TO_HA.get(SKU_TO_BASE_DEVICE.get(dev.device_type)) == "humidifier":
+            entities.append(VeSyncHumidifierHA(dev))
+        else:
+            _LOGGER.warning(
+                "%s - Unknown device type - %s", dev.device_name, dev.device_type
+            )
+            continue
+
+    async_add_entities(entities, update_before_add=True)
+
+
+class VeSyncHumidifierHA(VeSyncDevice, HumidifierEntity):
+    """Representation of a VeSync humidifier."""
+
+    def __init__(self, humidifier):
+        """Initialize the VeSync humidifier device."""
+        super().__init__(humidifier)
+        self.smarthumidifier = humidifier
+
+    @property
+    def target_humidity(self) -> int | None:
+        """Return the humidity we try to reach."""
+        return self.smarthumidifier.config["auto_target_humidity"]
+
+    @property
+    def available_modes(self) -> list[str] | None:
+        """Return a list of available modes."""
+        return self.smarthumidifier.mist_modes
+
+    @property
+    def mode(self) -> str | None:
+        """Return current modes."""
+        return self.smarthumidifier.details["mode"]
+
+    @property
+    def min_humidity(self) -> int:
+        """Return the minimum humidity."""
+        return 40
+
+    @property
+    def max_humidity(self) -> int:
+        """Return the maximum humidity."""
+        return 80
+
+    @property
+    def supported_features(self) -> HumidifierEntityFeature:
+        """Return the list of supported features."""
+        return HumidifierEntityFeature.MODES
+
+    def set_humidity(self, humidity: int) -> None:
+        """Set new target humidity."""
+        return self.smarthumidifier.set_humidity(humidity)
+
+    def set_mode(self, mode: str) -> None:
+        """Set new mode."""
+        return self.smarthumidifier.set_humidity_mode(mode)
+
+    def turn_on(self, **kwargs):
+        """Turn the device on."""
+        return self.smarthumidifier.turn_on()
+
+    def turn_off(self, **kwargs):
+        """Turn the device off."""
+        return self.smarthumidifier.turn_off()

--- a/homeassistant/components/vesync/sensor.py
+++ b/homeassistant/components/vesync/sensor.py
@@ -75,6 +75,7 @@ def ha_dev_type(device):
 FILTER_LIFE_SUPPORTED = ["LV-PUR131S", "Core200S", "Core300S", "Core400S", "Core600S"]
 AIR_QUALITY_SUPPORTED = ["LV-PUR131S", "Core300S", "Core400S", "Core600S"]
 PM25_SUPPORTED = ["Core300S", "Core400S", "Core600S"]
+HUMIDITY_SUPPORTED = ["LUH-A602S-WUS"]
 
 SENSORS: tuple[VeSyncSensorEntityDescription, ...] = (
     VeSyncSensorEntityDescription(
@@ -100,6 +101,15 @@ SENSORS: tuple[VeSyncSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda device: device.details["air_quality_value"],
         exists_fn=lambda device: sku_supported(device, PM25_SUPPORTED),
+    ),
+    VeSyncSensorEntityDescription(
+        key="humidity",
+        name="Humidity",
+        device_class=SensorDeviceClass.HUMIDITY,
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda device: device.details["humidity"],
+        exists_fn=lambda device: sku_supported(device, HUMIDITY_SUPPORTED),
     ),
     VeSyncSensorEntityDescription(
         key="power",

--- a/tests/components/vesync/conftest.py
+++ b/tests/components/vesync/conftest.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock, patch
 import pytest
 from pyvesync import VeSync
 from pyvesync.vesyncbulb import VeSyncBulb
-from pyvesync.vesyncfan import VeSyncAirBypass
+from pyvesync.vesyncfan import VeSyncAirBypass, VeSyncHumid200300S
 from pyvesync.vesyncoutlet import VeSyncOutlet
 from pyvesync.vesyncswitch import VeSyncSwitch
 
@@ -71,6 +71,13 @@ def manager_fixture() -> VeSync:
 def fan_fixture():
     """Create a mock VeSync fan fixture."""
     mock_fixture = Mock(VeSyncAirBypass)
+    return mock_fixture
+
+
+@pytest.fixture(name="humidifier")
+def humidifier_fixture():
+    """Create a mock VeSync humidifier fixture."""
+    mock_fixture = Mock(VeSyncHumid200300S)
     return mock_fixture
 
 

--- a/tests/components/vesync/snapshots/test_diagnostics.ambr
+++ b/tests/components/vesync/snapshots/test_diagnostics.ambr
@@ -6,6 +6,8 @@
       ]),
       'fans': list([
       ]),
+      'humidifiers': list([
+      ]),
       'outlets': list([
       ]),
       'switches': list([
@@ -14,6 +16,7 @@
     'vesync': dict({
       'bulb_count': 0,
       'fan_count': 0,
+      'humidifier_count': 0,
       'outlets_count': 0,
       'switch_count': 0,
       'timezone': 'US/Pacific',
@@ -26,6 +29,8 @@
       'bulbs': list([
       ]),
       'fans': list([
+      ]),
+      'humidifiers': list([
         dict({
           '_api_modes': list([
             'getHumidifierStatus',
@@ -148,7 +153,8 @@
     }),
     'vesync': dict({
       'bulb_count': 0,
-      'fan_count': 1,
+      'fan_count': 0,
+      'humidifier_count': 1,
       'outlets_count': 0,
       'switch_count': 0,
       'timezone': 'US/Pacific',


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for vesync humidifiers. This is an additional capability for the existing VeSync integration, using pyvesync as with other VeSync devices.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**.
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works. _Note: test is really just for set up functions, matches existing tests for vesync integration._

The following tests fail, however they are unrelated to this change so I believe they are pre-existing failures:

         - tests/components/frontend/test_init.py:135 test_frontend_and_static
         - tests/components/history_stats/test_sensor.py:1368 test_end_time_with_microseconds_zeroed[Europe/Berlin]
         - tests/components/history_stats/test_sensor.py:1368 test_end_time_with_microseconds_zeroed[America/Chicago]
         - tests/components/history_stats/test_sensor.py:1368 test_end_time_with_microseconds_zeroed[US/Hawaii]
         - tests/components/mobile_app/test_webhook.py:268 test_webhook_handle_get_config
         - tests/components/modbus/test_init.py:690 test_pymodbus_connect_fail
         - tests/components/nest/test_camera_sdm.py:577 test_camera_web_rtc[yaml-config-only]
         - tests/components/nest/test_camera_sdm.py:577 test_camera_web_rtc[app-creds]
         - tests/components/nest/test_media_source.py:1391 test_camera_image_resize[yaml-config-only]
         - tests/components/nest/test_media_source.py:1391 test_camera_image_resize[app-creds]
         - tests/components/stream/test_hls.py:138 test_hls_stream
         - tests/helpers/test_translation.py:101 test_get_translations


If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository] - _https://github.com/home-assistant/home-assistant.io/pull/26884_

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [X] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository. - _I'm looking for some PRs I can review, I don't want to block creating the PR on that though as I'm a first time contributor and it may take me some time._

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
