### PR TITLE
Date Time Improvements

### DIFF
--- a/homeassistant/components/homeassistant/triggers/time.py
+++ b/homeassistant/components/homeassistant/triggers/time.py
@@ -25,9 +25,10 @@ import homeassistant.util.dt as dt_util
 
 _TIME_TRIGGER_SCHEMA = vol.Any(
     cv.time,
+    cv.datetime,
     vol.All(str, cv.entity_domain(["input_datetime", "sensor"])),
     msg=(
-        "Expected HH:MM, HH:MM:SS or Entity ID with domain 'input_datetime' or 'sensor'"
+        "Expected HH:MM, HH:MM:SS, YYYY-MM-DD, YYYY-MM-DD HH:MM:SS or Entity ID with domain 'input_datetime' or 'sensor'"
     ),
 )
 

--- a/homeassistant/components/homeassistant/triggers/time.py
+++ b/homeassistant/components/homeassistant/triggers/time.py
@@ -163,6 +163,17 @@ async def async_attach_trigger(
             # entity
             to_track.append(at_time)
             update_entity_trigger(at_time, new_state=hass.states.get(at_time))
+        elif isinstance(at_time, datetime):
+            # datetime.datetime
+            localdt = dt_util.as_local(at_time)
+            if localdt >= dt_util.now():
+                removes.append(
+                    async_track_point_in_time(
+                        hass,
+                        partial(time_automation_listener, "datetime"),
+                        localdt,
+                    )
+                )
         else:
             # datetime.time
             removes.append(

--- a/homeassistant/components/trafikverket_ferry/config_flow.py
+++ b/homeassistant/components/trafikverket_ferry/config_flow.py
@@ -24,7 +24,9 @@ DATA_SCHEMA = vol.Schema(
         ),
         vol.Required(CONF_FROM): selector.TextSelector(selector.TextSelectorConfig()),
         vol.Optional(CONF_TO): selector.TextSelector(selector.TextSelectorConfig()),
-        vol.Optional(CONF_TIME): selector.TimeSelector(selector.TimeSelectorConfig()),
+        vol.Optional(CONF_TIME): selector.TimeSelector(
+            selector.TimeSelectorConfig(multiple=False)
+        ),
         vol.Required(CONF_WEEKDAY, default=WEEKDAYS): selector.SelectSelector(
             selector.SelectSelectorConfig(
                 options=WEEKDAYS,

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -483,6 +483,8 @@ class ConstantSelector(Selector[ConstantSelectorConfig]):
 class DateSelectorConfig(TypedDict):
     """Class to represent a date selector config."""
 
+    multiple: bool
+
 
 @SELECTORS.register("date")
 class DateSelector(Selector[DateSelectorConfig]):
@@ -490,7 +492,11 @@ class DateSelector(Selector[DateSelectorConfig]):
 
     selector_type = "date"
 
-    CONFIG_SCHEMA = vol.Schema({})
+    CONFIG_SCHEMA = vol.Schema(
+        {
+            vol.Optional("multiple", default=False): cv.boolean,
+        }
+    )
 
     def __init__(self, config: DateSelectorConfig | None = None) -> None:
         """Instantiate a selector."""
@@ -498,12 +504,18 @@ class DateSelector(Selector[DateSelectorConfig]):
 
     def __call__(self, data: Any) -> Any:
         """Validate the passed selection."""
-        cv.date(data)
-        return data
+        if not self.config["multiple"]:
+            cv.date(data)
+            return data
+        if not isinstance(data, list):
+            raise vol.Invalid("Value should be a list")
+        return [vol.Schema(str)(val) for val in data]
 
 
 class DateTimeSelectorConfig(TypedDict):
     """Class to represent a date time selector config."""
+
+    multiple: bool
 
 
 @SELECTORS.register("datetime")
@@ -512,7 +524,11 @@ class DateTimeSelector(Selector[DateTimeSelectorConfig]):
 
     selector_type = "datetime"
 
-    CONFIG_SCHEMA = vol.Schema({})
+    CONFIG_SCHEMA = vol.Schema(
+        {
+            vol.Optional("multiple", default=False): cv.boolean,
+        }
+    )
 
     def __init__(self, config: DateTimeSelectorConfig | None = None) -> None:
         """Instantiate a selector."""
@@ -520,8 +536,12 @@ class DateTimeSelector(Selector[DateTimeSelectorConfig]):
 
     def __call__(self, data: Any) -> Any:
         """Validate the passed selection."""
-        cv.datetime(data)
-        return data
+        if not self.config["multiple"]:
+            cv.datetime(data)
+            return data
+        if not isinstance(data, list):
+            raise vol.Invalid("Value should be a list")
+        return [vol.Schema(str)(val) for val in data]
 
 
 class DeviceSelectorConfig(TypedDict, total=False):
@@ -1133,6 +1153,8 @@ class ThemeSelector(Selector[ThemeSelectorConfig]):
 class TimeSelectorConfig(TypedDict):
     """Class to represent a time selector config."""
 
+    multiple: bool
+
 
 @SELECTORS.register("time")
 class TimeSelector(Selector[TimeSelectorConfig]):
@@ -1140,16 +1162,24 @@ class TimeSelector(Selector[TimeSelectorConfig]):
 
     selector_type = "time"
 
-    CONFIG_SCHEMA = vol.Schema({})
+    CONFIG_SCHEMA = vol.Schema(
+        {
+            vol.Optional("multiple", default=False): cv.boolean,
+        }
+    )
 
     def __init__(self, config: TimeSelectorConfig | None = None) -> None:
         """Instantiate a selector."""
         super().__init__(config)
 
-    def __call__(self, data: Any) -> str:
+    def __call__(self, data: Any) -> Any:
         """Validate the passed selection."""
-        cv.time(data)
-        return cast(str, data)
+        if not self.config["multiple"]:
+            cv.time(data)
+            return cast(str, data)
+        if not isinstance(data, list):
+            raise vol.Invalid("Value should be a list")
+        return [vol.Schema(str)(val) for val in data]
 
 
 class FileSelectorConfig(TypedDict):

--- a/tests/components/homeassistant/triggers/test_time.py
+++ b/tests/components/homeassistant/triggers/test_time.py
@@ -543,10 +543,12 @@ def test_schema_invalid(conf) -> None:
 async def test_date_and_datetime(hass: HomeAssistant, calls, val) -> None:
     """Make sure we handle date or datetime string."""
     when = cv.datetime(val)
+    yr_before = when - timedelta(days=365)
     before = when - timedelta(minutes=1)
+    after = when + timedelta(seconds=1)
     with patch(
         "homeassistant.util.dt.utcnow",
-        return_value=dt_util.as_utc(before),
+        return_value=dt_util.as_utc(yr_before),
     ):
         assert await async_setup_component(
             hass,
@@ -565,7 +567,9 @@ async def test_date_and_datetime(hass: HomeAssistant, calls, val) -> None:
         )
         await hass.async_block_till_done()
     assert len(calls) == 0
-    after = when + timedelta(seconds=1)
+    async_fire_time_changed(hass, before)
+    await hass.async_block_till_done()
+    assert len(calls) == 0
     async_fire_time_changed(hass, after)
     await hass.async_block_till_done()
     assert len(calls) == 1

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -454,7 +454,18 @@ def test_config_entry_selector_schema(
 
 @pytest.mark.parametrize(
     ("schema", "valid_selections", "invalid_selections"),
-    (({}, ("00:00:00",), ("blah", None)),),
+    (
+        (
+            {},
+            ("00:00:00",),
+            ("blah", None, ["00:00:00"]),
+        ),
+        (
+            {"multiple": True},
+            (["00:00:00", "12:34:56"],),
+            (None, "00:00:00", ["00:00:00", None]),
+        ),
+    ),
 )
 def test_time_selector_schema(schema, valid_selections, invalid_selections) -> None:
     """Test time selector."""
@@ -865,7 +876,12 @@ def test_color_tempselector_schema(
         (
             {},
             ("2022-03-24",),
-            (None, "abc", "00:00", "2022-03-24 00:00", "2022-03-32"),
+            (None, "abc", "00:00", "2022-03-24 00:00", "2022-03-32", ["2022-03-24"]),
+        ),
+        (
+            {"multiple": True},
+            (["2022-03-24", "2023-04-08"],),
+            (None, "2022-03-24", ["2022-03-24", None]),
         ),
     ),
 )
@@ -881,7 +897,12 @@ def test_date_selector_schema(schema, valid_selections, invalid_selections) -> N
         (
             {},
             ("2022-03-24 00:00", "2022-03-24"),
-            (None, "abc", "00:00", "2022-03-24 24:01"),
+            (None, "abc", "00:00", "2022-03-24 24:01", ["2022-03-24 00:00"]),
+        ),
+        (
+            {"multiple": True},
+            (["2022-03-24 00:00", "2022-03-24"],),
+            (None, "2022-03-24 00:00", ["2022-03-24 00:00", None]),
         ),
     ),
 )


### PR DESCRIPTION
## Proposed change
Allow the Date, DateTime, and Time selectors to optionally support multiple selections.
Update the Time platform trigger to accept a Date and DateTime string as well as the current Time string.
The semantics are the same as the input_datetime with date, time, or date and time options.
This allows blueprints to setup inputs for multiple date, time or datetime, triggers.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- Link to documentation pull request:  https://github.com/home-assistant/home-assistant.io/pull/27143
- Link to frontent pull request: https://github.com/home-assistant/frontend/pull/16312

## Checklist

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
