### PR TITLE
Remove deprecated set_doorbell_message UniFi Protect service

### DIFF
--- a/homeassistant/components/unifiprotect/select.py
+++ b/homeassistant/components/unifiprotect/select.py
@@ -30,9 +30,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.entity_platform import (
-    AddEntitiesCallback,
-)
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DISPATCH_ADOPT, DOMAIN, TYPE_EMPTY_VALUE
 from .data import ProtectData

--- a/homeassistant/components/unifiprotect/select.py
+++ b/homeassistant/components/unifiprotect/select.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from datetime import timedelta
 from enum import Enum
 import logging
 from typing import Any, Final
@@ -25,22 +24,17 @@ from pyunifiprotect.data import (
     Sensor,
     Viewer,
 )
-import voluptuous as vol
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_ENTITY_ID, EntityCategory
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import config_validation as cv, issue_registry as ir
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import (
     AddEntitiesCallback,
-    async_get_current_platform,
 )
-from homeassistant.util.dt import utcnow
 
-from .const import ATTR_DURATION, ATTR_MESSAGE, DISPATCH_ADOPT, DOMAIN, TYPE_EMPTY_VALUE
+from .const import DISPATCH_ADOPT, DOMAIN, TYPE_EMPTY_VALUE
 from .data import ProtectData
 from .entity import ProtectDeviceEntity, async_all_device_entities
 from .models import PermRequired, ProtectSetableKeysMixin, T

--- a/homeassistant/components/unifiprotect/services.yaml
+++ b/homeassistant/components/unifiprotect/services.yaml
@@ -52,38 +52,6 @@ set_default_doorbell_text:
       required: true
       selector:
         text:
-set_doorbell_message:
-  name: Set Doorbell message
-  description: >
-    Use to dynamically set the message on a Doorbell LCD screen. This service should only be used to set dynamic messages (i.e. setting the current outdoor temperature on your Doorbell). Static messages should still be set using the Select entity and can be added/removed using the add_doorbell_text/remove_doorbell_text services.
-  fields:
-    entity_id:
-      name: Doorbell Text
-      description: The Doorbell Text select entity for your Doorbell.
-      example: "select.front_doorbell_camera_doorbell_text"
-      required: true
-      selector:
-        entity:
-          integration: unifiprotect
-          domain: select
-    message:
-      name: Message to display
-      description: The message you would like to display on the LCD screen of your Doorbell. Must be less than 30 characters.
-      example: "Welcome | 09:23 | 25°C"
-      required: true
-      selector:
-        text:
-    duration:
-      name: Duration
-      description: Number of minutes to display the message for before returning to the default message. The default is to not expire.
-      example: 5
-      selector:
-        number:
-          min: 1
-          max: 120
-          step: 1
-          mode: slider
-          unit_of_measurement: minutes
 set_chime_paired_doorbells:
   name: Set Chime Paired Doorbells
   description: >

--- a/tests/components/unifiprotect/test_select.py
+++ b/tests/components/unifiprotect/test_select.py
@@ -31,7 +31,6 @@ from homeassistant.components.unifiprotect.select import (
     CAMERA_SELECTS,
     LIGHT_MODE_OFF,
     LIGHT_SELECTS,
-    SERVICE_SET_DOORBELL_MESSAGE,
     VIEWER_SELECTS,
 )
 from homeassistant.const import ATTR_ATTRIBUTION, ATTR_ENTITY_ID, ATTR_OPTION, Platform
@@ -547,99 +546,3 @@ async def test_select_set_option_viewer(
     )
 
     viewer.set_liveview.assert_called_once_with(liveview)
