### PR TITLE
Pipelines to default to Home Assistant agent

### DIFF
--- a/homeassistant/components/conversation/__init__.py
+++ b/homeassistant/components/conversation/__init__.py
@@ -18,10 +18,12 @@ from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import bind_hass
 
 from .agent import AbstractConversationAgent, ConversationInput, ConversationResult
+from .const import HOME_ASSISTANT_AGENT
 from .default_agent import DefaultAgent
 
 __all__ = [
     "DOMAIN",
+    "HOME_ASSISTANT_AGENT",
     "async_converse",
     "async_get_agent_info",
     "async_set_agent",
@@ -333,8 +335,6 @@ async def async_converse(
 class AgentManager:
     """Class to manage conversation agents."""
 
-    HOME_ASSISTANT_AGENT = "homeassistant"
-
     default_agent: str = HOME_ASSISTANT_AGENT
     _builtin_agent: AbstractConversationAgent | None = None
 
@@ -351,7 +351,7 @@ class AgentManager:
         if agent_id is None:
             agent_id = self.default_agent
 
-        if agent_id == AgentManager.HOME_ASSISTANT_AGENT:
+        if agent_id == HOME_ASSISTANT_AGENT:
             if self._builtin_agent is not None:
                 return self._builtin_agent
 
@@ -376,7 +376,7 @@ class AgentManager:
         """List all agents."""
         agents: list[AgentInfo] = [
             {
-                "id": AgentManager.HOME_ASSISTANT_AGENT,
+                "id": HOME_ASSISTANT_AGENT,
                 "name": "Home Assistant",
             }
         ]
@@ -401,18 +401,18 @@ class AgentManager:
     @core.callback
     def async_is_valid_agent_id(self, agent_id: str) -> bool:
         """Check if the agent id is valid."""
-        return agent_id in self._agents or agent_id == AgentManager.HOME_ASSISTANT_AGENT
+        return agent_id in self._agents or agent_id == HOME_ASSISTANT_AGENT
 
     @core.callback
     def async_set_agent(self, agent_id: str, agent: AbstractConversationAgent) -> None:
         """Set the agent."""
         self._agents[agent_id] = agent
-        if self.default_agent == AgentManager.HOME_ASSISTANT_AGENT:
+        if self.default_agent == HOME_ASSISTANT_AGENT:
             self.default_agent = agent_id
 
     @core.callback
     def async_unset_agent(self, agent_id: str) -> None:
         """Unset the agent."""
         if self.default_agent == agent_id:
-            self.default_agent = AgentManager.HOME_ASSISTANT_AGENT
+            self.default_agent = HOME_ASSISTANT_AGENT
         self._agents.pop(agent_id, None)

--- a/homeassistant/components/conversation/const.py
+++ b/homeassistant/components/conversation/const.py
@@ -1,3 +1,4 @@
 """Const for conversation integration."""
 
 DOMAIN = "conversation"
+HOME_ASSISTANT_AGENT = "homeassistant"

--- a/homeassistant/components/voice_assistant/pipeline.py
+++ b/homeassistant/components/voice_assistant/pipeline.py
@@ -289,7 +289,10 @@ class PipelineRun:
     async def prepare_recognize_intent(self) -> None:
         """Prepare recognizing an intent."""
         agent_info = conversation.async_get_agent_info(
-            self.hass, self.pipeline.conversation_engine
+            self.hass,
+            # If no conversation engine is set, use the Home Assistant agent
+            # (the conversation integration default is currently the last one set)
+            self.pipeline.conversation_engine or conversation.HOME_ASSISTANT_AGENT,
         )
 
         if agent_info is None:

--- a/tests/components/conversation/test_init.py
+++ b/tests/components/conversation/test_init.py
@@ -25,7 +25,7 @@ from . import expose_entity, expose_new
 from tests.common import MockConfigEntry, MockUser, async_mock_service
 from tests.typing import ClientSessionGenerator, WebSocketGenerator
 
-AGENT_ID_OPTIONS = [None, conversation.AgentManager.HOME_ASSISTANT_AGENT]
+AGENT_ID_OPTIONS = [None, conversation.HOME_ASSISTANT_AGENT]
 
 
 class OrderBeerIntentHandler(intent.IntentHandler):
@@ -1569,7 +1569,7 @@ async def test_agent_id_validator_invalid_agent(hass: HomeAssistant) -> None:
     with pytest.raises(vol.Invalid):
         conversation.agent_id_validator("invalid_agent")
 
-    conversation.agent_id_validator(conversation.AgentManager.HOME_ASSISTANT_AGENT)
+    conversation.agent_id_validator(conversation.HOME_ASSISTANT_AGENT)
 
 
 async def test_get_agent_list(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Voice Assistant pipelines that have conversation agent set to "default" should load the Home Assistant agent instead of the last conversation agent to be loaded.

This PR can be reverted if conversation gets migrated to service entities and removes the notion of default conversation agents (probably never).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
