### PR TITLE
Rename Particulate matter sensors to PM

### DIFF
--- a/homeassistant/components/gios/strings.json
+++ b/homeassistant/components/gios/strings.json
@@ -74,7 +74,7 @@
         "name": "[%key:component::sensor::entity_component::pm10::name%]"
       },
       "pm10_index": {
-        "name": "Particulate matter 10 μm index",
+        "name": "PM10 index",
         "state": {
           "very_bad": "[%key:component::gios::entity::sensor::aqi::state::very_bad%]",
           "bad": "[%key:component::gios::entity::sensor::aqi::state::bad%]",
@@ -88,7 +88,7 @@
         "name": "[%key:component::sensor::entity_component::pm25::name%]"
       },
       "pm25_index": {
-        "name": "Particulate matter 2.5 μm index",
+        "name": "PM2.5 index",
         "state": {
           "very_bad": "[%key:component::gios::entity::sensor::aqi::state::very_bad%]",
           "bad": "[%key:component::gios::entity::sensor::aqi::state::bad%]",

--- a/homeassistant/components/nam/strings.json
+++ b/homeassistant/components/nam/strings.json
@@ -89,13 +89,13 @@
         }
       },
       "pmsx003_pm1": {
-        "name": "PMSx003 particulate matter 1 μm"
+        "name": "PMSx003 PM1"
       },
       "pmsx003_pm10": {
-        "name": "PMSx003 particulate matter 10 μm"
+        "name": "PMSx003 PM10"
       },
       "pmsx003_pm25": {
-        "name": "PMSx003 particulate matter 2.5 μm"
+        "name": "PMSx003 PM2.5"
       },
       "sds011_caqi": {
         "name": "SDS011 common air quality index"
@@ -111,10 +111,10 @@
         }
       },
       "sds011_pm10": {
-        "name": "SDS011 particulate matter 10 μm"
+        "name": "SDS011 PM10"
       },
       "sds011_pm25": {
-        "name": "SDS011 particulate matter 2.5 μm"
+        "name": "SDS011 PM2.5"
       },
       "sht3x_humidity": {
         "name": "SHT3X humidity"
@@ -136,16 +136,16 @@
         }
       },
       "sps30_pm1": {
-        "name": "SPS30 particulate matter 1 μm"
+        "name": "SPS30 PM1"
       },
       "sps30_pm10": {
-        "name": "SPS30 particulate matter 10 μm"
+        "name": "SPS30 PM10"
       },
       "sps30_pm25": {
-        "name": "SPS30 particulate matter 2.5 μm"
+        "name": "SPS30 PM2.5"
       },
       "sps30_pm4": {
-        "name": "SPS30 Particulate matter 4 μm"
+        "name": "SPS30 PM4"
       },
       "dht22_humidity": {
         "name": "DHT22 humidity"

--- a/homeassistant/components/sensor/strings.json
+++ b/homeassistant/components/sensor/strings.json
@@ -197,13 +197,13 @@
       "name": "Ozone"
     },
     "pm1": {
-      "name": "Particulate matter 1 μm"
+      "name": "PM1"
     },
     "pm10": {
-      "name": "Particulate matter 10 μm"
+      "name": "PM10"
     },
     "pm25": {
-      "name": "Particulate matter 2.5 μm"
+      "name": "PM2.5"
     },
     "power_factor": {
       "name": "Power factor"

--- a/tests/components/airly/test_init.py
+++ b/tests/components/airly/test_init.py
@@ -25,7 +25,7 @@ async def test_async_setup_entry(
     """Test a successful setup entry."""
     await init_integration(hass, aioclient_mock)
 
-    state = hass.states.get("sensor.home_particulate_matter_2_5_mm")
+    state = hass.states.get("sensor.home_pm2_5")
     assert state is not None
     assert state.state != STATE_UNAVAILABLE
     assert state.state == "4.37"

--- a/tests/components/airly/test_sensor.py
+++ b/tests/components/airly/test_sensor.py
@@ -63,7 +63,7 @@ async def test_sensor(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker) 
     assert entry.unique_id == "123-456-humidity"
     assert entry.options["sensor"] == {"suggested_display_precision": 1}
 
-    state = hass.states.get("sensor.home_particulate_matter_1_mm")
+    state = hass.states.get("sensor.home_pm1")
     assert state
     assert state.state == "2.83"
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
@@ -74,12 +74,12 @@ async def test_sensor(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker) 
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.PM1
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
 
-    entry = registry.async_get("sensor.home_particulate_matter_1_mm")
+    entry = registry.async_get("sensor.home_pm1")
     assert entry
     assert entry.unique_id == "123-456-pm1"
     assert entry.options["sensor"] == {"suggested_display_precision": 0}
 
-    state = hass.states.get("sensor.home_particulate_matter_2_5_mm")
+    state = hass.states.get("sensor.home_pm2_5")
     assert state
     assert state.state == "4.37"
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
@@ -90,12 +90,12 @@ async def test_sensor(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker) 
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.PM25
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
 
-    entry = registry.async_get("sensor.home_particulate_matter_2_5_mm")
+    entry = registry.async_get("sensor.home_pm2_5")
     assert entry
     assert entry.unique_id == "123-456-pm25"
     assert entry.options["sensor"] == {"suggested_display_precision": 0}
 
-    state = hass.states.get("sensor.home_particulate_matter_10_mm")
+    state = hass.states.get("sensor.home_pm10")
     assert state
     assert state.state == "6.06"
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
@@ -106,7 +106,7 @@ async def test_sensor(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker) 
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.PM10
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
 
-    entry = registry.async_get("sensor.home_particulate_matter_10_mm")
+    entry = registry.async_get("sensor.home_pm10")
     assert entry
     assert entry.unique_id == "123-456-pm10"
     assert entry.options["sensor"] == {"suggested_display_precision": 0}

--- a/tests/components/gios/test_init.py
+++ b/tests/components/gios/test_init.py
@@ -18,7 +18,7 @@ async def test_async_setup_entry(hass: HomeAssistant) -> None:
     """Test a successful setup entry."""
     await init_integration(hass)
 
-    state = hass.states.get("sensor.home_particulate_matter_2_5_mm")
+    state = hass.states.get("sensor.home_pm2_5")
     assert state is not None
     assert state.state != STATE_UNAVAILABLE
     assert state.state == "4"

--- a/tests/components/gios/test_sensor.py
+++ b/tests/components/gios/test_sensor.py
@@ -131,7 +131,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
     assert entry
     assert entry.unique_id == "123-o3-index"
 
-    state = hass.states.get("sensor.home_particulate_matter_10_mm")
+    state = hass.states.get("sensor.home_pm10")
     assert state
     assert state.state == "16.8344"
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
@@ -142,11 +142,11 @@ async def test_sensor(hass: HomeAssistant) -> None:
         == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
 
-    entry = registry.async_get("sensor.home_particulate_matter_10_mm")
+    entry = registry.async_get("sensor.home_pm10")
     assert entry
     assert entry.unique_id == "123-pm10"
 
-    state = hass.states.get("sensor.home_particulate_matter_10_mm_index")
+    state = hass.states.get("sensor.home_pm10_index")
     assert state
     assert state.state == "good"
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
@@ -160,11 +160,11 @@ async def test_sensor(hass: HomeAssistant) -> None:
         "very_good",
     ]
 
-    entry = registry.async_get("sensor.home_particulate_matter_10_mm_index")
+    entry = registry.async_get("sensor.home_pm10_index")
     assert entry
     assert entry.unique_id == "123-pm10-index"
 
-    state = hass.states.get("sensor.home_particulate_matter_2_5_mm")
+    state = hass.states.get("sensor.home_pm2_5")
     assert state
     assert state.state == "4"
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
@@ -175,11 +175,11 @@ async def test_sensor(hass: HomeAssistant) -> None:
         == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
 
-    entry = registry.async_get("sensor.home_particulate_matter_2_5_mm")
+    entry = registry.async_get("sensor.home_pm2_5")
     assert entry
     assert entry.unique_id == "123-pm25"
 
-    state = hass.states.get("sensor.home_particulate_matter_2_5_mm_index")
+    state = hass.states.get("sensor.home_pm2_5_index")
     assert state
     assert state.state == "good"
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
@@ -193,7 +193,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
         "very_good",
     ]
 
