### PR TITLE
Add option to select list of accepted ssl ciphers in httpx client

### DIFF
--- a/homeassistant/helpers/httpx_client.py
+++ b/homeassistant/helpers/httpx_client.py
@@ -12,7 +12,7 @@ from homeassistant.const import APPLICATION_NAME, EVENT_HOMEASSISTANT_CLOSE, __v
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.loader import bind_hass
 from homeassistant.util.ssl import (
-    SslCipherList,
+    SSLCipherList,
     client_context,
     create_no_verify_ssl_context,
 )
@@ -60,7 +60,7 @@ def create_async_httpx_client(
     hass: HomeAssistant,
     verify_ssl: bool = True,
     auto_cleanup: bool = True,
-    ssl_cipher_list: SslCipherList = SslCipherList.PYTHON_DEFAULT,
+    ssl_cipher_list: SSLCipherList = SSLCipherList.PYTHON_DEFAULT,
     **kwargs: Any,
 ) -> httpx.AsyncClient:
     """Create a new httpx.AsyncClient with kwargs, i.e. for cookies.

--- a/homeassistant/helpers/httpx_client.py
+++ b/homeassistant/helpers/httpx_client.py
@@ -11,7 +11,11 @@ from typing_extensions import Self
 from homeassistant.const import APPLICATION_NAME, EVENT_HOMEASSISTANT_CLOSE, __version__
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.loader import bind_hass
-from homeassistant.util.ssl import get_default_context, get_default_no_verify_context
+from homeassistant.util.ssl import (
+    SslCipherList,
+    client_context,
+    create_no_verify_ssl_context,
+)
 
 from .frame import warn_use
 
@@ -56,6 +60,7 @@ def create_async_httpx_client(
     hass: HomeAssistant,
     verify_ssl: bool = True,
     auto_cleanup: bool = True,
+    ssl_cipher_list: SslCipherList = SslCipherList.PYTHON_DEFAULT,
     **kwargs: Any,
 ) -> httpx.AsyncClient:
     """Create a new httpx.AsyncClient with kwargs, i.e. for cookies.
