### PR TITLE
Remove incorrect constant usage in test

### DIFF
--- a/tests/components/accuweather/test_config_flow.py
+++ b/tests/components/accuweather/test_config_flow.py
@@ -26,7 +26,7 @@ async def test_show_form(hass: HomeAssistant) -> None:
     )
 
     assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["step_id"] == SOURCE_USER
+    assert result["step_id"] == "user"
 
 
 async def test_api_key_too_short(hass: HomeAssistant) -> None:

--- a/tests/components/aemet/test_config_flow.py
+++ b/tests/components/aemet/test_config_flow.py
@@ -36,7 +36,7 @@ async def test_form(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> None:
         )
 
         assert result["type"] == data_entry_flow.FlowResultType.FORM
-        assert result["step_id"] == SOURCE_USER
+        assert result["step_id"] == "user"
         assert result["errors"] == {}
 
         result = await hass.config_entries.flow.async_configure(

--- a/tests/components/airly/test_config_flow.py
+++ b/tests/components/airly/test_config_flow.py
@@ -29,7 +29,7 @@ async def test_show_form(hass: HomeAssistant) -> None:
     )
 
     assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["step_id"] == SOURCE_USER
+    assert result["step_id"] == "user"
 
 
 async def test_invalid_api_key(

--- a/tests/components/airzone/test_config_flow.py
+++ b/tests/components/airzone/test_config_flow.py
@@ -54,7 +54,7 @@ async def test_form(hass: HomeAssistant) -> None:
         )
 
         assert result["type"] == data_entry_flow.FlowResultType.FORM
-        assert result["step_id"] == SOURCE_USER
+        assert result["step_id"] == "user"
         assert result["errors"] == {}
 
         result = await hass.config_entries.flow.async_configure(
@@ -97,7 +97,7 @@ async def test_form_invalid_system_id(hass: HomeAssistant) -> None:
         )
 
         assert result["type"] == data_entry_flow.FlowResultType.FORM
-        assert result["step_id"] == SOURCE_USER
+        assert result["step_id"] == "user"
         assert result["errors"] == {CONF_ID: "invalid_system_id"}
 
         mock_hvac.return_value = HVAC_MOCK[API_SYSTEMS][0]

--- a/tests/components/apcupsd/test_config_flow.py
+++ b/tests/components/apcupsd/test_config_flow.py
@@ -117,7 +117,7 @@ async def test_flow_works(hass: HomeAssistant) -> None:
             context={CONF_SOURCE: SOURCE_USER},
         )
         assert result["type"] == FlowResultType.FORM
-        assert result["step_id"] == SOURCE_USER
+        assert result["step_id"] == "user"
 
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input=CONF_DATA

--- a/tests/components/awair/test_config_flow.py
+++ b/tests/components/awair/test_config_flow.py
@@ -29,7 +29,7 @@ async def test_show_form(hass: HomeAssistant) -> None:
     )
 
     assert result["type"] == data_entry_flow.FlowResultType.MENU
-    assert result["step_id"] == SOURCE_USER
+    assert result["step_id"] == "user"
 
 
 async def test_invalid_access_token(hass: HomeAssistant) -> None:

--- a/tests/components/axis/test_config_flow.py
+++ b/tests/components/axis/test_config_flow.py
@@ -56,7 +56,7 @@ async def test_flow_manual_configuration(
     )
 
     assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == SOURCE_USER
+    assert result["step_id"] == "user"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -91,7 +91,7 @@ async def test_manual_configuration_update_configuration(
     )
 
     assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == SOURCE_USER
+    assert result["step_id"] == "user"
 
     mock_vapix_requests("2.3.4.5")
     result = await hass.config_entries.flow.async_configure(
@@ -117,7 +117,7 @@ async def test_flow_fails_faulty_credentials(hass: HomeAssistant) -> None:
     )
 
     assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == SOURCE_USER
+    assert result["step_id"] == "user"
 
     with patch(
         "homeassistant.components.axis.config_flow.get_axis_device",
@@ -143,7 +143,7 @@ async def test_flow_fails_cannot_connect(hass: HomeAssistant) -> None:
     )
 
     assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == SOURCE_USER
