### PR TITLE
Skip adding WeMo device on failure

### DIFF
--- a/homeassistant/components/wemo/__init__.py
+++ b/homeassistant/components/wemo/__init__.py
@@ -149,7 +149,12 @@ class WemoDispatcher:
         if wemo.serialnumber in self._added_serial_numbers:
             return
 
-        coordinator = await async_register_device(hass, self._config_entry, wemo)
+        try:
+            coordinator = await async_register_device(hass, self._config_entry, wemo)
+        except pywemo.PyWeMoException as err:
+            _LOGGER.error("Unable to add WeMo %s %s: %s", repr(wemo), wemo.host, err)
+            return
+
         platforms = set(WEMO_MODEL_DISPATCH.get(wemo.model_name, [Platform.SWITCH]))
         platforms.add(Platform.SENSOR)
         for platform in platforms:

--- a/homeassistant/components/wemo/__init__.py
+++ b/homeassistant/components/wemo/__init__.py
@@ -153,8 +153,8 @@ class WemoDispatcher:
         try:
             coordinator = await async_register_device(hass, self._config_entry, wemo)
         except pywemo.PyWeMoException as err:
-            if wemo.serial_number not in self._failed_serial_numbers:
-                self._failed_serial_numbers.add(wemo.serial_number)
+            if wemo.serialnumber not in self._failed_serial_numbers:
+                self._failed_serial_numbers.add(wemo.serialnumber)
                 _LOGGER.error(
                     "Unable to add WeMo %s %s: %s", repr(wemo), wemo.host, err
                 )

--- a/homeassistant/components/wemo/__init__.py
+++ b/homeassistant/components/wemo/__init__.py
@@ -188,6 +188,7 @@ class WemoDispatcher:
                 )
 
         self._added_serial_numbers.add(wemo.serialnumber)
+        self._failed_serial_numbers.discard(wemo.serialnumber)
 
 
 class WemoDiscovery:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Some WeMo devices can get into an unresponsive state where they always return a HTTP 500 status code when probing their state. When the wemo component is setup using a list of static devices, the first device to fail this way causes the remaining devices to not be setup. This PR handles an exception from WeMo devices that fail to return their current state when requested during setup. 

If the user resets the device, it will become responsive again, and the next scheduled `async_discover_and_schedule` call will cause it to be added to Home Assistant.

Traceback of the issue from https://github.com/home-assistant/core/issues/88602#issuecomment-1512207246

```
Traceback (most recent call last):
  File "/srv/venv_310/lib/python3.10/site-packages/homeassistant/components/wemo/__init__.py", line 211, in async_discover_and_schedule
    await self._wemo_dispatcher.async_add_unique_device(self._hass, device)
  File "/srv/venv_310/lib/python3.10/site-packages/homeassistant/components/wemo/__init__.py", line 152, in async_add_unique_device
    coordinator = await async_register_device(hass, self._config_entry, wemo)
  File "/srv/venv_310/lib/python3.10/site-packages/homeassistant/components/wemo/wemo_device.py", line 154, in async_register_device
    await hass.async_add_executor_job(wemo.get_state, True)
  File "/usr/lib/python3.10/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/srv/venv_310/lib/python3.10/site-packages/pywemo/ouimeaux_device/__init__.py", line 222, in get_state
    self.update_binary_state()
  File "/srv/venv_310/lib/python3.10/site-packages/pywemo/ouimeaux_device/__init__.py", line 200, in update_binary_state
    self.basic_state_params = self.basicevent.GetBinaryState() or {}
  File "/srv/venv_310/lib/python3.10/site-packages/pywemo/ouimeaux_device/api/service.py", line 267, in __call__
    raise ActionException(msg) from last_exception
pywemo.exceptions.ActionException: Error communicating with Grow Lights after 3 attempts. Giving up.
```

Thank you to @wilpig for providing this Traceback!

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #88602

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
