### PR TITLE
Switch back to using call_later for the slow entity update warning

### DIFF
--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -723,6 +723,15 @@ class Entity(ABC):
         else:
             self.async_write_ha_state()
 
+    @callback
+    def _async_slow_update_warning(self) -> None:
+        """Log a warning if update is taking too long."""
+        _LOGGER.warning(
+            "Update of %s is taking over %s seconds",
+            self.entity_id,
+            SLOW_UPDATE_WARNING,
+        )
+
     async def async_device_update(self, warning: bool = True) -> None:
         """Process 'update' or 'async_update' from entity.
 
@@ -730,42 +739,33 @@ class Entity(ABC):
         """
         if self._update_staged:
             return
+
+        hass = self.hass
+        assert hass is not None
+
+        if hasattr(self, "async_update"):
+            coro: asyncio.Future[None] = self.async_update()
+        elif hasattr(self, "update"):
+            coro = hass.async_add_executor_job(self.update)
+        else:
+            return
+
         self._update_staged = True
 
         # Process update sequential
         if self.parallel_updates:
             await self.parallel_updates.acquire()
 
-        try:
-            task: asyncio.Future[None]
-            if hasattr(self, "async_update"):
-                task = self.hass.async_create_task(
-                    self.async_update(), f"Entity async update {self.entity_id}"
-                )
-            elif hasattr(self, "update"):
-                task = self.hass.async_add_executor_job(self.update)
-            else:
-                return
-
-            if not warning:
-                await task
-                return
-
-            finished, _ = await asyncio.wait([task], timeout=SLOW_UPDATE_WARNING)
-
-            for done in finished:
-                if exc := done.exception():
-                    raise exc
-                return
-
-            _LOGGER.warning(
-                "Update of %s is taking over %s seconds",
-                self.entity_id,
-                SLOW_UPDATE_WARNING,
+        if warning:
+            update_warn = hass.loop.call_later(
+                SLOW_UPDATE_WARNING, self._async_slow_update_warning
             )
-            await task
+        try:
+            await coro
         finally:
             self._update_staged = False
+            if warning:
+                update_warn.cancel()
             if self.parallel_updates:
                 self.parallel_updates.release()
 

--- a/tests/components/dlna_dmr/test_media_player.py
+++ b/tests/components/dlna_dmr/test_media_player.py
@@ -1274,6 +1274,7 @@ async def test_unavailable_device(
     hass.config_entries.async_update_entry(
         config_entry_mock, options={CONF_POLL_AVAILABILITY: True}
     )
+    await hass.async_block_till_done()
     await async_update_entity(hass, mock_entity_id)
     domain_data_mock.upnp_factory.async_create_device.assert_awaited_once_with(
         MOCK_DEVICE_LOCATION


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I had originally changed this to create a task and wait in #41184 but that does not make sense anymore at least with newer `cpython` (in hindsight, I don't think it was a good change than either) as the profile now shows the original method is cheaper when I subtract the execution time of the update function. 

While `cpython` has had quite a few improvements in scheduling performance since 2020 and thats helping here, I'm pretty sure I did the profiling wrong in 2020 and didn't account for the task creation moving the execution of the update coro to another branch which hid it from the original profile. 🤦  I never noticed this difference in previous profiles over the last few years since so much has moved to use `DataUpdateCoordinator` which kept moving the execution path away from here so it never was large enough to pop up until I created a lot of `rest` sensors for testing another issue.

before (we only care about the cost of the `wait` as we assume the execution of the update function to be constant):
<img width="1304" alt="Screenshot 2023-04-07 at 9 30 35 PM" src="https://user-images.githubusercontent.com/663432/230709387-30105a7e-e337-4f89-bce2-0c9c9dd96c37.png">
![async_device_update](https://user-images.githubusercontent.com/663432/230709454-b48a3b0d-1b7d-4d2c-b7f3-c56867e1f0dc.png)

after (we only care about the cost of `call_later` and `cancel` as we assume the execution of the update function to be constant). In this case since there is no task creation we see the actual execution happening lower in the stack:
<img width="838" alt="Screenshot 2023-04-07 at 9 49 51 PM" src="https://user-images.githubusercontent.com/663432/230710252-4985e19f-41f0-4c25-8049-27ea32fc8736.png">
![async_device_update_after](https://user-images.githubusercontent.com/663432/230710000-9c10ac37-8eda-4a04-a565-62bac2966087.png)



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
