### PR TITLE
Support unknown state, position or tilt for template cover

### DIFF
--- a/homeassistant/components/template/cover.py
+++ b/homeassistant/components/template/cover.py
@@ -52,6 +52,7 @@ _VALID_STATES = [
     STATE_CLOSING,
     "true",
     "false",
+    "none",
 ]
 
 CONF_POSITION_TEMPLATE = "position_template"
@@ -138,11 +139,11 @@ class CoverTemplate(TemplateEntity, CoverEntity):
 
     def __init__(
         self,
-        hass,
+        hass: HomeAssistant,
         object_id,
         config,
         unique_id,
-    ):
+    ) -> None:
         """Initialize the Template cover."""
         super().__init__(
             hass, config=config, fallback_name=object_id, unique_id=unique_id
@@ -150,24 +151,24 @@ class CoverTemplate(TemplateEntity, CoverEntity):
         self.entity_id = async_generate_entity_id(
             ENTITY_ID_FORMAT, object_id, hass=hass
         )
-        friendly_name = self._attr_name
+        friendly_name = self._attr_name or ""
         self._template = config.get(CONF_VALUE_TEMPLATE)
         self._position_template = config.get(CONF_POSITION_TEMPLATE)
         self._tilt_template = config.get(CONF_TILT_TEMPLATE)
         self._device_class: CoverDeviceClass | None = config.get(CONF_DEVICE_CLASS)
-        self._open_script = None
+        self._open_script: Script | None = None
         if (open_action := config.get(OPEN_ACTION)) is not None:
             self._open_script = Script(hass, open_action, friendly_name, DOMAIN)
-        self._close_script = None
+        self._close_script: Script | None = None
         if (close_action := config.get(CLOSE_ACTION)) is not None:
             self._close_script = Script(hass, close_action, friendly_name, DOMAIN)
-        self._stop_script = None
+        self._stop_script: Script | None = None
         if (stop_action := config.get(STOP_ACTION)) is not None:
             self._stop_script = Script(hass, stop_action, friendly_name, DOMAIN)
-        self._position_script = None
+        self._position_script: Script | None = None
         if (position_action := config.get(POSITION_ACTION)) is not None:
             self._position_script = Script(hass, position_action, friendly_name, DOMAIN)
-        self._tilt_script = None
+        self._tilt_script: Script | None = None
         if (tilt_action := config.get(TILT_ACTION)) is not None:
             self._tilt_script = Script(hass, tilt_action, friendly_name, DOMAIN)
         optimistic = config.get(CONF_OPTIMISTIC)
@@ -176,10 +177,10 @@ class CoverTemplate(TemplateEntity, CoverEntity):
         )
         tilt_optimistic = config.get(CONF_TILT_OPTIMISTIC)
         self._tilt_optimistic = tilt_optimistic or not self._tilt_template
-        self._position = None
+        self._position: int | None = None
         self._is_opening = False
         self._is_closing = False
-        self._tilt_value = None
+        self._tilt_value: int | None = None
 
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""
@@ -206,7 +207,7 @@ class CoverTemplate(TemplateEntity, CoverEntity):
         await super().async_added_to_hass()
 
     @callback
-    def _update_state(self, result):
+    def _update_state(self, result: Any | TemplateError) -> None:
         super()._update_state(result)
         if isinstance(result, TemplateError):
             self._position = None
@@ -237,7 +238,11 @@ class CoverTemplate(TemplateEntity, CoverEntity):
             self._is_closing = False
 
     @callback
-    def _update_position(self, result):
+    def _update_position(self, result: Any) -> None:
+        if result is None:
+            self._position = None
+            return
+
         try:
             state = float(result)
         except ValueError as err:
@@ -252,10 +257,14 @@ class CoverTemplate(TemplateEntity, CoverEntity):
                 state,
             )
         else:
-            self._position = state
+            self._position = round(state)
 
     @callback
-    def _update_tilt(self, result):
+    def _update_tilt(self, result: Any) -> None:
+        if result is None:
+            self._tilt_value = None
+            return
+
         try:
             state = float(result)
         except ValueError as err:
@@ -270,7 +279,7 @@ class CoverTemplate(TemplateEntity, CoverEntity):
                 state,
             )
         else:
