### PR TITLE
Fix lingering timer in ZHA tests

### DIFF
--- a/tests/components/zha/test_discover.py
+++ b/tests/components/zha/test_discover.py
@@ -353,6 +353,8 @@ async def test_discover_endpoint(
             ent_info[DEV_SIG_CLUSTER_HANDLERS]
         )
 
+    device.async_cleanup_handles()
+
 
 def _ch_mock(cluster):
     """Return mock of a cluster_handler with a cluster."""

--- a/tests/components/zha/test_discover.py
+++ b/tests/components/zha/test_discover.py
@@ -1,5 +1,7 @@
 """Test ZHA device discovery."""
+from collections.abc import Callable
 import re
+from typing import Any
 from unittest import mock
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -16,6 +18,7 @@ import zigpy.zcl.foundation as zcl_f
 import homeassistant.components.zha.binary_sensor
 import homeassistant.components.zha.core.cluster_handlers as cluster_handlers
 import homeassistant.components.zha.core.const as zha_const
+from homeassistant.components.zha.core.device import ZHADevice
 import homeassistant.components.zha.core.discovery as disc
 from homeassistant.components.zha.core.endpoint import Endpoint
 import homeassistant.components.zha.core.registries as zha_regs
@@ -301,7 +304,9 @@ def test_discover_probe_single_cluster() -> None:
 
 @pytest.mark.parametrize("device_info", DEVICES)
 async def test_discover_endpoint(
-    device_info, zha_device_mock, hass: HomeAssistant
+    device_info: dict[str, Any],
+    zha_device_mock: Callable[..., ZHADevice],
+    hass: HomeAssistant,
 ) -> None:
     """Test device discovery."""
 

--- a/tests/components/zha/test_gateway.py
+++ b/tests/components/zha/test_gateway.py
@@ -1,5 +1,6 @@
 """Test ZHA Gateway."""
 import asyncio
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -8,6 +9,7 @@ import zigpy.profiles.zha as zha
 import zigpy.zcl.clusters.general as general
 import zigpy.zcl.clusters.lighting as lighting
 
+from homeassistant.components.zha.core.device import ZHADevice
 from homeassistant.components.zha.core.group import GroupMember
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
@@ -238,7 +240,10 @@ async def test_gateway_create_group_with_id(
     ],
 )
 async def test_gateway_initialize_success(
-    startup, hass: HomeAssistant, device_light_1, coordinator
+    startup: list[Any],
+    hass: HomeAssistant,
+    device_light_1: ZHADevice,
+    coordinator: ZHADevice,
 ) -> None:
     """Test ZHA initializing the gateway successfully."""
     zha_gateway = get_zha_gateway(hass)
@@ -252,6 +257,8 @@ async def test_gateway_initialize_success(
         await zha_gateway.async_initialize()
 
     assert mock_new.call_count == len(startup)
+
+    device_light_1.async_cleanup_handles()
 
 
 @patch("homeassistant.components.zha.core.gateway.STARTUP_FAILURE_DELAY_S", 0.01)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Linked to #91360

Since the devices are created manually, they need to be cleaned up manually

```console
FAILED tests/components/zha/test_discover.py::test_discover_endpoint[device_info96] - Failed: Lingering timer after job <Job track time interval 0:01:14 <bound method ZHADevice._check_available of <homeassistant.components.zha.core.device.ZHADevice object at 0x7...
FAILED tests/components/zha/test_discover.py::test_discover_endpoint[device_info97] - Failed: Lingering timer after job <Job track time interval 0:01:10 <bound method ZHADevice._check_available of <homeassistant.components.zha.core.device.ZHADevice object at 0x7...
FAILED tests/components/zha/test_discover.py::test_discover_endpoint[device_info98] - Failed: Lingering timer after job <Job track time interval 0:01:05 <bound method ZHADevice._check_available of <homeassistant.components.zha.core.device.ZHADevice object at 0x7...
FAILED tests/components/zha/test_discover.py::test_discover_endpoint[device_info99] - Failed: Lingering timer after job <Job track time interval 0:01:02 <bound method ZHADevice._check_available of <homeassistant.components.zha.core.device.ZHADevice object at 0x7...
```

and

```console
FAILED tests/components/zha/test_gateway.py::test_gateway_initialize_success[startup0] - Failed: Lingering timer after job <Job track time interval 0:01:25 <bound method ZHADevice._check_available of <homeassistant.components.zha.core.device.ZHADevice object at 0x7...
FAILED tests/components/zha/test_gateway.py::test_gateway_initialize_success[startup1] - Failed: Lingering timer after job <Job track time interval 0:01:26 <bound method ZHADevice._check_available of <homeassistant.components.zha.core.device.ZHADevice object at 0x7...
FAILED tests/components/zha/test_gateway.py::test_gateway_initialize_success[startup2] - Failed: Lingering timer after job <Job track time interval 0:01:06 <bound method ZHADevice._check_available of <homeassistant.components.zha.core.device.ZHADevice object at 0x7...
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
