### PR TITLE
Fix lingering timer in feedreader

### DIFF
--- a/homeassistant/components/feedreader/__init__.py
+++ b/homeassistant/components/feedreader/__init__.py
@@ -93,7 +93,12 @@ class FeedManager:
 
     def _init_regular_updates(self, hass: HomeAssistant) -> None:
         """Schedule regular updates at the top of the clock."""
-        track_time_interval(hass, lambda now: self._update(), self._scan_interval)
+        track_time_interval(
+            hass,
+            lambda now: self._update(),
+            self._scan_interval,
+            cancel_on_shutdown=True,
+        )
 
     @property
     def last_update_successful(self) -> bool:

--- a/tests/components/feedreader/test_init.py
+++ b/tests/components/feedreader/test_init.py
@@ -85,7 +85,9 @@ async def test_setup_one_feed(hass: HomeAssistant) -> None:
         assert await async_setup_component(hass, feedreader.DOMAIN, VALID_CONFIG_1)
         await hass.async_block_till_done()
 
-        track_method.assert_called_once_with(hass, mock.ANY, DEFAULT_SCAN_INTERVAL)
+        track_method.assert_called_once_with(
+            hass, mock.ANY, DEFAULT_SCAN_INTERVAL, cancel_on_shutdown=True
+        )
 
 
 async def test_setup_scan_interval(hass: HomeAssistant) -> None:
@@ -96,7 +98,9 @@ async def test_setup_scan_interval(hass: HomeAssistant) -> None:
         assert await async_setup_component(hass, feedreader.DOMAIN, VALID_CONFIG_2)
         await hass.async_block_till_done()
 
-        track_method.assert_called_once_with(hass, mock.ANY, timedelta(seconds=60))
+        track_method.assert_called_once_with(
+            hass, mock.ANY, timedelta(seconds=60), cancel_on_shutdown=True
+        )
 
 
 async def test_setup_max_entries(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Linked to #91360
https://github.com/home-assistant/core/actions/runs/4829217579/jobs/8604239501?pr=91360

```console
ERROR tests/components/feedreader/test_init.py::test_setup_max_entries - Failed: Lingering timer after job <Job track time interval 1:00:00 <function FeedManager._init_regular_updates.<locals>.<lambda> at 0x7fbce5380ee0> HassJobType.Callback <function async_track_time_interval.<locals>.interval_listener at 0x7fbce53805e0>>
ERROR tests/components/feedreader/test_init.py::test_feed - Failed: Lingering timer after job <Job track time interval 0:01:00 <function FeedManager._init_regular_updates.<locals>.<lambda> at 0x7fbce7d34820> HassJobType.Callback <function async_track_time_interval.<locals>.interval_listener at 0x7fbce76465f0>>
ERROR tests/components/feedreader/test_init.py::test_atom_feed - Failed: Lingering timer after job <Job track time interval 1:00:00 <function FeedManager._init_regular_updates.<locals>.<lambda> at 0x7fbcd3e17d00> HassJobType.Callback <function async_track_time_interval.<locals>.interval_listener at 0x7fbcd3e171c0>>
ERROR tests/components/feedreader/test_init.py::test_feed_updates - Failed: Lingering timer after job <Job track time interval 0:01:00 <function FeedManager._init_regular_updates.<locals>.<lambda> at 0x7fbce747d480> HassJobType.Callback <function async_track_time_interval.<locals>.interval_listener at 0x7fbce747e200>>
ERROR tests/components/feedreader/test_init.py::test_feed_default_max_length - Failed: Lingering timer after job <Job track time interval 0:01:00 <function FeedManager._init_regular_updates.<locals>.<lambda> at 0x7fbce7e91ea0> HassJobType.Callback <function async_track_time_interval.<locals>.interval_listener at 0x7fbce7e93910>>
ERROR tests/components/feedreader/test_init.py::test_feed_max_length - Failed: Lingering timer after job <Job track time interval 1:00:00 <function FeedManager._init_regular_updates.<locals>.<lambda> at 0x7fbce640acb0> HassJobType.Callback <function async_track_time_interval.<locals>.interval_listener at 0x7fbce6408ee0>>
ERROR tests/components/feedreader/test_init.py::test_feed_without_publication_date_and_title - Failed: Lingering timer after job <Job track time interval 0:01:00 <function FeedManager._init_regular_updates.<locals>.<lambda> at 0x7fbcd3c60940> HassJobType.Callback <function async_track_time_interval.<locals>.interval_listener at 0x7fbcd3c60f70>>
ERROR tests/components/feedreader/test_init.py::test_feed_with_unrecognized_publication_date - Failed: Lingering timer after job <Job track time interval 0:01:00 <function FeedManager._init_regular_updates.<locals>.<lambda> at 0x7fbce7adaf80> HassJobType.Callback <function async_track_time_interval.<locals>.interval_listener at 0x7fbce7628790>>
ERROR tests/components/feedreader/test_init.py::test_feed_invalid_data - Failed: Lingering timer after job <Job track time interval 0:01:00 <function FeedManager._init_regular_updates.<locals>.<lambda> at 0x7fbcd8810280> HassJobType.Callback <function async_track_time_interval.<locals>.interval_listener at 0x7fbcd88127a0>>
ERROR tests/components/feedreader/test_init.py::test_feed_parsing_failed - Failed: Lingering timer after job <Job track time interval 0:01:00 <function FeedManager._init_regular_updates.<locals>.<lambda> at 0x7fbce7ef5750> HassJobType.Callback <function async_track_time_interval.<locals>.interval_listener at 0x7fbce7ef7e20>>
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
