### PR TITLE
Remove previously deprecated ISY994 YAML support

### DIFF
--- a/homeassistant/components/isy994/__init__.py
+++ b/homeassistant/components/isy994/__init__.py
@@ -25,19 +25,15 @@ from homeassistant.helpers import aiohttp_client, config_validation as cv
 import homeassistant.helpers.device_registry as dr
 from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo
-from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
-from homeassistant.helpers.typing import ConfigType
 
 from .const import (
     _LOGGER,
     CONF_IGNORE_STRING,
     CONF_NETWORK,
-    CONF_RESTORE_LIGHT_STATE,
     CONF_SENSOR_STRING,
     CONF_TLS_VER,
     CONF_VAR_SENSOR_STRING,
     DEFAULT_IGNORE_STRING,
-    DEFAULT_RESTORE_LIGHT_STATE,
     DEFAULT_SENSOR_STRING,
     DEFAULT_VAR_SENSOR_STRING,
     DOMAIN,
@@ -55,90 +51,16 @@ from .services import async_setup_services, async_unload_services
 from .util import _async_cleanup_registry_entries
 
 CONFIG_SCHEMA = vol.Schema(
-    vol.All(
-        cv.deprecated(DOMAIN),
-        {
-            DOMAIN: vol.Schema(
-                {
-                    vol.Required(CONF_HOST): cv.url,
-                    vol.Required(CONF_USERNAME): cv.string,
-                    vol.Required(CONF_PASSWORD): cv.string,
-                    vol.Optional(CONF_TLS_VER): vol.Coerce(float),
-                    vol.Optional(
-                        CONF_IGNORE_STRING, default=DEFAULT_IGNORE_STRING
-                    ): cv.string,
-                    vol.Optional(
-                        CONF_SENSOR_STRING, default=DEFAULT_SENSOR_STRING
-                    ): cv.string,
-                    vol.Optional(
-                        CONF_VAR_SENSOR_STRING, default=DEFAULT_VAR_SENSOR_STRING
-                    ): cv.string,
-                    vol.Required(
-                        CONF_RESTORE_LIGHT_STATE, default=DEFAULT_RESTORE_LIGHT_STATE
-                    ): bool,
-                },
-            )
-        },
-    ),
+    cv.deprecated(DOMAIN),
     extra=vol.ALLOW_EXTRA,
 )
-
-
-async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up the isy994 integration from YAML."""
-    isy_config: ConfigType | None = config.get(DOMAIN)
-    hass.data.setdefault(DOMAIN, {})
-
-    if not isy_config:
-        return True
-
-    async_create_issue(
-        hass,
-        DOMAIN,
-        "deprecated_yaml",
-        breaks_in_ha_version="2023.5.0",
-        is_fixable=False,
-        severity=IssueSeverity.WARNING,
-        translation_key="deprecated_yaml",
-    )
-
-    # Only import if we haven't before.
-    config_entry = _async_find_matching_config_entry(hass)
-    if not config_entry:
-        hass.async_create_task(
-            hass.config_entries.flow.async_init(
-                DOMAIN,
-                context={"source": config_entries.SOURCE_IMPORT},
-                data=dict(isy_config),
-            )
-        )
-        return True
-
-    # Update the entry based on the YAML configuration, in case it changed.
-    hass.config_entries.async_update_entry(config_entry, data=dict(isy_config))
-    return True
-
-
-@callback
-def _async_find_matching_config_entry(
-    hass: HomeAssistant,
-) -> config_entries.ConfigEntry | None:
-    for entry in hass.config_entries.async_entries(DOMAIN):
-        if entry.source == config_entries.SOURCE_IMPORT:
-            return entry
-    return None
 
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: config_entries.ConfigEntry
 ) -> bool:
     """Set up the ISY 994 integration."""
-    # As there currently is no way to import options from yaml
-    # when setting up a config entry, we fallback to adding
-    # the options to the config entry and pull them out here if
-    # they are missing from the options
-    _async_import_options_from_data_if_missing(hass, entry)
-
+    hass.data.setdefault(DOMAIN, {})
     isy_data = hass.data[DOMAIN][entry.entry_id] = IsyData()
 
     isy_config = entry.data
@@ -266,25 +188,6 @@ async def _async_update_listener(
 ) -> None:
     """Handle options update."""
     await hass.config_entries.async_reload(entry.entry_id)
-
-
-@callback
-def _async_import_options_from_data_if_missing(
-    hass: HomeAssistant, entry: config_entries.ConfigEntry
-) -> None:
-    options = dict(entry.options)
-    modified = False
-    for importable_option in (
-        CONF_IGNORE_STRING,
-        CONF_SENSOR_STRING,
-        CONF_RESTORE_LIGHT_STATE,
-    ):
-        if importable_option not in entry.options and importable_option in entry.data:
-            options[importable_option] = entry.data[importable_option]
-            modified = True
-
-    if modified:
-        hass.config_entries.async_update_entry(entry, options=options)
 
 
 @callback

--- a/homeassistant/components/isy994/config_flow.py
+++ b/homeassistant/components/isy994/config_flow.py
@@ -168,10 +168,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
-    async def async_step_import(self, user_input: dict[str, Any]) -> FlowResult:
-        """Handle import."""
-        return await self.async_step_user(user_input)
-
     async def _async_set_unique_id_or_update(
         self, isy_mac: str, ip_address: str, port: int | None
     ) -> None:

--- a/homeassistant/components/isy994/strings.json
+++ b/homeassistant/components/isy994/strings.json
@@ -53,22 +53,5 @@
       "last_heartbeat": "Last Heartbeat Time",
       "websocket_status": "Event Socket Status"
     }
-  },
-  "issues": {
-    "deprecated_service": {
-      "title": "The {deprecated_service} service will be removed",
-      "fix_flow": {
-        "step": {
-          "confirm": {
-            "title": "The {deprecated_service} service will be removed",
-            "description": "Update any automations or scripts that use this service to instead use the `{alternate_service}` service with a target entity ID of `{alternate_target}`."
-          },
-          "deprecated_yaml": {
-            "title": "The ISY/IoX YAML configuration is being removed",
-            "description": "Configuring Universal Devices ISY/IoX using YAML is being removed.\n\nYour existing YAML configuration has been imported into the UI automatically.\n\nRemove the `isy994` YAML configuration from your configuration.yaml file and restart Home Assistant to fix this issue."
-          }
-        }
-      }
-    }
   }
 }

--- a/tests/components/isy994/test_config_flow.py
+++ b/tests/components/isy994/test_config_flow.py
@@ -8,21 +8,12 @@ import pytest
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components import dhcp, ssdp
 from homeassistant.components.isy994.const import (
-    CONF_IGNORE_STRING,
-    CONF_RESTORE_LIGHT_STATE,
-    CONF_SENSOR_STRING,
     CONF_TLS_VER,
-    CONF_VAR_SENSOR_STRING,
     DOMAIN,
     ISY_URL_POSTFIX,
     UDN_UUID_PREFIX,
 )
-from homeassistant.config_entries import (
-    SOURCE_DHCP,
-    SOURCE_IGNORE,
-    SOURCE_IMPORT,
-    SOURCE_SSDP,
-)
+from homeassistant.config_entries import SOURCE_DHCP, SOURCE_IGNORE, SOURCE_SSDP
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 
@@ -50,27 +41,6 @@ MOCK_IOX_USER_INPUT = {
     CONF_USERNAME: MOCK_USERNAME,
     CONF_PASSWORD: MOCK_PASSWORD,
     CONF_TLS_VER: MOCK_TLS_VERSION,
-}
-MOCK_IMPORT_WITH_SSL = {
-    CONF_HOST: f"https://{MOCK_HOSTNAME}",
-    CONF_USERNAME: MOCK_USERNAME,
-    CONF_PASSWORD: MOCK_PASSWORD,
-    CONF_TLS_VER: MOCK_TLS_VERSION,
-}
-MOCK_IMPORT_BASIC_CONFIG = {
-    CONF_HOST: f"http://{MOCK_HOSTNAME}",
-    CONF_USERNAME: MOCK_USERNAME,
-    CONF_PASSWORD: MOCK_PASSWORD,
-}
-MOCK_IMPORT_FULL_CONFIG = {
-    CONF_HOST: f"http://{MOCK_HOSTNAME}",
-    CONF_USERNAME: MOCK_USERNAME,
-    CONF_PASSWORD: MOCK_PASSWORD,
-    CONF_IGNORE_STRING: MOCK_IGNORE_STRING,
-    CONF_RESTORE_LIGHT_STATE: MOCK_RESTORE_LIGHT_STATE,
-    CONF_SENSOR_STRING: MOCK_SENSOR_STRING,
-    CONF_TLS_VER: MOCK_TLS_VERSION,
-    CONF_VAR_SENSOR_STRING: MOCK_VARIABLE_SENSOR_STRING,
 }
 
 MOCK_DEVICE_NAME = "Name of the device"
@@ -121,8 +91,6 @@ async def test_form(hass: HomeAssistant) -> None:
     assert result["errors"] == {}
 
     with patch(PATCH_CONNECTION, return_value=MOCK_CONFIG_RESPONSE), patch(
-        PATCH_ASYNC_SETUP, return_value=True
-    ) as mock_setup, patch(
         PATCH_ASYNC_SETUP_ENTRY,
         return_value=True,
     ) as mock_setup_entry:
@@ -135,7 +103,6 @@ async def test_form(hass: HomeAssistant) -> None:
     assert result2["title"] == f"{MOCK_DEVICE_NAME} ({MOCK_HOSTNAME})"
     assert result2["result"].unique_id == MOCK_UUID
     assert result2["data"] == MOCK_USER_INPUT
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -271,72 +238,6 @@ async def test_form_existing_config_entry(hass: HomeAssistant) -> None:
     assert result2["type"] == data_entry_flow.FlowResultType.ABORT
 
 
-async def test_import_flow_some_fields(hass: HomeAssistant) -> None:
-    """Test import config flow with just the basic fields."""
-    with patch(PATCH_CONNECTION, return_value=MOCK_CONFIG_RESPONSE), patch(
-        PATCH_ASYNC_SETUP, return_value=True
-    ), patch(
-        PATCH_ASYNC_SETUP_ENTRY,
-        return_value=True,
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_IMPORT},
-            data=MOCK_IMPORT_BASIC_CONFIG,
-        )
-
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
-    assert result["data"][CONF_HOST] == f"http://{MOCK_HOSTNAME}"
-    assert result["data"][CONF_USERNAME] == MOCK_USERNAME
-    assert result["data"][CONF_PASSWORD] == MOCK_PASSWORD
-
-
-async def test_import_flow_with_https(hass: HomeAssistant) -> None:
-    """Test import config with https."""
-
-    with patch(PATCH_CONNECTION, return_value=MOCK_CONFIG_RESPONSE), patch(
-        PATCH_ASYNC_SETUP, return_value=True
-    ), patch(
-        PATCH_ASYNC_SETUP_ENTRY,
-        return_value=True,
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_IMPORT},
-            data=MOCK_IMPORT_WITH_SSL,
-        )
-
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
-    assert result["data"][CONF_HOST] == f"https://{MOCK_HOSTNAME}"
-    assert result["data"][CONF_USERNAME] == MOCK_USERNAME
-    assert result["data"][CONF_PASSWORD] == MOCK_PASSWORD
-
-
-async def test_import_flow_all_fields(hass: HomeAssistant) -> None:
-    """Test import config flow with all fields."""
-    with patch(PATCH_CONNECTION, return_value=MOCK_CONFIG_RESPONSE), patch(
-        PATCH_ASYNC_SETUP, return_value=True
-    ), patch(
-        PATCH_ASYNC_SETUP_ENTRY,
-        return_value=True,
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_IMPORT},
-            data=MOCK_IMPORT_FULL_CONFIG,
-        )
-
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
-    assert result["data"][CONF_HOST] == f"http://{MOCK_HOSTNAME}"
-    assert result["data"][CONF_USERNAME] == MOCK_USERNAME
-    assert result["data"][CONF_PASSWORD] == MOCK_PASSWORD
-    assert result["data"][CONF_IGNORE_STRING] == MOCK_IGNORE_STRING
-    assert result["data"][CONF_RESTORE_LIGHT_STATE] == MOCK_RESTORE_LIGHT_STATE
-    assert result["data"][CONF_SENSOR_STRING] == MOCK_SENSOR_STRING
-    assert result["data"][CONF_VAR_SENSOR_STRING] == MOCK_VARIABLE_SENSOR_STRING
-    assert result["data"][CONF_TLS_VER] == MOCK_TLS_VERSION
-
-
 async def test_form_ssdp_already_configured(hass: HomeAssistant) -> None:
     """Test ssdp abort when the serial number is already configured."""
 
@@ -383,8 +284,6 @@ async def test_form_ssdp(hass: HomeAssistant) -> None:
     assert result["errors"] == {}
 
     with patch(PATCH_CONNECTION, return_value=MOCK_CONFIG_RESPONSE), patch(
-        PATCH_ASYNC_SETUP, return_value=True
-    ) as mock_setup, patch(
         PATCH_ASYNC_SETUP_ENTRY,
         return_value=True,
     ) as mock_setup_entry:
@@ -398,7 +297,6 @@ async def test_form_ssdp(hass: HomeAssistant) -> None:
     assert result2["title"] == f"{MOCK_DEVICE_NAME} ({MOCK_HOSTNAME})"
     assert result2["result"].unique_id == MOCK_UUID
     assert result2["data"] == MOCK_USER_INPUT
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -545,8 +443,6 @@ async def test_form_dhcp(hass: HomeAssistant) -> None:
     assert result["errors"] == {}
 
     with patch(PATCH_CONNECTION, return_value=MOCK_CONFIG_RESPONSE), patch(
-        PATCH_ASYNC_SETUP, return_value=True
-    ) as mock_setup, patch(
         PATCH_ASYNC_SETUP_ENTRY,
         return_value=True,
     ) as mock_setup_entry:
@@ -560,7 +456,6 @@ async def test_form_dhcp(hass: HomeAssistant) -> None:
     assert result2["title"] == f"{MOCK_DEVICE_NAME} ({MOCK_HOSTNAME})"
     assert result2["result"].unique_id == MOCK_UUID
     assert result2["data"] == MOCK_USER_INPUT
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -585,8 +480,6 @@ async def test_form_dhcp_with_polisy(hass: HomeAssistant) -> None:
     )
 
     with patch(PATCH_CONNECTION, return_value=MOCK_CONFIG_RESPONSE), patch(
-        PATCH_ASYNC_SETUP, return_value=True
-    ) as mock_setup, patch(
         PATCH_ASYNC_SETUP_ENTRY,
         return_value=True,
     ) as mock_setup_entry:
@@ -600,7 +493,6 @@ async def test_form_dhcp_with_polisy(hass: HomeAssistant) -> None:
     assert result2["title"] == f"{MOCK_DEVICE_NAME} ({MOCK_HOSTNAME})"
     assert result2["result"].unique_id == MOCK_UUID
     assert result2["data"] == MOCK_IOX_USER_INPUT
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -625,8 +517,6 @@ async def test_form_dhcp_with_eisy(hass: HomeAssistant) -> None:
     )
 
     with patch(PATCH_CONNECTION, return_value=MOCK_CONFIG_RESPONSE), patch(
-        PATCH_ASYNC_SETUP, return_value=True
-    ) as mock_setup, patch(
         PATCH_ASYNC_SETUP_ENTRY,
         return_value=True,
     ) as mock_setup_entry:
@@ -640,7 +530,6 @@ async def test_form_dhcp_with_eisy(hass: HomeAssistant) -> None:
     assert result2["title"] == f"{MOCK_DEVICE_NAME} ({MOCK_HOSTNAME})"
     assert result2["result"].unique_id == MOCK_UUID
     assert result2["data"] == MOCK_IOX_USER_INPUT
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The previously deprecated support for ISY994 YAML configuration has been removed. Your existing `isy994` section in `configuration.yaml` will have already been imported and should be removed.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove YAML support for ISY994 which was previously deprecated in PR #85797

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #85797
- Link to documentation pull request: N/A - Documentation updated previously

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
