### PR TITLE
Don't add id to storage collection data

### DIFF
--- a/homeassistant/components/application_credentials/__init__.py
+++ b/homeassistant/components/application_credentials/__init__.py
@@ -20,7 +20,6 @@ from homeassistant.const import (
     CONF_CLIENT_ID,
     CONF_CLIENT_SECRET,
     CONF_DOMAIN,
-    CONF_ID,
     CONF_NAME,
 )
 from homeassistant.core import HomeAssistant, callback
@@ -125,10 +124,10 @@ class ApplicationCredentialsStorageCollection(collection.DictStorageCollection):
     def async_client_credentials(self, domain: str) -> dict[str, ClientCredential]:
         """Return ClientCredentials in storage for the specified domain."""
         credentials = {}
-        for item in self.async_items():
+        for item_id, item in self.data.items():
             if item[CONF_DOMAIN] != domain:
                 continue
-            auth_domain = item.get(CONF_AUTH_DOMAIN, item[CONF_ID])
+            auth_domain = item.get(CONF_AUTH_DOMAIN, item_id)
             credentials[auth_domain] = ClientCredential(
                 client_id=item[CONF_CLIENT_ID],
                 client_secret=item[CONF_CLIENT_SECRET],
@@ -244,8 +243,7 @@ async def _async_config_entry_app_credentials(
         return None
 
     storage_collection = hass.data[DOMAIN][DATA_STORAGE]
-    for item in storage_collection.async_items():
-        item_id = item[CONF_ID]
+    for item_id, item in storage_collection.async_items().items():
         if (
             item[CONF_DOMAIN] == config_entry.domain
             and item.get(CONF_AUTH_DOMAIN, item_id) == auth_domain

--- a/homeassistant/components/assist_pipeline/pipeline.py
+++ b/homeassistant/components/assist_pipeline/pipeline.py
@@ -63,7 +63,7 @@ async def async_get_pipeline(
 
     # Construct a pipeline for the required/configured language
     language = language or hass.config.language
-    return await pipeline_data.pipeline_store.async_create_item(
+    _, pipeline = await pipeline_data.pipeline_store.async_create_item(
         {
             "name": language,
             "language": language,
@@ -72,6 +72,7 @@ async def async_get_pipeline(
             "tts_engine": None,  # first engine
         }
     )
+    return pipeline
 
 
 class PipelineEventType(StrEnum):
@@ -610,7 +611,7 @@ class PipelineStorageCollection(
         """Create an item from its serialized representation."""
         return Pipeline(**data)
 
-    def _serialize_item(self, item_id: str, item: Pipeline) -> dict:
+    def _serialize_item(self, item: Pipeline) -> dict:
         """Return the serialized representation of an item for storing."""
         return item.to_json()
 

--- a/homeassistant/components/counter/__init__.py
+++ b/homeassistant/components/counter/__init__.py
@@ -139,7 +139,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
-class CounterStorageCollection(collection.DictStorageCollection):
+class CounterStorageCollection(collection.LegacyDictStorageCollection):
     """Input storage based collection."""
 
     CREATE_UPDATE_SCHEMA = vol.Schema(STORAGE_FIELDS)

--- a/homeassistant/components/image_upload/__init__.py
+++ b/homeassistant/components/image_upload/__init__.py
@@ -57,7 +57,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
-class ImageStorageCollection(collection.DictStorageCollection):
+class ImageStorageCollection(collection.LegacyDictStorageCollection):
     """Image collection stored in storage."""
 
     CREATE_SCHEMA = vol.Schema(CREATE_FIELDS)
@@ -156,7 +156,7 @@ class ImageUploadView(HomeAssistantView):
         request._client_max_size = MAX_SIZE  # pylint: disable=protected-access
 
         data = await request.post()
-        item = await request.app["hass"].data[DOMAIN].async_create_item(data)
+        _, item = await request.app["hass"].data[DOMAIN].async_create_item(data)
         return self.json(item)
 
 

--- a/homeassistant/components/input_boolean/__init__.py
+++ b/homeassistant/components/input_boolean/__init__.py
@@ -65,7 +65,7 @@ STORAGE_KEY = DOMAIN
 STORAGE_VERSION = 1
 
 
-class InputBooleanStorageCollection(collection.DictStorageCollection):
+class InputBooleanStorageCollection(collection.LegacyDictStorageCollection):
     """Input boolean collection stored in storage."""
 
     CREATE_UPDATE_SCHEMA = vol.Schema(STORAGE_FIELDS)

--- a/homeassistant/components/input_button/__init__.py
+++ b/homeassistant/components/input_button/__init__.py
@@ -56,7 +56,7 @@ STORAGE_KEY = DOMAIN
 STORAGE_VERSION = 1
 
 
-class InputButtonStorageCollection(collection.DictStorageCollection):
+class InputButtonStorageCollection(collection.LegacyDictStorageCollection):
     """Input button collection stored in storage."""
 
     CREATE_UPDATE_SCHEMA = vol.Schema(STORAGE_FIELDS)

--- a/homeassistant/components/input_datetime/__init__.py
+++ b/homeassistant/components/input_datetime/__init__.py
@@ -203,7 +203,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
-class DateTimeStorageCollection(collection.DictStorageCollection):
+class DateTimeStorageCollection(collection.LegacyDictStorageCollection):
     """Input storage based collection."""
 
     CREATE_UPDATE_SCHEMA = vol.Schema(vol.All(STORAGE_FIELDS, has_date_or_time))

--- a/homeassistant/components/input_number/__init__.py
+++ b/homeassistant/components/input_number/__init__.py
@@ -170,7 +170,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
-class NumberStorageCollection(collection.DictStorageCollection):
+class NumberStorageCollection(collection.LegacyDictStorageCollection):
     """Input storage based collection."""
 
     SCHEMA = vol.Schema(vol.All(STORAGE_FIELDS, _cv_input_number))
@@ -184,7 +184,9 @@ class NumberStorageCollection(collection.DictStorageCollection):
         """Suggest an ID based on the config."""
         return info[CONF_NAME]
 
-    async def _async_load_data(self) -> collection.SerializedStorageCollection | None:
+    async def _async_load_data(  # type: ignore[override]
+        self,
+    ) -> collection.LegacySerializedStorageCollection | None:
         """Load the data.
 
         A past bug caused frontend to add initial value to all input numbers.

--- a/homeassistant/components/input_select/__init__.py
+++ b/homeassistant/components/input_select/__init__.py
@@ -231,7 +231,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
-class InputSelectStorageCollection(collection.DictStorageCollection):
+class InputSelectStorageCollection(collection.LegacyDictStorageCollection):
     """Input storage based collection."""
 
     CREATE_UPDATE_SCHEMA = vol.Schema(vol.All(STORAGE_FIELDS, _cv_input_select))

--- a/homeassistant/components/input_text/__init__.py
+++ b/homeassistant/components/input_text/__init__.py
@@ -164,7 +164,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
-class InputTextStorageCollection(collection.DictStorageCollection):
+class InputTextStorageCollection(collection.LegacyDictStorageCollection):
     """Input storage based collection."""
 
     CREATE_UPDATE_SCHEMA = vol.Schema(vol.All(STORAGE_FIELDS, _cv_input_text))

--- a/homeassistant/components/lovelace/dashboard.py
+++ b/homeassistant/components/lovelace/dashboard.py
@@ -217,7 +217,7 @@ def _config_info(mode, config):
     }
 
 
-class DashboardsCollection(collection.DictStorageCollection):
+class DashboardsCollection(collection.LegacyDictStorageCollection):
     """Collection of dashboards."""
 
     CREATE_SCHEMA = vol.Schema(STORAGE_DASHBOARD_CREATE_FIELDS)
@@ -229,9 +229,11 @@ class DashboardsCollection(collection.DictStorageCollection):
             storage.Store(hass, DASHBOARDS_STORAGE_VERSION, DASHBOARDS_STORAGE_KEY),
         )
 
-    async def _async_load_data(self) -> collection.SerializedStorageCollection | None:
+    async def _async_load_data(  # type: ignore[override]
+        self,
+    ) -> collection.LegacySerializedStorageCollection | None:
         """Load the data."""
-        if (data := await self.store.async_load()) is None:
+        if (data := await super()._async_load_data()) is None:
             return data
 
         updated = False
@@ -242,7 +244,7 @@ class DashboardsCollection(collection.DictStorageCollection):
                 item[CONF_URL_PATH] = f"lovelace-{item[CONF_URL_PATH]}"
 
         if updated:
-            await self.store.async_save(data)
+            await self.store.async_save(data)  # type: ignore[arg-type]
 
         return data
 

--- a/homeassistant/components/lovelace/resources.py
+++ b/homeassistant/components/lovelace/resources.py
@@ -37,15 +37,15 @@ class ResourceYAMLCollection:
 
     async def async_get_info(self):
         """Return the resources info for YAML mode."""
-        return {"resources": len(self.async_items() or [])}
+        return {"resources": len(self.async_values() or [])}
 
     @callback
-    def async_items(self) -> list[dict]:
+    def async_values(self) -> list[dict]:
         """Return list of items in collection."""
         return self.data
 
 
-class ResourceStorageCollection(collection.DictStorageCollection):
+class ResourceStorageCollection(collection.LegacyDictStorageCollection):
     """Collection to store resources."""
 
     loaded = False
@@ -67,9 +67,11 @@ class ResourceStorageCollection(collection.DictStorageCollection):
 
         return {"resources": len(self.async_items() or [])}
 
-    async def _async_load_data(self) -> collection.SerializedStorageCollection | None:
+    async def _async_load_data(  # type: ignore[override]
+        self,
+    ) -> collection.LegacySerializedStorageCollection | None:
         """Load the data."""
-        if (store_data := await self.store.async_load()) is not None:
+        if (store_data := await super()._async_load_data()) is not None:
             return store_data
 
         # Import it from config.
@@ -95,9 +97,9 @@ class ResourceStorageCollection(collection.DictStorageCollection):
         for item in resources:
             item[CONF_ID] = uuid.uuid4().hex
 
-        data: collection.SerializedStorageCollection = {"items": resources}
+        data: collection.LegacySerializedStorageCollection = {"items": resources}
 
-        await self.store.async_save(data)
+        await self.store.async_save(data)  # type: ignore[arg-type]
         await self.ll_config.async_save(conf)
 
         return data

--- a/homeassistant/components/lovelace/websocket.py
+++ b/homeassistant/components/lovelace/websocket.py
@@ -64,7 +64,7 @@ async def websocket_lovelace_resources(
         await resources.async_load()
         resources.loaded = True
 
-    connection.send_result(msg["id"], resources.async_items())
+    connection.send_result(msg["id"], resources.async_values())
 
 
 @websocket_api.websocket_command(

--- a/homeassistant/components/schedule/__init__.py
+++ b/homeassistant/components/schedule/__init__.py
@@ -20,10 +20,10 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.helpers.collection import (
     CollectionEntity,
-    DictStorageCollection,
     DictStorageCollectionWebsocket,
     IDManager,
-    SerializedStorageCollection,
+    LegacyDictStorageCollection,
+    LegacySerializedStorageCollection,
     YamlCollection,
     sync_entity_lifecycle,
 )
@@ -209,7 +209,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
-class ScheduleStorageCollection(DictStorageCollection):
+class ScheduleStorageCollection(LegacyDictStorageCollection):
     """Schedules stored in storage."""
 
     SCHEMA = vol.Schema(BASE_SCHEMA | STORAGE_SCHEDULE_SCHEMA)
@@ -230,7 +230,7 @@ class ScheduleStorageCollection(DictStorageCollection):
         self.SCHEMA(update_data)
         return item | update_data
 
-    async def _async_load_data(self) -> SerializedStorageCollection | None:
+    async def _async_load_data(self) -> LegacySerializedStorageCollection | None:  # type: ignore[override]
         """Load the data."""
         if data := await super()._async_load_data():
             data["items"] = [STORAGE_SCHEMA(item) for item in data["items"]]

--- a/homeassistant/components/tag/__init__.py
+++ b/homeassistant/components/tag/__init__.py
@@ -59,7 +59,7 @@ class TagIDManager(collection.IDManager):
         return suggestion
 
 
-class TagStorageCollection(collection.DictStorageCollection):
+class TagStorageCollection(collection.LegacyDictStorageCollection):
     """Tag collection stored in storage."""
 
     CREATE_SCHEMA = vol.Schema(CREATE_FIELDS)

--- a/homeassistant/components/timer/__init__.py
+++ b/homeassistant/components/timer/__init__.py
@@ -162,7 +162,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
-class TimerStorageCollection(collection.DictStorageCollection):
+class TimerStorageCollection(collection.LegacyDictStorageCollection):
     """Timer storage based collection."""
 
     CREATE_UPDATE_SCHEMA = vol.Schema(STORAGE_FIELDS)

--- a/homeassistant/components/zone/__init__.py
+++ b/homeassistant/components/zone/__init__.py
@@ -163,7 +163,7 @@ def in_zone(zone: State, latitude: float, longitude: float, radius: float = 0) -
     return zone_dist - radius < cast(float, zone.attributes[ATTR_RADIUS])
 
 
-class ZoneStorageCollection(collection.DictStorageCollection):
+class ZoneStorageCollection(collection.LegacyDictStorageCollection):
     """Zone collection stored in storage."""
 
     CREATE_SCHEMA = vol.Schema(CREATE_FIELDS)

--- a/tests/components/assist_pipeline/test_pipeline.py
+++ b/tests/components/assist_pipeline/test_pipeline.py
@@ -15,7 +15,7 @@ from homeassistant.setup import async_setup_component
 from tests.common import flush_store
 
 
-async def test_load_datasets(hass: HomeAssistant, init_components) -> None:
+async def test_load_pipelines(hass: HomeAssistant, init_components) -> None:
     """Make sure that we can load/save data correctly."""
 
     pipelines = [
@@ -46,7 +46,7 @@ async def test_load_datasets(hass: HomeAssistant, init_components) -> None:
     pipeline_data: PipelineData = hass.data[DOMAIN]
     store1 = pipeline_data.pipeline_store
     for pipeline in pipelines:
-        pipeline_ids.append((await store1.async_create_item(pipeline)).id)
+        pipeline_ids.append((await store1.async_create_item(pipeline))[1].id)
     assert len(store1.data) == 3
     assert store1.async_get_preferred_item() == list(store1.data)[0]
 
@@ -64,10 +64,10 @@ async def test_load_datasets(hass: HomeAssistant, init_components) -> None:
     assert store1.async_get_preferred_item() == store2.async_get_preferred_item()
 
 
-async def test_loading_datasets_from_storage(
+async def test_loading_pipelines_from_storage(
     hass: HomeAssistant, hass_storage: dict[str, Any]
 ) -> None:
-    """Test loading stored datasets on start."""
+    """Test loading stored pipelines on start."""
     hass_storage[STORAGE_KEY] = {
         "version": 1,
         "minor_version": 1,

--- a/tests/components/person/test_init.py
+++ b/tests/components/person/test_init.py
@@ -473,7 +473,7 @@ async def test_ws_create(
     )
     resp = await client.receive_json()
 
-    persons = manager.async_items()
+    persons = manager.async_values()
     assert len(persons) == 2
 
     assert resp["success"]
@@ -504,7 +504,7 @@ async def test_ws_create_requires_admin(
     )
     resp = await client.receive_json()
 
-    persons = manager.async_items()
+    persons = manager.async_values()
     assert len(persons) == 1
 
     assert not resp["success"]
@@ -517,7 +517,7 @@ async def test_ws_update(
     manager = hass.data[DOMAIN][1]
 
     client = await hass_ws_client(hass)
-    persons = manager.async_items()
+    persons = manager.async_values()
 
     resp = await client.send_json(
         {
@@ -544,7 +544,7 @@ async def test_ws_update(
     )
     resp = await client.receive_json()
 
-    persons = manager.async_items()
+    persons = manager.async_values()
     assert len(persons) == 1
 
     assert resp["success"]
@@ -570,7 +570,7 @@ async def test_ws_update_require_admin(
     manager = hass.data[DOMAIN][1]
 
     client = await hass_ws_client(hass)
-    original = dict(manager.async_items()[0])
+    original = dict(manager.async_values()[0])
 
     resp = await client.send_json(
         {
@@ -585,7 +585,7 @@ async def test_ws_update_require_admin(
     resp = await client.receive_json()
     assert not resp["success"]
 
-    not_updated = dict(manager.async_items()[0])
+    not_updated = dict(manager.async_values()[0])
     assert original == not_updated
 
 
@@ -596,14 +596,14 @@ async def test_ws_delete(
     manager = hass.data[DOMAIN][1]
 
     client = await hass_ws_client(hass)
-    persons = manager.async_items()
+    persons = manager.async_values()
 
     resp = await client.send_json(
         {"id": 6, "type": "person/delete", "person_id": persons[0]["id"]}
     )
     resp = await client.receive_json()
 
-    persons = manager.async_items()
+    persons = manager.async_values()
     assert len(persons) == 0
 
     assert resp["success"]
@@ -628,7 +628,7 @@ async def test_ws_delete_require_admin(
         {
             "id": 6,
             "type": "person/delete",
-            "person_id": manager.async_items()[0]["id"],
+            "person_id": manager.async_values()[0]["id"],
             "name": "Updated Name",
             "device_trackers": [DEVICE_TRACKER_2],
             "user_id": None,
@@ -637,7 +637,7 @@ async def test_ws_delete_require_admin(
     resp = await client.receive_json()
     assert not resp["success"]
 
-    persons = manager.async_items()
+    persons = manager.async_values()
     assert len(persons) == 1
 
 
@@ -670,7 +670,7 @@ async def test_update_double_user_id(
     await storage_collection.async_create_item(
         {"name": "Hello", "user_id": hass_admin_user.id}
     )
-    person = await storage_collection.async_create_item({"name": "Hello"})
+    _, person = await storage_collection.async_create_item({"name": "Hello"})
 
     with pytest.raises(ValueError):
         await storage_collection.async_update_item(
@@ -680,7 +680,7 @@ async def test_update_double_user_id(
 
 async def test_update_invalid_user_id(hass: HomeAssistant, storage_collection) -> None:
     """Test updating to invalid user ID."""
-    person = await storage_collection.async_create_item({"name": "Hello"})
+    _, person = await storage_collection.async_create_item({"name": "Hello"})
 
     with pytest.raises(ValueError):
         await storage_collection.async_update_item(
@@ -694,7 +694,7 @@ async def test_update_person_when_user_removed(
     """Update person when user is removed."""
     storage_collection = hass.data[DOMAIN][1]
 
-    person = await storage_collection.async_create_item(
+    _, person = await storage_collection.async_create_item(
         {"name": "Hello", "user_id": hass_read_only_user.id}
     )
 
@@ -712,7 +712,7 @@ async def test_removing_device_tracker(hass: HomeAssistant, storage_setup) -> No
         "device_tracker", "mobile_app", "bla", suggested_object_id="pixel"
     )
 
-    person = await storage_collection.async_create_item(
+    _, person = await storage_collection.async_create_item(
         {"name": "Hello", "device_trackers": [entry.entity_id]}
     )
 
@@ -727,7 +727,7 @@ async def test_add_user_device_tracker(
 ) -> None:
     """Test adding a device tracker to a person tied to a user."""
     storage_collection = hass.data[DOMAIN][1]
-    pers = await storage_collection.async_create_item(
+    _, pers = await storage_collection.async_create_item(
         {
             "name": "Hello",
             "user_id": hass_read_only_user.id,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Don't add the automatically assigned id to storage collection data items, instead use the id as the item's key

The serialized format of storage collections are changed from a list of items to a dict where the key is the id and the value is the item.

Data stored in the old format will be migrated.

This PR updates`application_credentials` according to the new format.
Other integration are changed to use the `LegacyDictStorageCollection` which still stores data in the old format, and will be updated in follow-up PRs.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
