### PR TITLE
Add file.write service

### DIFF
--- a/homeassistant/components/file/__init__.py
+++ b/homeassistant/components/file/__init__.py
@@ -1,7 +1,16 @@
 """The file component."""
 
+import logging
+from os import path
+
+import voluptuous as vol
+
 from homeassistant.core import HomeAssistant, ServiceCall, callback
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import ConfigType
+
+_LOGGER = logging.getLogger(__name__)
+
 
 DOMAIN = "file"
 
@@ -9,9 +18,30 @@ WRITE_PARAM_FILENAME = "filename"
 WRITE_PARAM_CONTENT = "content"
 WRITE_PARAM_MODE = "mode"
 
+CONF_ALLOWLIST_WRITE_DIRS = "allowlist_write_dirs"
+
+CONFIG_SCHEMA = vol.Schema(
+    {
+        DOMAIN: vol.Schema(
+            {
+                vol.Optional(CONF_ALLOWLIST_WRITE_DIRS, default=[]): vol.All(
+                    cv.ensure_list, [cv.path]
+                )
+            }
+        )
+    },
+    required=False,
+    extra=vol.ALLOW_EXTRA,
+)
+
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the file write service."""
+
+    allowlist_write_dirs = [
+        path.normpath(hass.config.path(p) + path.sep)
+        for p in config.get(DOMAIN, {}).get(CONF_ALLOWLIST_WRITE_DIRS, [])
+    ]
 
     @callback
     def write(call: ServiceCall) -> None:
@@ -20,7 +50,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         content = call.data[WRITE_PARAM_CONTENT]
         mode = call.data.get(WRITE_PARAM_MODE, "w")
 
-        filepath = hass.config.path(filename)
+        filepath = path.normpath(hass.config.path(filename))
+
+        if not any(path.commonpath([filepath, p]) == p for p in allowlist_write_dirs):
+            _LOGGER.error("Path is not allowed: %s", filepath)
+            raise ValueError("Path is not allowed: %s" % filepath)
 
         with open(filepath, mode, encoding="utf8") as file:
             file.write(content)

--- a/homeassistant/components/file/__init__.py
+++ b/homeassistant/components/file/__init__.py
@@ -1,1 +1,30 @@
 """The file component."""
+
+from homeassistant.core import HomeAssistant, ServiceCall, callback
+from homeassistant.helpers.typing import ConfigType
+
+DOMAIN = "file"
+
+WRITE_PARAM_FILENAME = "filename"
+WRITE_PARAM_CONTENT = "content"
+WRITE_PARAM_MODE = "mode"
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the file write service."""
+
+    @callback
+    def write(call: ServiceCall) -> None:
+        """Write a file."""
+        filename = call.data[WRITE_PARAM_FILENAME]
+        content = call.data[WRITE_PARAM_CONTENT]
+        mode = call.data.get(WRITE_PARAM_MODE, "w")
+
+        filepath = hass.config.path(filename)
+
+        with open(filepath, mode, encoding="utf8") as file:
+            file.write(content)
+
+    hass.services.async_register(DOMAIN, "write", write)
+
+    return True

--- a/homeassistant/components/file/services.yaml
+++ b/homeassistant/components/file/services.yaml
@@ -1,0 +1,28 @@
+write:
+  name: "Write file"
+  description: "Writes a file to disk."
+  fields:
+    filename:
+      name: Filename
+      description: The name of the file to write. Relative paths use '/config' as the working directory.
+      required: true
+      example: "output/example.txt"
+      selector:
+        text:
+    content:
+      name: Content
+      description: The content to write to the file as a string.
+      required: true
+      example: "File content"
+      selector:
+        template:
+    mode:
+      name: Mode
+      description: 'The mode to write to the file ("w": overwrite, "a": append, or "x": new file).'
+      default: w
+      selector:
+        select:
+          options:
+            - w
+            - a
+            - x

