### PR TITLE
Merge pending MQTT subscribes to a single call to the paho client

### DIFF
--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -898,22 +898,13 @@ class MQTT:
             )
 
 
-def _raise_on_errors(result_codes: Iterable[int]) -> None:
+def _raise_on_error(result_code: int) -> None:
     """Raise error if error result."""
     # pylint: disable-next=import-outside-toplevel
     import paho.mqtt.client as mqtt
 
-    if messages := [
-        mqtt.error_string(result_code)
-        for result_code in result_codes
-        if result_code != 0
-    ]:
-        raise HomeAssistantError(f"Error talking to MQTT: {', '.join(messages)}")
-
-
-def _raise_on_error(result_code: int) -> None:
-    """Raise error if error result."""
-    _raise_on_errors((result_code,))
+    if result_code and (message := mqtt.error_string(result_code)):
+        raise HomeAssistantError(f"Error talking to MQTT: {message}")
 
 
 def _matcher_for_topic(subscription: str) -> Any:

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -662,15 +662,12 @@ class MQTT:
         subscriptions: dict[str, int] = self._pending_subscriptions
         self._pending_subscriptions = {}
 
-        def _process_client_subscriptions() -> tuple[int, int]:
-            """Initiate all subscriptions on the MQTT client and return the results."""
-            result, mid = self._mqttc.subscribe(list(subscriptions.items()))
-            return result, mid
-
         async with self._paho_lock:
+            subscription_list = list(subscriptions.items())
             result, mid = await self.hass.async_add_executor_job(
-                _process_client_subscriptions
+                self._mqttc.subscribe, subscription_list
             )
+
         for topic, qos in subscriptions.items():
             _LOGGER.debug("Subscribing to %s, mid: %s, qos: %s", topic, mid, qos)
         self._last_subscribe = time.time()

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -664,17 +664,15 @@ class MQTT:
 
         def _process_client_subscriptions() -> tuple[int, int]:
             """Initiate all subscriptions on the MQTT client and return the results."""
-            subscribe_result_list: list[tuple[int, int]] = []
             result, mid = self._mqttc.subscribe(list(subscriptions.items()))
-            subscribe_result_list.append((result, mid))
-            for topic, qos in subscriptions.items():
-                _LOGGER.debug("Subscribing to %s, mid: %s, qos: %s", topic, mid, qos)
             return result, mid
 
         async with self._paho_lock:
             result, mid = await self.hass.async_add_executor_job(
                 _process_client_subscriptions
             )
+        for topic, qos in subscriptions.items():
+            _LOGGER.debug("Subscribing to %s, mid: %s, qos: %s", topic, mid, qos)
         self._last_subscribe = time.time()
 
         if result == 0:

