### PR TITLE
Update xknx to 2.9.0

### DIFF
--- a/homeassistant/components/knx/config_flow.py
+++ b/homeassistant/components/knx/config_flow.py
@@ -9,10 +9,15 @@ from typing import Any, Final
 
 import voluptuous as vol
 from xknx import XKNX
-from xknx.exceptions.exception import CommunicationError, InvalidSecureConfiguration
+from xknx.exceptions.exception import (
+    CommunicationError,
+    InvalidSecureConfiguration,
+    XKNXException,
+)
 from xknx.io import DEFAULT_MCAST_GRP, DEFAULT_MCAST_PORT
 from xknx.io.gateway_scanner import GatewayDescriptor, GatewayScanner
 from xknx.io.self_description import request_description
+from xknx.io.util import validate_ip as xknx_validate_ip
 from xknx.secure.keyring import Keyring, XMLInterface, sync_load_keyring
 
 from homeassistant.components.file_upload import process_uploaded_file
@@ -258,21 +263,25 @@ class KNXCommonFlow(ABC, FlowHandler):
 
         if user_input is not None:
             try:
-                _host = ip_v4_validator(user_input[CONF_HOST], multicast=False)
-            except vol.Invalid:
+                _host = user_input[CONF_HOST]
+                _host_ip = await xknx_validate_ip(_host)
+                ip_v4_validator(_host_ip, multicast=False)
+            except (vol.Invalid, XKNXException):
                 errors[CONF_HOST] = "invalid_ip_address"
 
-            if _local_ip := user_input.get(CONF_KNX_LOCAL_IP):
+            _local_ip = None
+            if _local := user_input.get(CONF_KNX_LOCAL_IP):
                 try:
-                    _local_ip = ip_v4_validator(_local_ip, multicast=False)
-                except vol.Invalid:
+                    _local_ip = await xknx_validate_ip(_local)
+                    ip_v4_validator(_local_ip, multicast=False)
+                except (vol.Invalid, XKNXException):
                     errors[CONF_KNX_LOCAL_IP] = "invalid_ip_address"
 
             selected_tunnelling_type = user_input[CONF_KNX_TUNNELING_TYPE]
             if not errors:
                 try:
                     self._selected_tunnel = await request_description(
-                        gateway_ip=_host,
+                        gateway_ip=_host_ip,
                         gateway_port=user_input[CONF_PORT],
                         local_ip=_local_ip,
                         route_back=user_input[CONF_KNX_ROUTE_BACK],
@@ -296,7 +305,7 @@ class KNXCommonFlow(ABC, FlowHandler):
                     host=_host,
                     port=user_input[CONF_PORT],
                     route_back=user_input[CONF_KNX_ROUTE_BACK],
-                    local_ip=_local_ip,
+                    local_ip=_local,
                     device_authentication=None,
                     user_id=None,
                     user_password=None,
@@ -636,10 +645,11 @@ class KNXCommonFlow(ABC, FlowHandler):
                 ip_v4_validator(_multicast_group, multicast=True)
             except vol.Invalid:
                 errors[CONF_KNX_MCAST_GRP] = "invalid_ip_address"
-            if _local_ip := user_input.get(CONF_KNX_LOCAL_IP):
+            if _local := user_input.get(CONF_KNX_LOCAL_IP):
                 try:
+                    _local_ip = await xknx_validate_ip(_local)
                     ip_v4_validator(_local_ip, multicast=False)
-                except vol.Invalid:
+                except (vol.Invalid, XKNXException):
                     errors[CONF_KNX_LOCAL_IP] = "invalid_ip_address"
 
             if not errors:
@@ -653,7 +663,7 @@ class KNXCommonFlow(ABC, FlowHandler):
                     individual_address=_individual_address,
                     multicast_group=_multicast_group,
                     multicast_port=_multicast_port,
-                    local_ip=_local_ip,
+                    local_ip=_local,
                     device_authentication=None,
                     user_id=None,
                     user_password=None,

--- a/homeassistant/components/knx/manifest.json
+++ b/homeassistant/components/knx/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_push",
   "loggers": ["xknx"],
   "quality_scale": "platinum",
-  "requirements": ["xknx==2.7.0"]
+  "requirements": ["xknx==2.8.0"]
 }

--- a/homeassistant/components/knx/manifest.json
+++ b/homeassistant/components/knx/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_push",
   "loggers": ["xknx"],
   "quality_scale": "platinum",
