### PR TITLE
Add a warning step to ZHA's config flow to advise against some radios

### DIFF
--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -32,7 +32,11 @@ from .core.const import (
     DOMAIN,
     RadioType,
 )
-from .radio_manager import HARDWARE_DISCOVERY_SCHEMA, ZhaRadioManager
+from .radio_manager import (
+    HARDWARE_DISCOVERY_SCHEMA,
+    RECOMMENDED_RADIOS,
+    ZhaRadioManager,
+)
 
 CONF_MANUAL_PATH = "Enter Manually"
 SUPPORTED_PORT_SETTINGS = (
@@ -192,7 +196,7 @@ class BaseZhaFlow(FlowHandler):
                 else ""
             )
 
-            return await self.async_step_choose_formation_strategy()
+            return await self.async_step_verify_radio()
 
         # Pre-select the currently configured port
         default_port = vol.UNDEFINED
@@ -252,7 +256,7 @@ class BaseZhaFlow(FlowHandler):
             self._radio_mgr.device_settings = user_input.copy()
 
             if await self._radio_mgr.radio_type.controller.probe(user_input):
-                return await self.async_step_choose_formation_strategy()
+                return await self.async_step_verify_radio()
 
             errors["base"] = "cannot_connect"
 
@@ -287,6 +291,23 @@ class BaseZhaFlow(FlowHandler):
             step_id="manual_port_config",
             data_schema=vol.Schema(schema),
             errors=errors,
