### PR TITLE
Migrate entity unique ids in PI-Hole

### DIFF
--- a/homeassistant/components/pi_hole/__init__.py
+++ b/homeassistant/components/pi_hole/__init__.py
@@ -16,9 +16,9 @@ from homeassistant.const import (
     CONF_VERIFY_SSL,
     Platform,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed
-from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import config_validation as cv, entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import (
@@ -63,6 +63,38 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.config_entries.async_update_entry(entry, data=entry_data)
 
     _LOGGER.debug("Setting up %s integration with host %s", DOMAIN, host)
+
+    @callback
+    def update_unique_id(
+        entity_entry: er.RegistryEntry,
+    ) -> dict[str, str] | None:
+        """Update unique ID of entity entry."""
+        name_to_key = {
+            "Core Update Available": "core_update_available",
+            "Web Update Available": "web_update_available",
+            "FTL Update Available": "ftl_update_available",
+            "Status": "status",
+            "Ads Blocked Today": "ads_blocked_today",
+            "Ads Percentage Blocked Today": "ads_percentage_today",
+            "Seen Clients": "clients_ever_seen",
+            "DNS Queries Today": "dns_queries_today",
+            "Domains Blocked": "domains_being_blocked",
+            "DNS Queries Cached": "queries_cached",
+            "DNS Queries Forwarded": "queries_forwarded",
+            "DNS Unique Clients": "unique_clients",
+            "DNS Unique Domains": "unique_domains",
+        }
+
+        unique_id_parts = entity_entry.unique_id.split("/")
+        if len(unique_id_parts) == 2 and unique_id_parts[1] in name_to_key:
+            name = unique_id_parts[1]
+            new_unique_id = entity_entry.unique_id.replace(name, name_to_key[name])
+            _LOGGER.debug("Migrate %s to %s", entity_entry.unique_id, new_unique_id)
+            return {"new_unique_id": new_unique_id}
+
+        return None
+
+    await er.async_migrate_entries(hass, entry.entry_id, update_unique_id)
 
     session = async_get_clientsession(hass, verify_tls)
     api = Hole(

--- a/homeassistant/components/pi_hole/__init__.py
+++ b/homeassistant/components/pi_hole/__init__.py
@@ -64,27 +64,27 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     _LOGGER.debug("Setting up %s integration with host %s", DOMAIN, host)
 
+    name_to_key = {
+        "Core Update Available": "core_update_available",
+        "Web Update Available": "web_update_available",
+        "FTL Update Available": "ftl_update_available",
+        "Status": "status",
+        "Ads Blocked Today": "ads_blocked_today",
+        "Ads Percentage Blocked Today": "ads_percentage_today",
+        "Seen Clients": "clients_ever_seen",
+        "DNS Queries Today": "dns_queries_today",
+        "Domains Blocked": "domains_being_blocked",
+        "DNS Queries Cached": "queries_cached",
+        "DNS Queries Forwarded": "queries_forwarded",
+        "DNS Unique Clients": "unique_clients",
+        "DNS Unique Domains": "unique_domains",
+    }
+
     @callback
     def update_unique_id(
         entity_entry: er.RegistryEntry,
     ) -> dict[str, str] | None:
         """Update unique ID of entity entry."""
-        name_to_key = {
-            "Core Update Available": "core_update_available",
-            "Web Update Available": "web_update_available",
-            "FTL Update Available": "ftl_update_available",
-            "Status": "status",
-            "Ads Blocked Today": "ads_blocked_today",
-            "Ads Percentage Blocked Today": "ads_percentage_today",
-            "Seen Clients": "clients_ever_seen",
-            "DNS Queries Today": "dns_queries_today",
-            "Domains Blocked": "domains_being_blocked",
-            "DNS Queries Cached": "queries_cached",
-            "DNS Queries Forwarded": "queries_forwarded",
-            "DNS Unique Clients": "unique_clients",
-            "DNS Unique Domains": "unique_domains",
-        }
-
         unique_id_parts = entity_entry.unique_id.split("/")
         if len(unique_id_parts) == 2 and unique_id_parts[1] in name_to_key:
             name = unique_id_parts[1]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
With #90713 building of entity unique id has been changed (_from include `description.name` to `description.key`_).
This is now fixed by migrating the unique ids

locally tested
```
2023-04-05 22:58:05.117 DEBUG (MainThread) [homeassistant.components.pi_hole] Setting up pi_hole integration with host x.x.x.x:80
2023-04-05 22:58:05.117 DEBUG (MainThread) [homeassistant.components.pi_hole] Migrate 6fa81c6b1ce11fbedb7b2f2391561fd5/Ads Percentage Blocked Today to 6fa81c6b1ce11fbedb7b2f2391561fd5/ads_percentage_today
2023-04-05 22:58:05.117 DEBUG (MainThread) [homeassistant.components.pi_hole] Migrate 6fa81c6b1ce11fbedb7b2f2391561fd5/Seen Clients to 6fa81c6b1ce11fbedb7b2f2391561fd5/clients_ever_seen
2023-04-05 22:58:05.118 DEBUG (MainThread) [homeassistant.components.pi_hole] Migrate 6fa81c6b1ce11fbedb7b2f2391561fd5/DNS Queries Today to 6fa81c6b1ce11fbedb7b2f2391561fd5/dns_queries_today
2023-04-05 22:58:05.118 DEBUG (MainThread) [homeassistant.components.pi_hole] Migrate 6fa81c6b1ce11fbedb7b2f2391561fd5/Domains Blocked to 6fa81c6b1ce11fbedb7b2f2391561fd5/domains_being_blocked
2023-04-05 22:58:05.118 DEBUG (MainThread) [homeassistant.components.pi_hole] Migrate 6fa81c6b1ce11fbedb7b2f2391561fd5/DNS Queries Cached to 6fa81c6b1ce11fbedb7b2f2391561fd5/queries_cached
2023-04-05 22:58:05.118 DEBUG (MainThread) [homeassistant.components.pi_hole] Migrate 6fa81c6b1ce11fbedb7b2f2391561fd5/DNS Queries Forwarded to 6fa81c6b1ce11fbedb7b2f2391561fd5/queries_forwarded
2023-04-05 22:58:05.118 DEBUG (MainThread) [homeassistant.components.pi_hole] Migrate 6fa81c6b1ce11fbedb7b2f2391561fd5/DNS Unique Clients to 6fa81c6b1ce11fbedb7b2f2391561fd5/unique_clients
2023-04-05 22:58:05.118 DEBUG (MainThread) [homeassistant.components.pi_hole] Migrate 6fa81c6b1ce11fbedb7b2f2391561fd5/DNS Unique Domains to 6fa81c6b1ce11fbedb7b2f2391561fd5/unique_domains
2023-04-05 22:58:05.118 DEBUG (MainThread) [homeassistant.components.pi_hole] Migrate 6fa81c6b1ce11fbedb7b2f2391561fd5/Ads Blocked Today to 6fa81c6b1ce11fbedb7b2f2391561fd5/ads_blocked_today
2023-04-05 22:58:05.119 DEBUG (MainThread) [homeassistant.components.pi_hole] Migrate 6fa81c6b1ce11fbedb7b2f2391561fd5/Core Update Available to 6fa81c6b1ce11fbedb7b2f2391561fd5/core_update_available
2023-04-05 22:58:05.119 DEBUG (MainThread) [homeassistant.components.pi_hole] Migrate 6fa81c6b1ce11fbedb7b2f2391561fd5/Web Update Available to 6fa81c6b1ce11fbedb7b2f2391561fd5/web_update_available
2023-04-05 22:58:05.119 DEBUG (MainThread) [homeassistant.components.pi_hole] Migrate 6fa81c6b1ce11fbedb7b2f2391561fd5/FTL Update Available to 6fa81c6b1ce11fbedb7b2f2391561fd5/ftl_update_available
2023-04-05 22:58:05.119 DEBUG (MainThread) [homeassistant.components.pi_hole] Migrate 6fa81c6b1ce11fbedb7b2f2391561fd5/Core Update Available to 6fa81c6b1ce11fbedb7b2f2391561fd5/core_update_available
2023-04-05 22:58:05.119 DEBUG (MainThread) [homeassistant.components.pi_hole] Migrate 6fa81c6b1ce11fbedb7b2f2391561fd5/Web Update Available to 6fa81c6b1ce11fbedb7b2f2391561fd5/web_update_available
2023-04-05 22:58:05.119 DEBUG (MainThread) [homeassistant.components.pi_hole] Migrate 6fa81c6b1ce11fbedb7b2f2391561fd5/FTL Update Available to 6fa81c6b1ce11fbedb7b2f2391561fd5/ftl_update_available
2023-04-05 22:58:05.119 DEBUG (MainThread) [homeassistant.components.pi_hole] Migrate 6fa81c6b1ce11fbedb7b2f2391561fd5/Status to 6fa81c6b1ce11fbedb7b2f2391561fd5/status
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
