### PR TITLE
Add gateway WAN/LAN port connectivity entities to TP-Link Omada

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1293,6 +1293,7 @@ omit =
     homeassistant/components/touchline/climate.py
     homeassistant/components/tplink_lte/*
     homeassistant/components/tplink_omada/__init__.py
+    homeassistant/components/tplink_omada/binary_sensor.py
     homeassistant/components/tplink_omada/controller.py
     homeassistant/components/tplink_omada/coordinator.py
     homeassistant/components/tplink_omada/entity.py

--- a/homeassistant/components/tplink_omada/__init__.py
+++ b/homeassistant/components/tplink_omada/__init__.py
@@ -18,7 +18,7 @@ from .config_flow import CONF_SITE, create_omada_client
 from .const import DOMAIN
 from .controller import OmadaSiteController
 
-PLATFORMS: list[Platform] = [Platform.SWITCH, Platform.UPDATE]
+PLATFORMS: list[Platform] = [Platform.SWITCH, Platform.UPDATE, Platform.BINARY_SENSOR]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/tplink_omada/binary_sensor.py
+++ b/homeassistant/components/tplink_omada/binary_sensor.py
@@ -25,11 +25,10 @@ async def async_setup_entry(
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up switches."""
+    """Set up binary sensors."""
     controller: OmadaSiteController = hass.data[DOMAIN][config_entry.entry_id]
     omada_client = controller.omada_client
 
-    # Naming fun. Omada switches, as in the network hardware
     gateway_coordinator = await controller.get_gateway_coordinator()
     if not gateway_coordinator:
         return

--- a/homeassistant/components/tplink_omada/binary_sensor.py
+++ b/homeassistant/components/tplink_omada/binary_sensor.py
@@ -1,0 +1,121 @@
+"""Support for TPLink Omada binary sensors."""
+from __future__ import annotations
+
+from collections.abc import Callable, Generator
+
+from attr import dataclass
+from tplink_omada_client.definitions import GatewayPortMode, LinkStatus
+from tplink_omada_client.devices import OmadaDevice, OmadaGateway, OmadaGatewayPort
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .controller import OmadaGatewayCoordinator, OmadaSiteController
+from .entity import OmadaDeviceEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up switches."""
+    controller: OmadaSiteController = hass.data[DOMAIN][config_entry.entry_id]
+    omada_client = controller.omada_client
+
+    # Naming fun. Omada switches, as in the network hardware
+    gateway_coordinator = await controller.get_gateway_coordinator()
+    if not gateway_coordinator:
+        return
+
+    gateway = await omada_client.get_gateway(gateway_coordinator.mac)
+
+    async_add_entities(
+        get_gateway_port_status_sensors(gateway, hass, gateway_coordinator)
+    )
+
+    await gateway_coordinator.async_request_refresh()
+
+
+def get_gateway_port_status_sensors(
+    gateway: OmadaGateway, hass: HomeAssistant, coordinator: OmadaGatewayCoordinator
+) -> Generator[BinarySensorEntity, None, None]:
+    """Generate binary sensors for gateway ports."""
+    for port in gateway.port_status:
+        if port.mode == GatewayPortMode.WAN:
+            yield OmadaGatewayPortBinarySensor(
+                coordinator,
+                gateway,
+                GatewayPortBinarySensorConfig(
+                    port_number=port.port_number,
+                    id_suffix="wan_link",
+                    name_suffix="Internet Link",
+                    device_class=BinarySensorDeviceClass.CONNECTIVITY,
+                    update_func=lambda p: p.wan_connected,
+                ),
+            )
+        if port.mode == GatewayPortMode.LAN:
+            yield OmadaGatewayPortBinarySensor(
+                coordinator,
+                gateway,
+                GatewayPortBinarySensorConfig(
+                    port_number=port.port_number,
+                    id_suffix="lan_status",
+                    name_suffix="LAN Status",
+                    device_class=BinarySensorDeviceClass.CONNECTIVITY,
+                    update_func=lambda p: p.link_status == LinkStatus.LINK_UP,
+                ),
+            )
+
+
+@dataclass
+class GatewayPortBinarySensorConfig:
+    """Config for a binary status derived from a gateway port."""
+
+    port_number: int
+    id_suffix: str
+    name_suffix: str
+    device_class: BinarySensorDeviceClass
+    update_func: Callable[[OmadaGatewayPort], bool]
+
+
+class OmadaGatewayPortBinarySensor(OmadaDeviceEntity[OmadaGateway], BinarySensorEntity):
+    """Binary status of a property on an internet gateway."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: OmadaGatewayCoordinator,
+        device: OmadaDevice,
+        config: GatewayPortBinarySensorConfig,
+    ) -> None:
+        """Initialize the gateway port binary sensor."""
+        super().__init__(coordinator, device)
+        self._config = config
+        self._attr_unique_id = f"{device.mac}_{config.port_number}_{config.id_suffix}"
+        self._attr_device_class = config.device_class
+
+        self._attr_name = f"Port {config.port_number} {config.name_suffix}"
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        gateway = self.coordinator.data[self.device.mac]
+
+        port = next(
+            p for p in gateway.port_status if p.port_number == self._config.port_number
+        )
+        if port:
+            self._attr_is_on = self._config.update_func(port)
+            self._attr_available = True
+        else:
+            self._attr_available = False
+
+        self.async_write_ha_state()

--- a/homeassistant/components/tplink_omada/controller.py
+++ b/homeassistant/components/tplink_omada/controller.py
@@ -1,6 +1,10 @@
 """Controller for sharing Omada API coordinators between platforms."""
 
-from tplink_omada_client.devices import OmadaSwitch, OmadaSwitchPortDetails
+from tplink_omada_client.devices import (
+    OmadaGateway,
+    OmadaSwitch,
+    OmadaSwitchPortDetails,
+)
 from tplink_omada_client.omadasiteclient import OmadaSiteClient
 
 from homeassistant.core import HomeAssistant
@@ -8,6 +12,7 @@ from homeassistant.core import HomeAssistant
 from .coordinator import OmadaCoordinator
 
 POLL_SWITCH_PORT = 300
+POLL_GATEWAY = 300
 
 
 class OmadaSwitchPortCoordinator(OmadaCoordinator[OmadaSwitchPortDetails]):
@@ -31,8 +36,30 @@ class OmadaSwitchPortCoordinator(OmadaCoordinator[OmadaSwitchPortDetails]):
         return {p.port_id: p for p in ports}
 
 
+class OmadaGatewayCoordinator(OmadaCoordinator[OmadaGateway]):
+    """Coordinator for getting details about the site's gateway."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        omada_client: OmadaSiteClient,
+        mac: str,
+    ) -> None:
+        """Initialize my coordinator."""
+        super().__init__(hass, omada_client, "Gateway", POLL_GATEWAY)
+        self.mac = mac
+
+    async def poll_update(self) -> dict[str, OmadaGateway]:
+        """Poll a the gateway's current state."""
+        gateway = await self.omada_client.get_gateway(self.mac)
+        return {self.mac: gateway}
+
+
 class OmadaSiteController:
     """Controller for the Omada SDN site."""
+
+    _gateway_coordinator: OmadaGatewayCoordinator | None = None
+    _initialized_gateway_coordinator = False
 
     def __init__(self, hass: HomeAssistant, omada_client: OmadaSiteClient) -> None:
         """Create the controller."""
@@ -56,3 +83,18 @@ class OmadaSiteController:
             )
 
         return self._switch_port_coordinators[switch.mac]
+
+    async def get_gateway_coordinator(self) -> OmadaGatewayCoordinator | None:
+        """Get coordinator for site's gateway, or None if there is no gateway."""
+        if not self._initialized_gateway_coordinator:
+            self._initialized_gateway_coordinator = True
+            devices = await self._omada_client.get_devices()
+            gateway = next((d for d in devices if d.type == "gateway"), None)
+            if not gateway:
+                return None
+
+            self._gateway_coordinator = OmadaGatewayCoordinator(
+                self._hass, self._omada_client, gateway.mac
+            )
+
+        return self._gateway_coordinator


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds the binary_sensor platform to tplink_omada. Exposing LAN/WAN connectivity status for ports on the gateway for now.

The platform setup code is quite prosaic at the moment. Eventually I will have to refactor to simplify it, following the pattern of the unifi integration. However, there are not yet quite enough similar entities spanning platforms to make this worthwhile.

I also want to confirm whether using multiple coordinators, each polling a different object list from the hub is a reasonable way to continue. In the future, there will be a controller for the list of access points and one for the list of switches.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: [27103](https://github.com/home-assistant/home-assistant.io/pull/27103)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
