### PR TITLE
ESPHome voice assistant: Version 2 - Stream raw tts audio back to device for playback

### DIFF
--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -288,39 +288,47 @@ async def async_setup_entry(  # noqa: C901
 
     voice_assistant_udp_server: VoiceAssistantUDPServer | None = None
 
-    def handle_pipeline_event(
+    def _handle_pipeline_event(
         event_type: VoiceAssistantEventType, data: dict[str, str] | None
     ) -> None:
-        """Handle a voice assistant pipeline event."""
         cli.send_voice_assistant_event(event_type, data)
 
-    async def handle_pipeline_start() -> int | None:
+    def _handle_pipeline_finished() -> None:
+        nonlocal voice_assistant_udp_server
+
+        entry_data.async_set_assist_pipeline_state(False)
+
+        if voice_assistant_udp_server is not None:
+            voice_assistant_udp_server.close()
+            voice_assistant_udp_server = None
+
+    async def _handle_pipeline_start() -> int | None:
         """Start a voice assistant pipeline."""
         nonlocal voice_assistant_udp_server
 
         if voice_assistant_udp_server is not None:
             return None
 
-        voice_assistant_udp_server = VoiceAssistantUDPServer(hass, entry_data)
+        voice_assistant_udp_server = VoiceAssistantUDPServer(
+            hass, entry_data, _handle_pipeline_event, _handle_pipeline_finished
+        )
         port = await voice_assistant_udp_server.start_server()
 
         hass.async_create_background_task(
-            voice_assistant_udp_server.run_pipeline(handle_pipeline_event),
+            voice_assistant_udp_server.run_pipeline(),
             "esphome.voice_assistant_udp_server.run_pipeline",
         )
         entry_data.async_set_assist_pipeline_state(True)
 
         return port
 
-    async def handle_pipeline_stop() -> None:
+    async def _handle_pipeline_stop() -> None:
         """Stop a voice assistant pipeline."""
         nonlocal voice_assistant_udp_server
 
-        entry_data.async_set_assist_pipeline_state(False)
-
         if voice_assistant_udp_server is not None:
             voice_assistant_udp_server.stop()
-            voice_assistant_udp_server = None
+            # voice_assistant_udp_server = None
 
     async def on_connect() -> None:
         """Subscribe to states and list entities on successful API login."""
@@ -369,8 +377,8 @@ async def async_setup_entry(  # noqa: C901
             if device_info.voice_assistant_version:
                 entry_data.disconnect_callbacks.append(
                     await cli.subscribe_voice_assistant(
-                        handle_pipeline_start,
-                        handle_pipeline_stop,
+                        _handle_pipeline_start,
+                        _handle_pipeline_stop,
                     )
                 )
 

--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -328,7 +328,6 @@ async def async_setup_entry(  # noqa: C901
 
         if voice_assistant_udp_server is not None:
             voice_assistant_udp_server.stop()
-            # voice_assistant_udp_server = None
 
     async def on_connect() -> None:
         """Subscribe to states and list entities on successful API login."""

--- a/homeassistant/components/esphome/voice_assistant.py
+++ b/homeassistant/components/esphome/voice_assistant.py
@@ -187,6 +187,9 @@ class VoiceAssistantUDPServer(asyncio.DatagramProtocol):
     ) -> None:
         """Run the Voice Assistant pipeline."""
         try:
+            tts_audio_output = (
+                "raw" if self.device_info.voice_assistant_version >= 2 else "mp3"
+            )
             async with async_timeout.timeout(pipeline_timeout):
                 await async_pipeline_from_audio_stream(
                     self.hass,
@@ -204,7 +207,7 @@ class VoiceAssistantUDPServer(asyncio.DatagramProtocol):
                     pipeline_id=pipeline_select.get_chosen_pipeline(
                         self.hass, DOMAIN, self.device_info.mac_address
                     ),
-                    tts_audio_output="raw",
+                    tts_audio_output=tts_audio_output,
                 )
 
                 # Block until TTS is done sending

--- a/homeassistant/components/esphome/voice_assistant.py
+++ b/homeassistant/components/esphome/voice_assistant.py
@@ -8,8 +8,9 @@ import socket
 from typing import cast
 
 from aioesphomeapi import VoiceAssistantEventType
+import async_timeout
 
-from homeassistant.components import stt
+from homeassistant.components import stt, tts
 from homeassistant.components.assist_pipeline import (
     PipelineEvent,
     PipelineEventType,
@@ -26,6 +27,7 @@ from .enum_mapper import EsphomeEnumMapper
 _LOGGER = logging.getLogger(__name__)
 
 UDP_PORT = 0  # Set to 0 to let the OS pick a free random port
+UDP_MAX_PACKET_SIZE = 1024
 
 _VOICE_ASSISTANT_EVENT_TYPES: EsphomeEnumMapper[
     VoiceAssistantEventType, PipelineEventType
@@ -50,11 +52,14 @@ class VoiceAssistantUDPServer(asyncio.DatagramProtocol):
     started = False
     queue: asyncio.Queue[bytes] | None = None
     transport: asyncio.DatagramTransport | None = None
+    remote_addr: tuple[str, int] | None = None
 
     def __init__(
         self,
         hass: HomeAssistant,
         entry_data: RuntimeEntryData,
+        handle_event: Callable[[VoiceAssistantEventType, dict[str, str] | None], None],
+        handle_finished: Callable[[None], None],
     ) -> None:
         """Initialize UDP receiver."""
         self.context = Context()
@@ -64,6 +69,9 @@ class VoiceAssistantUDPServer(asyncio.DatagramProtocol):
         self.device_info = entry_data.device_info
 
         self.queue = asyncio.Queue()
+        self.handle_event = handle_event
+        self.handle_finished = handle_finished
+        self._tts_done = asyncio.Event()
 
     async def start_server(self) -> int:
         """Start accepting connections."""
@@ -97,6 +105,10 @@ class VoiceAssistantUDPServer(asyncio.DatagramProtocol):
     @callback
     def datagram_received(self, data: bytes, addr: tuple[str, int]) -> None:
         """Handle incoming UDP packet."""
+        if not self.started:
+            return
+        if self.remote_addr is None:
+            self.remote_addr = addr
         if self.queue is not None:
             self.queue.put_nowait(data)
 
@@ -106,12 +118,18 @@ class VoiceAssistantUDPServer(asyncio.DatagramProtocol):
         (Other than BlockingIOError or InterruptedError.)
         """
         _LOGGER.error("ESPHome Voice Assistant UDP server error received: %s", exc)
+        self.handle_finished()
 
     @callback
     def stop(self) -> None:
         """Stop the receiver."""
         if self.queue is not None:
             self.queue.put_nowait(b"")
+        self.started = False
+
+    def close(self) -> None:
+        """Close the receiver."""
+        if self.queue is not None:
             self.queue = None
         if self.transport is not None:
             self.transport.close()
@@ -124,57 +142,109 @@ class VoiceAssistantUDPServer(asyncio.DatagramProtocol):
         while data := await self.queue.get():
             yield data
 
+    def _event_callback(self, event: PipelineEvent) -> None:
+        """Handle pipeline events."""
+
+        try:
+            event_type = _VOICE_ASSISTANT_EVENT_TYPES.from_hass(event.type)
+        except KeyError:
+            _LOGGER.warning("Received unknown pipeline event type: %s", event.type)
+            return
+
+        data_to_send = None
+        if event_type == VoiceAssistantEventType.VOICE_ASSISTANT_STT_END:
+            assert event.data is not None
+            data_to_send = {"text": event.data["stt_output"]["text"]}
+        elif event_type == VoiceAssistantEventType.VOICE_ASSISTANT_TTS_START:
+            assert event.data is not None
+            data_to_send = {"text": event.data["tts_input"]}
+        elif event_type == VoiceAssistantEventType.VOICE_ASSISTANT_TTS_END:
+            assert event.data is not None
+            path = event.data["tts_output"]["url"]
+            url = async_process_play_media_url(self.hass, path)
+            data_to_send = {"url": url}
+
+            if self.device_info.voice_assistant_version >= 2:
+                media_id = event.data["tts_output"]["media_id"]
+                self.hass.async_create_background_task(
+                    self._send_tts(media_id), "esphome_voice_assistant_tts"
+                )
+            else:
+                self._tts_done.set()
+        elif event_type == VoiceAssistantEventType.VOICE_ASSISTANT_ERROR:
+            assert event.data is not None
+            data_to_send = {
+                "code": event.data["code"],
+                "message": event.data["message"],
+            }
+            self.handle_finished()
+
+        self.handle_event(event_type, data_to_send)
+
     async def run_pipeline(
         self,
-        handle_event: Callable[[VoiceAssistantEventType, dict[str, str] | None], None],
+        pipeline_timeout: float = 30.0,
     ) -> None:
         """Run the Voice Assistant pipeline."""
+        try:
+            async with async_timeout.timeout(pipeline_timeout):
+                await async_pipeline_from_audio_stream(
+                    self.hass,
+                    context=self.context,
+                    event_callback=self._event_callback,
+                    stt_metadata=stt.SpeechMetadata(
+                        language="",  # set in async_pipeline_from_audio_stream
+                        format=stt.AudioFormats.WAV,
+                        codec=stt.AudioCodecs.PCM,
+                        bit_rate=stt.AudioBitRates.BITRATE_16,
+                        sample_rate=stt.AudioSampleRates.SAMPLERATE_16000,
+                        channel=stt.AudioChannels.CHANNEL_MONO,
+                    ),
+                    stt_stream=self._iterate_packets(),
+                    pipeline_id=pipeline_select.get_chosen_pipeline(
+                        self.hass, DOMAIN, self.device_info.mac_address
+                    ),
+                    tts_audio_output="raw",
+                )
 
-        @callback
-        def handle_pipeline_event(event: PipelineEvent) -> None:
-            """Handle pipeline events."""
+                # Block until TTS is done sending
+                await self._tts_done.wait()
 
-            try:
-                event_type = _VOICE_ASSISTANT_EVENT_TYPES.from_hass(event.type)
-            except KeyError:
-                _LOGGER.warning("Received unknown pipeline event type: %s", event.type)
+            _LOGGER.debug("Pipeline finished")
+        except asyncio.TimeoutError:
+            _LOGGER.warning("Pipeline timeout")
+        finally:
+            self.handle_finished()
+
+    async def _send_tts(self, media_id: str) -> None:
+        """Send TTS audio to device via UDP."""
+        try:
+            if self.transport is None:
                 return
 
-            data_to_send = None
-            if event_type == VoiceAssistantEventType.VOICE_ASSISTANT_STT_END:
-                assert event.data is not None
-                data_to_send = {"text": event.data["stt_output"]["text"]}
-            elif event_type == VoiceAssistantEventType.VOICE_ASSISTANT_TTS_START:
-                assert event.data is not None
-                data_to_send = {"text": event.data["tts_input"]}
-            elif event_type == VoiceAssistantEventType.VOICE_ASSISTANT_TTS_END:
-                assert event.data is not None
-                path = event.data["tts_output"]["url"]
-                url = async_process_play_media_url(self.hass, path)
-                data_to_send = {"url": url}
-            elif event_type == VoiceAssistantEventType.VOICE_ASSISTANT_ERROR:
-                assert event.data is not None
-                data_to_send = {
-                    "code": event.data["code"],
-                    "message": event.data["message"],
-                }
+            _extension, audio_bytes = await tts.async_get_media_source_audio(
+                self.hass,
+                media_id,
+            )
 
-            handle_event(event_type, data_to_send)
+            _LOGGER.debug("Sending %d bytes of audio", len(audio_bytes))
 
-        await async_pipeline_from_audio_stream(
-            self.hass,
-            context=self.context,
-            event_callback=handle_pipeline_event,
-            stt_metadata=stt.SpeechMetadata(
-                language="",  # set in async_pipeline_from_audio_stream
-                format=stt.AudioFormats.WAV,
-                codec=stt.AudioCodecs.PCM,
-                bit_rate=stt.AudioBitRates.BITRATE_16,
-                sample_rate=stt.AudioSampleRates.SAMPLERATE_16000,
-                channel=stt.AudioChannels.CHANNEL_MONO,
-            ),
-            stt_stream=self._iterate_packets(),
-            pipeline_id=pipeline_select.get_chosen_pipeline(
-                self.hass, DOMAIN, self.device_info.mac_address
-            ),
-        )
+            bytes_per_sample = stt.AudioBitRates.BITRATE_16 // 8
+            sample_offset = 0
+            samples_left = len(audio_bytes) // bytes_per_sample
+
+            while samples_left > 0:
+                bytes_offset = sample_offset * bytes_per_sample
+                chunk: bytes = audio_bytes[bytes_offset : bytes_offset + 1024]
+                samples_in_chunk = len(chunk) // bytes_per_sample
+                samples_left -= samples_in_chunk
+
+                self.transport.sendto(chunk, self.remote_addr)
+                await asyncio.sleep(
+                    samples_in_chunk / stt.AudioSampleRates.SAMPLERATE_16000 * 0.99
+                )
+
+                sample_offset += samples_in_chunk
+
+        finally:
+            self._tts_done.set()

--- a/homeassistant/components/esphome/voice_assistant.py
+++ b/homeassistant/components/esphome/voice_assistant.py
@@ -59,7 +59,7 @@ class VoiceAssistantUDPServer(asyncio.DatagramProtocol):
         hass: HomeAssistant,
         entry_data: RuntimeEntryData,
         handle_event: Callable[[VoiceAssistantEventType, dict[str, str] | None], None],
-        handle_finished: Callable[[None], None],
+        handle_finished: Callable[[], None],
     ) -> None:
         """Initialize UDP receiver."""
         self.context = Context()

--- a/tests/components/esphome/conftest.py
+++ b/tests/components/esphome/conftest.py
@@ -157,3 +157,38 @@ async def mock_voice_assistant_v1_entry(
     await hass.async_block_till_done()
 
     return entry
+
+
+@pytest.fixture
+async def mock_voice_assistant_v2_entry(
+    hass: HomeAssistant,
+    mock_client,
+) -> MockConfigEntry:
+    """Set up an ESPHome entry with voice assistant."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: "test.local",
+            CONF_PORT: 6053,
+            CONF_PASSWORD: "",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    device_info = DeviceInfo(
+        name="test",
+        friendly_name="Test",
+        voice_assistant_version=2,
+        mac_address="11:22:33:44:55:aa",
+        esphome_version="1.0.0",
+    )
+
+    mock_client.device_info = AsyncMock(return_value=device_info)
+    mock_client.subscribe_voice_assistant = AsyncMock(return_value=Mock())
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+
+    return entry

--- a/tests/components/esphome/test_voice_assistant.py
+++ b/tests/components/esphome/test_voice_assistant.py
@@ -164,18 +164,26 @@ async def test_udp_server_queue(
     assert voice_assistant_udp_server_v1.queue.qsize() == 0
 
     voice_assistant_udp_server_v1.datagram_received(bytes(1024), ("localhost", 0))
-
     assert voice_assistant_udp_server_v1.queue.qsize() == 1
 
     voice_assistant_udp_server_v1.datagram_received(bytes(1024), ("localhost", 0))
-
     assert voice_assistant_udp_server_v1.queue.qsize() == 2
 
     async for data in voice_assistant_udp_server_v1._iterate_packets():
         assert data == bytes(1024)
         break
+    assert voice_assistant_udp_server_v1.queue.qsize() == 1  # One message removed
 
     voice_assistant_udp_server_v1.stop()
+    assert (
+        voice_assistant_udp_server_v1.queue.qsize() == 2
+    )  # An empty message added by stop
+
+    voice_assistant_udp_server_v1.datagram_received(bytes(1024), ("localhost", 0))
+    assert (
+        voice_assistant_udp_server_v1.queue.qsize() == 2
+    )  # No new messages added after stop
+
     voice_assistant_udp_server_v1.close()
 
     with pytest.raises(RuntimeError):

--- a/tests/components/esphome/test_voice_assistant.py
+++ b/tests/components/esphome/test_voice_assistant.py
@@ -193,7 +193,7 @@ async def test_unknown_event_type(
     hass: HomeAssistant,
     voice_assistant_udp_server_v1: VoiceAssistantUDPServer,
 ) -> None:
-    """Test the UDP server runs and queues incoming data."""
+    """Test the UDP server does not call handle_event for unknown events."""
     voice_assistant_udp_server_v1._event_callback(
         PipelineEvent(
             type="unknown-event",
@@ -208,7 +208,7 @@ async def test_error_event_type(
     hass: HomeAssistant,
     voice_assistant_udp_server_v1: VoiceAssistantUDPServer,
 ) -> None:
-    """Test the UDP server runs and queues incoming data."""
+    """Test the UDP server calls event handler with error."""
     voice_assistant_udp_server_v1._event_callback(
         PipelineEvent(
             type=PipelineEventType.ERROR,
@@ -224,20 +224,12 @@ async def test_error_event_type(
 
 async def test_send_tts_not_called(
     hass: HomeAssistant,
-    socket_enabled,
-    unused_udp_port_factory,
     voice_assistant_udp_server_v1: VoiceAssistantUDPServer,
 ) -> None:
-    """Test the UDP server runs and queues incoming data."""
-    port_to_use = unused_udp_port_factory()
-
+    """Test the UDP server with a v1 device does not call _send_tts."""
     with patch(
-        "homeassistant.components.esphome.voice_assistant.UDP_PORT", new=port_to_use
-    ), patch(
         "homeassistant.components.esphome.voice_assistant.VoiceAssistantUDPServer._send_tts"
     ) as mock_send_tts:
-        await voice_assistant_udp_server_v1.start_server()
-
         voice_assistant_udp_server_v1._event_callback(
             PipelineEvent(
                 type=PipelineEventType.TTS_END,
@@ -252,20 +244,12 @@ async def test_send_tts_not_called(
 
 async def test_send_tts_called(
     hass: HomeAssistant,
-    socket_enabled,
-    unused_udp_port_factory,
     voice_assistant_udp_server_v2: VoiceAssistantUDPServer,
 ) -> None:
-    """Test the UDP server runs and queues incoming data."""
-    port_to_use = unused_udp_port_factory()
-
+    """Test the UDP server with a v2 device calls _send_tts."""
     with patch(
-        "homeassistant.components.esphome.voice_assistant.UDP_PORT", new=port_to_use
-    ), patch(
         "homeassistant.components.esphome.voice_assistant.VoiceAssistantUDPServer._send_tts"
     ) as mock_send_tts:
-        await voice_assistant_udp_server_v2.start_server()
-
         voice_assistant_udp_server_v2._event_callback(
             PipelineEvent(
                 type=PipelineEventType.TTS_END,
@@ -280,16 +264,10 @@ async def test_send_tts_called(
 
 async def test_send_tts(
     hass: HomeAssistant,
-    socket_enabled,
-    unused_udp_port_factory,
     voice_assistant_udp_server_v2: VoiceAssistantUDPServer,
 ) -> None:
-    """Test the UDP server runs and queues incoming data."""
-    port_to_use = unused_udp_port_factory()
-
+    """Test the UDP server calls sendto to transmit audio data to device."""
     with patch(
-        "homeassistant.components.esphome.voice_assistant.UDP_PORT", new=port_to_use
-    ), patch(
         "homeassistant.components.esphome.voice_assistant.tts.async_get_media_source_audio",
         return_value=("raw", bytes(1024)),
     ):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Stream the raw tts audio back to device for playback if the device says it have voice_assistant_version 2, otherwise stop at sending the media URL.

This also adds the `pipeline_id` to `async_pipeline_from_audio_stream`, otherwise any ESPHome device would ignore the `select` state and just use the default.

Related PRs:
- https://github.com/esphome/esphome/pull/4743

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
