### PR TITLE
Enable open,close,stop device actions for all covers

### DIFF
--- a/homeassistant/components/cover/device_action.py
+++ b/homeassistant/components/cover/device_action.py
@@ -82,21 +82,19 @@ async def async_get_actions(
 
         if supported_features & SUPPORT_SET_POSITION:
             actions.append({**base_action, CONF_TYPE: "set_position"})
-        else:
-            if supported_features & SUPPORT_OPEN:
-                actions.append({**base_action, CONF_TYPE: "open"})
-            if supported_features & SUPPORT_CLOSE:
-                actions.append({**base_action, CONF_TYPE: "close"})
-            if supported_features & SUPPORT_STOP:
-                actions.append({**base_action, CONF_TYPE: "stop"})
+        if supported_features & SUPPORT_OPEN:
+            actions.append({**base_action, CONF_TYPE: "open"})
+        if supported_features & SUPPORT_CLOSE:
+            actions.append({**base_action, CONF_TYPE: "close"})
+        if supported_features & SUPPORT_STOP:
+            actions.append({**base_action, CONF_TYPE: "stop"})
 
         if supported_features & SUPPORT_SET_TILT_POSITION:
             actions.append({**base_action, CONF_TYPE: "set_tilt_position"})
-        else:
-            if supported_features & SUPPORT_OPEN_TILT:
-                actions.append({**base_action, CONF_TYPE: "open_tilt"})
-            if supported_features & SUPPORT_CLOSE_TILT:
-                actions.append({**base_action, CONF_TYPE: "close_tilt"})
+        if supported_features & SUPPORT_OPEN_TILT:
+            actions.append({**base_action, CONF_TYPE: "open_tilt"})
+        if supported_features & SUPPORT_CLOSE_TILT:
+            actions.append({**base_action, CONF_TYPE: "close_tilt"})
 
     return actions
 

--- a/tests/components/cover/test_device_action.py
+++ b/tests/components/cover/test_device_action.py
@@ -224,9 +224,9 @@ async def test_get_action_capabilities_set_pos(
     actions = await async_get_device_automations(
         hass, DeviceAutomationType.ACTION, device_entry.id
     )
-    assert len(actions) == 1  # set_position
+    assert len(actions) == 4  # set_position, open, close, stop
     action_types = {action["type"] for action in actions}
-    assert action_types == {"set_position"}
+    assert action_types == {"set_position", "open", "close", "stop"}
     for action in actions:
         capabilities = await async_get_device_automation_capabilities(
             hass, DeviceAutomationType.ACTION, action
@@ -275,9 +275,15 @@ async def test_get_action_capabilities_set_tilt_pos(
     actions = await async_get_device_automations(
         hass, DeviceAutomationType.ACTION, device_entry.id
     )
-    assert len(actions) == 3
+    assert len(actions) == 5
     action_types = {action["type"] for action in actions}
-    assert action_types == {"open", "close", "set_tilt_position"}
+    assert action_types == {
+        "open",
+        "close",
+        "set_tilt_position",
+        "open_tilt",
+        "close_tilt",
+    }
     for action in actions:
         capabilities = await async_get_device_automation_capabilities(
             hass, DeviceAutomationType.ACTION, action


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->n.a.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When creating automations for covers I typically want to open or close the covers (not set a specific position). However Home Assistant only offers the open/close device actions for some of the covers (the ones _not_ supporting position). For the covers that support position HA only offeres the Set Position device action. 

While position _can_ be used to get the same result it is confusing to me that not all covers offer the same open/close actions. Not sure if it makes sense, but mentally I am thinking about opening/closing a cover, it took me a while to realize I could ruse Set Position to get the same result, but it required a mental "shift". Next to that I always need to lookup is 0% position is open or closed. For me HA and the manufacturer app have the definitions swapped and I always get lost. From some of the threads on the forums there seems to be more opinions/confusion on what 0/100% should be. Offering open, close avoids that confusion.

Judging from the code it was an explicit decision to exclude the open, close, stop actions for devices that support setting position, but I could not find the reasoning behind it. Maybe to keep the list of device actions small?

(while I don't own any tilt capable covers the open, close reasoning probably applies for those to so I included that also)

Screenshot of how it looks after the change with a cover from the demo integration
![image](https://user-images.githubusercontent.com/732514/234288236-ce7b8898-15d7-42ba-bb1e-fa1bf578ab1f.png)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

Feels a bit small, but I guess it is a new feature,

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

Not yet, will try to find a few.

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
