### PR TITLE
Improve exception logging for SMTP Notify

### DIFF
--- a/homeassistant/components/smtp/notify.py
+++ b/homeassistant/components/smtp/notify.py
@@ -223,14 +223,80 @@ class MailNotificationService(BaseNotificationService):
             try:
                 mail.sendmail(self._sender, recipients, msg.as_string())
                 break
-            except smtplib.SMTPServerDisconnected:
+            except smtplib.SMTPServerDisconnected as err:
                 _LOGGER.warning(
-                    "SMTPServerDisconnected sending mail: retrying connection"
+                    "SMTPServerDisconnected while sending mail: Retrying Connection"
                 )
+                _LOGGER.debug("SMTPServerDisconnected Full Error Contents: %s", err)
                 mail.quit()
                 mail = self.connect()
-            except smtplib.SMTPException:
-                _LOGGER.warning("SMTPException sending mail: retrying connection")
+            except smtplib.SMTPSenderRefused as err:
+                _LOGGER.warning(
+                    "SMTPSenderRefused while sending mail: Retrying Connection --- "
+                    "Error Code: %s  - Error Message: %s",
+                    err.smtp_code,
+                    err.smtp_error,
+                )
+                _LOGGER.debug("SMTPSenderRefused Full Error Contents: %s", err)
+                mail.quit()
+                mail = self.connect()
+            except smtplib.SMTPRecipientsRefused as err:
+                _LOGGER.warning(
+                    "SMTPRecipientsRefused while sending mail: Retrying Connection"
+                )
+                _LOGGER.debug("SMTPRecipientsRefused Full Error Contents: %s", err)
+                mail.quit()
+                mail = self.connect()
+            except smtplib.SMTPDataError as err:
+                _LOGGER.warning(
+                    "SMTPDataError while sending mail (The SMTP server refused to accept the message data): Retrying Connection --- "
+                    "Error Code: %s  - Error Message: %s",
+                    err.smtp_code,
+                    err.smtp_error,
+                )
+                _LOGGER.debug("SMTPDataError Full Error Contents: %s", err)
+                mail.quit()
+                mail = self.connect()
+            except smtplib.SMTPConnectError as err:
+                _LOGGER.warning(
+                    "SMTPConnectError while sending mail (Error occurred during establishment of a connection with the server): Retrying Connection --- "
+                    "Error Code: %s  - Error Message: %s",
+                    err.smtp_code,
+                    err.smtp_error,
+                )
+                _LOGGER.debug("SMTPConnectError Full Error Contents: %s", err)
+                mail.quit()
+                mail = self.connect()
+            except smtplib.SMTPHeloError as err:
+                _LOGGER.warning(
+                    "SMTPHeloError while sending mail: Retrying Connection --- "
+                    "Error Code: %s  - Error Message: %s",
+                    err.smtp_code,
+                    err.smtp_error,
+                )
+                _LOGGER.debug("SMTPHeloError Full Error Contents: %s", err)
+                mail.quit()
+                mail = self.connect()
+            except smtplib.SMTPResponseException as err:
+                _LOGGER.warning(
+                    "SMTPResponseException while sending mail: Retrying Connection --- "
+                    "Error Code: %s  - Error Message: %s",
+                    err.smtp_code,
+                    err.smtp_error,
+                )
+                _LOGGER.debug("SMTPResponseException Full Error Contents: %s", err)
+                mail.quit()
+                mail = self.connect()
+            except smtplib.SMTPNotSupportedError as err:
+                _LOGGER.warning(
+                    "SMTPNotSupportedError while sending mail: Retrying Connection"
+                )
+                _LOGGER.debug("SMTPNotSupportedError Full Error Contents: %s", err)
+                mail.quit()
+                mail = self.connect()
+            except smtplib.SMTPException as err:
+                _LOGGER.warning("SMTPException while sending mail: Retrying Connection")
+                _LOGGER.debug("SMTPException Full Error Contents: %s", err)
                 mail.quit()
                 mail = self.connect()
         mail.quit()

--- a/homeassistant/components/smtp/notify.py
+++ b/homeassistant/components/smtp/notify.py
@@ -223,80 +223,31 @@ class MailNotificationService(BaseNotificationService):
             try:
                 mail.sendmail(self._sender, recipients, msg.as_string())
                 break
