### PR TITLE
Fix flaky filesize tests

### DIFF
--- a/tests/components/filesize/__init__.py
+++ b/tests/components/filesize/__init__.py
@@ -1,13 +1,9 @@
 """Tests for the filesize component."""
-import os
 
 from homeassistant.core import HomeAssistant
 
-TEST_DIR = os.path.join(os.path.dirname(__file__))
 TEST_FILE_NAME = "mock_file_test_filesize.txt"
 TEST_FILE_NAME2 = "mock_file_test_filesize2.txt"
-TEST_FILE = os.path.join(TEST_DIR, TEST_FILE_NAME)
-TEST_FILE2 = os.path.join(TEST_DIR, TEST_FILE_NAME2)
 
 
 async def async_create_file(hass: HomeAssistant, path: str) -> None:

--- a/tests/components/filesize/conftest.py
+++ b/tests/components/filesize/conftest.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from collections.abc import Generator
-import os
 from pathlib import Path
 from unittest.mock import patch
 
@@ -19,7 +18,7 @@ from tests.common import MockConfigEntry
 @pytest.fixture
 def mock_config_entry(tmp_path: Path) -> MockConfigEntry:
     """Return the default mocked config entry."""
-    test_file = os.path.join(tmp_path, TEST_FILE_NAME)
+    test_file = str(tmp_path.joinpath(TEST_FILE_NAME))
     return MockConfigEntry(
         title=TEST_FILE_NAME,
         domain=DOMAIN,

--- a/tests/components/filesize/conftest.py
+++ b/tests/components/filesize/conftest.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from collections.abc import Generator
 import os
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -10,19 +11,20 @@ import pytest
 from homeassistant.components.filesize.const import DOMAIN
 from homeassistant.const import CONF_FILE_PATH
 
-from . import TEST_FILE, TEST_FILE2, TEST_FILE_NAME
+from . import TEST_FILE_NAME
 
 from tests.common import MockConfigEntry
 
 
 @pytest.fixture
-def mock_config_entry() -> MockConfigEntry:
+def mock_config_entry(tmp_path: Path) -> MockConfigEntry:
     """Return the default mocked config entry."""
+    test_file = os.path.join(tmp_path, TEST_FILE_NAME)
     return MockConfigEntry(
         title=TEST_FILE_NAME,
         domain=DOMAIN,
-        data={CONF_FILE_PATH: TEST_FILE},
-        unique_id=TEST_FILE,
+        data={CONF_FILE_PATH: test_file},
+        unique_id=test_file,
     )
 
 
@@ -33,13 +35,3 @@ def mock_setup_entry() -> Generator[None, None, None]:
         "homeassistant.components.filesize.async_setup_entry", return_value=True
     ):
         yield
-
-
-@pytest.fixture(autouse=True)
-def remove_file() -> None:
-    """Remove test file."""
-    yield
-    if os.path.isfile(TEST_FILE):
-        os.remove(TEST_FILE)
-    if os.path.isfile(TEST_FILE2):
-        os.remove(TEST_FILE2)

--- a/tests/components/filesize/test_config_flow.py
+++ b/tests/components/filesize/test_config_flow.py
@@ -1,4 +1,6 @@
 """Tests for the Filesize config flow."""
+import os
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -9,17 +11,18 @@ from homeassistant.const import CONF_FILE_PATH
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
-from . import TEST_DIR, TEST_FILE, TEST_FILE_NAME, async_create_file
+from . import TEST_FILE_NAME, async_create_file
 
 from tests.common import MockConfigEntry
 
 pytestmark = pytest.mark.usefixtures("mock_setup_entry")
 
 
-async def test_full_user_flow(hass: HomeAssistant) -> None:
+async def test_full_user_flow(hass: HomeAssistant, tmp_path: Path) -> None:
     """Test the full user configuration flow."""
-    await async_create_file(hass, TEST_FILE)
-    hass.config.allowlist_external_dirs = {TEST_DIR}
+    test_file = os.path.join(tmp_path, TEST_FILE_NAME)
+    await async_create_file(hass, test_file)
+    hass.config.allowlist_external_dirs = {tmp_path}
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
@@ -29,34 +32,34 @@ async def test_full_user_flow(hass: HomeAssistant) -> None:
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        user_input={CONF_FILE_PATH: TEST_FILE},
+        user_input={CONF_FILE_PATH: test_file},
     )
 
     assert result2.get("type") == FlowResultType.CREATE_ENTRY
     assert result2.get("title") == TEST_FILE_NAME