-    entry = registry.async_get("sensor.home_particulate_matter_2_5_mm_index")
+    entry = registry.async_get("sensor.home_pm2_5_index")
     assert entry
     assert entry.unique_id == "123-pm25-index"
 
@@ -257,11 +257,11 @@ async def test_availability(hass: HomeAssistant) -> None:
 
     await init_integration(hass)
 
-    state = hass.states.get("sensor.home_particulate_matter_2_5_mm")
+    state = hass.states.get("sensor.home_pm2_5")
     assert state
     assert state.state == "4"
 
-    state = hass.states.get("sensor.home_particulate_matter_2_5_mm_index")
+    state = hass.states.get("sensor.home_pm2_5_index")
     assert state
     assert state.state == "good"
 
@@ -277,11 +277,11 @@ async def test_availability(hass: HomeAssistant) -> None:
         async_fire_time_changed(hass, future)
         await hass.async_block_till_done()
 
-        state = hass.states.get("sensor.home_particulate_matter_2_5_mm")
+        state = hass.states.get("sensor.home_pm2_5")
         assert state
         assert state.state == STATE_UNAVAILABLE
 
-        state = hass.states.get("sensor.home_particulate_matter_2_5_mm_index")
+        state = hass.states.get("sensor.home_pm2_5_index")
         assert state
         assert state.state == STATE_UNAVAILABLE
 