--- a/tests/components/file/test_init.py
+++ b/tests/components/file/test_init.py
@@ -24,11 +24,11 @@ async def test_file_write(hass: HomeAssistant, mode: str) -> None:
     """Test the notify file output."""
     filename = "mock_file"
     content = "one, two, testing, testing"
-    with assert_setup_component(0):
+    with assert_setup_component(1):
         assert await async_setup_component(
             hass,
             file.DOMAIN,
-            {},
+            {"file": {"allowlist_write_dirs": [hass.config.path()]}},
         )
 
     m_open = mock_open()
@@ -44,3 +44,18 @@ async def test_file_write(hass: HomeAssistant, mode: str) -> None:
             full_filename, mode if mode is not None else "w", encoding="utf8"
         )
         assert m_open.return_value.write.call_count == 1
+
+
+async def test_file_write_allowlist(hass: HomeAssistant) -> None:
+    """Test the allowlist."""
+    content = "one, two, testing, testing"
+    with assert_setup_component(1):
+        assert await async_setup_component(
+            hass,
+            file.DOMAIN,
+            {"file": {"allowlist_write_dirs": ["inner"]}},
+        )
+
+    with pytest.raises(ValueError):
+        args = {"content": content, "filename": "mock_file"}
+        await hass.services.async_call("file", "write", args, blocking=True)

--- a/tests/components/file/test_init.py
+++ b/tests/components/file/test_init.py
@@ -1,0 +1,46 @@
+"""The tests for the file component."""
+import os
+from unittest.mock import call, mock_open, patch
+
+import pytest
+
+from homeassistant.components import file
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from tests.common import assert_setup_component
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [
+        None,
+        "w",
+        "x",
+        "a",
+    ],
+)
+async def test_file_write(hass: HomeAssistant, mode: str) -> None:
+    """Test the notify file output."""
+    filename = "mock_file"
+    content = "one, two, testing, testing"
+    with assert_setup_component(0):
+        assert await async_setup_component(
+            hass,
+            file.DOMAIN,
+            {},
+        )
+
+    m_open = mock_open()
+    with patch("homeassistant.components.file.open", m_open, create=True):
+        args = {"content": content, "filename": filename}
+        if mode is not None:
+            args["mode"] = mode
+        await hass.services.async_call("file", "write", args, blocking=True)
+
+        full_filename = os.path.join(hass.config.path(), filename)
+        assert m_open.call_count == 1
+        assert m_open.call_args == call(
+            full_filename, mode if mode is not None else "w", encoding="utf8"
+        )
+        assert m_open.return_value.write.call_count == 1

--- a/tests/components/file/test_notify.py
+++ b/tests/components/file/test_notify.py
@@ -32,7 +32,7 @@ async def test_notify_file(hass: HomeAssistant, timestamp: bool) -> None:
     """Test the notify file output."""
     filename = "mock_file"
     message = "one, two, testing, testing"
-    with assert_setup_component(1) as handle_config:
+    with assert_setup_component(1, notify.DOMAIN) as handle_config:
         assert await async_setup_component(
             hass,
             notify.DOMAIN,
@@ -42,7 +42,7 @@ async def test_notify_file(hass: HomeAssistant, timestamp: bool) -> None:
                     "platform": "file",
                     "filename": filename,
                     "timestamp": timestamp,
-                }
+                },
             },
         )
     assert handle_config[notify.DOMAIN]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds a `file.write` service that lets you write a string to a file using the file integration from within e.g. a script.

There are lots of potential use cases for this (and most are far more simple than the one I'm about to suggest), but the one that got me searching for a way to do it was to do some meta-templating -- e.g. use templating to generate YAML for template entities.  As an example, I have a number of Nest cameras that raise person detection device events -- I've added a number of template sensors driven by those events, but every time I tweak one of them I have to tweak all of them.  I'd like to be able to use templating to generate the YAML for those sensors whenever I add a new camera, then pick them up at the next configuration reload.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
