### PR TITLE
Use Selectors for waze_travel_time flows

### DIFF
--- a/homeassistant/components/waze_travel_time/config_flow.py
+++ b/homeassistant/components/waze_travel_time/config_flow.py
@@ -62,6 +62,21 @@ OPTIONS_SCHEMA = vol.Schema(
     }
 )
 
+CONFIG_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_NAME, default=DEFAULT_NAME): TextSelector(),
+        vol.Required(CONF_ORIGIN): TextSelector(),
+        vol.Required(CONF_DESTINATION): TextSelector(),
+        vol.Required(CONF_REGION): SelectSelector(
+            SelectSelectorConfig(
+                options=sorted(REGIONS),
+                mode=SelectSelectorMode.DROPDOWN,
+                translation_key=CONF_REGION,
+            )
+        ),
+    }
+)
+
 
 def default_options(hass: HomeAssistant) -> dict[str, str | bool]:
     """Get the default options."""
@@ -129,24 +144,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             # If we get here, it's because we couldn't connect
             errors["base"] = "cannot_connect"
+            user_input[CONF_REGION] = user_input[CONF_REGION].lower()
 
         return self.async_show_form(
             step_id="user",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(
-                        CONF_NAME, default=user_input.get(CONF_NAME, DEFAULT_NAME)
-                    ): TextSelector(),
-                    vol.Required(CONF_ORIGIN): TextSelector(),
-                    vol.Required(CONF_DESTINATION): TextSelector(),
-                    vol.Required(CONF_REGION): SelectSelector(
-                        SelectSelectorConfig(
-                            options=sorted(REGIONS),
-                            mode=SelectSelectorMode.DROPDOWN,
-                            translation_key=CONF_REGION,
-                        )
-                    ),
-                }
-            ),
+            data_schema=self.add_suggested_values_to_schema(CONFIG_SCHEMA, user_input),
             errors=errors,
         )

--- a/homeassistant/components/waze_travel_time/config_flow.py
+++ b/homeassistant/components/waze_travel_time/config_flow.py
@@ -7,7 +7,13 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_NAME, CONF_REGION
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult
-import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.selector import (
+    BooleanSelector,
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+    TextSelector,
+)
 from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
 from .const import (
@@ -33,14 +39,27 @@ from .helpers import is_valid_config_entry
 
 OPTIONS_SCHEMA = vol.Schema(
     {
-        vol.Optional(CONF_INCL_FILTER, default=""): cv.string,
-        vol.Optional(CONF_EXCL_FILTER, default=""): cv.string,
-        vol.Optional(CONF_REALTIME): cv.boolean,
+        vol.Optional(CONF_INCL_FILTER, default=""): TextSelector(),
+        vol.Optional(CONF_EXCL_FILTER, default=""): TextSelector(),
+        vol.Optional(CONF_REALTIME): BooleanSelector(),
         vol.Optional(CONF_VEHICLE_TYPE): vol.In(VEHICLE_TYPES),
-        vol.Optional(CONF_UNITS): vol.In(UNITS),
-        vol.Optional(CONF_AVOID_TOLL_ROADS): cv.boolean,
-        vol.Optional(CONF_AVOID_SUBSCRIPTION_ROADS): cv.boolean,
-        vol.Optional(CONF_AVOID_FERRIES): cv.boolean,
+        vol.Required(CONF_VEHICLE_TYPE): SelectSelector(
+            SelectSelectorConfig(
+                options=sorted(VEHICLE_TYPES),
+                mode=SelectSelectorMode.DROPDOWN,
+                translation_key=CONF_VEHICLE_TYPE,
+            )
+        ),
+        vol.Required(CONF_UNITS): SelectSelector(
+            SelectSelectorConfig(
+                options=sorted(UNITS),
+                mode=SelectSelectorMode.DROPDOWN,
+                translation_key=CONF_UNITS,
+            )
+        ),
+        vol.Optional(CONF_AVOID_TOLL_ROADS): BooleanSelector(),
+        vol.Optional(CONF_AVOID_SUBSCRIPTION_ROADS): BooleanSelector(),
+        vol.Optional(CONF_AVOID_FERRIES): BooleanSelector(),
     }
 )
 
@@ -95,6 +114,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         user_input = user_input or {}
 
         if user_input:
+            user_input[CONF_REGION] = user_input[CONF_REGION].upper()
             if await self.hass.async_add_executor_job(
                 is_valid_config_entry,
                 self.hass,
@@ -117,10 +137,16 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 {
                     vol.Required(
                         CONF_NAME, default=user_input.get(CONF_NAME, DEFAULT_NAME)
-                    ): cv.string,
-                    vol.Required(CONF_ORIGIN): cv.string,
-                    vol.Required(CONF_DESTINATION): cv.string,
-                    vol.Required(CONF_REGION): vol.In(REGIONS),
+                    ): TextSelector(),
+                    vol.Required(CONF_ORIGIN): TextSelector(),
+                    vol.Required(CONF_DESTINATION): TextSelector(),
+                    vol.Required(CONF_REGION): SelectSelector(
+                        SelectSelectorConfig(
+                            options=sorted(REGIONS),
+                            mode=SelectSelectorMode.DROPDOWN,
+                            translation_key=CONF_REGION,
+                        )
+                    ),
                 }
             ),
             errors=errors,

