### PR TITLE
Add config flow to dwd_weather_warnings

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -288,6 +288,7 @@ build.json @home-assistant/supervisor
 /homeassistant/components/dunehd/ @bieniu
 /tests/components/dunehd/ @bieniu
 /homeassistant/components/dwd_weather_warnings/ @runningman84 @stephan192 @Hummel95 @andarotajo
+/tests/components/dwd_weather_warnings/ @runningman84 @stephan192 @Hummel95 @andarotajo
 /homeassistant/components/dynalite/ @ziv1234
 /tests/components/dynalite/ @ziv1234
 /homeassistant/components/eafm/ @Jc2k

--- a/homeassistant/components/dwd_weather_warnings/__init__.py
+++ b/homeassistant/components/dwd_weather_warnings/__init__.py
@@ -1,1 +1,37 @@
 """The dwd_weather_warnings component."""
+
+from __future__ import annotations
+
+from dwdwfsapi import DwdWeatherWarningsAPI
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import CONF_REGION_IDENTIFIER, DOMAIN, PLATFORMS
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up a config entry."""
+    region_identifier: str = entry.data.get(CONF_REGION_IDENTIFIER, None)
+
+    # Initialize the API.
+    if region_identifier is not None:
+        api = await hass.async_add_executor_job(
+            DwdWeatherWarningsAPI, region_identifier
+        )
+
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][entry.entry_id] = api
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id)
+
+    return unload_ok

--- a/homeassistant/components/dwd_weather_warnings/__init__.py
+++ b/homeassistant/components/dwd_weather_warnings/__init__.py
@@ -27,8 +27,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-    if unload_ok:
+    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok

--- a/homeassistant/components/dwd_weather_warnings/__init__.py
+++ b/homeassistant/components/dwd_weather_warnings/__init__.py
@@ -12,13 +12,10 @@ from .const import CONF_REGION_IDENTIFIER, DOMAIN, PLATFORMS
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up a config entry."""
-    region_identifier: str = entry.data.get(CONF_REGION_IDENTIFIER, None)
+    region_identifier: str = entry.data[CONF_REGION_IDENTIFIER]
 
     # Initialize the API.
-    if region_identifier is not None:
-        api = await hass.async_add_executor_job(
-            DwdWeatherWarningsAPI, region_identifier
-        )
+    api = await hass.async_add_executor_job(DwdWeatherWarningsAPI, region_identifier)
 
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = api

--- a/homeassistant/components/dwd_weather_warnings/config_flow.py
+++ b/homeassistant/components/dwd_weather_warnings/config_flow.py
@@ -13,8 +13,8 @@ from homeassistant.data_entry_flow import FlowResult
 import homeassistant.helpers.config_validation as cv
 
 from .const import (
-    CONF_OLD_REGION_NAME,
     CONF_REGION_IDENTIFIER,
+    CONF_REGION_NAME,
     DEFAULT_NAME,
     DOMAIN,
     LOGGER,
@@ -70,7 +70,7 @@ class DwdWeatherWarningsConfigFlow(ConfigFlow, domain=DOMAIN):
         )
 
         # Adjust data to new format.
-        region_identifier = import_config.pop(CONF_OLD_REGION_NAME)
+        region_identifier = import_config.pop(CONF_REGION_NAME)
         import_config[CONF_REGION_IDENTIFIER] = region_identifier
 
         if CONF_NAME not in import_config:

