### PR TITLE
Run `socket.gethostbyname` in executor in Obihai and Sonos

### DIFF
--- a/homeassistant/components/obihai/config_flow.py
+++ b/homeassistant/components/obihai/config_flow.py
@@ -66,7 +66,9 @@ class ObihaiFlowHandler(ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             try:
-                ip = gethostbyname(user_input[CONF_HOST])
+                ip = await self.hass.async_add_executor_job(
+                    gethostbyname, user_input[CONF_HOST]
+                )
             except gaierror:
                 errors["base"] = "cannot_connect"
 
@@ -139,7 +141,7 @@ class ObihaiFlowHandler(ConfigFlow, domain=DOMAIN):
         """Handle a flow initialized by importing a config."""
 
         try:
-            _ = gethostbyname(config[CONF_HOST])
+            _ = await self.hass.async_add_executor_job(gethostbyname, config[CONF_HOST])
         except gaierror:
             return self.async_abort(reason="cannot_connect")
 

--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -346,7 +346,7 @@ class SonosDiscoveryManager:
             return soco.visible_zones
 
         for host in self.hosts:
-            ip_addr = socket.gethostbyname(host)
+            ip_addr = await self.hass.async_add_executor_job(socket.gethostbyname, host)
             soco = SoCo(ip_addr)
             try:
                 visible_zones = await self.hass.async_add_executor_job(
@@ -382,7 +382,7 @@ class SonosDiscoveryManager:
                 break
 
         for host in self.hosts.copy():
-            ip_addr = socket.gethostbyname(host)
+            ip_addr = await self.hass.async_add_executor_job(socket.gethostbyname, host)
             if self.is_device_invisible(ip_addr):
                 _LOGGER.debug("Discarding %s from manual hosts", ip_addr)
                 self.hosts.discard(ip_addr)

--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -48,6 +48,7 @@ from .const import (
 )
 from .exception import SonosUpdateError
 from .favorites import SonosFavorites
+from .helpers import sync_get_visible_zones
 from .speaker import SonosSpeaker
 
 _LOGGER = logging.getLogger(__name__)
@@ -338,19 +339,12 @@ class SonosDiscoveryManager:
         self, now: datetime.datetime | None = None
     ) -> None:
         """Add and maintain Sonos devices from a manual configuration."""
-
-        def get_sync_attributes(soco: SoCo) -> set[SoCo]:
-            """Ensure I/O attributes are cached and return visible zones."""
-            _ = soco.household_id
-            _ = soco.uid
-            return soco.visible_zones
-
         for host in self.hosts:
             ip_addr = await self.hass.async_add_executor_job(socket.gethostbyname, host)
             soco = SoCo(ip_addr)
             try:
                 visible_zones = await self.hass.async_add_executor_job(
-                    get_sync_attributes,
+                    sync_get_visible_zones,
                     soco,
                 )
             except (OSError, SoCoException, Timeout) as ex:

--- a/homeassistant/components/sonos/helpers.py
+++ b/homeassistant/components/sonos/helpers.py
@@ -117,3 +117,10 @@ def hostname_to_uid(hostname: str) -> str:
     else:
         raise ValueError(f"{hostname} is not a sonos device.")
     return f"{UID_PREFIX}{baseuid}{UID_POSTFIX}"
+
+
+def sync_get_visible_zones(soco: SoCo) -> set[SoCo]:
+    """Ensure I/O attributes are cached and return visible zones."""
+    _ = soco.household_id
+    _ = soco.uid
+    return soco.visible_zones

--- a/tests/components/sonos/test_init.py
+++ b/tests/components/sonos/test_init.py
@@ -1,6 +1,6 @@
 """Tests for the Sonos config flow."""
 import logging
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -86,24 +86,17 @@ async def test_async_poll_manual_hosts_warnings(
         manager, "_async_handle_discovery_message"
     ), patch("homeassistant.components.sonos.async_call_later"), patch(
         "homeassistant.components.sonos.async_dispatcher_send"
-    ), patch.object(
-        hass, "async_add_executor_job", new=AsyncMock()
-    ) as mock_async_add_executor_job:
-        _should_raise = True
-
-        def executor_side_effect(_, arg):
-            if arg == "10.10.10.10":
-                # for socket.gethostbyaddr which is mocked by an autoused fixture
-                return arg
-            nonlocal _should_raise
-            if _should_raise:
-                raise OSError()
-            return []
-
-        mock_async_add_executor_job.side_effect = executor_side_effect
-
+    ), patch(
+        "homeassistant.components.sonos.sync_get_visible_zones",
+        side_effect=[
+            OSError(),
+            OSError(),
+            [],
+            [],
+            OSError(),
+        ],
+    ):
         # First call fails, it should be logged as a WARNING message
-        _should_raise = True
         caplog.clear()
         await manager.async_poll_manual_hosts()
         assert len(caplog.messages) == 1
@@ -112,7 +105,6 @@ async def test_async_poll_manual_hosts_warnings(
         assert "Could not get visible Sonos devices from" in record.message
 
         # Second call fails again, it should be logged as a DEBUG message
-        _should_raise = True
         caplog.clear()
         await manager.async_poll_manual_hosts()
         assert len(caplog.messages) == 1
@@ -121,7 +113,6 @@ async def test_async_poll_manual_hosts_warnings(
         assert "Could not get visible Sonos devices from" in record.message
 
         # Third call succeeds, it should log an info message
-        _should_raise = False
         caplog.clear()
         await manager.async_poll_manual_hosts()
         assert len(caplog.messages) == 1
@@ -130,13 +121,11 @@ async def test_async_poll_manual_hosts_warnings(
         assert "Connection restablished to Sonos device" in record.message
 
         # Fourth call succeeds again, no need to log
-        _should_raise = False
         caplog.clear()
         await manager.async_poll_manual_hosts()
         assert len(caplog.messages) == 0
 
         # Fifth call fail again again, should be logged as a WARNING message
-        _should_raise = True
         caplog.clear()
         await manager.async_poll_manual_hosts()
         assert len(caplog.messages) == 1


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Run `socket.gethostbyname` in executor in Obihai and Sonos.

I stumbled upon this as I was looking for an example usage of `gethostbyname`. I personally don't use any of the two integrations, so have not tested it locally.
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
