### PR TITLE
Fixes Issue Configuring Flo Integration Instances

### DIFF
--- a/homeassistant/components/flo/config_flow.py
+++ b/homeassistant/components/flo/config_flow.py
@@ -29,11 +29,6 @@ async def validate_input(hass: core.HomeAssistant, data):
         LOGGER.error("Error connecting to the Flo API: %s", request_error)
         raise CannotConnect from request_error
 
-    user_info = await api.user.get_info()
-    a_location_id = user_info["locations"][0]["id"]
-    location_info = await api.location.get_info(a_location_id)
-    return {"title": location_info["nickname"]}
-
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for flo."""
@@ -47,8 +42,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             await self.async_set_unique_id(user_input[CONF_USERNAME])
             self._abort_if_unique_id_configured()
             try:
-                info = await validate_input(self.hass, user_input)
-                return self.async_create_entry(title=info["title"], data=user_input)
+                await validate_input(self.hass, user_input)
+                return self.async_create_entry(
+                    title=user_input[CONF_USERNAME], data=user_input
+                    )
             except CannotConnect:
                 errors["base"] = "cannot_connect"
 

--- a/homeassistant/components/flo/config_flow.py
+++ b/homeassistant/components/flo/config_flow.py
@@ -9,7 +9,9 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import DOMAIN, LOGGER
 
-DATA_SCHEMA = vol.Schema({vol.Required("username"): str, vol.Required("password"): str})
+DATA_SCHEMA = vol.Schema({
+    vol.Required(CONF_USERNAME): str, vol.Required(CONF_PASSWORD): str
+    })
 
 
 async def validate_input(hass: core.HomeAssistant, data):

--- a/homeassistant/components/flo/config_flow.py
+++ b/homeassistant/components/flo/config_flow.py
@@ -22,7 +22,7 @@ async def validate_input(hass: core.HomeAssistant, data):
 
     session = async_get_clientsession(hass)
     try:
-        api = await async_get_api(
+        await async_get_api(
             data[CONF_USERNAME], data[CONF_PASSWORD], session=session
         )
     except RequestError as request_error:

--- a/homeassistant/components/flo/config_flow.py
+++ b/homeassistant/components/flo/config_flow.py
@@ -9,9 +9,9 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import DOMAIN, LOGGER
 
-DATA_SCHEMA = vol.Schema({
-    vol.Required(CONF_USERNAME): str, vol.Required(CONF_PASSWORD): str
-    })
+DATA_SCHEMA = vol.Schema(
+    {vol.Required(CONF_USERNAME): str, vol.Required(CONF_PASSWORD): str}
+)
 
 
 async def validate_input(hass: core.HomeAssistant, data):
@@ -22,9 +22,7 @@ async def validate_input(hass: core.HomeAssistant, data):
 
     session = async_get_clientsession(hass)
     try:
-        await async_get_api(
-            data[CONF_USERNAME], data[CONF_PASSWORD], session=session
-        )
+        await async_get_api(data[CONF_USERNAME], data[CONF_PASSWORD], session=session)
     except RequestError as request_error:
         LOGGER.error("Error connecting to the Flo API: %s", request_error)
         raise CannotConnect from request_error
@@ -45,7 +43,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 await validate_input(self.hass, user_input)
                 return self.async_create_entry(
                     title=user_input[CONF_USERNAME], data=user_input
-                    )
+                )
             except CannotConnect:
                 errors["base"] = "cannot_connect"
 

--- a/homeassistant/components/flo/manifest.json
+++ b/homeassistant/components/flo/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "flo",
   "name": "Flo",
-  "codeowners": ["@dmulcahey"],
+  "codeowners": ["@dmulcahey", "@amattas"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/flo",
   "iot_class": "cloud_polling",

--- a/homeassistant/components/flo/manifest.json
+++ b/homeassistant/components/flo/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "flo",
   "name": "Flo",
-  "codeowners": ["@dmulcahey", "@amattas"],
+  "codeowners": ["@dmulcahey"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/flo",
   "iot_class": "cloud_polling",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
This fixes an outstanding bug that prevents Home Assistant users from adding new instances of the Flo integration to their installation. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
The root of this issue is that Flo has changed the data it returns from its locations API, and is returning locations without the "nickname" property. Since this integration currently doesn't support filtering devices by location the easiest way to fix this issue in a consistant manner is to use the username to name the instance of the integration instead of relying on the first location to have a proper nickname. This unblocks this integration and allows Home Assistant users to begin to use it again. 

Longer term it would be beneficial to give users the ability to select a location for the specific integration instance, but more importantly right now is fixing the bug. 

- This PR fixes or closes issue: 88908, 86826
- This PR is related to issue: 88908, 86826

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