-            self._tilt_value = state
+            self._tilt_value = round(state)
 
     @property
     def is_closed(self) -> bool | None:
@@ -365,6 +374,7 @@ class CoverTemplate(TemplateEntity, CoverEntity):
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Set cover position."""
         self._position = kwargs[ATTR_POSITION]
+        assert self._position_script is not None
         await self.async_run_script(
             self._position_script,
             run_variables={"position": self._position},
@@ -376,6 +386,7 @@ class CoverTemplate(TemplateEntity, CoverEntity):
     async def async_open_cover_tilt(self, **kwargs: Any) -> None:
         """Tilt the cover open."""
         self._tilt_value = 100
+        assert self._tilt_script is not None
         await self.async_run_script(
             self._tilt_script,
             run_variables={"tilt": self._tilt_value},
@@ -387,6 +398,7 @@ class CoverTemplate(TemplateEntity, CoverEntity):
     async def async_close_cover_tilt(self, **kwargs: Any) -> None:
         """Tilt the cover closed."""
         self._tilt_value = 0
+        assert self._tilt_script is not None
         await self.async_run_script(
             self._tilt_script,
             run_variables={"tilt": self._tilt_value},
@@ -398,6 +410,7 @@ class CoverTemplate(TemplateEntity, CoverEntity):
     async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
         """Move the cover tilt to a specific position."""
         self._tilt_value = kwargs[ATTR_TILT_POSITION]
+        assert self._tilt_script is not None
         await self.async_run_script(
             self._tilt_script,
             run_variables={"tilt": self._tilt_value},

--- a/homeassistant/components/template/cover.py
+++ b/homeassistant/components/template/cover.py
@@ -139,11 +139,11 @@ class CoverTemplate(TemplateEntity, CoverEntity):
 
     def __init__(
         self,
-        hass: HomeAssistant,
+        hass,
         object_id,
         config,
         unique_id,
-    ) -> None:
+    ):
         """Initialize the Template cover."""
         super().__init__(
             hass, config=config, fallback_name=object_id, unique_id=unique_id
@@ -151,24 +151,24 @@ class CoverTemplate(TemplateEntity, CoverEntity):
         self.entity_id = async_generate_entity_id(
             ENTITY_ID_FORMAT, object_id, hass=hass
         )
-        friendly_name = self._attr_name or ""
+        friendly_name = self._attr_name
         self._template = config.get(CONF_VALUE_TEMPLATE)
         self._position_template = config.get(CONF_POSITION_TEMPLATE)
         self._tilt_template = config.get(CONF_TILT_TEMPLATE)
         self._device_class: CoverDeviceClass | None = config.get(CONF_DEVICE_CLASS)
-        self._open_script: Script | None = None
+        self._open_script = None
         if (open_action := config.get(OPEN_ACTION)) is not None:
             self._open_script = Script(hass, open_action, friendly_name, DOMAIN)
-        self._close_script: Script | None = None
+        self._close_script = None
         if (close_action := config.get(CLOSE_ACTION)) is not None:
             self._close_script = Script(hass, close_action, friendly_name, DOMAIN)
-        self._stop_script: Script | None = None
+        self._stop_script = None
         if (stop_action := config.get(STOP_ACTION)) is not None:
             self._stop_script = Script(hass, stop_action, friendly_name, DOMAIN)
-        self._position_script: Script | None = None
+        self._position_script = None
         if (position_action := config.get(POSITION_ACTION)) is not None:
             self._position_script = Script(hass, position_action, friendly_name, DOMAIN)
-        self._tilt_script: Script | None = None
+        self._tilt_script = None
         if (tilt_action := config.get(TILT_ACTION)) is not None:
             self._tilt_script = Script(hass, tilt_action, friendly_name, DOMAIN)
         optimistic = config.get(CONF_OPTIMISTIC)
@@ -177,10 +177,10 @@ class CoverTemplate(TemplateEntity, CoverEntity):
         )
         tilt_optimistic = config.get(CONF_TILT_OPTIMISTIC)
         self._tilt_optimistic = tilt_optimistic or not self._tilt_template
-        self._position: int | None = None
+        self._position = None
         self._is_opening = False
         self._is_closing = False
-        self._tilt_value: int | None = None
+        self._tilt_value = None
 
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""
@@ -207,7 +207,7 @@ class CoverTemplate(TemplateEntity, CoverEntity):
         await super().async_added_to_hass()
 
     @callback
-    def _update_state(self, result: Any | TemplateError) -> None:
+    def _update_state(self, result):
         super()._update_state(result)
         if isinstance(result, TemplateError):
             self._position = None
@@ -238,7 +238,7 @@ class CoverTemplate(TemplateEntity, CoverEntity):
             self._is_closing = False
 
     @callback
-    def _update_position(self, result: Any) -> None:
+    def _update_position(self, result):
         if result is None:
             self._position = None
             return
@@ -257,10 +257,10 @@ class CoverTemplate(TemplateEntity, CoverEntity):
                 state,
             )
         else:
-            self._position = round(state)
+            self._position = state
 
     @callback
-    def _update_tilt(self, result: Any) -> None:
+    def _update_tilt(self, result):
         if result is None:
             self._tilt_value = None
             return
@@ -279,7 +279,7 @@ class CoverTemplate(TemplateEntity, CoverEntity):
                 state,
             )
         else:
-            self._tilt_value = round(state)
+            self._tilt_value = state
 
     @property
     def is_closed(self) -> bool | None:
@@ -374,7 +374,6 @@ class CoverTemplate(TemplateEntity, CoverEntity):
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Set cover position."""
         self._position = kwargs[ATTR_POSITION]
