### PR TITLE
Turn AVM FRITZ!Box Tools call deflection switches into coordinator entities

### DIFF
--- a/homeassistant/components/fritz/binary_sensor.py
+++ b/homeassistant/components/fritz/binary_sensor.py
@@ -80,7 +80,10 @@ class FritzBoxBinarySensor(FritzBoxBaseCoordinatorEntity, BinarySensorEntity):
     def is_on(self) -> bool | None:
         """Return true if the binary sensor is on."""
         if isinstance(
-            state := self.coordinator.data.get(self.entity_description.key), bool
+            state := self.coordinator.data["entity_states"].get(
+                self.entity_description.key
+            ),
+            bool,
         ):
             return state
         return None

--- a/homeassistant/components/fritz/common.py
+++ b/homeassistant/components/fritz/common.py
@@ -272,7 +272,7 @@ class FritzBoxTools(
 
     async def _async_update_data(self) -> UpdateCoordinatorDataType:
         """Update FritzboxTools data."""
-        enity_data: UpdateCoordinatorDataType = {
+        entity_data: UpdateCoordinatorDataType = {
             "call_deflections": {},
             "entity_states": {},
         }
@@ -280,20 +280,20 @@ class FritzBoxTools(
             await self.async_scan_devices()
             for key, update_fn in self._entity_update_functions.items():
                 _LOGGER.debug("update entity %s", key)
-                enity_data["entity_states"][
+                entity_data["entity_states"][
                     key
                 ] = await self.hass.async_add_executor_job(
                     update_fn, self.fritz_status, self.data.get(key)
                 )
             if self.has_call_deflections:
-                enity_data[
+                entity_data[
                     "call_deflections"
                 ] = await self.async_update_call_deflections()
         except FRITZ_EXCEPTIONS as ex:
             raise update_coordinator.UpdateFailed(ex) from ex
 
-        _LOGGER.debug("enity_data: %s", enity_data)
-        return enity_data
+        _LOGGER.debug("enity_data: %s", entity_data)
+        return entity_data
 
     @property
     def unique_id(self) -> str:

--- a/homeassistant/components/fritz/sensor.py
+++ b/homeassistant/components/fritz/sensor.py
@@ -309,4 +309,4 @@ class FritzBoxSensor(FritzBoxBaseCoordinatorEntity, SensorEntity):
     @property
     def native_value(self) -> StateType:
         """Return the value reported by the sensor."""
-        return self.coordinator.data.get(self.entity_description.key)
+        return self.coordinator.data["entity_states"].get(self.entity_description.key)

--- a/homeassistant/components/fritz/switch.py
+++ b/homeassistant/components/fritz/switch.py
@@ -4,10 +4,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-import xmltodict
-
 from homeassistant.components.network import async_get_source_ip
-from homeassistant.components.switch import SwitchEntity
+from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
@@ -15,6 +13,7 @@ from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import DeviceInfo, Entity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import slugify
 
 from .common import (
@@ -47,31 +46,15 @@ async def _async_deflection_entities_list(
 
     _LOGGER.debug("Setting up %s switches", SWITCH_TYPE_DEFLECTION)
 
-    deflections_response = await avm_wrapper.async_get_ontel_num_deflections()
-    if not deflections_response:
+    if (
+        call_deflections := avm_wrapper.data.get("call_deflections")
+    ) is None or not isinstance(call_deflections, dict):
         _LOGGER.debug("The FRITZ!Box has no %s options", SWITCH_TYPE_DEFLECTION)
         return []
-
-    _LOGGER.debug(
-        "Specific %s response: GetNumberOfDeflections=%s",
-        SWITCH_TYPE_DEFLECTION,
-        deflections_response,
-    )
-
-    if deflections_response["NewNumberOfDeflections"] == 0:
-        _LOGGER.debug("The FRITZ!Box has no %s options", SWITCH_TYPE_DEFLECTION)
-        return []
-
-    if not (deflection_list := await avm_wrapper.async_get_ontel_deflections()):
-        return []
-
-    items = xmltodict.parse(deflection_list["NewDeflectionList"])["List"]["Item"]
-    if not isinstance(items, list):
-        items = [items]
 
     return [
-        FritzBoxDeflectionSwitch(avm_wrapper, device_friendly_name, dict_of_deflection)
-        for dict_of_deflection in items
+        FritzBoxDeflectionSwitch(avm_wrapper, device_friendly_name, cd_id)
+        for cd_id in call_deflections
     ]
 
 
@@ -273,6 +256,61 @@ async def async_setup_entry(
     )
 
 
+class FritzBoxBaseCoordinatorSwitch(CoordinatorEntity, SwitchEntity):
+    """Fritz switch coordinator base class."""
+
+    coordinator: AvmWrapper
+    entity_description: SwitchEntityDescription
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        avm_wrapper: AvmWrapper,
+        device_name: str,
+        description: SwitchEntityDescription,
+    ) -> None:
+        """Init device info class."""
+        super().__init__(avm_wrapper)
+        self.entity_description = description
+        self._device_name = device_name
+        self._attr_unique_id = f"{avm_wrapper.unique_id}-{description.key}"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device information."""
+        return DeviceInfo(
+            configuration_url=f"http://{self.coordinator.host}",
+            connections={(CONNECTION_NETWORK_MAC, self.coordinator.mac)},
+            identifiers={(DOMAIN, self.coordinator.unique_id)},
+            manufacturer="AVM",
+            model=self.coordinator.model,
+            name=self._device_name,
+            sw_version=self.coordinator.current_firmware,
+        )
+
+    @property
+    def data(self) -> dict[str, Any]:
+        """Return entity data from coordinator data."""
+        raise NotImplementedError()
+
+    @property
+    def available(self) -> bool:
+        """Return availability based on data availability."""
+        return bool(self.data)
+
+    async def _async_handle_turn_on_off(self, turn_on: bool) -> None:
+        """Handle switch state change request."""
+        raise NotImplementedError()
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn on switch."""
+        await self._async_handle_turn_on_off(turn_on=True)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off switch."""
+        await self._async_handle_turn_on_off(turn_on=False)
+
+
 class FritzBoxBaseSwitch(FritzBoxBaseEntity):
     """Fritz switch base class."""
 
@@ -417,69 +455,54 @@ class FritzBoxPortSwitch(FritzBoxBaseSwitch, SwitchEntity):
         return bool(resp is not None)
 
 
-class FritzBoxDeflectionSwitch(FritzBoxBaseSwitch, SwitchEntity):
+class FritzBoxDeflectionSwitch(FritzBoxBaseCoordinatorSwitch):
     """Defines a FRITZ!Box Tools PortForward switch."""
+
+    _attr_entity_category = EntityCategory.CONFIG
 
     def __init__(
         self,
         avm_wrapper: AvmWrapper,
         device_friendly_name: str,
-        dict_of_deflection: Any,
+        deflection_id: int,
     ) -> None:
         """Init Fritxbox Deflection class."""
-        self._avm_wrapper = avm_wrapper
-
-        self.dict_of_deflection = dict_of_deflection
-        self._attributes = {}
-        self.id = int(self.dict_of_deflection["DeflectionId"])
-        self._attr_entity_category = EntityCategory.CONFIG
-
-        switch_info = SwitchInfo(
-            description=f"Call deflection {self.id}",
-            friendly_name=device_friendly_name,
+        self.deflection_id = deflection_id
+        description = SwitchEntityDescription(
+            key=f"call_deflection_{self.deflection_id}",
+            name=f"Call deflection {self.deflection_id}",
             icon="mdi:phone-forward",
-            type=SWITCH_TYPE_DEFLECTION,
-            callback_update=self._async_fetch_update,
-            callback_switch=self._async_switch_on_off_executor,
         )
-        super().__init__(self._avm_wrapper, device_friendly_name, switch_info)
+        super().__init__(avm_wrapper, device_friendly_name, description)
 
-    async def _async_fetch_update(self) -> None:
-        """Fetch updates."""
+    @property
+    def data(self) -> dict[str, Any]:
+        """Return call deflection data."""
+        call_deflections = self.coordinator.data.get("call_deflections")
+        if not call_deflections or not isinstance(call_deflections, dict):
+            return {}
+        return call_deflections.get(self.deflection_id, {})
 
-        resp = await self._avm_wrapper.async_get_ontel_deflections()
-        if not resp:
-            self._is_available = False
-            return
+    @property
+    def extra_state_attributes(self) -> dict[str, str]:
+        """Return device attributes."""
+        return {
+            "type": self.data["Type"],
+            "number": self.data["Number"],
+            "deflection_to_number": self.data["DeflectionToNumber"],
+            "mode": self.data["Mode"][1:],
+            "outgoing": self.data["Outgoing"],
+            "phonebook_id": self.data["PhonebookID"],
+        }
 
-        self.dict_of_deflection = xmltodict.parse(resp["NewDeflectionList"])["List"][
-            "Item"
-        ]
-        if isinstance(self.dict_of_deflection, list):
-            self.dict_of_deflection = self.dict_of_deflection[self.id]
+    @property
+    def is_on(self) -> bool | None:
+        """Switch status."""
+        return self.data.get("Enable") == "1"
 
-        _LOGGER.debug(
-            "Specific %s response: NewDeflectionList=%s",
-            SWITCH_TYPE_DEFLECTION,
-            self.dict_of_deflection,
-        )
-
-        self._attr_is_on = self.dict_of_deflection["Enable"] == "1"
-        self._is_available = True
-
-        self._attributes["type"] = self.dict_of_deflection["Type"]
-        self._attributes["number"] = self.dict_of_deflection["Number"]
-        self._attributes["deflection_to_number"] = self.dict_of_deflection[
-            "DeflectionToNumber"
-        ]
-        # Return mode sample: "eImmediately"
-        self._attributes["mode"] = self.dict_of_deflection["Mode"][1:]
-        self._attributes["outgoing"] = self.dict_of_deflection["Outgoing"]
-        self._attributes["phonebook_id"] = self.dict_of_deflection["PhonebookID"]
-
-    async def _async_switch_on_off_executor(self, turn_on: bool) -> None:
+    async def _async_handle_turn_on_off(self, turn_on: bool) -> None:
         """Handle deflection switch."""
-        await self._avm_wrapper.async_set_deflection_enable(self.id, turn_on)
+        await self.coordinator.async_set_deflection_enable(self.deflection_id, turn_on)
 
 
 class FritzBoxProfileSwitch(FritzDeviceBase, SwitchEntity):

--- a/homeassistant/components/fritz/switch.py
+++ b/homeassistant/components/fritz/switch.py
@@ -478,10 +478,7 @@ class FritzBoxDeflectionSwitch(FritzBoxBaseCoordinatorSwitch):
     @property
     def data(self) -> dict[str, Any]:
         """Return call deflection data."""
-        call_deflections = self.coordinator.data.get("call_deflections")
-        if not call_deflections or not isinstance(call_deflections, dict):
-            return {}
-        return call_deflections.get(self.deflection_id, {})
+        return self.coordinator.data["call_deflections"].get(self.deflection_id, {})
 
     @property
     def extra_state_attributes(self) -> dict[str, str]:

--- a/homeassistant/components/fritz/switch.py
+++ b/homeassistant/components/fritz/switch.py
@@ -296,7 +296,7 @@ class FritzBoxBaseCoordinatorSwitch(CoordinatorEntity, SwitchEntity):
     @property
     def available(self) -> bool:
         """Return availability based on data availability."""
-        return super.available and bool(self.data)
+        return super().available and bool(self.data)
 
     async def _async_handle_turn_on_off(self, turn_on: bool) -> None:
         """Handle switch state change request."""

--- a/homeassistant/components/fritz/switch.py
+++ b/homeassistant/components/fritz/switch.py
@@ -296,7 +296,7 @@ class FritzBoxBaseCoordinatorSwitch(CoordinatorEntity, SwitchEntity):
     @property
     def available(self) -> bool:
         """Return availability based on data availability."""
-        return super.available() and bool(self.data)
+        return super.available and bool(self.data)
 
     async def _async_handle_turn_on_off(self, turn_on: bool) -> None:
         """Handle switch state change request."""

--- a/homeassistant/components/fritz/switch.py
+++ b/homeassistant/components/fritz/switch.py
@@ -296,7 +296,7 @@ class FritzBoxBaseCoordinatorSwitch(CoordinatorEntity, SwitchEntity):
     @property
     def available(self) -> bool:
         """Return availability based on data availability."""
-        return bool(self.data)
+        return super.available() and bool(self.data)
 
     async def _async_handle_turn_on_off(self, turn_on: bool) -> None:
         """Handle switch state change request."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This reduces the API calls, prior each existing call deflection caused one API call to fetch all deflections and filter to the current one, now all call deflections are get by the coordinator once and each call deflection entity use the data from coordinator.  If there are about 20 existing call deflections, only 1 call is made as opposed to 20 before.

This is also the pre-work for migrating the other switch (_port forwarding, wifi and profile_) entities.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #91635
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