@@ -66,7 +71,9 @@ def create_async_httpx_client(
     This method must be run in the event loop.
     """
     ssl_context = (
-        get_default_context() if verify_ssl else get_default_no_verify_context()
+        client_context(ssl_cipher_list)
+        if verify_ssl
+        else create_no_verify_ssl_context(ssl_cipher_list)
     )
     client = HassHttpXAsyncClient(
         verify=ssl_context,

--- a/homeassistant/util/ssl.py
+++ b/homeassistant/util/ssl.py
@@ -107,14 +107,19 @@ def client_context(
     return sslcontext
 
 
+# Create this only once and reuse it
+_DEFAULT_SSL_CONTEXT = client_context()
+_DEFAULT_NO_VERIFY_SSL_CONTEXT = create_no_verify_ssl_context()
+
+
 def get_default_context() -> ssl.SSLContext:
     """Return the default SSL context."""
-    return client_context(SSLCipherList.PYTHON_DEFAULT)
+    return _DEFAULT_SSL_CONTEXT
 
 
 def get_default_no_verify_context() -> ssl.SSLContext:
     """Return the default SSL context that does not verify the server certificate."""
-    return create_no_verify_ssl_context(SSLCipherList.PYTHON_DEFAULT)
+    return _DEFAULT_NO_VERIFY_SSL_CONTEXT
 
 
 def server_context_modern() -> ssl.SSLContext:

--- a/homeassistant/util/ssl.py
+++ b/homeassistant/util/ssl.py
@@ -1,103 +1,24 @@
 """Helper to create SSL contexts."""
 import contextlib
+from functools import cache
 from os import environ
 import ssl
 
 import certifi
 
-
-def create_no_verify_ssl_context() -> ssl.SSLContext:
-    """Return an SSL context that does not verify the server certificate.
-
-    This is a copy of aiohttp's create_default_context() function, with the
-    ssl verify turned off.
-
-    https://github.com/aio-libs/aiohttp/blob/33953f110e97eecc707e1402daa8d543f38a189b/aiohttp/connector.py#L911
-    """
-    sslcontext = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
-    sslcontext.options |= ssl.OP_NO_SSLv2
-    sslcontext.options |= ssl.OP_NO_SSLv3
-    sslcontext.check_hostname = False
-    sslcontext.verify_mode = ssl.CERT_NONE
-    with contextlib.suppress(AttributeError):
-        # This only works for OpenSSL >= 1.0.0
-        sslcontext.options |= ssl.OP_NO_COMPRESSION
-    sslcontext.set_default_verify_paths()
-    return sslcontext
+from homeassistant.backports.enum import StrEnum
 
 
-def client_context() -> ssl.SSLContext:
-    """Return an SSL context for making requests."""
+class SslCipherList(StrEnum):
+    """SSL cipher lists."""
 
-    # Reuse environment variable definition from requests, since it's already a
-    # requirement. If the environment variable has no value, fall back to using
-    # certs from certifi package.
-    cafile = environ.get("REQUESTS_CA_BUNDLE", certifi.where())
-
-    return ssl.create_default_context(purpose=ssl.Purpose.SERVER_AUTH, cafile=cafile)
+    PYTHON_DEFAULT = "python_default"
+    INTERMEDIATE = "intermediate"
+    MODERN = "modern"
 
 
-# Create this only once and reuse it
-_DEFAULT_SSL_CONTEXT = client_context()
-_DEFAULT_NO_VERIFY_SSL_CONTEXT = create_no_verify_ssl_context()
-
-
-def get_default_context() -> ssl.SSLContext:
-    """Return the default SSL context."""
-    return _DEFAULT_SSL_CONTEXT
-
-
-def get_default_no_verify_context() -> ssl.SSLContext:
-    """Return the default SSL context that does not verify the server certificate."""
-    return _DEFAULT_NO_VERIFY_SSL_CONTEXT
-
-
-def server_context_modern() -> ssl.SSLContext:
-    """Return an SSL context following the Mozilla recommendations.
-
-    TLS configuration follows the best-practice guidelines specified here:
-    https://wiki.mozilla.org/Security/Server_Side_TLS
-    Modern guidelines are followed.
-    """
-    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
-
-    context.options |= (
-        ssl.OP_NO_SSLv2
-        | ssl.OP_NO_SSLv3
-        | ssl.OP_NO_TLSv1
-        | ssl.OP_NO_TLSv1_1
-        | ssl.OP_CIPHER_SERVER_PREFERENCE
-    )
-    if hasattr(ssl, "OP_NO_COMPRESSION"):
-        context.options |= ssl.OP_NO_COMPRESSION
-
-    context.set_ciphers(
-        "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:"
-        "ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:"
-        "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:"
-        "ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:"
-        "ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256"
-    )
-
-    return context
-
-
-def server_context_intermediate() -> ssl.SSLContext:
-    """Return an SSL context following the Mozilla recommendations.
-
-    TLS configuration follows the best-practice guidelines specified here:
-    https://wiki.mozilla.org/Security/Server_Side_TLS
-    Intermediate guidelines are followed.
-    """
-    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
-
-    context.options |= (
-        ssl.OP_NO_SSLv2 | ssl.OP_NO_SSLv3 | ssl.OP_CIPHER_SERVER_PREFERENCE
-    )
-    if hasattr(ssl, "OP_NO_COMPRESSION"):
-        context.options |= ssl.OP_NO_COMPRESSION
-
-    context.set_ciphers(
+SSL_CIPHER_LISTS = {
+    SslCipherList.INTERMEDIATE: (
         "ECDHE-ECDSA-CHACHA20-POLY1305:"
         "ECDHE-RSA-CHACHA20-POLY1305:"
         "ECDHE-ECDSA-AES128-GCM-SHA256:"
@@ -129,6 +50,112 @@ def server_context_intermediate() -> ssl.SSLContext:
         "AES256-SHA:"
         "DES-CBC3-SHA:"
         "!DSS"
+    ),
+    SslCipherList.MODERN: (
+        "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:"
+        "ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:"
+        "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:"
+        "ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:"
+        "ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256"
+    ),
+}
+
+
+@cache
+def create_no_verify_ssl_context(
+    ssl_cipher_list: SslCipherList = SslCipherList.PYTHON_DEFAULT,
+) -> ssl.SSLContext:
+    """Return an SSL context that does not verify the server certificate.
+
+    This is a copy of aiohttp's create_default_context() function, with the
+    ssl verify turned off.
+
+    https://github.com/aio-libs/aiohttp/blob/33953f110e97eecc707e1402daa8d543f38a189b/aiohttp/connector.py#L911
+    """
+    sslcontext = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    sslcontext.options |= ssl.OP_NO_SSLv2
+    sslcontext.options |= ssl.OP_NO_SSLv3
+    sslcontext.check_hostname = False
+    sslcontext.verify_mode = ssl.CERT_NONE
+    with contextlib.suppress(AttributeError):
+        # This only works for OpenSSL >= 1.0.0
+        sslcontext.options |= ssl.OP_NO_COMPRESSION
+    sslcontext.set_default_verify_paths()
+    if ssl_cipher_list != SslCipherList.PYTHON_DEFAULT:
+        sslcontext.set_ciphers(SSL_CIPHER_LISTS[ssl_cipher_list])
+
+    return sslcontext
+
+
+@cache
+def client_context(
+    ssl_cipher_list: SslCipherList = SslCipherList.PYTHON_DEFAULT,
+) -> ssl.SSLContext:
+    """Return an SSL context for making requests."""
+
+    # Reuse environment variable definition from requests, since it's already a
+    # requirement. If the environment variable has no value, fall back to using
+    # certs from certifi package.
+    cafile = environ.get("REQUESTS_CA_BUNDLE", certifi.where())
+
+    sslcontext = ssl.create_default_context(
+        purpose=ssl.Purpose.SERVER_AUTH, cafile=cafile
     )
+    if ssl_cipher_list != SslCipherList.PYTHON_DEFAULT:
+        sslcontext.set_ciphers(SSL_CIPHER_LISTS[ssl_cipher_list])
+
+    return sslcontext
+
+
+def get_default_context() -> ssl.SSLContext:
+    """Return the default SSL context."""
+    return client_context(SslCipherList.PYTHON_DEFAULT)
+
+
+def get_default_no_verify_context() -> ssl.SSLContext:
+    """Return the default SSL context that does not verify the server certificate."""
+    return create_no_verify_ssl_context(SslCipherList.PYTHON_DEFAULT)
+
+
+def server_context_modern() -> ssl.SSLContext:
+    """Return an SSL context following the Mozilla recommendations.
+
+    TLS configuration follows the best-practice guidelines specified here:
+    https://wiki.mozilla.org/Security/Server_Side_TLS
+    Modern guidelines are followed.
+    """
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+
+    context.options |= (
+        ssl.OP_NO_SSLv2
+        | ssl.OP_NO_SSLv3
+        | ssl.OP_NO_TLSv1
+        | ssl.OP_NO_TLSv1_1
+        | ssl.OP_CIPHER_SERVER_PREFERENCE
+    )
+    if hasattr(ssl, "OP_NO_COMPRESSION"):
+        context.options |= ssl.OP_NO_COMPRESSION
+
+    context.set_ciphers(SSL_CIPHER_LISTS[SslCipherList.MODERN])
+
+    return context
+
+
+def server_context_intermediate() -> ssl.SSLContext:
+    """Return an SSL context following the Mozilla recommendations.
+
+    TLS configuration follows the best-practice guidelines specified here:
+    https://wiki.mozilla.org/Security/Server_Side_TLS
+    Intermediate guidelines are followed.
+    """
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+
+    context.options |= (
+        ssl.OP_NO_SSLv2 | ssl.OP_NO_SSLv3 | ssl.OP_CIPHER_SERVER_PREFERENCE
+    )
+    if hasattr(ssl, "OP_NO_COMPRESSION"):
+        context.options |= ssl.OP_NO_COMPRESSION
+
+    context.set_ciphers(SSL_CIPHER_LISTS[SslCipherList.INTERMEDIATE])
 
     return context

--- a/homeassistant/util/ssl.py
+++ b/homeassistant/util/ssl.py
@@ -9,7 +9,7 @@ import certifi
 from homeassistant.backports.enum import StrEnum
 
 
-class SslCipherList(StrEnum):
+class SSLCipherList(StrEnum):
     """SSL cipher lists."""
 
     PYTHON_DEFAULT = "python_default"
@@ -18,7 +18,7 @@ class SslCipherList(StrEnum):
 
 
 SSL_CIPHER_LISTS = {
-    SslCipherList.INTERMEDIATE: (
+    SSLCipherList.INTERMEDIATE: (
         "ECDHE-ECDSA-CHACHA20-POLY1305:"
         "ECDHE-RSA-CHACHA20-POLY1305:"
         "ECDHE-ECDSA-AES128-GCM-SHA256:"
@@ -51,7 +51,7 @@ SSL_CIPHER_LISTS = {
         "DES-CBC3-SHA:"
         "!DSS"
     ),
-    SslCipherList.MODERN: (
+    SSLCipherList.MODERN: (
         "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:"
         "ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:"
         "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:"
@@ -63,7 +63,7 @@ SSL_CIPHER_LISTS = {
 
 @cache
 def create_no_verify_ssl_context(
-    ssl_cipher_list: SslCipherList = SslCipherList.PYTHON_DEFAULT,
+    ssl_cipher_list: SSLCipherList = SSLCipherList.PYTHON_DEFAULT,
 ) -> ssl.SSLContext:
     """Return an SSL context that does not verify the server certificate.
 
@@ -81,7 +81,7 @@ def create_no_verify_ssl_context(
         # This only works for OpenSSL >= 1.0.0
         sslcontext.options |= ssl.OP_NO_COMPRESSION
     sslcontext.set_default_verify_paths()
-    if ssl_cipher_list != SslCipherList.PYTHON_DEFAULT:
+    if ssl_cipher_list != SSLCipherList.PYTHON_DEFAULT:
         sslcontext.set_ciphers(SSL_CIPHER_LISTS[ssl_cipher_list])
 
     return sslcontext
@@ -89,7 +89,7 @@ def create_no_verify_ssl_context(
 
 @cache
 def client_context(
-    ssl_cipher_list: SslCipherList = SslCipherList.PYTHON_DEFAULT,
+    ssl_cipher_list: SSLCipherList = SSLCipherList.PYTHON_DEFAULT,
 ) -> ssl.SSLContext:
     """Return an SSL context for making requests."""
 
@@ -101,7 +101,7 @@ def client_context(
     sslcontext = ssl.create_default_context(
         purpose=ssl.Purpose.SERVER_AUTH, cafile=cafile
     )
-    if ssl_cipher_list != SslCipherList.PYTHON_DEFAULT:
+    if ssl_cipher_list != SSLCipherList.PYTHON_DEFAULT:
         sslcontext.set_ciphers(SSL_CIPHER_LISTS[ssl_cipher_list])
 
     return sslcontext
@@ -109,12 +109,12 @@ def client_context(
 
 def get_default_context() -> ssl.SSLContext:
     """Return the default SSL context."""
-    return client_context(SslCipherList.PYTHON_DEFAULT)
+    return client_context(SSLCipherList.PYTHON_DEFAULT)
 
 
 def get_default_no_verify_context() -> ssl.SSLContext:
     """Return the default SSL context that does not verify the server certificate."""
-    return create_no_verify_ssl_context(SslCipherList.PYTHON_DEFAULT)
+    return create_no_verify_ssl_context(SSLCipherList.PYTHON_DEFAULT)
 
 
 def server_context_modern() -> ssl.SSLContext:
@@ -136,7 +136,7 @@ def server_context_modern() -> ssl.SSLContext:
     if hasattr(ssl, "OP_NO_COMPRESSION"):
         context.options |= ssl.OP_NO_COMPRESSION
 
-    context.set_ciphers(SSL_CIPHER_LISTS[SslCipherList.MODERN])
+    context.set_ciphers(SSL_CIPHER_LISTS[SSLCipherList.MODERN])
 
     return context
 
@@ -156,6 +156,6 @@ def server_context_intermediate() -> ssl.SSLContext:
     if hasattr(ssl, "OP_NO_COMPRESSION"):
         context.options |= ssl.OP_NO_COMPRESSION
 
-    context.set_ciphers(SSL_CIPHER_LISTS[SslCipherList.INTERMEDIATE])
+    context.set_ciphers(SSL_CIPHER_LISTS[SSLCipherList.INTERMEDIATE])
 
     return context

--- a/tests/util/test_ssl.py
+++ b/tests/util/test_ssl.py
@@ -1,0 +1,53 @@
+"""Test Home Assistant ssl utility functions."""
+
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+from homeassistant.util.ssl import (
+    SSL_CIPHER_LISTS,
+    SslCipherList,
+    client_context,
+    create_no_verify_ssl_context,
+)
+
+
+@pytest.fixture
+def mock_sslcontext():
+    """Mock the ssl lib."""
+    ssl_mock = MagicMock(set_ciphers=Mock(return_value=True))
+    return ssl_mock
+
+
+def test_client_context(mock_sslcontext) -> None:
+    """Test client context."""
+    with patch("homeassistant.util.ssl.ssl.SSLContext", return_value=mock_sslcontext):
+        client_context()
+        mock_sslcontext.set_ciphers.assert_not_called()
+
+        client_context(SslCipherList.MODERN)
+        mock_sslcontext.set_ciphers.assert_called_with(
+            SSL_CIPHER_LISTS[SslCipherList.MODERN]
+        )
+
+        client_context(SslCipherList.INTERMEDIATE)
+        mock_sslcontext.set_ciphers.assert_called_with(
+            SSL_CIPHER_LISTS[SslCipherList.INTERMEDIATE]
+        )
+
+
+def test_no_verify_ssl_context(mock_sslcontext) -> None:
+    """Test no verify ssl context."""
+    with patch("homeassistant.util.ssl.ssl.SSLContext", return_value=mock_sslcontext):
+        create_no_verify_ssl_context()
+        mock_sslcontext.set_ciphers.assert_not_called()
+
+        create_no_verify_ssl_context(SslCipherList.MODERN)
+        mock_sslcontext.set_ciphers.assert_called_with(
+            SSL_CIPHER_LISTS[SslCipherList.MODERN]
+        )
+
+        create_no_verify_ssl_context(SslCipherList.INTERMEDIATE)
+        mock_sslcontext.set_ciphers.assert_called_with(
+            SSL_CIPHER_LISTS[SslCipherList.INTERMEDIATE]
+        )

--- a/tests/util/test_ssl.py
+++ b/tests/util/test_ssl.py
@@ -6,7 +6,7 @@ import pytest
 
 from homeassistant.util.ssl import (
     SSL_CIPHER_LISTS,
-    SslCipherList,
+    SSLCipherList,
     client_context,
     create_no_verify_ssl_context,
 )
@@ -25,14 +25,14 @@ def test_client_context(mock_sslcontext) -> None:
         client_context()
         mock_sslcontext.set_ciphers.assert_not_called()
 
-        client_context(SslCipherList.MODERN)
+        client_context(SSLCipherList.MODERN)
         mock_sslcontext.set_ciphers.assert_called_with(
-            SSL_CIPHER_LISTS[SslCipherList.MODERN]
+            SSL_CIPHER_LISTS[SSLCipherList.MODERN]
         )
 
-        client_context(SslCipherList.INTERMEDIATE)
+        client_context(SSLCipherList.INTERMEDIATE)
         mock_sslcontext.set_ciphers.assert_called_with(
-            SSL_CIPHER_LISTS[SslCipherList.INTERMEDIATE]
+            SSL_CIPHER_LISTS[SSLCipherList.INTERMEDIATE]
         )
 
 
@@ -42,12 +42,12 @@ def test_no_verify_ssl_context(mock_sslcontext) -> None:
         create_no_verify_ssl_context()
         mock_sslcontext.set_ciphers.assert_not_called()
 
-        create_no_verify_ssl_context(SslCipherList.MODERN)
+        create_no_verify_ssl_context(SSLCipherList.MODERN)
         mock_sslcontext.set_ciphers.assert_called_with(
-            SSL_CIPHER_LISTS[SslCipherList.MODERN]
+            SSL_CIPHER_LISTS[SSLCipherList.MODERN]
         )
 
-        create_no_verify_ssl_context(SslCipherList.INTERMEDIATE)
+        create_no_verify_ssl_context(SSLCipherList.INTERMEDIATE)
         mock_sslcontext.set_ciphers.assert_called_with(
-            SSL_CIPHER_LISTS[SslCipherList.INTERMEDIATE]
+            SSL_CIPHER_LISTS[SSLCipherList.INTERMEDIATE]
         )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Carve out from #91078

---
Allowed ssl cipher lists (_based on https://wiki.mozilla.org/Security/Server_Side_TLS_)
- default (_based on used python version_)
- modern
- intermediate


resulting cipher lists

#### ssl_cipher_list =  SslCipherList.PYTHON_DEFAULT (_based on python 3.10_)

```
'TLS_AES_256_GCM_SHA384  TLSv1.3 Kx=any      Au=any  Enc=AESGCM(256) Mac=AEAD'
'TLS_CHACHA20_POLY1305_SHA256 TLSv1.3 Kx=any      Au=any  Enc=CHACHA20/POLY1305(256) Mac=AEAD'
'TLS_AES_128_GCM_SHA256  TLSv1.3 Kx=any      Au=any  Enc=AESGCM(128) Mac=AEAD'
'ECDHE-ECDSA-AES256-GCM-SHA384 TLSv1.2 Kx=ECDH     Au=ECDSA Enc=AESGCM(256) Mac=AEAD'
'ECDHE-RSA-AES256-GCM-SHA384 TLSv1.2 Kx=ECDH     Au=RSA  Enc=AESGCM(256) Mac=AEAD'
'ECDHE-ECDSA-AES128-GCM-SHA256 TLSv1.2 Kx=ECDH     Au=ECDSA Enc=AESGCM(128) Mac=AEAD'
'ECDHE-RSA-AES128-GCM-SHA256 TLSv1.2 Kx=ECDH     Au=RSA  Enc=AESGCM(128) Mac=AEAD'
'ECDHE-ECDSA-CHACHA20-POLY1305 TLSv1.2 Kx=ECDH     Au=ECDSA Enc=CHACHA20/POLY1305(256) Mac=AEAD'
'ECDHE-RSA-CHACHA20-POLY1305 TLSv1.2 Kx=ECDH     Au=RSA  Enc=CHACHA20/POLY1305(256) Mac=AEAD'
'ECDHE-ECDSA-AES256-SHA384 TLSv1.2 Kx=ECDH     Au=ECDSA Enc=AES(256)  Mac=SHA384'
'ECDHE-RSA-AES256-SHA384 TLSv1.2 Kx=ECDH     Au=RSA  Enc=AES(256)  Mac=SHA384'
'ECDHE-ECDSA-AES128-SHA256 TLSv1.2 Kx=ECDH     Au=ECDSA Enc=AES(128)  Mac=SHA256'
'ECDHE-RSA-AES128-SHA256 TLSv1.2 Kx=ECDH     Au=RSA  Enc=AES(128)  Mac=SHA256'
'DHE-RSA-AES256-GCM-SHA384 TLSv1.2 Kx=DH       Au=RSA  Enc=AESGCM(256) Mac=AEAD'
'DHE-RSA-AES128-GCM-SHA256 TLSv1.2 Kx=DH       Au=RSA  Enc=AESGCM(128) Mac=AEAD'
'DHE-RSA-AES256-SHA256   TLSv1.2 Kx=DH       Au=RSA  Enc=AES(256)  Mac=SHA256'
'DHE-RSA-AES128-SHA256   TLSv1.2 Kx=DH       Au=RSA  Enc=AES(128)  Mac=SHA256'
```

#### ssl_cipher_list = SslCipherList.MODERN

```
'TLS_AES_256_GCM_SHA384  TLSv1.3 Kx=any      Au=any  Enc=AESGCM(256) Mac=AEAD'
'TLS_CHACHA20_POLY1305_SHA256 TLSv1.3 Kx=any      Au=any  Enc=CHACHA20/POLY1305(256) Mac=AEAD'
'TLS_AES_128_GCM_SHA256  TLSv1.3 Kx=any      Au=any  Enc=AESGCM(128) Mac=AEAD'
'ECDHE-ECDSA-AES256-GCM-SHA384 TLSv1.2 Kx=ECDH     Au=ECDSA Enc=AESGCM(256) Mac=AEAD'
'ECDHE-RSA-AES256-GCM-SHA384 TLSv1.2 Kx=ECDH     Au=RSA  Enc=AESGCM(256) Mac=AEAD'
'ECDHE-ECDSA-CHACHA20-POLY1305 TLSv1.2 Kx=ECDH     Au=ECDSA Enc=CHACHA20/POLY1305(256) Mac=AEAD'
'ECDHE-RSA-CHACHA20-POLY1305 TLSv1.2 Kx=ECDH     Au=RSA  Enc=CHACHA20/POLY1305(256) Mac=AEAD'
'ECDHE-ECDSA-AES128-GCM-SHA256 TLSv1.2 Kx=ECDH     Au=ECDSA Enc=AESGCM(128) Mac=AEAD'
'ECDHE-RSA-AES128-GCM-SHA256 TLSv1.2 Kx=ECDH     Au=RSA  Enc=AESGCM(128) Mac=AEAD'
'ECDHE-ECDSA-AES256-SHA384 TLSv1.2 Kx=ECDH     Au=ECDSA Enc=AES(256)  Mac=SHA384'
'ECDHE-RSA-AES256-SHA384 TLSv1.2 Kx=ECDH     Au=RSA  Enc=AES(256)  Mac=SHA384'
'ECDHE-ECDSA-AES128-SHA256 TLSv1.2 Kx=ECDH     Au=ECDSA Enc=AES(128)  Mac=SHA256'
'ECDHE-RSA-AES128-SHA256 TLSv1.2 Kx=ECDH     Au=RSA  Enc=AES(128)  Mac=SHA256'
```

#### ssl_cipher_list = SslCipherList.INTERMEDIATE

```
'TLS_AES_256_GCM_SHA384  TLSv1.3 Kx=any      Au=any  Enc=AESGCM(256) Mac=AEAD'
'TLS_CHACHA20_POLY1305_SHA256 TLSv1.3 Kx=any      Au=any  Enc=CHACHA20/POLY1305(256) Mac=AEAD'
'TLS_AES_128_GCM_SHA256  TLSv1.3 Kx=any      Au=any  Enc=AESGCM(128) Mac=AEAD'
'ECDHE-ECDSA-CHACHA20-POLY1305 TLSv1.2 Kx=ECDH     Au=ECDSA Enc=CHACHA20/POLY1305(256) Mac=AEAD'
'ECDHE-RSA-CHACHA20-POLY1305 TLSv1.2 Kx=ECDH     Au=RSA  Enc=CHACHA20/POLY1305(256) Mac=AEAD'
'ECDHE-ECDSA-AES128-GCM-SHA256 TLSv1.2 Kx=ECDH     Au=ECDSA Enc=AESGCM(128) Mac=AEAD'
'ECDHE-RSA-AES128-GCM-SHA256 TLSv1.2 Kx=ECDH     Au=RSA  Enc=AESGCM(128) Mac=AEAD'
'ECDHE-ECDSA-AES256-GCM-SHA384 TLSv1.2 Kx=ECDH     Au=ECDSA Enc=AESGCM(256) Mac=AEAD'
'ECDHE-RSA-AES256-GCM-SHA384 TLSv1.2 Kx=ECDH     Au=RSA  Enc=AESGCM(256) Mac=AEAD'
'DHE-RSA-AES128-GCM-SHA256 TLSv1.2 Kx=DH       Au=RSA  Enc=AESGCM(128) Mac=AEAD'
'DHE-RSA-AES256-GCM-SHA384 TLSv1.2 Kx=DH       Au=RSA  Enc=AESGCM(256) Mac=AEAD'
'ECDHE-ECDSA-AES128-SHA256 TLSv1.2 Kx=ECDH     Au=ECDSA Enc=AES(128)  Mac=SHA256'
'ECDHE-RSA-AES128-SHA256 TLSv1.2 Kx=ECDH     Au=RSA  Enc=AES(128)  Mac=SHA256'
'ECDHE-ECDSA-AES128-SHA  TLSv1 Kx=ECDH     Au=ECDSA Enc=AES(128)  Mac=SHA1'
'ECDHE-RSA-AES256-SHA384 TLSv1.2 Kx=ECDH     Au=RSA  Enc=AES(256)  Mac=SHA384'
'ECDHE-RSA-AES128-SHA    TLSv1 Kx=ECDH     Au=RSA  Enc=AES(128)  Mac=SHA1'
'ECDHE-ECDSA-AES256-SHA384 TLSv1.2 Kx=ECDH     Au=ECDSA Enc=AES(256)  Mac=SHA384'
'ECDHE-ECDSA-AES256-SHA  TLSv1 Kx=ECDH     Au=ECDSA Enc=AES(256)  Mac=SHA1'
'ECDHE-RSA-AES256-SHA    TLSv1 Kx=ECDH     Au=RSA  Enc=AES(256)  Mac=SHA1'
'DHE-RSA-AES128-SHA256   TLSv1.2 Kx=DH       Au=RSA  Enc=AES(128)  Mac=SHA256'
'DHE-RSA-AES128-SHA      SSLv3 Kx=DH       Au=RSA  Enc=AES(128)  Mac=SHA1'
'DHE-RSA-AES256-SHA256   TLSv1.2 Kx=DH       Au=RSA  Enc=AES(256)  Mac=SHA256'
'DHE-RSA-AES256-SHA      SSLv3 Kx=DH       Au=RSA  Enc=AES(256)  Mac=SHA1'
'AES128-GCM-SHA256       TLSv1.2 Kx=RSA      Au=RSA  Enc=AESGCM(128) Mac=AEAD'
'AES256-GCM-SHA384       TLSv1.2 Kx=RSA      Au=RSA  Enc=AESGCM(256) Mac=AEAD'
'AES128-SHA256           TLSv1.2 Kx=RSA      Au=RSA  Enc=AES(128)  Mac=SHA256'
'AES256-SHA256           TLSv1.2 Kx=RSA      Au=RSA  Enc=AES(256)  Mac=SHA256'
'AES128-SHA              SSLv3 Kx=RSA      Au=RSA  Enc=AES(128)  Mac=SHA1'
'AES256-SHA              SSLv3 Kx=RSA      Au=RSA  Enc=AES(256)  Mac=SHA1'
```
---


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
