### PR TITLE
Avoid creating a TimerHandle in cancelled Debouncer

### DIFF
--- a/homeassistant/helpers/debounce.py
+++ b/homeassistant/helpers/debounce.py
@@ -125,11 +125,7 @@ class Debouncer(Generic[_R_co]):
 
     @callback
     def async_cancel(self) -> None:
-        """Cancel any scheduled call.
-
-        Note: calling `async_call` after cancel will follow cooldown,
-        use `async_shutdown` if this is not desired.
-        """
+        """Cancel any scheduled call."""
         self._cancel_requested = True
         if self._timer_task:
             self._timer_task.cancel()

--- a/homeassistant/helpers/debounce.py
+++ b/homeassistant/helpers/debounce.py
@@ -129,7 +129,6 @@ class Debouncer(Generic[_R_co]):
         """Cancel any scheduled call."""
         self._cancel_requested = True
         if self._timer_task:
-            self._cooldown_until = self._timer_task.when()
             self._timer_task.cancel()
             self._timer_task = None
 
@@ -155,3 +154,4 @@ class Debouncer(Generic[_R_co]):
             self._timer_task = self.hass.loop.call_at(when, self._on_debounce)
             return
         self._timer_task = self.hass.loop.call_later(self.cooldown, self._on_debounce)
+        self._cooldown_until = self._timer_task.when()

--- a/homeassistant/helpers/debounce.py
+++ b/homeassistant/helpers/debounce.py
@@ -128,6 +128,7 @@ class Debouncer(Generic[_R_co]):
         """Cancel any scheduled call."""
         self._cancel_requested = True
         if self._timer_task:
+            self._cooldown_until = self._timer_task.when()
             self._timer_task.cancel()
             self._timer_task = None
 

--- a/homeassistant/helpers/debounce.py
+++ b/homeassistant/helpers/debounce.py
@@ -147,11 +147,9 @@ class Debouncer(Generic[_R_co]):
     @callback
     def _schedule_timer(self, when: float | None = None) -> None:
         """Schedule a timer."""
+        self._cooldown_until = when if when else self.hass.loop.time() + self.cooldown
         if self._cancel_requested:
-            self._cooldown_until = self.hass.loop.time() + self.cooldown
             return
-        if when:
-            self._timer_task = self.hass.loop.call_at(when, self._on_debounce)
-            return
-        self._timer_task = self.hass.loop.call_later(self.cooldown, self._on_debounce)
-        self._cooldown_until = self._timer_task.when()
+        self._timer_task = self.hass.loop.call_at(
+            self._cooldown_until, self._on_debounce
+        )

--- a/homeassistant/helpers/debounce.py
+++ b/homeassistant/helpers/debounce.py
@@ -90,7 +90,8 @@ class Debouncer(Generic[_R_co]):
             if task:
                 await task
 
-            self._schedule_timer()
+            if not self._cancelled:
+                self._schedule_timer()
 
     async def _handle_timer_finish(self) -> None:
         """Handle a finished timer."""

--- a/homeassistant/helpers/debounce.py
+++ b/homeassistant/helpers/debounce.py
@@ -92,6 +92,7 @@ class Debouncer(Generic[_R_co]):
                 self._execute_at_end_of_timer = True
                 self._schedule_timer(self._cooldown_until)
                 return
+            self._cooldown_until = None
 
             task = self.hass.async_run_hass_job(self._job)
             if task:

--- a/homeassistant/helpers/debounce.py
+++ b/homeassistant/helpers/debounce.py
@@ -87,6 +87,7 @@ class Debouncer(Generic[_R_co]):
             if self._timer_task:
                 return
 
+            # Check original cooldown if a run is requested after a cancellation
             if self._cooldown_until and self._cooldown_until > self.hass.loop.time():
                 self._execute_at_end_of_timer = True
                 self._schedule_timer(self._cooldown_until)

