### PR TITLE
Allow None device_class and UOM for mqtt entities

### DIFF
--- a/homeassistant/components/mqtt/button.py
+++ b/homeassistant/components/mqtt/button.py
@@ -105,7 +105,7 @@ class MqttButton(MqttEntity, ButtonEntity):
         self._command_template = MqttCommandTemplate(
             config.get(CONF_COMMAND_TEMPLATE), entity=self
         ).async_render
-        self._attr_device_class = config.get(CONF_DEVICE_CLASS)
+        self._attr_device_class = self._config.get(CONF_DEVICE_CLASS)
 
     def _prepare_subscribe_topics(self) -> None:
         """(Re)Subscribe to topics."""

--- a/homeassistant/components/mqtt/button.py
+++ b/homeassistant/components/mqtt/button.py
@@ -105,7 +105,7 @@ class MqttButton(MqttEntity, ButtonEntity):
         self._command_template = MqttCommandTemplate(
             config.get(CONF_COMMAND_TEMPLATE), entity=self
         ).async_render
-        self._attr_device_class = self._config.get(CONF_DEVICE_CLASS)
+        self._attr_device_class = config.get(CONF_DEVICE_CLASS)
 
     def _prepare_subscribe_topics(self) -> None:
         """(Re)Subscribe to topics."""

--- a/homeassistant/components/mqtt/humidifier.py
+++ b/homeassistant/components/mqtt/humidifier.py
@@ -227,8 +227,7 @@ class MqttHumidifier(MqttEntity, HumidifierEntity):
 
     def _setup_from_config(self, config: ConfigType) -> None:
         """(Re)Setup the entity."""
-        if device_class := config.get(CONF_DEVICE_CLASS):
-            self._attr_device_class = device_class
+        self._attr_device_class = config.get(CONF_DEVICE_CLASS)
         self._attr_min_humidity = config[CONF_TARGET_HUMIDITY_MIN]
         self._attr_max_humidity = config[CONF_TARGET_HUMIDITY_MAX]
 

--- a/homeassistant/components/mqtt/humidifier.py
+++ b/homeassistant/components/mqtt/humidifier.py
@@ -125,7 +125,7 @@ _PLATFORM_SCHEMA_BASE = MQTT_RW_SCHEMA.extend(
         vol.Optional(
             CONF_DEVICE_CLASS, default=HumidifierDeviceClass.HUMIDIFIER
         ): vol.In(
-            [HumidifierDeviceClass.HUMIDIFIER, HumidifierDeviceClass.DEHUMIDIFIER]
+            [HumidifierDeviceClass.HUMIDIFIER, HumidifierDeviceClass.DEHUMIDIFIER, None]
         ),
         vol.Optional(CONF_MODE_COMMAND_TEMPLATE): cv.template,
         vol.Optional(CONF_MODE_STATE_TOPIC): valid_subscribe_topic,
@@ -227,7 +227,8 @@ class MqttHumidifier(MqttEntity, HumidifierEntity):
 
     def _setup_from_config(self, config: ConfigType) -> None:
         """(Re)Setup the entity."""
-        self._attr_device_class = config.get(CONF_DEVICE_CLASS)
+        if device_class := config.get(CONF_DEVICE_CLASS):
+            self._attr_device_class = device_class
         self._attr_min_humidity = config[CONF_TARGET_HUMIDITY_MIN]
         self._attr_max_humidity = config[CONF_TARGET_HUMIDITY_MAX]
 

--- a/homeassistant/components/mqtt/number.py
+++ b/homeassistant/components/mqtt/number.py
@@ -186,8 +186,7 @@ class MqttNumber(MqttEntity, RestoreNumber):
         self._attr_native_max_value = config[CONF_MAX]
         self._attr_native_min_value = config[CONF_MIN]
         self._attr_native_step = config[CONF_STEP]
-        if unit_of_measurement := config.get(CONF_UNIT_OF_MEASUREMENT):
-            self._attr_native_unit_of_measurement = unit_of_measurement
+        self._attr_native_unit_of_measurement = config.get(CONF_UNIT_OF_MEASUREMENT)
 
     def _prepare_subscribe_topics(self) -> None:
         """(Re)Subscribe to topics."""

--- a/homeassistant/components/mqtt/number.py
+++ b/homeassistant/components/mqtt/number.py
@@ -97,7 +97,7 @@ _PLATFORM_SCHEMA_BASE = MQTT_RW_SCHEMA.extend(
         vol.Optional(CONF_STEP, default=DEFAULT_STEP): vol.All(
             vol.Coerce(float), vol.Range(min=1e-3)
         ),
-        vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
+        vol.Optional(CONF_UNIT_OF_MEASUREMENT): vol.Any(cv.string, None),
         vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
     },
 ).extend(MQTT_ENTITY_COMMON_SCHEMA.schema)