--- a/homeassistant/components/dwd_weather_warnings/config_flow.py
+++ b/homeassistant/components/dwd_weather_warnings/config_flow.py
@@ -1,0 +1,111 @@
+"""Config flow for the dwd_weather_warnings integration."""
+
+from __future__ import annotations
+
+from typing import Any, Final
+
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigFlow
+from homeassistant.const import CONF_MONITORED_CONDITIONS, CONF_NAME
+from homeassistant.data_entry_flow import FlowResult
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.selector import (
+    SelectOptionDict,
+    SelectSelector,
+    SelectSelectorConfig,
+)
+
+from .const import (
+    ADVANCE_WARNING_SENSOR,
+    CONF_OLD_REGION_NAME,
+    CONF_REGION_IDENTIFIER,
+    CURRENT_WARNING_SENSOR,
+    DEFAULT_MONITORED_CONDITIONS,
+    DEFAULT_NAME,
+    DOMAIN,
+    LOGGER,
+)
+
+CONFIG_SCHEMA: Final = vol.Schema(
+    {
+        vol.Required(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Required(CONF_REGION_IDENTIFIER): cv.string,
+        vol.Required(
+            CONF_MONITORED_CONDITIONS, default=DEFAULT_MONITORED_CONDITIONS
+        ): SelectSelector(
+            SelectSelectorConfig(
+                options=[
+                    SelectOptionDict(
+                        label="Current warning level",
+                        value=CURRENT_WARNING_SENSOR,
+                    ),
+                    SelectOptionDict(
+                        label="Advance warning level",
+                        value=ADVANCE_WARNING_SENSOR,
+                    ),
+                ],
+                multiple=True,
+            )
+        ),
+    }
+)
+
+
+class DwdWeatherWarningsConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle the config flow for the dwd_weather_warnings integration."""
+
+    VERSION = 1
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle the initial step."""
+        errors: dict = {}
+
+        if user_input is not None:
+            # Check, if either CONF_REGION or CONF_GPS_TRACKER has been set.
+            if CONF_REGION_IDENTIFIER not in user_input:
+                errors["base"] = "no_identifier"
+            else:
+                # Abort, if a sensor with this name already exists.
+                for entry in self._async_current_entries():
+                    if entry.data[CONF_NAME] == user_input[CONF_NAME]:
+                        return self.async_abort(reason="already_configured")
+
+                # Monitor all conditions by default, if none are set.
+                if not user_input[CONF_MONITORED_CONDITIONS]:
+                    user_input[CONF_MONITORED_CONDITIONS] = DEFAULT_MONITORED_CONDITIONS
+
+                return self.async_create_entry(
+                    title=user_input[CONF_NAME], data=user_input
+                )
+
+        return self.async_show_form(
+            step_id="user", errors=errors, data_schema=CONFIG_SCHEMA
+        )
+
+    async def async_step_import(self, import_config: dict[str, Any]) -> FlowResult:
+        """Import a config entry from configuration.yaml."""
+        LOGGER.debug(
+            "Starting import of sensor from configuration.yaml - %s", import_config
+        )
+
+        # Adjust data to new format.
+        region_identifier = import_config.pop(CONF_OLD_REGION_NAME)
+        import_config[CONF_REGION_IDENTIFIER] = region_identifier
+
+        if CONF_NAME not in import_config:
+            import_config[CONF_NAME] = DEFAULT_NAME
+
+        if CONF_MONITORED_CONDITIONS not in import_config:
+            import_config[CONF_MONITORED_CONDITIONS] = DEFAULT_MONITORED_CONDITIONS
+
+        # Abort, if a sensor with this name already exists.
+        for entry in self._async_current_entries():
+            if entry.data[CONF_NAME] == import_config[CONF_NAME]:
+                return self.async_abort(reason="already_configured")
+
+        return self.async_create_entry(
+            title=import_config[CONF_NAME], data=import_config
+        )

--- a/homeassistant/components/dwd_weather_warnings/config_flow.py
+++ b/homeassistant/components/dwd_weather_warnings/config_flow.py
@@ -53,11 +53,9 @@ class DwdWeatherWarningsConfigFlow(ConfigFlow, domain=DOMAIN):
                 self._abort_if_unique_id_configured()
 
                 # Set the name for this config entry.
-                user_input[CONF_NAME] = f"{DEFAULT_NAME} {region_identifier}"
+                name = f"{DEFAULT_NAME} {region_identifier}"
 
-                return self.async_create_entry(
-                    title=user_input[CONF_NAME], data=user_input
-                )
+                return self.async_create_entry(title=name, data=user_input)
 
         return self.async_show_form(
             step_id="user", errors=errors, data_schema=CONFIG_SCHEMA
@@ -83,11 +81,8 @@ class DwdWeatherWarningsConfigFlow(ConfigFlow, domain=DOMAIN):
         ):
             return self.async_abort(reason="invalid_identifier")
 
-        if CONF_NAME not in import_config:
-            import_config[
-                CONF_NAME
-            ] = f"{DEFAULT_NAME} {import_config[CONF_REGION_IDENTIFIER]}"
-
-        return self.async_create_entry(
-            title=import_config[CONF_NAME], data=import_config
+        name = import_config.get(
+            CONF_NAME, f"{DEFAULT_NAME} {import_config[CONF_REGION_IDENTIFIER]}"
         )
+
+        return self.async_create_entry(title=name, data=import_config)

--- a/homeassistant/components/dwd_weather_warnings/const.py
+++ b/homeassistant/components/dwd_weather_warnings/const.py
@@ -12,7 +12,7 @@ LOGGER = logging.getLogger(__package__)
 
 DOMAIN: Final = "dwd_weather_warnings"
 
-CONF_OLD_REGION_NAME: Final = "region_name"
+CONF_REGION_NAME: Final = "region_name"
 CONF_REGION_IDENTIFIER: Final = "region_identifier"
 
 ATTR_REGION_NAME: Final = "region_name"

--- a/homeassistant/components/dwd_weather_warnings/const.py
+++ b/homeassistant/components/dwd_weather_warnings/const.py
@@ -11,7 +11,6 @@ from homeassistant.const import Platform
 LOGGER = logging.getLogger(__package__)
 
 DOMAIN: Final = "dwd_weather_warnings"
-ATTRIBUTION: Final = "Data provided by DWD"
 
 CONF_OLD_REGION_NAME: Final = "region_name"
 CONF_REGION_IDENTIFIER: Final = "region_identifier"

--- a/homeassistant/components/dwd_weather_warnings/const.py
+++ b/homeassistant/components/dwd_weather_warnings/const.py
@@ -6,9 +6,15 @@ from datetime import timedelta
 import logging
 from typing import Final
 
+from homeassistant.const import Platform
+
 LOGGER = logging.getLogger(__package__)
 
-CONF_REGION_NAME: Final = "region_name"
+DOMAIN: Final = "dwd_weather_warnings"
+ATTRIBUTION: Final = "Data provided by DWD"
+
+CONF_OLD_REGION_NAME: Final = "region_name"
+CONF_REGION_IDENTIFIER: Final = "region_identifier"
 
 ATTR_REGION_NAME: Final = "region_name"
 ATTR_REGION_ID: Final = "region_id"
@@ -29,5 +35,8 @@ API_ATTR_WARNING_COLOR: Final = "color"
 CURRENT_WARNING_SENSOR: Final = "current_warning_level"
 ADVANCE_WARNING_SENSOR: Final = "advance_warning_level"
 
-DEFAULT_NAME: Final = "DWD-Weather-Warnings"
+DEFAULT_NAME: Final = "DWD Weather Warnings"
 DEFAULT_SCAN_INTERVAL: Final = timedelta(minutes=15)
+DEFAULT_MONITORED_CONDITIONS: Final = [CURRENT_WARNING_SENSOR, ADVANCE_WARNING_SENSOR]
+
+PLATFORMS: Final[list[Platform]] = [Platform.SENSOR]

--- a/homeassistant/components/dwd_weather_warnings/const.py
+++ b/homeassistant/components/dwd_weather_warnings/const.py
@@ -36,6 +36,5 @@ ADVANCE_WARNING_SENSOR: Final = "advance_warning_level"
 
 DEFAULT_NAME: Final = "DWD Weather Warnings"
 DEFAULT_SCAN_INTERVAL: Final = timedelta(minutes=15)
-DEFAULT_MONITORED_CONDITIONS: Final = [CURRENT_WARNING_SENSOR, ADVANCE_WARNING_SENSOR]
 
 PLATFORMS: Final[list[Platform]] = [Platform.SENSOR]

--- a/homeassistant/components/dwd_weather_warnings/manifest.json
+++ b/homeassistant/components/dwd_weather_warnings/manifest.json
@@ -2,6 +2,7 @@
   "domain": "dwd_weather_warnings",
   "name": "Deutscher Wetterdienst (DWD) Weather Warnings",
   "codeowners": ["@runningman84", "@stephan192", "@Hummel95", "@andarotajo"],
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/dwd_weather_warnings",
   "iot_class": "cloud_polling",
   "loggers": ["dwdwfsapi"],

--- a/homeassistant/components/dwd_weather_warnings/sensor.py
+++ b/homeassistant/components/dwd_weather_warnings/sensor.py
@@ -11,6 +11,8 @@ Wetterwarnungen (Stufe 1)
 
 from __future__ import annotations
 
+from typing import Final
+
 import voluptuous as vol
 
 from homeassistant.components.sensor import (
@@ -45,7 +47,6 @@ from .const import (
     ATTR_WARNING_COUNT,
     CONF_REGION_NAME,
     CURRENT_WARNING_SENSOR,
-    DEFAULT_MONITORED_CONDITIONS,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     LOGGER,
@@ -64,13 +65,16 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
     ),
 )
 
+# Should be removed together with the old YAML configuration.
+YAML_MONITORED_CONDITIONS: Final = [CURRENT_WARNING_SENSOR, ADVANCE_WARNING_SENSOR]
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_REGION_NAME): cv.string,
         vol.Optional(CONF_NAME): cv.string,
         vol.Optional(
-            CONF_MONITORED_CONDITIONS, default=DEFAULT_MONITORED_CONDITIONS
-        ): vol.All(cv.ensure_list, [vol.In(DEFAULT_MONITORED_CONDITIONS)]),
+            CONF_MONITORED_CONDITIONS, default=YAML_MONITORED_CONDITIONS
+        ): vol.All(cv.ensure_list, [vol.In(YAML_MONITORED_CONDITIONS)]),
     }
 )
 
