### PR TITLE
Fix lingering timer in shelly

### DIFF
--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -156,11 +156,13 @@ async def _async_setup_block_entry(hass: HomeAssistant, entry: ConfigEntry) -> b
         """Set up a block based device that is online."""
         shelly_entry_data.block = ShellyBlockCoordinator(hass, entry, device)
         shelly_entry_data.block.async_setup()
+        entry.async_on_unload(shelly_entry_data.block.async_shutdown)
 
         platforms = BLOCK_SLEEPING_PLATFORMS
 
         if not entry.data.get(CONF_SLEEP_PERIOD):
             shelly_entry_data.rest = ShellyRestCoordinator(hass, device, entry)
+            entry.async_on_unload(shelly_entry_data.rest.async_shutdown)
             platforms = BLOCK_PLATFORMS
 
         await hass.config_entries.async_forward_entry_setups(entry, platforms)
@@ -240,6 +242,7 @@ async def _async_setup_rpc_entry(hass: HomeAssistant, entry: ConfigEntry) -> boo
         """Set up a RPC based device that is online."""
         shelly_entry_data.rpc = ShellyRpcCoordinator(hass, entry, device)
         shelly_entry_data.rpc.async_setup()
+        entry.async_on_unload(shelly_entry_data.rpc.async_shutdown)
 
         platforms = RPC_SLEEPING_PLATFORMS
 
@@ -247,6 +250,7 @@ async def _async_setup_rpc_entry(hass: HomeAssistant, entry: ConfigEntry) -> boo
             shelly_entry_data.rpc_poll = ShellyRpcPollingCoordinator(
                 hass, entry, device
             )
+            entry.async_on_unload(shelly_entry_data.rpc_poll.async_shutdown)
             platforms = RPC_PLATFORMS
 
         await hass.config_entries.async_forward_entry_setups(entry, platforms)

--- a/homeassistant/components/shelly/coordinator.py
+++ b/homeassistant/components/shelly/coordinator.py
@@ -136,7 +136,7 @@ class ShellyCoordinatorBase(DataUpdateCoordinator[None], Generic[_DeviceT]):
 
     async def _async_reload_entry(self) -> None:
         """Reload entry."""
-        self._debounced_reload.async_cancel()
+        await self._debounced_reload.async_shutdown()
         LOGGER.debug("Reloading entry %s", self.name)
         await self.hass.config_entries.async_reload(self.entry.entry_id)
 
@@ -463,7 +463,7 @@ class ShellyRpcCoordinator(ShellyCoordinatorBase[RpcDevice]):
             self.connected = False
             self._async_run_disconnected_events()
         # Try to reconnect right away if hass is not stopping
-        if not self.hass.is_stopping:
+        if not self._shutdown_requested and not self.hass.is_stopping:
             await self.async_request_refresh()
 
     @callback


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Linked to #91360
https://github.com/home-assistant/core/actions/runs/4745958809/jobs/8429084200?pr=91360

```console
ERROR tests/components/shelly/test_binary_sensor.py::test_rpc_binary_sensor - Failed: Lingering timer after test <TimerHandle when=897.816432755 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:149>
ERROR tests/components/shelly/test_binary_sensor.py::test_rpc_binary_sensor_removal - Failed: Lingering timer after test <TimerHandle when=898.111078386 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:149>
ERROR tests/components/shelly/test_button.py::test_rpc_button - Failed: Lingering timer after test <TimerHandle when=900.680903254 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:149>
ERROR tests/components/shelly/test_config_flow.py::test_options_flow_enabled_gen_2 - Failed: Lingering timer after test <TimerHandle when=911.751268294 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:149>
ERROR tests/components/shelly/test_config_flow.py::test_options_flow_ble - Failed: Lingering timer after test <TimerHandle when=912.357949407 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:149>
ERROR tests/components/shelly/test_config_flow.py::test_options_flow_pre_ble_device - Failed: Lingering timer after test <TimerHandle when=912.707266409 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:149>
ERROR tests/components/shelly/test_coordinator.py::test_block_reload_on_cfg_change - Failed: Lingering timer after test <TimerHandle when=965.475423696 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:149>
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
