### PR TITLE
Reolink prevent ONVIF push being lost due to ConnectionResetError

### DIFF
--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -369,7 +369,7 @@ class ReolinkHost:
         except ConnectionResetError:
             await asyncio.shield(self.handle_webhook_error_shielded(hass, webhook_id))
             return
-            
+
         await asyncio.shield(self.handle_webhook_shielded(hass, webhook_id, data))
 
     async def handle_webhook_shielded(
@@ -395,13 +395,18 @@ class ReolinkHost:
 
     async def handle_webhook_error_shielded(self, hass: HomeAssistant, webhook_id: str):
         """Handle error from incoming webhook by polling the state."""
-        _LOGGER.debug("Webhook '%s' called, but lost connection before reading message, issuing poll", webhook_id)
+        _LOGGER.debug(
+            "Webhook '%s' called, but lost connection before reading message, issuing poll",
+            webhook_id,
+        )
         if not await self._api.get_motion_state_all_ch():
-            _LOGGER.error("Could not poll motion state after getting error during receiving ONVIF event")
+            _LOGGER.error(
+                "Could not poll motion state after getting error during receiving ONVIF event"
+            )
             return
 
         async_dispatcher_send(hass, f"{webhook_id}_all", {})
-        
+
         if not self._webhook_reachable.is_set():
             self._webhook_reachable.set()
             ir.async_delete_issue(self._hass, DOMAIN, "webhook_url")

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -364,7 +364,12 @@ class ReolinkHost:
     ):
         """Shield the incoming webhook callback from cancellation."""
         _LOGGER.debug("Webhook '%s' called", webhook_id)
-        data = await request.text()
+        try:
+            data = await request.text()
+        except ConnectionResetError:
+            await asyncio.shield(self.handle_webhook_error_shielded(hass, webhook_id))
+            return
+            
         await asyncio.shield(self.handle_webhook_shielded(hass, webhook_id, data))
 
     async def handle_webhook_shielded(
@@ -387,3 +392,15 @@ class ReolinkHost:
         else:
             for channel in channels:
                 async_dispatcher_send(hass, f"{webhook_id}_{channel}", {})
+
+    async def handle_webhook_error_shielded(self, hass: HomeAssistant, webhook_id: str):
+        """Handle error from incoming webhook by polling the state."""
+        _LOGGER.debug("Webhook '%s' called, but lost connection before reading message, issuing poll", webhook_id)
+        if not await self._api.get_motion_state_all_ch():
+            _LOGGER.error("Could not poll motion state after getting error during receiving ONVIF event")
+            return
+
+        async_dispatcher_send(hass, f"{webhook_id}_all", {})
+        
+        if not self._webhook_reachable.is_set():
+            self._webhook_reachable.set()

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -60,7 +60,7 @@ class ReolinkHost:
         self._webhook_url: str = ""
         self._webhook_reachable: asyncio.Event = asyncio.Event()
         self._webhook_read_done: asyncio.Event = asyncio.Event()
-        self._webhook_tasks: set[asyncio.Future] = set()
+        self._webhook_tasks: set[asyncio.Task] = set()
         self._lost_subscription: bool = False
 
     @property
@@ -414,5 +414,5 @@ class ReolinkHost:
             for channel in channels:
                 async_dispatcher_send(hass, f"{webhook_id}_{channel}", {})
         except Exception as err:  # pylint: disable=broad-except
-            # In case handle_webhook was cancelled before the exception occured
+            # In case handle_webhook was cancelled before the exception occurred
             _LOGGER.exception(err)

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -366,7 +366,7 @@ class ReolinkHost:
         _LOGGER.debug("Webhook '%s' called", webhook_id)
         try:
             data = await request.text()
-        except ConnectionResetError:
+        except ConnectionResetError, asyncio.CancelledError:
             await asyncio.shield(self.handle_webhook_error_shielded(hass, webhook_id))
             return
 

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -366,10 +366,11 @@ class ReolinkHost:
     ):
         """Shield the incoming webhook callback from cancellation."""
         self._webhook_read_done.clear()
-        shielded_future = asyncio.shield(self._handle_webhook(hass, webhook_id, request))
+        shielded_task = asyncio.create_task(self._handle_webhook(hass, webhook_id, request))
+        asyncio.shield(shielded_task)
         # To protect agains garbage collection