@@ -87,7 +91,7 @@ async def async_setup_platform(
         hass,
         DOMAIN,
         "deprecated_yaml",
-        breaks_in_ha_version="2023.7.0",
+        breaks_in_ha_version="2023.8.0",
         is_fixable=False,
         severity=IssueSeverity.WARNING,
         translation_key="deprecated_yaml",

--- a/homeassistant/components/dwd_weather_warnings/sensor.py
+++ b/homeassistant/components/dwd_weather_warnings/sensor.py
@@ -108,17 +108,15 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up entities from config entry."""
-    name: str = entry.data[CONF_NAME]
     api = WrappedDwDWWAPI(hass.data[DOMAIN][entry.entry_id])
 
-    # Add sensor for every monitored condition.
-    entities: list[DwdWeatherWarningsSensor] = []
-    for description in SENSOR_TYPES:
-        entities.append(
-            DwdWeatherWarningsSensor(api, name, entry.unique_id, description)
-        )
-
-    async_add_entities(entities, True)
+    async_add_entities(
+        [
+            DwdWeatherWarningsSensor(api, entry.title, entry.unique_id, description)
+            for description in SENSOR_TYPES
+        ],
+        True,
+    )
 
 
 class DwdWeatherWarningsSensor(SensorEntity):

--- a/homeassistant/components/dwd_weather_warnings/sensor.py
+++ b/homeassistant/components/dwd_weather_warnings/sensor.py
@@ -43,7 +43,6 @@ from .const import (
     ATTR_REGION_ID,
     ATTR_REGION_NAME,
     ATTR_WARNING_COUNT,
-    ATTRIBUTION,
     CONF_OLD_REGION_NAME,
     CURRENT_WARNING_SENSOR,
     DEFAULT_MONITORED_CONDITIONS,
@@ -106,14 +105,14 @@ async def async_setup_entry(
 ) -> None:
     """Set up entities from config entry."""
     name: str = entry.data[CONF_NAME]
-    monitored_conditions: list[str] = entry.data[CONF_MONITORED_CONDITIONS]
     api = WrappedDwDWWAPI(hass.data[DOMAIN][entry.entry_id])
 
     # Add sensor for every monitored condition.
     entities: list[DwdWeatherWarningsSensor] = []
     for description in SENSOR_TYPES:
-        if description.key in monitored_conditions:
-            entities.append(DwdWeatherWarningsSensor(api, name, description))
+        entities.append(
+            DwdWeatherWarningsSensor(api, name, entry.unique_id, description)
+        )
 
     async_add_entities(entities, True)
 
@@ -121,18 +120,20 @@ async def async_setup_entry(
 class DwdWeatherWarningsSensor(SensorEntity):
     """Representation of a DWD-Weather-Warnings sensor."""
 
-    _attr_attribution = ATTRIBUTION
+    _attr_attribution = "Data provided by DWD"
 
     def __init__(
         self,
         api,
         name,
+        unique_id,
         description: SensorEntityDescription,
     ) -> None:
         """Initialize a DWD-Weather-Warnings sensor."""
         self._api = api
         self.entity_description = description
         self._attr_name = f"{name} {description.name}"
+        self._attr_unique_id = f"{unique_id}-{description.key}"
 
     @property
     def native_value(self):

--- a/homeassistant/components/dwd_weather_warnings/sensor.py
+++ b/homeassistant/components/dwd_weather_warnings/sensor.py
@@ -8,20 +8,15 @@ Unwetterwarnungen (Stufe 3)
 Warnungen vor markantem Wetter (Stufe 2)
 Wetterwarnungen (Stufe 1)
 """
+
 from __future__ import annotations
 
-from dwdwfsapi import DwdWeatherWarningsAPI
-import voluptuous as vol
-
-from homeassistant.components.sensor import (
-    PLATFORM_SCHEMA,
-    SensorEntity,
-    SensorEntityDescription,
-)
-from homeassistant.const import CONF_MONITORED_CONDITIONS, CONF_NAME
+from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.const import ATTR_ATTRIBUTION, CONF_MONITORED_CONDITIONS, CONF_NAME
 from homeassistant.core import HomeAssistant
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util import Throttle
 
@@ -41,10 +36,10 @@ from .const import (
     ATTR_REGION_ID,
     ATTR_REGION_NAME,
     ATTR_WARNING_COUNT,
-    CONF_REGION_NAME,
+    ATTRIBUTION,
     CURRENT_WARNING_SENSOR,
-    DEFAULT_NAME,
     DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
     LOGGER,
 )
 
@@ -60,45 +55,51 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
         icon="mdi:close-octagon-outline",
     ),
 )
