### PR TITLE
Use snapshot in onewire diagnostics tests

### DIFF
--- a/tests/components/onewire/snapshots/test_diagnostics.ambr
+++ b/tests/components/onewire/snapshots/test_diagnostics.ambr
@@ -1,0 +1,41 @@
+# serializer version: 1
+# name: test_entry_diagnostics[EF.111111111113]
+  dict({
+    'devices': list([
+      dict({
+        'device_info': dict({
+          'identifiers': list([
+            list([
+              'onewire',
+              'EF.111111111113',
+            ]),
+          ]),
+          'manufacturer': 'Hobby Boards',
+          'model': 'HB_HUB',
+          'name': 'EF.111111111113',
+        }),
+        'family': 'EF',
+        'id': 'EF.111111111113',
+        'path': '/EF.111111111113/',
+        'type': 'HB_HUB',
+      }),
+    ]),
+    'entry': dict({
+      'data': dict({
+        'host': '**REDACTED**',
+        'port': 1234,
+      }),
+      'options': dict({
+        'device_options': dict({
+          '28.222222222222': dict({
+            'precision': 'temperature9',
+          }),
+          '28.222222222223': dict({
+            'precision': 'temperature5',
+          }),
+        }),
+      }),
+      'title': 'Mock Title',
+    }),
+  })
+# ---

--- a/tests/components/onewire/test_diagnostics.py
+++ b/tests/components/onewire/test_diagnostics.py
@@ -3,8 +3,8 @@ from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
 import pytest
+from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.diagnostics import REDACTED
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
@@ -43,25 +43,14 @@ async def test_entry_diagnostics(
     hass_client: ClientSessionGenerator,
     owproxy: MagicMock,
     device_id: str,
+    snapshot: SnapshotAssertion,
 ) -> None:
     """Test config entry diagnostics."""
     setup_owproxy_mock_devices(owproxy, Platform.SENSOR, [device_id])
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert await get_diagnostics_for_config_entry(hass, hass_client, config_entry) == {
-        "entry": {
-            "data": {
-                "host": REDACTED,
-                "port": 1234,
-            },
-            "options": {
-                "device_options": {
-                    "28.222222222222": {"precision": "temperature9"},
-                    "28.222222222223": {"precision": "temperature5"},
-                }
-            },
-            "title": "Mock Title",
-        },
-        "devices": [DEVICE_DETAILS],
-    }
+    assert (
+        await get_diagnostics_for_config_entry(hass, hass_client, config_entry)
+        == snapshot
+    )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use snapshot in onewire diagnostics tests

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
