### PR TITLE
Bump zwave-js-server-python to 0.48.0

### DIFF
--- a/homeassistant/components/zwave_js/manifest.json
+++ b/homeassistant/components/zwave_js/manifest.json
@@ -8,7 +8,7 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "loggers": ["zwave_js_server"],
-  "requirements": ["pyserial==3.5", "zwave-js-server-python==0.47.3"],
+  "requirements": ["pyserial==3.5", "zwave-js-server-python==0.38.0"],
   "usb": [
     {
       "vid": "0658",

--- a/homeassistant/components/zwave_js/manifest.json
+++ b/homeassistant/components/zwave_js/manifest.json
@@ -8,7 +8,7 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "loggers": ["zwave_js_server"],
-  "requirements": ["pyserial==3.5", "zwave-js-server-python==0.38.0"],
+  "requirements": ["pyserial==3.5", "zwave-js-server-python==0.48.0"],
   "usb": [
     {
       "vid": "0658",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2745,7 +2745,7 @@ zigpy==0.54.1
 zm-py==0.5.2
 
 # homeassistant.components.zwave_js
-zwave-js-server-python==0.47.3
+zwave-js-server-python==0.38.0
 
 # homeassistant.components.zwave_me
 zwave_me_ws==0.4.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2745,7 +2745,7 @@ zigpy==0.54.1
 zm-py==0.5.2
 
 # homeassistant.components.zwave_js
-zwave-js-server-python==0.38.0
+zwave-js-server-python==0.48.0
 
 # homeassistant.components.zwave_me
 zwave_me_ws==0.4.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1982,7 +1982,7 @@ zigpy-znp==0.10.0
 zigpy==0.54.1
 
 # homeassistant.components.zwave_js
-zwave-js-server-python==0.38.0
+zwave-js-server-python==0.48.0
 
 # homeassistant.components.zwave_me
 zwave_me_ws==0.4.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1982,7 +1982,7 @@ zigpy-znp==0.10.0
 zigpy==0.54.1
 
 # homeassistant.components.zwave_js
-zwave-js-server-python==0.47.3
+zwave-js-server-python==0.38.0
 
 # homeassistant.components.zwave_me
 zwave_me_ws==0.4.2

--- a/tests/components/zwave_js/test_services.py
+++ b/tests/components/zwave_js/test_services.py
@@ -1245,8 +1245,9 @@ async def test_multicast_set_value(
             blocking=True,
         )
 
-    # Test that when we get an exception from the library we raise an exception
     client.async_send_command.reset_mock()
+
+    # Test that when we get an exception from the library we raise an exception
     client.async_send_command.side_effect = FailedZWaveCommand("test", 12, "test")
     with pytest.raises(HomeAssistantError):
         await hass.services.async_call(
@@ -1264,6 +1265,8 @@ async def test_multicast_set_value(
             },
             blocking=True,
         )
+
+    client.async_send_command.reset_mock()
 
     # Create a fake node with a different home ID from a real node and patch it into
     # return of helper function to check the validation for two nodes having different

--- a/tests/components/zwave_js/test_services.py
+++ b/tests/components/zwave_js/test_services.py
@@ -1225,9 +1225,29 @@ async def test_multicast_set_value(
             blocking=True,
         )
 
-    # Test that when a command fails we raise an exception
+    # Test that when a command is unsuccessful we raise an exception
     client.async_send_command.return_value = {"success": False}
 
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_MULTICAST_SET_VALUE,
+            {
+                ATTR_ENTITY_ID: [
+                    CLIMATE_DANFOSS_LC13_ENTITY,
+                    CLIMATE_EUROTRONICS_SPIRIT_Z_ENTITY,
+                ],
+                ATTR_COMMAND_CLASS: 67,
+                ATTR_PROPERTY: "setpoint",
+                ATTR_PROPERTY_KEY: 1,
+                ATTR_VALUE: 2,
+            },
+            blocking=True,
+        )
+
+    # Test that when we get an exception from the library we raise an exception
+    client.async_send_command.reset_mock()
+    client.async_send_command.side_effect = FailedZWaveCommand("test", 12, "test")
     with pytest.raises(HomeAssistantError):
         await hass.services.async_call(
             DOMAIN,


### PR DESCRIPTION
## Breaking change
With this release, you will need to update your `zwave-js-server` instance. You must use `zwave-js-server` 1.28.0 or greater (schema 28).

- If you use the `Z-Wave JS` add-on, you need at least version `0.1.79`.
- If you use the `Z-Wave JS UI` add-on, you need at least version `1.11.2`.
- If you use the `Z-Wave JS UI` Docker container, you need at least version `8.14.2`.
- If you run your own Docker container or some other installation method, you will need to update your `zwave-js-server` instance to at least `1.28.0`.

## Proposed change
Adds some additional zwave commands - https://github.com/home-assistant-libs/zwave-js-server-python/pull/639
Removes validation on multicast set value commands - https://github.com/home-assistant-libs/zwave-js-server-python/pull/643


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