+    assert result["step_id"] == "user"
 
     with patch(
         "homeassistant.components.axis.config_flow.get_axis_device",
@@ -182,7 +182,7 @@ async def test_flow_create_entry_multiple_existing_entries_of_same_model(
     )
 
     assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == SOURCE_USER
+    assert result["step_id"] == "user"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -223,7 +223,7 @@ async def test_reauth_flow_update_configuration(
     )
 
     assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == SOURCE_USER
+    assert result["step_id"] == "user"
 
     mock_vapix_requests("2.3.4.5")
     result = await hass.config_entries.flow.async_configure(
@@ -321,7 +321,7 @@ async def test_discovery_flow(
     )
 
     assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == SOURCE_USER
+    assert result["step_id"] == "user"
 
     flows = hass.config_entries.flow.async_progress()
     assert len(flows) == 1

--- a/tests/components/balboa/test_config_flow.py
+++ b/tests/components/balboa/test_config_flow.py
@@ -5,7 +5,6 @@ from pybalboa.exceptions import SpaConnectionError
 
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.balboa.const import CONF_SYNC_TIME, DOMAIN
-from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -111,7 +110,7 @@ async def test_already_configured(hass: HomeAssistant, client: MagicMock) -> Non
     )
 
     assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == SOURCE_USER
+    assert result["step_id"] == "user"
 
     with patch(
         "homeassistant.components.balboa.config_flow.SpaClient.__aenter__",

--- a/tests/components/braviatv/test_config_flow.py
+++ b/tests/components/braviatv/test_config_flow.py
@@ -94,7 +94,7 @@ async def test_show_form(hass: HomeAssistant) -> None:
     )
 
     assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["step_id"] == SOURCE_USER
+    assert result["step_id"] == "user"
 
 
 async def test_ssdp_discovery(hass: HomeAssistant) -> None:

--- a/tests/components/brother/test_config_flow.py
+++ b/tests/components/brother/test_config_flow.py
@@ -26,7 +26,7 @@ async def test_show_form(hass: HomeAssistant) -> None:
     )
 
     assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["step_id"] == SOURCE_USER
+    assert result["step_id"] == "user"
 
 
 async def test_create_entry_with_hostname(hass: HomeAssistant) -> None:

--- a/tests/components/bsblan/test_config_flow.py
+++ b/tests/components/bsblan/test_config_flow.py
@@ -31,7 +31,7 @@ async def test_full_user_flow_implementation(
     )
 
     assert result.get("type") == RESULT_TYPE_FORM
-    assert result.get("step_id") == SOURCE_USER
+    assert result.get("step_id") == "user"
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],

--- a/tests/components/cpuspeed/test_config_flow.py
+++ b/tests/components/cpuspeed/test_config_flow.py
@@ -21,7 +21,7 @@ async def test_full_user_flow(
     )
 
     assert result.get("type") == FlowResultType.FORM
-    assert result.get("step_id") == SOURCE_USER
+    assert result.get("step_id") == "user"
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -67,7 +67,7 @@ async def test_not_compatible(
     )
 
     assert result.get("type") == FlowResultType.FORM
