### PR TITLE
Fix race condition in deconz

### DIFF
--- a/homeassistant/components/deconz/gateway.py
+++ b/homeassistant/components/deconz/gateway.py
@@ -235,9 +235,15 @@ class DeconzGateway:
     ) -> None:
         """Handle signals of config entry being updated.
 
-        This is a static method because a class method (bound method), cannot be used with weak references.
-        Causes for this is either discovery updating host address or config entry options changing.
+        This is a static method because a class method (bound method),
+        cannot be used with weak references.
+        Causes for this is either discovery updating host address or
+        config entry options changing.
         """
+        if entry.entry_id not in hass.data[DECONZ_DOMAIN]:
+            # A race condition can occur if multiple config entries are
+            # unloaded in parallel
+            return
         gateway = get_gateway_from_config_entry(hass, entry)
 
         if gateway.api.host != gateway.host:

--- a/tests/components/deconz/test_init.py
+++ b/tests/components/deconz/test_init.py
@@ -98,10 +98,6 @@ async def test_setup_entry_multiple_gateways(
     assert hass.data[DECONZ_DOMAIN][config_entry.entry_id].master
     assert not hass.data[DECONZ_DOMAIN][config_entry2.entry_id].master
 
-    await asyncio.gather(
-        config_entry.async_unload(hass), config_entry2.async_unload(hass)
-    )
-
 
 async def test_unload_entry(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
@@ -136,6 +132,31 @@ async def test_unload_entry_multiple_gateways(
 
     assert len(hass.data[DECONZ_DOMAIN]) == 1
     assert hass.data[DECONZ_DOMAIN][config_entry2.entry_id].master
+
+
+async def test_unload_entry_multiple_gateways_parallel(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Test race condition when unloading multiple config entries in parallel."""
+    config_entry = await setup_deconz_integration(hass, aioclient_mock)
+    aioclient_mock.clear_requests()
+
+    data = {"config": {"bridgeid": "01234E56789B"}}
+    with patch.dict(DECONZ_WEB_REQUEST, data):
+        config_entry2 = await setup_deconz_integration(
+            hass,
+            aioclient_mock,
+            entry_id="2",
+            unique_id="01234E56789B",
+        )
+
+    assert len(hass.data[DECONZ_DOMAIN]) == 2
+
+    await asyncio.gather(
+        config_entry.async_unload(hass), config_entry2.async_unload(hass)
+    )
+
+    assert len(hass.data[DECONZ_DOMAIN]) == 0
 
 
 async def test_update_group_unique_id(hass: HomeAssistant) -> None:

--- a/tests/components/deconz/test_init.py
+++ b/tests/components/deconz/test_init.py
@@ -1,4 +1,5 @@
 """Test deCONZ component setup process."""
+import asyncio
 from unittest.mock import patch
 
 from homeassistant.components.deconz import (
@@ -96,6 +97,10 @@ async def test_setup_entry_multiple_gateways(
     assert len(hass.data[DECONZ_DOMAIN]) == 2
     assert hass.data[DECONZ_DOMAIN][config_entry.entry_id].master
     assert not hass.data[DECONZ_DOMAIN][config_entry2.entry_id].master
+
+    await asyncio.gather(
+        config_entry.async_unload(hass), config_entry2.async_unload(hass)
+    )
 
 
 async def test_unload_entry(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Spotted in #90850

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
