### PR TITLE
Fallback to generating a new ULID on migraiton if context is missing or invalid

### DIFF
--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -93,7 +93,6 @@ if TYPE_CHECKING:
     from . import Recorder
 
 LIVE_MIGRATION_MIN_SCHEMA_VERSION = 0
-_EMPTY_CONTEXT_ID = b"\x00" * 16
 _EMPTY_ENTITY_ID = "missing.entity_id"
 _EMPTY_EVENT_TYPE = "missing_event_type"
 

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -1371,6 +1371,11 @@ def _context_id_to_bytes(context_id: str | None) -> bytes | None:
     return None
 
 
+def _generate_ulid_bytes_at_time(timestamp: float | None) -> bytes:
+    """Generate a ulid with a specific timestamp."""
+    return ulid_to_bytes(ulid_at_time(timestamp or time()))
+
+
 @retryable_database_job("migrate states context_ids to binary format")
 def migrate_states_context_ids(instance: Recorder) -> bool:
     """Migrate states context_ids to use binary format."""
@@ -1386,7 +1391,7 @@ def migrate_states_context_ids(instance: Recorder) -> bool:
                         "state_id": state_id,
                         "context_id": None,
                         "context_id_bin": _to_bytes(context_id)
-                        or ulid_to_bytes(ulid_at_time(last_updated_ts or time())),
+                        or _generate_ulid_bytes_at_time(last_updated_ts),
                         "context_user_id": None,
                         "context_user_id_bin": _to_bytes(context_user_id),
                         "context_parent_id": None,
@@ -1421,7 +1426,7 @@ def migrate_events_context_ids(instance: Recorder) -> bool:
                         "event_id": event_id,
                         "context_id": None,
                         "context_id_bin": _to_bytes(context_id)
-                        or ulid_to_bytes(ulid_at_time(time_fired_ts or time())),
+                        or _generate_ulid_bytes_at_time(time_fired_ts),
                         "context_user_id": None,
                         "context_user_id_bin": _to_bytes(context_user_id),
                         "context_parent_id": None,

