### PR TITLE
Bump roborock to 0.8.1 for beta fixes

### DIFF
--- a/homeassistant/components/roborock/config_flow.py
+++ b/homeassistant/components/roborock/config_flow.py
@@ -49,14 +49,11 @@ class RoborockFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             self._client = RoborockApiClient(username)
             try:
                 await self._client.request_code()
-            except RoborockAccountDoesNotExist as ex:
-                _LOGGER.exception(ex)
+            except RoborockAccountDoesNotExist:
                 errors["base"] = "invalid_email"
-            except RoborockUrlException as ex:
-                _LOGGER.exception(ex)
+            except RoborockUrlException:
                 errors["base"] = "unknown_url"
-            except RoborockInvalidEmail as ex:
-                _LOGGER.exception(ex)
+            except RoborockInvalidEmail:
                 errors["base"] = "invalid_email_format"
             except RoborockException as ex:
                 _LOGGER.exception(ex)
@@ -85,8 +82,7 @@ class RoborockFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             _LOGGER.debug("Logging into Roborock account using email provided code")
             try:
                 login_data = await self._client.code_login(code)
-            except RoborockInvalidCode as ex:
-                _LOGGER.exception(ex)
+            except RoborockInvalidCode:
                 errors["base"] = "invalid_code"
             except RoborockException as ex:
                 _LOGGER.exception(ex)

--- a/homeassistant/components/roborock/coordinator.py
+++ b/homeassistant/components/roborock/coordinator.py
@@ -13,7 +13,7 @@ from roborock.containers import (
 )
 from roborock.exceptions import RoborockException
 from roborock.local_api import RoborockLocalClient
-from roborock.typing import RoborockDeviceProp
+from roborock.typing import DeviceProp
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -26,9 +26,7 @@ SCAN_INTERVAL = timedelta(seconds=30)
 _LOGGER = logging.getLogger(__name__)
 
 
-class RoborockDataUpdateCoordinator(
-    DataUpdateCoordinator[dict[str, RoborockDeviceProp]]
-):
+class RoborockDataUpdateCoordinator(DataUpdateCoordinator[dict[str, DeviceProp]]):
     """Class to manage fetching data from the API."""
 
     def __init__(
@@ -50,7 +48,7 @@ class RoborockDataUpdateCoordinator(
                 device,
                 networking,
                 product_info[device.product_id],
-                RoborockDeviceProp(),
+                DeviceProp(),
             )
             local_devices_info[device.duid] = RoborockLocalDeviceInfo(
                 device, networking
@@ -71,7 +69,7 @@ class RoborockDataUpdateCoordinator(
             else:
                 device_info.props = device_prop
 
-    async def _async_update_data(self) -> dict[str, RoborockDeviceProp]:
+    async def _async_update_data(self) -> dict[str, DeviceProp]:
         """Update data via library."""
         try:
             await asyncio.gather(

--- a/homeassistant/components/roborock/manifest.json
+++ b/homeassistant/components/roborock/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/roborock",
   "iot_class": "local_polling",
   "loggers": ["roborock"],
-  "requirements": ["python-roborock==0.6.5"]
+  "requirements": ["python-roborock==0.8.1"]
 }

--- a/homeassistant/components/roborock/models.py
+++ b/homeassistant/components/roborock/models.py
@@ -2,7 +2,7 @@
 from dataclasses import dataclass
 
 from roborock.containers import HomeDataDevice, HomeDataProduct, NetworkInfo
-from roborock.typing import RoborockDeviceProp
+from roborock.typing import DeviceProp
 
 
 @dataclass
@@ -12,4 +12,4 @@ class RoborockHassDeviceInfo:
     device: HomeDataDevice
     network_info: NetworkInfo
     product: HomeDataProduct
-    props: RoborockDeviceProp
+    props: DeviceProp

--- a/homeassistant/components/roborock/strings.json
+++ b/homeassistant/components/roborock/strings.json
@@ -17,6 +17,9 @@
     "error": {
       "invalid_code": "The code you entered was incorrect, please check it and try again.",
       "invalid_email": "There is no account associated with the email you entered, please try again.",
+      "invalid_email_format": "There is an issue with the formatting of your email - please try again.",
+      "unknown_roborock": "There was an unknown roborock exception - please check your logs.",
+      "unknown_url": "There was an issue determining the correct url for your roborock account - please check your logs.",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2108,7 +2108,7 @@ python-qbittorrent==0.4.2
 python-ripple-api==0.0.3
 
 # homeassistant.components.roborock
-python-roborock==0.6.5
+python-roborock==0.8.1
 
 # homeassistant.components.smarttub
 python-smarttub==0.0.33

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1516,7 +1516,7 @@ python-picnic-api==1.1.0
 python-qbittorrent==0.4.2
 
 # homeassistant.components.roborock
-python-roborock==0.6.5
+python-roborock==0.8.1
 
 # homeassistant.components.smarttub
 python-smarttub==0.0.33

--- a/tests/components/roborock/mock_data.py
+++ b/tests/components/roborock/mock_data.py
@@ -10,7 +10,7 @@ from roborock.containers import (
     Status,
     UserData,
 )
-from roborock.typing import RoborockDeviceProp
+from roborock.typing import DeviceProp
 
 # All data is based on a U.S. customer with a Roborock S7 MaxV Ultra
 USER_EMAIL = "user@domain.com"
@@ -367,4 +367,4 @@ STATUS = Status.from_dict(
     }
 )
 
-PROP = RoborockDeviceProp(STATUS, DND_TIMER, CLEAN_SUMMARY, CONSUMABLE, CLEAN_RECORD)
+PROP = DeviceProp(STATUS, DND_TIMER, CLEAN_SUMMARY, CONSUMABLE, CLEAN_RECORD)

--- a/tests/components/roborock/test_config_flow.py
+++ b/tests/components/roborock/test_config_flow.py
@@ -2,7 +2,13 @@
 from unittest.mock import patch
 
 import pytest
-from roborock.exceptions import RoborockException
+from roborock.exceptions import (
+    RoborockAccountDoesNotExist,
+    RoborockException,
+    RoborockInvalidCode,
+    RoborockInvalidEmail,
+    RoborockUrlException,
+)
 
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.roborock.const import CONF_ENTRY_CODE, DOMAIN
@@ -55,7 +61,10 @@ async def test_config_flow_success(
         "request_code_errors",
     ),
     [
-        (RoborockException(), {"base": "invalid_email"}),
+        (RoborockException(), {"base": "unknown_roborock"}),
+        (RoborockAccountDoesNotExist(), {"base": "invalid_email"}),
+        (RoborockInvalidEmail(), {"base": "invalid_email_format"}),
+        (RoborockUrlException(), {"base": "unknown_url"}),
         (Exception(), {"base": "unknown"}),
     ],
 )
@@ -115,7 +124,8 @@ async def test_config_flow_failures_request_code(
         "code_login_errors",
     ),
     [
-        (RoborockException(), {"base": "invalid_code"}),
+        (RoborockException(), {"base": "unknown_roborock"}),
+        (RoborockInvalidCode(), {"base": "invalid_code"}),
         (Exception(), {"base": "unknown"}),
     ],
 )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bumps the version from 0.6.5 to 0.8.1 

Changelog: https://github.com/humbertogontijo/python-roborock/blob/main/CHANGELOG.md

Summary: 

- fixes missing dock info (not used in core, but when the dataclasses get built if the data is missing it throws an error)
- Improves how the local api works
- adds better error catching for setting up a account
- The rest of the changes are not used in core

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #92104 fixes #92128 fixes #92133
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
