### PR TITLE
Add pretty printing, key sorting, and better performance to to_json in Jinja

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -2029,9 +2029,11 @@ def from_json(value):
     return json_loads(value)
 
 
-def to_json(value, ensure_ascii=True):
+def to_json(value, ensure_ascii=True, indent=None, sort_keys=False):
     """Convert an object to a JSON string."""
-    return json.dumps(value, ensure_ascii=ensure_ascii)
+    return json.dumps(
+        value, ensure_ascii=ensure_ascii, indent=indent, sort_keys=sort_keys
+    )
 
 
 @pass_context

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -2042,12 +2042,12 @@ def to_json(value, ensure_ascii=True):
     return json.dumps(value, ensure_ascii=ensure_ascii)
 
 
-def _as_json_default(obj):
+def _as_json_default(obj: Any) -> None:
     """Disable custom types in json serialization."""
     raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
 
 
-def as_json(value, pretty_print=False, sort_keys=False):
+def as_json(value: Any, pretty_print: bool=False, sort_keys: bool=False) -> str:
     """Convert an object to a JSON string."""
 
     option = (

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -2036,7 +2036,9 @@ def from_json(value):
 
 def to_json(value, ensure_ascii=True):
     """Convert an object to a JSON string."""
-    _LOGGER.warning("Template warning: 'to_json' is deprecated and will be removed in Home Assistant 2023.8, use 'as_json' instead")
+    _LOGGER.warning(
+        "Template warning: 'to_json' is deprecated and will be removed in Home Assistant 2023.8, use 'as_json' instead"
+    )
     return json.dumps(value, ensure_ascii=ensure_ascii)
 
 

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -2036,7 +2036,7 @@ def from_json(value):
 
 def to_json(value, ensure_ascii=True):
     """Convert an object to a JSON string."""
-    _LOGGER.warning("Template warning: 'to_json' is deprecated, use 'as_json' instead")
+    _LOGGER.warning("Template warning: 'to_json' is deprecated and will be removed in Home Assistant 2023.8, use 'as_json' instead")
     return json.dumps(value, ensure_ascii=ensure_ascii)
 
 
@@ -2286,7 +2286,7 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.filters["timestamp_custom"] = timestamp_custom
         self.filters["timestamp_local"] = timestamp_local
         self.filters["timestamp_utc"] = timestamp_utc
-        self.filters["to_json"] = to_json  # deprecated
+        self.filters["to_json"] = to_json  # deprecated, remove in 2023.8
         self.filters["as_json"] = as_json
         self.filters["from_json"] = from_json
         self.filters["is_defined"] = fail_when_undefined

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -2041,22 +2041,19 @@ def _to_json_default(obj: Any) -> None:
 
 def to_json(
     value: Any,
-    ensure_ascii: bool | None = None,  # deprecated - remove in 2023.8
+    ensure_ascii: bool | None = None,
     pretty_print: bool = False,
     sort_keys: bool = False,
 ) -> str:
     """Convert an object to a JSON string."""
     if ensure_ascii is not None:
-        if pretty_print or sort_keys:
-            raise TemplateError(
-                "Template warning: 'to_json' does not support pretty_print or sort_keys when ensure_ascii is specified"
-            )
-        _LOGGER.warning(
-            "Template warning: 'ensure_ascii' is deprecated and will be removed in Home Assistant 2023.8"
-        )
+        # For those who need ascii, we can't use orjson, so we fall back to the json library.
         return json.dumps(
-            value, ensure_ascii=ensure_ascii
-        )  # deprecated - remove in 2023.8
+            value,
+            ensure_ascii=ensure_ascii,
+            indent=2 if pretty_print else None,
+            sort_keys=sort_keys,
+        )
 
     option = (
         ORJSON_PASSTHROUGH_OPTIONS

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -2047,7 +2047,7 @@ def _as_json_default(obj: Any) -> None:
     raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
 
 
-def as_json(value: Any, pretty_print: bool=False, sort_keys: bool=False) -> str:
+def as_json(value: Any, pretty_print: bool = False, sort_keys: bool = False) -> str:
     """Convert an object to a JSON string."""
 
     option = (

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -151,6 +151,10 @@ CACHED_TEMPLATE_NO_COLLECT_LRU: MutableMapping[State, TemplateState] = LRU(
 )
 ENTITY_COUNT_GROWTH_FACTOR = 1.2
 
+ORJSON_PASSTHROUGH_OPTIONS = (
+    orjson.OPT_PASSTHROUGH_DATACLASS | orjson.OPT_PASSTHROUGH_DATETIME
+)
+
 
 def _template_state_no_collect(hass: HomeAssistant, state: State) -> TemplateState:
     """Return a TemplateState for a state without collecting."""
@@ -2036,17 +2040,16 @@ def to_json(value, ensure_ascii=True):
     return json.dumps(value, ensure_ascii=ensure_ascii)
 
 
+def _as_json_default(obj):
+    """Disable custom types in json serialization."""
+    raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
+
+
 def as_json(value, pretty_print=False, sort_keys=False):
     """Convert an object to a JSON string."""
 
-    def default(obj):
-        """Disable custom types."""
-        raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
-
     option = (
-        orjson.OPT_PASSTHROUGH_DATACLASS
-        | orjson.OPT_PASSTHROUGH_DATETIME
-        | orjson.OPT_PASSTHROUGH_SUBCLASS
+        ORJSON_PASSTHROUGH_OPTIONS
         | (orjson.OPT_INDENT_2 if pretty_print else 0)
         | (orjson.OPT_SORT_KEYS if sort_keys else 0)
     )
@@ -2054,7 +2057,7 @@ def as_json(value, pretty_print=False, sort_keys=False):
     return orjson.dumps(
         value,
         option=option,
-        default=default,
+        default=_as_json_default,
     ).decode("utf-8")
 
 

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -2041,12 +2041,12 @@ def _to_json_default(obj: Any) -> None:
 
 def to_json(
     value: Any,
-    ensure_ascii: bool | None = None,
+    ensure_ascii: bool = False,
     pretty_print: bool = False,
     sort_keys: bool = False,
 ) -> str:
     """Convert an object to a JSON string."""
-    if ensure_ascii is not None:
+    if ensure_ascii:
         # For those who need ascii, we can't use orjson, so we fall back to the json library.
         return json.dumps(
             value,

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from datetime import datetime, timedelta
+import json
 import logging
 import math
 import random
@@ -1045,6 +1046,18 @@ def test_to_json(hass: HomeAssistant) -> None:
     actual_result = template.Template(
         "{{ {'Foo': 'Bar'} | to_json }}", hass
     ).async_render()
+    assert actual_result == expected_result
+
+    expected_result = json.dumps({"Foo": "Bar"}, indent=2)
+    actual_result = template.Template(
+        "{{ {'Foo': 'Bar'} | to_json(indent=2) }}", hass
+    ).async_render(parse_result=False)
+    assert actual_result == expected_result
+
+    expected_result = json.dumps({"Z": 26, "A": 1, "M": 13}, sort_keys=True)
+    actual_result = template.Template(
+        "{{ {'Z': 26, 'A': 1, 'M': 13} | to_json(sort_keys=True) }}", hass
+    ).async_render(parse_result=False)
     assert actual_result == expected_result
 
 

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1052,7 +1052,7 @@ def test_to_json(hass: HomeAssistant) -> None:
 def test_as_json(hass: HomeAssistant) -> None:
     """Test the object to JSON string filter."""
 
-    # Note that we're not testing the actua orjson.dumps methods,
+    # Note that we're not testing the actual orjson.dumps methods,
     # only the filters, so we don't need to be exhaustive with our sample JSON.
     expected_result = {"Foo": "Bar"}
     actual_result = template.Template(

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1077,7 +1077,7 @@ def test_to_json_string(hass: HomeAssistant) -> None:
     # Note that we're not testing the actual json.loads and json.dumps methods,
     # only the filters, so we don't need to be exhaustive with our sample JSON.
     actual_value_ascii = template.Template(
-        "{{ 'Bar ҝ éèà' | to_json }}", hass
+        "{{ 'Bar ҝ éèà' | to_json(ensure_ascii=True) }}", hass
     ).async_render()
     assert actual_value_ascii == '"Bar \\u049d \\u00e9\\u00e8\\u00e0"'
     actual_value = template.Template(

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1048,21 +1048,9 @@ def test_to_json(hass: HomeAssistant) -> None:
     ).async_render()
     assert actual_result == expected_result
 
-
-def test_as_json(hass: HomeAssistant) -> None:
-    """Test the object to JSON string filter."""
-
-    # Note that we're not testing the actual orjson.dumps methods,
-    # only the filters, so we don't need to be exhaustive with our sample JSON.
-    expected_result = {"Foo": "Bar"}
-    actual_result = template.Template(
-        "{{ {'Foo': 'Bar'} | as_json }}", hass
-    ).async_render()
-    assert actual_result == expected_result
-
     expected_result = orjson.dumps({"Foo": "Bar"}, option=orjson.OPT_INDENT_2).decode()
     actual_result = template.Template(
-        "{{ {'Foo': 'Bar'} | as_json(pretty_print=True) }}", hass
+        "{{ {'Foo': 'Bar'} | to_json(pretty_print=True) }}", hass
     ).async_render(parse_result=False)
     assert actual_result == expected_result
 
@@ -1070,12 +1058,17 @@ def test_as_json(hass: HomeAssistant) -> None:
         {"Z": 26, "A": 1, "M": 13}, option=orjson.OPT_SORT_KEYS
     ).decode()
     actual_result = template.Template(
-        "{{ {'Z': 26, 'A': 1, 'M': 13} | as_json(sort_keys=True) }}", hass
+        "{{ {'Z': 26, 'A': 1, 'M': 13} | to_json(sort_keys=True) }}", hass
     ).async_render(parse_result=False)
     assert actual_result == expected_result
 
     with pytest.raises(TemplateError):
-        template.Template("{{ {'Foo': now()} | as_json }}", hass).async_render()
+        template.Template("{{ {'Foo': now()} | to_json }}", hass).async_render()
+
+    with pytest.raises(TemplateError):
+        template.Template(
+            "{{ {'Foo': 'Bar'} | to_json(ensure_ascii=True, pretty_print=True) }}", hass
+        ).async_render()
 
 
 def test_to_json_string(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The `ensure_ascii` argument for `to_json` in Jinja templates now defaults to `False`, allowing us to use a faster JSON encoder by default.  For most people, this should not be an issue as JSON parsers broadly accept unicode input.  If you still need to encode unicode characters inside of JSON strings, set `ensure_ascii` to `True` explicitly to restore the old behavior.

## Proposed change

Adds `pretty_print` and `sort_keys`to `to_json` in Jinja templates.  `to_json` now uses the faster orjson serializer by default, which requires us to default `ensure_ascii` to false, though this shouldn't impact many people as parsers following the JSON standard should support unicode in strings anyway. `ensure_ascii` continues to exist for people to set explicitly if they still need this compatibility option.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/26956

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