-        assert self._position_script is not None
         await self.async_run_script(
             self._position_script,
             run_variables={"position": self._position},
@@ -386,7 +385,6 @@ class CoverTemplate(TemplateEntity, CoverEntity):
     async def async_open_cover_tilt(self, **kwargs: Any) -> None:
         """Tilt the cover open."""
         self._tilt_value = 100
-        assert self._tilt_script is not None
         await self.async_run_script(
             self._tilt_script,
             run_variables={"tilt": self._tilt_value},
@@ -398,7 +396,6 @@ class CoverTemplate(TemplateEntity, CoverEntity):
     async def async_close_cover_tilt(self, **kwargs: Any) -> None:
         """Tilt the cover closed."""
         self._tilt_value = 0
-        assert self._tilt_script is not None
         await self.async_run_script(
             self._tilt_script,
             run_variables={"tilt": self._tilt_value},
@@ -410,7 +407,6 @@ class CoverTemplate(TemplateEntity, CoverEntity):
     async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
         """Move the cover tilt to a specific position."""
         self._tilt_value = kwargs[ATTR_TILT_POSITION]
-        assert self._tilt_script is not None
         await self.async_run_script(
             self._tilt_script,
             run_variables={"tilt": self._tilt_value},

--- a/tests/components/template/test_cover.py
+++ b/tests/components/template/test_cover.py
@@ -1,4 +1,6 @@
 """The tests for the Template cover platform."""
+from typing import Any
+
 import pytest
 
 from homeassistant import setup
@@ -151,6 +153,72 @@ async def test_template_state_text(
 
 @pytest.mark.parametrize(("count", "domain"), [(1, DOMAIN)])
 @pytest.mark.parametrize(
+    ("config", "entity", "set_state", "test_state", "attr"),
+    [
+        (
+            {
+                DOMAIN: {
+                    "platform": "template",
+                    "covers": {
+                        "test_template_cover": {
+                            **OPEN_CLOSE_COVER_CONFIG,
+                            "position_template": (
+                                "{{ states.cover.test.attributes.position }}"
+                            ),
+                            "value_template": "{{ states.cover.test_state.state }}",
+                        }
+                    },
+                }
+            },
+            "cover.test_state",
+            "",
+            STATE_UNKNOWN,
+            {},
+        ),
+        (
+            {
+                DOMAIN: {
+                    "platform": "template",
+                    "covers": {
+                        "test_template_cover": {
+                            **OPEN_CLOSE_COVER_CONFIG,
+                            "position_template": (
+                                "{{ states.cover.test.attributes.position }}"
+                            ),
+                            "value_template": "{{ states.cover.test_state.state }}",
+                        }
+                    },
+                }
+            },
+            "cover.test_state",
+            None,
+            STATE_UNKNOWN,
+            {},
+        ),
+    ],
+)
+async def test_template_state_text_ignored_if_none_or_empty(
+    hass: HomeAssistant,
+    entity: str,
+    set_state: str,
+    test_state: str,
+    attr: dict[str, Any],
+    start_ha,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test ignoring an empty state text of a template."""
+    state = hass.states.get("cover.test_template_cover")
+    assert state.state == STATE_UNKNOWN
+
+    hass.states.async_set(entity, set_state, attributes=attr)
+    await hass.async_block_till_done()
+    state = hass.states.get("cover.test_template_cover")
+    assert state.state == test_state
+    assert "ERROR" not in caplog.text
+
+
+@pytest.mark.parametrize(("count", "domain"), [(1, DOMAIN)])
+@pytest.mark.parametrize(
     "config",
     [
         {
@@ -191,7 +259,9 @@ async def test_template_state_boolean(hass: HomeAssistant, start_ha) -> None:
         },
     ],
 )
-async def test_template_position(hass: HomeAssistant, start_ha) -> None:
+async def test_template_position(
+    hass: HomeAssistant, start_ha, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test the position_template attribute."""
     hass.states.async_set("cover.test", STATE_OPEN)
     attrs = {}
@@ -199,6 +269,7 @@ async def test_template_position(hass: HomeAssistant, start_ha) -> None:
     for set_state, pos, test_state in [
         (STATE_CLOSED, 42, STATE_OPEN),
         (STATE_OPEN, 0.0, STATE_CLOSED),
+        (STATE_CLOSED, None, STATE_UNKNOWN),
     ]:
         attrs["position"] = pos
         hass.states.async_set("cover.test", set_state, attributes=attrs)
@@ -206,6 +277,7 @@ async def test_template_position(hass: HomeAssistant, start_ha) -> None:
         state = hass.states.get("cover.test_template_cover")
         assert state.attributes.get("current_position") == pos
         assert state.state == test_state
+        assert "ValueError" not in caplog.text
 
 
 @pytest.mark.parametrize(("count", "domain"), [(1, DOMAIN)])
@@ -233,26 +305,46 @@ async def test_template_not_optimistic(hass: HomeAssistant, start_ha) -> None:
 
 @pytest.mark.parametrize(("count", "domain"), [(1, DOMAIN)])
 @pytest.mark.parametrize(
-    "config",
+    ("config", "tilt_position"),
     [
-        {
-            DOMAIN: {
-                "platform": "template",
-                "covers": {
-                    "test_template_cover": {
-                        **OPEN_CLOSE_COVER_CONFIG,
-                        "value_template": "{{ 1 == 1 }}",
-                        "tilt_template": "{{ 42 }}",
-                    }
-                },
-            }
-        },
+        (
+            {
+                DOMAIN: {
+                    "platform": "template",
+                    "covers": {
+                        "test_template_cover": {
+                            **OPEN_CLOSE_COVER_CONFIG,
+                            "value_template": "{{ 1 == 1 }}",
+                            "tilt_template": "{{ 42 }}",
+                        }
+                    },
+                }
+            },
+            42.0,
+        ),
+        (
+            {
+                DOMAIN: {
+                    "platform": "template",
+                    "covers": {
+                        "test_template_cover": {
+                            **OPEN_CLOSE_COVER_CONFIG,
+                            "value_template": "{{ 1 == 1 }}",
+                            "tilt_template": "{{ None }}",
+                        }
+                    },
+                }
+            },
+            None,
+        ),
     ],
 )
-async def test_template_tilt(hass: HomeAssistant, start_ha) -> None:
+async def test_template_tilt(
+    hass: HomeAssistant, tilt_position: float | None, start_ha
+) -> None:
     """Test the tilt_template attribute."""
     state = hass.states.get("cover.test_template_cover")
-    assert state.attributes.get("current_tilt_position") == 42.0
+    assert state.attributes.get("current_tilt_position") == tilt_position
 
 
 @pytest.mark.parametrize(("count", "domain"), [(1, DOMAIN)])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow the `state`, `current_cover_position` or `current_cover_tilt_position` to be `unknown`. Without the PR an error will be logged, reporting an invalid state update.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #91139
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/26939

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