-            except smtplib.SMTPServerDisconnected as err:
-                _LOGGER.warning(
-                    "SMTPServerDisconnected while sending mail: Retrying Connection"
+            except (
+                smtplib.SMTPSenderRefused,
+                smtplib.SMTPDataError,
+                smtplib.SMTPConnectError,
+                smtplib.SMTPHeloError,
+                smtplib.SMTPResponseException,
+                smtplib.SMTPServerDisconnected,
+                smtplib.SMTPRecipientsRefused,
+                smtplib.SMTPNotSupportedError,
+                smtplib.SMTPException,
+            ) as err:
+                warning_string = "{} while sending mail ({}): Will Retry".format(
+                    type(err).__name__,
+                    type(err).__doc__,
                 )
-                _LOGGER.debug("SMTPServerDisconnected Full Error Contents: %s", err)
-                mail.quit()
-                mail = self.connect()
-            except smtplib.SMTPSenderRefused as err:
-                _LOGGER.warning(
-                    "SMTPSenderRefused while sending mail: Retrying Connection --- "
-                    "Error Code: %s  - Error Message: %s",
-                    err.smtp_code,
-                    err.smtp_error,
+                if hasattr(err, "smtp_code"):
+                    warning_string += " --- Error Code: %s" % err.smtp_code
+                if hasattr(err, "smtp_error"):
+                    warning_string += " --- Error Message: %s" % err.smtp_error
+                _LOGGER.warning(warning_string)
+                _LOGGER.debug(
+                    "Exception while sending mail: smtplib.%s --- Full Error Contents: %s",
+                    type(err).__name__,
+                    err,
                 )
-                _LOGGER.debug("SMTPSenderRefused Full Error Contents: %s", err)
-                mail.quit()
-                mail = self.connect()
-            except smtplib.SMTPRecipientsRefused as err:
-                _LOGGER.warning(
-                    "SMTPRecipientsRefused while sending mail: Retrying Connection"
-                )
-                _LOGGER.debug("SMTPRecipientsRefused Full Error Contents: %s", err)
-                mail.quit()
-                mail = self.connect()
-            except smtplib.SMTPDataError as err:
-                _LOGGER.warning(
-                    "SMTPDataError while sending mail (The SMTP server refused to accept the message data): Retrying Connection --- "
-                    "Error Code: %s  - Error Message: %s",
-                    err.smtp_code,
-                    err.smtp_error,
-                )
-                _LOGGER.debug("SMTPDataError Full Error Contents: %s", err)
-                mail.quit()
-                mail = self.connect()
-            except smtplib.SMTPConnectError as err:
-                _LOGGER.warning(
-                    "SMTPConnectError while sending mail (Error occurred during establishment of a connection with the server): Retrying Connection --- "
-                    "Error Code: %s  - Error Message: %s",
-                    err.smtp_code,
-                    err.smtp_error,
-                )
-                _LOGGER.debug("SMTPConnectError Full Error Contents: %s", err)
-                mail.quit()
-                mail = self.connect()
-            except smtplib.SMTPHeloError as err:
-                _LOGGER.warning(
-                    "SMTPHeloError while sending mail: Retrying Connection --- "
-                    "Error Code: %s  - Error Message: %s",
-                    err.smtp_code,
-                    err.smtp_error,
-                )
-                _LOGGER.debug("SMTPHeloError Full Error Contents: %s", err)
-                mail.quit()
-                mail = self.connect()
-            except smtplib.SMTPResponseException as err:
-                _LOGGER.warning(
-                    "SMTPResponseException while sending mail: Retrying Connection --- "
-                    "Error Code: %s  - Error Message: %s",
-                    err.smtp_code,
-                    err.smtp_error,
-                )
-                _LOGGER.debug("SMTPResponseException Full Error Contents: %s", err)
-                mail.quit()
-                mail = self.connect()
-            except smtplib.SMTPNotSupportedError as err:
-                _LOGGER.warning(
-                    "SMTPNotSupportedError while sending mail: Retrying Connection"
-                )
-                _LOGGER.debug("SMTPNotSupportedError Full Error Contents: %s", err)
-                mail.quit()
-                mail = self.connect()
-            except smtplib.SMTPException as err:
-                _LOGGER.warning("SMTPException while sending mail: Retrying Connection")
-                _LOGGER.debug("SMTPException Full Error Contents: %s", err)
                 mail.quit()
                 mail = self.connect()
         mail.quit()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
For the smtp.notify component, adds handling for each type of smtplib exception found [here](https://docs.python.org/3/library/smtplib.html), and creates a log warning and/or debug message for each, which contains details such as returned error code and message. 

This will help users to diagnose issues with their SMTP configuration. I was having the same problem as the user [here](https://community.home-assistant.io/t/how-to-debug-notification-error-smtpexception-sending-email/383368), and I imagine many others have too. The current handling gives no information about the nature of the error if there is one, and does not give the returned error message. But this pull request will provide that information.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
