### PR TITLE
Pin `pyasn1` and `pysnmplib` since `pyasn1` 0.5.0 has breaking changes and `pysnmp-pyasn1` and `pyasn1` are both using the `pyasn1` namespace

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -168,3 +168,10 @@ faust-cchardet>=2.1.18
 # which break wheel builds so we need at least 11.0.1
 # https://github.com/aaugustin/websockets/issues/1329
 websockets>=11.0.1
+
+# pyasn1 0.5.0 has breaking changes which cause pysnmplib to fail
+# until they are resolved, we need to pin pyasn1 to 0.4.8 and
+# pysnmplib to 5.0.21 to avoid the issue.
+# https://github.com/pyasn1/pyasn1/pull/30#issuecomment-1517564335
+pyasn1==0.4.8
+pysnmplib==5.0.21

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -173,5 +173,6 @@ websockets>=11.0.1
 # until they are resolved, we need to pin pyasn1 to 0.4.8 and
 # pysnmplib to 5.0.21 to avoid the issue.
 # https://github.com/pyasn1/pyasn1/pull/30#issuecomment-1517564335
+# https://github.com/pysnmp/pysnmp/issues/51
 pyasn1==0.4.8
 pysnmplib==5.0.21

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -177,6 +177,7 @@ websockets>=11.0.1
 # until they are resolved, we need to pin pyasn1 to 0.4.8 and
 # pysnmplib to 5.0.21 to avoid the issue.
 # https://github.com/pyasn1/pyasn1/pull/30#issuecomment-1517564335
