### PR TITLE
Add language util

### DIFF
--- a/homeassistant/util/language.py
+++ b/homeassistant/util/language.py
@@ -79,6 +79,7 @@ class Dialect:
             # Language + region match
             return 1
 
+        pref_regions: set[str | None] = set()
         if (self.region is None) or (dialect.region is None):
             # Generate a set of preferred regions
             pref_regions = set(

--- a/homeassistant/util/language.py
+++ b/homeassistant/util/language.py
@@ -1,0 +1,144 @@
+"""Helper methods for language selection in Home Assistant."""
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+import operator
+import re
+
+SEPARATOR_RE = re.compile(r"[-_]")
+
+
+def preferred_regions(
+    language: str,
+    country: str | None = None,
+    code: str | None = None,
+) -> Iterable[str | None]:
+    """Yield preferred regions for a language based on country/code hints."""
+    if country is not None:
+        yield country.upper()
+
+    if language == "en":
+        # Prefer U.S. English if no country
+        if country is None:
+            yield "US"
+    elif language == "zh":
+        if code == "Hant":
+            yield "HK"
+        elif code == "Hans":
+            yield "TW"
+        else:
+            # Prefer China if no matching code
+            yield "CN"
+
+    # fr -> fr-FR
+    yield language.upper()
+
+
+def is_region(language: str, region: str | None) -> bool:
+    """Return true if region is not known to be a script/code instead."""
+    if language == "es":
+        return region != "419"
+
+    if language == "sr":
+        return region != "Latn"
+
+    if language == "zh":
+        return region not in ("Hans", "Hant")
+
+    return True
+
+
+@dataclass
+class Dialect:
+    """Language with optional region and script/code."""
+
+    language: str
+    region: str | None
+    code: str | None = None
+
+    def __post_init__(self) -> None:
+        """Fix casing of language/region."""
+        # Languages are lower-cased
+        self.language = self.language.casefold()
+
+        if self.region is not None:
+            # Regions are upper-cased
+            self.region = self.region.upper()
+
+    def score(self, dialect: Dialect, country: str | None = None) -> int:
+        """Return score for match with another dialect where higher is better.
+
+        Score < 0 indicates a failure to match.
+        """
+        if self.language != dialect.language:
+            # Not a match
+            return -1
+
+        if self.region == dialect.region:
+            # Language + region match
+            return 1
+
+        if (self.region is None) or (dialect.region is None):
+            # Generate a set of preferred regions
+            pref_regions = set(
+                preferred_regions(
+                    self.language,
+                    country=country,
+                    code=self.code,
+                )
+            )
+
+        # Replace missing regions with preferred
+        regions = pref_regions if self.region is None else {self.region}
+        other_regions = pref_regions if dialect.region is None else {dialect.region}
+
+        # Better match if there is overlap in regions
+        return 1 if regions.intersection(other_regions) else 0
+
+    @staticmethod
+    def parse(tag: str) -> Dialect:
+        """Parse language tag into language/region/code."""
+        parts = SEPARATOR_RE.split(tag, maxsplit=1)
+        language = parts[0]
+        region: str | None = None
+        code: str | None = None
+
+        if len(parts) > 1:
+            region_or_code = parts[1]
+            if is_region(language, region_or_code):
+                # US, GB, etc.
+                region = region_or_code
+            else:
+                # Hant, 419, etc.
+                code = region_or_code
+
+        return Dialect(
+            language=language,
+            region=region,
+            code=code,
+        )
+
+
+def matches(
+    target: str, supported: Iterable[str], country: str | None = None
+) -> list[str]:
+    """Return a sorted list of matching language tags based on a target tag and country hint."""
+    target_dialect = Dialect.parse(target)
+
+    # Higher score is better
+    scored = sorted(
+        (
+            (
+                dialect := Dialect.parse(tag),
+                target_dialect.score(dialect, country=country),
+                tag,
+            )
+            for tag in supported
+        ),
+        key=operator.itemgetter(1),
+        reverse=True,
+    )
+
+    # Score < 0 is not a match
+    return [tag for _dialect, score, tag in scored if score >= 0]

--- a/tests/util/test_language.py
+++ b/tests/util/test_language.py
@@ -12,6 +12,25 @@ def test_region_match() -> None:
     ]
 
 