--- a/homeassistant/components/waze_travel_time/config_flow.py
+++ b/homeassistant/components/waze_travel_time/config_flow.py
@@ -42,7 +42,6 @@ OPTIONS_SCHEMA = vol.Schema(
         vol.Optional(CONF_INCL_FILTER, default=""): TextSelector(),
         vol.Optional(CONF_EXCL_FILTER, default=""): TextSelector(),
         vol.Optional(CONF_REALTIME): BooleanSelector(),
-        vol.Optional(CONF_VEHICLE_TYPE): vol.In(VEHICLE_TYPES),
         vol.Required(CONF_VEHICLE_TYPE): SelectSelector(
             SelectSelectorConfig(
                 options=sorted(VEHICLE_TYPES),

--- a/homeassistant/components/waze_travel_time/const.py
+++ b/homeassistant/components/waze_travel_time/const.py
@@ -25,7 +25,7 @@ IMPERIAL_UNITS = "imperial"
 METRIC_UNITS = "metric"
 UNITS = [METRIC_UNITS, IMPERIAL_UNITS]
 
-REGIONS = ["US", "NA", "EU", "IL", "AU"]
+REGIONS = ["us", "na", "eu", "il", "au"]
 VEHICLE_TYPES = ["car", "taxi", "motorcycle"]
 
 DEFAULT_OPTIONS: dict[str, str | bool] = {

--- a/homeassistant/components/waze_travel_time/strings.json
+++ b/homeassistant/components/waze_travel_time/strings.json
@@ -50,7 +50,7 @@
         "imperial": "Imperial System"
       }
     },
-    "regions": {
+    "region": {
       "options": {
         "us": "USA",
         "na": "North America",

--- a/homeassistant/components/waze_travel_time/strings.json
+++ b/homeassistant/components/waze_travel_time/strings.json
@@ -35,5 +35,29 @@
         }
       }
     }
+  },
+  "selector": {
+    "vehicle_type": {
+      "options": {
+        "car": "Car",
+        "taxi": "Taxi",
+        "motorcycle": "Motorcycle"
+      }
+    },
+    "units": {
+      "options": {
+        "metric": "Metric System",
+        "imperial": "Imperial System"
+      }
+    },
+    "regions": {
+      "options": {
+        "us": "USA",
+        "na": "North America",
+        "eu": "Europe",
+        "il": "Israel",
+        "au": "Australia"
+      }
+    }
   }
 }

--- a/tests/components/waze_travel_time/const.py
+++ b/tests/components/waze_travel_time/const.py
@@ -11,3 +11,9 @@ MOCK_CONFIG = {
     CONF_DESTINATION: "location2",
     CONF_REGION: "US",
 }
+
+CONFIG_FLOW_USER_INPUT = {
+    CONF_ORIGIN: "location1",
+    CONF_DESTINATION: "location2",
+    CONF_REGION: "us",
+}

--- a/tests/components/waze_travel_time/test_config_flow.py
+++ b/tests/components/waze_travel_time/test_config_flow.py
@@ -21,7 +21,7 @@ from homeassistant.components.waze_travel_time.const import (
 from homeassistant.const import CONF_NAME, CONF_REGION
 from homeassistant.core import HomeAssistant
 
-from .const import MOCK_CONFIG
+from .const import CONFIG_FLOW_USER_INPUT, MOCK_CONFIG
 
 from tests.common import MockConfigEntry
 
@@ -37,7 +37,7 @@ async def test_minimum_fields(hass: HomeAssistant) -> None:
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        MOCK_CONFIG,
+        CONFIG_FLOW_USER_INPUT,
     )
     await hass.async_block_till_done()
 
@@ -116,7 +116,7 @@ async def test_dupe(hass: HomeAssistant) -> None:
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        MOCK_CONFIG,
+        CONFIG_FLOW_USER_INPUT,
     )
     await hass.async_block_till_done()
 
@@ -131,7 +131,7 @@ async def test_dupe(hass: HomeAssistant) -> None:
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        MOCK_CONFIG,
+        CONFIG_FLOW_USER_INPUT,
     )
     await hass.async_block_till_done()
 
@@ -150,7 +150,7 @@ async def test_invalid_config_entry(
     assert result["errors"] == {}
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        MOCK_CONFIG,
+        CONFIG_FLOW_USER_INPUT,
     )
 
     assert result2["type"] == data_entry_flow.FlowResultType.FORM


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Use selectors in ConfigFlow and OptionFlow.
Related to #88256

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
