### PR TITLE
Conversation list command to support match-all languages agents

### DIFF
--- a/homeassistant/components/conversation/__init__.py
+++ b/homeassistant/components/conversation/__init__.py
@@ -270,7 +270,7 @@ async def websocket_list_agents(
         supported_languages = agent.supported_languages
         if language and supported_languages != MATCH_ALL:
             supported_languages = language_util.matches(
-                language, agent.supported_languages, country
+                language, supported_languages, country
             )
 
         agent_dict: dict[str, Any] = {

--- a/homeassistant/components/conversation/__init__.py
+++ b/homeassistant/components/conversation/__init__.py
@@ -266,15 +266,18 @@ async def websocket_list_agents(
 
     for agent_info in manager.async_get_agent_info():
         agent = await manager.async_get_agent(agent_info.id)
+
+        supported_languages = agent.supported_languages
+        if language and supported_languages != MATCH_ALL:
+            supported_languages = language_util.matches(
+                language, agent.supported_languages, country
+            )
+
         agent_dict: dict[str, Any] = {
             "id": agent_info.id,
             "name": agent_info.name,
-            "supported_languages": agent.supported_languages,
+            "supported_languages": supported_languages,
         }
-        if language:
-            agent_dict["supported_languages"] = language_util.matches(
-                language, agent.supported_languages, country
-            )
         agents.append(agent_dict)
 
     connection.send_message(websocket_api.result_message(msg["id"], {"agents": agents}))

--- a/tests/components/conversation/__init__.py
+++ b/tests/components/conversation/__init__.py
@@ -1,6 +1,8 @@
 """Tests for the conversation component."""
 from __future__ import annotations
 
+from typing import Literal
+
 from homeassistant.components import conversation
 from homeassistant.components.homeassistant.exposed_entities import (
     DATA_EXPOSED_ENTITIES,
@@ -12,11 +14,14 @@ from homeassistant.helpers import intent
 class MockAgent(conversation.AbstractConversationAgent):
     """Test Agent."""
 
-    def __init__(self, agent_id: str) -> None:
+    def __init__(
+        self, agent_id: str, supported_languages: list[str] | Literal["*"]
+    ) -> None:
         """Initialize the agent."""
         self.agent_id = agent_id
         self.calls = []
         self.response = "Test response"
+        self._supported_languages = supported_languages
 
     @property
     def attribution(self) -> conversation.Attribution | None:
@@ -26,7 +31,7 @@ class MockAgent(conversation.AbstractConversationAgent):
     @property
     def supported_languages(self) -> list[str]:
         """Return a list of supported languages."""
-        return ["smurfish"]
+        return self._supported_languages
 
     async def async_process(
         self, user_input: conversation.ConversationInput

--- a/tests/components/conversation/conftest.py
+++ b/tests/components/conversation/conftest.py
@@ -3,6 +3,7 @@
 import pytest
 
 from homeassistant.components import conversation
+from homeassistant.const import MATCH_ALL
 
 from . import MockAgent
 
@@ -14,6 +15,16 @@ def mock_agent(hass):
     """Mock agent."""
     entry = MockConfigEntry(entry_id="mock-entry")
     entry.add_to_hass(hass)
-    agent = MockAgent(entry.entry_id)
+    agent = MockAgent(entry.entry_id, ["smurfish"])
+    conversation.async_set_agent(hass, entry, agent)
+    return agent
+
+
+@pytest.fixture
+def mock_agent_support_all(hass):
+    """Mock agent that supports all languages."""
+    entry = MockConfigEntry(entry_id="mock-entry-support-all")
+    entry.add_to_hass(hass)
+    agent = MockAgent(entry.entry_id, MATCH_ALL)
     conversation.async_set_agent(hass, entry, agent)
     return agent

--- a/tests/components/conversation/snapshots/test_init.ambr
+++ b/tests/components/conversation/snapshots/test_init.ambr
@@ -85,6 +85,11 @@
           'smurfish',
         ]),
       }),
+      dict({
+        'id': 'mock-entry-support-all',
+        'name': 'Mock Title',
+        'supported_languages': '*',
+      }),
     ]),
   })
 # ---
@@ -103,6 +108,11 @@
         'supported_languages': list([
           'smurfish',
         ]),
+      }),
+      dict({
+        'id': 'mock-entry-support-all',
+        'name': 'Mock Title',
+        'supported_languages': '*',
       }),
     ]),
   })
@@ -123,6 +133,11 @@
         'supported_languages': list([
         ]),
       }),
+      dict({
+        'id': 'mock-entry-support-all',
+        'name': 'Mock Title',
+        'supported_languages': '*',
+      }),
     ]),
   })
 # ---
@@ -141,6 +156,11 @@
         'name': 'Mock Title',
         'supported_languages': list([
         ]),
+      }),
+      dict({
+        'id': 'mock-entry-support-all',
+        'name': 'Mock Title',
+        'supported_languages': '*',
       }),
     ]),
   })
@@ -162,6 +182,11 @@
         'supported_languages': list([
         ]),
       }),
+      dict({
+        'id': 'mock-entry-support-all',
+        'name': 'Mock Title',
+        'supported_languages': '*',
+      }),
     ]),
   })
 # ---
@@ -181,6 +206,11 @@
         'name': 'Mock Title',
         'supported_languages': list([
         ]),
+      }),
+      dict({
+        'id': 'mock-entry-support-all',
+        'name': 'Mock Title',
+        'supported_languages': '*',
       }),
     ]),
   })

--- a/tests/components/conversation/test_init.py
+++ b/tests/components/conversation/test_init.py
@@ -1576,6 +1576,7 @@ async def test_get_agent_list(
     hass: HomeAssistant,
     init_components,
     mock_agent,
+    mock_agent_support_all,
     hass_ws_client: WebSocketGenerator,
     snapshot: SnapshotAssertion,
 ) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If a conversation agent supports all languages (value `MATCH_ALL`), it will now no longer be overridden with an empty array when a language is passed into the `conversation/agent/list` WS command.

Needs a frontend fix too, as it currently doesn't handle `*`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
