### PR TITLE
Relax calendar event validation to allow existing zero duration events

### DIFF
--- a/tests/components/caldav/test_calendar.py
+++ b/tests/components/caldav/test_calendar.py
@@ -255,6 +255,32 @@ SUMMARY:Event with a provided Timezone
 END:VEVENT
 END:VCALENDAR
 """,
+    """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Global Corp.//CalDAV Client//EN
+BEGIN:VEVENT
+UID:16
+DTSTAMP:20171125T000000Z
+DTSTART:20171127
+DTEND:20171128
+SUMMARY:All day event with same start and end
+LOCATION:Hamburg
+END:VEVENT
+END:VCALENDAR
+""",
+    """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Global Corp.//CalDAV Client//EN
+BEGIN:VEVENT
+UID:17
+DTSTAMP:20171125T000000Z
+DTSTART:20171127T010000
+DTEND:20171127T010000
+SUMMARY:Event with no duration
+LOCATION:Hamburg
+END:VEVENT
+END:VCALENDAR
+""",
 ]
 
 CALDAV_CONFIG = {
@@ -1001,7 +1027,7 @@ async def test_get_events(hass: HomeAssistant, calendar, get_api_events) -> None
     await hass.async_block_till_done()
 
     events = await get_api_events("calendar.private")
-    assert len(events) == 16
+    assert len(events) == 18
     assert calendar.call
 
 

--- a/tests/components/calendar/test_init.py
+++ b/tests/components/calendar/test_init.py
@@ -324,7 +324,7 @@ async def test_unsupported_create_event_service(hass: HomeAssistant) -> None:
                 "end_date_time": "2022-04-01T06:00:00",
             },
             vol.error.MultipleInvalid,
-            "Expected positive event duration",
+            "Expected minimum event duration",
         ),
         (
             {
@@ -332,7 +332,7 @@ async def test_unsupported_create_event_service(hass: HomeAssistant) -> None:
                 "end_date": "2022-04-01",
             },
             vol.error.MultipleInvalid,
-            "Expected positive event duration",
+            "Expected minimum event duration",
         ),
         (
             {
@@ -340,7 +340,7 @@ async def test_unsupported_create_event_service(hass: HomeAssistant) -> None:
                 "end_date": "2022-04-01",
             },
             vol.error.MultipleInvalid,
-            "Expected positive event duration",
+            "Expected minimum event duration",
         ),
     ],
     ids=[

--- a/tests/components/google/test_calendar.py
+++ b/tests/components/google/test_calendar.py
@@ -1238,3 +1238,60 @@ async def test_reader_in_progress_event(
         "location": event["location"],
         "description": event["description"],
     }
+
+
+async def test_all_day_event_without_duration(
+    hass: HomeAssistant, mock_events_list_items, component_setup
+) -> None:
+    """Test that an all day event without a duration is adjusted to have a duration of one day."""
+    week_from_today = dt_util.now().date() + datetime.timedelta(days=7)
+    event = {
+        **TEST_EVENT,
+        "start": {"date": week_from_today.isoformat()},
+        "end": {"date": week_from_today.isoformat()},
+    }
+    mock_events_list_items([event])
+
+    assert await component_setup()
+
+    expected_end_event = week_from_today + datetime.timedelta(days=1)
+
+    state = hass.states.get(TEST_ENTITY)
+    assert state.name == TEST_ENTITY_NAME
+    assert state.state == STATE_OFF
+    assert dict(state.attributes) == {
+        "friendly_name": TEST_ENTITY_NAME,
+        "message": event["summary"],
+        "all_day": True,
+        "offset_reached": False,
+        "start_time": week_from_today.strftime(DATE_STR_FORMAT),
+        "end_time": expected_end_event.strftime(DATE_STR_FORMAT),
+        "location": event["location"],
+        "description": event["description"],
+        "supported_features": 3,
+    }
+
+
+async def test_event_without_duration(
+    hass: HomeAssistant, mock_events_list_items, component_setup
+) -> None:
+    """Google calendar UI allows creating events without a duration."""
+    one_hour_from_now = dt_util.now() + datetime.timedelta(minutes=30)
+    event = {
+        **TEST_EVENT,
+        "start": {"dateTime": one_hour_from_now.isoformat()},
+        "end": {"dateTime": one_hour_from_now.isoformat()},
+    }
+    mock_events_list_items([event])
+
+    assert await component_setup()
+
+    state = hass.states.get(TEST_ENTITY)
+    assert state.name == TEST_ENTITY_NAME
+    assert state.state == STATE_OFF
+    # Confirm the event is parsed successfully, but we don't assert on the
+    # specific end date as the client library may adjust it
+    assert state.attributes.get("message") == event["summary"]
+    assert state.attributes.get("start_time") == one_hour_from_now.strftime(
+        DATE_STR_FORMAT
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Relax calendar event duration rules to preserve existing events from integrations that have no duration. Google Calendar allows creating instantaneous events in the UI, and it actually is valid according to rfc5545. 

There are now different rules used for verifying existing events vs creating events. Event creation websocket and service still require events in home assistant to be created with a positive duration.  All day events are coerced to preserve the expectation that they have a duration of one day.

These cases were previously handled in #91062 #90970 #90968 but I've reconsidered given the discussion in #91123. I will likely revert changes that coerce minimum datetime event durations in gcal and local calendar.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #91123
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
