### PR TITLE
Remove `ozone` state attribute and `ozone` sensors from Accuweather

### DIFF
--- a/homeassistant/components/accuweather/sensor.py
+++ b/homeassistant/components/accuweather/sensor.py
@@ -63,13 +63,6 @@ class AccuWeatherSensorDescription(
 
 FORECAST_SENSOR_TYPES: tuple[AccuWeatherSensorDescription, ...] = (
     AccuWeatherSensorDescription(
-        key="AirQuality",
-        icon="mdi:air-filter",
-        name="Air quality",
-        entity_registry_enabled_default=True,
-        value_fn=lambda data: cast(str, data[ATTR_CATEGORY]),
-    ),
-    AccuWeatherSensorDescription(
         key="CloudCoverDay",
         icon="mdi:weather-cloudy",
         name="Cloud cover day",

--- a/homeassistant/components/accuweather/sensor.py
+++ b/homeassistant/components/accuweather/sensor.py
@@ -63,6 +63,13 @@ class AccuWeatherSensorDescription(
 
 FORECAST_SENSOR_TYPES: tuple[AccuWeatherSensorDescription, ...] = (
     AccuWeatherSensorDescription(
+        key="AirQuality",
+        icon="mdi:air-filter",
+        name="Air quality",
+        entity_registry_enabled_default=True,
+        value_fn=lambda data: cast(str, data[ATTR_CATEGORY]),
+    ),
+    AccuWeatherSensorDescription(
         key="CloudCoverDay",
         icon="mdi:weather-cloudy",
         name="Cloud cover day",
@@ -100,14 +107,6 @@ FORECAST_SENSOR_TYPES: tuple[AccuWeatherSensorDescription, ...] = (
         name="Mold pollen",
         entity_registry_enabled_default=False,
         native_unit_of_measurement=CONCENTRATION_PARTS_PER_CUBIC_METER,
-        value_fn=lambda data: cast(int, data[ATTR_VALUE]),
-        attr_fn=lambda data: {ATTR_LEVEL: data[ATTR_CATEGORY]},
-    ),
-    AccuWeatherSensorDescription(
-        key="Ozone",
-        icon="mdi:vector-triangle",
-        name="Ozone",
-        entity_registry_enabled_default=False,
         value_fn=lambda data: cast(int, data[ATTR_VALUE]),
         attr_fn=lambda data: {ATTR_LEVEL: data[ATTR_CATEGORY]},
     ),

--- a/homeassistant/components/accuweather/weather.py
+++ b/homeassistant/components/accuweather/weather.py
@@ -110,16 +110,6 @@ class AccuWeatherEntity(
         return cast(float, self.coordinator.data["Visibility"][API_METRIC]["Value"])
 
     @property
-    def ozone(self) -> int | None:
-        """Return the ozone level."""
-        # We only have ozone data for certain locations and only in the forecast data.
-        if self.coordinator.forecast and self.coordinator.data[ATTR_FORECAST][0].get(
-            "Ozone"
-        ):
-            return cast(int, self.coordinator.data[ATTR_FORECAST][0]["Ozone"]["Value"])
-        return None
-
-    @property
     def forecast(self) -> list[Forecast] | None:
         """Return the forecast array."""
         if not self.coordinator.forecast:

--- a/tests/components/accuweather/test_init.py
+++ b/tests/components/accuweather/test_init.py
@@ -5,9 +5,11 @@ from unittest.mock import patch
 from accuweather import ApiError
 
 from homeassistant.components.accuweather.const import DOMAIN
+from homeassistant.components.sensor import DOMAIN as SENSOR_PLATFORM
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.util.dt import utcnow
 
 from . import init_integration
@@ -113,3 +115,21 @@ async def test_update_interval_forecast(hass: HomeAssistant) -> None:
 
         assert mock_current.call_count == 1
         assert mock_forecast.call_count == 1
+
+
+async def test_remove_ozone_sensors(hass: HomeAssistant) -> None:
+    """Test remove ozone sensors from registry."""
+    registry = er.async_get(hass)
+
+    registry.async_get_or_create(
+        SENSOR_PLATFORM,
+        DOMAIN,
+        "0123456-ozone-0",
+        suggested_object_id="home_ozone_0d",
+        disabled_by=None,
+    )
+
+    await init_integration(hass)
+
+    entry = registry.async_get("sensor.home_ozone_0d")
+    assert entry is None

--- a/tests/components/accuweather/test_sensor.py
+++ b/tests/components/accuweather/test_sensor.py
@@ -308,13 +308,6 @@ async def test_sensor_enabled_without_forecast(hass: HomeAssistant) -> None:
     registry.async_get_or_create(
         SENSOR_DOMAIN,
         DOMAIN,
-        "0123456-ozone-0",
-        suggested_object_id="home_ozone_0d",
-        disabled_by=None,
-    )
-    registry.async_get_or_create(
-        SENSOR_DOMAIN,
-        DOMAIN,
         "0123456-ragweed-0",
         suggested_object_id="home_ragweed_pollen_0d",
         disabled_by=None,
@@ -528,18 +521,6 @@ async def test_sensor_enabled_without_forecast(hass: HomeAssistant) -> None:
     entry = registry.async_get("sensor.home_mold_pollen_0d")
     assert entry
     assert entry.unique_id == "0123456-mold-0"
-
-    state = hass.states.get("sensor.home_ozone_0d")
-    assert state
-    assert state.state == "32"
-    assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
-    assert state.attributes.get("level") == "Good"
-    assert state.attributes.get(ATTR_ICON) == "mdi:vector-triangle"
-    assert state.attributes.get(ATTR_STATE_CLASS) is None
-
-    entry = registry.async_get("sensor.home_ozone_0d")
-    assert entry
-    assert entry.unique_id == "0123456-ozone-0"
 
     state = hass.states.get("sensor.home_ragweed_pollen_0d")
     assert state

--- a/tests/components/accuweather/test_weather.py
+++ b/tests/components/accuweather/test_weather.py
@@ -14,7 +14,6 @@ from homeassistant.components.weather import (
     ATTR_FORECAST_WIND_BEARING,
     ATTR_FORECAST_WIND_SPEED,
     ATTR_WEATHER_HUMIDITY,
-    ATTR_WEATHER_OZONE,
     ATTR_WEATHER_PRESSURE,
     ATTR_WEATHER_TEMPERATURE,
     ATTR_WEATHER_VISIBILITY,
@@ -46,7 +45,6 @@ async def test_weather_without_forecast(hass: HomeAssistant) -> None:
     assert state.state == "sunny"
     assert not state.attributes.get(ATTR_FORECAST)
     assert state.attributes.get(ATTR_WEATHER_HUMIDITY) == 67
-    assert not state.attributes.get(ATTR_WEATHER_OZONE)
     assert state.attributes.get(ATTR_WEATHER_PRESSURE) == 1012.0
     assert state.attributes.get(ATTR_WEATHER_TEMPERATURE) == 22.6
     assert state.attributes.get(ATTR_WEATHER_VISIBILITY) == 16.1
@@ -68,7 +66,6 @@ async def test_weather_with_forecast(hass: HomeAssistant) -> None:
     assert state
     assert state.state == "sunny"
     assert state.attributes.get(ATTR_WEATHER_HUMIDITY) == 67
-    assert state.attributes.get(ATTR_WEATHER_OZONE) == 32
     assert state.attributes.get(ATTR_WEATHER_PRESSURE) == 1012.0
     assert state.attributes.get(ATTR_WEATHER_TEMPERATURE) == 22.6
     assert state.attributes.get(ATTR_WEATHER_VISIBILITY) == 16.1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The `ozone` sensors and the `ozone` state attribute of the weather entity showed incorrect values and are being removed. If you use these values in your automations, you need to update them.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Due to my misinterpretation of the Accuweather API documentation, the ozone values of the sensors and the weather entity attribute show incorrect values - these are numeric values describing air quality (air quality index), not the concentration of ozone in the air. For this reason, I completely remove the ozone sensors and the ozone weather entity attribute. In the next step, I will add an air quality sensor.

![obraz](https://user-images.githubusercontent.com/478555/232290790-96cce075-fe0c-41b5-9d02-be0bc7af61a7.png)

![obraz](https://user-images.githubusercontent.com/478555/232298336-e52e18cf-4409-4da9-a068-006847950056.png)



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
