### PR TITLE
Update typing on recorder pool for sqlalchemy 2.0

### DIFF
--- a/homeassistant/components/recorder/pool.py
+++ b/homeassistant/components/recorder/pool.py
@@ -52,7 +52,7 @@ class RecorderPool(SingletonThreadPool, NullPool):  # type: ignore[misc]
             thread_name == "Recorder" or thread_name.startswith(DB_WORKER_PREFIX)
         )
 
-    def _do_return_conn(self, record: ConnectionPoolEntry) -> Any:
+    def _do_return_conn(self, record: ConnectionPoolEntry) -> None:
         if self.recorder_or_dbworker:
             return super()._do_return_conn(record)
         record.close()
@@ -72,8 +72,7 @@ class RecorderPool(SingletonThreadPool, NullPool):  # type: ignore[misc]
         if self.recorder_or_dbworker:
             super().dispose()
 
-    # Any can be switched out for ConnectionPoolEntry in the next version of sqlalchemy
-    def _do_get(self) -> Any:
+    def _do_get(self) -> ConnectionPoolEntry:
         if self.recorder_or_dbworker:
             return super()._do_get()
         check_loop(
@@ -83,7 +82,7 @@ class RecorderPool(SingletonThreadPool, NullPool):  # type: ignore[misc]
         )
         return self._do_get_db_connection_protected()
 
-    def _do_get_db_connection_protected(self) -> Any:
+    def _do_get_db_connection_protected(self) -> ConnectionPoolEntry:
         report(
             (
                 "accesses the database without the database executor; "
@@ -106,7 +105,7 @@ class MutexPool(StaticPool):
     _reference_counter = 0
     pool_lock: threading.RLock
 
-    def _do_return_conn(self, record: ConnectionPoolEntry) -> Any:
+    def _do_return_conn(self, record: ConnectionPoolEntry) -> None:
         if DEBUG_MUTEX_POOL_TRACE:
             trace = traceback.extract_stack()
             trace_msg = "\n" + "".join(traceback.format_list(trace[:-1]))
@@ -124,7 +123,7 @@ class MutexPool(StaticPool):
             )
         MutexPool.pool_lock.release()
 
-    def _do_get(self) -> Any:
+    def _do_get(self) -> ConnectionPoolEntry:
         if DEBUG_MUTEX_POOL_TRACE:
             trace = traceback.extract_stack()
             trace_msg = "".join(traceback.format_list(trace[:-1]))


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update typing on recorder pool for sqlalchemy 2.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
