### PR TITLE
Debounce and group mqtt unsubscribes

### DIFF
--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -688,16 +688,11 @@ class MQTT:
         topics = set(self._pending_unsubscribes)
         self._pending_unsubscribes = set()
 
-        def _process_client_unsubscribes() -> tuple[int, int]:
-            """Initiate all subscriptions on the MQTT client and return the results."""
-            result, mid = self._mqttc.unsubscribe(list(topics))
-            return result, mid
-
         async with self._paho_lock:
             result, mid = await self.hass.async_add_executor_job(
-                _process_client_unsubscribes
+                self._mqttc.unsubscribe, list(topics)
             )
-            _raise_on_error(result)
+        _raise_on_error(result)
         for topic in topics:
             _LOGGER.debug("Unsubscribing from %s, mid: %s", topic, mid)
 

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -613,15 +613,13 @@ class MQTT:
             self._matching_subscriptions.cache_clear()
             # Only unsubscribe if currently connected
             if self.connected:
-                self.hass.async_create_task(self._async_unsubscribe(topic))
+                self._async_unsubscribe(topic)
 
         return async_remove
 
-    async def _async_unsubscribe(self, topic: str) -> None:
-        """Unsubscribe from a topic.
-
-        This method is a coroutine.
-        """
+    @callback
+    def _async_unsubscribe(self, topic: str) -> None:
+        """Unsubscribe from a topic."""
         if self._is_active_subscription(topic):
             if self._max_qos[topic] == 0:
                 return

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -691,8 +691,6 @@ class MQTT:
         def _process_client_unsubscribes() -> tuple[int, int]:
             """Initiate all subscriptions on the MQTT client and return the results."""
             result, mid = self._mqttc.unsubscribe(list(topics))
-            for topic in topics:
-                _LOGGER.debug("Unsubscribing from %s, mid: %s", topic, mid)
             return result, mid
 
         async with self._paho_lock:
@@ -700,6 +698,8 @@ class MQTT:
                 _process_client_unsubscribes
             )
             _raise_on_error(result)
+        for topic in topics:
+            _LOGGER.debug("Unsubscribing from %s, mid: %s", topic, mid)
 
         await self._wait_for_mid(mid)
 

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -515,6 +515,10 @@ class MQTT:
         await self._subscribe_debouncer.async_cleanup()
         # reset timeout to initial subscribe cooldown
         self._subscribe_debouncer.set_timeout(INITIAL_SUBSCRIBE_COOLDOWN)
+        # stop the unsubscribe debouncer
+        await self._unsubscribe_debouncer.async_cleanup()
+        # make sure the unsubscribes are processed
+        await self._async_perform_unsubscribes()
 
         # wait for ACKs to be processed
         async with self._pending_operations_condition:

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -684,12 +684,12 @@ class MQTT:
         if not self._pending_unsubscribes:
             return
 
-        topics = set(self._pending_unsubscribes)
+        topics = list(self._pending_unsubscribes)
         self._pending_unsubscribes = set()
 
         async with self._paho_lock:
             result, mid = await self.hass.async_add_executor_job(
-                self._mqttc.unsubscribe, list(topics)
+                self._mqttc.unsubscribe, topics
             )
         _raise_on_error(result)
         for topic in topics:

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -577,14 +577,13 @@ class MQTT:
         self, subscriptions: Iterable[tuple[str, int]], queue_only: bool = False
     ) -> None:
         """Queue requested subscriptions."""
-        pending_unsubscribes = set(self._pending_unsubscribes)
         for subscription in subscriptions:
             topic, qos = subscription
             max_qos = max(qos, self._max_qos.setdefault(topic, qos))
             self._max_qos[topic] = max_qos
             self._pending_subscriptions[topic] = max_qos
             # Cancel any pending unsubscribe since we are subscribing now
-            if topic in pending_unsubscribes:
+            if topic in self._pending_unsubscribes:
                 self._pending_unsubscribes.remove(topic)
         if queue_only:
             return

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -577,13 +577,14 @@ class MQTT:
         self, subscriptions: Iterable[tuple[str, int]], queue_only: bool = False
     ) -> None:
         """Queue requested subscriptions."""
+        pending_unsubscribes = set(self._pending_unsubscribes)
         for subscription in subscriptions:
             topic, qos = subscription
             max_qos = max(qos, self._max_qos.setdefault(topic, qos))
             self._max_qos[topic] = max_qos
             self._pending_subscriptions[topic] = max_qos
             # Cancel any pending unsubscribe since we are subscribing now
-            if topic in set(self._pending_unsubscribes):
+            if topic in pending_unsubscribes:
                 self._pending_unsubscribes.remove(topic)
         if queue_only:
             return

--- a/tests/components/mqtt/test_discovery.py
+++ b/tests/components/mqtt/test_discovery.py
@@ -1,4 +1,5 @@
 """The tests for the MQTT discovery."""
+import asyncio
 import copy
 import json
 from pathlib import Path