-
-
-async def test_select_service_doorbell_invalid(
-    hass: HomeAssistant, ufp: MockUFPFixture, doorbell: Camera
-) -> None:
-    """Test Doorbell Text service (invalid)."""
-
-    await init_entry(hass, ufp, [doorbell])
-    assert_entity_counts(hass, Platform.SELECT, 4, 4)
-
-    _, entity_id = ids_from_device_description(
-        Platform.SELECT, doorbell, CAMERA_SELECTS[1]
-    )
-
-    doorbell.__fields__["set_lcd_text"] = Mock(final=False)
-    doorbell.set_lcd_text = AsyncMock()
-
-    with pytest.raises(HomeAssistantError):
-        await hass.services.async_call(
-            "unifiprotect",
-            SERVICE_SET_DOORBELL_MESSAGE,
-            {ATTR_ENTITY_ID: entity_id, ATTR_MESSAGE: "Test"},
-            blocking=True,
-        )
-
-    assert not doorbell.set_lcd_text.called
-
-
-async def test_select_service_doorbell_success(
-    hass: HomeAssistant, ufp: MockUFPFixture, doorbell: Camera
-) -> None:
-    """Test Doorbell Text service (success)."""
-
-    await init_entry(hass, ufp, [doorbell])
-    assert_entity_counts(hass, Platform.SELECT, 4, 4)
-
-    _, entity_id = ids_from_device_description(
-        Platform.SELECT, doorbell, CAMERA_SELECTS[2]
-    )
-
-    doorbell.__fields__["set_lcd_text"] = Mock(final=False)
-    doorbell.set_lcd_text = AsyncMock()
-
-    await hass.services.async_call(
-        "unifiprotect",
-        SERVICE_SET_DOORBELL_MESSAGE,
-        {
-            ATTR_ENTITY_ID: entity_id,
-            ATTR_MESSAGE: "Test",
-        },
-        blocking=True,
-    )
-
-    doorbell.set_lcd_text.assert_called_once_with(
-        DoorbellMessageType.CUSTOM_MESSAGE, "Test", reset_at=None
-    )
-
-
-@patch("homeassistant.components.unifiprotect.select.utcnow")
-async def test_select_service_doorbell_with_reset(
-    mock_now,
-    hass: HomeAssistant,
-    ufp: MockUFPFixture,
-    doorbell: Camera,
-    fixed_now: datetime,
-) -> None:
-    """Test Doorbell Text service (success with reset time)."""
-
-    mock_now.return_value = fixed_now
-
-    _, entity_id = ids_from_device_description(
-        Platform.SELECT, doorbell, CAMERA_SELECTS[2]
-    )
-
-    await init_entry(hass, ufp, [doorbell])
-    assert_entity_counts(hass, Platform.SELECT, 4, 4)
-
-    doorbell.__fields__["set_lcd_text"] = Mock(final=False)
-    doorbell.set_lcd_text = AsyncMock()
-
-    await hass.services.async_call(
-        "unifiprotect",
-        SERVICE_SET_DOORBELL_MESSAGE,
-        {
-            ATTR_ENTITY_ID: entity_id,
-            ATTR_MESSAGE: "Test",
-            ATTR_DURATION: 60,
-        },
-        blocking=True,
-    )
-
-    doorbell.set_lcd_text.assert_called_once_with(
-        DoorbellMessageType.CUSTOM_MESSAGE,
-        "Test",
-        reset_at=fixed_now + timedelta(minutes=60),
-    )

--- a/tests/components/unifiprotect/test_select.py
+++ b/tests/components/unifiprotect/test_select.py
@@ -3,10 +3,8 @@
 from __future__ import annotations
 
 from copy import copy
-from datetime import datetime, timedelta
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, Mock
 
-import pytest
 from pyunifiprotect.data import (
     Camera,
     DoorbellMessageType,
@@ -22,11 +20,7 @@ from pyunifiprotect.data import (
 from pyunifiprotect.data.nvr import DoorbellMessage
 
 from homeassistant.components.select import ATTR_OPTIONS
-from homeassistant.components.unifiprotect.const import (
-    ATTR_DURATION,
-    ATTR_MESSAGE,
-    DEFAULT_ATTRIBUTION,
-)
+from homeassistant.components.unifiprotect.const import DEFAULT_ATTRIBUTION
 from homeassistant.components.unifiprotect.select import (
     CAMERA_SELECTS,
     LIGHT_MODE_OFF,
@@ -35,7 +29,6 @@ from homeassistant.components.unifiprotect.select import (
 )
 from homeassistant.const import ATTR_ATTRIBUTION, ATTR_ENTITY_ID, ATTR_OPTION, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
 from .utils import (


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

The previous deprecated `set_doorbell_message` service has been removed. Use the text entity for UniFi Protect LCD screen instead.

## Proposed change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

Removes deprecated service (was slated to be removed in 2023.3.0)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
