### PR TITLE
Do not allow zerovalue as total_increasing for homewizard sensors

### DIFF
--- a/homeassistant/components/homewizard/sensor.py
+++ b/homeassistant/components/homewizard/sensor.py
@@ -386,7 +386,7 @@ async def async_setup_entry(
     async_add_entities(
         HomeWizardSensorEntity(coordinator, entry, description)
         for description in SENSORS
-        if description.value_fn(coordinator.data.data) is not None
+        if getattr(coordinator.data.data, description.key, None) is not None
     )
 
 
@@ -417,7 +417,7 @@ class HomeWizardSensorEntity(HomeWizardEntity, SensorEntity):
                 "total_power_export_t3_kwh",
                 "total_power_export_t4_kwh",
             ]
-            and self.native_value == 0
+            and self.native_value is None
         ):
             self._attr_entity_registry_enabled_default = False
 

--- a/homeassistant/components/homewizard/sensor.py
+++ b/homeassistant/components/homewizard/sensor.py
@@ -38,6 +38,7 @@ PARALLEL_UPDATES = 1
 class HomeWizardEntityDescriptionMixin:
     """Mixin values for HomeWizard entities."""
 
+    has_fn: Callable[[Data], bool]
     value_fn: Callable[[Data], float | int | str | None]
 
 
@@ -47,6 +48,8 @@ class HomeWizardSensorEntityDescription(
 ):
     """Class describing HomeWizard sensor entities."""
 
