### PR TITLE
Wheels: Don't build azure-servicebus on cp311

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -137,6 +137,7 @@ jobs:
         run: |
           requirement_files="requirements_all.txt requirements_diff.txt"
           for requirement_file in ${requirement_files}; do
+            sed -i "s|# azure-servicebus|azure-servicebus|g" ${requirement_file}
             sed -i "s|# pybluez|pybluez|g" ${requirement_file}
             sed -i "s|# beacontools|beacontools|g" ${requirement_file}
             sed -i "s|# fritzconnection|fritzconnection|g" ${requirement_file}
@@ -258,6 +259,12 @@ jobs:
             # try to install it.
             # sed -i "s|# pybluez|pybluez|g" ${requirement_file}
 
+            # azure-servicebus requires uamqp, which requires OpenSSL 1.1 to
+            # compile/build. This is not available on Alpine 3.17. The compat
+            # layer offered by Alpine conflicts, so we have no way to build
+            # this package.
+            # sed -i "s|# azure-servicebus|azure-servicebus|g" ${requirement_file}
+
             sed -i "s|# beacontools|beacontools|g" ${requirement_file}
             sed -i "s|# fritzconnection|fritzconnection|g" ${requirement_file}
             sed -i "s|# pyuserinput|pyuserinput|g" ${requirement_file}
@@ -301,7 +308,7 @@ jobs:
           arch: ${{ matrix.arch }}
           wheels-key: ${{ secrets.WHEELS_KEY }}
           env-file: true
-          apk: "bluez-dev;libffi-dev;openssl-dev;glib-dev;eudev-dev;libxml2-dev;libxslt-dev;libpng-dev;libjpeg-turbo-dev;tiff-dev;cups-dev;gmp-dev;mpfr-dev;mpc1-dev;ffmpeg-dev;gammu-dev;yaml-dev;openblas-dev;fftw-dev;lapack-dev;gfortran;blas-dev;eigen-dev;freetype-dev;glew-dev;harfbuzz-dev;hdf5-dev;libdc1394-dev;libtbb-dev;mesa-dev;openexr-dev;openjpeg-dev;openssl1.1-compat-dev;uchardet-dev"
+          apk: "bluez-dev;libffi-dev;openssl-dev;glib-dev;eudev-dev;libxml2-dev;libxslt-dev;libpng-dev;libjpeg-turbo-dev;tiff-dev;cups-dev;gmp-dev;mpfr-dev;mpc1-dev;ffmpeg-dev;gammu-dev;yaml-dev;openblas-dev;fftw-dev;lapack-dev;gfortran;blas-dev;eigen-dev;freetype-dev;glew-dev;harfbuzz-dev;hdf5-dev;libdc1394-dev;libtbb-dev;mesa-dev;openexr-dev;openjpeg-dev;uchardet-dev"
           skip-binary: aiohttp;grpcio;sqlalchemy;protobuf
           legacy: true
           constraints: "homeassistant/package_constraints.txt"
@@ -316,7 +323,7 @@ jobs:
           arch: ${{ matrix.arch }}
           wheels-key: ${{ secrets.WHEELS_KEY }}
           env-file: true
-          apk: "bluez-dev;libffi-dev;openssl-dev;glib-dev;eudev-dev;libxml2-dev;libxslt-dev;libpng-dev;libjpeg-turbo-dev;tiff-dev;cups-dev;gmp-dev;mpfr-dev;mpc1-dev;ffmpeg-dev;gammu-dev;yaml-dev;openblas-dev;fftw-dev;lapack-dev;gfortran;blas-dev;eigen-dev;freetype-dev;glew-dev;harfbuzz-dev;hdf5-dev;libdc1394-dev;libtbb-dev;mesa-dev;openexr-dev;openjpeg-dev;openssl1.1-compat-dev;uchardet-dev"
+          apk: "bluez-dev;libffi-dev;openssl-dev;glib-dev;eudev-dev;libxml2-dev;libxslt-dev;libpng-dev;libjpeg-turbo-dev;tiff-dev;cups-dev;gmp-dev;mpfr-dev;mpc1-dev;ffmpeg-dev;gammu-dev;yaml-dev;openblas-dev;fftw-dev;lapack-dev;gfortran;blas-dev;eigen-dev;freetype-dev;glew-dev;harfbuzz-dev;hdf5-dev;libdc1394-dev;libtbb-dev;mesa-dev;openexr-dev;openjpeg-dev;uchardet-dev"
           skip-binary: aiohttp;grpcio;sqlalchemy;protobuf
           legacy: true
           constraints: "homeassistant/package_constraints.txt"

--- a/homeassistant/components/azure_service_bus/notify.py
+++ b/homeassistant/components/azure_service_bus/notify.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 import json
 import logging
 
-from azure.servicebus import ServiceBusMessage
-from azure.servicebus.aio import ServiceBusClient, ServiceBusSender
-from azure.servicebus.exceptions import (
+from azure.servicebus import ServiceBusMessage  # pylint: disable=import-error
+from azure.servicebus.aio import (  # pylint: disable=import-error
+    ServiceBusClient,
+    ServiceBusSender,
+)
+from azure.servicebus.exceptions import (  # pylint: disable=import-error
     MessagingEntityNotFoundError,
     ServiceBusConnectionError,
     ServiceBusError,

--- a/homeassistant/components/azure_service_bus/notify.py
+++ b/homeassistant/components/azure_service_bus/notify.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 import json
 import logging
 
-from azure.servicebus import ServiceBusMessage  # pylint: disable=import-error
-from azure.servicebus.aio import (  # pylint: disable=import-error
-    ServiceBusClient,
-    ServiceBusSender,
-)
-from azure.servicebus.exceptions import (  # pylint: disable=import-error
+# pylint: disable-next=import-error, no-name-in-module
+from azure.servicebus import ServiceBusMessage
+
+# pylint: disable-next=import-error, no-name-in-module
+from azure.servicebus.aio import ServiceBusClient, ServiceBusSender
+
+# pylint: disable-next=import-error, no-name-in-module
+from azure.servicebus.exceptions import (
     MessagingEntityNotFoundError,
     ServiceBusConnectionError,
     ServiceBusError,

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -404,7 +404,7 @@ axis==47
 azure-eventhub==5.11.1
 
 # homeassistant.components.azure_service_bus
-azure-servicebus==7.8.0
+# azure-servicebus==7.8.0
 
 # homeassistant.components.baidu
 baidu-aip==1.6.6

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -23,6 +23,7 @@ COMMENT_REQUIREMENTS = (
     "Adafruit_BBIO",
     "avea",  # depends on bluepy
     "avion",
+    "azure-servicebus",  # depends on uamqp, which requires OpenSSL 1.1
     "beacontools",
     "beewi_smartclim",  # depends on bluepy
     "bluepy",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR disables building wheels for the `Azure Service Bus` integration. It depends on the `azure-servicebus` Python package, which has `uamqp` as a subdepedency. 

`uamqp` is the problem maker in this case, as it specifically requires OpenSSL 1.1 to build, while we build our Python 3.11 wheels on Alpine Linux 3.17, which ships with OpenSSL 3.0.x.

Although Alpine provides a compatibility package (`openssl1.1-compat-dev`) that technically should be sufficient to build wheels, it does conflict with our existing OpenSSL development headers.

At this point, there is no direct path forward. This resulting in this integration becoming unusable on our container-based installation types once we switch to Python 3.11.

Everything in this PR, including the above, does not affect our current releases.

Upstream issue: <https://github.com/Azure/azure-uamqp-python/issues/276>

CC @hfurubotten (codeowner of the `azure_service_bus` integration)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