+def test_no_match() -> None:
+    """Test that an empty list is returned when there is no match."""
+    assert (
+        language.matches(
+            "en-US",
+            ["de-DE", "fr-FR", "zh"],
+        )
+        == []
+    )
+
+    assert (
+        language.matches(
+            "en",
+            ["de-DE", "fr-FR", "zh"],
+        )
+        == []
+    )
+
+
 def test_prefer_us_english() -> None:
     """Test that U.S. English is preferred when no region is provided."""
     assert language.matches("en", ["en-GB", "en-US", "fr-FR"]) == [

--- a/tests/util/test_language.py
+++ b/tests/util/test_language.py
@@ -1,0 +1,102 @@
+"""Test Home Assistant language util methods."""
+from __future__ import annotations
+
+from homeassistant.util import language
+
+
+def test_region_match() -> None:
+    """Test that an exact language/region match is preferred."""
+    assert language.matches("en-GB", ["fr-Fr", "en-US", "en-GB"]) == [
+        "en-GB",
+        "en-US",
+    ]
+
+
+def test_prefer_us_english() -> None:
+    """Test that U.S. English is preferred when no region is provided."""
+    assert language.matches("en", ["en-GB", "en-US", "fr-FR"]) == [
+        "en-US",
+        "en-GB",
+    ]
+
+
+def test_country_preferred() -> None:
+    """Test that country hint disambiguates."""
+    assert language.matches(
+        "en",
+        ["fr-Fr", "en-US", "en-GB"],
+        country="GB",
+    ) == [
+        "en-GB",
+        "en-US",
+    ]
+
+
+def test_language_as_region() -> None:
+    """Test that the language itself can be interpreted as a region."""
+    assert language.matches(
+        "fr",
+        ["en-US", "en-GB", "fr-CA", "fr-FR"],
+    ) == [
+        "fr-FR",
+        "fr-CA",
+    ]
+
+
+def test_zh_hant() -> None:
+    """Test that the zh-Hant defaults to HK."""
+    assert language.matches(
+        "zh-Hant",
+        ["en-US", "en-GB", "zh-CN", "zh-HK", "zh-TW"],
+    ) == [
+        "zh-HK",
+        "zh-CN",
+        "zh-TW",
+    ]
+
+
+def test_zh_hans() -> None:
+    """Test that the zh-Hans defaults to TW."""
+    assert language.matches(
+        "zh-Hans",
+        ["en-US", "en-GB", "zh-CN", "zh-HK", "zh-TW"],
+    ) == [
+        "zh-TW",
+        "zh-CN",
+        "zh-HK",
+    ]
+
+
+def test_zh_no_code() -> None:
+    """Test that the zh defaults to CN."""
+    assert language.matches(
+        "zh",
+        ["en-US", "en-GB", "zh-CN", "zh-HK", "zh-TW"],
+    ) == [
+        "zh-CN",
+        "zh-HK",
+        "zh-TW",
+    ]
+
+
+def test_es_419() -> None:
+    """Test that the es-419 matches es dialects."""
+    assert language.matches(
+        "es-419",
+        ["en-US", "en-GB", "es-CL", "es-US", "es-ES"],
+    ) == [
+        "es-ES",
+        "es-CL",
+        "es-US",
+    ]
+
+
+def test_sr_latn() -> None:
+    """Test that the sr_Latn matches sr dialects."""
+    assert language.matches(
+        "sr-Latn",
+        ["en-US", "en-GB", "sr-CS", "sr-RS"],
+    ) == [
+        "sr-CS",
+        "sr-RS",
+    ]

--- a/tests/util/test_language.py
+++ b/tests/util/test_language.py
@@ -30,6 +30,8 @@ def test_no_match() -> None:
         == []
     )
 
+    assert language.matches("en", []) == []
+
 
 def test_prefer_us_english() -> None:
     """Test that U.S. English is preferred when no region is provided."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds `util.language.matches` to filter/sort a list of supported languages based on a target language.
Allows for a country hint, and handles cases where language includes script (e.g., `Hant`) instead of region. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