-    assert result.get("step_id") == SOURCE_USER
+    assert result.get("step_id") == "user"
 
     mock_cpuinfo_config_flow.return_value = {}
     result2 = await hass.config_entries.flow.async_configure(

--- a/tests/components/easyenergy/test_config_flow.py
+++ b/tests/components/easyenergy/test_config_flow.py
@@ -17,7 +17,7 @@ async def test_full_user_flow(
     )
 
     assert result.get("type") == FlowResultType.FORM
-    assert result.get("step_id") == SOURCE_USER
+    assert result.get("step_id") == "user"
     assert "flow_id" in result
 
     result2 = await hass.config_entries.flow.async_configure(

--- a/tests/components/econet/test_config_flow.py
+++ b/tests/components/econet/test_config_flow.py
@@ -20,7 +20,7 @@ async def test_bad_credentials(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": SOURCE_USER}
     )
     assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == SOURCE_USER
+    assert result["step_id"] == "user"
 
     with patch(
         "pyeconet.EcoNetApiInterface.login",
@@ -50,7 +50,7 @@ async def test_generic_error_from_library(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": SOURCE_USER}
     )
     assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == SOURCE_USER
+    assert result["step_id"] == "user"
 
     with patch(
         "pyeconet.EcoNetApiInterface.login",
@@ -80,7 +80,7 @@ async def test_auth_worked(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": SOURCE_USER}
     )
     assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == SOURCE_USER
+    assert result["step_id"] == "user"
 
     with patch(
         "pyeconet.EcoNetApiInterface.login",
@@ -117,7 +117,7 @@ async def test_already_configured(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": SOURCE_USER}
     )
     assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == SOURCE_USER
+    assert result["step_id"] == "user"
 
     with patch(
         "pyeconet.EcoNetApiInterface.login",

--- a/tests/components/elgato/test_config_flow.py
+++ b/tests/components/elgato/test_config_flow.py
@@ -28,7 +28,7 @@ async def test_full_user_flow_implementation(
     )
 
     assert result.get("type") == FlowResultType.FORM
-    assert result.get("step_id") == SOURCE_USER
+    assert result.get("step_id") == "user"
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={CONF_HOST: "127.0.0.1", CONF_PORT: 9123}

--- a/tests/components/energyzero/test_config_flow.py
+++ b/tests/components/energyzero/test_config_flow.py
@@ -20,7 +20,7 @@ async def test_full_user_flow(
     )
 
     assert result.get("type") == FlowResultType.FORM
-    assert result.get("step_id") == SOURCE_USER
+    assert result.get("step_id") == "user"
     assert "flow_id" in result
 
     result2 = await hass.config_entries.flow.async_configure(

--- a/tests/components/filesize/test_config_flow.py
+++ b/tests/components/filesize/test_config_flow.py
@@ -25,7 +25,7 @@ async def test_full_user_flow(hass: HomeAssistant) -> None:
     )
 
     assert result.get("type") == FlowResultType.FORM
-    assert result.get("step_id") == "user"
+    assert result.get("step_id") == SOURCE_USER
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -64,7 +64,7 @@ async def test_flow_fails_on_validation(hass: HomeAssistant) -> None:
     )
 
     assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == "user"
+    assert result["step_id"] == SOURCE_USER
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],

--- a/tests/components/filesize/test_config_flow.py
+++ b/tests/components/filesize/test_config_flow.py
@@ -25,7 +25,7 @@ async def test_full_user_flow(hass: HomeAssistant) -> None:
     )
 
     assert result.get("type") == FlowResultType.FORM
-    assert result.get("step_id") == SOURCE_USER
+    assert result.get("step_id") == "user"
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -64,7 +64,7 @@ async def test_flow_fails_on_validation(hass: HomeAssistant) -> None:
     )
 
     assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == SOURCE_USER
+    assert result["step_id"] == "user"
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],

--- a/tests/components/forecast_solar/test_config_flow.py
+++ b/tests/components/forecast_solar/test_config_flow.py
@@ -24,7 +24,7 @@ async def test_user_flow(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> No
     )
 
     assert result.get("type") == FlowResultType.FORM
-    assert result.get("step_id") == SOURCE_USER
+    assert result.get("step_id") == "user"
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],

--- a/tests/components/forked_daapd/test_config_flow.py
+++ b/tests/components/forked_daapd/test_config_flow.py
@@ -60,7 +60,7 @@ async def test_show_form(hass: HomeAssistant) -> None:
     )
 
     assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["step_id"] == SOURCE_USER
+    assert result["step_id"] == "user"
 
 
 async def test_config_flow(hass: HomeAssistant, config_entry) -> None:

--- a/tests/components/freedompro/test_config_flow.py
+++ b/tests/components/freedompro/test_config_flow.py
@@ -25,7 +25,7 @@ async def test_show_form(hass: HomeAssistant) -> None:
     )
 
     assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["step_id"] == SOURCE_USER
+    assert result["step_id"] == "user"
 
 
 async def test_invalid_auth(hass: HomeAssistant) -> None:

--- a/tests/components/fully_kiosk/test_config_flow.py
+++ b/tests/components/fully_kiosk/test_config_flow.py
@@ -28,7 +28,7 @@ async def test_user_flow(
         DOMAIN, context={"source": SOURCE_USER}
     )
     assert result.get("type") == FlowResultType.FORM
