### PR TITLE
Add a channel changing API to ZHA

### DIFF
--- a/homeassistant/components/zha/api.py
+++ b/homeassistant/components/zha/api.py
@@ -115,7 +115,7 @@ def async_get_radio_path(
     return config_entry.data[CONF_DEVICE][CONF_DEVICE_PATH]
 
 
-async def change_channel(
+async def async_change_channel(
     hass: HomeAssistant, new_channel: int | Literal["auto"]
 ) -> None:
     """Migrate the ZHA network to a new channel."""

--- a/homeassistant/components/zha/api.py
+++ b/homeassistant/components/zha/api.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from zigpy.backups import NetworkBackup
 from zigpy.config import CONF_DEVICE, CONF_DEVICE_PATH
+from zigpy.types import Channels
+from zigpy.util import pick_optimal_channel
 
 from .core.const import (
     CONF_RADIO_TYPE,
@@ -111,3 +113,22 @@ def async_get_radio_path(
         config_entry = _get_config_entry(hass)
 
     return config_entry.data[CONF_DEVICE][CONF_DEVICE_PATH]
+
+
+async def change_channel(
+    hass: HomeAssistant, new_channel: int | Literal["auto"]
+) -> None:
+    """Migrate the ZHA network to a new channel."""
+
+    zha_gateway: ZHAGateway = _get_gateway(hass)
+    app = zha_gateway.application_controller
+
+    if new_channel == "auto":
+        channel_energy = await app.energy_scan(
+            channels=Channels.ALL_CHANNELS,
+            duration_exp=4,
+            count=1,
+        )
+        new_channel = pick_optimal_channel(channel_energy)
+
+    await app.move_network_to_channel(new_channel)

--- a/homeassistant/components/zha/services.yaml
+++ b/homeassistant/components/zha/services.yaml
@@ -435,36 +435,3 @@ set_lock_user_code:
       example: 1234
       selector:
         text:
-
-change_channel:
-  name: Change the Zigbee network channel
-  description: >-
-    Attempts to migrate devices to a new channel. Not all devices will migrate so use with care!
-    The default of `auto` should generally be used, as the radio will scan all available channels and the least noisy one will be picked.
-  fields:
-    new_channel:
-      name: New channel
-      description: New channel for the network
-      required: true
-      default: "auto"
-      example: "auto"
-      selector:
-        select:
-          options:
-            - "auto"
-            - "11"
-            - "12"
-            - "13"
-            - "14"
-            - "15"
-            - "16"
-            - "17"
-            - "18"
-            - "19"
-            - "20"
-            - "21"
-            - "22"
-            - "23"
-            - "24"
-            - "25"
-            - "26"

--- a/homeassistant/components/zha/services.yaml
+++ b/homeassistant/components/zha/services.yaml
@@ -438,7 +438,9 @@ set_lock_user_code:
 
 change_channel:
   name: Change the Zigbee network channel
-  description: Attempts to migrate devices to a new channel. Not all devices will migrate so use with care!
+  description: >-
+    Attempts to migrate devices to a new channel. Not all devices will migrate so use with care!
+    The default of `auto` should generally be used, as the radio will scan all available channels and the least noisy one will be picked.
   fields:
     new_channel:
       name: New channel

--- a/homeassistant/components/zha/services.yaml
+++ b/homeassistant/components/zha/services.yaml
@@ -435,3 +435,34 @@ set_lock_user_code:
       example: 1234
       selector:
         text:
+
+change_channel:
+  name: Change the Zigbee network channel
+  description: Attempts to migrate devices to a new channel. Not all devices will migrate so use with care!
+  fields:
+    new_channel:
+      name: New channel
+      description: New channel for the network
+      required: true
+      default: "auto"
+      example: "auto"
+      selector:
+        select:
+          options:
+            - "auto"
+            - "11"
+            - "12"
+            - "13"
+            - "14"
+            - "15"
+            - "16"
+            - "17"
+            - "18"
+            - "19"
+            - "20"
+            - "21"
+            - "22"
+            - "23"
+            - "24"
+            - "25"
+            - "26"

--- a/homeassistant/components/zha/websocket_api.py
+++ b/homeassistant/components/zha/websocket_api.py
@@ -1213,9 +1213,7 @@ async def websocket_restore_network_backup(
 @websocket_api.websocket_command(
     {
         vol.Required(TYPE): "zha/network/change_channel",
-        vol.Required(ATTR_NEW_CHANNEL): vol.Any(
-            "auto", vol.Range(11, 26)
-        ),
+        vol.Required(ATTR_NEW_CHANNEL): vol.Any("auto", vol.Range(11, 26)),
     }
 )
 @websocket_api.async_response

--- a/homeassistant/components/zha/websocket_api.py
+++ b/homeassistant/components/zha/websocket_api.py
@@ -19,7 +19,11 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.service import async_register_admin_service
 
-from .api import async_get_active_network_settings, async_get_radio_type, change_channel
+from .api import (
+    async_change_channel,
+    async_get_active_network_settings,
+    async_get_radio_type,
+)
 from .core.const import (
     ATTR_ARGS,
     ATTR_ATTRIBUTE,
@@ -1228,7 +1232,7 @@ async def websocket_change_channel(
 ) -> None:
     """Migrate the Zigbee network to a new channel."""
     new_channel = cast(Literal["auto"] | int, msg[ATTR_NEW_CHANNEL])
-    await change_channel(hass, new_channel=new_channel)
+    await async_change_channel(hass, new_channel=new_channel)
     connection.send_result(msg[ID])
 
 
@@ -1538,7 +1542,7 @@ def async_load_api(hass: HomeAssistant) -> None:
         else:
             new_channel = "auto"
 
-        await change_channel(hass, new_channel=new_channel)
+        await async_change_channel(hass, new_channel=new_channel)
 
     async_register_admin_service(
         hass,

--- a/homeassistant/components/zha/websocket_api.py
+++ b/homeassistant/components/zha/websocket_api.py
@@ -102,7 +102,6 @@ ATTR_SOURCE_IEEE = "source_ieee"
 ATTR_TARGET_IEEE = "target_ieee"
 ATTR_QR_CODE = "qr_code"
 
-SERVICE_CHANGE_CHANNEL = "change_channel"
 SERVICE_PERMIT = "permit"
 SERVICE_REMOVE = "remove"
 SERVICE_SET_ZIGBEE_CLUSTER_ATTRIBUTE = "set_zigbee_cluster_attribute"
@@ -141,13 +140,6 @@ SERVICE_PERMIT_PARAMS = {
 }
 
 SERVICE_SCHEMAS = {
-    SERVICE_CHANGE_CHANNEL: vol.Schema(
-        {
-            vol.Required(ATTR_NEW_CHANNEL): vol.Any(
-                "auto", vol.All(cv.positive_int, vol.Range(11, 26))
-            ),
-        }
-    ),
     SERVICE_PERMIT: vol.Schema(
         vol.All(
             cv.deprecated(ATTR_IEEE_ADDRESS, replacement_key=ATTR_IEEE),
@@ -1530,26 +1522,6 @@ def async_load_api(hass: HomeAssistant) -> None:
         SERVICE_WARNING_DEVICE_WARN,
         warning_device_warn,
         schema=SERVICE_SCHEMAS[SERVICE_WARNING_DEVICE_WARN],
-    )
-
-    async def service_change_channel(service: ServiceCall) -> None:
-        """Migrate the Zigbee network to a new channel."""
-
-        new_channel: Literal["auto"] | int
-
-        if service.data[ATTR_NEW_CHANNEL] != "auto":
-            new_channel = int(service.data[ATTR_NEW_CHANNEL])
-        else:
-            new_channel = "auto"
-
-        await async_change_channel(hass, new_channel=new_channel)
-
-    async_register_admin_service(
-        hass,
-        DOMAIN,
-        SERVICE_CHANGE_CHANNEL,
-        service_change_channel,
-        schema=SERVICE_SCHEMAS[SERVICE_CHANGE_CHANNEL],
     )
 
     websocket_api.async_register_command(hass, websocket_permit_devices)

--- a/homeassistant/components/zha/websocket_api.py
+++ b/homeassistant/components/zha/websocket_api.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING, Any, NamedTuple, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple, TypeVar, cast
 
 import voluptuous as vol
 import zigpy.backups
@@ -19,7 +19,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.service import async_register_admin_service
 
-from .api import async_get_active_network_settings, async_get_radio_type
+from .api import async_get_active_network_settings, async_get_radio_type, change_channel
 from .core.const import (
     ATTR_ARGS,
     ATTR_ATTRIBUTE,
@@ -93,6 +93,7 @@ ATTR_DURATION = "duration"
 ATTR_GROUP = "group"
 ATTR_IEEE_ADDRESS = "ieee_address"
 ATTR_INSTALL_CODE = "install_code"
+ATTR_NEW_CHANNEL = "new_channel"
 ATTR_SOURCE_IEEE = "source_ieee"
 ATTR_TARGET_IEEE = "target_ieee"
 ATTR_QR_CODE = "qr_code"
@@ -1204,6 +1205,25 @@ async def websocket_restore_network_backup(
         connection.send_result(msg[ID])
 
 
+@websocket_api.require_admin
+@websocket_api.websocket_command(
+    {
+        vol.Required(TYPE): "zha/network/change_channel",
+        vol.Required(ATTR_NEW_CHANNEL): vol.Any(
+            "auto", vol.All(cv.positive_int, vol.Range(11, 26))
+        ),
+    }
+)
+@websocket_api.async_response
+async def websocket_change_channel(
+    hass: HomeAssistant, connection: ActiveConnection, msg: dict[str, Any]
+) -> None:
+    """Migrate to a new channel."""
+    new_channel = cast(Literal["auto"] | int, msg[ATTR_NEW_CHANNEL])
+    await change_channel(hass, new_channel=new_channel)
+    connection.send_result(msg[ID])
+
+
 @callback
 def async_load_api(hass: HomeAssistant) -> None:
     """Set up the web socket API."""
@@ -1527,6 +1547,7 @@ def async_load_api(hass: HomeAssistant) -> None:
     websocket_api.async_register_command(hass, websocket_list_network_backups)
     websocket_api.async_register_command(hass, websocket_create_network_backup)
     websocket_api.async_register_command(hass, websocket_restore_network_backup)
+    websocket_api.async_register_command(hass, websocket_change_channel)
 
 
 @callback

--- a/homeassistant/components/zha/websocket_api.py
+++ b/homeassistant/components/zha/websocket_api.py
@@ -1214,7 +1214,7 @@ async def websocket_restore_network_backup(
     {
         vol.Required(TYPE): "zha/network/change_channel",
         vol.Required(ATTR_NEW_CHANNEL): vol.Any(
-            "auto", vol.All(cv.positive_int, vol.Range(11, 26))
+            "auto", vol.Range(11, 26)
         ),
     }
 )

--- a/tests/components/zha/conftest.py
+++ b/tests/components/zha/conftest.py
@@ -116,7 +116,9 @@ def zigpy_app_controller():
     app.state.network_info.channel = 15
     app.state.network_info.network_key.key = zigpy.types.KeyData(range(16))
 
-    with patch("zigpy.device.Device.request"):
+    with patch("zigpy.device.Device.request"), patch.object(
+        app, "permit", autospec=True
+    ), patch.object(app, "permit_with_key", autospec=True):
         yield app
 
 

--- a/tests/components/zha/test_api.py
+++ b/tests/components/zha/test_api.py
@@ -117,7 +117,7 @@ async def test_change_channel(
     with patch.object(
         zigpy_app_controller, "move_network_to_channel", autospec=True
     ) as mock_move_network_to_channel:
-        await api.change_channel(hass, 20)
+        await api.async_change_channel(hass, 20)
 
     assert mock_move_network_to_channel.mock_calls == [call(20)]
 
@@ -138,6 +138,6 @@ async def test_change_channel_auto(
     ), patch.object(
         api, "pick_optimal_channel", autospec=True, return_value=25
     ):
-        await api.change_channel(hass, "auto")
+        await api.async_change_channel(hass, "auto")
 
     assert mock_move_network_to_channel.mock_calls == [call(25)]

--- a/tests/components/zha/test_api.py
+++ b/tests/components/zha/test_api.py
@@ -1,5 +1,8 @@
 """Test ZHA API."""
-from unittest.mock import patch
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import call, patch
 
 import pytest
 import zigpy.backups
@@ -9,6 +12,9 @@ from homeassistant.components import zha
 from homeassistant.components.zha import api
 from homeassistant.components.zha.core.const import RadioType
 from homeassistant.core import HomeAssistant
+
+if TYPE_CHECKING:
+    from zigpy.application import ControllerApplication
 
 
 @pytest.fixture(autouse=True)
@@ -29,7 +35,7 @@ async def test_async_get_network_settings_active(
 
 
 async def test_async_get_network_settings_inactive(
-    hass: HomeAssistant, setup_zha, zigpy_app_controller
+    hass: HomeAssistant, setup_zha, zigpy_app_controller: ControllerApplication
 ) -> None:
     """Test reading settings with an inactive ZHA installation."""
     await setup_zha()
@@ -59,7 +65,7 @@ async def test_async_get_network_settings_inactive(
 
 
 async def test_async_get_network_settings_missing(
-    hass: HomeAssistant, setup_zha, zigpy_app_controller
+    hass: HomeAssistant, setup_zha, zigpy_app_controller: ControllerApplication
 ) -> None:
     """Test reading settings with an inactive ZHA installation, no valid channel."""
     await setup_zha()
@@ -100,3 +106,38 @@ async def test_async_get_radio_path_active(hass: HomeAssistant, setup_zha) -> No
 
     radio_path = api.async_get_radio_path(hass)
     assert radio_path == "/dev/ttyUSB0"
+
+
+async def test_change_channel(
+    hass: HomeAssistant, setup_zha, zigpy_app_controller: ControllerApplication
+) -> None:
+    """Test changing the channel."""
+    await setup_zha()
+
+    with patch.object(
+        zigpy_app_controller, "move_network_to_channel", autospec=True
+    ) as mock_move_network_to_channel:
+        await api.change_channel(hass, 20)
+
+    assert mock_move_network_to_channel.mock_calls == [call(20)]
+
+
+async def test_change_channel_auto(
+    hass: HomeAssistant, setup_zha, zigpy_app_controller: ControllerApplication
+) -> None:
+    """Test changing the channel automatically using an energy scan."""
+    await setup_zha()
+
+    with patch.object(
+        zigpy_app_controller, "move_network_to_channel", autospec=True
+    ) as mock_move_network_to_channel, patch.object(
+        zigpy_app_controller,
+        "energy_scan",
+        autospec=True,
+        return_value={c: c for c in range(11, 26 + 1)},
+    ), patch.object(
+        api, "pick_optimal_channel", autospec=True, return_value=25
+    ):
+        await api.change_channel(hass, "auto")
+
+    assert mock_move_network_to_channel.mock_calls == [call(25)]

--- a/tests/components/zha/test_websocket_api.py
+++ b/tests/components/zha/test_websocket_api.py
@@ -1,6 +1,9 @@
 """Test ZHA WebSocket API."""
+from __future__ import annotations
+
 from binascii import unhexlify
 from copy import deepcopy
+from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -24,8 +27,6 @@ from homeassistant.components.zha.core.const import (
     ATTR_NEIGHBORS,
     ATTR_QUIRK_APPLIED,
     CLUSTER_TYPE_IN,
-    DATA_ZHA,
-    DATA_ZHA_GATEWAY,
     EZSP_OVERWRITE_EUI64,
     GROUP_ID,
     GROUP_IDS,
@@ -58,6 +59,9 @@ from tests.common import MockUser
 
 IEEE_SWITCH_DEVICE = "01:2d:6f:00:0a:90:69:e7"
 IEEE_GROUPABLE_DEVICE = "01:2d:6f:00:0a:90:69:e8"
+
+if TYPE_CHECKING:
+    from zigpy.application import ControllerApplication
 
 
 @pytest.fixture(autouse=True)
@@ -282,15 +286,17 @@ async def test_get_zha_config_with_alarm(
     assert configuration == BASE_CUSTOM_CONFIGURATION
 
 
-async def test_update_zha_config(zha_client, zigpy_app_controller) -> None:
+async def test_update_zha_config(
+    zha_client, app_controller: ControllerApplication
+) -> None:
     """Test updating ZHA custom configuration."""
 
-    configuration = deepcopy(CONFIG_WITH_ALARM_OPTIONS)
+    configuration: dict = deepcopy(CONFIG_WITH_ALARM_OPTIONS)
     configuration["data"]["zha_options"]["default_light_transition"] = 10
 
     with patch(
         "bellows.zigbee.application.ControllerApplication.new",
-        return_value=zigpy_app_controller,
+        return_value=app_controller,
     ):
         await zha_client.send_json(
             {ID: 5, TYPE: "zha/configuration/update", "data": configuration["data"]}
@@ -463,14 +469,12 @@ async def test_remove_group(zha_client) -> None:
 
 
 @pytest.fixture
-async def app_controller(hass, setup_zha):
+async def app_controller(
+    hass: HomeAssistant, setup_zha, zigpy_app_controller: ControllerApplication
+) -> ControllerApplication:
     """Fixture for zigpy Application Controller."""
     await setup_zha()
-    controller = hass.data[DATA_ZHA][DATA_ZHA_GATEWAY].application_controller
-    p1 = patch.object(controller, "permit")
-    p2 = patch.object(controller, "permit_with_key", new=AsyncMock())
-    with p1, p2:
-        yield controller
+    return zigpy_app_controller
 
 
 @pytest.mark.parametrize(
@@ -492,7 +496,7 @@ async def app_controller(hass, setup_zha):
 )
 async def test_permit_ha12(
     hass: HomeAssistant,
-    app_controller,
+    app_controller: ControllerApplication,
     hass_admin_user: MockUser,
     params,
     duration,
@@ -532,7 +536,7 @@ IC_TEST_PARAMS = (
 @pytest.mark.parametrize(("params", "src_ieee", "code"), IC_TEST_PARAMS)
 async def test_permit_with_install_code(
     hass: HomeAssistant,
-    app_controller,
+    app_controller: ControllerApplication,
     hass_admin_user: MockUser,
     params,
     src_ieee,
@@ -587,7 +591,10 @@ IC_FAIL_PARAMS = (
 
 @pytest.mark.parametrize("params", IC_FAIL_PARAMS)
 async def test_permit_with_install_code_fail(
-    hass: HomeAssistant, app_controller, hass_admin_user: MockUser, params
+    hass: HomeAssistant,
+    app_controller: ControllerApplication,
+    hass_admin_user: MockUser,
+    params,
 ) -> None:
     """Test permit service with install code."""
 
@@ -626,7 +633,7 @@ IC_QR_CODE_TEST_PARAMS = (
 @pytest.mark.parametrize(("params", "src_ieee", "code"), IC_QR_CODE_TEST_PARAMS)
 async def test_permit_with_qr_code(
     hass: HomeAssistant,
-    app_controller,
+    app_controller: ControllerApplication,
     hass_admin_user: MockUser,
     params,
     src_ieee,
@@ -646,7 +653,7 @@ async def test_permit_with_qr_code(
 
 @pytest.mark.parametrize(("params", "src_ieee", "code"), IC_QR_CODE_TEST_PARAMS)
 async def test_ws_permit_with_qr_code(
-    app_controller, zha_client, params, src_ieee, code
+    app_controller: ControllerApplication, zha_client, params, src_ieee, code
 ) -> None:
     """Test permit service with install code from qr code."""
 
@@ -668,7 +675,7 @@ async def test_ws_permit_with_qr_code(
 
 @pytest.mark.parametrize("params", IC_FAIL_PARAMS)
 async def test_ws_permit_with_install_code_fail(
-    app_controller, zha_client, params
+    app_controller: ControllerApplication, zha_client, params
 ) -> None:
     """Test permit ws service with install code."""
 
@@ -703,7 +710,7 @@ async def test_ws_permit_with_install_code_fail(
     ),
 )
 async def test_ws_permit_ha12(
-    app_controller, zha_client, params, duration, node
+    app_controller: ControllerApplication, zha_client, params, duration, node
 ) -> None:
     """Test permit ws service."""
 
@@ -722,7 +729,9 @@ async def test_ws_permit_ha12(
     assert app_controller.permit_with_key.call_count == 0
 
 
-async def test_get_network_settings(app_controller, zha_client) -> None:
+async def test_get_network_settings(
+    app_controller: ControllerApplication, zha_client
+) -> None:
     """Test current network settings are returned."""
 
     await app_controller.backups.create_backup()
@@ -737,7 +746,9 @@ async def test_get_network_settings(app_controller, zha_client) -> None:
     assert "network_info" in msg["result"]["settings"]
 
 
-async def test_list_network_backups(app_controller, zha_client) -> None:
+async def test_list_network_backups(
+    app_controller: ControllerApplication, zha_client
+) -> None:
     """Test backups are serialized."""
 
     await app_controller.backups.create_backup()
@@ -751,7 +762,9 @@ async def test_list_network_backups(app_controller, zha_client) -> None:
     assert "network_info" in msg["result"][0]
 
 
-async def test_create_network_backup(app_controller, zha_client) -> None:
+async def test_create_network_backup(
+    app_controller: ControllerApplication, zha_client
+) -> None:
     """Test creating backup."""
 
     assert not app_controller.backups.backups
@@ -765,7 +778,9 @@ async def test_create_network_backup(app_controller, zha_client) -> None:
     assert "backup" in msg["result"] and "is_complete" in msg["result"]
 
 
-async def test_restore_network_backup_success(app_controller, zha_client) -> None:
+async def test_restore_network_backup_success(
+    app_controller: ControllerApplication, zha_client
+) -> None:
     """Test successfully restoring a backup."""
 
     backup = zigpy.backups.NetworkBackup()
@@ -789,7 +804,7 @@ async def test_restore_network_backup_success(app_controller, zha_client) -> Non
 
 
 async def test_restore_network_backup_force_write_eui64(
-    app_controller, zha_client
+    app_controller: ControllerApplication, zha_client
 ) -> None:
     """Test successfully restoring a backup."""
 
@@ -821,7 +836,9 @@ async def test_restore_network_backup_force_write_eui64(
 
 
 @patch("zigpy.backups.NetworkBackup.from_dict", new=lambda v: v)
-async def test_restore_network_backup_failure(app_controller, zha_client) -> None:
+async def test_restore_network_backup_failure(
+    app_controller: ControllerApplication, zha_client
+) -> None:
     """Test successfully restoring a backup."""
 
     with patch.object(

--- a/tests/components/zha/test_websocket_api.py
+++ b/tests/components/zha/test_websocket_api.py
@@ -867,7 +867,7 @@ async def test_websocket_change_channel(
     """Test websocket API to migrate the network to a new channel."""
 
     with patch(
-        "homeassistant.components.zha.websocket_api.change_channel",
+        "homeassistant.components.zha.websocket_api.async_change_channel",
         autospec=True,
     ) as change_channel_mock:
         await zha_client.send_json(
@@ -896,7 +896,7 @@ async def test_service_change_channel(
     """Test service to migrate the network to a new channel."""
 
     with patch(
-        "homeassistant.components.zha.websocket_api.change_channel",
+        "homeassistant.components.zha.websocket_api.async_change_channel",
         autospec=True,
     ) as change_channel_mock:
         await hass.services.async_call(

--- a/tests/components/zha/test_websocket_api.py
+++ b/tests/components/zha/test_websocket_api.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from binascii import unhexlify
 from copy import deepcopy
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 from unittest.mock import ANY, AsyncMock, call, patch
 
 import pytest
@@ -38,7 +38,6 @@ from homeassistant.components.zha.websocket_api import (
     ATTR_QR_CODE,
     ATTR_SOURCE_IEEE,
     ID,
-    SERVICE_CHANGE_CHANNEL,
     SERVICE_PERMIT,
     TYPE,
     async_load_api,
@@ -884,27 +883,3 @@ async def test_websocket_change_channel(
     assert msg["success"]
 
     change_channel_mock.mock_calls == [call(ANY, new_channel)]
-
-
-@pytest.mark.parametrize("params", [{"new_channel": "auto"}, {"new_channel": 15}])
-async def test_service_change_channel(
-    hass: HomeAssistant,
-    app_controller: ControllerApplication,
-    hass_admin_user: MockUser,
-    params: dict[str, Any],
-) -> None:
-    """Test service to migrate the network to a new channel."""
-
-    with patch(
-        "homeassistant.components.zha.websocket_api.async_change_channel",
-        autospec=True,
-    ) as change_channel_mock:
-        await hass.services.async_call(
-            DOMAIN,
-            SERVICE_CHANGE_CHANNEL,
-            params,
-            True,
-            Context(user_id=hass_admin_user.id),
-        )
-
-    change_channel_mock.mock_calls == [call(ANY, params["new_channel"])]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Exposes the ZHA channel changing API from #91969 as a websocket API.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
