### PR TITLE
Allow entity names for STT entities

### DIFF
--- a/homeassistant/components/assist_pipeline/pipeline.py
+++ b/homeassistant/components/assist_pipeline/pipeline.py
@@ -304,7 +304,10 @@ class PipelineRun:
         if self.stt_provider is None:
             raise RuntimeError("Speech to text was not prepared")
 
-        engine = self.stt_provider.name
+        if isinstance(self.stt_provider, stt.Provider):
+            engine = self.stt_provider.name
+        else:
+            engine = self.stt_provider.entity_id
 
         self.process_event(
             PipelineEvent(

--- a/homeassistant/components/demo/stt.py
+++ b/homeassistant/components/demo/stt.py
@@ -44,6 +44,8 @@ async def async_setup_entry(
 class DemoProviderEntity(SpeechToTextEntity):
     """Demo speech API provider entity."""
 
+    _attr_name = "Demo STT"
+
     @property
     def supported_languages(self) -> list[str]:
         """Return a list of supported languages."""

--- a/homeassistant/components/stt/__init__.py
+++ b/homeassistant/components/stt/__init__.py
@@ -278,11 +278,7 @@ class SpeechToTextView(HomeAssistantView):
         """Return provider specific audio information."""
         hass: HomeAssistant = request.app["hass"]
         if (
-            not (
-                provider_entity := async_get_speech_to_text_entity(
-                    hass, f"{DOMAIN}.{provider}"
-                )
-            )
+            not (provider_entity := async_get_speech_to_text_entity(hass, provider))
             and provider not in self.providers
         ):
             raise HTTPNotFound()

--- a/homeassistant/components/stt/__init__.py
+++ b/homeassistant/components/stt/__init__.py
@@ -130,16 +130,6 @@ class SpeechToTextEntity(RestoreEntity):
 
     @property
     @final
-    def name(self) -> str:
-        """Return the name of the provider entity."""
-        # Only one entity is allowed per platform for now.
-        if self.platform is None:
-            raise RuntimeError("Entity is not added to hass yet.")
-
-        return self.platform.platform_name
-
-    @property
-    @final
     def state(self) -> str | None:
         """Return the state of the provider entity."""
         if self.__last_processed is None:
@@ -249,11 +239,7 @@ class SpeechToTextView(HomeAssistantView):
         hass: HomeAssistant = request.app["hass"]
         provider_entity: SpeechToTextEntity | None = None
         if (
-            not (
-                provider_entity := async_get_speech_to_text_entity(
-                    hass, f"{DOMAIN}.{provider}"
-                )
-            )
+            not (provider_entity := async_get_speech_to_text_entity(hass, provider))
             and provider not in self.providers
         ):
             raise HTTPNotFound()

--- a/tests/components/assist_pipeline/conftest.py
+++ b/tests/components/assist_pipeline/conftest.py
@@ -89,6 +89,8 @@ class MockSttProvider(BaseProvider, stt.Provider):
 class MockSttProviderEntity(BaseProvider, stt.SpeechToTextEntity):
     """Mock provider entity."""
 
+    _attr_name = "Mock STT"
+
 
 class MockTTSProvider(tts.Provider):
     """Mock TTS provider."""

--- a/tests/components/assist_pipeline/snapshots/test_init.ambr
+++ b/tests/components/assist_pipeline/snapshots/test_init.ambr
@@ -97,7 +97,7 @@
     }),
     dict({
       'data': dict({
-        'engine': 'test',
+        'engine': 'stt.mock_stt',
         'metadata': dict({
           'bit_rate': <AudioBitRates.BITRATE_16: 16>,
           'channel': <AudioChannels.CHANNEL_MONO: 1>,

--- a/tests/components/demo/test_stt.py
+++ b/tests/components/demo/test_stt.py
@@ -1,10 +1,12 @@
 """The tests for the demo stt component."""
 from http import HTTPStatus
+from unittest.mock import patch
 
 import pytest
 
 from homeassistant.components import stt
 from homeassistant.components.demo import DOMAIN as DEMO_DOMAIN
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -24,7 +26,11 @@ async def setup_config_entry(hass: HomeAssistant) -> None:
     """Set up demo component from config entry."""
     config_entry = MockConfigEntry(domain=DEMO_DOMAIN)
     config_entry.add_to_hass(hass)
-    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    with patch(
+        "homeassistant.components.demo.COMPONENTS_WITH_CONFIG_ENTRY_DEMO_PLATFORM",
+        [Platform.STT],
+    ):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
 
@@ -103,7 +109,7 @@ async def test_config_entry_demo_speech(
     client = await hass_client()
 
     response = await client.post(
-        "/api/stt/demo",
+        "/api/stt/stt.demo_stt",
         headers={
             "X-Speech-Content": (
                 "format=wav; codec=pcm; sample_rate=16000; bit_rate=16; channel=2;"

--- a/tests/components/stt/test_init.py
+++ b/tests/components/stt/test_init.py
@@ -97,6 +97,8 @@ class MockProvider(BaseProvider, Provider):
 class MockProviderEntity(BaseProvider, SpeechToTextEntity):
     """Mock provider entity."""
 
+    _attr_name = "test"
+
 
 @pytest.fixture
 def mock_provider() -> MockProvider:
@@ -260,9 +262,14 @@ async def test_stream_audio(
     """Test streaming audio and getting response."""
     client = await hass_client()
 
+    if setup == "mock_setup":
+        provider = TEST_DOMAIN
+    else:
+        provider = "stt.test"
+
     # Language en is matched with en-US
     response = await client.post(
-        f"/api/stt/{TEST_DOMAIN}",
+        f"/api/stt/{provider}",
         headers={
             "X-Speech-Content": (
                 "format=wav; codec=pcm; sample_rate=16000; bit_rate=16; channel=1;"
@@ -349,16 +356,6 @@ async def test_config_entry_unload(
     assert config_entry.state == ConfigEntryState.LOADED
     await hass.config_entries.async_unload(config_entry.entry_id)
     assert config_entry.state == ConfigEntryState.NOT_LOADED
-
-
-def test_entity_name_raises_before_addition(
-    hass: HomeAssistant,
-    tmp_path: Path,
-    mock_provider_entity: MockProviderEntity,
-) -> None:
-    """Test entity name raises before addition to Home Assistant."""
-    with pytest.raises(RuntimeError):
-        mock_provider_entity.name  # pylint: disable=pointless-statement
 
 
 async def test_restore_state(

--- a/tests/components/wyoming/test_stt.py
+++ b/tests/components/wyoming/test_stt.py
@@ -13,10 +13,10 @@ from . import MockAsyncTcpClient
 
 async def test_support(hass: HomeAssistant, init_wyoming_stt) -> None:
     """Test supported properties."""
-    state = hass.states.get("stt.wyoming")
+    state = hass.states.get("stt.test_asr")
     assert state is not None
 
-    entity = stt.async_get_speech_to_text_entity(hass, "stt.wyoming")
+    entity = stt.async_get_speech_to_text_entity(hass, "stt.test_asr")
     assert entity is not None
 
     assert entity.supported_languages == ["en-US"]
@@ -29,7 +29,7 @@ async def test_support(hass: HomeAssistant, init_wyoming_stt) -> None:
 
 async def test_streaming_audio(hass: HomeAssistant, init_wyoming_stt, snapshot) -> None:
     """Test streaming audio."""
-    entity = stt.async_get_speech_to_text_entity(hass, "stt.wyoming")
+    entity = stt.async_get_speech_to_text_entity(hass, "stt.test_asr")
     assert entity is not None
 
     async def audio_stream():
@@ -51,7 +51,7 @@ async def test_streaming_audio_connection_lost(
     hass: HomeAssistant, init_wyoming_stt
 ) -> None:
     """Test streaming audio and losing connection."""
-    entity = stt.async_get_speech_to_text_entity(hass, "stt.wyoming")
+    entity = stt.async_get_speech_to_text_entity(hass, "stt.test_asr")
     assert entity is not None
 
     async def audio_stream():
@@ -69,7 +69,7 @@ async def test_streaming_audio_connection_lost(
 
 async def test_streaming_audio_oserror(hass: HomeAssistant, init_wyoming_stt) -> None:
     """Test streaming audio and error raising."""
-    entity = stt.async_get_speech_to_text_entity(hass, "stt.wyoming")
+    entity = stt.async_get_speech_to_text_entity(hass, "stt.test_asr")
     assert entity is not None
 
     async def audio_stream():


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Change the way STT entities are referenced in the STT webview such that we can have STT entities have any name.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