+# https://github.com/pysnmp/pysnmp/issues/51
 pyasn1==0.4.8
 pysnmplib==5.0.21
 """

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -172,6 +172,13 @@ faust-cchardet>=2.1.18
 # which break wheel builds so we need at least 11.0.1
 # https://github.com/aaugustin/websockets/issues/1329
 websockets>=11.0.1
+
+# pyasn1 0.5.0 has breaking changes which cause pysnmplib to fail
+# until they are resolved, we need to pin pyasn1 to 0.4.8 and
+# pysnmplib to 5.0.21 to avoid the issue.
+# https://github.com/pyasn1/pyasn1/pull/30#issuecomment-1517564335
+pyasn1==0.4.8
+pysnmplib==5.0.21
 """
 
 IGNORE_PRE_COMMIT_HOOK_ID = (


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
see https://github.com/pyasn1/pyasn1/pull/30#issuecomment-1517564335 https://github.com/pysnmp/pysnmp/issues/51

This is a temporary solution for the namespace conflict since `pysnmp-pyasn1` and `pyasn1` are both using the `pyasn1` namespace.
```
pysnmp-pyasn1==1.1.2
  - pysnmplib==5.0.21 [requires: pysnmp-pyasn1>=1.0.3,<2.0.0]
    - brother==2.3.0 [requires: pysnmplib>=5.0.21]
pyasn1==0.4.8
  - adb-shell==0.4.3 [requires: pyasn1]
    - androidtv==0.0.70 [requires: adb-shell>=0.4.0]
  - oauth2client==4.1.3 [requires: pyasn1>=0.1.7]
  - pyasn1-modules==0.2.8 [requires: pyasn1>=0.4.6,<0.5.0]
    - google-auth==2.17.3 [requires: pyasn1-modules>=0.2.1]
      - gassist-text==0.0.10 [requires: google-auth>=0.3.0,<3]
      - google-api-core==2.11.0 [requires: google-auth>=2.14.1,<3.0dev]
        - google-api-python-client==2.71.0 [requires: google-api-core>=1.31.5,<3.0.0dev,!=2.3.0,!=2.2.*,!=2.1.*,!=2.0.*]
        - google-cloud-pubsub==2.13.11 [requires: google-api-core>=1.32.0,<3.0.0dev,!=2.7.*,!=2.6.*,!=2.5.*,!=2.4.*,!=2.3.*,!=2.2.*,!=2.1.*,!=2.0.*]
          - google-nest-sdm==2.2.4 [requires: google-cloud-pubsub>=2.1.0]
      - google-api-python-client==2.71.0 [requires: google-auth>=1.19.0,<3.0.0dev]
      - google-auth-httplib2==0.1.0 [requires: google-auth]
        - google-api-python-client==2.71.0 [requires: google-auth-httplib2>=0.1.0]
      - google-auth-oauthlib==1.0.0 [requires: google-auth>=2.15.0]
        - google-nest-sdm==2.2.4 [requires: google-auth-oauthlib>=0.4.1]
        - gspread==5.5.0 [requires: google-auth-oauthlib>=0.4.1]
      - google-nest-sdm==2.2.4 [requires: google-auth>=1.22.0]
      - gspread==5.5.0 [requires: google-auth>=1.12.0]
    - oauth2client==4.1.3 [requires: pyasn1-modules>=0.0.5]
    - slixmpp==1.8.2 [requires: pyasn1-modules]
      - aioharmony==0.2.10 [requires: slixmpp]
  - pysmb==1.2.9.1 [requires: pyasn1]
    - pyairvisual==2022.12.1 [requires: pysmb>=1.2.6,<2.0.0]
  - python-jose==3.3.0 [requires: pyasn1]
    - pycognito==2022.12.0 [requires: python-jose>=3.2.0]
      - hass-nabucasa==0.66.2 [requires: pycognito==2022.12.0]
    - warrant-lite==1.0.4 [requires: python-jose>=3.0,<4.0]
      - pyoverkiz==1.7.7 [requires: warrant-lite>=1.0.4,<2.0.0]
  - rsa==4.8 [requires: pyasn1>=0.1.3]
    - adb-shell==0.4.3 [requires: rsa]
      - androidtv==0.0.70 [requires: adb-shell>=0.4.0]
    - google-auth==2.17.3 [requires: rsa>=3.1.4,<5]
      - gassist-text==0.0.10 [requires: google-auth>=0.3.0,<3]
      - google-api-core==2.11.0 [requires: google-auth>=2.14.1,<3.0dev]
        - google-api-python-client==2.71.0 [requires: google-api-core>=1.31.5,<3.0.0dev,!=2.3.0,!=2.2.*,!=2.1.*,!=2.0.*]
        - google-cloud-pubsub==2.13.11 [requires: google-api-core>=1.32.0,<3.0.0dev,!=2.7.*,!=2.6.*,!=2.5.*,!=2.4.*,!=2.3.*,!=2.2.*,!=2.1.*,!=2.0.*]
          - google-nest-sdm==2.2.4 [requires: google-cloud-pubsub>=2.1.0]
      - google-api-python-client==2.71.0 [requires: google-auth>=1.19.0,<3.0.0dev]
      - google-auth-httplib2==0.1.0 [requires: google-auth]
        - google-api-python-client==2.71.0 [requires: google-auth-httplib2>=0.1.0]
      - google-auth-oauthlib==1.0.0 [requires: google-auth>=2.15.0]
        - google-nest-sdm==2.2.4 [requires: google-auth-oauthlib>=0.4.1]
        - gspread==5.5.0 [requires: google-auth-oauthlib>=0.4.1]
      - google-nest-sdm==2.2.4 [requires: google-auth>=1.22.0]
      - gspread==5.5.0 [requires: google-auth>=1.12.0]
    - oauth2client==4.1.3 [requires: rsa>=3.1.4]
    - python-jose==3.3.0 [requires: rsa]
      - pycognito==2022.12.0 [requires: python-jose>=3.2.0]
        - hass-nabucasa==0.66.2 [requires: pycognito==2022.12.0]
      - warrant-lite==1.0.4 [requires: python-jose>=3.0,<4.0]
        - pyoverkiz==1.7.7 [requires: warrant-lite>=1.0.4,<2.0.0]
  - slixmpp==1.8.2 [requires: pyasn1]
    - aioharmony==0.2.10 [requires: slixmpp]
```
fixes
```
2023-04-29 16:48:23.561 ERROR (MainThread) [homeassistant] Error doing job: Exception in callback AbstractTransportDispatcher._cbFun(<pysnmp.carri...x7ff257601110>, (192.168.210.25, 161), b00x02x01...Bx02x01xef)
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/asyncio/events.py", line 80, in _run
    self._context.run(self._callback, *self._args)
  File "/usr/local/lib/python3.11/site-packages/pysnmp/carrier/base.py", line 80, in _cbFun
    self.__recvCallables[recvId](
  File "/usr/local/lib/python3.11/site-packages/pysnmp/entity/engine.py", line 151, in __receiveMessageCbFun
    self.msgAndPduDsp.receiveMessage(
  File "/usr/local/lib/python3.11/site-packages/pysnmp/proto/rfc3412.py", line 291, in receiveMessage
    msgVersion = verdec.decodeMessageVersion(wholeMsg)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/pysnmp/proto/api/verdec.py", line 15, in decodeMessageVersion
    seq, wholeMsg = decoder.decode(
                    ^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/pyasn1/codec/ber/decoder.py", line 2003, in __call__
    for asn1Object in streamingDecoder:
  File "/usr/local/lib/python3.11/site-packages/pyasn1/codec/ber/decoder.py", line 1918, in __iter__
    for asn1Object in self._singleItemDecoder(
  File "/usr/local/lib/python3.11/site-packages/pyasn1/codec/ber/decoder.py", line 1778, in __call__
    for value in concreteDecoder.valueDecoder(
  File "/usr/local/lib/python3.11/site-packages/pyasn1/codec/ber/decoder.py", line 654, in valueDecoder
    for chunk in substrateFun(asn1Object, substrate, length, options):
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