-        self._webhook_tasks.add(shielded_future)
-        shielded_future.add_done_callback(self._webhook_tasks.discard)
+        self._webhook_tasks.add(shielded_task)
+        shielded_task.add_done_callback(self._webhook_tasks.discard)
         _LOGGER.debug("Webhook '%s' called", webhook_id)
         await self._webhook_read_done.wait()
 

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -404,3 +404,4 @@ class ReolinkHost:
         
         if not self._webhook_reachable.is_set():
             self._webhook_reachable.set()
+            ir.async_delete_issue(self._hass, DOMAIN, "webhook_url")

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -366,7 +366,7 @@ class ReolinkHost:
         _LOGGER.debug("Webhook '%s' called", webhook_id)
         try:
             data = await request.text()
-        except ConnectionResetError, asyncio.CancelledError:
+        except (ConnectionResetError, asyncio.CancelledError):
             await asyncio.shield(self.handle_webhook_error_shielded(hass, webhook_id))
             return
 

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -366,7 +366,9 @@ class ReolinkHost:
     ):
         """Shield the incoming webhook callback from cancellation."""
         self._webhook_read_done.clear()
-        shielded_task = asyncio.create_task(self._handle_webhook(hass, webhook_id, request))
+        shielded_task = asyncio.create_task(
+            self._handle_webhook(hass, webhook_id, request)
+        )
         asyncio.shield(shielded_task)
         # To protect agains garbage collection
         self._webhook_tasks.add(shielded_task)

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -368,7 +368,7 @@ class ReolinkHost:
             data = await request.text()
         except (ConnectionResetError, asyncio.CancelledError):
             await asyncio.shield(self.handle_webhook_error_shielded(hass, webhook_id))
-            return
+            raise
 
         await asyncio.shield(self.handle_webhook_shielded(hass, webhook_id, data))
 

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -363,7 +363,7 @@ class ReolinkHost:
         self, hass: HomeAssistant, webhook_id: str, request: Request
     ):
         """Shield the incoming webhook callback from cancellation."""
-        shielded_future =  = asyncio.shield(
+        shielded_future = asyncio.shield(
             self._handle_webhook(hass, webhook_id, request)
         )
         _LOGGER.debug("Webhook '%s' called", webhook_id)

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -370,7 +370,7 @@ class ReolinkHost:
             self._handle_webhook(hass, webhook_id, request)
         )
         asyncio.shield(shielded_task)
-        # To protect agains garbage collection
+        # To protect against garbage collection
         self._webhook_tasks.add(shielded_task)
         shielded_task.add_done_callback(self._webhook_tasks.discard)
         _LOGGER.debug("Webhook '%s' called", webhook_id)

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -363,22 +363,17 @@ class ReolinkHost:
         self, hass: HomeAssistant, webhook_id: str, request: Request
     ):
         """Shield the incoming webhook callback from cancellation."""
-        await asyncio.shield(self.handle_webhook_shielded(hass, webhook_id, request))
+        _LOGGER.debug("Webhook '%s' called", webhook_id)
+        data = await request.text()
+        await asyncio.shield(self.handle_webhook_shielded(hass, webhook_id, data))
 
     async def handle_webhook_shielded(
-        self, hass: HomeAssistant, webhook_id: str, request: Request
+        self, hass: HomeAssistant, webhook_id: str, data: str
     ):
         """Handle incoming webhook from Reolink for inbound messages and calls."""
-
-        _LOGGER.debug("Webhook '%s' called", webhook_id)
         if not self._webhook_reachable.is_set():
             self._webhook_reachable.set()
 
-        if not request.body_exists:
-            _LOGGER.debug("Webhook '%s' triggered without payload", webhook_id)
-            return
-
-        data = await request.text()
         if not data:
             _LOGGER.debug(
                 "Webhook '%s' triggered with unknown payload: %s", webhook_id, data

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -387,10 +387,10 @@ class ReolinkHost:
                 "Could not poll motion state after losing connection during receiving ONVIF event"
             )
             return