-  "requirements": ["xknx==2.8.0"]
+  "requirements": ["xknx==2.9.0"]
 }

--- a/homeassistant/components/knx/schema.py
+++ b/homeassistant/components/knx/schema.py
@@ -10,7 +10,7 @@ from typing import Any, ClassVar, Final
 import voluptuous as vol
 from xknx.devices.climate import SetpointShiftMode
 from xknx.dpt import DPTBase, DPTNumeric, DPTString
-from xknx.exceptions import ConversionError, CouldNotParseAddress
+from xknx.exceptions import ConversionError, CouldNotParseAddress, CouldNotParseTelegram
 from xknx.telegram.address import IndividualAddress, parse_device_group_address
 
 from homeassistant.components.binary_sensor import (
@@ -185,13 +185,13 @@ def button_payload_sub_validator(entity_config: OrderedDict) -> OrderedDict:
             raise vol.Invalid(f"'type: {_type}' is not a valid sensor type.")
         entity_config[CONF_PAYLOAD_LENGTH] = transcoder.payload_length
         try:
-            entity_config[CONF_PAYLOAD] = int.from_bytes(
-                transcoder.to_knx(_payload), byteorder="big"
-            )
-        except ConversionError as ex:
+            _dpt_payload = transcoder.to_knx(_payload)
+            _raw_payload = transcoder.validate_payload(_dpt_payload)
+        except (ConversionError, CouldNotParseTelegram) as ex:
             raise vol.Invalid(
                 f"'payload: {_payload}' not valid for 'type: {_type}'"
             ) from ex
+        entity_config[CONF_PAYLOAD] = int.from_bytes(_raw_payload, byteorder="big")
         return entity_config
 
     _payload = entity_config[CONF_PAYLOAD]

--- a/homeassistant/components/knx/strings.json
+++ b/homeassistant/components/knx/strings.json
@@ -23,13 +23,13 @@
           "port": "[%key:common::config_flow::data::port%]",
           "host": "[%key:common::config_flow::data::host%]",
           "route_back": "Route back / NAT mode",
-          "local_ip": "Local IP of Home Assistant"
+          "local_ip": "Local IP interface"
         },
         "data_description": {
           "port": "Port of the KNX/IP tunneling device.",
-          "host": "IP address of the KNX/IP tunneling device.",
+          "host": "IP address or hostname of the KNX/IP tunneling device.",
           "route_back": "Enable if your KNXnet/IP tunneling server is behind NAT. Only applies for UDP connections.",
-          "local_ip": "Leave blank to use auto-discovery."
+          "local_ip": "Local IP or interface name used for the connection from Home Assistant. Leave blank to use auto-discovery."
         }
       },
       "secure_key_source": {
@@ -93,11 +93,11 @@
           "routing_secure": "Use KNX IP Secure",
           "multicast_group": "Multicast group",
           "multicast_port": "Multicast port",
-          "local_ip": "Local IP of Home Assistant"
+          "local_ip": "[%key:component::knx::config::step::manual_tunnel::data::local_ip%]"
         },
         "data_description": {
           "individual_address": "KNX address to be used by Home Assistant, e.g. `0.0.4`",
-          "local_ip": "Leave blank to use auto-discovery."
+          "local_ip": "[%key:component::knx::config::step::manual_tunnel::data_description::local_ip%]"
         }
       }
     },

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2650,7 +2650,7 @@ xbox-webapi==2.0.11
 xiaomi-ble==0.17.0
 
 # homeassistant.components.knx
-xknx==2.8.0
+xknx==2.9.0
 
 # homeassistant.components.bluesound
 # homeassistant.components.fritz

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2650,7 +2650,7 @@ xbox-webapi==2.0.11
 xiaomi-ble==0.17.0
 
 # homeassistant.components.knx
-xknx==2.7.0
+xknx==2.8.0
 
 # homeassistant.components.bluesound
 # homeassistant.components.fritz

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1908,7 +1908,7 @@ xbox-webapi==2.0.11
 xiaomi-ble==0.17.0
 
 # homeassistant.components.knx
-xknx==2.8.0
+xknx==2.9.0
 
 # homeassistant.components.bluesound
 # homeassistant.components.fritz

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1908,7 +1908,7 @@ xbox-webapi==2.0.11
 xiaomi-ble==0.17.0
 
 # homeassistant.components.knx
-xknx==2.7.0
+xknx==2.8.0
 
 # homeassistant.components.bluesound
 # homeassistant.components.fritz

