### PR TITLE
Several changes to Wheels building for the cp311 ABI

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -252,7 +252,12 @@ jobs:
         run: |
           requirement_files="requirements_all.txt requirements_diff.txt"
           for requirement_file in ${requirement_files}; do
-            sed -i "s|# pybluez|pybluez|g" ${requirement_file}
+
+            # PyBluez no longer compiles. Commented it out for now.
+            # It need further cleanup down the line, as all machine images
+            # try to install it.
+            # sed -i "s|# pybluez|pybluez|g" ${requirement_file}
+
             sed -i "s|# beacontools|beacontools|g" ${requirement_file}
             sed -i "s|# fritzconnection|fritzconnection|g" ${requirement_file}
             sed -i "s|# pyuserinput|pyuserinput|g" ${requirement_file}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -283,11 +283,12 @@ jobs:
             echo "NPY_DISABLE_SVML=1" >> .env_file
           fi
 
-          (
-            # cmake > 3.22.2 have issue on arm
-            # Tested until 3.22.5
-            echo "cmake==3.22.2"
-          ) >> homeassistant/package_constraints.txt
+          # Probably not an issue anymore. Removing for now.
+          # (
+          #   # cmake > 3.22.2 have issue on arm
+          #   # Tested until 3.22.5
+          #   echo "cmake==3.22.2"
+          # ) >> homeassistant/package_constraints.txt
 
           # Do not pin numpy in wheels building
           sed -i "/numpy/d" homeassistant/package_constraints.txt

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -219,15 +219,34 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@v3.5.2
 
-      - name: Download env_file
-        uses: actions/download-artifact@v3
-        with:
-          name: env_file
+      - name: Write alternative env-file for cp311
+        run: |
+          (
+            echo "GRPC_BUILD_WITH_BORING_SSL_ASM=false"
+            echo "GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=true"
+            echo "GRPC_PYTHON_BUILD_WITH_CYTHON=true"
+            echo "GRPC_PYTHON_DISABLE_LIBC_COMPATIBILITY=true"
 
-      - name: Download env_file
+            # GRPC on armv7 needed -lexecinfo (issue #56669) since home assistant installed
+            # execinfo-dev when building wheels. However, this package is no longer available
+            # Alpine 3.17, which we use for the cp311 ABI, so the flag should no longer be needed.
+            echo "GRPC_PYTHON_LDFLAGS=-lpthread -Wl,-wrap,memcpy -static-libgcc" # -lexecinfo
+
+            # Fix out of memory issues with rust
+            echo "CARGO_NET_GIT_FETCH_WITH_CLI=true"
+
+            # OpenCV headless installation
+            echo "CI_BUILD=1"
+            echo "ENABLE_HEADLESS=1"
+
+            # Use C-Extension for sqlalchemy
+            echo "REQUIRE_SQLALCHEMY_CEXT=1"
+          ) > .env_file
+
+      - name: Download requirements_diff
         uses: actions/download-artifact@v3
         with:
-          name: env_file
+          name: requirements_diff
 
       - name: Uncomment packages
         run: |

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -301,7 +301,7 @@ jobs:
           arch: ${{ matrix.arch }}
           wheels-key: ${{ secrets.WHEELS_KEY }}
           env-file: true
-          apk: "bluez-dev;libffi-dev;openssl-dev;glib-dev;eudev-dev;libxml2-dev;libxslt-dev;libpng-dev;libjpeg-turbo-dev;tiff-dev;cups-dev;gmp-dev;mpfr-dev;mpc1-dev;ffmpeg-dev;gammu-dev;yaml-dev;openblas-dev;fftw-dev;lapack-dev;gfortran;blas-dev;eigen-dev;freetype-dev;glew-dev;harfbuzz-dev;hdf5-dev;libdc1394-dev;libtbb-dev;mesa-dev;openexr-dev;openjpeg-dev;uchardet-dev"
+          apk: "bluez-dev;libffi-dev;openssl-dev;glib-dev;eudev-dev;libxml2-dev;libxslt-dev;libpng-dev;libjpeg-turbo-dev;tiff-dev;cups-dev;gmp-dev;mpfr-dev;mpc1-dev;ffmpeg-dev;gammu-dev;yaml-dev;openblas-dev;fftw-dev;lapack-dev;gfortran;blas-dev;eigen-dev;freetype-dev;glew-dev;harfbuzz-dev;hdf5-dev;libdc1394-dev;libtbb-dev;mesa-dev;openexr-dev;openjpeg-dev;openssl1.1-compat-dev;uchardet-dev"
           skip-binary: aiohttp;grpcio;sqlalchemy;protobuf
           legacy: true
           constraints: "homeassistant/package_constraints.txt"
