### PR TITLE
Bump pyunifiprotect to 4.8.3

### DIFF
--- a/homeassistant/components/unifiprotect/manifest.json
+++ b/homeassistant/components/unifiprotect/manifest.json
@@ -41,7 +41,7 @@
   "iot_class": "local_push",
   "loggers": ["pyunifiprotect", "unifi_discovery"],
   "quality_scale": "platinum",
-  "requirements": ["pyunifiprotect==4.8.2", "unifi-discovery==1.1.7"],
+  "requirements": ["pyunifiprotect==4.8.3", "unifi-discovery==1.1.7"],
   "ssdp": [
     {
       "manufacturer": "Ubiquiti Networks",

--- a/homeassistant/components/unifiprotect/services.py
+++ b/homeassistant/components/unifiprotect/services.py
@@ -161,8 +161,9 @@ async def set_chime_paired_doorbells(hass: HomeAssistant, call: ServiceCall) -> 
         camera = instance.bootstrap.get_device_from_mac(doorbell_mac)
         assert camera is not None
         doorbell_ids.add(camera.id)
+    data_before_changed = chime.dict_with_excludes()
     chime.camera_ids = sorted(doorbell_ids)
-    await chime.save_device()
+    await chime.save_device(data_before_changed)
 
 
 def async_setup_services(hass: HomeAssistant) -> None:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2149,7 +2149,7 @@ pytrafikverket==0.2.3
 pyudev==0.23.2
 
 # homeassistant.components.unifiprotect
-pyunifiprotect==4.8.2
+pyunifiprotect==4.8.3
 
 # homeassistant.components.uptimerobot
 pyuptimerobot==22.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1554,7 +1554,7 @@ pytrafikverket==0.2.3
 pyudev==0.23.2
 
 # homeassistant.components.unifiprotect
-pyunifiprotect==4.8.2
+pyunifiprotect==4.8.3
 
 # homeassistant.components.uptimerobot
 pyuptimerobot==22.2.0

--- a/tests/components/unifiprotect/utils.py
+++ b/tests/components/unifiprotect/utils.py
@@ -150,7 +150,6 @@ def add_device(
 
     if regenerate_ids:
         regenerate_device_ids(device)
-    device._initial_data = device.dict()
 
     devices = getattr(bootstrap, f"{device.model.value}s")
     devices[device.id] = device


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

changelog: https://github.com/AngellusMortis/pyunifiprotect/compare/v4.8.2...v4.8.3
fixes #92108
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
