### PR TITLE
Fix broken eufy integration by upgrading lakeside to lakeside2

### DIFF
--- a/homeassistant/components/eufy/__init__.py
+++ b/homeassistant/components/eufy/__init__.py
@@ -1,5 +1,5 @@
 """Support for EufyHome devices."""
-import lakeside
+import lakeside2
 import voluptuous as vol
 
 from homeassistant.const import (
@@ -58,7 +58,7 @@ def setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up EufyHome devices."""
 
     if CONF_USERNAME in config[DOMAIN] and CONF_PASSWORD in config[DOMAIN]:
-        data = lakeside.get_devices(
+        data = lakeside2.get_devices(
             config[DOMAIN][CONF_USERNAME], config[DOMAIN][CONF_PASSWORD]
         )
         for device in data:

--- a/homeassistant/components/eufy/light.py
+++ b/homeassistant/components/eufy/light.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any
 
-import lakeside
+import lakeside2
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
@@ -51,7 +51,7 @@ class EufyHomeLight(LightEntity):
         self._address = device["address"]
         self._code = device["code"]
         self._type = device["type"]
-        self._bulb = lakeside.bulb(self._address, self._code, self._type)
+        self._bulb = lakeside2.bulb(self._address, self._code, self._type)
         self._colormode = False
         if self._type == "T1011":
             self._attr_supported_color_modes = {ColorMode.BRIGHTNESS}

--- a/homeassistant/components/eufy/manifest.json
+++ b/homeassistant/components/eufy/manifest.json
@@ -4,6 +4,6 @@
   "codeowners": [],
   "documentation": "https://www.home-assistant.io/integrations/eufy",
   "iot_class": "local_polling",
-  "loggers": ["lakeside"],
-  "requirements": ["lakeside==0.12"]
+  "loggers": ["lakeside2"],
+  "requirements": ["lakeside2==0.13"]
 }

--- a/homeassistant/components/eufy/switch.py
+++ b/homeassistant/components/eufy/switch.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any
 
-import lakeside
+import lakeside2
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import HomeAssistant
@@ -34,7 +34,7 @@ class EufyHomeSwitch(SwitchEntity):
         self._address = device["address"]
         self._code = device["code"]
         self._type = device["type"]
-        self._switch = lakeside.switch(self._address, self._code, self._type)
+        self._switch = lakeside2.switch(self._address, self._code, self._type)
         self._switch.connect()
 
     def update(self) -> None:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1034,7 +1034,7 @@ krakenex==2.1.0
 lacrosse-view==0.0.9
 
 # homeassistant.components.eufy
-lakeside==0.12
+lakeside2==0.13
 
 # homeassistant.components.laundrify
 laundrify_aio==1.1.2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Upgrade the `lakeside` dependency to `lakeside2`.  `lakeside` is used to communicate with Eufy devices.  It has been archived by its owner, and is no longer working in the latest versions of home assistant.

This PR updates to `lakeside2` which is a new package I published with new protobuf definitions to fix the issue with `lakeside`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #91614 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