--- a/homeassistant/components/recorder/queries.py
+++ b/homeassistant/components/recorder/queries.py
@@ -690,6 +690,7 @@ def find_events_context_ids_to_migrate() -> StatementLambdaElement:
     return lambda_stmt(
         lambda: select(
             Events.event_id,
+            Events.time_fired_ts,
             Events.context_id,
             Events.context_user_id,
             Events.context_parent_id,
@@ -788,6 +789,7 @@ def find_states_context_ids_to_migrate() -> StatementLambdaElement:
     return lambda_stmt(
         lambda: select(
             States.state_id,
+            States.last_updated_ts,
             States.context_id,
             States.context_user_id,
             States.context_parent_id,

--- a/tests/components/recorder/test_migration_from_schema_32.py
+++ b/tests/components/recorder/test_migration_from_schema_32.py
@@ -5,6 +5,7 @@ import sys
 from unittest.mock import patch
 import uuid
 
+from freezegun import freeze_time
 import pytest
 from sqlalchemy import create_engine, inspect
 from sqlalchemy.orm import Session
@@ -28,7 +29,7 @@ from homeassistant.components.recorder.tasks import (
 from homeassistant.components.recorder.util import session_scope
 from homeassistant.core import HomeAssistant
 import homeassistant.util.dt as dt_util
-from homeassistant.util.ulid import bytes_to_ulid
+from homeassistant.util.ulid import bytes_to_ulid, ulid_at_time, ulid_to_bytes
 
 from .common import async_recorder_block_till_done, async_wait_recording_done
 
@@ -115,7 +116,7 @@ async def test_migrate_events_context_ids(
                         event_data=None,
                         origin_idx=0,
                         time_fired=None,
-                        time_fired_ts=1677721632.452529,
+                        time_fired_ts=1877721632.452529,
                         context_id=uuid_hex,
                         context_id_bin=None,
                         context_user_id=None,
@@ -128,7 +129,7 @@ async def test_migrate_events_context_ids(
                         event_data=None,
                         origin_idx=0,
                         time_fired=None,
-                        time_fired_ts=1677721632.552529,
+                        time_fired_ts=1877721632.552529,
                         context_id=None,
                         context_id_bin=None,
                         context_user_id=None,
@@ -141,7 +142,7 @@ async def test_migrate_events_context_ids(
                         event_data=None,
                         origin_idx=0,
                         time_fired=None,
-                        time_fired_ts=1677721632.552529,
+                        time_fired_ts=1877721632.552529,
                         context_id="01ARZ3NDEKTSV4RRFFQ69G5FAV",
                         context_id_bin=None,
                         context_user_id="9400facee45711eaa9308bfd3d19e474",
@@ -154,7 +155,7 @@ async def test_migrate_events_context_ids(
                         event_data=None,
                         origin_idx=0,
                         time_fired=None,
-                        time_fired_ts=1677721632.552529,
+                        time_fired_ts=1877721632.552529,
                         context_id="invalid",
                         context_id_bin=None,
                         context_user_id=None,
@@ -167,7 +168,20 @@ async def test_migrate_events_context_ids(
                         event_data=None,
                         origin_idx=0,
                         time_fired=None,
-                        time_fired_ts=1677721632.552529,
+                        time_fired_ts=1277721632.552529,
+                        context_id="adapt_lgt:b'5Cf*':interval:b'0R'",
+                        context_id_bin=None,
+                        context_user_id=None,
+                        context_user_id_bin=None,
+                        context_parent_id=None,
+                        context_parent_id_bin=None,
+                    ),
+                    Events(
+                        event_type="event_with_garbage_context_id_no_time_fired_ts",
+                        event_data=None,
+                        origin_idx=0,
+                        time_fired=None,
+                        time_fired_ts=None,
                         context_id="adapt_lgt:b'5Cf*':interval:b'0R'",
                         context_id_bin=None,
                         context_user_id=None,
@@ -181,9 +195,12 @@ async def test_migrate_events_context_ids(
     await instance.async_add_executor_job(_insert_events)
 
     await async_wait_recording_done(hass)
-    # This is a threadsafe way to add a task to the recorder
-    instance.queue_task(EventsContextIDMigrationTask())
-    await async_recorder_block_till_done(hass)
+    now = dt_util.utcnow()
+    expected_ulid_fallback_start = ulid_to_bytes(ulid_at_time(now.timestamp()))[0:6]
+    with freeze_time(now):
+        # This is a threadsafe way to add a task to the recorder
+        instance.queue_task(EventsContextIDMigrationTask())
+        await async_recorder_block_till_done(hass)
 
     def _object_as_dict(obj):
         return {c.key: getattr(obj, c.key) for c in inspect(obj).mapper.column_attrs}
@@ -200,12 +217,13 @@ async def test_migrate_events_context_ids(
                             "ulid_context_id_event",
                             "invalid_context_id_event",
                             "garbage_context_id_event",
+                            "event_with_garbage_context_id_no_time_fired_ts",
                         ]
                     )
                 )
                 .all()
             )
-            assert len(events) == 5
+            assert len(events) == 6
             return {event.event_type: _object_as_dict(event) for event in events}
 
     events_by_type = await instance.async_add_executor_job(_fetch_migrated_events)
@@ -223,7 +241,7 @@ async def test_migrate_events_context_ids(
     assert empty_context_id_event["context_user_id"] is None
     assert empty_context_id_event["context_parent_id"] is None
     assert empty_context_id_event["context_id_bin"].startswith(
-        b"\x01\x86\xa0\x00\x7f"
+        b"\x01\xb50\xeeO("
     )  # 6 bytes of timestamp + random
     assert empty_context_id_event["context_user_id_bin"] is None
     assert empty_context_id_event["context_parent_id_bin"] is None
@@ -250,7 +268,7 @@ async def test_migrate_events_context_ids(
     assert invalid_context_id_event["context_user_id"] is None
     assert invalid_context_id_event["context_parent_id"] is None
     assert invalid_context_id_event["context_id_bin"].startswith(
-        b"\x01\x86\xa0\x00\x7f"
+        b"\x01\xb50\xeeO("
     )  # 6 bytes of timestamp + random
     assert invalid_context_id_event["context_user_id_bin"] is None
     assert invalid_context_id_event["context_parent_id_bin"] is None
@@ -260,10 +278,24 @@ async def test_migrate_events_context_ids(
     assert garbage_context_id_event["context_user_id"] is None
     assert garbage_context_id_event["context_parent_id"] is None
     assert garbage_context_id_event["context_id_bin"].startswith(
-        b"\x01\x86\xa0\x00\x7f"
+        b"\x01)~$\xdf("
     )  # 6 bytes of timestamp + random
     assert garbage_context_id_event["context_user_id_bin"] is None
     assert garbage_context_id_event["context_parent_id_bin"] is None
+
+    event_with_garbage_context_id_no_time_fired_ts = events_by_type[
+        "event_with_garbage_context_id_no_time_fired_ts"
+    ]
+    assert event_with_garbage_context_id_no_time_fired_ts["context_id"] is None
+    assert event_with_garbage_context_id_no_time_fired_ts["context_user_id"] is None
+    assert event_with_garbage_context_id_no_time_fired_ts["context_parent_id"] is None
+    assert event_with_garbage_context_id_no_time_fired_ts["context_id_bin"].startswith(
+        expected_ulid_fallback_start
+    )  # 6 bytes of timestamp + random
+    assert event_with_garbage_context_id_no_time_fired_ts["context_user_id_bin"] is None
+    assert (
+        event_with_garbage_context_id_no_time_fired_ts["context_parent_id_bin"] is None
+    )
 
 
 @pytest.mark.parametrize("enable_migrate_context_ids", [True])
@@ -284,7 +316,7 @@ async def test_migrate_states_context_ids(
                 (
                     States(
                         entity_id="state.old_uuid_context_id",
-                        last_updated_ts=1677721632.452529,
+                        last_updated_ts=1477721632.452529,
                         context_id=uuid_hex,
                         context_id_bin=None,
                         context_user_id=None,
@@ -294,7 +326,7 @@ async def test_migrate_states_context_ids(
                     ),
                     States(
                         entity_id="state.empty_context_id",
-                        last_updated_ts=1677721632.552529,
+                        last_updated_ts=1477721632.552529,
                         context_id=None,
                         context_id_bin=None,
                         context_user_id=None,
@@ -304,7 +336,7 @@ async def test_migrate_states_context_ids(
                     ),
                     States(
                         entity_id="state.ulid_context_id",
-                        last_updated_ts=1677721632.552529,
+                        last_updated_ts=1477721632.552529,
                         context_id="01ARZ3NDEKTSV4RRFFQ69G5FAV",
                         context_id_bin=None,
                         context_user_id="9400facee45711eaa9308bfd3d19e474",
@@ -314,7 +346,7 @@ async def test_migrate_states_context_ids(
                     ),
                     States(
                         entity_id="state.invalid_context_id",
-                        last_updated_ts=1677721632.552529,
+                        last_updated_ts=1477721632.552529,
                         context_id="invalid",
                         context_id_bin=None,
                         context_user_id=None,
@@ -324,7 +356,7 @@ async def test_migrate_states_context_ids(
                     ),
                     States(
                         entity_id="state.garbage_context_id",
-                        last_updated_ts=1677721632.552529,
+                        last_updated_ts=1477721632.552529,
                         context_id="adapt_lgt:b'5Cf*':interval:b'0R'",
                         context_id_bin=None,
                         context_user_id=None,
@@ -334,8 +366,18 @@ async def test_migrate_states_context_ids(
                     ),
                     States(
                         entity_id="state.human_readable_uuid_context_id",
-                        last_updated_ts=1677721632.552529,
+                        last_updated_ts=1477721632.552529,
                         context_id="0ae29799-ee4e-4f45-8116-f582d7d3ee65",
+                        context_id_bin=None,
+                        context_user_id="0ae29799-ee4e-4f45-8116-f582d7d3ee65",
+                        context_user_id_bin=None,
+                        context_parent_id="0ae29799-ee4e-4f45-8116-f582d7d3ee65",
+                        context_parent_id_bin=None,
+                    ),
+                    States(
+                        entity_id="state.garbage_context_id_no_last_updated_ts",
+                        last_updated_ts=None,
+                        context_id="GaRBaGE",
                         context_id_bin=None,
                         context_user_id="0ae29799-ee4e-4f45-8116-f582d7d3ee65",
                         context_user_id_bin=None,
@@ -348,9 +390,12 @@ async def test_migrate_states_context_ids(
     await instance.async_add_executor_job(_insert_events)
 
     await async_wait_recording_done(hass)
-    # This is a threadsafe way to add a task to the recorder
-    instance.queue_task(StatesContextIDMigrationTask())
-    await async_recorder_block_till_done(hass)
+    now = dt_util.utcnow()
+    expected_ulid_fallback_start = ulid_to_bytes(ulid_at_time(now.timestamp()))[0:6]
+    with freeze_time(now):
+        # This is a threadsafe way to add a task to the recorder
+        instance.queue_task(StatesContextIDMigrationTask())
+        await async_recorder_block_till_done(hass)
 
     def _object_as_dict(obj):
         return {c.key: getattr(obj, c.key) for c in inspect(obj).mapper.column_attrs}
@@ -368,12 +413,13 @@ async def test_migrate_states_context_ids(
                             "state.invalid_context_id",
                             "state.garbage_context_id",
                             "state.human_readable_uuid_context_id",
+                            "state.garbage_context_id_no_last_updated_ts",
                         ]
                     )
                 )
                 .all()
             )
-            assert len(events) == 6
+            assert len(events) == 7
             return {state.entity_id: _object_as_dict(state) for state in events}
 
     states_by_entity_id = await instance.async_add_executor_job(_fetch_migrated_states)
@@ -391,7 +437,7 @@ async def test_migrate_states_context_ids(
     assert empty_context_id["context_user_id"] is None
     assert empty_context_id["context_parent_id"] is None
     assert empty_context_id["context_id_bin"].startswith(
-        b"\x01\x86\xa0\x00\x7f"
+        b"\x01X\x0f\x12\xaf("
     )  # 6 bytes of timestamp + random
     assert empty_context_id["context_user_id_bin"] is None
     assert empty_context_id["context_parent_id_bin"] is None
@@ -417,7 +463,7 @@ async def test_migrate_states_context_ids(
     assert invalid_context_id["context_user_id"] is None
     assert invalid_context_id["context_parent_id"] is None
     assert invalid_context_id["context_id_bin"].startswith(
-        b"\x01\x86\xa0\x00\x7f"
+        b"\x01X\x0f\x12\xaf("
     )  # 6 bytes of timestamp + random
     assert invalid_context_id["context_user_id_bin"] is None
     assert invalid_context_id["context_parent_id_bin"] is None
@@ -427,7 +473,7 @@ async def test_migrate_states_context_ids(
     assert garbage_context_id["context_user_id"] is None
     assert garbage_context_id["context_parent_id"] is None
     assert garbage_context_id["context_id_bin"].startswith(
-        b"\x01\x86\xa0\x00\x7f"
+        b"\x01X\x0f\x12\xaf("
     )  # 6 bytes of timestamp + random
     assert garbage_context_id["context_user_id_bin"] is None
     assert garbage_context_id["context_parent_id_bin"] is None
@@ -448,6 +494,24 @@ async def test_migrate_states_context_ids(
     )
     assert (
         human_readable_uuid_context_id["context_parent_id_bin"]
+        == b"\n\xe2\x97\x99\xeeNOE\x81\x16\xf5\x82\xd7\xd3\xeee"
+    )
+
+    garbage_context_id_no_last_updated_ts = states_by_entity_id[
+        "state.garbage_context_id_no_last_updated_ts"
+    ]
+    assert garbage_context_id_no_last_updated_ts["context_id"] is None
+    assert garbage_context_id_no_last_updated_ts["context_user_id"] is None
+    assert garbage_context_id_no_last_updated_ts["context_parent_id"] is None
+    assert garbage_context_id_no_last_updated_ts["context_id_bin"].startswith(
+        expected_ulid_fallback_start
+    )
+    assert (
+        garbage_context_id_no_last_updated_ts["context_user_id_bin"]
+        == b"\n\xe2\x97\x99\xeeNOE\x81\x16\xf5\x82\xd7\xd3\xeee"
+    )
+    assert (
+        garbage_context_id_no_last_updated_ts["context_parent_id_bin"]
         == b"\n\xe2\x97\x99\xeeNOE\x81\x16\xf5\x82\xd7\xd3\xeee"
     )
 

--- a/tests/components/recorder/test_migration_from_schema_32.py
+++ b/tests/components/recorder/test_migration_from_schema_32.py
@@ -222,7 +222,9 @@ async def test_migrate_events_context_ids(
     assert empty_context_id_event["context_id"] is None
     assert empty_context_id_event["context_user_id"] is None
     assert empty_context_id_event["context_parent_id"] is None
-    assert empty_context_id_event["context_id_bin"] == b"\x00" * 16
+    assert empty_context_id_event["context_id_bin"].startswith(
+        b"\x01\x86\xa0\x00\x7f"
+    )  # 6 bytes of timestamp + random
     assert empty_context_id_event["context_user_id_bin"] is None
     assert empty_context_id_event["context_parent_id_bin"] is None
 
@@ -247,7 +249,9 @@ async def test_migrate_events_context_ids(
     assert invalid_context_id_event["context_id"] is None
     assert invalid_context_id_event["context_user_id"] is None
     assert invalid_context_id_event["context_parent_id"] is None
-    assert invalid_context_id_event["context_id_bin"] == b"\x00" * 16
+    assert invalid_context_id_event["context_id_bin"].startswith(
+        b"\x01\x86\xa0\x00\x7f"
+    )  # 6 bytes of timestamp + random
     assert invalid_context_id_event["context_user_id_bin"] is None
     assert invalid_context_id_event["context_parent_id_bin"] is None
 
@@ -255,7 +259,9 @@ async def test_migrate_events_context_ids(
     assert garbage_context_id_event["context_id"] is None
     assert garbage_context_id_event["context_user_id"] is None
     assert garbage_context_id_event["context_parent_id"] is None
-    assert garbage_context_id_event["context_id_bin"] == b"\x00" * 16
+    assert garbage_context_id_event["context_id_bin"].startswith(
+        b"\x01\x86\xa0\x00\x7f"
+    )  # 6 bytes of timestamp + random
     assert garbage_context_id_event["context_user_id_bin"] is None
     assert garbage_context_id_event["context_parent_id_bin"] is None
 
@@ -384,7 +390,9 @@ async def test_migrate_states_context_ids(
     assert empty_context_id["context_id"] is None
     assert empty_context_id["context_user_id"] is None
     assert empty_context_id["context_parent_id"] is None
-    assert empty_context_id["context_id_bin"] == b"\x00" * 16
+    assert empty_context_id["context_id_bin"].startswith(
+        b"\x01\x86\xa0\x00\x7f"
+    )  # 6 bytes of timestamp + random
     assert empty_context_id["context_user_id_bin"] is None
     assert empty_context_id["context_parent_id_bin"] is None
 
@@ -408,7 +416,9 @@ async def test_migrate_states_context_ids(
     assert invalid_context_id["context_id"] is None
     assert invalid_context_id["context_user_id"] is None
     assert invalid_context_id["context_parent_id"] is None
-    assert invalid_context_id["context_id_bin"] == b"\x00" * 16
+    assert invalid_context_id["context_id_bin"].startswith(
+        b"\x01\x86\xa0\x00\x7f"
+    )  # 6 bytes of timestamp + random
     assert invalid_context_id["context_user_id_bin"] is None
     assert invalid_context_id["context_parent_id_bin"] is None
 
@@ -416,7 +426,9 @@ async def test_migrate_states_context_ids(
     assert garbage_context_id["context_id"] is None
     assert garbage_context_id["context_user_id"] is None
     assert garbage_context_id["context_parent_id"] is None
-    assert garbage_context_id["context_id_bin"] == b"\x00" * 16
+    assert garbage_context_id["context_id_bin"].startswith(
+        b"\x01\x86\xa0\x00\x7f"
+    )  # 6 bytes of timestamp + random
     assert garbage_context_id["context_user_id_bin"] is None
     assert garbage_context_id["context_parent_id_bin"] is None
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
It was [discovered by @terba that postgresql](https://dba.stackexchange.com/questions/105537/postgres-is-performing-sequential-scan-instead-of-index-scan) will do a full scan if there is a low cardinality on the index because of missing context ids. We will now generate a ULID for the timestamp of the row if the context data is missing or invalid. In the issue there were millions missing pre-migration

```
# select context_id,count(*) from events group by context_id order by count(*) desc;

              context_id              |  count  
--------------------------------------+---------
                                      | 1585053
 3f84230c734911eb94e6b1b2b6fc4b77     |     893
 a786da9b5d3311eb88390d27aa71c368     |     458
 938989285eeb3850a69d7a4994889041     |     455
```

fixes #91514


A workaround for anyone reading this PR who has this problem who can't do another migration:

> `random_bytea` from https://dba.stackexchange.com/questions/22512/how-can-i-generate-a-random-bytea
```sql
create function random_bytea(p_length in integer) returns bytea language plpgsql as $$
declare
  o bytea := '';
begin 
  for i in 1..p_length loop
    o := o||decode(lpad(to_hex(width_bucket(random(), 0, 1, 256)-1),2,'0'), 'hex');
  end loop;
  return o;
end;$$;
update states set context_id_bin=random_bytea(16) where context_id_bin='\x00000000000000000000000000000000';
update events set context_id_bin=random_bytea(16) where context_id_bin='\x00000000000000000000000000000000';
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
