### PR TITLE
Remove check on remove deprecated call back for mqtt subscribe

### DIFF
--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Callable, Coroutine, Iterable
 from functools import lru_cache
-import inspect
 from itertools import chain, groupby
 import logging
 from operator import attrgetter
@@ -172,25 +171,6 @@ async def async_subscribe(
             f"Cannot subscribe to topic '{topic}', MQTT is not enabled"
         )
     mqtt_data = get_mqtt_data(hass)
-    # Support for a deprecated callback type was removed with HA core 2023.3.0
-    # The signature validation code can be removed from HA core 2023.5.0
-    non_default = 0
-    if msg_callback:
-        non_default = sum(
-            p.default == inspect.Parameter.empty
-            for _, p in inspect.signature(msg_callback).parameters.items()
-        )
-
-    # Check for not supported callback signatures
-    # Can be removed from HA core 2023.5.0
-    if non_default != 1:
-        module = inspect.getmodule(msg_callback)
-        raise HomeAssistantError(
-            "Signature for MQTT msg_callback '{}.{}' is not supported".format(
-                module.__name__ if module else "<unknown>", msg_callback.__name__
-            )
-        )
-
     async_remove = await mqtt_data.client.async_subscribe(
         topic,
         catch_log_exception(

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -32,7 +32,6 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er, template
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_platform import async_get_platforms
-from homeassistant.helpers.service_info.mqtt import ReceivePayloadType
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
@@ -944,46 +943,6 @@ async def test_subscribe_bad_topic(
     await mqtt_mock_entry()
     with pytest.raises(HomeAssistantError):
         await mqtt.async_subscribe(hass, 55, record_calls)  # type: ignore[arg-type]
-
-
-# Support for a deprecated callback type was removed with HA core 2023.3.0
-# Test can be removed from HA core 2023.5.0
-async def test_subscribe_with_deprecated_callback_fails(
-    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
-) -> None:
-    """Test the subscription of a topic using deprecated callback signature fails."""
-    await mqtt_mock_entry()
-
-    async def record_calls(topic: str, payload: ReceivePayloadType, qos: int) -> None:
-        """Record calls."""
-
-    with pytest.raises(HomeAssistantError):
-        await mqtt.async_subscribe(hass, "test-topic", record_calls)
-    # Test with partial wrapper
-    with pytest.raises(HomeAssistantError):
-        await mqtt.async_subscribe(hass, "test-topic", RecordCallsPartial(record_calls))
-
-
-# Support for a deprecated callback type was removed with HA core 2023.3.0
-# Test can be removed from HA core 2023.5.0
-async def test_subscribe_deprecated_async_fails(
-    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
-) -> None:
-    """Test the subscription of a topic using deprecated coroutine signature fails."""
-    await mqtt_mock_entry()
-
-    @callback
-    def async_record_calls(topic: str, payload: ReceivePayloadType, qos: int) -> None:
-        """Record calls."""
-
-    with pytest.raises(HomeAssistantError):
-        await mqtt.async_subscribe(hass, "test-topic", async_record_calls)
-
-    # Test with partial wrapper
-    with pytest.raises(HomeAssistantError):
-        await mqtt.async_subscribe(
-            hass, "test-topic", RecordCallsPartial(async_record_calls)
-        )
 
 
 async def test_subscribe_topic_not_match(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove check on remove deprecated call back for mqtt subscribe.
The support was ended with ha 2023.3 and stopped working. With this PR the checks ans tests are cleaned up.

PR is be targetted for ha core 2023.5.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
