### PR TITLE
Move nextbus constants and utils

### DIFF
--- a/homeassistant/components/nextbus/const.py
+++ b/homeassistant/components/nextbus/const.py
@@ -1,0 +1,6 @@
+"""NextBus Constants."""
+DOMAIN = "nextbus"
+
+CONF_AGENCY = "agency"
+CONF_ROUTE = "route"
+CONF_STOP = "stop"

--- a/homeassistant/components/nextbus/sensor.py
+++ b/homeassistant/components/nextbus/sensor.py
@@ -19,13 +19,10 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util.dt import utc_from_timestamp
 
+from .const import CONF_AGENCY, CONF_ROUTE, CONF_STOP
+from .util import listify, maybe_first
+
 _LOGGER = logging.getLogger(__name__)
-
-DOMAIN = "nextbus"
-
-CONF_AGENCY = "agency"
-CONF_ROUTE = "route"
-CONF_STOP = "stop"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
@@ -35,29 +32,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_NAME): cv.string,
     }
 )
-
-
-def listify(maybe_list):
-    """Return list version of whatever value is passed in.
-
-    This is used to provide a consistent way of interacting with the JSON
-    results from the API. There are several attributes that will either missing
-    if there are no values, a single dictionary if there is only one value, and
-    a list if there are multiple.
-    """
-    if maybe_list is None:
-        return []
-    if isinstance(maybe_list, list):
-        return maybe_list
-    return [maybe_list]
-
-
-def maybe_first(maybe_list):
-    """Return the first item out of a list or returns back the input."""
-    if isinstance(maybe_list, list) and maybe_list:
-        return maybe_list[0]
-
-    return maybe_list
 
 
 def validate_value(value_name, value, value_list):

--- a/homeassistant/components/nextbus/util.py
+++ b/homeassistant/components/nextbus/util.py
@@ -1,13 +1,6 @@
 """Utils for NextBus integration module."""
 from typing import Any
 
-UserConfig = dict[str, Any]
-
-
-def invert_dict(source_dict: dict[Any, Any]) -> dict[Any, Any]:
-    """Invert keys and values in a dict."""
-    return {value: key for key, value in source_dict.items()}
-
 
 def listify(maybe_list: Any) -> list[Any]:
     """Return list version of whatever value is passed in.

--- a/homeassistant/components/nextbus/util.py
+++ b/homeassistant/components/nextbus/util.py
@@ -1,0 +1,32 @@
+"""Utils for NextBus integration module."""
+from typing import Any
+
+UserConfig = dict[str, Any]
+
+
+def invert_dict(source_dict: dict[Any, Any]) -> dict[Any, Any]:
+    """Invert keys and values in a dict."""
+    return {value: key for key, value in source_dict.items()}
+
+
+def listify(maybe_list: Any) -> list[Any]:
+    """Return list version of whatever value is passed in.
+
+    This is used to provide a consistent way of interacting with the JSON
+    results from the API. There are several attributes that will either missing
+    if there are no values, a single dictionary if there is only one value, and
+    a list if there are multiple.
+    """
+    if maybe_list is None:
+        return []
+    if isinstance(maybe_list, list):
+        return maybe_list
+    return [maybe_list]
+
+
+def maybe_first(maybe_list: list[Any]) -> Any:
+    """Return the first item out of a list or returns back the input."""
+    if isinstance(maybe_list, list) and maybe_list:
+        return maybe_list[0]
+
+    return maybe_list


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Moves common values from sensor to const and util modules for future refactor use.

Split from #92149

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #92149 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
