### PR TITLE
Improve exception handling for BMW remote services

### DIFF
--- a/homeassistant/components/bmw_connected_drive/button.py
+++ b/homeassistant/components/bmw_connected_drive/button.py
@@ -116,7 +116,7 @@ class BMWButton(BMWBaseEntity, ButtonEntity):
             try:
                 await self.entity_description.remote_function(self.vehicle)
             except MyBMWAPIError as ex:
-                raise HomeAssistantError(str(ex)) from ex
+                raise HomeAssistantError(ex) from ex
         elif self.entity_description.account_function:
             _LOGGER.warning(
                 "The 'Refresh from cloud' button is deprecated. Use the"
@@ -128,6 +128,6 @@ class BMWButton(BMWBaseEntity, ButtonEntity):
             try:
                 await self.entity_description.account_function(self.coordinator)
             except MyBMWAPIError as ex:
-                raise HomeAssistantError(str(ex)) from ex
+                raise HomeAssistantError(ex) from ex
 
         self.coordinator.async_update_listeners()

--- a/homeassistant/components/bmw_connected_drive/button.py
+++ b/homeassistant/components/bmw_connected_drive/button.py
@@ -6,12 +6,14 @@ from dataclasses import dataclass
 import logging
 from typing import TYPE_CHECKING, Any
 
+from bimmer_connected.models import MyBMWAPIError
 from bimmer_connected.vehicle import MyBMWVehicle
 from bimmer_connected.vehicle.remote_services import RemoteServiceStatus
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import BMWBaseEntity
@@ -111,7 +113,10 @@ class BMWButton(BMWBaseEntity, ButtonEntity):
     async def async_press(self) -> None:
         """Press the button."""
         if self.entity_description.remote_function:
-            await self.entity_description.remote_function(self.vehicle)
+            try:
+                await self.entity_description.remote_function(self.vehicle)
+            except MyBMWAPIError as ex:
+                raise HomeAssistantError(str(ex)) from ex
         elif self.entity_description.account_function:
             _LOGGER.warning(
                 "The 'Refresh from cloud' button is deprecated. Use the"
@@ -120,6 +125,9 @@ class BMWButton(BMWBaseEntity, ButtonEntity):
                 " https://www.home-assistant.io/integrations/bmw_connected_drive/#update-the-state--refresh-from-api"
                 " for details"
             )
-            await self.entity_description.account_function(self.coordinator)
+            try:
+                await self.entity_description.account_function(self.coordinator)
+            except MyBMWAPIError as ex:
+                raise HomeAssistantError(str(ex)) from ex
 
         self.coordinator.async_update_listeners()

--- a/homeassistant/components/bmw_connected_drive/lock.py
+++ b/homeassistant/components/bmw_connected_drive/lock.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from bimmer_connected.models import MyBMWAPIError
 from bimmer_connected.vehicle import MyBMWVehicle
 from bimmer_connected.vehicle.doors_windows import LockState
 
 from homeassistant.components.lock import LockEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import BMWBaseEntity
@@ -66,7 +68,12 @@ class BMWLock(BMWBaseEntity, LockEntity):
             # update callback response
             self._attr_is_locked = True
             self.async_write_ha_state()
-        await self.vehicle.remote_services.trigger_remote_door_lock()
+        try:
+            await self.vehicle.remote_services.trigger_remote_door_lock()
+        except MyBMWAPIError as ex:
+            self._attr_is_locked = False
+            self.async_write_ha_state()
+            raise HomeAssistantError(str(ex)) from ex
 
         self.coordinator.async_update_listeners()
 
@@ -79,7 +86,12 @@ class BMWLock(BMWBaseEntity, LockEntity):
             # update callback response
             self._attr_is_locked = False
             self.async_write_ha_state()
-        await self.vehicle.remote_services.trigger_remote_door_unlock()
+        try:
+            await self.vehicle.remote_services.trigger_remote_door_unlock()
+        except MyBMWAPIError as ex:
+            self._attr_is_locked = True
+            self.async_write_ha_state()
+            raise HomeAssistantError(str(ex)) from ex
 
         self.coordinator.async_update_listeners()
 

--- a/homeassistant/components/bmw_connected_drive/lock.py
+++ b/homeassistant/components/bmw_connected_drive/lock.py
@@ -73,7 +73,7 @@ class BMWLock(BMWBaseEntity, LockEntity):
         except MyBMWAPIError as ex:
             self._attr_is_locked = False
             self.async_write_ha_state()
-            raise HomeAssistantError(str(ex)) from ex
+            raise HomeAssistantError(ex) from ex
 
         self.coordinator.async_update_listeners()
 
@@ -91,7 +91,7 @@ class BMWLock(BMWBaseEntity, LockEntity):
         except MyBMWAPIError as ex:
             self._attr_is_locked = True
             self.async_write_ha_state()
-            raise HomeAssistantError(str(ex)) from ex
+            raise HomeAssistantError(ex) from ex
 
         self.coordinator.async_update_listeners()
 

--- a/homeassistant/components/bmw_connected_drive/notify.py
+++ b/homeassistant/components/bmw_connected_drive/notify.py
@@ -94,6 +94,6 @@ class BMWNotificationService(BaseNotificationService):
                 except TypeError as ex:
                     raise ValueError(str(ex)) from ex
                 except MyBMWAPIError as ex:
-                    raise HomeAssistantError(str(ex)) from ex
+                    raise HomeAssistantError(ex) from ex
             else:
                 raise ValueError(f"'data.{ATTR_LOCATION}' is required.")

--- a/homeassistant/components/bmw_connected_drive/notify.py
+++ b/homeassistant/components/bmw_connected_drive/notify.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import logging
 from typing import Any, cast
 
+from bimmer_connected.models import MyBMWAPIError
 from bimmer_connected.vehicle import MyBMWVehicle
 
 from homeassistant.components.notify import (
@@ -19,6 +20,7 @@ from homeassistant.const import (
     CONF_ENTITY_ID,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from .const import DOMAIN
@@ -87,7 +89,11 @@ class BMWNotificationService(BaseNotificationService):
                         if k in ATTR_LOCATION_ATTRIBUTES
                     }
                 )
-
-                await vehicle.remote_services.trigger_send_poi(location_dict)
+                try:
+                    await vehicle.remote_services.trigger_send_poi(location_dict)
+                except TypeError as ex:
+                    raise ValueError(str(ex)) from ex
+                except MyBMWAPIError as ex:
+                    raise HomeAssistantError(str(ex)) from ex
             else:
                 raise ValueError(f"'data.{ATTR_LOCATION}' is required.")

--- a/homeassistant/components/bmw_connected_drive/select.py
+++ b/homeassistant/components/bmw_connected_drive/select.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 import logging
 from typing import Any
 
+from bimmer_connected.models import MyBMWAPIError
 from bimmer_connected.vehicle import MyBMWVehicle
 from bimmer_connected.vehicle.charging_profile import ChargingMode
 
@@ -11,6 +12,7 @@ from homeassistant.components.select import SelectEntity, SelectEntityDescriptio
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfElectricCurrent
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import BMWBaseEntity
@@ -123,6 +125,9 @@ class BMWSelect(BMWBaseEntity, SelectEntity):
             self.vehicle.vin,
             option,
         )