--- a/tests/components/knx/test_button.py
+++ b/tests/components/knx/test_button.py
@@ -1,9 +1,13 @@
 """Test KNX button."""
 from datetime import timedelta
+import logging
+
+import pytest
 
 from homeassistant.components.knx.const import (
     CONF_PAYLOAD,
     CONF_PAYLOAD_LENGTH,
+    DOMAIN,
     KNX_ADDRESS,
 )
 from homeassistant.components.knx.schema import ButtonSchema
@@ -86,3 +90,49 @@ async def test_button_type(hass: HomeAssistant, knx: KNXTestKit) -> None:
         "button", "press", {"entity_id": "button.test"}, blocking=True
     )
     await knx.assert_write("1/2/3", (0x0C, 0x33))
+
+
+@pytest.mark.parametrize(
+    ("conf_type", "conf_value", "error_msg"),
+    [
+        (
+            "2byte_float",
+            "not_valid",
+            "'payload: not_valid' not valid for 'type: 2byte_float'",
+        ),
+        (
+            "not_valid",
+            3,
+            "type 'not_valid' is not a valid DPT identifier",
+        ),
+    ],
+)
+async def test_button_invalid(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    knx: KNXTestKit,
+    conf_type: str,
+    conf_value: str,
+    error_msg: str,
+) -> None:
+    """Test KNX button with configured payload that can't be encoded."""
+    with caplog.at_level(logging.ERROR):
+        await knx.setup_integration(
+            {
+                ButtonSchema.PLATFORM: {
+                    CONF_NAME: "test",
+                    KNX_ADDRESS: "1/2/3",
+                    ButtonSchema.CONF_VALUE: conf_value,
+                    CONF_TYPE: conf_type,
+                }
+            }
+        )
+        assert len(caplog.messages) == 2
+        record = caplog.records[0]
+        assert record.levelname == "ERROR"
+        assert f"Invalid config for [knx]: {error_msg}" in record.message
+        record = caplog.records[1]
+        assert record.levelname == "ERROR"
+        assert "Setup failed for knx: Invalid config." in record.message
+    assert hass.states.get("button.test") is None
+    assert hass.data.get(DOMAIN) is None

--- a/tests/components/knx/test_events.py
+++ b/tests/components/knx/test_events.py
@@ -1,4 +1,7 @@
 """Test KNX events."""
+import logging
+
+import pytest
 
 from homeassistant.components.knx import CONF_EVENT, CONF_TYPE, KNX_ADDRESS
 from homeassistant.core import HomeAssistant
@@ -8,7 +11,11 @@ from .conftest import KNXTestKit
 from tests.common import async_capture_events
 
 
-async def test_knx_event(hass: HomeAssistant, knx: KNXTestKit) -> None:
+async def test_knx_event(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    knx: KNXTestKit,
+) -> None:
     """Test the `knx_event` event."""
     test_group_a = "0/4/*"
     test_address_a_1 = "0/4/0"
@@ -95,3 +102,16 @@ async def test_knx_event(hass: HomeAssistant, knx: KNXTestKit) -> None:
     await knx.receive_write("2/6/6", True)
     await hass.async_block_till_done()
     assert len(events) == 0
+
+    # receive telegrams with wrong payload length
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        await knx.receive_write(test_address_a_1, (0x03, 0x2F, 0xFF))
+        assert len(caplog.messages) == 1
+        record = caplog.records[0]
+        assert record.levelname == "WARNING"
+        assert (
+            "Error in `knx_event` at decoding type "
+            "'DPT2ByteUnsigned' from telegram" in record.message
+        )
+    await test_event_data(test_address_a_1, (0x03, 0x2F, 0xFF), value=None)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update xknx to 2.9.0 (from 2.7.0)

https://github.com/XKNX/xknx/releases/tag/2.8.0
https://github.com/XKNX/xknx/releases/tag/2.9.0

Some xknx internal method signatures, used in HA, have been changed in this release. These require changes in `__init__.py` and `schema.py`. 
Added tests for these changed validators as they were not tested previously.

Also the xknx internal address validator is now used in `config_flow.py` which allows to pass hostnames and interface names directly (but most users probably use auto-discovery anyway). The IP addresses were saved as stings before, so apart from using the validator and amending `strings.json` there is nothing else to do 😃

In 2.9.0 `asyncio.wait_for` is replaces by `asyncio.timeout`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