-    assert result2.get("data") == {CONF_FILE_PATH: TEST_FILE}
+    assert result2.get("data") == {CONF_FILE_PATH: test_file}
 
 
 async def test_unique_path(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry, tmp_path: Path
 ) -> None:
     """Test we abort if already setup."""
-    await async_create_file(hass, TEST_FILE)
-    hass.config.allowlist_external_dirs = {TEST_DIR}
+    test_file = os.path.join(tmp_path, TEST_FILE_NAME)
+    await async_create_file(hass, test_file)
+    hass.config.allowlist_external_dirs = {tmp_path}
     mock_config_entry.add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}, data={CONF_FILE_PATH: TEST_FILE}
+        DOMAIN, context={"source": SOURCE_USER}, data={CONF_FILE_PATH: test_file}
     )
 
     assert result.get("type") == FlowResultType.ABORT
     assert result.get("reason") == "already_configured"
 
 
-async def test_flow_fails_on_validation(hass: HomeAssistant) -> None:
+async def test_flow_fails_on_validation(hass: HomeAssistant, tmp_path: Path) -> None:
     """Test config flow errors."""
-
+    test_file = os.path.join(tmp_path, TEST_FILE_NAME)
     hass.config.allowlist_external_dirs = {}
 
     result = await hass.config_entries.flow.async_init(
@@ -69,13 +72,13 @@ async def test_flow_fails_on_validation(hass: HomeAssistant) -> None:
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={
-            CONF_FILE_PATH: TEST_FILE,
+            CONF_FILE_PATH: test_file,
         },
     )
 
     assert result2["errors"] == {"base": "not_valid"}
 
-    await async_create_file(hass, TEST_FILE)
+    await async_create_file(hass, test_file)
 
     with patch(
         "homeassistant.components.filesize.config_flow.pathlib.Path",
@@ -83,25 +86,25 @@ async def test_flow_fails_on_validation(hass: HomeAssistant) -> None:
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             user_input={
-                CONF_FILE_PATH: TEST_FILE,
+                CONF_FILE_PATH: test_file,
             },
         )
 
     assert result2["errors"] == {"base": "not_allowed"}
 
-    hass.config.allowlist_external_dirs = {TEST_DIR}
+    hass.config.allowlist_external_dirs = {tmp_path}
     with patch(
         "homeassistant.components.filesize.config_flow.pathlib.Path",
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             user_input={
-                CONF_FILE_PATH: TEST_FILE,
+                CONF_FILE_PATH: test_file,
             },
         )
 
     assert result2["type"] == FlowResultType.CREATE_ENTRY
     assert result2["title"] == TEST_FILE_NAME
     assert result2["data"] == {
-        CONF_FILE_PATH: TEST_FILE,
+        CONF_FILE_PATH: test_file,
     }

--- a/tests/components/filesize/test_config_flow.py
+++ b/tests/components/filesize/test_config_flow.py
@@ -1,5 +1,4 @@
 """Tests for the Filesize config flow."""
-import os
 from pathlib import Path
 from unittest.mock import patch
 
@@ -20,7 +19,7 @@ pytestmark = pytest.mark.usefixtures("mock_setup_entry")
 
 async def test_full_user_flow(hass: HomeAssistant, tmp_path: Path) -> None:
     """Test the full user configuration flow."""
-    test_file = os.path.join(tmp_path, TEST_FILE_NAME)
+    test_file = str(tmp_path.joinpath(TEST_FILE_NAME))
     await async_create_file(hass, test_file)
     hass.config.allowlist_external_dirs = {tmp_path}
     result = await hass.config_entries.flow.async_init(
@@ -44,7 +43,7 @@ async def test_unique_path(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry, tmp_path: Path
 ) -> None:
     """Test we abort if already setup."""
-    test_file = os.path.join(tmp_path, TEST_FILE_NAME)
+    test_file = str(tmp_path.joinpath(TEST_FILE_NAME))
     await async_create_file(hass, test_file)
     hass.config.allowlist_external_dirs = {tmp_path}
     mock_config_entry.add_to_hass(hass)
@@ -59,7 +58,7 @@ async def test_unique_path(
 
 async def test_flow_fails_on_validation(hass: HomeAssistant, tmp_path: Path) -> None:
     """Test config flow errors."""
-    test_file = os.path.join(tmp_path, TEST_FILE_NAME)
+    test_file = str(tmp_path.joinpath(TEST_FILE_NAME))
     hass.config.allowlist_external_dirs = {}
 
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/filesize/test_config_flow.py
+++ b/tests/components/filesize/test_config_flow.py
@@ -28,7 +28,7 @@ async def test_full_user_flow(hass: HomeAssistant, tmp_path: Path) -> None:
     )
 
     assert result.get("type") == FlowResultType.FORM
-    assert result.get("step_id") == SOURCE_USER
+    assert result.get("step_id") == "user"
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -67,7 +67,7 @@ async def test_flow_fails_on_validation(hass: HomeAssistant, tmp_path: Path) -> 
     )
 
     assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == SOURCE_USER
