### PR TITLE
Fix lingering timer in usb

### DIFF
--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -207,14 +207,14 @@ class USBDiscovery:
         self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, self.async_start)
         self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, self.async_stop)
 
+    async def async_start(self, event: Event) -> None:
+        """Start USB Discovery and run a manual scan."""
+        await self._async_scan_serial()
+
     async def async_stop(self, event: Event) -> None:
         """Stop USB Discovery."""
         if self._request_debouncer:
             await self._request_debouncer.async_shutdown()
-
-    async def async_start(self, event: Event) -> None:
-        """Start USB Discovery and run a manual scan."""
-        await self._async_scan_serial()
 
     async def _async_start_monitor(self) -> None:
         """Start monitoring hardware with pyudev."""

--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -205,6 +205,12 @@ class USBDiscovery:
         """Set up USB Discovery."""
         await self._async_start_monitor()
         self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, self.async_start)
+        self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, self.async_stop)
+
+    async def async_stop(self, event: Event) -> None:
+        """Stop USB Discovery."""
+        if self._request_debouncer:
+            await self._request_debouncer.async_shutdown()
 
     async def async_start(self, event: Event) -> None:
         """Start USB Discovery and run a manual scan."""


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Linked to #91360
https://github.com/home-assistant/core/actions/runs/4745958809/jobs/8429084980?pr=91360

```console
ERROR tests/components/usb/test_init.py::test_discovered_by_websocket_scan - Failed: Lingering timer after test <TimerHandle when=1005.470259733 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:149>
ERROR tests/components/usb/test_init.py::test_discovered_by_websocket_scan_limited_by_description_matcher - Failed: Lingering timer after test <TimerHandle when=1005.956111622 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:149>
ERROR tests/components/usb/test_init.py::test_most_targeted_matcher_wins - Failed: Lingering timer after test <TimerHandle when=1006.284284424 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:149>
ERROR tests/components/usb/test_init.py::test_discovered_by_websocket_scan_rejected_by_description_matcher - Failed: Lingering timer after test <TimerHandle when=1006.53927879 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:149>
ERROR tests/components/usb/test_init.py::test_discovered_by_websocket_scan_limited_by_serial_number_matcher - Failed: Lingering timer after test <TimerHandle when=1006.800004717 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:149>
ERROR tests/components/usb/test_init.py::test_discovered_by_websocket_scan_rejected_by_serial_number_matcher - Failed: Lingering timer after test <TimerHandle when=1007.052190268 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:149>
ERROR tests/components/usb/test_init.py::test_discovered_by_websocket_scan_limited_by_manufacturer_matcher - Failed: Lingering timer after test <TimerHandle when=1007.296023798 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:149>
ERROR tests/components/usb/test_init.py::test_discovered_by_websocket_scan_rejected_by_manufacturer_matcher - Failed: Lingering timer after test <TimerHandle when=1007.538133003 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:149>
ERROR tests/components/usb/test_init.py::test_discovered_by_websocket_rejected_with_empty_serial_number_only - Failed: Lingering timer after test <TimerHandle when=1007.766720613 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:149>
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
