### PR TITLE
Add arming/disarming state to Concord232

### DIFF
--- a/homeassistant/components/concord232/alarm_control_panel.py
+++ b/homeassistant/components/concord232/alarm_control_panel.py
@@ -115,10 +115,6 @@ class Concord232Alarm(alarm.AlarmControlPanelEntity):
 
         return STATE_ALARM_ARMED_AWAY
 
-    def update(self) -> None:
-        """Update alarm panel state."""
-        self._attr_state = self.alarm_status
-
     def alarm_disarm(self, code: str | None = None) -> None:
         """Send disarm command."""
         if not self._validate_code(code, STATE_ALARM_DISARMED):

--- a/homeassistant/components/concord232/alarm_control_panel.py
+++ b/homeassistant/components/concord232/alarm_control_panel.py
@@ -145,7 +145,7 @@ class Concord232Alarm(alarm.AlarmControlPanelEntity):
 
     def wait_for_state(self, target_state: str, timeout: int = 5) -> None:
         """Wait for alarm panel to arm/disarm."""
-        if target_state.startswith("disarm"):
+        if target_state == STATE_ALARM_DISARMED:
             self._attr_state = STATE_ALARM_DISARMING
         else:
             self._attr_state = STATE_ALARM_ARMING

--- a/homeassistant/components/concord232/alarm_control_panel.py
+++ b/homeassistant/components/concord232/alarm_control_panel.py
@@ -83,7 +83,7 @@ class Concord232Alarm(alarm.AlarmControlPanelEntity):
         | AlarmControlPanelEntityFeature.ARM_AWAY
     )
 
-    def __init__(self, url, name, code, mode) -> None:
+    def __init__(self, url: str, name: str, code: str | None, mode: str) -> None:
         """Initialize the Concord232 alarm panel."""
 
         self._attr_name = name
@@ -168,7 +168,7 @@ class Concord232Alarm(alarm.AlarmControlPanelEntity):
 
         self._attr_state = self.alarm_status
 
-    def _validate_code(self, code, state) -> bool:
+    def _validate_code(self, code: str | None, state: str) -> bool:
         """Validate given code."""
         if self._code is None:
             return True

--- a/homeassistant/components/concord232/alarm_control_panel.py
+++ b/homeassistant/components/concord232/alarm_control_panel.py
@@ -80,7 +80,7 @@ class Concord232Alarm(alarm.AlarmControlPanelEntity):
         | AlarmControlPanelEntityFeature.ARM_AWAY
     )
 
-    def __init__(self, url, name, code, mode):
+    def __init__(self, url, name, code, mode) -> None:
         """Initialize the Concord232 alarm panel."""
 
         self._attr_name = name
@@ -137,7 +137,7 @@ class Concord232Alarm(alarm.AlarmControlPanelEntity):
             return
         self._alarm.arm("away")
 
-    def _validate_code(self, code, state):
+    def _validate_code(self, code, state) -> bool:
         """Validate given code."""
         if self._code is None:
             return True


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Arming/disarming of the Concord232 currently takes up to 10 seconds to reflect in Home Assistant and it is not uncommon for an arm/disarm command to fail upstream meaning the user must stare at the screen for some time waiting to see if the command was successful trying to figure out if there was an error or they just need to keep waiting.

This PR adds arming/disarming states after submitting the command to the alarm API. It also initiates a more frequent polling of the panel to determine if/when the change has taken place (every 0.5 seconds vs the current default scan interval of 10 seconds). This more rapid polling times out at 5 seconds and falls back to the standard 10 second scan interval. In my testing a successful arm/disarm never takes more than 2.5 seconds.

This has been a longstanding shortcoming of the Concord232 component but is highlighted more with the new 2023.4 UI update to alarm panels.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