+    enabled_fn: Callable[[Data], bool] = lambda data: True
+
 
 SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
     HomeWizardSensorEntityDescription(
@@ -54,6 +57,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         name="DSMR version",
         icon="mdi:counter",
         entity_category=EntityCategory.DIAGNOSTIC,
+        has_fn=lambda data: data.smr_version is not None,
         value_fn=lambda data: data.smr_version,
     ),
     HomeWizardSensorEntityDescription(
@@ -61,6 +65,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         name="Smart meter model",
         icon="mdi:gauge",
         entity_category=EntityCategory.DIAGNOSTIC,
+        has_fn=lambda data: data.meter_model is not None,
         value_fn=lambda data: data.meter_model,
     ),
     HomeWizardSensorEntityDescription(
@@ -68,6 +73,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         name="Smart meter identifier",
         icon="mdi:alphabetical-variant",
         entity_category=EntityCategory.DIAGNOSTIC,
+        has_fn=lambda data: data.unique_meter_id is not None,
         value_fn=lambda data: data.unique_meter_id,
     ),
     HomeWizardSensorEntityDescription(
@@ -75,12 +81,14 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         name="Wi-Fi SSID",
         icon="mdi:wifi",
         entity_category=EntityCategory.DIAGNOSTIC,
+        has_fn=lambda data: data.wifi_ssid is not None,
         value_fn=lambda data: data.wifi_ssid,
     ),
     HomeWizardSensorEntityDescription(
         key="active_tariff",
         name="Active tariff",
         icon="mdi:calendar-clock",
+        has_fn=lambda data: data.active_tariff is not None,
         value_fn=lambda data: (
             None if data.active_tariff is None else str(data.active_tariff)
         ),
@@ -95,6 +103,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
+        has_fn=lambda data: data.wifi_strength is not None,
         value_fn=lambda data: data.wifi_strength,
     ),
     HomeWizardSensorEntityDescription(
@@ -103,6 +112,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
+        has_fn=lambda data: data.total_power_import_kwh is not None,
         value_fn=lambda data: data.total_power_import_kwh or None,
     ),
     HomeWizardSensorEntityDescription(
@@ -111,6 +121,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
+        has_fn=lambda data: data.total_power_import_t1_kwh is not None,
         value_fn=lambda data: data.total_power_import_t1_kwh or None,
     ),
     HomeWizardSensorEntityDescription(
@@ -119,6 +130,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
+        has_fn=lambda data: data.total_power_import_t2_kwh is not None,
         value_fn=lambda data: data.total_power_import_t2_kwh or None,
     ),
     HomeWizardSensorEntityDescription(
@@ -127,6 +139,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
+        has_fn=lambda data: data.total_power_import_t3_kwh is not None,
         value_fn=lambda data: data.total_power_import_t3_kwh or None,
     ),
     HomeWizardSensorEntityDescription(
@@ -135,6 +148,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
+        has_fn=lambda data: data.total_power_import_t4_kwh is not None,
         value_fn=lambda data: data.total_power_import_t4_kwh or None,
     ),
     HomeWizardSensorEntityDescription(
@@ -143,6 +157,8 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
+        has_fn=lambda data: data.total_power_export_kwh is not None,
+        enabled_fn=lambda data: data.total_power_export_kwh != 0,
         value_fn=lambda data: data.total_power_export_kwh or None,
     ),
     HomeWizardSensorEntityDescription(
@@ -151,6 +167,8 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
+        has_fn=lambda data: data.total_power_export_t1_kwh is not None,
+        enabled_fn=lambda data: data.total_power_export_t1_kwh != 0,
         value_fn=lambda data: data.total_power_export_t1_kwh or None,
     ),
     HomeWizardSensorEntityDescription(
@@ -159,6 +177,8 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
+        has_fn=lambda data: data.total_power_export_t2_kwh is not None,
+        enabled_fn=lambda data: data.total_power_export_t2_kwh != 0,
         value_fn=lambda data: data.total_power_export_t2_kwh or None,
     ),
     HomeWizardSensorEntityDescription(
@@ -167,6 +187,8 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
+        has_fn=lambda data: data.total_power_export_t3_kwh is not None,
+        enabled_fn=lambda data: data.total_power_export_t3_kwh != 0,
         value_fn=lambda data: data.total_power_export_t3_kwh or None,
     ),
     HomeWizardSensorEntityDescription(
@@ -175,6 +197,8 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
+        has_fn=lambda data: data.total_power_export_t4_kwh is not None,
+        enabled_fn=lambda data: data.total_power_export_t4_kwh != 0,
         value_fn=lambda data: data.total_power_export_t4_kwh or None,
     ),
     HomeWizardSensorEntityDescription(
@@ -183,6 +207,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
+        has_fn=lambda data: data.active_power_w is not None,
         value_fn=lambda data: data.active_power_w,
     ),
     HomeWizardSensorEntityDescription(
@@ -191,6 +216,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
+        has_fn=lambda data: data.active_power_l1_w is not None,
         value_fn=lambda data: data.active_power_l1_w,
     ),
     HomeWizardSensorEntityDescription(
@@ -199,6 +225,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
+        has_fn=lambda data: data.active_power_l2_w is not None,
         value_fn=lambda data: data.active_power_l2_w,
     ),
     HomeWizardSensorEntityDescription(
@@ -207,6 +234,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
+        has_fn=lambda data: data.active_power_l3_w is not None,
         value_fn=lambda data: data.active_power_l3_w,
     ),
     HomeWizardSensorEntityDescription(
@@ -216,6 +244,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
+        has_fn=lambda data: data.active_voltage_l1_v is not None,
         value_fn=lambda data: data.active_voltage_l1_v,
     ),
     HomeWizardSensorEntityDescription(
@@ -225,6 +254,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
+        has_fn=lambda data: data.active_voltage_l2_v is not None,
         value_fn=lambda data: data.active_voltage_l2_v,
     ),
     HomeWizardSensorEntityDescription(
@@ -234,6 +264,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
+        has_fn=lambda data: data.active_voltage_l3_v is not None,
         value_fn=lambda data: data.active_voltage_l3_v,
     ),
     HomeWizardSensorEntityDescription(
@@ -243,6 +274,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
+        has_fn=lambda data: data.active_current_l1_a is not None,
         value_fn=lambda data: data.active_current_l1_a,
     ),
     HomeWizardSensorEntityDescription(
@@ -252,6 +284,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
+        has_fn=lambda data: data.active_current_l2_a is not None,
         value_fn=lambda data: data.active_current_l2_a,
     ),
     HomeWizardSensorEntityDescription(
@@ -261,6 +294,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
+        has_fn=lambda data: data.active_current_l3_a is not None,
         value_fn=lambda data: data.active_current_l3_a,
     ),
     HomeWizardSensorEntityDescription(
@@ -270,6 +304,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.FREQUENCY,
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
+        has_fn=lambda data: data.active_frequency_hz is not None,
         value_fn=lambda data: data.active_frequency_hz,
     ),
     HomeWizardSensorEntityDescription(
@@ -277,6 +312,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         name="Voltage sags detected L1",
         icon="mdi:alert",
         entity_category=EntityCategory.DIAGNOSTIC,
+        has_fn=lambda data: data.voltage_sag_l1_count is not None,
         value_fn=lambda data: data.voltage_sag_l1_count,
     ),
     HomeWizardSensorEntityDescription(
@@ -284,6 +320,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         name="Voltage sags detected L2",
         icon="mdi:alert",
         entity_category=EntityCategory.DIAGNOSTIC,
+        has_fn=lambda data: data.voltage_sag_l2_count is not None,
         value_fn=lambda data: data.voltage_sag_l2_count,
     ),
     HomeWizardSensorEntityDescription(
@@ -291,6 +328,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         name="Voltage sags detected L3",
         icon="mdi:alert",
         entity_category=EntityCategory.DIAGNOSTIC,
+        has_fn=lambda data: data.voltage_sag_l3_count is not None,
         value_fn=lambda data: data.voltage_sag_l3_count,
     ),
     HomeWizardSensorEntityDescription(
@@ -298,6 +336,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         name="Voltage swells detected L1",
         icon="mdi:alert",
         entity_category=EntityCategory.DIAGNOSTIC,
+        has_fn=lambda data: data.voltage_swell_l1_count is not None,
         value_fn=lambda data: data.voltage_swell_l1_count,
     ),
     HomeWizardSensorEntityDescription(
@@ -305,6 +344,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         name="Voltage swells detected L2",
         icon="mdi:alert",
         entity_category=EntityCategory.DIAGNOSTIC,
+        has_fn=lambda data: data.voltage_swell_l2_count is not None,
         value_fn=lambda data: data.voltage_swell_l2_count,
     ),
     HomeWizardSensorEntityDescription(
@@ -312,6 +352,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         name="Voltage swells detected L3",
         icon="mdi:alert",
         entity_category=EntityCategory.DIAGNOSTIC,
+        has_fn=lambda data: data.voltage_swell_l3_count is not None,
         value_fn=lambda data: data.voltage_swell_l3_count,
     ),
     HomeWizardSensorEntityDescription(
@@ -319,6 +360,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         name="Power failures detected",
         icon="mdi:transmission-tower-off",
         entity_category=EntityCategory.DIAGNOSTIC,
+        has_fn=lambda data: data.any_power_fail_count is not None,
         value_fn=lambda data: data.any_power_fail_count,
     ),
     HomeWizardSensorEntityDescription(
@@ -326,6 +368,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         name="Long power failures detected",
         icon="mdi:transmission-tower-off",
         entity_category=EntityCategory.DIAGNOSTIC,
+        has_fn=lambda data: data.long_power_fail_count is not None,
         value_fn=lambda data: data.long_power_fail_count,
     ),
     HomeWizardSensorEntityDescription(
@@ -333,6 +376,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         name="Active average demand",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
+        has_fn=lambda data: data.active_power_average_w is not None,
         value_fn=lambda data: data.active_power_average_w,
     ),
     HomeWizardSensorEntityDescription(
@@ -340,6 +384,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         name="Peak demand current month",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
+        has_fn=lambda data: data.monthly_power_peak_w is not None,
         value_fn=lambda data: data.monthly_power_peak_w,
     ),
     HomeWizardSensorEntityDescription(
@@ -348,6 +393,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfVolume.CUBIC_METERS,
         device_class=SensorDeviceClass.GAS,
         state_class=SensorStateClass.TOTAL_INCREASING,
+        has_fn=lambda data: data.total_gas_m3 is not None,
         value_fn=lambda data: data.total_gas_m3 or None,
     ),
     HomeWizardSensorEntityDescription(
@@ -355,6 +401,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         name="Gas meter identifier",
         icon="mdi:alphabetical-variant",
         entity_category=EntityCategory.DIAGNOSTIC,
+        has_fn=lambda data: data.gas_unique_id is not None,
         value_fn=lambda data: data.gas_unique_id,
     ),
     HomeWizardSensorEntityDescription(
@@ -363,6 +410,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         native_unit_of_measurement="l/min",
         icon="mdi:water",
         state_class=SensorStateClass.MEASUREMENT,
+        has_fn=lambda data: data.active_liter_lpm is not None,
         value_fn=lambda data: data.active_liter_lpm,
     ),
     HomeWizardSensorEntityDescription(
@@ -372,6 +420,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         icon="mdi:gauge",
         device_class=SensorDeviceClass.WATER,
         state_class=SensorStateClass.TOTAL_INCREASING,
+        has_fn=lambda data: data.total_liter_m3 is not None,
         value_fn=lambda data: data.total_liter_m3 or None,
     ),
 )
