### PR TITLE
Support Sonos announcements using websockets

### DIFF
--- a/homeassistant/components/sonos/manifest.json
+++ b/homeassistant/components/sonos/manifest.json
@@ -8,7 +8,7 @@
   "documentation": "https://www.home-assistant.io/integrations/sonos",
   "iot_class": "local_push",
   "loggers": ["soco"],
-  "requirements": ["soco==0.29.1", "sonos-websocket==0.0.4"],
+  "requirements": ["soco==0.29.1", "sonos-websocket==0.0.5"],
   "ssdp": [
     {
       "st": "urn:schemas-upnp-org:device:ZonePlayer:1"

--- a/homeassistant/components/sonos/manifest.json
+++ b/homeassistant/components/sonos/manifest.json
@@ -8,7 +8,7 @@
   "documentation": "https://www.home-assistant.io/integrations/sonos",
   "iot_class": "local_push",
   "loggers": ["soco"],
-  "requirements": ["soco==0.29.1", "sonos-websocket==0.0.3"],
+  "requirements": ["soco==0.29.1", "sonos-websocket==0.0.4"],
   "ssdp": [
     {
       "st": "urn:schemas-upnp-org:device:ZonePlayer:1"

--- a/homeassistant/components/sonos/manifest.json
+++ b/homeassistant/components/sonos/manifest.json
@@ -8,7 +8,7 @@
   "documentation": "https://www.home-assistant.io/integrations/sonos",
   "iot_class": "local_push",
   "loggers": ["soco"],
-  "requirements": ["soco==0.29.1"],
+  "requirements": ["soco==0.29.1", "sonos-websocket==0.0.3"],
   "ssdp": [
     {
       "st": "urn:schemas-upnp-org:device:ZonePlayer:1"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2379,7 +2379,7 @@ solax==0.3.0
 somfy-mylink-synergy==1.0.6
 
 # homeassistant.components.sonos
-sonos-websocket==0.0.3
+sonos-websocket==0.0.4
 
 # homeassistant.components.marytts
 speak2mary==1.4.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2378,6 +2378,9 @@ solax==0.3.0
 # homeassistant.components.somfy_mylink
 somfy-mylink-synergy==1.0.6
 
+# homeassistant.components.sonos
+sonos-websocket==0.0.3
+
 # homeassistant.components.marytts
 speak2mary==1.4.0
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2379,7 +2379,7 @@ solax==0.3.0
 somfy-mylink-synergy==1.0.6
 
 # homeassistant.components.sonos
-sonos-websocket==0.0.4
+sonos-websocket==0.0.5
 
 # homeassistant.components.marytts
 speak2mary==1.4.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1699,6 +1699,9 @@ solax==0.3.0
 # homeassistant.components.somfy_mylink
 somfy-mylink-synergy==1.0.6
 
+# homeassistant.components.sonos
+sonos-websocket==0.0.3
+
 # homeassistant.components.marytts
 speak2mary==1.4.0
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1700,7 +1700,7 @@ solax==0.3.0
 somfy-mylink-synergy==1.0.6
 
 # homeassistant.components.sonos
-sonos-websocket==0.0.3
+sonos-websocket==0.0.4
 
 # homeassistant.components.marytts
 speak2mary==1.4.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1700,7 +1700,7 @@ solax==0.3.0
 somfy-mylink-synergy==1.0.6
 
 # homeassistant.components.sonos
-sonos-websocket==0.0.4
+sonos-websocket==0.0.5
 
 # homeassistant.components.marytts
 speak2mary==1.4.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds support for 'audio clip' announcements on Sonos devices using a new websocket library ([sonos-websocket](https://github.com/jjlawren/sonos-websocket)). This allows media to be played on top of music that is already playing, automatically reducing the music volume to continue playing in the background, and then resuming playback without interruption (besides the alert, of course). This avoids the snapshot/restore dance that's so commonly referenced in Sonos automations and scripts.

These announcements are triggered by enabling the `announce` parameter on `media_player.play_media` service calls. An optional volume override for this announcement can be provided in the `extra` dictionary. After the alert plays, the volume will return to the previously playing volume.

Example service call:
```yaml
service: media_player.play_media
data:  
  media_content_id: >-
    https://freetestdata.com/wp-content/uploads/2021/09/Free_Test_Data_100KB_MP3.mp3
  media_content_type: music
  announce: true
  extra:
    volume: 18
target:
  entity_id: media_player.sonos_bedroom
```

As this feature is not supported universally on all Sonos devices (e.g., older devices or those on S1 firmware), it will be attempted if `announce` is requested, but will fall back to the "normal" playback method if the attempt fails.

Note: I do not have any players which do _not_ support this feature, so some adjustments may be necessary based on user feedback.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/27010

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
