### PR TITLE
Preserves config flow information in case of error for SQL

### DIFF
--- a/homeassistant/components/sql/config_flow.py
+++ b/homeassistant/components/sql/config_flow.py
@@ -58,7 +58,7 @@ def validate_query(db_url: str, query: str, column: str) -> bool:
 
 def _generate_schema_config(current_data: dict[str, Any]) -> vol.Schema:
     """Generate schema for config flow."""
-    return vol.Schema(
+    schema: vol.Schema = vol.Schema(
         {
             vol.Required(
                 CONF_NAME,
@@ -66,30 +66,9 @@ def _generate_schema_config(current_data: dict[str, Any]) -> vol.Schema:
                     "suggested_value": current_data.get(CONF_NAME, "Select SQL Query")
                 },
             ): selector.TextSelector(),
-            vol.Optional(
-                CONF_DB_URL,
-                description={"suggested_value": current_data.get(CONF_DB_URL)},
-            ): selector.TextSelector(),
-            vol.Required(
-                CONF_COLUMN_NAME,
-                description={"suggested_value": current_data.get(CONF_COLUMN_NAME)},
-            ): selector.TextSelector(),
-            vol.Required(
-                CONF_QUERY,
-                description={"suggested_value": current_data.get(CONF_QUERY)},
-            ): selector.TextSelector(selector.TextSelectorConfig(multiline=True)),
-            vol.Optional(
-                CONF_UNIT_OF_MEASUREMENT,
-                description={
-                    "suggested_value": current_data.get(CONF_UNIT_OF_MEASUREMENT)
-                },
-            ): selector.TextSelector(),
-            vol.Optional(
-                CONF_VALUE_TEMPLATE,
-                description={"suggested_value": current_data.get(CONF_VALUE_TEMPLATE)},
-            ): selector.TemplateSelector(),
         }
     )
+    return schema.extend(_generate_schema_options(current_data).schema)
 
 
 def _generate_schema_options(

--- a/homeassistant/components/sql/config_flow.py
+++ b/homeassistant/components/sql/config_flow.py
@@ -125,6 +125,55 @@ class SQLConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     },
                 )
 
+            return self.async_show_form(
+                step_id="user",
+                data_schema=vol.Schema(
+                    {
+                        vol.Required(
+                            CONF_NAME,
+                            description={
+                                "suggested_value": user_input.get(
+                                    CONF_NAME, "Select SQL Query"
+                                )
+                            },
+                        ): selector.TextSelector(),
+                        vol.Optional(
+                            CONF_DB_URL,
+                            description={
+                                "suggested_value": user_input.get(CONF_DB_URL)
+                            },
+                        ): selector.TextSelector(),
+                        vol.Required(
+                            CONF_COLUMN_NAME,
+                            description={
+                                "suggested_value": user_input.get(CONF_COLUMN_NAME)
+                            },
+                        ): selector.TextSelector(),
+                        vol.Required(
+                            CONF_QUERY,
+                            description={"suggested_value": user_input.get(CONF_QUERY)},
+                        ): selector.TextSelector(
+                            selector.TextSelectorConfig(multiline=True)
+                        ),
+                        vol.Optional(
+                            CONF_UNIT_OF_MEASUREMENT,
+                            description={
+                                "suggested_value": user_input.get(
+                                    CONF_UNIT_OF_MEASUREMENT
+                                )
+                            },
+                        ): selector.TextSelector(),
+                        vol.Optional(
+                            CONF_VALUE_TEMPLATE,
+                            description={
+                                "suggested_value": user_input.get(CONF_VALUE_TEMPLATE)
+                            },
+                        ): selector.TemplateSelector(),
+                    }
+                ),
+                errors=errors,
+            )
+
         return self.async_show_form(
             step_id="user",
             data_schema=DATA_SCHEMA,
@@ -172,6 +221,47 @@ class SQLOptionsFlowHandler(config_entries.OptionsFlow):
                         **new_user_input,
                     },
                 )