--- a/tests/components/mqtt/test_common.py
+++ b/tests/components/mqtt/test_common.py
@@ -73,6 +73,15 @@ _StateDataType = list[tuple[_MqttMessageType, str | None, _AttributesType | None
 MQTT_YAML_SCHEMA = vol.Schema({mqtt.DOMAIN: PLATFORM_CONFIG_SCHEMA_BASE})
 
 
+def help_all_subscribe_calls(mqtt_client_mock: MqttMockPahoClient) -> list[Any]:
+    """Test of a call."""
+    all_calls = []
+    for calls in mqtt_client_mock.subscribe.mock_calls:
+        for call in calls[1]:
+            all_calls.extend(call)
+    return all_calls
+
+
 def help_test_validate_platform_config(
     hass: HomeAssistant, config: ConfigType
 ) -> ConfigType | None:

--- a/tests/components/mqtt/test_discovery.py
+++ b/tests/components/mqtt/test_discovery.py
@@ -28,7 +28,7 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.service_info.mqtt import MqttServiceInfo
 from homeassistant.setup import async_setup_component
 
-from .test_common import help_test_unload_config_entry
+from .test_common import help_all_subscribe_calls, help_test_unload_config_entry
 
 from tests.common import (
     MockConfigEntry,
@@ -1396,7 +1396,7 @@ async def test_mqtt_integration_discovery_subscribe_unsubscribe(
         await hass.async_block_till_done()
         await hass.async_block_till_done()
 
-    mqtt_client_mock.subscribe.assert_any_call("comp/discovery/#", 0)
+    assert ("comp/discovery/#", 0) in help_all_subscribe_calls(mqtt_client_mock)
     assert not mqtt_client_mock.unsubscribe.called
 
     class TestFlow(config_entries.ConfigFlow):
@@ -1407,7 +1407,7 @@ async def test_mqtt_integration_discovery_subscribe_unsubscribe(
             return self.async_abort(reason="already_configured")
 
     with patch.dict(config_entries.HANDLERS, {"comp": TestFlow}):
-        mqtt_client_mock.subscribe.assert_any_call("comp/discovery/#", 0)
+        assert ("comp/discovery/#", 0) in help_all_subscribe_calls(mqtt_client_mock)
         assert not mqtt_client_mock.unsubscribe.called
 
         async_fire_mqtt_message(hass, "comp/discovery/bla/config", "")
@@ -1443,7 +1443,7 @@ async def test_mqtt_discovery_unsubscribe_once(
         await hass.async_block_till_done()
         await hass.async_block_till_done()
 
-    mqtt_client_mock.subscribe.assert_any_call("comp/discovery/#", 0)
+    assert ("comp/discovery/#", 0) in help_all_subscribe_calls(mqtt_client_mock)
     assert not mqtt_client_mock.unsubscribe.called
 
     class TestFlow(config_entries.ConfigFlow):

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -36,7 +36,7 @@ from homeassistant.helpers.typing import ConfigType
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
-from .test_common import help_test_validate_platform_config
+from .test_common import help_all_subscribe_calls, help_test_validate_platform_config
 
 from tests.common import (
     MockConfigEntry,
@@ -1342,16 +1342,16 @@ async def test_unsubscribe_race(
     # We allow either calls [subscribe, unsubscribe, subscribe], [subscribe, subscribe] or
     # when both subscriptions were combined [subscribe]
     expected_calls_1 = [
-        call.subscribe("test/state", 0),
+        call.subscribe([("test/state", 0)]),
         call.unsubscribe("test/state"),
-        call.subscribe("test/state", 0),
+        call.subscribe([("test/state", 0)]),
     ]
     expected_calls_2 = [
-        call.subscribe("test/state", 0),
-        call.subscribe("test/state", 0),
+        call.subscribe([("test/state", 0)]),
+        call.subscribe([("test/state", 0)]),
     ]
     expected_calls_3 = [
-        call.subscribe("test/state", 0),
+        call.subscribe([("test/state", 0)]),
     ]
     assert mqtt_client_mock.mock_calls in (
         expected_calls_1,
@@ -1418,7 +1418,7 @@ async def test_restore_all_active_subscriptions_on_reconnect(
 
     # the subscribtion with the highest QoS should survive
     expected = [
-        call("test/state", 2),
+        call([("test/state", 2)]),
     ]
     assert mqtt_client_mock.subscribe.mock_calls == expected
 
@@ -1432,7 +1432,7 @@ async def test_restore_all_active_subscriptions_on_reconnect(
     async_fire_time_changed(hass, utcnow() + timedelta(seconds=3))  # cooldown
     await hass.async_block_till_done()
 
-    expected.append(call("test/state", 1))
+    expected.append(call([("test/state", 1)]))
     assert mqtt_client_mock.subscribe.mock_calls == expected
 
     async_fire_time_changed(hass, utcnow() + timedelta(seconds=3))  # cooldown
@@ -1463,9 +1463,7 @@ async def test_subscribed_at_highest_qos(
     await hass.async_block_till_done()
     async_fire_time_changed(hass, utcnow() + timedelta(seconds=5))  # cooldown
     await hass.async_block_till_done()
-    assert mqtt_client_mock.subscribe.mock_calls == [
-        call("test/state", 0),
-    ]
+    assert ("test/state", 0) in help_all_subscribe_calls(mqtt_client_mock)
     mqtt_client_mock.reset_mock()
     async_fire_time_changed(hass, utcnow() + timedelta(seconds=5))  # cooldown
     await hass.async_block_till_done()
@@ -1477,9 +1475,7 @@ async def test_subscribed_at_highest_qos(
     async_fire_time_changed(hass, utcnow() + timedelta(seconds=5))  # cooldown
     await hass.async_block_till_done()
     # the subscribtion with the highest QoS should survive
-    assert mqtt_client_mock.subscribe.mock_calls == [
-        call("test/state", 2),
-    ]
+    assert help_all_subscribe_calls(mqtt_client_mock) == [("test/state", 2)]
 
 
 async def test_reload_entry_with_restored_subscriptions(
@@ -2224,10 +2220,11 @@ async def test_mqtt_subscribes_topics_on_connect(
 
     assert mqtt_client_mock.disconnect.call_count == 0
 
-    assert mqtt_client_mock.subscribe.call_count == 3
-    mqtt_client_mock.subscribe.assert_any_call("topic/test", 0)
-    mqtt_client_mock.subscribe.assert_any_call("home/sensor", 2)
-    mqtt_client_mock.subscribe.assert_any_call("still/pending", 1)
+    subscribe_calls = help_all_subscribe_calls(mqtt_client_mock)
+    assert len(subscribe_calls) == 3
+    assert ("topic/test", 0) in subscribe_calls
+    assert ("home/sensor", 2) in subscribe_calls
+    assert ("still/pending", 1) in subscribe_calls
 
 
 async def test_default_entry_setting_are_applied(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Merge MQTT subscribes in one call to the Paho client. This gains performance during startup. As similar tweak could be done for client unsubscribes.

See also: #92201

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
