### PR TITLE
Fix lingering timer in lifx discovery

### DIFF
--- a/homeassistant/components/lifx/__init__.py
+++ b/homeassistant/components/lifx/__init__.py
@@ -19,7 +19,7 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STARTED,
     Platform,
 )
-from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
+from homeassistant.core import CALLBACK_TYPE, HassJob, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import async_call_later, async_track_time_interval
@@ -125,7 +125,7 @@ class LIFXDiscoveryManager:
             self.migrating,
         )
         self._cancel_discovery = async_track_time_interval(
-            self.hass, self.async_discovery, discovery_interval
+            self.hass, self.async_discovery, discovery_interval, cancel_on_shutdown=True
         )
 
     async def async_discovery(self, *_: Any) -> None:
@@ -174,7 +174,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     # to reduce the risk we miss devices because the event
     # loop is blocked at startup.
     discovery_manager.async_setup_discovery_interval()
-    async_call_later(hass, DISCOVERY_COOLDOWN, _async_delayed_discovery)
+    async_call_later(
+        hass,
+        DISCOVERY_COOLDOWN,
+        HassJob(_async_delayed_discovery, cancel_on_shutdown=True),
+    )
     hass.bus.async_listen_once(
         EVENT_HOMEASSISTANT_STARTED, discovery_manager.async_discovery
     )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Linked to #91360

```console
FAILED tests/components/lifx/test_select.py::test_set_infrared_brightness_50_percent - Failed: Lingering timer after job <Job track time interval 0:15:00 <bound method LIFXDiscoveryManager.async_discovery of <homeassistant.components.lifx.LIFXDiscoveryManager object at ...
FAILED tests/components/lifx/test_select.py::test_set_infrared_brightness_100_percent - Failed: Lingering timer after job <Job track time interval 0:15:00 <bound method LIFXDiscoveryManager.async_discovery of <homeassistant.components.lifx.LIFXDiscoveryManager object at ...
FAILED tests/components/lifx/test_select.py::test_disable_infrared - Failed: Lingering timer after job <Job track time interval 0:15:00 <bound method LIFXDiscoveryManager.async_discovery of <homeassistant.components.lifx.LIFXDiscoveryManager object at ...
FAILED tests/components/lifx/test_select.py::test_invalid_infrared_brightness - Failed: Lingering timer after job <Job track time interval 0:15:00 <bound method LIFXDiscoveryManager.async_discovery of <homeassistant.components.lifx.LIFXDiscoveryManager object at ...
FAILED tests/components/lifx/test_sensor.py::test_rssi_sensor - Failed: Lingering timer after job <Job track time interval 0:15:00 <bound method LIFXDiscoveryManager.async_discovery of <homeassistant.components.lifx.LIFXDiscoveryManager object at ...
FAILED tests/components/lifx/test_sensor.py::test_rssi_sensor_old_firmware - Failed: Lingering timer after job <Job track time interval 0:15:00 <bound method LIFXDiscoveryManager.async_discovery of <homeassistant.components.lifx.LIFXDiscoveryManager object at ...
```
and
```console
FAILED tests/components/lifx/test_init.py::test_get_version_fails - Failed: Lingering timer after job <Job call_later 5 HassJobType.Callback <function async_setup.<locals>._async_delayed_discovery at 0x7ff4083d8ca0>>
FAILED tests/components/lifx/test_init.py::test_dns_error_at_startup - Failed: Lingering timer after job <Job call_later 5 HassJobType.Callback <function async_setup.<locals>._async_delayed_discovery at 0x7ff4090c4b80>>
FAILED tests/components/lifx/test_light.py::test_light_unique_id - Failed: Lingering timer after job <Job call_later 5 HassJobType.Callback <function async_setup.<locals>._async_delayed_discovery at 0x7ff403ffa170>>
FAILED tests/components/lifx/test_light.py::test_light_unique_id_new_firmware - Failed: Lingering timer after job <Job call_later 5 HassJobType.Callback <function async_setup.<locals>._async_delayed_discovery at 0x7ff4082c4790>>
```
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
