### PR TITLE
Fix reconfigure by SSDP or Zeroconf discovery in Synology DSM

### DIFF
--- a/homeassistant/components/synology_dsm/config_flow.py
+++ b/homeassistant/components/synology_dsm/config_flow.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from ipaddress import ip_address
 import logging
 from typing import Any, cast
 from urllib.parse import urlparse
@@ -38,6 +37,10 @@ from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import DiscoveryInfoType
+from homeassistant.util.network import (
+    is_ip_address as is_ip,
+    is_ipv4_address as is_ipv4,
+)
 
 from .const import (
     CONF_DEVICE_TOKEN,
@@ -97,14 +100,6 @@ def _ordered_shared_schema(
             default=schema_input.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL),
         ): bool,
     }
-
-
-def _is_valid_ip(text: str) -> bool:
-    try:
-        ip_address(text)
-    except ValueError:
-        return False
-    return True
 
 
 def format_synology_mac(mac: str) -> str:
@@ -284,16 +279,11 @@ class SynologyDSMFlowHandler(ConfigFlow, domain=DOMAIN):
                 break
             self._abort_if_unique_id_configured()
 
-        fqdn_with_ssl_verification = (
-            existing_entry
-            and not _is_valid_ip(existing_entry.data[CONF_HOST])
-            and existing_entry.data[CONF_VERIFY_SSL]
-        )
-
         if (
             existing_entry
+            and is_ip(existing_entry.data[CONF_HOST])
             and existing_entry.data[CONF_HOST] != host
-            and not fqdn_with_ssl_verification
+            and is_ipv4(existing_entry.data[CONF_HOST]) == is_ipv4(host)
         ):
             _LOGGER.info(
                 "Update host from '%s' to '%s' for NAS '%s' via discovery",

--- a/homeassistant/components/synology_dsm/config_flow.py
+++ b/homeassistant/components/synology_dsm/config_flow.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from ipaddress import ip_address as ip
 import logging
 from typing import Any, cast
 from urllib.parse import urlparse
@@ -37,10 +38,7 @@ from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import DiscoveryInfoType
-from homeassistant.util.network import (
-    is_ip_address as is_ip,
-    is_ipv4_address as is_ipv4,
-)
+from homeassistant.util.network import is_ip_address as is_ip
 
 from .const import (
     CONF_DEVICE_TOKEN,
@@ -282,8 +280,9 @@ class SynologyDSMFlowHandler(ConfigFlow, domain=DOMAIN):
         if (
             existing_entry
             and is_ip(existing_entry.data[CONF_HOST])
+            and is_ip(host)
             and existing_entry.data[CONF_HOST] != host
-            and is_ipv4(existing_entry.data[CONF_HOST]) == is_ipv4(host)
+            and ip(existing_entry.data[CONF_HOST]).version == ip(host).version
         ):
             _LOGGER.info(
                 "Update host from '%s' to '%s' for NAS '%s' via discovery",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The automatic reconfiguration of an existing entry will only be done, when
- the current configured host is an ip address (_not hostname/fqdn_)
and
- the current configured ip is of same version as the discovered ip
- the current configured ip is different from the discovered ip

This will avoid accidental updates, which leads to an broken configuration in following cases:
- user has configured an FQDN, so updating with an ip is mostly not wanted
- user has configured an ipv4, but NAS has both ipv4 and ipv6 active
the NAS will always be discovered twice and those reconfigured

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
  - fixes #91668
  - fixes #91499
- This PR is related to issue:
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
