### PR TITLE
Remove deprecated ISY994 Insteon and variable sensor entities

### DIFF
--- a/homeassistant/components/isy994/__init__.py
+++ b/homeassistant/components/isy994/__init__.py
@@ -32,10 +32,8 @@ from .const import (
     CONF_NETWORK,
     CONF_SENSOR_STRING,
     CONF_TLS_VER,
-    CONF_VAR_SENSOR_STRING,
     DEFAULT_IGNORE_STRING,
     DEFAULT_SENSOR_STRING,
-    DEFAULT_VAR_SENSOR_STRING,
     DOMAIN,
     ISY_CONF_FIRMWARE,
     ISY_CONF_MODEL,
@@ -45,7 +43,7 @@ from .const import (
     SCHEME_HTTP,
     SCHEME_HTTPS,
 )
-from .helpers import _categorize_nodes, _categorize_programs, _categorize_variables
+from .helpers import _categorize_nodes, _categorize_programs
 from .models import IsyData
 from .services import async_setup_services, async_unload_services
 from .util import _async_cleanup_registry_entries
@@ -75,9 +73,6 @@ async def async_setup_entry(
     tls_version = isy_config.get(CONF_TLS_VER)
     ignore_identifier = isy_options.get(CONF_IGNORE_STRING, DEFAULT_IGNORE_STRING)
     sensor_identifier = isy_options.get(CONF_SENSOR_STRING, DEFAULT_SENSOR_STRING)
-    variable_identifier = isy_options.get(
-        CONF_VAR_SENSOR_STRING, DEFAULT_VAR_SENSOR_STRING
-    )
 
     if host.scheme == SCHEME_HTTP:
         https = False
@@ -132,9 +127,7 @@ async def async_setup_entry(
 
     _categorize_nodes(isy_data, isy.nodes, ignore_identifier, sensor_identifier)
     _categorize_programs(isy_data, isy.programs)
-    # Categorize variables call to be removed with variable sensors in 2023.5.0
-    _categorize_variables(isy_data, isy.variables, variable_identifier)
-    # Gather ISY Variables to be added. Identifier used to enable by default.
+    # Gather ISY Variables to be added.
     if isy.variables.children:
         isy_data.devices[CONF_VARIABLES] = _create_service_device_info(
             isy, name=CONF_VARIABLES.title(), unique_id=CONF_VARIABLES

--- a/homeassistant/components/isy994/helpers.py
+++ b/homeassistant/components/isy994/helpers.py
@@ -22,7 +22,6 @@ from pyisy.constants import (
 )
 from pyisy.nodes import Group, Node, Nodes
 from pyisy.programs import Programs
-from pyisy.variables import Variables
 
 from homeassistant.const import ATTR_MANUFACTURER, ATTR_MODEL, Platform
 from homeassistant.helpers.entity import DeviceInfo
@@ -349,8 +348,6 @@ def _categorize_nodes(
             if getattr(node, "is_dimmable", False):
                 aux_controls = ROOT_AUX_CONTROLS.intersection(node.aux_properties)
                 for control in aux_controls:
-                    # Deprecated all aux properties as sensors. Update in 2023.5.0 to remove extras.
-                    isy_data.aux_properties[Platform.SENSOR].append((node, control))
                     platform = NODE_AUX_FILTERS[control]
                     isy_data.aux_properties[platform].append((node, control))
             if hasattr(node, TAG_ENABLED):
@@ -430,20 +427,6 @@ def _categorize_programs(isy_data: IsyData, programs: Programs) -> None:
 
             entity = (entity_folder.name, status, actions)
             isy_data.programs[platform].append(entity)
-
-
-def _categorize_variables(
-    isy_data: IsyData, variables: Variables, identifier: str
-) -> None:
-    """Gather the ISY Variables to be added as sensors."""
-    try:
-        isy_data.variables[Platform.SENSOR] = [
-            variables[vtype][vid]
-            for (vtype, vname, vid) in variables.children
-            if identifier in vname
-        ]
-    except KeyError as err:
-        _LOGGER.error("Error adding ISY Variables: %s", err)
 
 
 def convert_isy_value_to_hass(

--- a/homeassistant/components/isy994/sensor.py
+++ b/homeassistant/components/isy994/sensor.py
@@ -22,7 +22,6 @@ from pyisy.constants import (
 )
 from pyisy.helpers import EventListener, NodeProperty
 from pyisy.nodes import Node, NodeChangedEvent
-from pyisy.variables import Variable
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -44,7 +43,7 @@ from .const import (
     UOM_ON_OFF,
     UOM_TO_STATES,
 )
-from .entity import ISYEntity, ISYNodeEntity
+from .entity import ISYNodeEntity
 from .helpers import convert_isy_value_to_hass
 
 # Disable general purpose and redundant sensors by default
@@ -111,7 +110,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up the ISY sensor platform."""
     isy_data = hass.data[DOMAIN][entry.entry_id]
-    entities: list[ISYSensorEntity | ISYSensorVariableEntity] = []
+    entities: list[ISYSensorEntity] = []
     devices: dict[str, DeviceInfo] = isy_data.devices
 
     for node in isy_data.nodes[Platform.SENSOR]:
@@ -133,9 +132,6 @@ async def async_setup_entry(
                 device_info=devices.get(node.primary_node),
             )
         )
-
-    for variable in isy_data.variables[Platform.SENSOR]:
-        entities.append(ISYSensorVariableEntity(variable))
 
     async_add_entities(entities)
 
@@ -292,35 +288,3 @@ class ISYAuxSensorEntity(ISYSensorEntity):
     def available(self) -> bool:
         """Return entity availability."""
         return cast(bool, self._node.enabled)
-
-
-class ISYSensorVariableEntity(ISYEntity, SensorEntity):
-    """Representation of an ISY variable as a sensor device."""
-
-    # Deprecated sensors, will be removed in 2023.5.0
-    _attr_entity_registry_enabled_default = False
-
-    def __init__(self, variable_node: Variable) -> None:
-        """Initialize the ISY binary sensor program."""
-        super().__init__(variable_node)
-        self._name = variable_node.name
-
-    @property
-    def native_value(self) -> float | int | None:
-        """Return the state of the variable."""
-        return convert_isy_value_to_hass(self._node.status, "", self._node.prec)
-
-    @property
-    def extra_state_attributes(self) -> dict[str, Any]:
-        """Get the state attributes for the device."""
-        return {
-            "init_value": convert_isy_value_to_hass(
-                self._node.init, "", self._node.prec
-            ),
-            "last_edited": self._node.last_edited,
-        }
-
-    @property
-    def icon(self) -> str:
-        """Return the icon."""
-        return "mdi:counter"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The previously deprecated sensor entities for Insteon devices' On Level and Ramp Rate, as well as ISY Variable sensors have been removed, please use the dedicated `number` and `select` entities instead.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Sensors for `on_level` and `ramp_rate` for Insteon device aux_properties, as well as ISY Variables as `sensor` were deprecated in 2023.2.0 when `number` and `select` entities were added to replace them. This removes those deprecated entities.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #85798, #85895, #85511
- Link to documentation pull request: N/A, already updated

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
