### PR TITLE
Use fast path for track_time_change that fires every second

### DIFF
--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -1553,7 +1553,7 @@ def async_track_utc_time_change(
     """Add a listener that will fire if time matches a pattern."""
     # We do not have to wrap the function with time pattern matching logic
     # if no pattern given
-    if all(val is None for val in (hour, minute, second)):
+    if all(val is None or val == "*" for val in (hour, minute, second)):
         # Previously this relied on EVENT_TIME_FIRED
         # which meant it would not fire right away because
         # the caller would always be misaligned with the call

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -3666,6 +3666,7 @@ async def test_track_sunset(hass: HomeAssistant) -> None:
 
 async def test_async_track_time_change(hass: HomeAssistant) -> None:
     """Test tracking time change."""
+    none_runs = []
     wildcard_runs = []
     specific_runs = []
 
@@ -3678,11 +3679,16 @@ async def test_async_track_time_change(hass: HomeAssistant) -> None:
     with patch(
         "homeassistant.util.dt.utcnow", return_value=time_that_will_not_match_right_away
     ):
-        unsub = async_track_time_change(
-            hass, callback(lambda x: wildcard_runs.append(x))
-        )
+        unsub = async_track_time_change(hass, callback(lambda x: none_runs.append(x)))
         unsub_utc = async_track_utc_time_change(
             hass, callback(lambda x: specific_runs.append(x)), second=[0, 30]
+        )
+        unsub_wildcard = async_track_time_change(
+            hass,
+            callback(lambda x: wildcard_runs.append(x)),
+            second="*",
+            minute="*",
+            hour="*",
         )
 
     async_fire_time_changed(
@@ -3691,6 +3697,7 @@ async def test_async_track_time_change(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
     assert len(specific_runs) == 1
     assert len(wildcard_runs) == 1
+    assert len(none_runs) == 1
 
     async_fire_time_changed(
         hass, datetime(now.year + 1, 5, 24, 12, 0, 15, 999999, tzinfo=dt_util.UTC)
@@ -3698,6 +3705,7 @@ async def test_async_track_time_change(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
     assert len(specific_runs) == 1
     assert len(wildcard_runs) == 2
+    assert len(none_runs) == 2
 
     async_fire_time_changed(
         hass, datetime(now.year + 1, 5, 24, 12, 0, 30, 999999, tzinfo=dt_util.UTC)
@@ -3705,9 +3713,11 @@ async def test_async_track_time_change(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
     assert len(specific_runs) == 2
     assert len(wildcard_runs) == 3
+    assert len(none_runs) == 3
 
     unsub()
     unsub_utc()
+    unsub_wildcard()
 
     async_fire_time_changed(
         hass, datetime(now.year + 1, 5, 24, 12, 0, 30, 999999, tzinfo=dt_util.UTC)
@@ -3715,6 +3725,7 @@ async def test_async_track_time_change(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
     assert len(specific_runs) == 2
     assert len(wildcard_runs) == 3
+    assert len(none_runs) == 3
 
 
 async def test_periodic_task_minute(hass: HomeAssistant) -> None:


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
We were missing a check for `*` and were only checking `None`. Automations use `*`, python code uses `None`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
