### PR TITLE
Fix incorrect entity category for SmartThings sensors

### DIFF
--- a/homeassistant/components/smartthings/sensor.py
+++ b/homeassistant/components/smartthings/sensor.py
@@ -45,7 +45,7 @@ CAPABILITY_TO_SENSORS: dict[str, list[Map]] = {
             None,
             None,
             None,
-            EntityCategory.CONFIG,
+            EntityCategory.DIAGNOSTIC,
         )
     ],
     Capability.air_conditioner_mode: [
@@ -55,7 +55,7 @@ CAPABILITY_TO_SENSORS: dict[str, list[Map]] = {
             None,
             None,
             None,
-            EntityCategory.CONFIG,
+            EntityCategory.DIAGNOSTIC,
         )
     ],
     Capability.air_quality_sensor: [
@@ -160,7 +160,7 @@ CAPABILITY_TO_SENSORS: dict[str, list[Map]] = {
             None,
             None,
             None,
-            EntityCategory.CONFIG,
+            EntityCategory.DIAGNOSTIC,
         )
     ],
     Capability.dryer_operating_state: [
@@ -303,7 +303,7 @@ CAPABILITY_TO_SENSORS: dict[str, list[Map]] = {
             None,
             None,
             None,
-            EntityCategory.CONFIG,
+            EntityCategory.DIAGNOSTIC,
         )
     ],
     Capability.oven_operating_state: [
@@ -362,7 +362,7 @@ CAPABILITY_TO_SENSORS: dict[str, list[Map]] = {
             None,
             None,
             None,
-            EntityCategory.CONFIG,
+            EntityCategory.DIAGNOSTIC,
         )
     ],
     Capability.robot_cleaner_movement: [
@@ -382,7 +382,7 @@ CAPABILITY_TO_SENSORS: dict[str, list[Map]] = {
             None,
             None,
             None,
-            EntityCategory.CONFIG,
+            EntityCategory.DIAGNOSTIC,
         )
     ],
     Capability.signal_strength: [
@@ -433,7 +433,7 @@ CAPABILITY_TO_SENSORS: dict[str, list[Map]] = {
             None,
             None,
             None,
-            EntityCategory.CONFIG,
+            EntityCategory.DIAGNOSTIC,
         )
     ],
     Capability.thermostat_heating_setpoint: [
@@ -443,7 +443,7 @@ CAPABILITY_TO_SENSORS: dict[str, list[Map]] = {
             None,
             SensorDeviceClass.TEMPERATURE,
             None,
-            EntityCategory.CONFIG,
+            EntityCategory.DIAGNOSTIC,
         )
     ],
     Capability.thermostat_mode: [
@@ -453,7 +453,7 @@ CAPABILITY_TO_SENSORS: dict[str, list[Map]] = {
             None,
             None,
             None,
-            EntityCategory.CONFIG,
+            EntityCategory.DIAGNOSTIC,
         )
     ],
     Capability.thermostat_operating_state: [
@@ -473,7 +473,7 @@ CAPABILITY_TO_SENSORS: dict[str, list[Map]] = {
             None,
             SensorDeviceClass.TEMPERATURE,
             None,
-            EntityCategory.CONFIG,
+            EntityCategory.DIAGNOSTIC,
         )
     ],
     Capability.three_axis: [],
@@ -518,7 +518,7 @@ CAPABILITY_TO_SENSORS: dict[str, list[Map]] = {
             None,
             None,
             None,
-            EntityCategory.CONFIG,
+            EntityCategory.DIAGNOSTIC,
         )
     ],
     Capability.washer_operating_state: [


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The `config` entity category is for read/write configuration values of a device. When values are read-only, the `diagnostic` entity category should be used.

This PR corrects the sensor entities of the SmartThings integration. Sensor entities are per definition read-only, so cannot have the `config` category. This PR changes those to `diagnostic`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
