### PR TITLE
Fix lingering timer in netatmo

### DIFF
--- a/homeassistant/components/netatmo/data_handler.py
+++ b/homeassistant/components/netatmo/data_handler.py
@@ -134,8 +134,10 @@ class NetatmoDataHandler:
 
     async def async_setup(self) -> None:
         """Set up the Netatmo data handler."""
-        async_track_time_interval(
-            self.hass, self.async_update, timedelta(seconds=SCAN_INTERVAL)
+        self.config_entry.async_on_unload(
+            async_track_time_interval(
+                self.hass, self.async_update, timedelta(seconds=SCAN_INTERVAL)
+            )
         )
 
         self.config_entry.async_on_unload(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Linked to #91360
https://github.com/home-assistant/core/actions/runs/4745958809/jobs/8429083908?pr=91360

```console
ERROR tests/components/netatmo/test_camera.py::test_setup_component_with_webhook - Failed: Lingering timer after job <Job track time interval 0:01:00 <bound method NetatmoDataHandler.async_update of <homeassistant.components.netatmo.data_handler.NetatmoDataHandler object at 0x7f526c641780>> HassJobType.Callback <function async_track_time_interval.<locals>.interval_listener at 0x7f526d9fc550>>
ERROR tests/components/netatmo/test_camera.py::test_camera_image_local - Failed: Lingering timer after job <Job track time interval 0:01:00 <bound method NetatmoDataHandler.async_update of <homeassistant.components.netatmo.data_handler.NetatmoDataHandler object at 0x7f526c6b2c20>> HassJobType.Callback <function async_track_time_interval.<locals>.interval_listener at 0x7f526d937760>>
ERROR tests/components/netatmo/test_camera.py::test_camera_image_vpn - Failed: Lingering timer after job <Job track time interval 0:01:00 <bound method NetatmoDataHandler.async_update of <homeassistant.components.netatmo.data_handler.NetatmoDataHandler object at 0x7f526ed54880>> HassJobType.Callback <function async_track_time_interval.<locals>.interval_listener at 0x7f526dca3b50>>
ERROR tests/components/netatmo/test_camera.py::test_service_set_person_away - Failed: Lingering timer after job <Job track time interval 0:01:00 <bound method NetatmoDataHandler.async_update of <homeassistant.components.netatmo.data_handler.NetatmoDataHandler object at 0x7f526c9427d0>> HassJobType.Callback <function async_track_time_interval.<locals>.interval_listener at 0x7f526de13760>>
ERROR tests/components/netatmo/test_camera.py::test_service_set_person_away_invalid_person - Failed: Lingering timer after job <Job track time interval 0:01:00 <bound method NetatmoDataHandler.async_update of <homeassistant.components.netatmo.data_handler.NetatmoDataHandler object at 0x7f526c9a7700>> HassJobType.Callback <function async_track_time_interval.<locals>.interval_listener at 0x7f526dfae0e0>>
ERROR tests/components/netatmo/test_camera.py::test_service_set_persons_home_invalid_person - Failed: Lingering timer after job <Job track time interval 0:01:00 <bound method NetatmoDataHandler.async_update of <homeassistant.components.netatmo.data_handler.NetatmoDataHandler object at 0x7f526c4b8040>> HassJobType.Callback <function async_track_time_interval.<locals>.interval_listener at 0x7f526c9e55a0>>
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