+
+            return self.async_show_form(
+                step_id="init",
+                data_schema=vol.Schema(
+                    {
+                        vol.Optional(
+                            CONF_DB_URL,
+                            description={
+                                "suggested_value": user_input.get(CONF_DB_URL)
+                            },
+                        ): selector.TextSelector(),
+                        vol.Required(
+                            CONF_QUERY,
+                            description={"suggested_value": user_input.get(CONF_QUERY)},
+                        ): selector.TextSelector(
+                            selector.TextSelectorConfig(multiline=True)
+                        ),
+                        vol.Required(
+                            CONF_COLUMN_NAME,
+                            description={
+                                "suggested_value": user_input.get(CONF_COLUMN_NAME)
+                            },
+                        ): selector.TextSelector(),
+                        vol.Optional(
+                            CONF_UNIT_OF_MEASUREMENT,
+                            description={
+                                "suggested_value": user_input.get(
+                                    CONF_UNIT_OF_MEASUREMENT
+                                )
+                            },
+                        ): selector.TextSelector(),
+                        vol.Optional(
+                            CONF_VALUE_TEMPLATE,
+                            description={
+                                "suggested_value": user_input.get(CONF_VALUE_TEMPLATE)
+                            },
+                        ): selector.TemplateSelector(),
+                    }
+                ),
+                errors=errors,
+            )
 
         return self.async_show_form(
             step_id="init",

--- a/homeassistant/components/sql/config_flow.py
+++ b/homeassistant/components/sql/config_flow.py
@@ -22,19 +22,6 @@ from .util import resolve_db_url
 
 _LOGGER = logging.getLogger(__name__)
 
-DATA_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_NAME, default="Select SQL Query"): selector.TextSelector(),
-        vol.Optional(CONF_DB_URL): selector.TextSelector(),
-        vol.Required(CONF_COLUMN_NAME): selector.TextSelector(),
-        vol.Required(CONF_QUERY): selector.TextSelector(
-            selector.TextSelectorConfig(multiline=True)
-        ),
-        vol.Optional(CONF_UNIT_OF_MEASUREMENT): selector.TextSelector(),
-        vol.Optional(CONF_VALUE_TEMPLATE): selector.TemplateSelector(),
-    }
-)
-
 
 def validate_sql_select(value: str) -> str | None:
     """Validate that value is a SQL SELECT query."""
