### PR TITLE
Move BMW Target SoC to number platform

### DIFF
--- a/homeassistant/components/bmw_connected_drive/__init__.py
+++ b/homeassistant/components/bmw_connected_drive/__init__.py
@@ -41,6 +41,7 @@ PLATFORMS = [
     Platform.DEVICE_TRACKER,
     Platform.LOCK,
     Platform.NOTIFY,
+    Platform.NUMBER,
     Platform.SELECT,
     Platform.SENSOR,
 ]

--- a/homeassistant/components/bmw_connected_drive/manifest.json
+++ b/homeassistant/components/bmw_connected_drive/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/bmw_connected_drive",
   "iot_class": "cloud_polling",
   "loggers": ["bimmer_connected"],
-  "requirements": ["bimmer_connected==0.13.0"]
+  "requirements": ["bimmer_connected==0.13.2"]
 }

--- a/homeassistant/components/bmw_connected_drive/number.py
+++ b/homeassistant/components/bmw_connected_drive/number.py
@@ -1,0 +1,119 @@
+"""Number platform for BMW."""
+from collections.abc import Callable, Coroutine
+from dataclasses import dataclass
+import logging
+from typing import Any
+
+from bimmer_connected.vehicle import MyBMWVehicle
+
+from homeassistant.components.number import (
+    NumberDeviceClass,
+    NumberEntity,
+    NumberEntityDescription,
+    NumberMode,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import BMWBaseEntity
+from .const import DOMAIN
+from .coordinator import BMWDataUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class BMWRequiredKeysMixin:
+    """Mixin for required keys."""
+
+    value_fn: Callable[[MyBMWVehicle], float | int | None]
+    remote_service: Callable[[MyBMWVehicle, float | int], Coroutine[Any, Any, Any]]
+
+
+@dataclass
+class BMWNumberEntityDescription(NumberEntityDescription, BMWRequiredKeysMixin):
+    """Describes BMW number entity."""
+
+    is_available: Callable[[MyBMWVehicle], bool] = lambda _: False
+    dynamic_options: Callable[[MyBMWVehicle], list[str]] | None = None
+    mode: NumberMode = NumberMode.AUTO
+
+
+NUMBER_TYPES: dict[str, BMWNumberEntityDescription] = {
+    "target_soc": BMWNumberEntityDescription(
+        key="target_soc",
+        name="Target SoC",
+        device_class=NumberDeviceClass.BATTERY,
+        is_available=lambda v: v.is_remote_set_target_soc_enabled,
+        native_max_value=100.0,
+        native_min_value=20.0,
+        native_step=5.0,
+        mode=NumberMode.SLIDER,
+        value_fn=lambda v: v.fuel_and_battery.charging_target,
+        remote_service=lambda v, o: v.remote_services.trigger_charging_settings_update(
+            target_soc=int(o)
+        ),
+        icon="mdi:battery-charging-medium",
+    ),
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the MyBMW number from config entry."""
+    coordinator: BMWDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+
+    entities: list[BMWNumber] = []
+
+    for vehicle in coordinator.account.vehicles:
+        if not coordinator.read_only:
+            entities.extend(
+                [
+                    BMWNumber(coordinator, vehicle, description)
+                    for description in NUMBER_TYPES.values()
+                    if description.is_available(vehicle)
+                ]
+            )
+    async_add_entities(entities)
+
+
+class BMWNumber(BMWBaseEntity, NumberEntity):
+    """Representation of BMW Number entity."""
+
+    entity_description: BMWNumberEntityDescription
+
+    def __init__(
+        self,
+        coordinator: BMWDataUpdateCoordinator,
+        vehicle: MyBMWVehicle,
+        description: BMWNumberEntityDescription,
+    ) -> None:
+        """Initialize an BMW Number."""
+        super().__init__(coordinator, vehicle)
+        self.entity_description = description
+        self._attr_unique_id = f"{vehicle.vin}-{description.key}"
+        self._attr_native_value = description.value_fn(vehicle)
+        self._attr_mode = description.mode
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        _LOGGER.debug(
+            "Updating Number '%s' of %s", self.entity_description.key, self.vehicle.name
+        )
+        self._attr_native_value = self.entity_description.value_fn(self.vehicle)
+        super()._handle_coordinator_update()
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Update to the vehicle."""
+        _LOGGER.debug(
+            "Executing '%s' on vehicle '%s' to value '%s'",
+            self.entity_description.key,
+            self.vehicle.vin,
+            value,
+        )
+        await self.entity_description.remote_service(self.vehicle, value)

--- a/homeassistant/components/bmw_connected_drive/number.py
+++ b/homeassistant/components/bmw_connected_drive/number.py
@@ -1,9 +1,11 @@
 """Number platform for BMW."""
+
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 import logging
 from typing import Any
 
+from bimmer_connected.models import MyBMWAPIError
 from bimmer_connected.vehicle import MyBMWVehicle
 
 from homeassistant.components.number import (
@@ -14,6 +16,7 @@ from homeassistant.components.number import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import BMWBaseEntity
@@ -111,4 +114,9 @@ class BMWNumber(BMWBaseEntity, NumberEntity):
             self.vehicle.vin,
             value,
         )
-        await self.entity_description.remote_service(self.vehicle, value)
+        try:
+            await self.entity_description.remote_service(self.vehicle, value)
+        except MyBMWAPIError as ex:
+            raise HomeAssistantError(str(ex)) from ex
+        except TypeError as ex:
+            raise ValueError(str(ex)) from ex

--- a/homeassistant/components/bmw_connected_drive/number.py
+++ b/homeassistant/components/bmw_connected_drive/number.py
@@ -117,4 +117,4 @@ class BMWNumber(BMWBaseEntity, NumberEntity):
         try:
             await self.entity_description.remote_service(self.vehicle, value)
         except MyBMWAPIError as ex:
-            raise HomeAssistantError(str(ex)) from ex
+            raise HomeAssistantError(ex) from ex

--- a/homeassistant/components/bmw_connected_drive/number.py
+++ b/homeassistant/components/bmw_connected_drive/number.py
@@ -96,7 +96,6 @@ class BMWNumber(BMWBaseEntity, NumberEntity):
         super().__init__(coordinator, vehicle)
         self.entity_description = description
         self._attr_unique_id = f"{vehicle.vin}-{description.key}"
-        self._attr_native_value = description.value_fn(vehicle)
         self._attr_mode = description.mode
 
     @property

--- a/homeassistant/components/bmw_connected_drive/number.py
+++ b/homeassistant/components/bmw_connected_drive/number.py
@@ -118,5 +118,3 @@ class BMWNumber(BMWBaseEntity, NumberEntity):
             await self.entity_description.remote_service(self.vehicle, value)
         except MyBMWAPIError as ex:
             raise HomeAssistantError(str(ex)) from ex
-        except TypeError as ex:
-            raise ValueError(str(ex)) from ex

--- a/homeassistant/components/bmw_connected_drive/select.py
+++ b/homeassistant/components/bmw_connected_drive/select.py
@@ -9,7 +9,7 @@ from bimmer_connected.vehicle.charging_profile import ChargingMode
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import PERCENTAGE, UnitOfElectricCurrent
+from homeassistant.const import UnitOfElectricCurrent
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -37,19 +37,6 @@ class BMWSelectEntityDescription(SelectEntityDescription, BMWRequiredKeysMixin):
 
 
 SELECT_TYPES: dict[str, BMWSelectEntityDescription] = {
-    # --- Generic ---
-    "target_soc": BMWSelectEntityDescription(
-        key="target_soc",
-        name="Target SoC",
-        is_available=lambda v: v.is_remote_set_target_soc_enabled,
-        options=[str(i * 5 + 20) for i in range(17)],
-        current_option=lambda v: str(v.fuel_and_battery.charging_target),
-        remote_service=lambda v, o: v.remote_services.trigger_charging_settings_update(
-            target_soc=int(o)
-        ),
-        icon="mdi:battery-charging-medium",
-        unit_of_measurement=PERCENTAGE,
-    ),
     "ac_limit": BMWSelectEntityDescription(
         key="ac_limit",
         name="AC Charging Limit",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -428,7 +428,7 @@ beautifulsoup4==4.11.1
 bellows==0.35.0
 
 # homeassistant.components.bmw_connected_drive
-bimmer_connected==0.13.0
+bimmer_connected==0.13.2
 
 # homeassistant.components.bizkaibus
 bizkaibus==0.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -361,7 +361,7 @@ beautifulsoup4==4.11.1
 bellows==0.35.0
 
 # homeassistant.components.bmw_connected_drive
-bimmer_connected==0.13.0
+bimmer_connected==0.13.2
 
 # homeassistant.components.bluetooth
 bleak-retry-connector==3.0.2

--- a/tests/components/bmw_connected_drive/snapshots/test_diagnostics.ambr
+++ b/tests/components/bmw_connected_drive/snapshots/test_diagnostics.ambr
@@ -139,6 +139,22 @@
             }),
           ]),
         }),
