### PR TITLE
Make the device_tracker more forgiving when passed an empty ip address string

### DIFF
--- a/homeassistant/components/device_tracker/config_entry.py
+++ b/homeassistant/components/device_tracker/config_entry.py
@@ -348,7 +348,7 @@ class ScannerEntity(BaseTrackerEntity):
                 self.mac_address,
                 self.unique_id,
             )
-            if self.is_connected:
+            if self.is_connected and self.ip_address:
                 _async_connected_device_registered(
                     hass,
                     self.mac_address,
@@ -405,7 +405,7 @@ class ScannerEntity(BaseTrackerEntity):
         """Return the device state attributes."""
         attr: dict[str, StateType] = {}
         attr.update(super().state_attributes)
-        if self.ip_address is not None:
+        if self.ip_address:
             attr[ATTR_IP] = self.ip_address
         if self.mac_address is not None:
             attr[ATTR_MAC] = self.mac_address

--- a/tests/components/device_tracker/test_config_entry.py
+++ b/tests/components/device_tracker/test_config_entry.py
@@ -197,21 +197,6 @@ async def test_connected_device_registered(
 
         @property
         def mac_address(self) -> str:
-            return "aa:bb:cc:dd:ee:ff"
-
-        @property
-        def is_connected(self) -> bool:
-            return True
-
-        @property
-        def hostname(self) -> str:
-            return "connected"
-
-    class MockConnectedScannerEntity(MockScannerEntity):
-        """Mock a disconnected scanner entity."""
-
-        @property
-        def mac_address(self) -> str:
             return "aa:bb:cc:dd:ee:00"
 
         @property
@@ -222,10 +207,44 @@ async def test_connected_device_registered(
         def hostname(self) -> str:
             return "disconnected"
 
+    class MockConnectedScannerEntity(MockScannerEntity):
+        """Mock a disconnected scanner entity."""
+
+        @property
+        def mac_address(self) -> str:
+            return "aa:bb:cc:dd:ee:ff"
+
+        @property
+        def is_connected(self) -> bool:
+            return True
+
+        @property
+        def hostname(self) -> str:
+            return "connected"
+
+    class MockConnectedScannerEntityBadIPAddress(MockConnectedScannerEntity):
+        """Mock a disconnected scanner entity."""
+
+        @property
+        def mac_address(self) -> str:
+            return "aa:bb:cc:dd:ee:01"
+
+        @property
+        def ip_address(self) -> str:
+            return ""
+
+        @property
+        def hostname(self) -> str:
+            return "connected_bad_ip"
+
     async def async_setup_entry(hass, config_entry, async_add_entities):
         """Mock setup entry method."""
         async_add_entities(
-            [MockConnectedScannerEntity(), MockDisconnectedScannerEntity()]
+            [
+                MockConnectedScannerEntity(),
+                MockDisconnectedScannerEntity(),
+                MockConnectedScannerEntityBadIPAddress(),
+            ]
         )
         return True
 
@@ -240,7 +259,7 @@ async def test_connected_device_registered(
     full_name = f"{entity_platform.domain}.{config_entry.domain}"
     assert full_name in hass.config.components
     assert len(hass.states.async_entity_ids()) == 0  # should be disabled
-    assert len(entity_registry.entities) == 2
+    assert len(entity_registry.entities) == 3
     assert (
         entity_registry.entities["test_domain.test_aa_bb_cc_dd_ee_ff"].config_entry_id
         == "super-mock-id"


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This has come up over and over and over again and there isn't a use case for an empty string as an ip address so it seems like its better to treat them the same as `None`

fixes #87165 fixes #51980


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