@@ -316,7 +316,7 @@ jobs:
           arch: ${{ matrix.arch }}
           wheels-key: ${{ secrets.WHEELS_KEY }}
           env-file: true
-          apk: "bluez-dev;libffi-dev;openssl-dev;glib-dev;eudev-dev;libxml2-dev;libxslt-dev;libpng-dev;libjpeg-turbo-dev;tiff-dev;cups-dev;gmp-dev;mpfr-dev;mpc1-dev;ffmpeg-dev;gammu-dev;yaml-dev;openblas-dev;fftw-dev;lapack-dev;gfortran;blas-dev;eigen-dev;freetype-dev;glew-dev;harfbuzz-dev;hdf5-dev;libdc1394-dev;libtbb-dev;mesa-dev;openexr-dev;openjpeg-dev;uchardet-dev"
+          apk: "bluez-dev;libffi-dev;openssl-dev;glib-dev;eudev-dev;libxml2-dev;libxslt-dev;libpng-dev;libjpeg-turbo-dev;tiff-dev;cups-dev;gmp-dev;mpfr-dev;mpc1-dev;ffmpeg-dev;gammu-dev;yaml-dev;openblas-dev;fftw-dev;lapack-dev;gfortran;blas-dev;eigen-dev;freetype-dev;glew-dev;harfbuzz-dev;hdf5-dev;libdc1394-dev;libtbb-dev;mesa-dev;openexr-dev;openjpeg-dev;openssl1.1-compat-dev;uchardet-dev"
           skip-binary: aiohttp;grpcio;sqlalchemy;protobuf
           legacy: true
           constraints: "homeassistant/package_constraints.txt"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -72,7 +72,7 @@ jobs:
           path: ./requirements_diff.txt
 
   core:
-    name: Build musllinux wheels with musllinux_1_2 / ${{ matrix.abi }} at ${{ matrix.arch }} for core
+    name: Build Core wheels ${{ matrix.abi }} for ${{ matrix.arch }} (musllinux_1_2)
     if: github.repository_owner == 'home-assistant'
     needs: init
     runs-on: ubuntu-latest
@@ -109,15 +109,15 @@ jobs:
           requirements-diff: "requirements_diff.txt"
           requirements: "requirements.txt"
 
-  integrations:
-    name: Build musllinux wheels with musllinux_1_2 / ${{ matrix.abi }} at ${{ matrix.arch }} for integrations
+  integrations_cp310:
+    name: Build wheels ${{ matrix.abi }} for ${{ matrix.arch }}
     if: github.repository_owner == 'home-assistant'
     needs: init
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        abi: ["cp310", "cp311"]
+        abi: ["cp310"]
         arch: ${{ fromJson(needs.init.outputs.architectures) }}
     steps:
       - name: Checkout the repository