+        'climate': dict({
+          'account_timezone': dict({
+            '_dst_offset': '0:00:00',
+            '_dst_saved': '0:00:00',
+            '_hasdst': False,
+            '_std_offset': '0:00:00',
+            '_tznames': list([
+              'UTC',
+              'UTC',
+            ]),
+          }),
+          'activity': 'STANDBY',
+          'activity_end_time': None,
+          'activity_end_time_no_tz': None,
+          'is_climate_on': False,
+        }),
         'condition_based_services': dict({
           'is_service_required': False,
           'messages': list([
@@ -808,6 +824,32 @@
         ]),
         'name': 'i4 eDrive40',
         'timestamp': '2023-01-04T14:57:06+00:00',
+        'tires': dict({
+          'front_left': dict({
+            'current_pressure': 241,
+            'manufacturing_week': '2021-10-04T00:00:00',
+            'season': 2,
+            'target_pressure': 269,
+          }),
+          'front_right': dict({
+            'current_pressure': 255,
+            'manufacturing_week': '2019-06-10T00:00:00',
+            'season': 2,
+            'target_pressure': 269,
+          }),
+          'rear_left': dict({
+            'current_pressure': 324,
+            'manufacturing_week': '2019-03-18T00:00:00',
+            'season': 2,
+            'target_pressure': 303,
+          }),
+          'rear_right': dict({
+            'current_pressure': 331,
+            'manufacturing_week': '2019-03-18T00:00:00',
+            'season': 2,
+            'target_pressure': 303,
+          }),
+        }),
         'vehicle_location': dict({
           'account_region': 'row',
           'heading': '**REDACTED**',
@@ -968,6 +1010,22 @@
           'has_check_control_messages': False,
           'messages': list([
           ]),
+        }),
+        'climate': dict({
+          'account_timezone': dict({
+            '_dst_offset': '0:00:00',
+            '_dst_saved': '0:00:00',
+            '_hasdst': False,
+            '_std_offset': '0:00:00',
+            '_tznames': list([
+              'UTC',
+              'UTC',
+            ]),
+          }),
+          'activity': 'UNKNOWN',
+          'activity_end_time': None,
+          'activity_end_time_no_tz': None,
+          'is_climate_on': False,
         }),
         'condition_based_services': dict({
           'is_service_required': False,
@@ -1466,6 +1524,7 @@
         ]),
         'name': 'i3 (+ REX)',
         'timestamp': '2022-07-10T09:25:53+00:00',
+        'tires': None,
         'vehicle_location': dict({
           'account_region': 'row',
           'heading': None,
@@ -2456,6 +2515,22 @@
         'messages': list([
         ]),
       }),
+      'climate': dict({
+        'account_timezone': dict({
+          '_dst_offset': '0:00:00',
+          '_dst_saved': '0:00:00',
+          '_hasdst': False,
+          '_std_offset': '0:00:00',
+          '_tznames': list([
+            'UTC',
+            'UTC',
+          ]),
+        }),
+        'activity': 'UNKNOWN',
+        'activity_end_time': None,
+        'activity_end_time_no_tz': None,
+        'is_climate_on': False,
+      }),
       'condition_based_services': dict({
         'is_service_required': False,
         'messages': list([
@@ -2953,6 +3028,7 @@
       ]),
       'name': 'i3 (+ REX)',
       'timestamp': '2022-07-10T09:25:53+00:00',
+      'tires': None,
       'vehicle_location': dict({
         'account_region': 'row',
         'heading': None,

--- a/tests/components/bmw_connected_drive/snapshots/test_number.ambr
+++ b/tests/components/bmw_connected_drive/snapshots/test_number.ambr
@@ -1,0 +1,22 @@
+# serializer version: 1
+# name: test_entity_state_attrs
+  list([
+    StateSnapshot({
+      'attributes': ReadOnlyDict({
+        'attribution': 'Data provided by MyBMW',
+        'device_class': 'battery',
+        'friendly_name': 'i4 eDrive40 Target SoC',
+        'icon': 'mdi:battery-charging-medium',
+        'max': 100.0,
+        'min': 20.0,
+        'mode': <NumberMode.SLIDER: 'slider'>,
+        'step': 5.0,
+      }),
+      'context': <ANY>,
+      'entity_id': 'number.i4_edrive40_target_soc',
+      'last_changed': <ANY>,
+      'last_updated': <ANY>,
+      'state': '80',
+    }),
+  ])
+# ---

--- a/tests/components/bmw_connected_drive/snapshots/test_select.ambr
+++ b/tests/components/bmw_connected_drive/snapshots/test_select.ambr
@@ -4,38 +4,6 @@
     StateSnapshot({
       'attributes': ReadOnlyDict({
         'attribution': 'Data provided by MyBMW',
-        'friendly_name': 'i4 eDrive40 Target SoC',
-        'icon': 'mdi:battery-charging-medium',
-        'options': list([
-          '20',
-          '25',
-          '30',
-          '35',
-          '40',
-          '45',
-          '50',
-          '55',
-          '60',
-          '65',
-          '70',
-          '75',
-          '80',
-          '85',
-          '90',
-          '95',
-          '100',
-        ]),
-        'unit_of_measurement': '%',
-      }),
-      'context': <ANY>,
-      'entity_id': 'select.i4_edrive40_target_soc',
-      'last_changed': <ANY>,
-      'last_updated': <ANY>,
-      'state': '80',
-    }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'attribution': 'Data provided by MyBMW',
         'friendly_name': 'i4 eDrive40 AC Charging Limit',
         'icon': 'mdi:current-ac',
         'options': list([

--- a/tests/components/bmw_connected_drive/test_number.py
+++ b/tests/components/bmw_connected_drive/test_number.py
@@ -1,4 +1,4 @@
-"""Test BMW selects."""
+"""Test BMW numbers."""
 from bimmer_connected.vehicle.remote_services import RemoteServices
 import pytest
 import respx
@@ -14,21 +14,19 @@ async def test_entity_state_attrs(
     bmw_fixture: respx.Router,
     snapshot: SnapshotAssertion,
 ) -> None:
-    """Test select options and values.."""
+    """Test number options and values.."""
 
     # Setup component
     assert await setup_mocked_integration(hass)
 
-    # Get all select entities
-    assert hass.states.async_all("select") == snapshot
+    # Get all number entities
+    assert hass.states.async_all("number") == snapshot
 
 
 @pytest.mark.parametrize(
     ("entity_id", "value"),
     [
-        ("select.i3_rex_charging_mode", "IMMEDIATE_CHARGING"),
-        ("select.i4_edrive40_ac_charging_limit", "16"),
-        ("select.i4_edrive40_charging_mode", "DELAYED_CHARGING"),
+        ("number.i4_edrive40_target_soc", "80"),
     ],
 )
 async def test_update_triggers_success(
@@ -37,16 +35,16 @@ async def test_update_triggers_success(
     value: str,
     bmw_fixture: respx.Router,
 ) -> None:
-    """Test allowed values for select inputs."""
+    """Test allowed values for number inputs."""
 
     # Setup component
     assert await setup_mocked_integration(hass)
 
     # Test
     await hass.services.async_call(
-        "select",
-        "select_option",
-        service_data={"option": value},
+        "number",
+        "set_value",
+        service_data={"value": value},
         blocking=True,
         target={"entity_id": entity_id},
     )
@@ -56,7 +54,7 @@ async def test_update_triggers_success(
 @pytest.mark.parametrize(
     ("entity_id", "value"),
     [
-        ("select.i4_edrive40_ac_charging_limit", "17"),
+        ("number.i4_edrive40_target_soc", "81"),
     ],
 )
 async def test_update_triggers_fail(
@@ -65,7 +63,7 @@ async def test_update_triggers_fail(
     value: str,
     bmw_fixture: respx.Router,
 ) -> None:
-    """Test not allowed values for select inputs."""
+    """Test not allowed values for number inputs."""
 
     # Setup component
     assert await setup_mocked_integration(hass)
@@ -73,9 +71,9 @@ async def test_update_triggers_fail(
     # Test
     with pytest.raises(ValueError):
         await hass.services.async_call(
-            "select",
-            "select_option",
-            service_data={"option": value},
+            "number",
+            "set_value",
+            service_data={"value": value},
             blocking=True,
             target={"entity_id": entity_id},
         )

--- a/tests/components/bmw_connected_drive/test_number.py
+++ b/tests/components/bmw_connected_drive/test_number.py
@@ -89,7 +89,6 @@ async def test_update_triggers_fail(
     [
         (MyBMWRemoteServiceError, HomeAssistantError),
         (MyBMWAPIError, HomeAssistantError),
-        (TypeError, ValueError),
         (ValueError, ValueError),
     ],
 )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As requested by @MartinHjelmare in https://github.com/home-assistant/core/pull/88759#discussion_r1155065854, this PR adds the `NUMBER` platform to bmw_connected_drive and moves Target SoC there.

No breaking change as #88759 was merged after the last beta cut, so it is not yet live.

Changelog: 
- https://github.com/bimmerconnected/bimmer_connected/releases/tag/0.13.1
- https://github.com/bimmerconnected/bimmer_connected/releases/tag/0.13.2

Diff: https://github.com/bimmerconnected/bimmer_connected/compare/0.13.0...0.13.2

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/bimmerconnected/bimmer_connected/discussions/435, https://github.com/bimmerconnected/bimmer_connected/discussions/440
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/26365

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
