### PR TITLE
Fix lingering timer in hassio

### DIFF
--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import asyncio
 from contextlib import suppress
-from datetime import timedelta
+from datetime import datetime, timedelta
 import logging
 import os
 from typing import Any, NamedTuple
@@ -29,6 +29,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import (
     DOMAIN as HASS_DOMAIN,
+    HassJob,
     HomeAssistant,
     ServiceCall,
     callback,
@@ -492,7 +493,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:  # noqa:
             DOMAIN, service, async_service_handler, schema=settings.schema
         )
 
-    async def update_info_data(now):
+    async def update_info_data(_: datetime | None = None) -> None:
         """Update last available supervisor information."""
 
         try:
@@ -516,11 +517,13 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:  # noqa:
             _LOGGER.warning("Can't read Supervisor data: %s", err)
 
         async_track_point_in_utc_time(
-            hass, update_info_data, utcnow() + HASSIO_UPDATE_INTERVAL
+            hass,
+            HassJob(update_info_data, cancel_on_shutdown=True),
+            utcnow() + HASSIO_UPDATE_INTERVAL,
         )
 
     # Fetch data
-    await update_info_data(None)
+    await update_info_data()
 
     async def async_handle_core_service(call: ServiceCall) -> None:
         """Service handler for handling core services."""


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Linked to #91360
https://github.com/home-assistant/core/actions/runs/4745958809/jobs/8429083016?pr=91360