-MONITORED_CONDITIONS: list[str] = [desc.key for desc in SENSOR_TYPES]
 
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Required(CONF_REGION_NAME): cv.string,
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Optional(
-            CONF_MONITORED_CONDITIONS, default=list(MONITORED_CONDITIONS)
-        ): vol.All(cv.ensure_list, [vol.In(MONITORED_CONDITIONS)]),
-    }
-)
-
-
-def setup_platform(
+async def async_setup_platform(
     hass: HomeAssistant,
     config: ConfigType,
     add_entities: AddEntitiesCallback,
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
-    """Set up the DWD-Weather-Warnings sensor."""
-    name = config.get(CONF_NAME)
-    region_name = config.get(CONF_REGION_NAME)
+    """Import the configurations from YAML to config flows."""
+    # Show issue as long as the YAML configuration exists.
+    async_create_issue(
+        hass,
+        DOMAIN,
+        "deprecated_yaml",
+        is_fixable=False,
+        severity=IssueSeverity.WARNING,
+        translation_key="deprecated_yaml",
+    )
 
-    api = WrappedDwDWWAPI(DwdWeatherWarningsAPI(region_name))
+    hass.async_create_task(
+        hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_IMPORT}, data=config
+        )
+    )
 
-    sensors = [
-        DwdWeatherWarningsSensor(api, name, description)
-        for description in SENSOR_TYPES
-        if description.key in config[CONF_MONITORED_CONDITIONS]
-    ]
 