@@ -87,6 +74,13 @@ class SQLConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle the user step."""
         errors = {}
 
+        current_name: str = "Select SQL Query"
+        current_db_url: str | None = None
+        current_column_name: str | None = None
+        current_query: str | None = None
+        current_unit_of_measurement: str | None = None
+        current_value_template: str | None = None
+
         if user_input is not None:
             db_url = user_input.get(CONF_DB_URL)
             query = user_input[CONF_QUERY]
@@ -124,59 +118,45 @@ class SQLConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         CONF_NAME: name,
                     },
                 )
-
-            return self.async_show_form(
-                step_id="user",
-                data_schema=vol.Schema(
-                    {
-                        vol.Required(
-                            CONF_NAME,
-                            description={
-                                "suggested_value": user_input.get(
-                                    CONF_NAME, "Select SQL Query"
-                                )
-                            },
-                        ): selector.TextSelector(),
-                        vol.Optional(
-                            CONF_DB_URL,
-                            description={
-                                "suggested_value": user_input.get(CONF_DB_URL)
-                            },
-                        ): selector.TextSelector(),
-                        vol.Required(
-                            CONF_COLUMN_NAME,
-                            description={
-                                "suggested_value": user_input.get(CONF_COLUMN_NAME)
-                            },
-                        ): selector.TextSelector(),
-                        vol.Required(
-                            CONF_QUERY,
-                            description={"suggested_value": user_input.get(CONF_QUERY)},
-                        ): selector.TextSelector(
-                            selector.TextSelectorConfig(multiline=True)
-                        ),
-                        vol.Optional(
-                            CONF_UNIT_OF_MEASUREMENT,
-                            description={
-                                "suggested_value": user_input.get(
-                                    CONF_UNIT_OF_MEASUREMENT
-                                )
-                            },
-                        ): selector.TextSelector(),
-                        vol.Optional(
-                            CONF_VALUE_TEMPLATE,
-                            description={
-                                "suggested_value": user_input.get(CONF_VALUE_TEMPLATE)
-                            },
-                        ): selector.TemplateSelector(),
-                    }
-                ),
-                errors=errors,
-            )
+            current_name = user_input.get(CONF_NAME, "Select SQL Query")
+            current_db_url = user_input.get(CONF_DB_URL)
+            current_column_name = user_input.get(CONF_COLUMN_NAME)
+            current_query = user_input.get(CONF_QUERY)
+            current_unit_of_measurement = user_input.get(CONF_UNIT_OF_MEASUREMENT)
+            current_value_template = user_input.get(CONF_VALUE_TEMPLATE)
 
         return self.async_show_form(
             step_id="user",
-            data_schema=DATA_SCHEMA,
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_NAME,
+                        description={"suggested_value": current_name},
+                    ): selector.TextSelector(),
+                    vol.Optional(
+                        CONF_DB_URL,
+                        description={"suggested_value": current_db_url},
+                    ): selector.TextSelector(),
+                    vol.Required(
+                        CONF_COLUMN_NAME,
+                        description={"suggested_value": current_column_name},
+                    ): selector.TextSelector(),
+                    vol.Required(
+                        CONF_QUERY,
+                        description={"suggested_value": current_query},
+                    ): selector.TextSelector(
+                        selector.TextSelectorConfig(multiline=True)
+                    ),
+                    vol.Optional(
+                        CONF_UNIT_OF_MEASUREMENT,
+                        description={"suggested_value": current_unit_of_measurement},
+                    ): selector.TextSelector(),
+                    vol.Optional(
+                        CONF_VALUE_TEMPLATE,
+                        description={"suggested_value": current_value_template},
+                    ): selector.TemplateSelector(),
+                }
+            ),
             errors=errors,
         )
 
@@ -193,6 +173,14 @@ class SQLOptionsFlowHandler(config_entries.OptionsFlow):
     ) -> FlowResult:
         """Manage SQL options."""
         errors = {}
+
+        current_db_url: str | None = self.entry.options.get(CONF_DB_URL)
+        current_column_name: str | None = self.entry.options.get(CONF_COLUMN_NAME)
+        current_query: str | None = self.entry.options.get(CONF_QUERY)
+        current_unit_of_measurement: str | None = self.entry.options.get(
+            CONF_UNIT_OF_MEASUREMENT
+        )
+        current_value_template: str | None = self.entry.options.get(CONF_VALUE_TEMPLATE)
 
         if user_input is not None:
             db_url = user_input.get(CONF_DB_URL)
@@ -222,46 +210,11 @@ class SQLOptionsFlowHandler(config_entries.OptionsFlow):
                     },
                 )
 
-            return self.async_show_form(
-                step_id="init",
-                data_schema=vol.Schema(
-                    {
-                        vol.Optional(
-                            CONF_DB_URL,
-                            description={
-                                "suggested_value": user_input.get(CONF_DB_URL)
-                            },
-                        ): selector.TextSelector(),
-                        vol.Required(
-                            CONF_QUERY,
-                            description={"suggested_value": user_input.get(CONF_QUERY)},
-                        ): selector.TextSelector(
-                            selector.TextSelectorConfig(multiline=True)
-                        ),
-                        vol.Required(
-                            CONF_COLUMN_NAME,
-                            description={
-                                "suggested_value": user_input.get(CONF_COLUMN_NAME)
-                            },
-                        ): selector.TextSelector(),
-                        vol.Optional(
-                            CONF_UNIT_OF_MEASUREMENT,
-                            description={
-                                "suggested_value": user_input.get(
-                                    CONF_UNIT_OF_MEASUREMENT
-                                )
-                            },
-                        ): selector.TextSelector(),
-                        vol.Optional(
-                            CONF_VALUE_TEMPLATE,
-                            description={
-                                "suggested_value": user_input.get(CONF_VALUE_TEMPLATE)
-                            },
-                        ): selector.TemplateSelector(),
-                    }
-                ),
-                errors=errors,
-            )
+            current_db_url = user_input.get(CONF_DB_URL)
+            current_column_name = user_input.get(CONF_COLUMN_NAME)
+            current_query = user_input.get(CONF_QUERY)
+            current_unit_of_measurement = user_input.get(CONF_UNIT_OF_MEASUREMENT)
+            current_value_template = user_input.get(CONF_VALUE_TEMPLATE)
 
         return self.async_show_form(
             step_id="init",
@@ -269,37 +222,25 @@ class SQLOptionsFlowHandler(config_entries.OptionsFlow):
                 {
                     vol.Optional(
                         CONF_DB_URL,
-                        description={
-                            "suggested_value": self.entry.options.get(CONF_DB_URL)
-                        },
+                        description={"suggested_value": current_db_url},
                     ): selector.TextSelector(),
                     vol.Required(
                         CONF_QUERY,
-                        description={"suggested_value": self.entry.options[CONF_QUERY]},
+                        description={"suggested_value": current_query},
                     ): selector.TextSelector(
                         selector.TextSelectorConfig(multiline=True)
                     ),
                     vol.Required(
                         CONF_COLUMN_NAME,
-                        description={
-                            "suggested_value": self.entry.options[CONF_COLUMN_NAME]
-                        },
+                        description={"suggested_value": current_column_name},
                     ): selector.TextSelector(),
                     vol.Optional(
                         CONF_UNIT_OF_MEASUREMENT,
-                        description={
-                            "suggested_value": self.entry.options.get(
-                                CONF_UNIT_OF_MEASUREMENT
-                            )
-                        },
+                        description={"suggested_value": current_unit_of_measurement},
                     ): selector.TextSelector(),
                     vol.Optional(
                         CONF_VALUE_TEMPLATE,
-                        description={
-                            "suggested_value": self.entry.options.get(
-                                CONF_VALUE_TEMPLATE
-                            )
-                        },
+                        description={"suggested_value": current_value_template},
                     ): selector.TemplateSelector(),
                 }
             ),

--- a/homeassistant/components/sql/config_flow.py
+++ b/homeassistant/components/sql/config_flow.py
@@ -161,8 +161,6 @@ class SQLOptionsFlowHandler(config_entries.OptionsFlow):
         """Manage SQL options."""
         errors = {}
 
-        current_data: MappingProxyType[str, Any] | dict[str, Any] = self.entry.options
-
         if user_input is not None:
             db_url = user_input.get(CONF_DB_URL)
             query = user_input[CONF_QUERY]

--- a/homeassistant/components/sql/config_flow.py
+++ b/homeassistant/components/sql/config_flow.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import logging
-from types import MappingProxyType
 from typing import Any
 
 import sqlalchemy
@@ -141,9 +140,7 @@ class SQLConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="user",
-            data_schema=self.add_suggested_values_to_schema(
-                CONFIG_SCHEMA, user_input
-            ),
+            data_schema=self.add_suggested_values_to_schema(CONFIG_SCHEMA, user_input),
             errors=errors,
         )
 

--- a/homeassistant/components/sql/config_flow.py
+++ b/homeassistant/components/sql/config_flow.py
@@ -189,8 +189,6 @@ class SQLOptionsFlowHandler(config_entries.OptionsFlow):
                     },
                 )
 
-            current_data = user_input
-
         return self.async_show_form(
             step_id="init",
             data_schema=self.add_suggested_values_to_schema(

--- a/homeassistant/components/sql/config_flow.py
+++ b/homeassistant/components/sql/config_flow.py
@@ -192,7 +192,7 @@ class SQLOptionsFlowHandler(config_entries.OptionsFlow):
         return self.async_show_form(
             step_id="init",
             data_schema=self.add_suggested_values_to_schema(
-                OPTIONS_SCHEMA, current_data
+                OPTIONS_SCHEMA, user_input if user_input else self.entry.options
             ),
             errors=errors,
         )

--- a/homeassistant/components/sql/config_flow.py
+++ b/homeassistant/components/sql/config_flow.py
@@ -142,7 +142,7 @@ class SQLConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="user",
             data_schema=self.add_suggested_values_to_schema(
-                CONFIG_SCHEMA, current_data
+                CONFIG_SCHEMA, user_input
             ),
             errors=errors,
         )

--- a/homeassistant/components/sql/config_flow.py
+++ b/homeassistant/components/sql/config_flow.py
@@ -192,7 +192,7 @@ class SQLOptionsFlowHandler(config_entries.OptionsFlow):
         return self.async_show_form(
             step_id="init",
             data_schema=self.add_suggested_values_to_schema(
-                OPTIONS_SCHEMA, user_input if user_input else self.entry.options
+                OPTIONS_SCHEMA, user_input or self.entry.options
             ),
             errors=errors,
         )

--- a/homeassistant/components/sql/config_flow.py
+++ b/homeassistant/components/sql/config_flow.py
@@ -139,8 +139,6 @@ class SQLConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     },
                 )
 
-            current_data = user_input
-
         return self.async_show_form(
             step_id="user",
             data_schema=self.add_suggested_values_to_schema(

--- a/homeassistant/components/sql/config_flow.py
+++ b/homeassistant/components/sql/config_flow.py
@@ -101,8 +101,6 @@ class SQLConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle the user step."""
         errors = {}
 
