### PR TITLE
Fix attribute reporting config failures in ZHA

### DIFF
--- a/homeassistant/components/zha/core/channels/base.py
+++ b/homeassistant/components/zha/core/channels/base.py
@@ -49,8 +49,8 @@ _LOGGER = logging.getLogger(__name__)
 class AttrReportConfig(TypedDict, total=True):
     """Configuration to report for the attributes."""
 
-    # Could be either an attribute name or attribute id
-    attr: str | int
+    # An attribute name
+    attr: str
     # The config for the attribute reporting configuration consists of a tuple for
     # (minimum_reported_time_interval_s, maximum_reported_time_interval_s, value_delta)
     config: tuple[int, int, int | float]
@@ -130,15 +130,13 @@ class ZigbeeChannel(LogMixin):
         unique_id = ch_pool.unique_id.replace("-", ":")
         self._unique_id = f"{unique_id}:0x{cluster.cluster_id:04x}"
         if not hasattr(self, "_value_attribute") and self.REPORT_CONFIG:
-            attr = self.REPORT_CONFIG[0].get("attr")
-            if isinstance(attr, str):
-                attribute: ZCLAttributeDef = self.cluster.attributes_by_name.get(attr)
-                if attribute is not None:
-                    self.value_attribute = attribute.id
-                else:
-                    self.value_attribute = None
+            attr_def: ZCLAttributeDef | None = self.cluster.attributes_by_name.get(
+                self.REPORT_CONFIG[0]["attr"]
+            )
+            if attr_def is not None:
+                self.value_attribute = attr_def.id
             else:
-                self.value_attribute = attr
+                self.value_attribute = None
         self._status = ChannelStatus.CREATED
         self._cluster.add_listener(self)
         self.data_cache: dict[str, Enum] = {}
@@ -287,7 +285,7 @@ class ZigbeeChannel(LogMixin):
         )
 
     def _configure_reporting_status(
-        self, attrs: dict[int | str, tuple[int, int, float | int]], res: list | tuple
+        self, attrs: dict[str, tuple[int, int, float | int]], res: list | tuple
     ) -> None:
         """Parse configure reporting result."""
         if isinstance(res, (Exception, ConfigureReportingResponseRecord)):
@@ -308,26 +306,15 @@ class ZigbeeChannel(LogMixin):
             )
             return
 
-        failed = []
-
-        for record in res:
-            if record.status != Status.SUCCESS:
-                try:
-                    failed.append(self.cluster.find_attribute(record.attrid).name)
-                except KeyError:
-                    failed.append(record.attrid)
-
-        attributes = set()
-
-        for attr_name_or_id in attrs:
-            try:
-                attributes.add(self.cluster.find_attribute(attr_name_or_id).name)
-            except KeyError:
-                attributes.add(attr_name_or_id)
+        failed = [
+            self.cluster.find_attribute(record.attrid).name
+            for record in res
+            if record.status != Status.SUCCESS
+        ]
 
         self.debug(
             "Successfully configured reporting for '%s' on '%s' cluster",
-            attributes - set(failed),
+            set(attrs) - set(failed),
             self.name,
         )
         self.debug(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Attribute reporting config is failing due to deprecated attribute definition item accesses still being in ZHA.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