-        await self.entity_description.remote_service(self.vehicle, option)
+        try:
+            await self.entity_description.remote_service(self.vehicle, option)
+        except MyBMWAPIError as ex:
+            raise HomeAssistantError(str(ex)) from ex
 
         self.coordinator.async_update_listeners()

--- a/homeassistant/components/bmw_connected_drive/select.py
+++ b/homeassistant/components/bmw_connected_drive/select.py
@@ -128,6 +128,6 @@ class BMWSelect(BMWBaseEntity, SelectEntity):
         try:
             await self.entity_description.remote_service(self.vehicle, option)
         except MyBMWAPIError as ex:
-            raise HomeAssistantError(str(ex)) from ex
+            raise HomeAssistantError(ex) from ex
 
         self.coordinator.async_update_listeners()

--- a/tests/components/bmw_connected_drive/test_select.py
+++ b/tests/components/bmw_connected_drive/test_select.py
@@ -125,8 +125,8 @@ async def test_remote_service_exceptions(
         await hass.services.async_call(
             "select",
             "select_option",
-            service_data={"option": "80"},
+            service_data={"option": "16"},
             blocking=True,
-            target={"entity_id": "select.i4_edrive40_target_soc"},
+            target={"entity_id": "select.i4_edrive40_ac_charging_limit"},
         )
     assert RemoteServices.trigger_remote_service.call_count == 1

--- a/tests/components/bmw_connected_drive/test_select.py
+++ b/tests/components/bmw_connected_drive/test_select.py
@@ -1,4 +1,7 @@
 """Test BMW selects."""
+from unittest.mock import AsyncMock
+
+from bimmer_connected.models import MyBMWAPIError, MyBMWRemoteServiceError
 from bimmer_connected.vehicle.remote_services import RemoteServices
 import pytest
 import respx
@@ -8,6 +11,7 @@ from homeassistant.components.bmw_connected_drive.coordinator import (
     BMWDataUpdateCoordinator,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 
 from . import setup_mocked_integration
 
@@ -87,3 +91,42 @@ async def test_update_triggers_fail(
         )
     assert RemoteServices.trigger_remote_service.call_count == 0
     assert BMWDataUpdateCoordinator.async_update_listeners.call_count == 0
+
+
+@pytest.mark.parametrize(
+    ("raised", "expected"),
+    [
+        (MyBMWRemoteServiceError, HomeAssistantError),
+        (MyBMWAPIError, HomeAssistantError),
+        (ValueError, ValueError),
+    ],
+)
+async def test_remote_service_exceptions(
+    hass: HomeAssistant,
+    raised: Exception,
+    expected: Exception,
+    bmw_fixture: respx.Router,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test exception handling for remote services."""
+
+    # Setup component
+    assert await setup_mocked_integration(hass)
+
+    # Setup exception
+    monkeypatch.setattr(
+        RemoteServices,
+        "trigger_remote_service",
+        AsyncMock(side_effect=raised),
+    )
+
+    # Test
+    with pytest.raises(expected):
+        await hass.services.async_call(
+            "select",
+            "select_option",
+            service_data={"option": "80"},
+            blocking=True,
+            target={"entity_id": "select.i4_edrive40_target_soc"},
+        )
+    assert RemoteServices.trigger_remote_service.call_count == 1


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As mentioned in https://github.com/home-assistant/core/pull/91081#discussion_r1177094374, this PR adds proper exception handling for all remote services (i.e. when sending a command to the car).

Related to https://github.com/home-assistant/core/pull/90274 which implements error handling for the `DataUpdateCoordinator`.

(Dependency bump already merged to `dev` through other PRs, leaving it in for reference)
~~Library changelog:~~
- ~~https://github.com/bimmerconnected/bimmer_connected/releases/tag/0.13.1~~
- ~~https://github.com/bimmerconnected/bimmer_connected/releases/tag/0.13.2~~

~~Diff: https://github.com/bimmerconnected/bimmer_connected/compare/0.13.0...0.13.2~~

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