```console
ERROR tests/components/hassio/test_sensor.py::test_sensor[sensor.home_assistant_operating_system_version-1.0.0] - Failed: Lingering timer after job <Job track point in utc time 2023-04-19 17:25:37.429766+00:00 HassJobType.Coroutinefunction <function async_setup.<locals>.update_info_data at 0x7fc066f6b760>>
ERROR tests/components/hassio/test_repairs.py::test_supervisor_issue_repair_flow_with_multiple_suggestions - Failed: Lingering timer after job <Job track point in utc time 2023-04-19 17:25:37.754923+00:00 HassJobType.Coroutinefunction <function async_setup.<locals>.update_info_data at 0x7f9d9cfacb80>>
ERROR tests/components/hassio/test_sensor.py::test_sensor[sensor.home_assistant_operating_system_newest_version-1.0.0] - Failed: Lingering timer after job <Job track point in utc time 2023-04-19 17:25:37.774112+00:00 HassJobType.Coroutinefunction <function async_setup.<locals>.update_info_data at 0x7fc075a4dfc0>>
ERROR tests/components/hassio/test_repairs.py::test_supervisor_issue_repair_flow_with_multiple_suggestions_and_confirmation - Failed: Lingering timer after job <Job track point in utc time 2023-04-19 17:25:37.979513+00:00 HassJobType.Coroutinefunction <function async_setup.<locals>.update_info_data at 0x7f9d9dda3490>>
ERROR tests/components/hassio/test_repairs.py::test_supervisor_issue_repair_flow_skip_confirmation - Failed: Lingering timer after job <Job track point in utc time 2023-04-19 17:25:38.209193+00:00 HassJobType.Coroutinefunction <function async_setup.<locals>.update_info_data at 0x7f9d9d1030a0>>
ERROR tests/components/hassio/test_sensor.py::test_sensor[sensor.home_assistant_host_os_agent_version-1.0.0] - Failed: Lingering timer after job <Job track point in utc time 2023-04-19 17:25:38.123127+00:00 HassJobType.Coroutinefunction <function async_setup.<locals>.update_info_data at 0x7fc076aede10>>
ERROR tests/components/hassio/test_sensor.py::test_sensor[sensor.home_assistant_core_cpu_percent-0.99] - Failed: Lingering timer after job <Job track point in utc time 2023-04-19 17:25:38.472115+00:00 HassJobType.Coroutinefunction <function async_setup.<locals>.update_info_data at 0x7fc0759adea0>>
ERROR tests/components/hassio/test_sensor.py::test_sensor[sensor.home_assistant_supervisor_cpu_percent-0.99] - Failed: Lingering timer after job <Job track point in utc time 2023-04-19 17:25:38.814659+00:00 HassJobType.Coroutinefunction <function async_setup.<locals>.update_info_data at 0x7fc0773d5a20>>
ERROR tests/components/hassio/test_sensor.py::test_sensor[sensor.test_version-2.0.0] - Failed: Lingering timer after job <Job track point in utc time 2023-04-19 17:25:39.159582+00:00 HassJobType.Coroutinefunction <function async_setup.<locals>.update_info_data at 0x7fc066f3a290>>
ERROR tests/components/hassio/test_sensor.py::test_sensor[sensor.test_newest_version-2.0.1] - Failed: Lingering timer after job <Job track point in utc time 2023-04-19 17:25:39.500239+00:00 HassJobType.Coroutinefunction <function async_setup.<locals>.update_info_data at 0x7fc066facc10>>
ERROR tests/components/hassio/test_sensor.py::test_sensor[sensor.test2_version-3.1.0] - Failed: Lingering timer after job <Job track point in utc time 2023-04-19 17:25:39.843655+00:00 HassJobType.Coroutinefunction <function async_setup.<locals>.update_info_data at 0x7fc067e1d090>>
ERROR tests/components/hassio/test_sensor.py::test_sensor[sensor.test2_newest_version-3.2.0] - Failed: Lingering timer after job <Job track point in utc time 2023-04-19 17:25:40.183143+00:00 HassJobType.Coroutinefunction <function async_setup.<locals>.update_info_data at 0x7fc067f76ef0>>
ERROR tests/components/hassio/test_sensor.py::test_sensor[sensor.test_cpu_percent-0.99] - Failed: Lingering timer after job <Job track point in utc time 2023-04-19 17:25:40.527832+00:00 HassJobType.Coroutinefunction <function async_setup.<locals>.update_info_data at 0x7fc0759fdbd0>>
ERROR tests/components/hassio/test_sensor.py::test_sensor[sensor.test2_cpu_percent-unavailable] - Failed: Lingering timer after job <Job track point in utc time 2023-04-19 17:25:40.871731+00:00 HassJobType.Coroutinefunction <function async_setup.<locals>.update_info_data at 0x7fc075603eb0>>
ERROR tests/components/hassio/test_sensor.py::test_sensor[sensor.test_memory_percent-4.59] - Failed: Lingering timer after job <Job track point in utc time 2023-04-19 17:25:41.204340+00:00 HassJobType.Coroutinefunction <function async_setup.<locals>.update_info_data at 0x7fc0770e0310>>
ERROR tests/components/hassio/test_update.py::test_update_entities[update.home_assistant_operating_system_update-on-False] - Failed: Lingering timer after job <Job track point in utc time 2023-04-19 17:25:41.288037+00:00 HassJobType.Coroutinefunction <function async_setup.<locals>.update_info_data at 0x7f9d9dda2320>>
ERROR tests/components/hassio/test_update.py::test_update_entities[update.home_assistant_supervisor_update-on-True] - Failed: Lingering timer after job <Job track point in utc time 2023-04-19 17:25:41.552259+00:00 HassJobType.Coroutinefunction <function async_setup.<locals>.update_info_data at 0x7f9d9dd3d7e0>>
ERROR tests/components/hassio/test_sensor.py::test_sensor[sensor.test2_memory_percent-unavailable] - Failed: Lingering timer after job <Job track point in utc time 2023-04-19 17:25:41.539727+00:00 HassJobType.Coroutinefunction <function async_setup.<locals>.update_info_data at 0x7fc0773b8c10>>
ERROR tests/components/hassio/test_update.py::test_update_entities[update.home_assistant_core_update-on-False] - Failed: Lingering timer after job <Job track point in utc time 2023-04-19 17:25:41.819245+00:00 HassJobType.Coroutinefunction <function async_setup.<locals>.update_info_data at 0x7f9d9d308c10>>
ERROR tests/components/hassio/test_update.py::test_update_entities[update.test_update-on-True] - Failed: Lingering timer after job <Job track point in utc time 2023-04-19 17:25:42.089236+00:00 HassJobType.Coroutinefunction <function async_setup.<locals>.update_info_data at 0x7f9d9d62d990>>
ERROR tests/components/hassio/test_update.py::test_update_entities[update.test2_update-off-False] - Failed: Lingering timer after job <Job track point in utc time 2023-04-19 17:25:42.356936+00:00 HassJobType.Coroutinefunction <function async_setup.<locals>.update_info_data at 0x7f9d9cfc2290>>
ERROR tests/components/hassio/test_update.py::test_update_addon - Failed: Lingering timer after job <Job track point in utc time 2023-04-19 17:25:42.629094+00:00 HassJobType.Coroutinefunction <function async_setup.<locals>.update_info_data at 0x7f9d9d11dcf0>>
ERROR tests/components/hassio/test_update.py::test_update_os - Failed: Lingering timer after job <Job track point in utc time 2023-04-19 17:25:42.910131+00:00 HassJobType.Coroutinefunction <function async_setup.<locals>.update_info_data at 0x7f9d9e30d870>>
ERROR tests/components/hassio/test_update.py::test_update_core - Failed: Lingering timer after job <Job track point in utc time 2023-04-19 17:25:43.183879+00:00 HassJobType.Coroutinefunction <function async_setup.<locals>.update_info_data at 0x7f9d9cc6c280>>
ERROR tests/components/hassio/test_websocket_api.py::test_ws_subscription - Failed: Lingering timer after job <Job track point in utc time 2023-04-19 17:25:43.253413+00:00 HassJobType.Coroutinefunction <function async_setup.<locals>.update_info_data at 0x7fc0740f0430>>
ERROR tests/components/hassio/test_websocket_api.py::test_websocket_supervisor_api - Failed: Lingering timer after job <Job track point in utc time 2023-04-19 17:25:43.467744+00:00 HassJobType.Coroutinefunction <function async_setup.<locals>.update_info_data at 0x7fc0740f3400>>
ERROR tests/components/hassio/test_update.py::test_update_supervisor - Failed: Lingering timer after job <Job track point in utc time 2023-04-19 17:25:43.454953+00:00 HassJobType.Coroutinefunction <function async_setup.<locals>.update_info_data at 0x7f9d9cf2f250>>
ERROR tests/components/hassio/test_websocket_api.py::test_websocket_supervisor_api_error - Failed: Lingering timer after job <Job track point in utc time 2023-04-19 17:25:43.669593+00:00 HassJobType.Coroutinefunction <function async_setup.<locals>.update_info_data at 0x7fc067e1ed40>>
ERROR tests/components/hassio/test_update.py::test_update_addon_with_error - Failed: Lingering timer after job <Job track point in utc time 2023-04-19 17:25:43.716926+00:00 HassJobType.Coroutinefunction <function async_setup.<locals>.update_info_data at 0x7f9d9c236a70>>
ERROR tests/components/hassio/test_websocket_api.py::test_websocket_non_admin_user - Failed: Lingering timer after job <Job track point in utc time 2023-04-19 17:25:43.867995+00:00 HassJobType.Coroutinefunction <function async_setup.<locals>.update_info_data at 0x7fc067cfce50>>
ERROR tests/components/hassio/test_update.py::test_update_os_with_error - Failed: Lingering timer after job <Job track point in utc time 2023-04-19 17:25:43.979107+00:00 HassJobType.Coroutinefunction <function async_setup.<locals>.update_info_data at 0x7f9d9c177be0>>
ERROR tests/components/hassio/test_update.py::test_update_supervisor_with_error - Failed: Lingering timer after job <Job track point in utc time 2023-04-19 17:25:44.245562+00:00 HassJobType.Coroutinefunction <function async_setup.<locals>.update_info_data at 0x7f9d9c416560>>
ERROR tests/components/hassio/test_update.py::test_update_core_with_error - Failed: Lingering timer after job <Job track point in utc time 2023-04-19 17:25:44.520134+00:00 HassJobType.Coroutinefunction <function async_setup.<locals>.update_info_data at 0x7f9d9c312b90>>
ERROR tests/components/hassio/test_update.py::test_release_notes_between_versions - Failed: Lingering timer after job <Job track point in utc time 2023-04-19 17:25:44.805391+00:00 HassJobType.Coroutinefunction <function async_setup.<locals>.update_info_data at 0x7f9d9e86fc70>>
ERROR tests/components/hassio/test_update.py::test_release_notes_full - Failed: Lingering timer after job <Job track point in utc time 2023-04-19 17:25:45.120484+00:00 HassJobType.Coroutinefunction <function async_setup.<locals>.update_info_data at 0x7f9d9c394ca0>>
ERROR tests/components/hassio/test_update.py::test_not_release_notes - Failed: Lingering timer after job <Job track point in utc time 2023-04-19 17:25:45.443795+00:00 HassJobType.Coroutinefunction <function async_setup.<locals>.update_info_data at 0x7f9d9e9cb910>>
ERROR tests/components/hassio/test_update.py::test_no_os_entity - Failed: Lingering timer after job <Job track point in utc time 2023-04-19 17:25:45.769648+00:00 HassJobType.Coroutinefunction <function async_setup.<locals>.update_info_data at 0x7f9d9ec2a4d0>>
ERROR tests/components/hassio/test_update.py::test_setting_up_core_update_when_addon_fails - Failed: Lingering timer after job <Job track point in utc time 2023-04-19 17:25:46.050758+00:00 HassJobType.Coroutinefunction <function async_setup.<locals>.update_info_data at 0x7f9d9ea2b520>>
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