-    add_entities(sensors, True)
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up entities from config entry."""
+    name: str = entry.data[CONF_NAME]
+    monitored_conditions: list[str] = entry.data[CONF_MONITORED_CONDITIONS]
+    api = WrappedDwDWWAPI(hass.data[DOMAIN][entry.entry_id])
+
+    # Add sensor for every monitored condition.
+    entities: list[DwdWeatherWarningsSensor] = []
+    for description in SENSOR_TYPES:
+        if description.key in monitored_conditions:
+            entities.append(DwdWeatherWarningsSensor(api, name, description))
+
+    async_add_entities(entities, True)
 
 
 class DwdWeatherWarningsSensor(SensorEntity):
     """Representation of a DWD-Weather-Warnings sensor."""
-
-    _attr_attribution = "Data provided by DWD"
 
     def __init__(
         self,
@@ -113,15 +114,17 @@ class DwdWeatherWarningsSensor(SensorEntity):
 
     @property
     def native_value(self):
-        """Return the state of the device."""
+        """Return the state of the sensor."""
         if self.entity_description.key == CURRENT_WARNING_SENSOR:
             return self._api.api.current_warning_level
+
         return self._api.api.expected_warning_level
 
     @property
     def extra_state_attributes(self):
-        """Return the state attributes of the DWD-Weather-Warnings."""
+        """Return the state attributes of the sensor."""
         data = {
+            ATTR_ATTRIBUTION: ATTRIBUTION,
             ATTR_REGION_NAME: self._api.api.warncell_name,
             ATTR_REGION_ID: self._api.api.warncell_id,
             ATTR_LAST_UPDATE: self._api.api.last_update,

--- a/homeassistant/components/dwd_weather_warnings/sensor.py
+++ b/homeassistant/components/dwd_weather_warnings/sensor.py
@@ -43,7 +43,7 @@ from .const import (
     ATTR_REGION_ID,
     ATTR_REGION_NAME,
     ATTR_WARNING_COUNT,
-    CONF_OLD_REGION_NAME,
+    CONF_REGION_NAME,
     CURRENT_WARNING_SENSOR,
     DEFAULT_MONITORED_CONDITIONS,
     DEFAULT_SCAN_INTERVAL,
@@ -66,7 +66,7 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
-        vol.Required(CONF_OLD_REGION_NAME): cv.string,
+        vol.Required(CONF_REGION_NAME): cv.string,
         vol.Optional(CONF_NAME): cv.string,
         vol.Optional(
             CONF_MONITORED_CONDITIONS, default=DEFAULT_MONITORED_CONDITIONS

--- a/homeassistant/components/dwd_weather_warnings/strings.json
+++ b/homeassistant/components/dwd_weather_warnings/strings.json
@@ -12,7 +12,8 @@
       "invalid_identifier": "The specified region identifier is invalid."
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "Warncell ID / name is already configured.",
+      "invalid_identifier": "[%key:component::dwd_weather_warnings::config::error::invalid_identifier%]"
     }
   },
   "issues": {

--- a/homeassistant/components/dwd_weather_warnings/strings.json
+++ b/homeassistant/components/dwd_weather_warnings/strings.json
@@ -1,0 +1,26 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "description": "To identify the desired region, the warncell ID / name is required.",
+        "data": {
+          "name": "Name of the sensor (default: DWD Weather Warnings)",
+          "region_identifier": "Warncell ID or name",
+          "monitored_conditions": "Monitored conditions (default: all)"
+        }
+      }
+    },
+    "error": {
+      "no_identifier": "The warncell identifier has to be specified."
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    }
+  },
+  "issues": {
+    "deprecated_yaml": {
+      "title": "The Deutscher Wetterdienst (DWD) Weather Warnings YAML configuration is being removed",
+      "description": "Configuring Deutscher Wetterdienst (DWD) Weather Warnings using YAML is being removed.\n\nYour existing YAML configuration has been imported into the UI automatically.\n\nRemove the Deutscher Wetterdienst (DWD) Weather Warnings YAML configuration from your configuration.yaml file and restart Home Assistant to fix this issue."
+    }
+  }
+}

--- a/homeassistant/components/dwd_weather_warnings/strings.json
+++ b/homeassistant/components/dwd_weather_warnings/strings.json
@@ -4,10 +4,12 @@
       "user": {
         "description": "To identify the desired region, the warncell ID / name is required.",
         "data": {
-          "name": "Name of the sensor (default: DWD Weather Warnings)",
           "region_identifier": "Warncell ID or name"
         }
       }
+    },
+    "error": {
+      "invalid_identifier": "The specified region identifier is invalid."
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"

--- a/homeassistant/components/dwd_weather_warnings/strings.json
+++ b/homeassistant/components/dwd_weather_warnings/strings.json
@@ -5,13 +5,9 @@
         "description": "To identify the desired region, the warncell ID / name is required.",
         "data": {
           "name": "Name of the sensor (default: DWD Weather Warnings)",
-          "region_identifier": "Warncell ID or name",
-          "monitored_conditions": "Monitored conditions (default: all)"
+          "region_identifier": "Warncell ID or name"
         }
       }
-    },
-    "error": {
-      "no_identifier": "The warncell identifier has to be specified."
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -103,6 +103,7 @@ FLOWS = {
         "dsmr",
         "dsmr_reader",
         "dunehd",
+        "dwd_weather_warnings",
         "dynalite",
         "eafm",
         "easyenergy",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -1200,7 +1200,7 @@
     "dwd_weather_warnings": {
       "name": "Deutscher Wetterdienst (DWD) Weather Warnings",
       "integration_type": "hub",
-      "config_flow": false,
+      "config_flow": true,
       "iot_class": "cloud_polling"
     },
     "dweet": {

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -493,6 +493,9 @@ doorbirdpy==2.1.0
 # homeassistant.components.dsmr
 dsmr_parser==0.33
 
+# homeassistant.components.dwd_weather_warnings
+dwdwfsapi==1.0.6
+
 # homeassistant.components.dynalite
 dynalite_devices==0.1.47
 

--- a/tests/components/dwd_weather_warnings/__init__.py
+++ b/tests/components/dwd_weather_warnings/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Deutscher Wetterdienst (DWD) Weather Warnings."""

