### PR TITLE
Coerce previously persisted local calendars to have valid durations

### DIFF
--- a/homeassistant/components/local_calendar/calendar.py
+++ b/homeassistant/components/local_calendar/calendar.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime, timedelta
 import logging
 from typing import Any
 
@@ -186,14 +186,23 @@ def _parse_event(event: dict[str, Any]) -> Event:
 
 def _get_calendar_event(event: Event) -> CalendarEvent:
     """Return a CalendarEvent from an API event."""
+    start: datetime | date
+    end: datetime | date
+    if isinstance(event.start, datetime) and isinstance(event.end, datetime):
+        start = dt_util.as_local(event.start)
+        end = dt_util.as_local(event.end)
+        if (end - start) <= timedelta(seconds=0):
+            end = start + timedelta(minutes=30)
+    else:
+        start = event.start
+        end = event.end
+        if (end - start) <= timedelta(days=0):
+            end = start + timedelta(days=1)
+
     return CalendarEvent(
         summary=event.summary,
-        start=dt_util.as_local(event.start)
-        if isinstance(event.start, datetime)
-        else event.start,
-        end=dt_util.as_local(event.end)
-        if isinstance(event.end, datetime)
-        else event.end,
+        start=start,
+        end=end,
         description=event.description,
         uid=event.uid,
         rrule=event.rrule.as_rrule_str() if event.rrule else None,

--- a/tests/components/local_calendar/conftest.py
+++ b/tests/components/local_calendar/conftest.py
@@ -26,10 +26,10 @@ TEST_ENTITY = "calendar.light_schedule"
 class FakeStore(LocalCalendarStore):
     """Mock storage implementation."""
 
-    def __init__(self, hass: HomeAssistant, path: Path) -> None:
+    def __init__(self, hass: HomeAssistant, path: Path, ics_content: str) -> None:
         """Initialize FakeStore."""
         super().__init__(hass, path)
-        self._content = ""
+        self._content = ics_content
 
     def _load(self) -> str:
         """Read from calendar storage."""
@@ -40,15 +40,21 @@ class FakeStore(LocalCalendarStore):
         self._content = ics_content
 
 
+@pytest.fixture(name="ics_content", autouse=True)
+def mock_ics_content() -> str:
+    """Fixture to allow tests to set initial ics content for the calendar store."""
+    return ""
+
+
 @pytest.fixture(name="store", autouse=True)
-def mock_store() -> Generator[None, None, None]:
+def mock_store(ics_content: str) -> Generator[None, None, None]:
     """Test cleanup, remove any media storage persisted during the test."""
 
     stores: dict[Path, FakeStore] = {}
 
     def new_store(hass: HomeAssistant, path: Path) -> FakeStore:
         if path not in stores:
-            stores[path] = FakeStore(hass, path)
+            stores[path] = FakeStore(hass, path, ics_content)
         return stores[path]
 
     with patch(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Coerce local calendars that were previously persisted with negative or zero durations to have positive durations when being returned from the APIs. Previously event error checking was not as stringent in the calendar service so users could create events with no duration.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #90670
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
