### PR TITLE
Bump reolink-aio to 0.5.10

### DIFF
--- a/homeassistant/components/reolink/binary_sensor.py
+++ b/homeassistant/components/reolink/binary_sensor.py
@@ -87,7 +87,7 @@ BINARY_SENSORS = (
         icon="mdi:bell-ring-outline",
         icon_off="mdi:doorbell",
         value=lambda api, ch: api.visitor_detected(ch),
-        supported=lambda api, ch: api.is_doorbell_enabled(ch),
+        supported=lambda api, ch: api.is_doorbell(ch),
     ),
 )
 

--- a/homeassistant/components/reolink/manifest.json
+++ b/homeassistant/components/reolink/manifest.json
@@ -18,5 +18,5 @@
   "documentation": "https://www.home-assistant.io/integrations/reolink",
   "iot_class": "local_push",
   "loggers": ["reolink_aio"],
-  "requirements": ["reolink-aio==0.5.9"]
+  "requirements": ["reolink-aio==0.5.10"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2234,7 +2234,7 @@ regenmaschine==2022.11.0
 renault-api==0.1.12
 
 # homeassistant.components.reolink
-reolink-aio==0.5.9
+reolink-aio==0.5.10
 
 # homeassistant.components.python_script
 restrictedpython==6.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1600,7 +1600,7 @@ regenmaschine==2022.11.0
 renault-api==0.1.12
 
 # homeassistant.components.reolink
-reolink-aio==0.5.9
+reolink-aio==0.5.10
 
 # homeassistant.components.python_script
 restrictedpython==6.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump reolink-aio to 0.5.10:
Breaking changes:
- [Depricate is_doorbell_enabled](https://github.com/starkillerOG/reolink_aio/commit/e4fbe0a4e8bc4aec62be906f23a4af281b25e0e8)

New features:
- [Add GetPtzCurPos for getting current pan position](https://github.com/starkillerOG/reolink_aio/commit/2da4629bfaa23534cb783edb46d3f0e6b9ef27c9)
- [Channel based FTP, email, push, recording and buzzer](https://github.com/starkillerOG/reolink_aio/commit/6f2bfa498a2c0f113b5f769d1783c9ddf722925a)

Bug fixes:
- [Split request in chunks when more than 40 requests](https://github.com/starkillerOG/reolink_aio/commit/83c67bebf157ce89e4b3d57e4d56e4e1afce213b)
- [Properly initialize capabilities for older cameras](https://github.com/starkillerOG/reolink_aio/commit/d1076240e30f11a125ea7f53957939b2bb3bbc81)
- [Fall back on aiTrack if bSmartTrack not available](https://github.com/starkillerOG/reolink_aio/commit/ecfac30b0974f44eb827270b637d3d86a3134862)
- [Use GetChnTypeInfo to get channel models](https://github.com/starkillerOG/reolink_aio/commit/6a496458b08ced8d6aed065fd019421567203cc1)
- [Improve channel_model handeling](https://github.com/starkillerOG/reolink_aio/commit/4c5471458c5239e4527b247a6dc758459cddd79e)
- [Bump min doorbell version](https://github.com/starkillerOG/reolink_aio/commit/d6ec7e00e18c2c5bfefbd7b9fdf99d29efa954e8)

**Full Changelog**: https://github.com/starkillerOG/reolink_aio/compare/0.5.9...0.5.10

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