--- a/tests/components/dwd_weather_warnings/conftest.py
+++ b/tests/components/dwd_weather_warnings/conftest.py
@@ -1,0 +1,16 @@
+"""Configuration for Deutscher Wetterdienst (DWD) Weather Warnings tests."""
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+    """Override async_setup_entry."""
+    with patch(
+        "homeassistant.components.dwd_weather_warnings.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        yield mock_setup_entry

--- a/tests/components/dwd_weather_warnings/test_config_flow.py
+++ b/tests/components/dwd_weather_warnings/test_config_flow.py
@@ -56,6 +56,29 @@ async def test_create_entry_with_region_identifier(hass: HomeAssistant) -> None:
     }
 
 
+async def test_create_entry_without_monitored_conditions(hass: HomeAssistant) -> None:
+    """Test that the user step works without any monitored condition set."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {}
+
+    data: dict = DEMO_CONFIG_ENTRY.copy()
+    data.pop(CONF_MONITORED_CONDITIONS)
+
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], data)
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == DEMO_CONFIG_ENTRY[CONF_NAME]
+    assert result["data"] == {
+        CONF_NAME: DEMO_CONFIG_ENTRY[CONF_NAME],
+        CONF_REGION_IDENTIFIER: DEMO_CONFIG_ENTRY[CONF_REGION_IDENTIFIER],
+        CONF_MONITORED_CONDITIONS: DEMO_CONFIG_ENTRY[CONF_MONITORED_CONDITIONS],
+    }
+
+
 async def test_user_no_identifier(hass: HomeAssistant) -> None:
     """Test that error is shown when no region_identifier is set."""
     data: dict = DEMO_CONFIG_ENTRY.copy()

--- a/tests/components/dwd_weather_warnings/test_config_flow.py
+++ b/tests/components/dwd_weather_warnings/test_config_flow.py
@@ -7,8 +7,8 @@ import pytest
 
 from homeassistant.components.dwd_weather_warnings.const import (
     ADVANCE_WARNING_SENSOR,
-    CONF_OLD_REGION_NAME,
     CONF_REGION_IDENTIFIER,
+    CONF_REGION_NAME,
     CURRENT_WARNING_SENSOR,
     DEFAULT_NAME,
     DOMAIN,
@@ -26,7 +26,7 @@ DEMO_CONFIG_ENTRY: Final = {
 
 DEMO_YAML_CONFIGURATION: Final = {
     CONF_NAME: "Unit Test",
-    CONF_OLD_REGION_NAME: "807111000",
+    CONF_REGION_NAME: "807111000",
     CONF_MONITORED_CONDITIONS: [CURRENT_WARNING_SENSOR, ADVANCE_WARNING_SENSOR],
 }
 
@@ -76,7 +76,7 @@ async def test_import_flow_full_data(hass: HomeAssistant) -> None:
     assert result["title"] == DEMO_YAML_CONFIGURATION[CONF_NAME]
 
     result_data = DEMO_YAML_CONFIGURATION.copy()
-    result_data[CONF_REGION_IDENTIFIER] = result_data.pop(CONF_OLD_REGION_NAME)
+    result_data[CONF_REGION_IDENTIFIER] = result_data.pop(CONF_REGION_NAME)
 
     assert result["data"] == result_data
 
@@ -95,7 +95,7 @@ async def test_import_flow_no_name(hass: HomeAssistant) -> None:
 
     result_data = DEMO_YAML_CONFIGURATION.copy()
     result_data[CONF_NAME] = EXPECTED_NAME
-    result_data[CONF_REGION_IDENTIFIER] = result_data.pop(CONF_OLD_REGION_NAME)
+    result_data[CONF_REGION_IDENTIFIER] = result_data.pop(CONF_REGION_NAME)
 
     assert result["data"] == result_data
 
@@ -114,7 +114,7 @@ async def test_import_flow_only_required(hass: HomeAssistant) -> None:
 
     result_data = DEMO_YAML_CONFIGURATION.copy()
     result_data[CONF_NAME] = EXPECTED_NAME
-    result_data[CONF_REGION_IDENTIFIER] = result_data.pop(CONF_OLD_REGION_NAME)
+    result_data[CONF_REGION_IDENTIFIER] = result_data.pop(CONF_REGION_NAME)
 
     assert result["data"] == result_data
 

--- a/tests/components/dwd_weather_warnings/test_config_flow.py
+++ b/tests/components/dwd_weather_warnings/test_config_flow.py
@@ -66,7 +66,6 @@ async def test_create_entry(hass: HomeAssistant) -> None:
     assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["title"] == "DWD Weather Warnings 807111000"
     assert result["data"] == {
-        CONF_NAME: "DWD Weather Warnings 807111000",
         CONF_REGION_IDENTIFIER: "807111000",
     }
 
@@ -126,7 +125,6 @@ async def test_import_flow_no_name(hass: HomeAssistant) -> None:
     assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["title"] == "DWD Weather Warnings 807111000"
     assert result["data"] == {
-        CONF_NAME: "DWD Weather Warnings 807111000",
         CONF_REGION_IDENTIFIER: "807111000",
         CONF_MONITORED_CONDITIONS: [CURRENT_WARNING_SENSOR, ADVANCE_WARNING_SENSOR],
     }
@@ -150,7 +148,6 @@ async def test_import_flow_only_required(hass: HomeAssistant) -> None:
     assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["title"] == "DWD Weather Warnings 807111000"
     assert result["data"] == {
-        CONF_NAME: "DWD Weather Warnings 807111000",
         CONF_REGION_IDENTIFIER: "807111000",
     }
 

--- a/tests/components/dwd_weather_warnings/test_config_flow.py
+++ b/tests/components/dwd_weather_warnings/test_config_flow.py
@@ -1,0 +1,165 @@
+"""Tests for Deutscher Wetterdienst (DWD) Weather Warnings config flow."""
+
+from typing import Final
+
+import pytest
+
+from homeassistant.components.dwd_weather_warnings.const import (
+    ADVANCE_WARNING_SENSOR,
+    CONF_OLD_REGION_NAME,
+    CONF_REGION_IDENTIFIER,
+    CURRENT_WARNING_SENSOR,
+    DEFAULT_NAME,
+    DOMAIN,
+)
+from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
+from homeassistant.const import CONF_MONITORED_CONDITIONS, CONF_NAME
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from tests.common import MockConfigEntry
+
+DEMO_CONFIG_ENTRY: Final = {
+    CONF_NAME: "Unit Test",
+    CONF_REGION_IDENTIFIER: "807111000",
+    CONF_MONITORED_CONDITIONS: [CURRENT_WARNING_SENSOR, ADVANCE_WARNING_SENSOR],
+}
+
+DEMO_YAML_CONFIGURATION: Final = {
+    CONF_NAME: "Unit Test",
+    CONF_OLD_REGION_NAME: "807111000",
+    CONF_MONITORED_CONDITIONS: [CURRENT_WARNING_SENSOR, ADVANCE_WARNING_SENSOR],
+}
+
+pytestmark = pytest.mark.usefixtures("mock_setup_entry")
+
+
+async def test_create_entry_with_region_identifier(hass: HomeAssistant) -> None:
+    """Test that the user step works with a region identifier set."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], DEMO_CONFIG_ENTRY
+    )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == DEMO_CONFIG_ENTRY[CONF_NAME]
+    assert result["data"] == {
+        CONF_NAME: DEMO_CONFIG_ENTRY[CONF_NAME],
+        CONF_REGION_IDENTIFIER: DEMO_CONFIG_ENTRY[CONF_REGION_IDENTIFIER],
+        CONF_MONITORED_CONDITIONS: DEMO_CONFIG_ENTRY[CONF_MONITORED_CONDITIONS],
+    }
+
+
+async def test_user_no_identifier(hass: HomeAssistant) -> None:
+    """Test that error is shown when no region_identifier is set."""
+    data: dict = DEMO_CONFIG_ENTRY.copy()
+    data.pop(CONF_REGION_IDENTIFIER)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}, data=data
+    )
+
+    assert result["errors"] == {"base": "no_identifier"}
+
+
+async def test_import_flow_full_data(hass: HomeAssistant) -> None:
+    """Test a successful import of a full YAML configuration."""
+    data = DEMO_YAML_CONFIGURATION.copy()
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_IMPORT}, data=data
+    )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == DEMO_YAML_CONFIGURATION[CONF_NAME]
+
+    result_data = DEMO_YAML_CONFIGURATION.copy()
+    result_data[CONF_REGION_IDENTIFIER] = result_data[CONF_OLD_REGION_NAME]
+    result_data.pop(CONF_OLD_REGION_NAME)
+
+    assert result["data"] == result_data
+
+
+async def test_import_flow_no_name(hass: HomeAssistant) -> None:
+    """Test a successful import of a YAML configuration with no name set."""
+    data = DEMO_YAML_CONFIGURATION.copy()
+    data.pop(CONF_NAME)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_IMPORT}, data=data
+    )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == DEFAULT_NAME
+
+    result_data = DEMO_YAML_CONFIGURATION.copy()
+    result_data[CONF_NAME] = DEFAULT_NAME
+    result_data[CONF_REGION_IDENTIFIER] = result_data[CONF_OLD_REGION_NAME]
+    result_data.pop(CONF_OLD_REGION_NAME)
+
+    assert result["data"] == result_data
+
+
+async def test_import_flow_only_required(hass: HomeAssistant) -> None:
+    """Test a successful import of a YAML configuration with only required properties."""
+    data = DEMO_YAML_CONFIGURATION.copy()
+    data.pop(CONF_NAME)
+    data.pop(CONF_MONITORED_CONDITIONS)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_IMPORT}, data=data
+    )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == DEFAULT_NAME
+
+    result_data = DEMO_YAML_CONFIGURATION.copy()
+    result_data[CONF_NAME] = DEFAULT_NAME
+    result_data[CONF_REGION_IDENTIFIER] = result_data[CONF_OLD_REGION_NAME]
+    result_data.pop(CONF_OLD_REGION_NAME)
+
+    assert result["data"] == result_data
+
+
+async def test_import_flow_device_already_configured(hass: HomeAssistant) -> None:
+    """Test aborting, if the device is already configured during the import."""
+    entry = MockConfigEntry(domain=DOMAIN, data=DEMO_CONFIG_ENTRY.copy())
+    entry.add_to_hass(hass)
+
+    yaml_data = DEMO_YAML_CONFIGURATION.copy()
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_IMPORT}, data=yaml_data
+    )
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_config_flow_device_already_configured(hass: HomeAssistant) -> None:
+    """Test aborting, if the device is already configured during the config."""
+    entry = MockConfigEntry(domain=DOMAIN, data=DEMO_CONFIG_ENTRY.copy())
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.FORM
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_NAME: DEMO_CONFIG_ENTRY[CONF_NAME],
+            CONF_REGION_IDENTIFIER: DEMO_CONFIG_ENTRY[CONF_REGION_IDENTIFIER],
+            CONF_MONITORED_CONDITIONS: DEMO_CONFIG_ENTRY[CONF_MONITORED_CONDITIONS],
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert result2["type"] == FlowResultType.ABORT
+    assert result2["reason"] == "already_configured"

