### PR TITLE
Small cleanups to bluetooth internals

### DIFF
--- a/homeassistant/components/bluetooth/base_scanner.py
+++ b/homeassistant/components/bluetooth/base_scanner.py
@@ -346,20 +346,20 @@ class BaseHaRemoteScanner(BaseHaScanner):
             device._rssi = rssi  # deprecated, will be removed in newer bleak
         else:
             device = BLEDevice(
-                address,
-                local_name,
-                self._details | details,
-                rssi,  # deprecated, will be removed in newer bleak
+                address=address,
+                name=local_name,
+                details=self._details | details,
+                rssi=rssi,  # deprecated, will be removed in newer bleak
             )
 
         advertisement_data = AdvertisementData(
-            None if local_name == "" else local_name,
-            manufacturer_data,
-            service_data,
-            service_uuids,
-            NO_RSSI_VALUE if tx_power is None else tx_power,
-            rssi,
-            (),
+            local_name=None if local_name == "" else local_name,
+            manufacturer_data=manufacturer_data,
+            service_data=service_data,
+            service_uuids=service_uuids,
+            tx_power=NO_RSSI_VALUE if tx_power is None else tx_power,
+            rssi=rssi,
+            platform_data=(),
         )
         self._discovered_device_advertisement_datas[address] = (
             device,
@@ -368,17 +368,17 @@ class BaseHaRemoteScanner(BaseHaScanner):
         self._discovered_device_timestamps[address] = now
         self._new_info_callback(
             BluetoothServiceInfoBleak(
-                local_name or address,
-                address,
-                rssi,
-                manufacturer_data,
-                service_data,
-                service_uuids,
-                self.source,
-                device,
-                advertisement_data,
-                self.connectable,
-                now,
+                name=local_name or address,
+                address=address,
+                rssi=rssi,
+                manufacturer_data=manufacturer_data,
+                service_data=service_data,
+                service_uuids=service_uuids,
+                source=self.source,
+                device=device,
+                advertisement=advertisement_data,
+                connectable=self.connectable,
+                time=now,
             )
         )
 

--- a/homeassistant/components/bluetooth/base_scanner.py
+++ b/homeassistant/components/bluetooth/base_scanner.py
@@ -309,43 +309,28 @@ class BaseHaRemoteScanner(BaseHaScanner):
             # merges the dicts on PropertiesChanged
             prev_device = prev_discovery[0]
             prev_advertisement = prev_discovery[1]
-            if (
-                local_name
-                and prev_device.name
-                and len(prev_device.name) > len(local_name)
-            ):
-                local_name = prev_device.name
-            if service_uuids and service_uuids != prev_advertisement.service_uuids:
-                service_uuids = list(
-                    set(service_uuids + prev_advertisement.service_uuids)
-                )
-            elif not service_uuids:
-                service_uuids = prev_advertisement.service_uuids
-            if service_data and service_data != prev_advertisement.service_data:
-                service_data = {**prev_advertisement.service_data, **service_data}
-            elif not service_data:
-                service_data = prev_advertisement.service_data
-            if (
-                manufacturer_data
-                and manufacturer_data != prev_advertisement.manufacturer_data
-            ):
-                manufacturer_data = {
-                    **prev_advertisement.manufacturer_data,
-                    **manufacturer_data,
-                }
-            elif not manufacturer_data:
-                manufacturer_data = prev_advertisement.manufacturer_data
+            prev_service_uuids = prev_advertisement.service_uuids
+            prev_service_data = prev_advertisement.service_data
+            prev_manufacturer_data = prev_advertisement.manufacturer_data
+            prev_name = prev_device.name
 
-        advertisement_data = AdvertisementData(
-            local_name=None if local_name == "" else local_name,
-            manufacturer_data=manufacturer_data,
-            service_data=service_data,
-            service_uuids=service_uuids,
-            rssi=rssi,
-            tx_power=NO_RSSI_VALUE if tx_power is None else tx_power,
-            platform_data=(),
-        )
-        if prev_discovery:
+            if local_name and prev_name and len(prev_name) > len(local_name):
+                local_name = prev_name
+
+            if service_uuids and service_uuids != prev_service_uuids:
+                service_uuids = list(set(service_uuids + prev_service_uuids))
+            elif not service_uuids:
+                service_uuids = prev_service_uuids
+
+            if service_data and service_data != prev_service_data:
+                service_data = prev_service_data | service_data
+            elif not service_data:
+                service_data = prev_service_data
+
+            if manufacturer_data and manufacturer_data != prev_manufacturer_data:
+                manufacturer_data = prev_manufacturer_data | manufacturer_data
+            elif not manufacturer_data:
+                manufacturer_data = prev_manufacturer_data
             #
             # Bleak updates the BLEDevice via create_or_update_device.
             # We need to do the same to ensure integrations that already
@@ -361,11 +346,21 @@ class BaseHaRemoteScanner(BaseHaScanner):
             device._rssi = rssi  # deprecated, will be removed in newer bleak
         else:
             device = BLEDevice(
-                address=address,
-                name=local_name,
-                details=self._details | details,
-                rssi=rssi,  # deprecated, will be removed in newer bleak
+                address,
+                local_name,
+                self._details | details,
+                rssi,  # deprecated, will be removed in newer bleak
             )
+
+        advertisement_data = AdvertisementData(
+            None if local_name == "" else local_name,
+            manufacturer_data,
+            service_data,
+            service_uuids,
+            NO_RSSI_VALUE if tx_power is None else tx_power,
+            rssi,
+            (),
+        )
         self._discovered_device_advertisement_datas[address] = (
             device,
             advertisement_data,
@@ -373,17 +368,17 @@ class BaseHaRemoteScanner(BaseHaScanner):
         self._discovered_device_timestamps[address] = now
         self._new_info_callback(
             BluetoothServiceInfoBleak(
-                name=advertisement_data.local_name or device.name or device.address,
-                address=device.address,
-                rssi=rssi,
-                manufacturer_data=advertisement_data.manufacturer_data,
-                service_data=advertisement_data.service_data,
-                service_uuids=advertisement_data.service_uuids,
-                source=self.source,
-                device=device,
-                advertisement=advertisement_data,
-                connectable=self.connectable,
-                time=now,
+                local_name or address,
+                address,
+                rssi,
+                manufacturer_data,
+                service_data,
+                service_uuids,
+                self.source,
+                device,
+                advertisement_data,
+                self.connectable,
+                now,
             )
         )
 

--- a/tests/components/bluetooth/test_models.py
+++ b/tests/components/bluetooth/test_models.py
@@ -503,7 +503,6 @@ async def test_ble_device_with_proxy_client_out_of_connections_uses_best_availab
         },
         rssi=-30,
     )
