### PR TITLE
Fix lingering timer in ZHA cluster tests

### DIFF
--- a/tests/components/zha/conftest.py
+++ b/tests/components/zha/conftest.py
@@ -1,4 +1,5 @@
 """Test configuration for the ZHA component."""
+from collections.abc import Callable
 import itertools
 import time
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
@@ -230,7 +231,9 @@ def zha_device_joined_restored(request):
 
 
 @pytest.fixture
-def zha_device_mock(hass, zigpy_device_mock):
+def zha_device_mock(
+    hass, zigpy_device_mock
+) -> Callable[..., zha_core_device.ZHADevice]:
     """Return a ZHA Device factory."""
 
     def _zha_device(
@@ -240,7 +243,7 @@ def zha_device_mock(hass, zigpy_device_mock):
         model="mock model",
         node_desc=b"\x02@\x807\x10\x7fd\x00\x00*d\x00\x00",
         patch_cluster=True,
-    ):
+    ) -> zha_core_device.ZHADevice:
         if endpoints is None:
             endpoints = {
                 1: {


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Linked to #91360

```console
ERROR tests/components/zha/test_cluster_handlers.py::test_ep_all_cluster_handlers - Failed: Lingering timer after job <Job track time interval 0:01:18 <bound method ZHADevice._check_available of <homeassistant.components.zha.core.device.ZHADevice object at 0x7f1b9010fe50>> HassJobType.Callback <function async_track_time_interval.<locals>.interval_listener at 0x7f1b901d53a0>>
ERROR tests/components/zha/test_cluster_handlers.py::test_cluster_handler_power_config - Failed: Lingering timer after job <Job track time interval 0:01:02 <bound method ZHADevice._check_available of <homeassistant.components.zha.core.device.ZHADevice object at 0x7f1b81e5ef50>> HassJobType.Callback <function async_track_time_interval.<locals>.interval_listener at 0x7f1b901b5a80>>
ERROR tests/components/zha/test_cluster_handlers.py::test_cluster_no_ep_attribute - Failed: Lingering timer after job <Job track time interval 0:01:16 <bound method ZHADevice._check_available of <homeassistant.components.zha.core.device.ZHADevice object at 0x7f1b81c85390>> HassJobType.Callback <function async_track_time_interval.<locals>.interval_listener at 0x7f1b81d2a020>>
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
