### PR TITLE
Bump ZHA dependencies

### DIFF
--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -24,11 +24,11 @@
     "pyserial==3.5",
     "pyserial-asyncio==0.6",
     "zha-quirks==0.0.97",
-    "zigpy-deconz==0.20.0",
-    "zigpy==0.54.1",
-    "zigpy-xbee==0.17.0",
-    "zigpy-zigate==0.10.3",
-    "zigpy-znp==0.10.0"
+    "zigpy-deconz==0.21.0",
+    "zigpy==0.55.0",
+    "zigpy-xbee==0.18.0",
+    "zigpy-zigate==0.11.0",
+    "zigpy-znp==0.11.1"
   ],
   "usb": [
     {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2727,19 +2727,19 @@ zhong_hong_hvac==1.0.9
 ziggo-mediabox-xl==1.1.0
 
 # homeassistant.components.zha
-zigpy-deconz==0.20.0
+zigpy-deconz==0.21.0
 
 # homeassistant.components.zha
-zigpy-xbee==0.17.0
+zigpy-xbee==0.18.0
 
 # homeassistant.components.zha
-zigpy-zigate==0.10.3
+zigpy-zigate==0.11.0
 
 # homeassistant.components.zha
-zigpy-znp==0.10.0
+zigpy-znp==0.11.1
 
 # homeassistant.components.zha
-zigpy==0.54.1
+zigpy==0.55.0
 
 # homeassistant.components.zoneminder
 zm-py==0.5.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1967,19 +1967,19 @@ zeversolar==0.3.1
 zha-quirks==0.0.97
 
 # homeassistant.components.zha
-zigpy-deconz==0.20.0
+zigpy-deconz==0.21.0
 
 # homeassistant.components.zha
-zigpy-xbee==0.17.0
+zigpy-xbee==0.18.0
 
 # homeassistant.components.zha
-zigpy-zigate==0.10.3
+zigpy-zigate==0.11.0
 
 # homeassistant.components.zha
-zigpy-znp==0.10.0
+zigpy-znp==0.11.1
 
 # homeassistant.components.zha
-zigpy==0.54.1
+zigpy==0.55.0
 
 # homeassistant.components.zwave_js
 zwave-js-server-python==0.47.3


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump ZHA dependencies:

 - zigpy-deconz to [0.21.0](https://github.com/zigpy/zigpy-deconz/releases/tag/0.21.0)
 - zigpy to [0.55.0](https://github.com/zigpy/zigpy/releases/tag/0.55.0)
 - zigpy-xbee to [0.18.0](https://github.com/zigpy/zigpy-xbee/releases/tag/0.18.0)
 - zigpy-zigate to [0.11.0](https://github.com/zigpy/zigpy-zigate/releases/tag/0.11.0)
 - zigpy-znp to [0.11.1](https://github.com/zigpy/zigpy-znp/releases/tag/v0.11.1)

This implements channel migration for all radios and fixes a bug with energy scanning for ZiGate radios. A future PR will add this functionality to ZHA.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #91467, #91014
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