@@ -186,7 +186,8 @@ class MqttNumber(MqttEntity, RestoreNumber):
         self._attr_native_max_value = config[CONF_MAX]
         self._attr_native_min_value = config[CONF_MIN]
         self._attr_native_step = config[CONF_STEP]
-        self._attr_native_unit_of_measurement = config.get(CONF_UNIT_OF_MEASUREMENT)
+        if unit_of_measurement := config.get(CONF_UNIT_OF_MEASUREMENT):
+            self._attr_native_unit_of_measurement = unit_of_measurement
 
     def _prepare_subscribe_topics(self) -> None:
         """(Re)Subscribe to topics."""

--- a/homeassistant/components/mqtt/sensor.py
+++ b/homeassistant/components/mqtt/sensor.py
@@ -107,7 +107,7 @@ _PLATFORM_SCHEMA_BASE = MQTT_RO_SCHEMA.extend(
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
         vol.Optional(CONF_SUGGESTED_DISPLAY_PRECISION): cv.positive_int,
         vol.Optional(CONF_STATE_CLASS): vol.Any(STATE_CLASSES_SCHEMA, None),
-        vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
+        vol.Optional(CONF_UNIT_OF_MEASUREMENT): vol.Any(cv.string, None),
     }
 ).extend(MQTT_ENTITY_COMMON_SCHEMA.schema)
 

--- a/tests/components/mqtt/test_binary_sensor.py
+++ b/tests/components/mqtt/test_binary_sensor.py
@@ -505,27 +505,44 @@ async def test_setting_sensor_value_via_mqtt_message_empty_template(
 
 
 @pytest.mark.parametrize(
-    "hass_config",
+    ("hass_config", "device_class"),
     [
-        {
-            mqtt.DOMAIN: {
-                binary_sensor.DOMAIN: {
-                    "name": "test",
-                    "device_class": "motion",
-                    "state_topic": "test-topic",
+        (
+            {
+                mqtt.DOMAIN: {
+                    binary_sensor.DOMAIN: {
+                        "name": "test",
+                        "device_class": "motion",
+                        "state_topic": "test-topic",
+                    }
                 }
-            }
-        }
+            },
+            "motion",
+        ),
+        (
+            {
+                mqtt.DOMAIN: {
+                    binary_sensor.DOMAIN: {
+                        "name": "test",
+                        "device_class": None,
+                        "state_topic": "test-topic",
+                    }
+                }
+            },
+            None,
+        ),
     ],
 )
 async def test_valid_device_class(
-    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
+    hass: HomeAssistant,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+    device_class: str | None,
 ) -> None:
-    """Test the setting of a valid sensor class."""
+    """Test the setting of a valid sensor class and ignoring an empty device_class."""
     await mqtt_mock_entry()
 
     state = hass.states.get("binary_sensor.test")
-    assert state.attributes.get("device_class") == "motion"
+    assert state.attributes.get("device_class") == device_class
 
 
 @pytest.mark.parametrize(

--- a/tests/components/mqtt/test_button.py
+++ b/tests/components/mqtt/test_button.py
@@ -477,6 +477,11 @@ async def test_invalid_device_class(
                         "name": "Test 3",
                         "command_topic": "test-topic",
                     },
+                    {
+                        "name": "Test 4",
+                        "command_topic": "test-topic",
+                        "device_class": None,
+                    },
                 ]
             }
         }

--- a/tests/components/mqtt/test_humidifier.py
+++ b/tests/components/mqtt/test_humidifier.py
@@ -871,6 +871,19 @@ async def test_attributes(
             {
                 mqtt.DOMAIN: {
                     humidifier.DOMAIN: {
+                        "name": "test_valid_4",
+                        "command_topic": "command-topic",
+                        "target_humidity_command_topic": "humidity-command-topic",
+                        "device_class": None,
+                    }
+                }
+            },
+            True,
+        ),
+        (
+            {
+                mqtt.DOMAIN: {
+                    humidifier.DOMAIN: {
                         "name": "test_invalid_device_class",
                         "command_topic": "command-topic",
                         "target_humidity_command_topic": "humidity-command-topic",

--- a/tests/components/mqtt/test_sensor.py
+++ b/tests/components/mqtt/test_sensor.py
@@ -851,16 +851,17 @@ async def test_invalid_device_class(
                         "name": "Test 3",
                         "state_topic": "test-topic",
                         "device_class": None,
+                        "unit_of_measurement": None,
                     },
                 ]
             }
         }
     ],
 )
