### PR TITLE
Add Supervisor add-on discovery to Wyoming integration

### DIFF
--- a/homeassistant/components/wyoming/config_flow.py
+++ b/homeassistant/components/wyoming/config_flow.py
@@ -2,10 +2,12 @@
 from __future__ import annotations
 
 from typing import Any
+from urllib.parse import urlparse
 
 import voluptuous as vol
 
 from homeassistant import config_entries
+from homeassistant.components.hassio import HassioServiceInfo
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.data_entry_flow import FlowResult
 
@@ -24,6 +26,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Wyoming integration."""
 
     VERSION = 1
+
+    _hassio_discovery: HassioServiceInfo
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -54,3 +58,36 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         name = asr_installed[0].name
 
         return self.async_create_entry(title=name, data=user_input)
+
+    async def async_step_hassio(self, discovery_info: HassioServiceInfo) -> FlowResult:
+        """Handle Supervisor add-on discovery."""
+        await self.async_set_unique_id(discovery_info.slug)
+        self._abort_if_unique_id_configured()
+
+        self._hassio_discovery = discovery_info
+        return await self.async_step_hassio_confirm()
+
+    async def async_step_hassio_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Confirm Supervisor discovery."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            uri = urlparse(self._hassio_discovery.config["uri"])
+            if service := await WyomingService.create(uri.hostname, uri.port):
+                if not any(asr for asr in service.info.asr if asr.installed):
+                    return self.async_abort(reason="no_services")
+
+                return self.async_create_entry(
+                    title=self._hassio_discovery.name,
+                    data={CONF_HOST: uri.hostname, CONF_PORT: uri.port},
+                )
+
+            errors = {"base": "cannot_connect"}
+
+        return self.async_show_form(
+            step_id="hassio_confirm",
+            description_placeholders={"addon": self._hassio_discovery.name},
+            errors=errors,
+        )

--- a/homeassistant/components/wyoming/strings.json
+++ b/homeassistant/components/wyoming/strings.json
@@ -6,12 +6,16 @@
           "host": "[%key:common::config_flow::data::host%]",
           "port": "[%key:common::config_flow::data::port%]"
         }
+      },
+      "hassio_confirm": {
+        "description": "Do you want to configure Home Assistant to connect to the Wyoming service provided by the add-on: {addon}?"
       }
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
     },
     "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_service%]",
       "no_services": "No services found at endpoint"
     }
   }

--- a/tests/components/wyoming/snapshots/test_config_flow.ambr
+++ b/tests/components/wyoming/snapshots/test_config_flow.ambr
@@ -1,0 +1,39 @@
+# serializer version: 1
+# name: test_hassio_addon_discovery
+  FlowResultSnapshot({
+    'context': dict({
+      'source': 'hassio',
+      'unique_id': 'mock_piper',
+    }),
+    'data': dict({
+      'host': 'mock-piper',
+      'port': 10200,
+    }),
+    'description': None,
+    'description_placeholders': None,
+    'flow_id': <ANY>,
+    'handler': 'wyoming',
+    'options': dict({
+    }),
+    'result': ConfigEntrySnapshot({
+      'data': dict({
+        'host': 'mock-piper',
+        'port': 10200,
+      }),
+      'disabled_by': None,
+      'domain': 'wyoming',
+      'entry_id': <ANY>,
+      'options': dict({
+      }),
+      'pref_disable_new_entities': False,
+      'pref_disable_polling': False,
+      'source': 'hassio',
+      'title': 'Piper',
+      'unique_id': 'mock_piper',
+      'version': 1,
+    }),
+    'title': 'Piper',
+    'type': <FlowResultType.CREATE_ENTRY: 'create_entry'>,
+    'version': 1,
+  })
+# ---

--- a/tests/components/wyoming/test_config_flow.py
+++ b/tests/components/wyoming/test_config_flow.py
@@ -2,13 +2,26 @@
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from syrupy.assertion import SnapshotAssertion
 
 from homeassistant import config_entries
+from homeassistant.components.hassio import HassioServiceInfo
 from homeassistant.components.wyoming.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from . import EMPTY_INFO, STT_INFO
+
+from tests.common import MockConfigEntry
+
+ADDON_DISCOVERY = HassioServiceInfo(
+    config={
+        "addon": "Piper",
+        "uri": "tcp://mock-piper:10200",
+    },
+    name="Piper",
+    slug="mock_piper",
+)
 
 pytestmark = pytest.mark.usefixtures("mock_setup_entry")
 
@@ -85,3 +98,85 @@ async def test_no_supported_services(hass: HomeAssistant) -> None:
 
     assert result2["type"] == FlowResultType.ABORT
     assert result2["reason"] == "no_services"
+
+
+async def test_hassio_addon_discovery(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test config flow initiated by Supervisor."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        data=ADDON_DISCOVERY,
+        context={"source": config_entries.SOURCE_HASSIO},
+    )
+
+    assert result.get("type") == FlowResultType.FORM
+    assert result.get("step_id") == "hassio_confirm"
+    assert result.get("description_placeholders") == {"addon": "Piper"}
+
+    with patch(
+        "homeassistant.components.wyoming.data.load_wyoming_info",
+        return_value=STT_INFO,
+    ) as mock_wyoming:
+        result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    assert result2.get("type") == FlowResultType.CREATE_ENTRY
+    assert result2 == snapshot
+
+    assert len(mock_setup_entry.mock_calls) == 1
+    assert len(mock_wyoming.mock_calls) == 1
+
+
+async def test_hassio_addon_already_configured(hass: HomeAssistant) -> None:
+    """Test we abort discovery if the add-on is already configured."""
+    MockConfigEntry(
+        domain=DOMAIN,
+        data={"host": "mock-piper", "port": "10200"},
+        unique_id="mock_piper",
+    ).add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        data=ADDON_DISCOVERY,
+        context={"source": config_entries.SOURCE_HASSIO},
+    )
+    assert result.get("type") == FlowResultType.ABORT
+    assert result.get("reason") == "already_configured"
+
+
+async def test_hassio_addon_cannot_connect(hass: HomeAssistant) -> None:
+    """Test we handle cannot connect error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        data=ADDON_DISCOVERY,
+        context={"source": config_entries.SOURCE_HASSIO},
+    )
+
+    with patch(
+        "homeassistant.components.wyoming.data.load_wyoming_info",
+        return_value=None,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    assert result2.get("type") == FlowResultType.FORM
+    assert result2.get("errors") == {"base": "cannot_connect"}
+
+
+async def test_hassio_addon_no_supported_services(hass: HomeAssistant) -> None:
+    """Test we handle no supported services error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        data=ADDON_DISCOVERY,
+        context={"source": config_entries.SOURCE_HASSIO},
+    )
+
+    with patch(
+        "homeassistant.components.wyoming.data.load_wyoming_info",
+        return_value=EMPTY_INFO,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    assert result2.get("type") == FlowResultType.ABORT
+    assert result2.get("reason") == "no_services"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add support for discovering add-ons that providing sst/tts services using the Wyoming protocol.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