-    switchbot_proxy_device_no_connection_slot.metadata["delegate"] = 0
     switchbot_proxy_device_no_connection_slot_adv = generate_advertisement_data(
         local_name="wohand",
         service_uuids=[],
@@ -518,7 +517,6 @@ async def test_ble_device_with_proxy_client_out_of_connections_uses_best_availab
             "path": "/org/bluez/hci0/dev_44_44_33_11_23_45",
         },
     )
-    switchbot_proxy_device_has_connection_slot.metadata["delegate"] = 0
     switchbot_proxy_device_has_connection_slot_adv = generate_advertisement_data(
         local_name="wohand",
         service_uuids=[],
@@ -532,7 +530,6 @@ async def test_ble_device_with_proxy_client_out_of_connections_uses_best_availab
         {},
         rssi=-100,
     )
-    switchbot_device.metadata["delegate"] = 0
     switchbot_device_adv = generate_advertisement_data(
         local_name="wohand",
         service_uuids=[],


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve the performance of _async_on_advertisement

Fixes

```
tests/components/bluetooth/test_models.py::test_ble_device_with_proxy_client_out_of_connections_uses_best_available
tests/components/bluetooth/test_models.py::test_ble_device_with_proxy_client_out_of_connections_uses_best_available_macos
/Users/bdraco/home-assistant/homeassistant/components/bluetooth/wrappers.py:226: FutureWarning: This method will be removed future version, pass the callback to the BleakClient constructor instead.
  self._backend.set_disconnected_callback(

tests/components/bluetooth/test_models.py::test_ble_device_with_proxy_client_out_of_connections_uses_best_available_macos
/Users/bdraco/home-assistant/tests/components/bluetooth/test_models.py:506: FutureWarning: BLEDevice.metadata is deprecated and will be removed in a future version of Bleak, use AdvertisementData instead
  switchbot_proxy_device_no_connection_slot.metadata["delegate"] = 0

tests/components/bluetooth/test_models.py::test_ble_device_with_proxy_client_out_of_connections_uses_best_available_macos
/Users/bdraco/home-assistant/tests/components/bluetooth/test_models.py:521: FutureWarning: BLEDevice.metadata is deprecated and will be removed in a future version of Bleak, use AdvertisementData instead
  switchbot_proxy_device_has_connection_slot.metadata["delegate"] = 0

tests/components/bluetooth/test_models.py::test_ble_device_with_proxy_client_out_of_connections_uses_best_available_macos
/Users/bdraco/home-assistant/tests/components/bluetooth/test_models.py:535: FutureWarning: BLEDevice.metadata is deprecated and will be removed in a future version of Bleak, use AdvertisementData instead
  switchbot_device.metadata["delegate"] = 0

```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
