### PR TITLE
Add a negative cache to the recorder event type manager

### DIFF
--- a/homeassistant/components/recorder/core.py
+++ b/homeassistant/components/recorder/core.py
@@ -1011,7 +1011,7 @@ class Recorder(threading.Thread):
         event_type_manager = self.event_type_manager
         if pending_event_types := event_type_manager.get_pending(event.event_type):
             dbevent.event_type_rel = pending_event_types
-        elif event_type_id := event_type_manager.get(event.event_type, session):
+        elif event_type_id := event_type_manager.get(event.event_type, session, True):
             dbevent.event_type_id = event_type_id
         else:
             event_types = EventTypes(event_type=event.event_type)

--- a/homeassistant/components/recorder/table_managers/event_types.py
+++ b/homeassistant/components/recorder/table_managers/event_types.py
@@ -40,9 +40,12 @@ class EventTypeManager(BaseLRUTableManager[EventTypes]):
         self.get_many(
             {event.event_type for event in events if event.event_type is not None},
             session,
+            True,
         )
 
-    def get(self, event_type: str, session: Session) -> int | None:
+    def get(
+        self, event_type: str, session: Session, from_recorder: bool = False
+    ) -> int | None:
         """Resolve event_type to the event_type_id.
 
         This call is not thread-safe and must be called from the

--- a/homeassistant/components/recorder/table_managers/event_types.py
+++ b/homeassistant/components/recorder/table_managers/event_types.py
@@ -83,13 +83,14 @@ class EventTypeManager(BaseLRUTableManager[EventTypes]):
                         int, event_type_id
                     )
 
-        for missed in missing:
-            if results[missed] is None:
-                non_existent.append(missed)
-
-        if non_existent:
+        if non_existent := [
+            event_type for event_type in missing if results[event_type] is None
+        ]:
             if from_recorder:
-                self._non_existent_event_types.update(non_existent)
+                # We are already in the recorder thread so we can update the
+                # non-existent event types directly.
+                for event_type in non_existent:
+                    self._non_existent_event_types[event_type] = None
             else:
                 # Queue a task to refresh the event types since its not
                 # thread-safe to do it here since we are not in the recorder

--- a/tests/components/recorder/common.py
+++ b/tests/components/recorder/common.py
@@ -358,8 +358,9 @@ def convert_pending_events_to_event_types(instance: Recorder, session: Session) 
             events.add(object)
 
     event_type_to_event_type_ids = instance.event_type_manager.get_many(
-        event_types, session
+        event_types, session, True
     )
+    manually_added_event_types: list[str] = []
 
     for event in events:
         event_type = event.event_type
@@ -371,7 +372,11 @@ def convert_pending_events_to_event_types(instance: Recorder, session: Session) 
             continue
         if event_type not in event_types_objects:
             event_types_objects[event_type] = EventTypes(event_type=event_type)
+            manually_added_event_types.append(event_type)
         event.event_type_rel = event_types_objects[event_type]
+
+    for event_type in manually_added_event_types:
+        instance.event_type_manager._non_existent_event_types.pop(event_type, None)
 
 
 def create_engine_test_for_schema_version_postfix(


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Its common to get cache misses for non-existent event types because some users will never manually create logbook events or click their shelly button, etc. If we have a cache miss we now ask the recorder to refresh the cache.

In testing this cut 45% of the logbook response time because it now avoids a round trip to the database once the cache is primed.

Should get rid of this constantly appearing in the log:
```
2023-04-20 19:03:41.423 INFO (DbWorker_2) [sqlalchemy.engine.Engine] SELECT event_types.event_type_id, event_types.event_type 
FROM event_types 
WHERE event_types.event_type IN (?, ?)
2023-04-20 19:03:41.423 INFO (DbWorker_2) [sqlalchemy.engine.Engine] [cached since 158.4s ago] ('logbook_entry', 'shelly.click')
2023-04-20 19:03:41.424 DEBUG (DbWorker_2) [sqlalchemy.engine.Engine] Col ('event_type_id', 'event_type')
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