--- a/tests/components/dwd_weather_warnings/test_init.py
+++ b/tests/components/dwd_weather_warnings/test_init.py
@@ -1,0 +1,43 @@
+"""Tests for Deutscher Wetterdienst (DWD) Weather Warnings integration."""
+
+from typing import Final
+
+from homeassistant.components.dwd_weather_warnings.const import (
+    CONF_REGION_IDENTIFIER,
+    DEFAULT_MONITORED_CONDITIONS,
+    DOMAIN,
+)
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_MONITORED_CONDITIONS, CONF_NAME
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+DEMO_CONFIG_ENTRY: Final = {
+    CONF_NAME: "Unit Test",
+    CONF_REGION_IDENTIFIER: "807111000",
+    CONF_MONITORED_CONDITIONS: DEFAULT_MONITORED_CONDITIONS,
+}
+
+
+async def test_config_entry_success(hass: HomeAssistant) -> None:
+    """Test setting up the integration from a config entry."""
+    entry = MockConfigEntry(domain=DOMAIN, data=DEMO_CONFIG_ENTRY)
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+
+    assert entry.state == ConfigEntryState.LOADED
+
+
+async def test_unload_entry(hass: HomeAssistant) -> None:
+    """Test unloading the integration."""
+    entry = MockConfigEntry(domain=DOMAIN, data=DEMO_CONFIG_ENTRY)
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.NOT_LOADED
+    assert entry.entry_id not in hass.data[DOMAIN]

