### PR TITLE
Fall back to polling if webhook cannot be registered on Nuki

### DIFF
--- a/homeassistant/components/nuki/__init__.py
+++ b/homeassistant/components/nuki/__init__.py
@@ -25,7 +25,6 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import Event, HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import (
     device_registry as dr,
     entity_registry as er,
@@ -47,7 +46,7 @@ from .const import (
     DOMAIN,
     ERROR_STATES,
 )
-from .helpers import parse_id
+from .helpers import NukiWebhookException, parse_id
 
 _NukiDeviceT = TypeVar("_NukiDeviceT", bound=NukiDevice)
 
@@ -59,6 +58,87 @@ UPDATE_INTERVAL = timedelta(seconds=30)
 
 def _get_bridge_devices(bridge: NukiBridge) -> tuple[list[NukiLock], list[NukiOpener]]:
     return bridge.locks, bridge.openers
+
+
+async def _create_webhook(
+    hass: HomeAssistant, entry: ConfigEntry, bridge: NukiBridge
+) -> None:
+    # Create HomeAssistant webhook
+    async def handle_webhook(
+        hass: HomeAssistant, webhook_id: str, request: web.Request
+    ) -> web.Response:
+        """Handle webhook callback."""
+        try:
+            data = await request.json()
+        except ValueError:
+            return web.Response(status=HTTPStatus.BAD_REQUEST)
+
+        locks = hass.data[DOMAIN][entry.entry_id][DATA_LOCKS]
+        openers = hass.data[DOMAIN][entry.entry_id][DATA_OPENERS]
+
+        devices = [x for x in locks + openers if x.nuki_id == data["nukiId"]]
+        if len(devices) == 1:
+            devices[0].update_from_callback(data)
+
+        coordinator = hass.data[DOMAIN][entry.entry_id][DATA_COORDINATOR]
+        coordinator.async_set_updated_data(None)
+
+        return web.Response(status=HTTPStatus.OK)
+
+    webhook.async_register(
+        hass, DOMAIN, entry.title, entry.entry_id, handle_webhook, local_only=True
+    )
+
+    webhook_url = webhook.async_generate_path(entry.entry_id)
+
+    try:
+        hass_url = get_url(
+            hass,
+            allow_cloud=False,
+            allow_external=False,
+            allow_ip=True,
+            require_ssl=False,
+        )
+    except NoURLAvailableError:
+        webhook.async_unregister(hass, entry.entry_id)
+        raise NukiWebhookException(
+            f"Error registering URL for webhook {entry.entry_id}: "
+            "HomeAssistant URL is not available"
+        ) from None
+
+    url = f"{hass_url}{webhook_url}"
+
+    if hass_url.startswith("https"):
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            "https_webhook",
+            is_fixable=False,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key="https_webhook",
+            translation_placeholders={
+                "base_url": hass_url,
+                "network_link": "https://my.home-assistant.io/redirect/network/",
+            },
+        )
+    else:
+        ir.async_delete_issue(hass, DOMAIN, "https_webhook")
+
+        try:
+            async with async_timeout.timeout(10):
+                await hass.async_add_executor_job(
+                    _register_webhook, bridge, entry.entry_id, url
+                )
+        except InvalidCredentialsException as err:
+            webhook.async_unregister(hass, entry.entry_id)
+            raise NukiWebhookException(
+                f"Invalid credentials for Bridge: {err}"
+            ) from err
+        except RequestException as err:
+            webhook.async_unregister(hass, entry.entry_id)
+            raise NukiWebhookException(
+                f"Error communicating with Bridge: {err}"
+            ) from err
 
 
 def _register_webhook(bridge: NukiBridge, entry_id: str, url: str) -> bool:
@@ -126,79 +206,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         sw_version=info["versions"]["firmwareVersion"],
     )
 
-    async def handle_webhook(
-        hass: HomeAssistant, webhook_id: str, request: web.Request
-    ) -> web.Response:
-        """Handle webhook callback."""
-        try:
-            data = await request.json()
-        except ValueError:
-            return web.Response(status=HTTPStatus.BAD_REQUEST)
-
-        locks = hass.data[DOMAIN][entry.entry_id][DATA_LOCKS]
-        openers = hass.data[DOMAIN][entry.entry_id][DATA_OPENERS]
-
-        devices = [x for x in locks + openers if x.nuki_id == data["nukiId"]]
-        if len(devices) == 1:
-            devices[0].update_from_callback(data)
-
-        coordinator = hass.data[DOMAIN][entry.entry_id][DATA_COORDINATOR]
-        coordinator.async_set_updated_data(None)
-
-        return web.Response(status=HTTPStatus.OK)
-
-    webhook.async_register(
-        hass, DOMAIN, entry.title, entry.entry_id, handle_webhook, local_only=True
-    )
-
-    webhook_url = webhook.async_generate_path(entry.entry_id)
-
     try:
-        hass_url = get_url(
-            hass,
-            allow_cloud=False,
-            allow_external=False,
-            allow_ip=True,
-            require_ssl=False,
-        )
-    except NoURLAvailableError:
-        webhook.async_unregister(hass, entry.entry_id)
-        raise ConfigEntryNotReady(
-            f"Error registering URL for webhook {entry.entry_id}: "
-            "HomeAssistant URL is not available"
-        ) from None
-
-    url = f"{hass_url}{webhook_url}"
-
-    if hass_url.startswith("https"):
-        ir.async_create_issue(
-            hass,
-            DOMAIN,
-            "https_webhook",
-            is_fixable=False,
-            severity=ir.IssueSeverity.WARNING,
-            translation_key="https_webhook",
-            translation_placeholders={
-                "base_url": hass_url,
-                "network_link": "https://my.home-assistant.io/redirect/network/",
-            },
-        )
-    else:
-        ir.async_delete_issue(hass, DOMAIN, "https_webhook")
-
-        try:
-            async with async_timeout.timeout(10):
-                await hass.async_add_executor_job(
-                    _register_webhook, bridge, entry.entry_id, url
-                )
-        except InvalidCredentialsException as err:
-            webhook.async_unregister(hass, entry.entry_id)
-            raise ConfigEntryNotReady(f"Invalid credentials for Bridge: {err}") from err
-        except RequestException as err:
-            webhook.async_unregister(hass, entry.entry_id)
-            raise ConfigEntryNotReady(
-                f"Error communicating with Bridge: {err}"
-            ) from err
+        await _create_webhook(hass, entry, bridge)
+    except NukiWebhookException as err:
+        _LOGGER.warning("Error registering HomeAssistant webhook: %s", err)
 
     async def _stop_nuki(_: Event):
         """Stop and remove the Nuki webhook."""

--- a/homeassistant/components/nuki/helpers.py
+++ b/homeassistant/components/nuki/helpers.py
@@ -13,3 +13,7 @@ class CannotConnect(exceptions.HomeAssistantError):
 
 class InvalidAuth(exceptions.HomeAssistantError):
     """Error to indicate there is invalid auth."""
+
+
+class NukiWebhookException(exceptions.HomeAssistantError):
+    """Error to indicate there was an issue with the webhook."""


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Just log a warning if the webhook cannot be registered inside HomeAssistant or the NukiBridge.
This allows the integration to fall back to polling.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #90962
- This PR is related to issue: #90926
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