-    assert result.get("step_id") == SOURCE_USER
+    assert result.get("step_id") == "user"
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -117,7 +117,7 @@ async def test_duplicate_updates_existing_entry(
         DOMAIN, context={"source": SOURCE_USER}
     )
     assert result.get("type") == FlowResultType.FORM
-    assert result.get("step_id") == SOURCE_USER
+    assert result.get("step_id") == "user"
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],

--- a/tests/components/iss/test_config_flow.py
+++ b/tests/components/iss/test_config_flow.py
@@ -18,7 +18,7 @@ async def test_create_entry(hass: HomeAssistant) -> None:
     )
 
     assert result.get("type") == data_entry_flow.FlowResultType.FORM
-    assert result.get("step_id") == SOURCE_USER
+    assert result.get("step_id") == "user"
 
     with patch("homeassistant.components.iss.async_setup_entry", return_value=True):
         result = await hass.config_entries.flow.async_configure(

--- a/tests/components/launch_library/test_config_flow.py
+++ b/tests/components/launch_library/test_config_flow.py
@@ -17,7 +17,7 @@ async def test_create_entry(hass: HomeAssistant) -> None:
     )
 
     assert result.get("type") == data_entry_flow.FlowResultType.FORM
-    assert result.get("step_id") == SOURCE_USER
+    assert result.get("step_id") == "user"
 
     with patch(
         "homeassistant.components.launch_library.async_setup_entry", return_value=True

--- a/tests/components/luftdaten/test_config_flow.py
+++ b/tests/components/luftdaten/test_config_flow.py
@@ -24,7 +24,7 @@ async def test_duplicate_error(
     )
 
     assert result.get("type") == FlowResultType.FORM
-    assert result.get("step_id") == SOURCE_USER
+    assert result.get("step_id") == "user"
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -44,7 +44,7 @@ async def test_communication_error(
     )
 
     assert result.get("type") == FlowResultType.FORM
-    assert result.get("step_id") == SOURCE_USER
+    assert result.get("step_id") == "user"
 
     mock_luftdaten_config_flow.get_data.side_effect = LuftdatenConnectionError
     result2 = await hass.config_entries.flow.async_configure(
@@ -53,7 +53,7 @@ async def test_communication_error(
     )
 
     assert result2.get("type") == FlowResultType.FORM
-    assert result2.get("step_id") == SOURCE_USER
+    assert result2.get("step_id") == "user"
     assert result2.get("errors") == {CONF_SENSOR_ID: "cannot_connect"}
 
     mock_luftdaten_config_flow.get_data.side_effect = None
@@ -79,7 +79,7 @@ async def test_invalid_sensor(
     )
 
     assert result.get("type") == FlowResultType.FORM
-    assert result.get("step_id") == SOURCE_USER
+    assert result.get("step_id") == "user"
 
     mock_luftdaten_config_flow.validate_sensor.return_value = False
     result2 = await hass.config_entries.flow.async_configure(
@@ -88,7 +88,7 @@ async def test_invalid_sensor(
     )
 
     assert result2.get("type") == FlowResultType.FORM
-    assert result2.get("step_id") == SOURCE_USER
+    assert result2.get("step_id") == "user"
     assert result2.get("errors") == {CONF_SENSOR_ID: "invalid_sensor"}
 
     mock_luftdaten_config_flow.validate_sensor.return_value = True
@@ -116,7 +116,7 @@ async def test_step_user(
     )
 
     assert result.get("type") == FlowResultType.FORM
-    assert result.get("step_id") == SOURCE_USER
+    assert result.get("step_id") == "user"
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],

--- a/tests/components/mjpeg/test_config_flow.py
+++ b/tests/components/mjpeg/test_config_flow.py
@@ -36,7 +36,7 @@ async def test_full_user_flow(
     )
 
     assert result.get("type") == FlowResultType.FORM
-    assert result.get("step_id") == SOURCE_USER
+    assert result.get("step_id") == "user"
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -81,7 +81,7 @@ async def test_full_flow_with_authentication_error(
     )
 
     assert result.get("type") == FlowResultType.FORM
-    assert result.get("step_id") == SOURCE_USER
+    assert result.get("step_id") == "user"
 
     mock_mjpeg_requests.get(
         "https://example.com/mjpeg", text="Access Denied!", status_code=401
@@ -97,7 +97,7 @@ async def test_full_flow_with_authentication_error(
     )
 
     assert result2.get("type") == FlowResultType.FORM
-    assert result2.get("step_id") == SOURCE_USER
+    assert result2.get("step_id") == "user"
     assert result2.get("errors") == {"username": "invalid_auth"}
 
     assert len(mock_setup_entry.mock_calls) == 0
@@ -141,7 +141,7 @@ async def test_connection_error(
     )
 
     assert result.get("type") == FlowResultType.FORM
-    assert result.get("step_id") == SOURCE_USER
+    assert result.get("step_id") == "user"
 
     # Test connectione error on MJPEG url
     mock_mjpeg_requests.get(
@@ -157,7 +157,7 @@ async def test_connection_error(
     )
 
     assert result2.get("type") == FlowResultType.FORM
-    assert result2.get("step_id") == SOURCE_USER
+    assert result2.get("step_id") == "user"
     assert result2.get("errors") == {"mjpeg_url": "cannot_connect"}
 
     assert len(mock_setup_entry.mock_calls) == 0
@@ -180,7 +180,7 @@ async def test_connection_error(
     )
 
     assert result3.get("type") == FlowResultType.FORM
-    assert result3.get("step_id") == SOURCE_USER
+    assert result3.get("step_id") == "user"
     assert result3.get("errors") == {"still_image_url": "cannot_connect"}
 
     assert len(mock_setup_entry.mock_calls) == 0

--- a/tests/components/moon/test_config_flow.py
+++ b/tests/components/moon/test_config_flow.py
@@ -19,7 +19,7 @@ async def test_full_user_flow(
     )
 
     assert result.get("type") == FlowResultType.FORM
-    assert result.get("step_id") == SOURCE_USER
+    assert result.get("step_id") == "user"
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],

--- a/tests/components/nam/test_config_flow.py
+++ b/tests/components/nam/test_config_flow.py
@@ -34,7 +34,7 @@ async def test_form_create_entry_without_auth(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": SOURCE_USER}
     )
     assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["step_id"] == SOURCE_USER
+    assert result["step_id"] == "user"
     assert result["errors"] == {}
 
     with patch(
@@ -64,7 +64,7 @@ async def test_form_create_entry_with_auth(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": SOURCE_USER}
     )
     assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["step_id"] == SOURCE_USER
+    assert result["step_id"] == "user"
     assert result["errors"] == {}
 
     with patch(

--- a/tests/components/nextdns/test_config_flow.py
+++ b/tests/components/nextdns/test_config_flow.py
@@ -24,7 +24,7 @@ async def test_form_create_entry(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": SOURCE_USER}
     )
     assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["step_id"] == SOURCE_USER
+    assert result["step_id"] == "user"
     assert result["errors"] == {}
 
     with patch(

--- a/tests/components/open_meteo/test_config_flow.py
+++ b/tests/components/open_meteo/test_config_flow.py
@@ -20,7 +20,7 @@ async def test_full_user_flow(
     )
 
     assert result.get("type") == FlowResultType.FORM
-    assert result.get("step_id") == SOURCE_USER
+    assert result.get("step_id") == "user"
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],

--- a/tests/components/openweathermap/test_config_flow.py
+++ b/tests/components/openweathermap/test_config_flow.py
@@ -47,7 +47,7 @@ async def test_form(hass: HomeAssistant) -> None:
         )
 
         assert result["type"] == data_entry_flow.FlowResultType.FORM
-        assert result["step_id"] == SOURCE_USER
+        assert result["step_id"] == "user"
         assert result["errors"] == {}
 
         result = await hass.config_entries.flow.async_init(

--- a/tests/components/p1_monitor/test_config_flow.py
+++ b/tests/components/p1_monitor/test_config_flow.py
@@ -17,7 +17,7 @@ async def test_full_user_flow(hass: HomeAssistant) -> None:
     )
 
     assert result.get("type") == FlowResultType.FORM
-    assert result.get("step_id") == SOURCE_USER
+    assert result.get("step_id") == "user"
 
     with patch(
         "homeassistant.components.p1_monitor.config_flow.P1Monitor.smartmeter"

--- a/tests/components/poolsense/test_config_flow.py
+++ b/tests/components/poolsense/test_config_flow.py
@@ -15,7 +15,7 @@ async def test_show_form(hass: HomeAssistant) -> None:
     )
 
     assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["step_id"] == SOURCE_USER
+    assert result["step_id"] == "user"
 
 
 async def test_invalid_credentials(hass: HomeAssistant) -> None:

--- a/tests/components/pure_energie/test_config_flow.py
+++ b/tests/components/pure_energie/test_config_flow.py
@@ -22,7 +22,7 @@ async def test_full_user_flow_implementation(
         context={"source": SOURCE_USER},
     )
 
-    assert result.get("step_id") == SOURCE_USER
+    assert result.get("step_id") == "user"
     assert result.get("type") == FlowResultType.FORM
 
     result = await hass.config_entries.flow.async_configure(

--- a/tests/components/pvoutput/test_config_flow.py
+++ b/tests/components/pvoutput/test_config_flow.py
@@ -24,7 +24,7 @@ async def test_full_user_flow(
     )
 
     assert result.get("type") == FlowResultType.FORM
-    assert result.get("step_id") == SOURCE_USER
+    assert result.get("step_id") == "user"
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -60,7 +60,7 @@ async def test_full_flow_with_authentication_error(
     )
 
     assert result.get("type") == FlowResultType.FORM
-    assert result.get("step_id") == SOURCE_USER
+    assert result.get("step_id") == "user"
 
     mock_pvoutput_config_flow.system.side_effect = PVOutputAuthenticationError
     result2 = await hass.config_entries.flow.async_configure(
@@ -72,7 +72,7 @@ async def test_full_flow_with_authentication_error(
     )
 
     assert result2.get("type") == FlowResultType.FORM
-    assert result2.get("step_id") == SOURCE_USER
+    assert result2.get("step_id") == "user"
     assert result2.get("errors") == {"base": "invalid_auth"}
 
     assert len(mock_setup_entry.mock_calls) == 0

--- a/tests/components/qnap_qsw/test_config_flow.py
+++ b/tests/components/qnap_qsw/test_config_flow.py
@@ -49,7 +49,7 @@ async def test_form(hass: HomeAssistant) -> None:
         )
 
         assert result["type"] == data_entry_flow.FlowResultType.FORM
-        assert result["step_id"] == SOURCE_USER
+        assert result["step_id"] == "user"
         assert result["errors"] == {}
 
         result = await hass.config_entries.flow.async_configure(

--- a/tests/components/rdw/test_config_flow.py
+++ b/tests/components/rdw/test_config_flow.py
@@ -19,7 +19,7 @@ async def test_full_user_flow(
     )
 
     assert result.get("type") == FlowResultType.FORM
-    assert result.get("step_id") == SOURCE_USER
+    assert result.get("step_id") == "user"
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -46,7 +46,7 @@ async def test_full_flow_with_authentication_error(
     )
 
     assert result.get("type") == FlowResultType.FORM
-    assert result.get("step_id") == SOURCE_USER
+    assert result.get("step_id") == "user"
 
     mock_rdw_config_flow.vehicle.side_effect = RDWUnknownLicensePlateError
     result2 = await hass.config_entries.flow.async_configure(
@@ -57,7 +57,7 @@ async def test_full_flow_with_authentication_error(
     )
 
     assert result2.get("type") == FlowResultType.FORM
-    assert result2.get("step_id") == SOURCE_USER
+    assert result2.get("step_id") == "user"
     assert result2.get("errors") == {"base": "unknown_license_plate"}
 
     mock_rdw_config_flow.vehicle.side_effect = None

--- a/tests/components/season/test_config_flow.py
+++ b/tests/components/season/test_config_flow.py
@@ -20,7 +20,7 @@ async def test_full_user_flow(
     )
 
     assert result.get("type") == FlowResultType.FORM
-    assert result.get("step_id") == SOURCE_USER
+    assert result.get("step_id") == "user"
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],

--- a/tests/components/stookalert/test_config_flow.py
+++ b/tests/components/stookalert/test_config_flow.py
@@ -16,7 +16,7 @@ async def test_full_user_flow(hass: HomeAssistant) -> None:
     )
 
     assert result.get("type") == FlowResultType.FORM
-    assert result.get("step_id") == SOURCE_USER
+    assert result.get("step_id") == "user"
 
     with patch(
         "homeassistant.components.stookalert.async_setup_entry", return_value=True

--- a/tests/components/stookwijzer/test_config_flow.py
+++ b/tests/components/stookwijzer/test_config_flow.py
@@ -15,7 +15,7 @@ async def test_full_user_flow(hass: HomeAssistant) -> None:
     )
 
     assert result.get("type") == FlowResultType.FORM
-    assert result.get("step_id") == SOURCE_USER
+    assert result.get("step_id") == "user"
     assert "flow_id" in result
 
     with patch(

--- a/tests/components/sun/test_config_flow.py
+++ b/tests/components/sun/test_config_flow.py
@@ -18,7 +18,7 @@ async def test_full_user_flow(hass: HomeAssistant) -> None:
     )
 
     assert result.get("type") == FlowResultType.FORM
-    assert result.get("step_id") == SOURCE_USER
+    assert result.get("step_id") == "user"
 
     with patch(
         "homeassistant.components.sun.async_setup_entry",

--- a/tests/components/tailscale/test_config_flow.py
+++ b/tests/components/tailscale/test_config_flow.py
@@ -24,7 +24,7 @@ async def test_full_user_flow(
     )
 
     assert result.get("type") == FlowResultType.FORM
-    assert result.get("step_id") == SOURCE_USER
+    assert result.get("step_id") == "user"
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -60,7 +60,7 @@ async def test_full_flow_with_authentication_error(
     )
 
     assert result.get("type") == FlowResultType.FORM
-    assert result.get("step_id") == SOURCE_USER
+    assert result.get("step_id") == "user"
 
     mock_tailscale_config_flow.devices.side_effect = TailscaleAuthenticationError
     result2 = await hass.config_entries.flow.async_configure(
@@ -72,7 +72,7 @@ async def test_full_flow_with_authentication_error(
     )
 
     assert result2.get("type") == FlowResultType.FORM
-    assert result2.get("step_id") == SOURCE_USER
+    assert result2.get("step_id") == "user"
     assert result2.get("errors") == {"base": "invalid_auth"}
 
     assert len(mock_setup_entry.mock_calls) == 0

--- a/tests/components/tolo/test_config_flow.py
+++ b/tests/components/tolo/test_config_flow.py
@@ -34,7 +34,7 @@ async def test_user_with_timed_out_host(hass: HomeAssistant, toloclient: Mock) -
     )
 
     assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == SOURCE_USER
+    assert result["step_id"] == "user"
     assert result["errors"] == {"base": "cannot_connect"}
 
 
@@ -45,7 +45,7 @@ async def test_user_walkthrough(hass: HomeAssistant, toloclient: Mock) -> None:
     )
 
     assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == SOURCE_USER
+    assert result["step_id"] == "user"
 
     toloclient().get_status_info.side_effect = lambda *args, **kwargs: None
 
@@ -55,7 +55,7 @@ async def test_user_walkthrough(hass: HomeAssistant, toloclient: Mock) -> None:
     )
 
     assert result2["type"] == FlowResultType.FORM
-    assert result2["step_id"] == SOURCE_USER
+    assert result2["step_id"] == "user"
     assert result2["errors"] == {"base": "cannot_connect"}
 
     toloclient().get_status_info.side_effect = lambda *args, **kwargs: object()

--- a/tests/components/twentemilieu/test_config_flow.py
+++ b/tests/components/twentemilieu/test_config_flow.py
@@ -30,7 +30,7 @@ async def test_full_user_flow(hass: HomeAssistant, snapshot: SnapshotAssertion) 
     )
 
     assert result.get("type") == FlowResultType.FORM
-    assert result.get("step_id") == SOURCE_USER
+    assert result.get("step_id") == "user"
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -60,7 +60,7 @@ async def test_invalid_address(
     )
 
     assert result.get("type") == FlowResultType.FORM
-    assert result.get("step_id") == SOURCE_USER
+    assert result.get("step_id") == "user"
 
     mock_twentemilieu.unique_id.side_effect = TwenteMilieuAddressError
     result2 = await hass.config_entries.flow.async_configure(
@@ -72,7 +72,7 @@ async def test_invalid_address(
     )
 
     assert result2.get("type") == FlowResultType.FORM
-    assert result2.get("step_id") == SOURCE_USER
+    assert result2.get("step_id") == "user"
     assert result2.get("errors") == {"base": "invalid_address"}
 
     mock_twentemilieu.unique_id.side_effect = None
@@ -106,7 +106,7 @@ async def test_connection_error(
     )
 
     assert result.get("type") == FlowResultType.FORM
-    assert result.get("step_id") == SOURCE_USER
+    assert result.get("step_id") == "user"
     assert result.get("errors") == {"base": "cannot_connect"}
 
 

--- a/tests/components/unifi/test_config_flow.py
+++ b/tests/components/unifi/test_config_flow.py
@@ -21,7 +21,7 @@ from homeassistant.components.unifi.const import (
     CONF_TRACK_WIRED_CLIENTS,
     DOMAIN as UNIFI_DOMAIN,
 )
-from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER
+from homeassistant.config_entries import SOURCE_REAUTH
 from homeassistant.const import (
     CONF_HOST,
     CONF_PASSWORD,
@@ -398,7 +398,7 @@ async def test_reauth_flow_update_configuration(
     )
 
     assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["step_id"] == SOURCE_USER
+    assert result["step_id"] == "user"
 
     aioclient_mock.clear_requests()
 

--- a/tests/components/uptime/test_config_flow.py
+++ b/tests/components/uptime/test_config_flow.py
@@ -22,7 +22,7 @@ async def test_full_user_flow(
     )
 
     assert result.get("type") == FlowResultType.FORM
-    assert result.get("step_id") == SOURCE_USER
+    assert result.get("step_id") == "user"
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],

--- a/tests/components/venstar/test_config_flow.py
+++ b/tests/components/venstar/test_config_flow.py
@@ -4,7 +4,6 @@ from unittest.mock import patch
 
 from homeassistant import config_entries
 from homeassistant.components.venstar.const import DOMAIN
-from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import (
     CONF_HOST,
     CONF_PASSWORD,
@@ -105,7 +104,7 @@ async def test_already_configured(hass: HomeAssistant) -> None:
     )
 
     assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == SOURCE_USER
+    assert result["step_id"] == "user"
 
     with patch(
         "homeassistant.components.venstar.VenstarColorTouch.update_info",

--- a/tests/components/whois/test_config_flow.py
+++ b/tests/components/whois/test_config_flow.py
@@ -31,7 +31,7 @@ async def test_full_user_flow(
     )
 
     assert result.get("type") == FlowResultType.FORM
-    assert result.get("step_id") == SOURCE_USER
+    assert result.get("step_id") == "user"
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -71,7 +71,7 @@ async def test_full_flow_with_error(
     )
 
     assert result.get("type") == FlowResultType.FORM
-    assert result.get("step_id") == SOURCE_USER
+    assert result.get("step_id") == "user"
 
     mock_whois.side_effect = throw
     result2 = await hass.config_entries.flow.async_configure(
@@ -80,7 +80,7 @@ async def test_full_flow_with_error(
     )
 
     assert result2.get("type") == FlowResultType.FORM
-    assert result2.get("step_id") == SOURCE_USER
+    assert result2.get("step_id") == "user"
     assert result2.get("errors") == {"base": reason}
 
     assert len(mock_setup_entry.mock_calls) == 0

--- a/tests/components/youless/test_config_flows.py
+++ b/tests/components/youless/test_config_flows.py
@@ -27,7 +27,7 @@ async def test_full_flow(hass: HomeAssistant) -> None:
 
     assert result.get("type") == FlowResultType.FORM
     assert result.get("errors") == {}
-    assert result.get("step_id") == SOURCE_USER
+    assert result.get("step_id") == "user"
 
     mock_youless = _get_mock_youless_api(
         initialize={"homes": [{"id": 1, "name": "myhome"}]}
@@ -54,7 +54,7 @@ async def test_not_found(hass: HomeAssistant) -> None:
 
     assert result.get("type") == FlowResultType.FORM
     assert result.get("errors") == {}
-    assert result.get("step_id") == SOURCE_USER
+    assert result.get("step_id") == "user"
 
     mock_youless = _get_mock_youless_api(initialize=URLError(""))
     with patch(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove incorrect constant usage in test.
`SOURCE_USER` is a constant referring to the source of the flow, not to the current step id.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