@@ -386,7 +435,7 @@ async def async_setup_entry(
     async_add_entities(
         HomeWizardSensorEntity(coordinator, entry, description)
         for description in SENSORS
-        if description.value_fn(coordinator.data.data) is not None
+        if description.has_fn(coordinator.data.data)
     )
 
 
@@ -405,20 +454,7 @@ class HomeWizardSensorEntity(HomeWizardEntity, SensorEntity):
         super().__init__(coordinator)
         self.entity_description = description
         self._attr_unique_id = f"{entry.unique_id}_{description.key}"
-
-        # Special case for export, not everyone has solar panels
-        # The chance that 'export' is non-zero when you have solar panels is nil
-        if (
-            description.key
-            in [
-                "total_power_export_kwh",
-                "total_power_export_t1_kwh",
-                "total_power_export_t2_kwh",
-                "total_power_export_t3_kwh",
-                "total_power_export_t4_kwh",
-            ]
-            and self.native_value is None
-        ):
+        if not description.enabled_fn(self.coordinator.data.data):
             self._attr_entity_registry_enabled_default = False
 
     @property

--- a/homeassistant/components/homewizard/sensor.py
+++ b/homeassistant/components/homewizard/sensor.py
@@ -386,7 +386,7 @@ async def async_setup_entry(
     async_add_entities(
         HomeWizardSensorEntity(coordinator, entry, description)
         for description in SENSORS
-        if getattr(coordinator.data.data, description.key, None) is not None
+        if description.value_fn(coordinator.data.data) is not None
     )
 
 

--- a/homeassistant/components/homewizard/sensor.py
+++ b/homeassistant/components/homewizard/sensor.py
@@ -103,7 +103,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        value_fn=lambda data: data.total_power_import_kwh,
+        value_fn=lambda data: data.total_power_import_kwh or None,
     ),
     HomeWizardSensorEntityDescription(
         key="total_power_import_t1_kwh",
@@ -111,7 +111,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        value_fn=lambda data: data.total_power_import_t1_kwh,
+        value_fn=lambda data: data.total_power_import_t1_kwh or None,
     ),
     HomeWizardSensorEntityDescription(
         key="total_power_import_t2_kwh",
@@ -119,7 +119,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        value_fn=lambda data: data.total_power_import_t2_kwh,
+        value_fn=lambda data: data.total_power_import_t2_kwh or None,
     ),
     HomeWizardSensorEntityDescription(
         key="total_power_import_t3_kwh",
@@ -127,7 +127,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        value_fn=lambda data: data.total_power_import_t3_kwh,
+        value_fn=lambda data: data.total_power_import_t3_kwh or None,
     ),
     HomeWizardSensorEntityDescription(
         key="total_power_import_t4_kwh",
@@ -135,7 +135,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        value_fn=lambda data: data.total_power_import_t4_kwh,
+        value_fn=lambda data: data.total_power_import_t4_kwh or None,
     ),
     HomeWizardSensorEntityDescription(
         key="total_power_export_kwh",
@@ -143,7 +143,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        value_fn=lambda data: data.total_power_export_kwh,
+        value_fn=lambda data: data.total_power_export_kwh or None,
     ),
     HomeWizardSensorEntityDescription(
         key="total_power_export_t1_kwh",
@@ -151,7 +151,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        value_fn=lambda data: data.total_power_export_t1_kwh,
+        value_fn=lambda data: data.total_power_export_t1_kwh or None,
     ),
     HomeWizardSensorEntityDescription(
         key="total_power_export_t2_kwh",
@@ -159,7 +159,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        value_fn=lambda data: data.total_power_export_t2_kwh,
+        value_fn=lambda data: data.total_power_export_t2_kwh or None,
     ),
     HomeWizardSensorEntityDescription(
         key="total_power_export_t3_kwh",
@@ -167,7 +167,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        value_fn=lambda data: data.total_power_export_t3_kwh,
+        value_fn=lambda data: data.total_power_export_t3_kwh or None,
     ),
     HomeWizardSensorEntityDescription(
         key="total_power_export_t4_kwh",
@@ -175,7 +175,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        value_fn=lambda data: data.total_power_export_t4_kwh,
+        value_fn=lambda data: data.total_power_export_t4_kwh or None,
     ),
     HomeWizardSensorEntityDescription(
         key="active_power_w",
@@ -348,7 +348,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfVolume.CUBIC_METERS,
         device_class=SensorDeviceClass.GAS,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        value_fn=lambda data: data.total_gas_m3,
+        value_fn=lambda data: data.total_gas_m3 or None,
     ),
     HomeWizardSensorEntityDescription(
         key="gas_unique_id",
@@ -372,7 +372,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         icon="mdi:gauge",
         device_class=SensorDeviceClass.WATER,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        value_fn=lambda data: data.total_liter_m3,
+        value_fn=lambda data: data.total_liter_m3 or None,
     ),
 )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I had some issues with my homewizard watermeter (local API fw 2.03) where the total water usage readout was reported as `0` where there was an error reading it out. In those cases a sensor could be unknown. If a `0` is processed and later the correct value is reported, the total sum be increased with the total usage. This need to be addressed. A way to address this as a work-a-round within Home assistant is to make the value `unknown`. That is what this PR tries to do.

An alternative is to make sure the API guarantees increasing values which is doesn't seem to do at currently, there is a big risk that this disturbs long term statistics for the sensors reporting wrong values. I had to correct my database to fix these.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #89021
- This PR is related to issue: #87432
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
