### PR TITLE
Allow uppercase state translation keys in hassfest

### DIFF
--- a/script/hassfest/translations.py
+++ b/script/hassfest/translations.py
@@ -22,6 +22,7 @@ REMOVED = 2
 
 RE_REFERENCE = r"\[\%key:(.+)\%\]"
 RE_TRANSLATION_KEY = re.compile(r"^(?!.+[_-]{2})(?![_-])[a-z0-9-_]+(?<![_-])$")
+RE_STATE_TRANSLATION_KEY = re.compile(r"^(?!.+[_-]{2})(?![_-])[a-zA-Z0-9-_]+(?<![_-])$")
 
 # Only allow translation of integration names if they contain non-brand names
 ALLOW_NAME_TRANSLATION = {
@@ -110,6 +111,17 @@ def translation_key_validator(value: str) -> str:
     if RE_TRANSLATION_KEY.match(value) is None:
         raise vol.Invalid(
             f"Invalid translation key '{value}', need to be [a-z0-9-_]+ and"
+            " cannot start or end with a hyphen or underscore."
+        )
+
+    return value
+
+
+def state_translation_key_validator(value: str) -> str:
+    """Validate value is valid translation key."""
+    if RE_STATE_TRANSLATION_KEY.match(value) is None:
+        raise vol.Invalid(
+            f"Invalid translation key '{value}', need to be [a-zA-Z0-9-_]+ and"
             " cannot start or end with a hyphen or underscore."
         )
 
@@ -269,14 +281,14 @@ def gen_strings_schema(config: Config, integration: Integration) -> vol.Schema:
                     vol.Optional("name"): str,
                     vol.Optional("state"): cv.schema_with_slug_keys(
                         cv.string_with_no_html,
-                        slug_validator=translation_key_validator,
+                        slug_validator=state_translation_key_validator,
                     ),
                     vol.Optional("state_attributes"): cv.schema_with_slug_keys(
                         {
                             vol.Optional("name"): str,
                             vol.Optional("state"): cv.schema_with_slug_keys(
                                 cv.string_with_no_html,
-                                slug_validator=translation_key_validator,
+                                slug_validator=state_translation_key_validator,
                             ),
                         },
                         slug_validator=translation_key_validator,
@@ -290,14 +302,14 @@ def gen_strings_schema(config: Config, integration: Integration) -> vol.Schema:
                         vol.Optional("name"): cv.string_with_no_html,
                         vol.Optional("state"): cv.schema_with_slug_keys(
                             cv.string_with_no_html,
-                            slug_validator=translation_key_validator,
+                            slug_validator=state_translation_key_validator,
                         ),
                         vol.Optional("state_attributes"): cv.schema_with_slug_keys(
                             {
                                 vol.Optional("name"): cv.string_with_no_html,
                                 vol.Optional("state"): cv.schema_with_slug_keys(
                                     cv.string_with_no_html,
-                                    slug_validator=translation_key_validator,
+                                    slug_validator=state_translation_key_validator,
                                 ),
                             },
                             slug_validator=translation_key_validator,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR allows translation keys for *state* and *state attribute* **values** to be uppercase. This enables translating existing mixed/upper case values without introducing breaking changes by forcing the values to be lowercase only.

---

While working on https://github.com/home-assistant/core/pull/91248, I also tried to add state translations using the JSON below.

It works perfectly, but `hassfest` doesn't allow uppercase translation keys.

```json
    "sensor": {
      "charging_status": {
        "name": "Charging Status",
        "state": {
          "DEFAULT": "Default",
          ...
          "TARGET_REACHED": "Target reached"
        }
      },
```

An alternative option would be adding a breaking change that forces all state and attribute values to be lower case, thereby possibly breaking automations & checks on these valuees.

Another alternative could be adjusting the frontend and always forcing the translation value to be looked up to lowercase. However I feel this would add even more complexity in understanding how translations are working - there would be just a random `lower()` somewhere in the frontend code.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/actions/issues/87
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
