### PR TITLE
Add 'Last update' timestamp attributes for timed HomeWizard sensors

### DIFF
--- a/homeassistant/components/homewizard/const.py
+++ b/homeassistant/components/homewizard/const.py
@@ -20,6 +20,8 @@ CONF_PRODUCT_NAME = "product_name"
 CONF_PRODUCT_TYPE = "product_type"
 CONF_SERIAL = "serial"
 
+ATTR_LAST_UPDATE = "last_update"
+
 UPDATE_INTERVAL = timedelta(seconds=5)
 
 

--- a/homeassistant/components/homewizard/sensor.py
+++ b/homeassistant/components/homewizard/sensor.py
@@ -29,7 +29,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
-from .const import DOMAIN
+from .const import ATTR_LAST_UPDATE, DOMAIN
 from .coordinator import HWEnergyDeviceUpdateCoordinator
 from .entity import HomeWizardEntity
 
@@ -345,7 +345,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         value_fn=lambda data: data.monthly_power_peak_w,
-        attr_fn=lambda data: {"last_update": data.monthly_power_peak_timestamp},
+        attr_fn=lambda data: {ATTR_LAST_UPDATE: data.monthly_power_peak_timestamp},
     ),
     HomeWizardSensorEntityDescription(
         key="total_gas_m3",
@@ -354,7 +354,7 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.GAS,
         state_class=SensorStateClass.TOTAL_INCREASING,
         value_fn=lambda data: data.total_gas_m3,
-        attr_fn=lambda data: {"last_update": data.gas_timestamp},
+        attr_fn=lambda data: {ATTR_LAST_UPDATE: data.gas_timestamp},
     ),
     HomeWizardSensorEntityDescription(
         key="gas_unique_id",

--- a/tests/components/homewizard/test_sensor.py
+++ b/tests/components/homewizard/test_sensor.py
@@ -1,5 +1,5 @@
 """Test the update coordinator for HomeWizard."""
-from datetime import timedelta
+from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, patch
 
 from homewizard_energy.errors import DisabledError, RequestError
@@ -586,7 +586,9 @@ async def test_sensor_entity_total_gas(
     """Test entity loads total gas."""
 
     api = get_mock_device()
-    api.data = AsyncMock(return_value=Data.from_dict({"total_gas_m3": 50}))
+    api.data = AsyncMock(
+        return_value=Data.from_dict({"total_gas_m3": 50, "gas_timestamp": 210314112233})
+    )
 
     with patch(
         "homeassistant.components.homewizard.coordinator.HomeWizardEnergy",
@@ -615,6 +617,7 @@ async def test_sensor_entity_total_gas(
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.TOTAL_INCREASING
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfVolume.CUBIC_METERS
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.GAS
+    assert state.attributes.get("last_update") == datetime(2021, 3, 14, 11, 22, 33)
     assert ATTR_ICON not in state.attributes
 
 
@@ -1437,7 +1440,14 @@ async def test_sensor_entity_monthly_power_peak(
     """Test entity loads monthly power peak."""
 
     api = get_mock_device()
-    api.data = AsyncMock(return_value=Data.from_dict({"montly_power_peak_w": 1234.456}))
+    api.data = AsyncMock(
+        return_value=Data.from_dict(
+            {
+                "montly_power_peak_w": 1234.456,
+                "montly_power_peak_timestamp": 230101080010,
+            }
+        )
+    )
 
     with patch(
         "homeassistant.components.homewizard.coordinator.HomeWizardEnergy",
@@ -1471,6 +1481,7 @@ async def test_sensor_entity_monthly_power_peak(
     assert state.attributes.get(ATTR_STATE_CLASS) is None
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfPower.WATT
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.POWER
+    assert state.attributes.get("last_update") == datetime(2023, 1, 1, 8, 0, 10)
     assert ATTR_ICON not in state.attributes
 
 

--- a/tests/components/homewizard/test_sensor.py
+++ b/tests/components/homewizard/test_sensor.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, patch
 from homewizard_energy.errors import DisabledError, RequestError
 from homewizard_energy.models import Data
 
+from homeassistant.components.homewizard.const import ATTR_LAST_UPDATE
 from homeassistant.components.sensor import (
     ATTR_OPTIONS,
     ATTR_STATE_CLASS,
@@ -617,7 +618,7 @@ async def test_sensor_entity_total_gas(
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.TOTAL_INCREASING
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfVolume.CUBIC_METERS
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.GAS
-    assert state.attributes.get("last_update") == datetime(2021, 3, 14, 11, 22, 33)
+    assert state.attributes.get(ATTR_LAST_UPDATE) == datetime(2021, 3, 14, 11, 22, 33)
     assert ATTR_ICON not in state.attributes
 
 
@@ -1481,7 +1482,7 @@ async def test_sensor_entity_monthly_power_peak(
     assert state.attributes.get(ATTR_STATE_CLASS) is None
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfPower.WATT
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.POWER
-    assert state.attributes.get("last_update") == datetime(2023, 1, 1, 8, 0, 10)
+    assert state.attributes.get(ATTR_LAST_UPDATE) == datetime(2023, 1, 1, 8, 0, 10)
     assert ATTR_ICON not in state.attributes
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add 'Last update' attributes for gas and peak demand.

- Gas updates once every hour or 5 minutes, the exact timestamp is available. Users can use the build-in 'Last changed/updated', but it won't change if you don't use gas.
- Peak demand current month shows the highest usage of this month. We got some request to show the real timestamp instead 'Last changed'. I think it is useful for new installations.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