--- a/tests/components/dwd_weather_warnings/test_init.py
+++ b/tests/components/dwd_weather_warnings/test_init.py
@@ -20,21 +20,14 @@ DEMO_CONFIG_ENTRY: Final = {
 }
 
 
-async def test_config_entry_success(hass: HomeAssistant) -> None:
-    """Test setting up the integration from a config entry."""
-    entry = MockConfigEntry(domain=DOMAIN, data=DEMO_CONFIG_ENTRY)
-    entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(entry.entry_id)
-
-    assert entry.state == ConfigEntryState.LOADED
-
-
-async def test_unload_entry(hass: HomeAssistant) -> None:
-    """Test unloading the integration."""
+async def test_load_unload_entry(hass: HomeAssistant) -> None:
+    """Test loading and unloading the integration."""
     entry = MockConfigEntry(domain=DOMAIN, data=DEMO_CONFIG_ENTRY)
     entry.add_to_hass(hass)
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
+
+    assert entry.state == ConfigEntryState.LOADED
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()

--- a/tests/components/dwd_weather_warnings/test_init.py
+++ b/tests/components/dwd_weather_warnings/test_init.py
@@ -3,8 +3,9 @@
 from typing import Final
 
 from homeassistant.components.dwd_weather_warnings.const import (
+    ADVANCE_WARNING_SENSOR,
     CONF_REGION_IDENTIFIER,
-    DEFAULT_MONITORED_CONDITIONS,
+    CURRENT_WARNING_SENSOR,
     DOMAIN,
 )
 from homeassistant.config_entries import ConfigEntryState
@@ -16,7 +17,7 @@ from tests.common import MockConfigEntry
 DEMO_CONFIG_ENTRY: Final = {
     CONF_NAME: "Unit Test",
     CONF_REGION_IDENTIFIER: "807111000",
-    CONF_MONITORED_CONDITIONS: DEFAULT_MONITORED_CONDITIONS,
+    CONF_MONITORED_CONDITIONS: [CURRENT_WARNING_SENSOR, ADVANCE_WARNING_SENSOR],
 }
 
 
@@ -28,6 +29,7 @@ async def test_load_unload_entry(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     assert entry.state == ConfigEntryState.LOADED
+    assert entry.entry_id in hass.data[DOMAIN]
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR switches the configuration for `dwd_weather_warnings` to config flow including the migration of the old YAML configuration. This is also split off from #79944 for easier reviewing. I'll update the linked documentation PR to only include the config flow changes.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/26914

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
