### PR TITLE
Fix Lutron keypad led state always off at startup

### DIFF
--- a/homeassistant/components/lutron/switch.py
+++ b/homeassistant/components/lutron/switch.py
@@ -107,8 +107,5 @@ class LutronLed(LutronDevice, SwitchEntity):
 
     def update(self) -> None:
         """Call when forcing a refresh of the device."""
-        if self._lutron_device.last_state is not None:
-            return
-
         # The following property getter actually triggers an update in Lutron
         self._lutron_device.state  # pylint: disable=pointless-statement


### PR DESCRIPTION
## Proposed change

At some point since this component was originally authored, when HA is starting up it seems `self._lutron_device.last_state` started getting a default of `False` set upstream somewhere instead of just being `None`.

The original logic is currently causing Lutron keypad LEDs to never update when Home Assistant is starting -- so all LEDs are reported "off". This small PR fixes it (verified locally) by removing the early return.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

There is no currently open issue about this as far as I'm aware, I seem to be the first reporter. The hass lutron keypad led docs are [here](https://www.home-assistant.io/integrations/lutron/#keypad-leds).

## Checklist

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.