-
-        if not self._webhook_reachable.is_set():
-            self._webhook_reachable.set()
-            ir.async_delete_issue(self._hass, DOMAIN, "webhook_url")
+        finally:
+            if not self._webhook_reachable.is_set():
+                self._webhook_reachable.set()
+                ir.async_delete_issue(self._hass, DOMAIN, "webhook_url")
 
         if not data:
             _LOGGER.debug(

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -413,6 +413,6 @@ class ReolinkHost:
 
             for channel in channels:
                 async_dispatcher_send(hass, f"{webhook_id}_{channel}", {})
-        except Exception as err: # pylint: disable=broad-except
+        except Exception as err:  # pylint: disable=broad-except
             # In case handle_webhook was cancelled before the exception occured
             _LOGGER.exception(err)

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -411,6 +411,5 @@ class ReolinkHost:
                 async_dispatcher_send(hass, f"{webhook_id}_{channel}", {})
         except Exception as err:  # pylint: disable=broad-except
             # Make sure unexpected error in "_handle_webhook" are logged,
-            # in case the parent function "handle_webhook" was cancelled
-            # or finishes before the exception occurred
+            # since nothing is awaiting this function
             _LOGGER.exception(err)

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -410,5 +410,7 @@ class ReolinkHost:
             for channel in channels:
                 async_dispatcher_send(hass, f"{webhook_id}_{channel}", {})
         except Exception as err:  # pylint: disable=broad-except
-            # In case the parent function "handle_webhook" was cancelled or finishes before the exception occurred
+            # Make sure unexpected error in "_handle_webhook" are logged,
+            # in case the parent function "handle_webhook" was cancelled
+            # or finishes before the exception occurred
             _LOGGER.exception(err)

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -410,5 +410,5 @@ class ReolinkHost:
             for channel in channels:
                 async_dispatcher_send(hass, f"{webhook_id}_{channel}", {})
         except Exception as err:  # pylint: disable=broad-except
-            # In case handle_webhook was cancelled before the exception occurred
+            # In case the parent function "handle_webhook" was cancelled or finishes before the exception occurred
             _LOGGER.exception(err)

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -59,7 +59,6 @@ class ReolinkHost:
         self._base_url: str = ""
         self._webhook_url: str = ""
         self._webhook_reachable: asyncio.Event = asyncio.Event()
-        self._webhook_read_done: asyncio.Event = asyncio.Event()
         self._lost_subscription: bool = False
 
     @property
@@ -362,54 +361,70 @@ class ReolinkHost:
 
     async def handle_webhook(
         self, hass: HomeAssistant, webhook_id: str, request: Request
-    ):
+    ) -> None:
         """Shield the incoming webhook callback from cancellation."""
-        self._webhook_read_done.clear()
-        shielded_task = hass.async_create_task(
+        shielded_future = asyncio.shield(
             self._handle_webhook(hass, webhook_id, request)
         )
-        asyncio.shield(shielded_task)
         _LOGGER.debug("Webhook '%s' called", webhook_id)
-        await self._webhook_read_done.wait()
+        if not self._webhook_reachable.is_set():
+            self._webhook_reachable.set()
+            ir.async_delete_issue(self._hass, DOMAIN, "webhook_url")
+        await shielded_future
 
     async def _handle_webhook(
         self, hass: HomeAssistant, webhook_id: str, request: Request
-    ):
+    ) -> None:
         """Handle incoming webhook from Reolink for inbound messages and calls."""
         try:
-            try:
-                data = await request.text()
-            except ConnectionResetError:
-                _LOGGER.debug(
-                    "Webhook '%s' called, but lost connection before reading message, issuing poll",
-                    webhook_id,
-                )
-                if await self._api.get_motion_state_all_ch():
-                    async_dispatcher_send(hass, f"{webhook_id}_all", {})
-                    return
+            data = await request.text()
+        except ConnectionResetError:
+            # We lost the connection before reading the message, fallback to polling
+            # No need for a background task here as we already know the connection is lost
+            _LOGGER.debug(
+                "Webhook '%s' called, but lost connection before reading message, issuing poll",
+                webhook_id,
+            )
+            if not await self._api.get_motion_state_all_ch():
                 _LOGGER.error(
                     "Could not poll motion state after losing connection during receiving ONVIF event"
                 )
                 return
-            finally:
-                self._webhook_read_done.set()
-                if not self._webhook_reachable.is_set():
-                    self._webhook_reachable.set()
-                    ir.async_delete_issue(self._hass, DOMAIN, "webhook_url")
+            async_dispatcher_send(hass, f"{webhook_id}_all", {})
+            return
 
