### PR TITLE
Bump hass-nabucasa from 0.65.0 to 0.66.1

### DIFF
--- a/homeassistant/components/cloud/__init__.py
+++ b/homeassistant/components/cloud/__init__.py
@@ -50,9 +50,9 @@ from .const import (
     CONF_RELAYER_SERVER,
     CONF_REMOTE_SNI_SERVER,
     CONF_REMOTESTATE_SERVER,
+    CONF_SERVICEHANDLERS_SERVER,
     CONF_THINGTALK_SERVER,
     CONF_USER_POOL_ID,
-    CONF_VOICE_SERVER,
     DOMAIN,
     MODE_DEV,
     MODE_PROD,
@@ -119,7 +119,7 @@ CONFIG_SCHEMA = vol.Schema(
                 vol.Optional(CONF_REMOTE_SNI_SERVER): str,
                 vol.Optional(CONF_REMOTESTATE_SERVER): str,
                 vol.Optional(CONF_THINGTALK_SERVER): str,
-                vol.Optional(CONF_VOICE_SERVER): str,
+                vol.Optional(CONF_SERVICEHANDLERS_SERVER): str,
             }
         )
     },

--- a/homeassistant/components/cloud/const.py
+++ b/homeassistant/components/cloud/const.py
@@ -58,7 +58,7 @@ CONF_RELAYER_SERVER = "relayer_server"
 CONF_REMOTE_SNI_SERVER = "remote_sni_server"
 CONF_REMOTESTATE_SERVER = "remotestate_server"
 CONF_THINGTALK_SERVER = "thingtalk_server"
-CONF_VOICE_SERVER = "voice_server"
+CONF_SERVICEHANDLERS_SERVER = "servicehandlers_server"
 
 MODE_DEV = "development"
 MODE_PROD = "production"

--- a/homeassistant/components/cloud/manifest.json
+++ b/homeassistant/components/cloud/manifest.json
@@ -8,5 +8,5 @@
   "integration_type": "system",
   "iot_class": "cloud_push",
   "loggers": ["hass_nabucasa"],
-  "requirements": ["hass-nabucasa==0.65.0"]
+  "requirements": ["hass-nabucasa==0.66.1"]
 }

--- a/homeassistant/components/cloud/stt.py
+++ b/homeassistant/components/cloud/stt.py
@@ -85,7 +85,7 @@ class CloudProvider(Provider):
                 language=metadata.language,
             )
         except VoiceError as err:
-            _LOGGER.debug("Voice error: %s", err)
+            _LOGGER.error("Voice error: %s", err)
             return SpeechResult(None, SpeechResultState.ERROR)
 
         # Return Speech as Text

--- a/homeassistant/components/cloud/tts.py
+++ b/homeassistant/components/cloud/tts.py
@@ -1,5 +1,7 @@
 """Support for the cloud for text to speech service."""
 
+import logging
+
 from hass_nabucasa import Cloud
 from hass_nabucasa.voice import MAP_VOICE, TTS_VOICES, AudioOutput, VoiceError
 import voluptuous as vol
@@ -19,6 +21,8 @@ from .const import DOMAIN
 ATTR_GENDER = "gender"
 
 SUPPORT_LANGUAGES = list(TTS_VOICES)
+
+_LOGGER = logging.getLogger(__name__)
 
 
 def validate_lang(value):
@@ -123,7 +127,8 @@ class CloudProvider(Provider):
                 voice=options.get(ATTR_VOICE),
                 output=options[ATTR_AUDIO_OUTPUT],
             )
-        except VoiceError:
+        except VoiceError as err:
+            _LOGGER.error("Voice error: %s", err)
             return (None, None)
 
         return (str(options[ATTR_AUDIO_OUTPUT]), data)

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -22,7 +22,7 @@ cryptography==40.0.2
 dbus-fast==1.85.0
 fnv-hash-fast==0.3.1
 ha-av==10.0.0
-hass-nabucasa==0.65.0
+hass-nabucasa==0.66.1
 hassil==1.0.6
 home-assistant-bluetooth==1.10.0
 home-assistant-frontend==20230411.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -872,7 +872,7 @@ ha-philipsjs==3.0.0
 habitipy==0.2.0
 
 # homeassistant.components.cloud
-hass-nabucasa==0.65.0
+hass-nabucasa==0.66.1
 
 # homeassistant.components.splunk
 hass_splunk==0.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -673,7 +673,7 @@ ha-philipsjs==3.0.0
 habitipy==0.2.0
 
 # homeassistant.components.cloud
-hass-nabucasa==0.65.0
+hass-nabucasa==0.66.1
 
 # homeassistant.components.conversation
 hassil==1.0.6


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

Only for development, the `voice_server` configuration option has been replaced with `servicehandlers_server`.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


Bumps the `hass-nabucasa` package from 0.65.0 to 0.66.1.
https://github.com/NabuCasa/hass-nabucasa/compare/0.65.0...0.66.1

Other than bumping the package, 2 changed are done because of the bump:
- For TTS and STT we now log error on `VoiceError` exception.
-  the `voice_server` configuration option has been replaced with `servicehandlers_server`.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
