### PR TITLE
Keep expose setting in sync for assist

### DIFF
--- a/homeassistant/components/conversation/__init__.py
+++ b/homeassistant/components/conversation/__init__.py
@@ -93,7 +93,9 @@ CONFIG_SCHEMA = vol.Schema(
 @core.callback
 def _get_agent_manager(hass: HomeAssistant) -> AgentManager:
     """Get the active agent."""
-    return AgentManager(hass)
+    manager = AgentManager(hass)
+    manager.async_setup()
+    return manager
 
 
 @core.callback
@@ -390,7 +392,10 @@ class AgentManager:
         self.hass = hass
         self._agents: dict[str, AbstractConversationAgent] = {}
         self._builtin_agent_init_lock = asyncio.Lock()
-        async_setup_default_agent(hass)
+
+    def async_setup(self) -> None:
+        """Set up the conversation agents."""
+        async_setup_default_agent(self.hass)
 
     async def async_get_agent(
         self, agent_id: str | None = None

--- a/homeassistant/components/conversation/__init__.py
+++ b/homeassistant/components/conversation/__init__.py
@@ -23,7 +23,7 @@ from homeassistant.util import language as language_util
 
 from .agent import AbstractConversationAgent, ConversationInput, ConversationResult
 from .const import HOME_ASSISTANT_AGENT
-from .default_agent import DefaultAgent
+from .default_agent import DefaultAgent, async_setup as async_setup_default_agent
 
 __all__ = [
     "DOMAIN",
@@ -389,7 +389,8 @@ class AgentManager:
         """Initialize the conversation agents."""
         self.hass = hass
         self._agents: dict[str, AbstractConversationAgent] = {}
-        self._default_agent_init_lock = asyncio.Lock()
+        self._builtin_agent_init_lock = asyncio.Lock()
+        async_setup_default_agent(hass)
 
     async def async_get_agent(
         self, agent_id: str | None = None
@@ -402,7 +403,7 @@ class AgentManager:
             if self._builtin_agent is not None:
                 return self._builtin_agent
 
-            async with self._default_agent_init_lock:
+            async with self._builtin_agent_init_lock:
                 if self._builtin_agent is not None:
                     return self._builtin_agent
 

--- a/tests/components/conversation/test_default_agent.py
+++ b/tests/components/conversation/test_default_agent.py
@@ -4,6 +4,9 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant.components import conversation
+from homeassistant.components.homeassistant.exposed_entities import (
+    async_get_assistant_settings,
+)
 from homeassistant.const import ATTR_FRIENDLY_NAME
 from homeassistant.core import DOMAIN as HASS_DOMAIN, Context, HomeAssistant
 from homeassistant.helpers import (
@@ -137,3 +140,34 @@ async def test_conversation_agent(
         return_value={"homeassistant": ["dwarvish", "elvish", "entish"]},
     ):
         assert agent.supported_languages == ["dwarvish", "elvish", "entish"]
+
+
+async def test_expose_flag_automatically_set(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test DefaultAgent sets the expose flag on all entities automatically."""
+    assert await async_setup_component(hass, "homeassistant", {})
+
+    light = entity_registry.async_get_or_create("light", "demo", "1234")
+    test = entity_registry.async_get_or_create("test", "demo", "1234")
+
+    assert async_get_assistant_settings(hass, conversation.DOMAIN) == {}
+
+    assert await async_setup_component(hass, "conversation", {})
+    await hass.async_block_till_done()
+
+    # After setting up conversation, the expose flag should now be set on all entities
+    assert async_get_assistant_settings(hass, conversation.DOMAIN) == {
+        light.entity_id: {"should_expose": True},
+        test.entity_id: {"should_expose": False},
+    }
+
+    # New entities will automatcially have the expose flag set
+    new_light = entity_registry.async_get_or_create("light", "demo", "2345")
+    await hass.async_block_till_done()
+    assert async_get_assistant_settings(hass, conversation.DOMAIN) == {
+        light.entity_id: {"should_expose": True},
+        new_light.entity_id: {"should_expose": True},
+        test.entity_id: {"should_expose": False},
+    }

--- a/tests/components/conversation/test_default_agent.py
+++ b/tests/components/conversation/test_default_agent.py
@@ -163,7 +163,7 @@ async def test_expose_flag_automatically_set(
         test.entity_id: {"should_expose": False},
     }
 
-    # New entities will automatcially have the expose flag set
+    # New entities will automatically have the expose flag set
     new_light = entity_registry.async_get_or_create("light", "demo", "2345")
     await hass.async_block_till_done()
     assert async_get_assistant_settings(hass, conversation.DOMAIN) == {

--- a/tests/components/mobile_app/test_webhook.py
+++ b/tests/components/mobile_app/test_webhook.py
@@ -18,6 +18,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.setup import async_setup_component
 
 from .const import CALL_SERVICE, FIRE_EVENT, REGISTER_CLEARTEXT, RENDER_TEMPLATE, UPDATE
 
@@ -26,6 +27,12 @@ from tests.components.conversation.conftest import mock_agent
 
 # To avoid autoflake8 removing the import
 mock_agent = mock_agent
+
+
+@pytest.fixture
+async def homeassistant(hass):
+    """Load the homeassistant integration."""
+    await async_setup_component(hass, "homeassistant", {})
 
 
 def encrypt_payload(secret_key, payload, encode_json=True):
@@ -1014,7 +1021,7 @@ async def test_reregister_sensor(
 
 
 async def test_webhook_handle_conversation_process(
-    hass: HomeAssistant, create_registrations, webhook_client, mock_agent
+    hass: HomeAssistant, homeassistant, create_registrations, webhook_client, mock_agent
 ) -> None:
     """Test that we can converse."""
     webhook_client.server.app.router._frozen = False


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Keep expose setting in sync for assist by:
- Iterate over all entities when the conversation manager is setup and set the expose flag for the built-in conversation agent automatically
- Set the expose flag for the built-in conversation engine automatically on newly created entities

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