+    assert result["step_id"] == "user"
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],

--- a/tests/components/filesize/test_init.py
+++ b/tests/components/filesize/test_init.py
@@ -1,5 +1,4 @@
 """Tests for the Filesize integration."""
-import os
 from pathlib import Path
 
 from homeassistant.components.filesize.const import DOMAIN
@@ -16,7 +15,7 @@ async def test_load_unload_config_entry(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry, tmp_path: Path
 ) -> None:
     """Test the Filesize configuration entry loading/unloading."""
-    testfile = os.path.join(tmp_path, "file.txt")
+    testfile = str(tmp_path.joinpath("file.txt"))
     await async_create_file(hass, testfile)
     hass.config.allowlist_external_dirs = {tmp_path}
     mock_config_entry.add_to_hass(hass)
@@ -40,7 +39,7 @@ async def test_cannot_access_file(
 ) -> None:
     """Test that an file not exist is caught."""
     mock_config_entry.add_to_hass(hass)
-    testfile = os.path.join(tmp_path, "file_not_exist.txt")
+    testfile = str(tmp_path.joinpath("file_not_exist.txt"))
     hass.config.allowlist_external_dirs = {tmp_path}
     hass.config_entries.async_update_entry(
         mock_config_entry, unique_id=testfile, data={CONF_FILE_PATH: testfile}
@@ -56,7 +55,7 @@ async def test_not_valid_path_to_file(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry, tmp_path: Path
 ) -> None:
     """Test that an invalid path is caught."""
-    testfile = os.path.join(tmp_path, "file.txt")
+    testfile = str(tmp_path.joinpath("file.txt"))
     await async_create_file(hass, testfile)
     mock_config_entry.add_to_hass(hass)
     hass.config_entries.async_update_entry(

--- a/tests/components/filesize/test_init.py
+++ b/tests/components/filesize/test_init.py
@@ -1,5 +1,6 @@
 """Tests for the Filesize integration."""
-import py
+import os
+from pathlib import Path
 
 from homeassistant.components.filesize.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
@@ -12,12 +13,12 @@ from tests.common import MockConfigEntry
 
 
 async def test_load_unload_config_entry(
-    hass: HomeAssistant, mock_config_entry: MockConfigEntry, tmpdir: py.path.local
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry, tmp_path: Path
 ) -> None:
     """Test the Filesize configuration entry loading/unloading."""
-    testfile = f"{tmpdir}/file.txt"
+    testfile = os.path.join(tmp_path, "file.txt")
     await async_create_file(hass, testfile)
-    hass.config.allowlist_external_dirs = {tmpdir}
+    hass.config.allowlist_external_dirs = {tmp_path}
     mock_config_entry.add_to_hass(hass)
     hass.config_entries.async_update_entry(
         mock_config_entry, unique_id=testfile, data={CONF_FILE_PATH: testfile}
@@ -35,12 +36,12 @@ async def test_load_unload_config_entry(
 
 
 async def test_cannot_access_file(
-    hass: HomeAssistant, mock_config_entry: MockConfigEntry, tmpdir: py.path.local
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry, tmp_path: Path
 ) -> None:
     """Test that an file not exist is caught."""
     mock_config_entry.add_to_hass(hass)
-    testfile = f"{tmpdir}/file_not_exist.txt"
-    hass.config.allowlist_external_dirs = {tmpdir}
+    testfile = os.path.join(tmp_path, "file_not_exist.txt")
+    hass.config.allowlist_external_dirs = {tmp_path}
     hass.config_entries.async_update_entry(
         mock_config_entry, unique_id=testfile, data={CONF_FILE_PATH: testfile}
     )
@@ -52,10 +53,10 @@ async def test_cannot_access_file(
 
 
 async def test_not_valid_path_to_file(
-    hass: HomeAssistant, mock_config_entry: MockConfigEntry, tmpdir: py.path.local
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry, tmp_path: Path
 ) -> None:
     """Test that an invalid path is caught."""
-    testfile = f"{tmpdir}/file.txt"
+    testfile = os.path.join(tmp_path, "file.txt")
     await async_create_file(hass, testfile)
     mock_config_entry.add_to_hass(hass)
     hass.config_entries.async_update_entry(

--- a/tests/components/filesize/test_sensor.py
+++ b/tests/components/filesize/test_sensor.py
@@ -15,7 +15,7 @@ async def test_invalid_path(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry, tmp_path: Path
 ) -> None:
     """Test that an invalid path is caught."""
-    test_file = os.path.join(tmp_path, TEST_FILE_NAME)
+    test_file = str(tmp_path.joinpath(TEST_FILE_NAME))
     mock_config_entry.add_to_hass(hass)
     hass.config_entries.async_update_entry(
         mock_config_entry, unique_id=test_file, data={CONF_FILE_PATH: test_file}
@@ -29,7 +29,7 @@ async def test_valid_path(
     hass: HomeAssistant, tmp_path: Path, mock_config_entry: MockConfigEntry
 ) -> None:
     """Test for a valid path."""
-    testfile = os.path.join(tmp_path, "file.txt")
+    testfile = str(tmp_path.joinpath("file.txt"))
     await async_create_file(hass, testfile)
     hass.config.allowlist_external_dirs = {tmp_path}
     mock_config_entry.add_to_hass(hass)
@@ -51,7 +51,7 @@ async def test_state_unavailable(
     hass: HomeAssistant, tmp_path: Path, mock_config_entry: MockConfigEntry
 ) -> None:
     """Verify we handle state unavailable."""
-    testfile = os.path.join(tmp_path, "file.txt")
+    testfile = str(tmp_path.joinpath("file.txt"))
     await async_create_file(hass, testfile)
     hass.config.allowlist_external_dirs = {tmp_path}
     mock_config_entry.add_to_hass(hass)

--- a/tests/components/filesize/test_sensor.py
+++ b/tests/components/filesize/test_sensor.py
@@ -1,24 +1,24 @@
 """The tests for the filesize sensor."""
 import os
-
-import py
+from pathlib import Path
 
 from homeassistant.const import CONF_FILE_PATH, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_component import async_update_entity
 
-from . import TEST_FILE, TEST_FILE_NAME, async_create_file
+from . import TEST_FILE_NAME, async_create_file
 
 from tests.common import MockConfigEntry
 
 
 async def test_invalid_path(
-    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry, tmp_path: Path
 ) -> None:
     """Test that an invalid path is caught."""
+    test_file = os.path.join(tmp_path, TEST_FILE_NAME)
     mock_config_entry.add_to_hass(hass)
     hass.config_entries.async_update_entry(
-        mock_config_entry, unique_id=TEST_FILE, data={CONF_FILE_PATH: TEST_FILE}
+        mock_config_entry, unique_id=test_file, data={CONF_FILE_PATH: test_file}
     )
 
     state = hass.states.get("sensor." + TEST_FILE_NAME)
@@ -26,12 +26,12 @@ async def test_invalid_path(
 
 
 async def test_valid_path(
-    hass: HomeAssistant, tmpdir: py.path.local, mock_config_entry: MockConfigEntry
+    hass: HomeAssistant, tmp_path: Path, mock_config_entry: MockConfigEntry
 ) -> None:
     """Test for a valid path."""
-    testfile = f"{tmpdir}/file.txt"
+    testfile = os.path.join(tmp_path, "file.txt")
     await async_create_file(hass, testfile)
-    hass.config.allowlist_external_dirs = {tmpdir}
+    hass.config.allowlist_external_dirs = {tmp_path}
     mock_config_entry.add_to_hass(hass)
     hass.config_entries.async_update_entry(
         mock_config_entry, unique_id=testfile, data={CONF_FILE_PATH: testfile}
@@ -48,12 +48,12 @@ async def test_valid_path(
 
 
 async def test_state_unavailable(
-    hass: HomeAssistant, tmpdir: py.path.local, mock_config_entry: MockConfigEntry
+    hass: HomeAssistant, tmp_path: Path, mock_config_entry: MockConfigEntry
 ) -> None:
     """Verify we handle state unavailable."""
-    testfile = f"{tmpdir}/file.txt"
+    testfile = os.path.join(tmp_path, "file.txt")
     await async_create_file(hass, testfile)
-    hass.config.allowlist_external_dirs = {tmpdir}
+    hass.config.allowlist_external_dirs = {tmp_path}
     mock_config_entry.add_to_hass(hass)
     hass.config_entries.async_update_entry(
         mock_config_entry, unique_id=testfile, data={CONF_FILE_PATH: testfile}


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use `tmp_path` fixture to fix flaky filesize tests
The current tests rely on the files being deleted at the end of the tests, but race condition means they end up leaking into one another when running partial CI

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