-async def test_valid_device_class(
+async def test_valid_device_class_and_uom(
     hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
 ) -> None:
-    """Test device_class option with valid values."""
+    """Test device_class option with valid values and test with an empty unit of measurement."""
     await mqtt_mock_entry()
 
     state = hass.states.get("sensor.test_1")

--- a/tests/components/mqtt/test_switch.py
+++ b/tests/components/mqtt/test_switch.py
@@ -62,31 +62,51 @@ def switch_platform_only():
 
 
 @pytest.mark.parametrize(
-    "hass_config",
+    ("hass_config", "device_class"),
     [
-        {
-            mqtt.DOMAIN: {
-                switch.DOMAIN: {
-                    "name": "test",
-                    "state_topic": "state-topic",
-                    "command_topic": "command-topic",
-                    "payload_on": 1,
-                    "payload_off": 0,
-                    "device_class": "switch",
+        (
+            {
+                mqtt.DOMAIN: {
+                    switch.DOMAIN: {
+                        "name": "test",
+                        "state_topic": "state-topic",
+                        "command_topic": "command-topic",
+                        "payload_on": 1,
+                        "payload_off": 0,
+                        "device_class": "switch",
+                    }
                 }
-            }
-        }
+            },
+            "switch",
+        ),
+        (
+            {
+                mqtt.DOMAIN: {
+                    switch.DOMAIN: {
+                        "name": "test",
+                        "state_topic": "state-topic",
+                        "command_topic": "command-topic",
+                        "payload_on": 1,
+                        "payload_off": 0,
+                        "device_class": None,
+                    }
+                }
+            },
+            None,
+        ),
     ],
 )
 async def test_controlling_state_via_topic(
-    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
+    hass: HomeAssistant,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+    device_class: str | None,
 ) -> None:
     """Test the controlling state via topic."""
     await mqtt_mock_entry()
 
     state = hass.states.get("switch.test")
     assert state.state == STATE_UNKNOWN
-    assert state.attributes.get(ATTR_DEVICE_CLASS) == "switch"
+    assert state.attributes.get(ATTR_DEVICE_CLASS) == device_class
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
 
     async_fire_mqtt_message(hass, "state-topic", "1")

--- a/tests/components/mqtt/test_update.py
+++ b/tests/components/mqtt/test_update.py
@@ -63,25 +63,48 @@ def update_platform_only():
 
 
 @pytest.mark.parametrize(
-    "hass_config",
+    ("hass_config", "device_class"),
     [
-        {
-            mqtt.DOMAIN: {
-                update.DOMAIN: {
-                    "state_topic": "test/installed-version",
-                    "latest_version_topic": "test/latest-version",
-                    "name": "Test Update",
-                    "release_summary": "Test release summary",
-                    "release_url": "https://example.com/release",
-                    "title": "Test Update Title",
-                    "entity_picture": "https://example.com/icon.png",
+        (
+            {
+                mqtt.DOMAIN: {
+                    update.DOMAIN: {
+                        "state_topic": "test/installed-version",
+                        "latest_version_topic": "test/latest-version",
+                        "name": "Test Update",
+                        "release_summary": "Test release summary",
+                        "release_url": "https://example.com/release",
+                        "title": "Test Update Title",
+                        "entity_picture": "https://example.com/icon.png",
+                        "device_class": "firmware",
+                    }
                 }
-            }
-        }
+            },
+            "firmware",
+        ),
+        (
+            {
+                mqtt.DOMAIN: {
+                    update.DOMAIN: {
+                        "state_topic": "test/installed-version",
+                        "latest_version_topic": "test/latest-version",
+                        "name": "Test Update",
+                        "release_summary": "Test release summary",
+                        "release_url": "https://example.com/release",
+                        "title": "Test Update Title",
+                        "entity_picture": "https://example.com/icon.png",
+                        "device_class": None,
+                    }
+                }
+            },
+            None,
+        ),
     ],
 )
 async def test_run_update_setup(
-    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
+    hass: HomeAssistant,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+    device_class: str | None,
 ) -> None:
     """Test that it fetches the given payload."""
     installed_version_topic = "test/installed-version"
@@ -101,6 +124,7 @@ async def test_run_update_setup(
     assert state.attributes.get("release_url") == "https://example.com/release"
     assert state.attributes.get("title") == "Test Update Title"
     assert state.attributes.get("entity_picture") == "https://example.com/icon.png"
+    assert state.attributes.get("device_class") == device_class
 
     async_fire_mqtt_message(hass, latest_version_topic, "2.0.0")
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
MQTT entities that support `device_class` or `unit_of_measurement` should be able to set those to `None`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/26973

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