-        current_data: dict[str, Any] = {}
-
         if user_input is not None:
             db_url = user_input.get(CONF_DB_URL)
             query = user_input[CONF_QUERY]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
None

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When the SQL integration configuration and options flow form presents an error, the information/changes entered by the user are lost.

This PR changes to preserve information in case of error.

### Current behavior:
* Error in config flow form (select query):
![image](https://user-images.githubusercontent.com/31328123/230801138-d771154b-9655-42f9-b3ac-5428917d7957.png)

* Result when the form is submitted (all data is lost):
![image](https://user-images.githubusercontent.com/31328123/230801147-9f0b0e77-46be-4789-b058-e38d0e8c38a7.png)

* Error in the options form (select query):
![image](https://user-images.githubusercontent.com/31328123/230801200-8a14ee81-f4d4-481d-a0bb-825f355afaeb.png)

* Result when the form is submitted (all changes are lost):
![image](https://user-images.githubusercontent.com/31328123/230801210-9fb04bcb-b42d-440a-a656-9e67ab1473e4.png)

### Behavior after change:
* Error in config flow form (select query):
![image](https://user-images.githubusercontent.com/31328123/230801387-78432004-faf8-42ee-af7e-5414b262d9af.png)

* Result after the form is submitted (all information is preserved):
![image](https://user-images.githubusercontent.com/31328123/230801394-9aa08a92-ae4b-4416-b9d5-71f3a632c6fb.png)

* Error in the options form (select query):
![image](https://user-images.githubusercontent.com/31328123/230801470-861aab5f-277d-4c46-a9a0-5792bf0ec92e.png)

* Result after the form is submitted (all changes are preserved):
![image](https://user-images.githubusercontent.com/31328123/230801487-7da2e5fc-9f08-4e0a-b1f2-463d4f5789ac.png)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