--- a/homeassistant/helpers/update_coordinator.py
+++ b/homeassistant/helpers/update_coordinator.py
@@ -237,7 +237,7 @@ class DataUpdateCoordinator(BaseDataUpdateCoordinatorProtocol, Generic[_T]):
             self._unsub_refresh()
             self._unsub_refresh = None
 
-        self._debounced_refresh.async_cancel()
+        self._debounced_refresh.async_cancel(keep_cooldown=True)
 
         if scheduled and self.hass.is_stopping:
             return

--- a/homeassistant/helpers/update_coordinator.py
+++ b/homeassistant/helpers/update_coordinator.py
@@ -237,7 +237,7 @@ class DataUpdateCoordinator(BaseDataUpdateCoordinatorProtocol, Generic[_T]):
             self._unsub_refresh()
             self._unsub_refresh = None
 
-        self._debounced_refresh.async_cancel(keep_cooldown=True)
+        self._debounced_refresh.async_cancel()
 
         if scheduled and self.hass.is_stopping:
             return

--- a/tests/helpers/test_debounce.py
+++ b/tests/helpers/test_debounce.py
@@ -1,4 +1,5 @@
 """Tests for debounce."""
+import asyncio
 from datetime import timedelta
 from unittest.mock import AsyncMock
 
@@ -174,3 +175,58 @@ async def test_immediate_works_with_function_swapped(hass: HomeAssistant) -> Non
     assert debouncer._execute_at_end_of_timer is False
     debouncer._execute_lock.release()
     assert debouncer._job.target == debouncer.function
+
+
+async def test_cancel_avoid_cooldown(hass: HomeAssistant) -> None:
+    """Test that cancellation during run avoids cooldown."""
+    calls = []
+    future = asyncio.Future()
+
+    async def _func() -> None:
+        nonlocal future
+        await future
+        future = asyncio.Future()
+        calls.append(None)
+
+    import logging
+
+    debouncer = debounce.Debouncer(
+        hass,
+        logging.Logger(__name__),
+        cooldown=0.01,
+        immediate=True,
+        function=_func,
+    )
+
+    # Cancel during initial run doesn't create a cooldown timer
+    hass.async_add_job(debouncer.async_call())
+    await asyncio.sleep(0.01)
+    debouncer.async_cancel()
+    future.set_result(True)
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    assert debouncer._timer_task is None
+
+    # Second run should create a cooldown timer
+    hass.async_add_job(debouncer.async_call())
+    await asyncio.sleep(0.01)
+    future.set_result(True)
+    await hass.async_block_till_done()
+    assert len(calls) == 2
+    assert debouncer._timer_task is not None
+
+    # Third run during cooldown timer gets scheduled
+    hass.async_add_job(debouncer.async_call())
+    await hass.async_block_till_done()
+    assert debouncer._timer_task is not None
+    await asyncio.sleep(0.01)
+    async_fire_time_changed(hass, utcnow() + timedelta(seconds=1))
+    assert len(calls) == 2  # still pending
+    assert debouncer._timer_task is None  # run in progress
+
+    # Cancel during third run doesn't create a cooldown timer
+    debouncer.async_cancel()
+    future.set_result(True)
+    await hass.async_block_till_done()
+    assert len(calls) == 3
+    assert debouncer._timer_task is None


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Avoid cooldown timer on debouncer cancel
Follow-up to #89370 and linked to https://github.com/home-assistant/core/pull/91360

I couldn't understand why samsungtv left a lingering timer in the tests.
```console
ERROR tests/components/samsungtv/test_media_player.py::test_websocket_unsupported_remote_control - Failed: Lingering timer after test <TimerHandle when=1004.132515261 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:140>
```

It turned out that:
- the debouncer was triggering a reload
- the reload was triggering a cancel of the debouncer (whilst the reload was in progress)
- when the reload was completed a cooldown timer was generated despite the earlier cancellation

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