+        )
+
+    async def async_step_verify_radio(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Add a warning step to dissuade the use of deprecated radios."""
+        assert self._radio_mgr.radio_type is not None
+
+        # Skip this step if we are using a recommended radio
+        if user_input is not None or self._radio_mgr.radio_type in RECOMMENDED_RADIOS:
+            return await self.async_step_choose_formation_strategy()
+
+        return self.async_show_form(
+            step_id="verify_radio",
+            description_placeholders={
+                CONF_NAME: self._radio_mgr.radio_type.description
+            },
         )
 
     async def async_step_choose_formation_strategy(
@@ -516,7 +537,7 @@ class ZhaConfigFlowHandler(BaseZhaFlow, config_entries.ConfigFlow, domain=DOMAIN
             if self._radio_mgr.device_settings is None:
                 return await self.async_step_manual_port_config()
 
-            return await self.async_step_choose_formation_strategy()
+            return await self.async_step_verify_radio()
 
         return self.async_show_form(
             step_id="confirm",

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -306,7 +306,10 @@ class BaseZhaFlow(FlowHandler):
         return self.async_show_form(
             step_id="verify_radio",
             description_placeholders={
-                CONF_NAME: self._radio_mgr.radio_type.description
+                CONF_NAME: self._radio_mgr.radio_type.description,
+                "docs_recommended_adapters_url": (
+                    "https://www.home-assistant.io/integrations/zha/#recommended-zigbee-radio-adapters-and-modules"
+                ),
             },
         )
 

--- a/homeassistant/components/zha/radio_manager.py
+++ b/homeassistant/components/zha/radio_manager.py
@@ -40,6 +40,12 @@ AUTOPROBE_RADIOS = (
     RadioType.zigate,
 )
 
+RECOMMENDED_RADIOS = (
+    RadioType.ezsp,
+    RadioType.znp,
+    RadioType.deconz,
+)
+
 CONNECT_DELAY_S = 1.0
 
 MIGRATION_RETRIES = 100

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -29,7 +29,7 @@
       },
       "verify_radio": {
         "title": "Radio is not recommended",
-        "description": "The radio you are using ({name}) is not recommended and support for it may be removed in the future. Please see the Zigbee Home Automation integration's documentation for [a list of recommended adapters](https://www.home-assistant.io/integrations/zha/#recommended-zigbee-radio-adapters-and-modules)."
+        "description": "The radio you are using ({name}) is not recommended and support for it may be removed in the future. Please see the Zigbee Home Automation integration's documentation for [a list of recommended adapters]({docs_recommended_adapters_url})."
       },
       "choose_formation_strategy": {
         "title": "Network Formation",

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -27,6 +27,10 @@
           "flow_control": "data flow control"
         }
       },
+      "verify_radio": {
+        "title": "Radio is not recommended",
+        "description": "The radio you are using ({name}) is not recommended and support for it may be removed in the future. Please see the Zigbee Home Automation integration's documentation for [a list of recommended adapters](https://www.home-assistant.io/integrations/zha/#recommended-zigbee-radio-adapters-and-modules)."
+      },
       "choose_formation_strategy": {
         "title": "Network Formation",
         "description": "Choose the network settings for your radio.",
@@ -115,6 +119,10 @@
           "baudrate": "[%key:component::zha::config::step::manual_port_config::data::baudrate%]",
           "flow_control": "[%key:component::zha::config::step::manual_port_config::data::flow_control%]"
         }
+      },
+      "verify_radio": {
+        "title": "[%key:component::zha::config::step::verify_radio::title%]",
+        "description": "[%key:component::zha::config::step::verify_radio::description%]"
       },
       "choose_formation_strategy": {
         "title": "[%key:component::zha::config::step::choose_formation_strategy::title%]",

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -191,23 +191,30 @@ async def test_zigate_via_zeroconf(setup_entry_mock, hass: HomeAssistant) -> Non
     )
     assert result1["step_id"] == "manual_port_config"
 
-    # Confirm port settings
+    # Confirm the radio is deprecated
     result2 = await hass.config_entries.flow.async_configure(
+        flow["flow_id"], user_input={}
+    )
+    assert result2["step_id"] == "verify_radio"
+    assert "ZiGate" in result2["description_placeholders"]["name"]
+
+    # Confirm port settings
+    result3 = await hass.config_entries.flow.async_configure(
         result1["flow_id"], user_input={}
     )
 
-    assert result2["type"] == FlowResultType.MENU
-    assert result2["step_id"] == "choose_formation_strategy"
+    assert result3["type"] == FlowResultType.MENU
+    assert result3["step_id"] == "choose_formation_strategy"
 
-    result3 = await hass.config_entries.flow.async_configure(
-        result2["flow_id"],
+    result4 = await hass.config_entries.flow.async_configure(
+        result3["flow_id"],
         user_input={"next_step_id": config_flow.FORMATION_REUSE_SETTINGS},
     )
     await hass.async_block_till_done()
 
-    assert result3["type"] == FlowResultType.CREATE_ENTRY
-    assert result3["title"] == "socket://192.168.1.200:1234"
-    assert result3["data"] == {
+    assert result4["type"] == FlowResultType.CREATE_ENTRY
+    assert result4["title"] == "socket://192.168.1.200:1234"
+    assert result4["data"] == {
         CONF_DEVICE: {
             CONF_DEVICE_PATH: "socket://192.168.1.200:1234",
         },
@@ -433,21 +440,26 @@ async def test_zigate_discovery_via_usb(probe_mock, hass: HomeAssistant) -> None
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={}
     )
+    assert result2["step_id"] == "verify_radio"
+
+    result3 = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
+    )
     await hass.async_block_till_done()
 
-    assert result2["type"] == FlowResultType.MENU
-    assert result2["step_id"] == "choose_formation_strategy"
+    assert result3["type"] == FlowResultType.MENU
+    assert result3["step_id"] == "choose_formation_strategy"
 
     with patch("homeassistant.components.zha.async_setup_entry", return_value=True):
-        result3 = await hass.config_entries.flow.async_configure(
-            result2["flow_id"],
+        result4 = await hass.config_entries.flow.async_configure(
+            result3["flow_id"],
             user_input={"next_step_id": config_flow.FORMATION_REUSE_SETTINGS},
         )
         await hass.async_block_till_done()
 
-    assert result3["type"] == FlowResultType.CREATE_ENTRY
-    assert result3["title"] == "zigate radio"
-    assert result3["data"] == {
+    assert result4["type"] == FlowResultType.CREATE_ENTRY
+    assert result4["title"] == "zigate radio"
+    assert result4["data"] == {
         "device": {
             "path": "/dev/ttyZIGBEE",
         },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The XBee and ZiGate Zigbee radios are uncommonly used, missing critical features (backup/restore support, energy scanning, general stability when sending requests), and are difficult to test and maintain. ZHA's documentation does not list them as recommended adapters.

This PR adds a step to ZHA's config flow that warns new users of these radios that they are not recommended and support for them may be dropped in the future. Formal deprecation will happen much later.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