-            if not data:
-                _LOGGER.debug(
-                    "Webhook '%s' triggered with unknown payload: %s", webhook_id, data
-                )
-                return
+        if not data:
+            _LOGGER.debug(
+                "Webhook '%s' triggered with unknown payload: %s", webhook_id, data
+            )
+            return
 
-            if (channels := await self._api.ONVIF_event_callback(data)) is None:
-                async_dispatcher_send(hass, f"{webhook_id}_all", {})
-                return
+        # We received the data but we want handle_webhook to return as soon as possible
+        # so we process the data in the background
+        hass.async_create_background_task(
+            self._process_webhook_data(hass, webhook_id, data),
+            "Process Reolink webhook",
+        )
 
-            for channel in channels:
-                async_dispatcher_send(hass, f"{webhook_id}_{channel}", {})
-        except Exception as err:  # pylint: disable=broad-except
-            # Make sure unexpected error in "_handle_webhook" are logged,
-            # since nothing is awaiting this function
-            _LOGGER.exception(err)
+    async def _process_webhook_data(
+        self, hass: HomeAssistant, webhook_id: str, data: str
+    ) -> None:
+        """Process the data from the webhook."""
+        # This task is executed in the background so we need to catch exceptions
+        # and log them
+        try:
+            channels = await self._api.ONVIF_event_callback(data)
+        except Exception as ex:  # pylint: disable=broad-except
+            _LOGGER.exception(
+                "Error processing ONVIF event for Reolink %s: %s",
+                self._api.nvr_name,
+                ex,
+            )
+            return
+
+        if channels is None:
+            async_dispatcher_send(hass, f"{webhook_id}_all", {})
+            return
+
+        for channel in channels:
+            async_dispatcher_send(hass, f"{webhook_id}_{channel}", {})


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When a ONVIF push message comes in, first the coroutine was shielded using asyncio.shield to prevent cancellation when the Reolink camera disconnects (The reolink camera has the nasty habbit of disconnecting really fast after sending the ONVIF push, it does not wait on the HTTP_OK).
However the await.shield can apperently take up to 182ms (and 68 ms) as seen in the image below (original situation).
T1 error message is logged just before the `await asyncio.shield(self.handle_webhook_shielded(hass, webhook_id, request))`
T2 error message is logged at the top of `handle_webhook_shielded`

![afbeelding](https://user-images.githubusercontent.com/14811189/230711683-df159d0c-cf18-4f96-bd77-46c41483b719.png)

In those cases the Reolink camera already disconnected, the couritine is successfully shielded, but the `data = await request.text()` would throw a `ConnectionResetError("Lost connection")` which was not handeld and did not apear in the log (probably because the parent task was already cancelled). In the image above I catched this error and logged it during testing.

This all would result in ONVIF pushes being lost halfway through processing meaning doorbell press, people detection events etc. would not be detected.

In this PR first the data is read from the webhook before schielding the rest of the processing, in this way there is no delay of up to 182 ms and the connection is still open. In my testing I did not lose any ONVIF pushes anymore.

However there might still be the possiblity the `handle_webhook` could be cancelled if the camera manages to disconnect before `data = await request.text()` finishes, I don't know enough about the details of aiohttp.web to know if this is realistic or even possible.

I would very much like to not have the task be cancelled in the first place, but I don't think that is possible unless the cancellation policy of all HomeAssistant webhooks is changed, which is probably not a good idea. Ideally a more complex `CancelOnDisconnectRequestHandler` could be made which allows a integration to set if the tasks of the specific webhook get cancelled or not when it registers the webhook. Something in this direction was implemented by @bdraco in https://github.com/home-assistant/core/pull/88046 to temporarily solve a issue in aiohttp. But that goes way above my capabilities.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/90981 https://github.com/home-assistant/core/issues/91030 https://github.com/starkillerOG/reolink_aio/issues/18 https://github.com/home-assistant/core/issues/91298
- This PR is related to issue: https://github.com/home-assistant/core/issues/90931 https://github.com/home-assistant/core/issues/90441 https://github.com/home-assistant/core/issues/91041 https://github.com/home-assistant/core/issues/89351
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