@@ -1376,6 +1377,7 @@ async def test_complex_discovery_topic_prefix(
 @patch("homeassistant.components.mqtt.PLATFORMS", [])
 @patch("homeassistant.components.mqtt.client.INITIAL_SUBSCRIBE_COOLDOWN", 0.0)
 @patch("homeassistant.components.mqtt.client.SUBSCRIBE_COOLDOWN", 0.0)
+@patch("homeassistant.components.mqtt.client.UNSUBSCRIBE_COOLDOWN", 0.0)
 async def test_mqtt_integration_discovery_subscribe_unsubscribe(
     hass: HomeAssistant,
     mqtt_client_mock: MqttMockPahoClient,
@@ -1407,15 +1409,18 @@ async def test_mqtt_integration_discovery_subscribe_unsubscribe(
             return self.async_abort(reason="already_configured")
 
     with patch.dict(config_entries.HANDLERS, {"comp": TestFlow}):
+        await asyncio.sleep(0.1)
         assert ("comp/discovery/#", 0) in help_all_subscribe_calls(mqtt_client_mock)
         assert not mqtt_client_mock.unsubscribe.called
 
         async_fire_mqtt_message(hass, "comp/discovery/bla/config", "")
+        await asyncio.sleep(0.1)
         await hass.async_block_till_done()
-        mqtt_client_mock.unsubscribe.assert_called_once_with("comp/discovery/#")
+        mqtt_client_mock.unsubscribe.assert_called_once_with(["comp/discovery/#"])
         mqtt_client_mock.unsubscribe.reset_mock()
 
         async_fire_mqtt_message(hass, "comp/discovery/bla/config", "")
+        await asyncio.sleep(0.1)
         await hass.async_block_till_done()
         assert not mqtt_client_mock.unsubscribe.called
 
@@ -1423,6 +1428,7 @@ async def test_mqtt_integration_discovery_subscribe_unsubscribe(
 @patch("homeassistant.components.mqtt.PLATFORMS", [])
 @patch("homeassistant.components.mqtt.client.INITIAL_SUBSCRIBE_COOLDOWN", 0.0)
 @patch("homeassistant.components.mqtt.client.SUBSCRIBE_COOLDOWN", 0.0)
+@patch("homeassistant.components.mqtt.client.UNSUBSCRIBE_COOLDOWN", 0.0)
 async def test_mqtt_discovery_unsubscribe_once(
     hass: HomeAssistant,
     mqtt_client_mock: MqttMockPahoClient,
@@ -1456,9 +1462,10 @@ async def test_mqtt_discovery_unsubscribe_once(
     with patch.dict(config_entries.HANDLERS, {"comp": TestFlow}):
         async_fire_mqtt_message(hass, "comp/discovery/bla/config", "")
         async_fire_mqtt_message(hass, "comp/discovery/bla/config", "")
+        await asyncio.sleep(0.1)
         await hass.async_block_till_done()
         await hass.async_block_till_done()
-        mqtt_client_mock.unsubscribe.assert_called_once_with("comp/discovery/#")
+        mqtt_client_mock.unsubscribe.assert_called_once_with(["comp/discovery/#"])
 
 
 @patch("homeassistant.components.mqtt.PLATFORMS", [Platform.SENSOR])

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -906,6 +906,46 @@ async def test_subscribe_topic(
         unsub()
 
 
+@patch("homeassistant.components.mqtt.client.INITIAL_SUBSCRIBE_COOLDOWN", 0.0)
+@patch("homeassistant.components.mqtt.client.UNSUBSCRIBE_COOLDOWN", 0.2)
+async def test_subscribe_and_resubscribe(
+    hass: HomeAssistant,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+    mqtt_client_mock: MqttMockPahoClient,
+    calls: list[ReceiveMessage],
+    record_calls: MessageCallbackType,
+) -> None:
+    """Test resubscribing within the debounce time."""
+    mqtt_mock = await mqtt_mock_entry()
+    # Fake that the client is connected
+    mqtt_mock().connected = True
+
+    unsub = await mqtt.async_subscribe(hass, "test-topic", record_calls)
+    # This unsub will be un-done with the following subscribe
+    # unsubscribe should not be called at the broker
+    unsub()
+    await asyncio.sleep(0.1)
+    unsub = await mqtt.async_subscribe(hass, "test-topic", record_calls)
+    await asyncio.sleep(0.1)
+    await hass.async_block_till_done()
+
+    async_fire_mqtt_message(hass, "test-topic", "test-payload")
+
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    assert calls[0].topic == "test-topic"
+    assert calls[0].payload == "test-payload"
+
+    # aseert unsubscribe was not called
+    mqtt_client_mock.unsubscribe.assert_not_called()
+
+    unsub()
+
+    await asyncio.sleep(0.2)
+    await hass.async_block_till_done()
+    mqtt_client_mock.unsubscribe.assert_called_once_with(["test-topic"])
+
+
 async def test_subscribe_topic_non_async(
     hass: HomeAssistant,
     mqtt_mock_entry: MqttMockHAClientGenerator,

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -930,13 +930,12 @@ async def test_subscribe_and_resubscribe(
     await hass.async_block_till_done()
 
     async_fire_mqtt_message(hass, "test-topic", "test-payload")
-
     await hass.async_block_till_done()
+
     assert len(calls) == 1
     assert calls[0].topic == "test-topic"
     assert calls[0].payload == "test-payload"
-
-    # aseert unsubscribe was not called
+    # assert unsubscribe was not called
     mqtt_client_mock.unsubscribe.assert_not_called()
 
     unsub()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When shutting down MQTT, and during a reload of the entry MQTT subscriptions will be unsubscribed at the broker.
This PR debounces the unsubscribe calls so then can be grouped gaining performance.

See also: #92172

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
