### PR TITLE
Fix tts add-on discovery for Wyoming

### DIFF
--- a/homeassistant/components/wyoming/config_flow.py
+++ b/homeassistant/components/wyoming/config_flow.py
@@ -80,7 +80,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             uri = urlparse(self._hassio_discovery.config["uri"])
             if service := await WyomingService.create(uri.hostname, uri.port):
-                if not any(asr for asr in service.info.asr if asr.installed):
+                if not any(
+                    asr for asr in service.info.asr if asr.installed
+                ) and not any(tts for tts in service.info.tts if tts.installed):
                     return self.async_abort(reason="no_services")
 
                 return self.async_create_entry(

--- a/tests/components/wyoming/snapshots/test_config_flow.ambr
+++ b/tests/components/wyoming/snapshots/test_config_flow.ambr
@@ -37,3 +37,79 @@
     'version': 1,
   })
 # ---
+# name: test_hassio_addon_discovery[info0]
+  FlowResultSnapshot({
+    'context': dict({
+      'source': 'hassio',
+      'unique_id': '1234',
+    }),
+    'data': dict({
+      'host': 'mock-piper',
+      'port': 10200,
+    }),
+    'description': None,
+    'description_placeholders': None,
+    'flow_id': <ANY>,
+    'handler': 'wyoming',
+    'options': dict({
+    }),
+    'result': ConfigEntrySnapshot({
+      'data': dict({
+        'host': 'mock-piper',
+        'port': 10200,
+      }),
+      'disabled_by': None,
+      'domain': 'wyoming',
+      'entry_id': <ANY>,
+      'options': dict({
+      }),
+      'pref_disable_new_entities': False,
+      'pref_disable_polling': False,
+      'source': 'hassio',
+      'title': 'Piper',
+      'unique_id': '1234',
+      'version': 1,
+    }),
+    'title': 'Piper',
+    'type': <FlowResultType.CREATE_ENTRY: 'create_entry'>,
+    'version': 1,
+  })
+# ---
+# name: test_hassio_addon_discovery[info1]
+  FlowResultSnapshot({
+    'context': dict({
+      'source': 'hassio',
+      'unique_id': '1234',
+    }),
+    'data': dict({
+      'host': 'mock-piper',
+      'port': 10200,
+    }),
+    'description': None,
+    'description_placeholders': None,
+    'flow_id': <ANY>,
+    'handler': 'wyoming',
+    'options': dict({
+    }),
+    'result': ConfigEntrySnapshot({
+      'data': dict({
+        'host': 'mock-piper',
+        'port': 10200,
+      }),
+      'disabled_by': None,
+      'domain': 'wyoming',
+      'entry_id': <ANY>,
+      'options': dict({
+      }),
+      'pref_disable_new_entities': False,
+      'pref_disable_polling': False,
+      'source': 'hassio',
+      'title': 'Piper',
+      'unique_id': '1234',
+      'version': 1,
+    }),
+    'title': 'Piper',
+    'type': <FlowResultType.CREATE_ENTRY: 'create_entry'>,
+    'version': 1,
+  })
+# ---

--- a/tests/components/wyoming/test_config_flow.py
+++ b/tests/components/wyoming/test_config_flow.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
+from wyoming.info import Info
 
 from homeassistant import config_entries
 from homeassistant.components.hassio import HassioServiceInfo
@@ -131,10 +132,12 @@ async def test_no_supported_services(hass: HomeAssistant) -> None:
     assert result2["reason"] == "no_services"
 
 
+@pytest.mark.parametrize("info", [STT_INFO, TTS_INFO])
 async def test_hassio_addon_discovery(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
     snapshot: SnapshotAssertion,
+    info: Info,
 ) -> None:
     """Test config flow initiated by Supervisor."""
     result = await hass.config_entries.flow.async_init(
@@ -149,7 +152,7 @@ async def test_hassio_addon_discovery(
 
     with patch(
         "homeassistant.components.wyoming.data.load_wyoming_info",
-        return_value=STT_INFO,
+        return_value=info,
     ) as mock_wyoming:
         result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fixes the Wyoming TTS discovery. It only accepted STT.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
