### PR TITLE
Add as_dict cache to Context and Event

### DIFF
--- a/homeassistant/components/homeassistant/triggers/event.py
+++ b/homeassistant/components/homeassistant/triggers/event.py
@@ -91,7 +91,7 @@ async def async_attach_trigger(
             if event_data_schema:
                 event_data_schema(event.data)
             if event_context_schema:
-                event_context_schema(event.context.as_dict())
+                event_context_schema(dict(event.context.as_dict()))
         except vol.Invalid:
             # If event doesn't match, skip event
             return False

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -850,7 +850,7 @@ class HomeAssistant:
 class Context:
     """The context that triggered something."""
 
-    __slots__ = ("user_id", "parent_id", "id", "origin_event")
+    __slots__ = ("user_id", "parent_id", "id", "origin_event", "_as_dict")
 
     def __init__(
         self,
@@ -863,6 +863,7 @@ class Context:
         self.user_id = user_id
         self.parent_id = parent_id
         self.origin_event: Event | None = None
+        self._as_dict: dict[str, str | None] | None = None
 
     def __eq__(self, other: Any) -> bool:
         """Compare contexts."""
@@ -870,7 +871,13 @@ class Context:
 
     def as_dict(self) -> dict[str, str | None]:
         """Return a dictionary representation of the context."""
-        return {"id": self.id, "parent_id": self.parent_id, "user_id": self.user_id}
+        if not self._as_dict:
+            self._as_dict = {
+                "id": self.id,
+                "parent_id": self.parent_id,
+                "user_id": self.user_id,
+            }
+        return self._as_dict
 
 
 class EventOrigin(enum.Enum):
@@ -887,7 +894,7 @@ class EventOrigin(enum.Enum):
 class Event:
     """Representation of an event within the bus."""
 
-    __slots__ = ["event_type", "data", "origin", "time_fired", "context"]
+    __slots__ = ("event_type", "data", "origin", "time_fired", "context", "_as_dict")
 
     def __init__(
         self,
@@ -905,19 +912,22 @@ class Event:
         self.context: Context = context or Context(
             id=ulid_util.ulid_at_time(dt_util.utc_to_timestamp(self.time_fired))
         )
+        self._as_dict: dict[str, Any] | None = None
 
     def as_dict(self) -> dict[str, Any]:
         """Create a dict representation of this Event.
 
         Async friendly.
         """
-        return {
-            "event_type": self.event_type,
-            "data": dict(self.data),
-            "origin": str(self.origin.value),
-            "time_fired": self.time_fired.isoformat(),
-            "context": self.context.as_dict(),
-        }
+        if not self._as_dict:
+            self._as_dict = {
+                "event_type": self.event_type,
+                "data": dict(self.data),
+                "origin": str(self.origin.value),
+                "time_fired": self.time_fired.isoformat(),
+                "context": self.context.as_dict(),
+            }
+        return self._as_dict
 
     def __repr__(self) -> str:
         """Return the representation."""
@@ -1189,7 +1199,7 @@ class State:
     object_id: Object id of this state.
     """
 
-    __slots__ = [
+    __slots__ = (
         "entity_id",
         "state",
         "attributes",
@@ -1200,7 +1210,7 @@ class State:
         "object_id",
         "_as_dict",
         "_as_compressed_state",
-    ]
+    )
 
     def __init__(
         self,

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -863,20 +863,22 @@ class Context:
         self.user_id = user_id
         self.parent_id = parent_id
         self.origin_event: Event | None = None
-        self._as_dict: dict[str, str | None] | None = None
+        self._as_dict: ReadOnlyDict[str, str | None] | None = None
 
     def __eq__(self, other: Any) -> bool:
         """Compare contexts."""
         return bool(self.__class__ == other.__class__ and self.id == other.id)
 
-    def as_dict(self) -> dict[str, str | None]:
+    def as_dict(self) -> ReadOnlyDict[str, str | None]:
         """Return a dictionary representation of the context."""
         if not self._as_dict:
-            self._as_dict = {
-                "id": self.id,
-                "parent_id": self.parent_id,
-                "user_id": self.user_id,
-            }
+            self._as_dict = ReadOnlyDict(
+                {
+                    "id": self.id,
+                    "parent_id": self.parent_id,
+                    "user_id": self.user_id,
+                }
+            )
         return self._as_dict
 
 
@@ -912,21 +914,23 @@ class Event:
         self.context: Context = context or Context(
             id=ulid_util.ulid_at_time(dt_util.utc_to_timestamp(self.time_fired))
         )
-        self._as_dict: dict[str, Any] | None = None
+        self._as_dict: ReadOnlyDict[str, Any] | None = None
 
-    def as_dict(self) -> dict[str, Any]:
+    def as_dict(self) -> ReadOnlyDict[str, Any]:
         """Create a dict representation of this Event.
 
         Async friendly.
         """
         if not self._as_dict:
-            self._as_dict = {
-                "event_type": self.event_type,
-                "data": dict(self.data),
-                "origin": str(self.origin.value),
-                "time_fired": self.time_fired.isoformat(),
-                "context": self.context.as_dict(),
-            }
+            self._as_dict = ReadOnlyDict(
+                {
+                    "event_type": self.event_type,
+                    "data": dict(self.data),
+                    "origin": str(self.origin.value),
+                    "time_fired": self.time_fired.isoformat(),
+                    "context": self.context.as_dict(),
+                }
+            )
         return self._as_dict
 
     def __repr__(self) -> str:

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -925,7 +925,7 @@ class Event:
             self._as_dict = ReadOnlyDict(
                 {
                     "event_type": self.event_type,
-                    "data": dict(self.data),
+                    "data": ReadOnlyDict(self.data),
                     "origin": str(self.origin.value),
                     "time_fired": self.time_fired.isoformat(),
                     "context": self.context.as_dict(),
@@ -1279,7 +1279,7 @@ class State:
                     "attributes": self.attributes,
                     "last_changed": last_changed_isoformat,
                     "last_updated": last_updated_isoformat,
-                    "context": ReadOnlyDict(self.context.as_dict()),
+                    "context": self.context.as_dict(),
                 }
             )
         return self._as_dict

--- a/tests/components/recorder/test_models.py
+++ b/tests/components/recorder/test_models.py
@@ -256,7 +256,9 @@ async def test_event_to_db_model() -> None:
     assert native.as_dict() == event.as_dict()
 
     native = Events.from_event(event).to_native()
-    event.data = {}
+    native.data = (
+        event.data
+    )  # data is not set by from_event as its in the event_data table
     native.event_type = event.event_type
     assert native.as_dict() == event.as_dict()
 


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
We had this for States but we never added it to Event or Context. When profiling I was looking at number of `dict` constructions realized it was missing  for these classes.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
