### PR TITLE
Revert "Update opencv-python-headless to 4.7.0.72"

### DIFF
--- a/homeassistant/components/opencv/manifest.json
+++ b/homeassistant/components/opencv/manifest.json
@@ -4,5 +4,5 @@
   "codeowners": [],
   "documentation": "https://www.home-assistant.io/integrations/opencv",
   "iot_class": "local_push",
-  "requirements": ["numpy==1.23.2", "opencv-python-headless==4.7.0.72"]
+  "requirements": ["numpy==1.23.2", "opencv-python-headless==4.6.0.66"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1273,7 +1273,7 @@ open-meteo==0.2.1
 openai==0.27.2
 
 # homeassistant.components.opencv
-# opencv-python-headless==4.7.0.72
+# opencv-python-headless==4.6.0.66
 
 # homeassistant.components.openerz
 openerz-api==0.2.0


### PR DESCRIPTION
Reverts home-assistant/core#91802

Reverts this bump, it is breaking our current Python 3.10 wheels building:

<https://github.com/home-assistant/core/actions/runs/4773860578/jobs/8487193796>

Additionally, it doesn't fix the wheels building for Python 3.11 either. So, reverting is at least resolving something for now.
