### PR TITLE
Bump httpx to 0.24.0 and httpcore to 0.17.0

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -27,7 +27,7 @@ hassil==1.0.6
 home-assistant-bluetooth==1.9.3
 home-assistant-frontend==20230411.0
 home-assistant-intents==2023.3.29
-httpx==0.23.3
+httpx==0.24.0
 ifaddr==0.1.7
 janus==1.0.0
 jinja2==3.1.2
@@ -100,7 +100,7 @@ regex==2021.8.28
 # requirements so we can directly link HA versions to these library versions.
 anyio==3.6.2
 h11==0.14.0
-httpcore==0.16.3
+httpcore==0.17.0
 
 # Ensure we have a hyperframe version that works in Python 3.10
 # 5.2.0 fixed a collections abc deprecation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies    = [
     "ciso8601==2.3.0",
     # When bumping httpx, please check the version pins of
     # httpcore, anyio, and h11 in gen_requirements_all
-    "httpx==0.23.3",
+    "httpx==0.24.0",
     "home-assistant-bluetooth==1.9.3",
     "ifaddr==0.1.7",
     "jinja2==3.1.2",

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ awesomeversion==22.9.0
 bcrypt==4.0.1
 certifi>=2021.5.30
 ciso8601==2.3.0
-httpx==0.23.3
+httpx==0.24.0
 home-assistant-bluetooth==1.9.3
 ifaddr==0.1.7
 jinja2==3.1.2

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -105,7 +105,7 @@ regex==2021.8.28
 # requirements so we can directly link HA versions to these library versions.
 anyio==3.6.2
 h11==0.14.0
-httpcore==0.16.3
+httpcore==0.17.0
 
 # Ensure we have a hyperframe version that works in Python 3.10
 # 5.2.0 fixed a collections abc deprecation

--- a/tests/components/generic/test_config_flow.py
+++ b/tests/components/generic/test_config_flow.py
@@ -308,7 +308,7 @@ async def test_form_only_still_sample(
         ),
         (
             "invalid1://invalid:4\\1",
-            "invalid1://invalid:4%5c1",
+            "invalid1://invalid:41",
             "user",
             {"still_image_url": "malformed_url"},
         ),

--- a/tests/components/generic/test_config_flow.py
+++ b/tests/components/generic/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test The generic (IP Camera) config flow."""
+import contextlib
 import errno
 from http import HTTPStatus
 import os.path
@@ -308,7 +309,7 @@ async def test_form_only_still_sample(
         ),
         (
             "invalid1://invalid:4\\1",
-            "invalid1://invalid:41",
+            "invalid1://invalid:4%5c1",
             "user",
             {"still_image_url": "malformed_url"},
         ),
@@ -330,7 +331,8 @@ async def test_still_template(
     expected_errors,
 ) -> None:
     """Test we can handle various templates."""
-    respx.get(url).respond(stream=fakeimgbytes_png)
+    with contextlib.suppress(httpx.InvalidURL):
+        respx.get(url).respond(stream=fakeimgbytes_png)
     data = TESTDATA.copy()
     data.pop(CONF_STREAM_SOURCE)
     data[CONF_STILL_IMAGE_URL] = template

--- a/tests/components/generic/test_config_flow.py
+++ b/tests/components/generic/test_config_flow.py
@@ -332,6 +332,8 @@ async def test_still_template(
 ) -> None:
     """Test we can handle various templates."""
     with contextlib.suppress(httpx.InvalidURL):
+        # There is no need to mock the request if its an
+        # invalid url because we will never make the request
         respx.get(url).respond(stream=fakeimgbytes_png)
     data = TESTDATA.copy()
     data.pop(CONF_STREAM_SOURCE)


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
changelog:
https://github.com/encode/httpcore/releases/tag/0.17.0 https://github.com/encode/httpx/releases/tag/0.24.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
