### PR TITLE
Fix lingering timer in smartthings tests

### DIFF
--- a/tests/components/smartthings/test_init.py
+++ b/tests/components/smartthings/test_init.py
@@ -179,7 +179,7 @@ async def test_scenes_unauthorized_loads_platforms(
     smartthings_mock.subscriptions.return_value = subscriptions
 
     with patch.object(hass.config_entries, "async_forward_entry_setup") as forward_mock:
-        assert await smartthings.async_setup_entry(hass, config_entry)
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
         # Assert platforms loaded
         await hass.async_block_till_done()
         assert forward_mock.call_count == len(PLATFORMS)
@@ -211,7 +211,7 @@ async def test_config_entry_loads_platforms(
     smartthings_mock.subscriptions.return_value = subscriptions
 
     with patch.object(hass.config_entries, "async_forward_entry_setup") as forward_mock:
-        assert await smartthings.async_setup_entry(hass, config_entry)
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
         # Assert platforms loaded
         await hass.async_block_till_done()
         assert forward_mock.call_count == len(PLATFORMS)
@@ -243,7 +243,7 @@ async def test_config_entry_loads_unconnected_cloud(
     ]
     smartthings_mock.subscriptions.return_value = subscriptions
     with patch.object(hass.config_entries, "async_forward_entry_setup") as forward_mock:
-        assert await smartthings.async_setup_entry(hass, config_entry)
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
         assert forward_mock.call_count == len(PLATFORMS)
 
@@ -480,6 +480,8 @@ async def test_event_handler_dispatches_updated_devices(
     assert devices[3].status.attributes["lock"].value == "locked"
     assert devices[3].status.attributes["lock"].data == {"codeId": "1"}
 
+    broker.disconnect()
+
 
 async def test_event_handler_ignores_other_installed_app(
     hass: HomeAssistant, config_entry, device_factory, event_request_factory
@@ -501,6 +503,8 @@ async def test_event_handler_ignores_other_installed_app(
     await hass.async_block_till_done()
 
     assert not called
+
+    broker.disconnect()
 
 
 async def test_event_handler_fires_button_events(
@@ -542,3 +546,5 @@ async def test_event_handler_fires_button_events(
     await hass.async_block_till_done()
 
     assert called
+
+    broker.disconnect()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Linked to #91360

```console
ERROR tests/components/smartthings/test_init.py::test_scenes_unauthorized_loads_platforms - Failed: Lingering timer after job <Job track time interval 14 days, 0:00:00 <function DeviceBroker.connect.<locals>.regenerate_refresh_token at 0x7fa19899c720> HassJobType.Callback <function async_track_time_interval.<locals>.interval_listener at 0x7fa19899ede0>>
ERROR tests/components/smartthings/test_init.py::test_config_entry_loads_platforms - Failed: Lingering timer after job <Job track time interval 14 days, 0:00:00 <function DeviceBroker.connect.<locals>.regenerate_refresh_token at 0x7fa1a334eac0> HassJobType.Callback <function async_track_time_interval.<locals>.interval_listener at 0x7fa19bce2840>>
ERROR tests/components/smartthings/test_init.py::test_config_entry_loads_unconnected_cloud - Failed: Lingering timer after job <Job track time interval 14 days, 0:00:00 <function DeviceBroker.connect.<locals>.regenerate_refresh_token at 0x7fa1a0597060> HassJobType.Callback <function async_track_time_interval.<locals>.interval_listener at 0x7fa1a2401a80>>
ERROR tests/components/smartthings/test_init.py::test_event_handler_dispatches_updated_devices - Failed: Lingering timer after job <Job track time interval 14 days, 0:00:00 <function DeviceBroker.connect.<locals>.regenerate_refresh_token at 0x7fa19b66cea0> HassJobType.Callback <function async_track_time_interval.<locals>.interval_listener at 0x7fa19b66d620>>
ERROR tests/components/smartthings/test_init.py::test_event_handler_ignores_other_installed_app - Failed: Lingering timer after job <Job track time interval 14 days, 0:00:00 <function DeviceBroker.connect.<locals>.regenerate_refresh_token at 0x7fa199dba480> HassJobType.Callback <function async_track_time_interval.<locals>.interval_listener at 0x7fa199db87c0>>
ERROR tests/components/smartthings/test_init.py::test_event_handler_fires_button_events - Failed: Lingering timer after job <Job track time interval 14 days, 0:00:00 <function DeviceBroker.connect.<locals>.regenerate_refresh_token at 0x7fa1a295c860> HassJobType.Callback <function async_track_time_interval.<locals>.interval_listener at 0x7fa1a295cae0>>
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
