### PR TITLE
Add sensor 'Estimated energy production - remaining today'

### DIFF
--- a/homeassistant/components/forecast_solar/const.py
+++ b/homeassistant/components/forecast_solar/const.py
@@ -27,6 +27,13 @@ SENSORS: tuple[ForecastSolarSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
     ),
     ForecastSolarSensorEntityDescription(
+        key="energy_production_today_remaining",
+        name="Estimated energy production - remaining today",
+        state=lambda estimate: estimate.energy_production_today_remaining / 1000,
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+    ),
+    ForecastSolarSensorEntityDescription(
         key="energy_production_tomorrow",
         name="Estimated energy production - tomorrow",
         state=lambda estimate: estimate.energy_production_tomorrow / 1000,

--- a/homeassistant/components/forecast_solar/diagnostics.py
+++ b/homeassistant/components/forecast_solar/diagnostics.py
@@ -34,6 +34,7 @@ async def async_get_config_entry_diagnostics(
         },
         "data": {
             "energy_production_today": coordinator.data.energy_production_today,
+            "energy_production_today_remaining": coordinator.data.energy_production_today_remaining,
             "energy_production_tomorrow": coordinator.data.energy_production_tomorrow,
             "energy_current_hour": coordinator.data.energy_current_hour,
             "power_production_now": coordinator.data.power_production_now,
@@ -47,7 +48,7 @@ async def async_get_config_entry_diagnostics(
             },
             "wh_hours": {
                 wh_datetime.isoformat(): wh_value
-                for wh_datetime, wh_value in coordinator.data.wh_hours.items()
+                for wh_datetime, wh_value in coordinator.data.wh_period.items()
             },
         },
         "account": {

--- a/homeassistant/components/forecast_solar/energy.py
+++ b/homeassistant/components/forecast_solar/energy.py
@@ -16,6 +16,6 @@ async def async_get_solar_forecast(
     return {
         "wh_hours": {
             timestamp.isoformat(): val
-            for timestamp, val in coordinator.data.wh_hours.items()
+            for timestamp, val in coordinator.data.wh_period.items()
         }
     }

--- a/homeassistant/components/forecast_solar/manifest.json
+++ b/homeassistant/components/forecast_solar/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "quality_scale": "platinum",
-  "requirements": ["forecast_solar==2.2.0"]
+  "requirements": ["forecast_solar==3.0.0"]
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change adds new sensor "Estimated energy production - remaining today" to utilize planed change in forecast-solar module. This new change is included in pull request https://github.com/home-assistant-libs/forecast_solar/pull/33.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to feature request: https://community.home-assistant.io/t/forecast-solar-remaining-energy-production-today/562097 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