@@ -300,7 +300,7 @@ async def test_availability(hass: HomeAssistant) -> None:
         async_fire_time_changed(hass, future)
         await hass.async_block_till_done()
 
-        state = hass.states.get("sensor.home_particulate_matter_2_5_mm")
+        state = hass.states.get("sensor.home_pm2_5")
         assert state
         assert state.state == "4"
 
@@ -310,7 +310,7 @@ async def test_availability(hass: HomeAssistant) -> None:
         assert state.state == STATE_UNAVAILABLE
 
         # Indexes are empty so the state should be unavailable
-        state = hass.states.get("sensor.home_particulate_matter_2_5_mm_index")
+        state = hass.states.get("sensor.home_pm2_5_index")
         assert state
         assert state.state == STATE_UNAVAILABLE
 
@@ -324,11 +324,11 @@ async def test_availability(hass: HomeAssistant) -> None:
         async_fire_time_changed(hass, future)
         await hass.async_block_till_done()
 
-        state = hass.states.get("sensor.home_particulate_matter_2_5_mm")
+        state = hass.states.get("sensor.home_pm2_5")
         assert state
         assert state.state == "4"
 
-        state = hass.states.get("sensor.home_particulate_matter_2_5_mm_index")
+        state = hass.states.get("sensor.home_pm2_5_index")
         assert state
         assert state.state == "good"
 
@@ -349,11 +349,11 @@ async def test_invalid_indexes(hass: HomeAssistant) -> None:
     assert state
     assert state.state == STATE_UNAVAILABLE
 
-    state = hass.states.get("sensor.home_particulate_matter_10_mm_index")
+    state = hass.states.get("sensor.home_pm10_index")
     assert state
     assert state.state == STATE_UNAVAILABLE
 
-    state = hass.states.get("sensor.home_particulate_matter_2_5_mm_index")
+    state = hass.states.get("sensor.home_pm2_5_index")
     assert state
     assert state.state == STATE_UNAVAILABLE
 
@@ -373,12 +373,12 @@ async def test_unique_id_migration(hass: HomeAssistant) -> None:
         PLATFORM,
         DOMAIN,
         "123-pm2.5",
-        suggested_object_id="home_particulate_matter_2_5_mm",
+        suggested_object_id="home_pm2_5",
         disabled_by=None,
     )
 
     await init_integration(hass)
 
-    entry = registry.async_get("sensor.home_particulate_matter_2_5_mm")
+    entry = registry.async_get("sensor.home_pm2_5")
     assert entry
     assert entry.unique_id == "123-pm25"

