### PR TITLE
Fix lingering timers in bluetooth (part 2)

### DIFF
--- a/homeassistant/components/bluetooth/active_update_coordinator.py
+++ b/homeassistant/components/bluetooth/active_update_coordinator.py
@@ -169,3 +169,9 @@ class ActiveBluetoothDataUpdateCoordinator(
         # possible after a device comes online or back in range, if a poll is due
         if self.needs_poll(service_info):
             self.hass.async_create_task(self._debounced_poll.async_call())
+
+    @callback
+    def _async_stop(self) -> None:
+        """Cancel debouncer and stop the callbacks."""
+        self._debounced_poll.async_cancel()
+        super()._async_stop()

--- a/homeassistant/components/bluetooth/active_update_processor.py
+++ b/homeassistant/components/bluetooth/active_update_processor.py
@@ -158,3 +158,9 @@ class ActiveBluetoothProcessorCoordinator(
         # possible after a device comes online or back in range, if a poll is due
         if self.needs_poll(service_info):
             self.hass.async_create_task(self._debounced_poll.async_call())
+
+    @callback
+    def _async_stop(self) -> None:
+        """Cancel debouncer and stop the callbacks."""
+        self._debounced_poll.async_cancel()
+        super()._async_stop()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Linked to #91360
https://github.com/home-assistant/core/actions/runs/4729883045/jobs/8393069269?pr=91360

```console
ERROR tests/components/bluetooth/test_active_update_coordinator.py::test_basic_usage - Failed: Lingering timer after test <TimerHandle when=866.832260742 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:149>
ERROR tests/components/bluetooth/test_active_update_coordinator.py::test_polling_debounce - Failed: Lingering timer after test <TimerHandle when=867.268652347 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:149>
ERROR tests/components/bluetooth/test_active_update_coordinator.py::test_polling_debounce_with_custom_debouncer - Failed: Lingering timer after test <TimerHandle when=857.5630074100001 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:149>
ERROR tests/components/bluetooth/test_active_update_coordinator.py::test_polling_rejecting_the_first_time - Failed: Lingering timer after test <TimerHandle when=867.643784735 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:149>
ERROR tests/components/bluetooth/test_active_update_coordinator.py::test_no_polling_after_stop_event - Failed: Lingering timer after test <TimerHandle when=867.822870843 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:149>
ERROR tests/components/bluetooth/test_active_update_processor.py::test_basic_usage - Failed: Lingering timer after test <TimerHandle when=868.742875731 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:149>
ERROR tests/components/bluetooth/test_active_update_processor.py::test_second_poll_needed - Failed: Lingering timer after test <TimerHandle when=869.32321999 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:149>
ERROR tests/components/bluetooth/test_active_update_processor.py::test_rate_limit - Failed: Lingering timer after test <TimerHandle when=869.498902964 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:149>
ERROR tests/components/bluetooth/test_active_update_processor.py::test_no_polling_after_stop_event - Failed: Lingering timer after test <TimerHandle when=869.67051533 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:149>
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
