### PR TITLE
Make hass test fixture async

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -484,23 +484,23 @@ def hass_fixture_setup() -> list[bool]:
 
 
 @pytest.fixture
-def hass(async_hass: HomeAssistant) -> HomeAssistant:
+def hass(_hass: HomeAssistant) -> HomeAssistant:
     """Fixture to provide a test instance of Home Assistant."""
-    # This cannot be a coroutine, to avoid issues with ContextVar
-    # See https://github.com/pytest-dev/pytest-asyncio/issues/127
-    ha._cv_hass.set(async_hass)
-    return async_hass
+    # This wraps the async _hass fixture inside a sync fixture, to avoid issues with
+    # ContextVar, see https://github.com/pytest-dev/pytest-asyncio/issues/127
+    ha._cv_hass.set(_hass)
+    return _hass
 
 
 @pytest.fixture
-async def async_hass(
+async def _hass(
     hass_fixture_setup: list[bool],
     event_loop: asyncio.AbstractEventLoop,
     load_registries: bool,
     hass_storage: dict[str, Any],
     request: pytest.FixtureRequest,
 ) -> AsyncGenerator[HomeAssistant, None]:
-    """Fixture to provide a test instance of Home Assistant."""
+    """Create a test instance of Home Assistant."""
 
     loop = event_loop
     hass_fixture_setup.append(True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -484,7 +484,16 @@ def hass_fixture_setup() -> list[bool]:
 
 
 @pytest.fixture
-async def hass(
+def hass(async_hass: HomeAssistant) -> HomeAssistant:
+    """Fixture to provide a test instance of Home Assistant."""
+    # This cannot be a coroutine, to avoid issues with ContextVar
+    # See https://github.com/pytest-dev/pytest-asyncio/issues/127
+    ha._cv_hass.set(async_hass)
+    return async_hass
+
+
+@pytest.fixture
+async def async_hass(
     hass_fixture_setup: list[bool],
     event_loop: asyncio.AbstractEventLoop,
     load_registries: bool,
@@ -516,7 +525,6 @@ async def hass(
 
     exceptions: list[Exception] = []
     hass = await async_test_home_assistant(loop, load_registries)
-    ha._cv_hass.set(hass)
 
     orig_exception_handler = loop.get_exception_handler()
     loop.set_exception_handler(exc_handle)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -484,13 +484,13 @@ def hass_fixture_setup() -> list[bool]:
 
 
 @pytest.fixture
-def hass(
+async def hass(
     hass_fixture_setup: list[bool],
     event_loop: asyncio.AbstractEventLoop,
     load_registries: bool,
     hass_storage: dict[str, Any],
     request: pytest.FixtureRequest,
-) -> Generator[HomeAssistant, None, None]:
+) -> AsyncGenerator[HomeAssistant, None]:
     """Fixture to provide a test instance of Home Assistant."""
 
     loop = event_loop
@@ -515,7 +515,7 @@ def hass(
         orig_exception_handler(loop, context)
 
     exceptions: list[Exception] = []
-    hass = loop.run_until_complete(async_test_home_assistant(loop, load_registries))
+    hass = await async_test_home_assistant(loop, load_registries)
     ha._cv_hass.set(hass)
 
     orig_exception_handler = loop.get_exception_handler()
@@ -523,7 +523,7 @@ def hass(
 
     yield hass
 
-    loop.run_until_complete(hass.async_stop(force=True))
+    await hass.async_stop(force=True)
 
     # Restore timezone, it is set when creating the hass object
     dt_util.DEFAULT_TIME_ZONE = orig_tz

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -486,8 +486,9 @@ def hass_fixture_setup() -> list[bool]:
 @pytest.fixture
 def hass(_hass: HomeAssistant) -> HomeAssistant:
     """Fixture to provide a test instance of Home Assistant."""
-    # This wraps the async _hass fixture inside a sync fixture, to avoid issues with
-    # ContextVar, see https://github.com/pytest-dev/pytest-asyncio/issues/127
+    # This wraps the async _hass fixture inside a sync fixture, to ensure
+    # the `hass` context variable is set in the execution context in which
+    # the test itself is executed
     ha._cv_hass.set(_hass)
     return _hass
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Make hass test fixture async

Linked to #90850

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