--- a/tests/components/luftdaten/test_sensor.py
+++ b/tests/components/luftdaten/test_sensor.py
@@ -87,18 +87,15 @@ async def test_luftdaten_sensors(
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfPressure.PA
     assert ATTR_ICON not in state.attributes
 
-    entry = entity_registry.async_get("sensor.sensor_12345_particulate_matter_10_mm")
+    entry = entity_registry.async_get("sensor.sensor_12345_pm10")
     assert entry
     assert entry.device_id
     assert entry.unique_id == "12345_P1"
 
-    state = hass.states.get("sensor.sensor_12345_particulate_matter_10_mm")
+    state = hass.states.get("sensor.sensor_12345_pm10")
     assert state
     assert state.state == "8.5"
-    assert (
-        state.attributes.get(ATTR_FRIENDLY_NAME)
-        == "Sensor 12345 Particulate matter 10 μm"
-    )
+    assert state.attributes.get(ATTR_FRIENDLY_NAME) == "Sensor 12345 PM10"
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.PM10
     assert state.attributes.get(ATTR_STATE_CLASS) is SensorStateClass.MEASUREMENT
     assert (
@@ -107,18 +104,15 @@ async def test_luftdaten_sensors(
     )
     assert ATTR_ICON not in state.attributes
 
-    entry = entity_registry.async_get("sensor.sensor_12345_particulate_matter_2_5_mm")
+    entry = entity_registry.async_get("sensor.sensor_12345_pm2_5")
     assert entry
     assert entry.device_id
     assert entry.unique_id == "12345_P2"
 
-    state = hass.states.get("sensor.sensor_12345_particulate_matter_2_5_mm")
+    state = hass.states.get("sensor.sensor_12345_pm2_5")
     assert state
     assert state.state == "4.07"
-    assert (
-        state.attributes.get(ATTR_FRIENDLY_NAME)
-        == "Sensor 12345 Particulate matter 2.5 μm"
-    )
+    assert state.attributes.get(ATTR_FRIENDLY_NAME) == "Sensor 12345 PM2.5"
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.PM25
     assert state.attributes.get(ATTR_STATE_CLASS) is SensorStateClass.MEASUREMENT
     assert (

--- a/tests/components/nam/test_init.py
+++ b/tests/components/nam/test_init.py
@@ -19,9 +19,7 @@ async def test_async_setup_entry(hass: HomeAssistant) -> None:
     """Test a successful setup entry."""
     await init_integration(hass)
 
-    state = hass.states.get(
-        "sensor.nettigo_air_monitor_sds011_particulate_matter_2_5_mm"
-    )
+    state = hass.states.get("sensor.nettigo_air_monitor_sds011_pm2_5")
     assert state is not None
     assert state.state != STATE_UNAVAILABLE
     assert state.state == "11.0"

--- a/tests/components/nam/test_sensor.py
+++ b/tests/components/nam/test_sensor.py
@@ -265,9 +265,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
     assert entry
     assert entry.unique_id == "aa:bb:cc:dd:ee:ff-pms_caqi"
 
-    state = hass.states.get(
-        "sensor.nettigo_air_monitor_pmsx003_particulate_matter_10_mm"
-    )
+    state = hass.states.get("sensor.nettigo_air_monitor_pmsx003_pm10")
     assert state
     assert state.state == "10.0"
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.PM10
@@ -277,15 +275,11 @@ async def test_sensor(hass: HomeAssistant) -> None:
         == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
 
-    entry = registry.async_get(
-        "sensor.nettigo_air_monitor_pmsx003_particulate_matter_10_mm"
-    )
+    entry = registry.async_get("sensor.nettigo_air_monitor_pmsx003_pm10")
     assert entry
     assert entry.unique_id == "aa:bb:cc:dd:ee:ff-pms_p1"
 
-    state = hass.states.get(
-        "sensor.nettigo_air_monitor_pmsx003_particulate_matter_2_5_mm"
-    )
+    state = hass.states.get("sensor.nettigo_air_monitor_pmsx003_pm2_5")
     assert state
     assert state.state == "11.0"
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.PM25
@@ -295,15 +289,11 @@ async def test_sensor(hass: HomeAssistant) -> None:
         == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
 
-    entry = registry.async_get(
-        "sensor.nettigo_air_monitor_pmsx003_particulate_matter_2_5_mm"
-    )
+    entry = registry.async_get("sensor.nettigo_air_monitor_pmsx003_pm2_5")
     assert entry
     assert entry.unique_id == "aa:bb:cc:dd:ee:ff-pms_p2"
 
-    state = hass.states.get(
-        "sensor.nettigo_air_monitor_pmsx003_particulate_matter_1_mm"
-    )
+    state = hass.states.get("sensor.nettigo_air_monitor_pmsx003_pm1")
     assert state
     assert state.state == "6.0"
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.PM1
@@ -313,15 +303,11 @@ async def test_sensor(hass: HomeAssistant) -> None:
         == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
 
-    entry = registry.async_get(
-        "sensor.nettigo_air_monitor_pmsx003_particulate_matter_1_mm"
-    )
+    entry = registry.async_get("sensor.nettigo_air_monitor_pmsx003_pm1")
     assert entry
     assert entry.unique_id == "aa:bb:cc:dd:ee:ff-pms_p0"
 
-    state = hass.states.get(
-        "sensor.nettigo_air_monitor_sds011_particulate_matter_10_mm"
-    )
+    state = hass.states.get("sensor.nettigo_air_monitor_sds011_pm10")
     assert state
     assert state.state == "18.6"
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.PM10
@@ -331,9 +317,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
         == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
 
-    entry = registry.async_get(
-        "sensor.nettigo_air_monitor_sds011_particulate_matter_10_mm"
-    )
+    entry = registry.async_get("sensor.nettigo_air_monitor_sds011_pm10")
     assert entry
     assert entry.unique_id == "aa:bb:cc:dd:ee:ff-sds011_p1"
 
@@ -372,9 +356,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
     assert entry.unique_id == "aa:bb:cc:dd:ee:ff-sds011_caqi_level"
     assert entry.translation_key == "sds011_caqi_level"
 
-    state = hass.states.get(
-        "sensor.nettigo_air_monitor_sds011_particulate_matter_2_5_mm"
-    )
+    state = hass.states.get("sensor.nettigo_air_monitor_sds011_pm2_5")
     assert state
     assert state.state == "11.0"
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.PM25
@@ -384,9 +366,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
         == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
 
-    entry = registry.async_get(
-        "sensor.nettigo_air_monitor_sds011_particulate_matter_2_5_mm"
-    )
+    entry = registry.async_get("sensor.nettigo_air_monitor_sds011_pm2_5")
     assert entry
     assert entry.unique_id == "aa:bb:cc:dd:ee:ff-sds011_p2"
 
@@ -423,7 +403,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
     assert entry.unique_id == "aa:bb:cc:dd:ee:ff-sps30_caqi_level"
     assert entry.translation_key == "sps30_caqi_level"
 
-    state = hass.states.get("sensor.nettigo_air_monitor_sps30_particulate_matter_1_mm")
+    state = hass.states.get("sensor.nettigo_air_monitor_sps30_pm1")
     assert state
     assert state.state == "31.2"
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.PM1
@@ -433,13 +413,11 @@ async def test_sensor(hass: HomeAssistant) -> None:
         == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
 
-    entry = registry.async_get(
-        "sensor.nettigo_air_monitor_sps30_particulate_matter_1_mm"
-    )
+    entry = registry.async_get("sensor.nettigo_air_monitor_sps30_pm1")
     assert entry
     assert entry.unique_id == "aa:bb:cc:dd:ee:ff-sps30_p0"
 
-    state = hass.states.get("sensor.nettigo_air_monitor_sps30_particulate_matter_10_mm")
+    state = hass.states.get("sensor.nettigo_air_monitor_sps30_pm10")
     assert state
     assert state.state == "21.2"
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.PM10
@@ -449,15 +427,11 @@ async def test_sensor(hass: HomeAssistant) -> None:
         == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
 
-    entry = registry.async_get(
-        "sensor.nettigo_air_monitor_sps30_particulate_matter_10_mm"
-    )
+    entry = registry.async_get("sensor.nettigo_air_monitor_sps30_pm10")
     assert entry
     assert entry.unique_id == "aa:bb:cc:dd:ee:ff-sps30_p1"
 
-    state = hass.states.get(
-        "sensor.nettigo_air_monitor_sps30_particulate_matter_2_5_mm"
-    )
+    state = hass.states.get("sensor.nettigo_air_monitor_sps30_pm2_5")
     assert state
     assert state.state == "34.3"
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.PM25
@@ -467,13 +441,11 @@ async def test_sensor(hass: HomeAssistant) -> None:
         == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
 
-    entry = registry.async_get(
-        "sensor.nettigo_air_monitor_sps30_particulate_matter_2_5_mm"
-    )
+    entry = registry.async_get("sensor.nettigo_air_monitor_sps30_pm2_5")
     assert entry
     assert entry.unique_id == "aa:bb:cc:dd:ee:ff-sps30_p2"
 
-    state = hass.states.get("sensor.nettigo_air_monitor_sps30_particulate_matter_4_mm")
+    state = hass.states.get("sensor.nettigo_air_monitor_sps30_pm4")
     assert state
     assert state.state == "24.7"
     assert state.attributes.get(ATTR_STATE_CLASS) is SensorStateClass.MEASUREMENT
@@ -483,9 +455,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
     )
     assert state.attributes.get(ATTR_ICON) == "mdi:molecule"
 
-    entry = registry.async_get(
-        "sensor.nettigo_air_monitor_sps30_particulate_matter_4_mm"
-    )
+    entry = registry.async_get("sensor.nettigo_air_monitor_sps30_pm4")
     assert entry
     assert entry.unique_id == "aa:bb:cc:dd:ee:ff-sps30_p4"
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

In a couple of recent video calls/discussions, we talked about the long names of the particulate matter sensors. Not only causes this the display name to be long (sometimes too long to display), it also causes long entity names.

Looking at other apps, like Awair, ApplHome and others, it is far more common to use just "PM". This PR adjusts this translation for Home Assistant to be similar. I've used the notation style, that had the most hits in an exact/literal search in Google  (determining the most common version).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