@@ -132,6 +132,102 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: requirements_diff
+
+      - name: Uncomment packages
+        run: |
+          requirement_files="requirements_all.txt requirements_diff.txt"
+          for requirement_file in ${requirement_files}; do
+            sed -i "s|# pybluez|pybluez|g" ${requirement_file}
+            sed -i "s|# beacontools|beacontools|g" ${requirement_file}
+            sed -i "s|# fritzconnection|fritzconnection|g" ${requirement_file}
+            sed -i "s|# pyuserinput|pyuserinput|g" ${requirement_file}
+            sed -i "s|# evdev|evdev|g" ${requirement_file}
+            sed -i "s|# pycups|pycups|g" ${requirement_file}
+            sed -i "s|# homekit|homekit|g" ${requirement_file}
+            sed -i "s|# decora_wifi|decora_wifi|g" ${requirement_file}
+            sed -i "s|# python-gammu|python-gammu|g" ${requirement_file}
+            sed -i "s|# opencv-python-headless|opencv-python-headless|g" ${requirement_file}
+          done
+
+      - name: Split requirements all
+        run: |
+          # We split requirements all into two different files.
+          # This is to prevent the build from running out of memory when
+          # resolving packages on 32-bits systems (like armhf, armv7).
+
+          split -l $(expr $(expr $(cat requirements_all.txt | wc -l) + 1) / 2) requirements_all.txt requirements_all.txt
+
+      - name: Adjust build env
+        run: |
+          if [ "${{ matrix.arch }}" = "i386" ]; then
+            echo "NPY_DISABLE_SVML=1" >> .env_file
+          fi
+
+          (
+            # cmake > 3.22.2 have issue on arm
+            # Tested until 3.22.5
+            echo "cmake==3.22.2"
+          ) >> homeassistant/package_constraints.txt
+
+          # Do not pin numpy in wheels building
+          sed -i "/numpy/d" homeassistant/package_constraints.txt
+
+      - name: Build wheels (part 1)
+        uses: home-assistant/wheels@2023.04.0
+        with:
+          abi: ${{ matrix.abi }}
+          tag: musllinux_1_2
+          arch: ${{ matrix.arch }}
+          wheels-key: ${{ secrets.WHEELS_KEY }}
+          env-file: true
+          apk: "bluez-dev;libffi-dev;openssl-dev;glib-dev;eudev-dev;libxml2-dev;libxslt-dev;libpng-dev;libjpeg-turbo-dev;tiff-dev;cups-dev;gmp-dev;mpfr-dev;mpc1-dev;ffmpeg-dev;gammu-dev;yaml-dev;openblas-dev;fftw-dev;lapack-dev;gfortran;blas-dev;eigen-dev;freetype-dev;glew-dev;harfbuzz-dev;hdf5-dev;libdc1394-dev;libtbb-dev;mesa-dev;openexr-dev;openjpeg-dev;uchardet-dev"
+          skip-binary: aiohttp;grpcio;sqlalchemy;protobuf
+          legacy: true
+          constraints: "homeassistant/package_constraints.txt"
+          requirements-diff: "requirements_diff.txt"
+          requirements: "requirements_all.txtaa"
+
+      - name: Build wheels (part 2)
+        uses: home-assistant/wheels@2023.04.0
+        with:
+          abi: ${{ matrix.abi }}
+          tag: musllinux_1_2
+          arch: ${{ matrix.arch }}
+          wheels-key: ${{ secrets.WHEELS_KEY }}
+          env-file: true
+          apk: "bluez-dev;libffi-dev;openssl-dev;glib-dev;eudev-dev;libxml2-dev;libxslt-dev;libpng-dev;libjpeg-turbo-dev;tiff-dev;cups-dev;gmp-dev;mpfr-dev;mpc1-dev;ffmpeg-dev;gammu-dev;yaml-dev;openblas-dev;fftw-dev;lapack-dev;gfortran;blas-dev;eigen-dev;freetype-dev;glew-dev;harfbuzz-dev;hdf5-dev;libdc1394-dev;libtbb-dev;mesa-dev;openexr-dev;openjpeg-dev;uchardet-dev"
+          skip-binary: aiohttp;grpcio;sqlalchemy;protobuf
+          legacy: true
+          constraints: "homeassistant/package_constraints.txt"
+          requirements-diff: "requirements_diff.txt"
+          requirements: "requirements_all.txtab"
+
+  # Wheels building for the cp311 ABI is currently split
+  # This is mainly until we have figured out to get all wheels built.
+  # Without harming our current workflow.
+  integrations_cp311:
+    name: Build wheels ${{ matrix.abi }} for ${{ matrix.arch }}
+    if: github.repository_owner == 'home-assistant'
+    needs: init
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        abi: ["cp311"]
+        arch: ${{ fromJson(needs.init.outputs.architectures) }}
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v3.5.2
+
+      - name: Download env_file
+        uses: actions/download-artifact@v3
+        with:
+          name: env_file
+
+      - name: Download env_file
+        uses: actions/download-artifact@v3
+        with:
+          name: env_file
 
       - name: Uncomment packages
         run: |


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR contains multiple changes, while normally we shouldn't do that, in this case it isn't really helpful to split it (for both CI and review).

All changes are based on this run: https://github.com/home-assistant/core/actions/runs/4769729574

Changes in this PR:

- Change the job/tasks names a little, to make it more readable in the GitHub output (as right now, you'll only see the first part, which is the same for all jobs)

- Duplicated the integration wheels building. This is to, for now, separate the cp310 and cp311 wheels building, allowing us to do different things in each. Main reasoning is to not touch our current actively used wheels in Python 3.10, while working on 3.11 support.

- Removes the libexecinfo linker flag for gRPC builds. We originally added it, because we had a libexecinfo stub installed in Alpine 3.16 which threw off gRPC builds. As Alpine 3.17 no longer provides this stub, the builds are failing now. This PR removes the linker flag (which is basically how it was meant to be).

- Don't build `pybluez`. It is outdated, unmaintained (published as such), and no longer building. We expected this to happen.

- Remove the pip cmake constraint. This should no longer be an issue. Additionally, we don't pre-install cmake via pip in the cp311 builder images anymore.

- Adds `openssl1.1-compat-dev` package, as `uamqp` isn't compatible with the OpenSSL3 that is shipped with Alpine 3.17. This OpenSSL 1.1 compatibility layer should make able to build.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
