### PR TITLE
Auto repair incorrect collation on MySQL schema

### DIFF
--- a/homeassistant/components/recorder/auto_repairs/schema.py
+++ b/homeassistant/components/recorder/auto_repairs/schema.py
@@ -5,6 +5,7 @@ from collections.abc import Iterable, Mapping
 import logging
 from typing import TYPE_CHECKING
 
+from sqlalchemy import MetaData
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import DeclarativeBase
 from sqlalchemy.orm.attributes import InstrumentedAttribute
@@ -57,6 +58,52 @@ def validate_table_schema_supports_utf8(
         _LOGGER.exception("Error when validating DB schema: %s", exc)
 
     _log_schema_errors(table_object, schema_errors)
+    return schema_errors
+
+
+def validate_table_schema_has_correct_collation(
+    instance: Recorder,
+    table_object: type[DeclarativeBase],
+) -> set[str]:
+    """Verify the table has the correct collation."""
+    schema_errors: set[str] = set()
+    # Lack of full utf8 support is only an issue for MySQL / MariaDB
+    if instance.dialect_name != SupportedDialect.MYSQL:
+        return schema_errors
+
+    try:
+        schema_errors = _validate_table_schema_has_correct_collation(
+            instance, table_object
+        )
+    except Exception as exc:  # pylint: disable=broad-except
+        _LOGGER.exception("Error when validating DB schema: %s", exc)
+
+    _log_schema_errors(table_object, schema_errors)
+    return schema_errors
+
+
+def _validate_table_schema_has_correct_collation(
+    instance: Recorder,
+    table_object: type[DeclarativeBase],
+) -> set[str]:
+    """Ensure the table has the correct collation to avoid union errors with mixed collations."""
+    schema_errors: set[str] = set()
+    # Mark the session as read_only to ensure that the test data is not committed
+    # to the database and we always rollback when the scope is exited
+    with session_scope(session=instance.get_session(), read_only=True) as session:
+        table = table_object.__tablename__
+        metadata_obj = MetaData()
+        metadata_obj.reflect(bind=session.connection())
+        dialect_kwargs = metadata_obj.tables[table].dialect_kwargs
+        collate = dialect_kwargs.get("mysql_collate") or dialect_kwargs.get(
+            "mariadb_collate"
+        )
+        if collate and collate != "utf8mb4_unicode_ci":
+            _LOGGER.debug(
+                "Database %s collation is not utf8mb4_unicode_ci",
+                table,
+            )
+            schema_errors.add(f"{table}.utf8mb4_unicode_ci")
     return schema_errors
 
 
@@ -184,7 +231,10 @@ def correct_db_schema_utf8(
 ) -> None:
     """Correct utf8 issues detected by validate_db_schema."""
     table_name = table_object.__tablename__
-    if f"{table_name}.4-byte UTF-8" in schema_errors:
+    if (
+        f"{table_name}.4-byte UTF-8" in schema_errors
+        or f"{table_name}.utf8mb4_unicode_ci" in schema_errors
+    ):
         from ..migration import (  # pylint: disable=import-outside-toplevel
             _correct_table_character_set_and_collation,
         )

--- a/homeassistant/components/recorder/auto_repairs/states/schema.py
+++ b/homeassistant/components/recorder/auto_repairs/states/schema.py
@@ -8,6 +8,7 @@ from ..schema import (
     correct_db_schema_precision,
     correct_db_schema_utf8,
     validate_db_schema_precision,
+    validate_table_schema_has_correct_collation,
     validate_table_schema_supports_utf8,
 )
 
@@ -26,6 +27,8 @@ def validate_db_schema(instance: Recorder) -> set[str]:
     for table, columns in TABLE_UTF8_COLUMNS.items():
         schema_errors |= validate_table_schema_supports_utf8(instance, table, columns)
     schema_errors |= validate_db_schema_precision(instance, States)
+    for table in (States, StateAttributes):
+        schema_errors |= validate_table_schema_has_correct_collation(instance, table)
     return schema_errors
 
 

--- a/homeassistant/components/recorder/auto_repairs/statistics/schema.py
+++ b/homeassistant/components/recorder/auto_repairs/statistics/schema.py
@@ -9,6 +9,7 @@ from ..schema import (
     correct_db_schema_precision,
     correct_db_schema_utf8,
     validate_db_schema_precision,
+    validate_table_schema_has_correct_collation,
     validate_table_schema_supports_utf8,
 )
 
@@ -26,6 +27,7 @@ def validate_db_schema(instance: Recorder) -> set[str]:
     )
     for table in (Statistics, StatisticsShortTerm):
         schema_errors |= validate_db_schema_precision(instance, table)
+        schema_errors |= validate_table_schema_has_correct_collation(instance, table)
     if schema_errors:
         _LOGGER.debug(
             "Detected statistics schema errors: %s", ", ".join(sorted(schema_errors))
@@ -41,3 +43,4 @@ def correct_db_schema(
     correct_db_schema_utf8(instance, StatisticsMeta, schema_errors)
     for table in (Statistics, StatisticsShortTerm):
         correct_db_schema_precision(instance, table, schema_errors)
+        correct_db_schema_utf8(instance, table, schema_errors)

--- a/tests/components/recorder/auto_repairs/events/test_schema.py
+++ b/tests/components/recorder/auto_repairs/events/test_schema.py
@@ -74,3 +74,32 @@ async def test_validate_db_schema_fix_utf8_issue_event_data(
         "Updating character set and collation of table event_data to utf8mb4"
         in caplog.text
     )
+
+
+@pytest.mark.parametrize("enable_schema_validation", [True])
+async def test_validate_db_schema_fix_collation_issue(
+    async_setup_recorder_instance: RecorderInstanceGenerator,
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test validating DB schema with MySQL.
+
+    Note: The test uses SQLite, the purpose is only to exercise the code.
+    """
+    with patch(
+        "homeassistant.components.recorder.core.Recorder.dialect_name", "mysql"
+    ), patch(
+        "homeassistant.components.recorder.auto_repairs.schema._validate_table_schema_has_correct_collation",
+        return_value={"events.utf8mb4_unicode_ci"},
+    ):
+        await async_setup_recorder_instance(hass)
+        await async_wait_recording_done(hass)
+
+    assert "Schema validation failed" not in caplog.text
+    assert (
+        "Database is about to correct DB schema errors: events.utf8mb4_unicode_ci"
+        in caplog.text
+    )
+    assert (
+        "Updating character set and collation of table events to utf8mb4" in caplog.text
+    )

--- a/tests/components/recorder/auto_repairs/states/test_schema.py
+++ b/tests/components/recorder/auto_repairs/states/test_schema.py
@@ -104,3 +104,32 @@ async def test_validate_db_schema_fix_utf8_issue_state_attributes(
         "Updating character set and collation of table state_attributes to utf8mb4"
         in caplog.text
     )
+
+
+@pytest.mark.parametrize("enable_schema_validation", [True])
+async def test_validate_db_schema_fix_collation_issue(
+    async_setup_recorder_instance: RecorderInstanceGenerator,
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test validating DB schema with MySQL.
+
+    Note: The test uses SQLite, the purpose is only to exercise the code.
+    """
+    with patch(
+        "homeassistant.components.recorder.core.Recorder.dialect_name", "mysql"
+    ), patch(
+        "homeassistant.components.recorder.auto_repairs.schema._validate_table_schema_has_correct_collation",
+        return_value={"states.utf8mb4_unicode_ci"},
+    ):
+        await async_setup_recorder_instance(hass)
+        await async_wait_recording_done(hass)
+
+    assert "Schema validation failed" not in caplog.text
+    assert (
+        "Database is about to correct DB schema errors: states.utf8mb4_unicode_ci"
+        in caplog.text
+    )
+    assert (
+        "Updating character set and collation of table states to utf8mb4" in caplog.text
+    )

--- a/tests/components/recorder/auto_repairs/test_schema.py
+++ b/tests/components/recorder/auto_repairs/test_schema.py
@@ -149,6 +149,27 @@ async def test_validate_db_schema_fix_incorrect_collation(
     assert schema_errors == set()
 
 
+async def test_validate_db_schema_precision_correct_collation(
+    async_setup_recorder_instance: RecorderInstanceGenerator,
+    hass: HomeAssistant,
+    recorder_db_url: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test validating DB schema when the schema is correct with the correct collation."""
+    if not recorder_db_url.startswith("mysql://"):
+        # This problem only happens on MySQL
+        return
+    await async_setup_recorder_instance(hass)
+    await async_wait_recording_done(hass)
+    instance = get_instance(hass)
+    schema_errors = await instance.async_add_executor_job(
+        validate_table_schema_has_correct_collation,
+        instance,
+        States,
+    )
+    assert schema_errors == set()
+
+
 async def test_validate_db_schema_fix_utf8_issue_with_broken_schema_unrepairable(
     async_setup_recorder_instance: RecorderInstanceGenerator,
     hass: HomeAssistant,

--- a/tests/components/recorder/auto_repairs/test_schema.py
+++ b/tests/components/recorder/auto_repairs/test_schema.py
@@ -10,6 +10,7 @@ from homeassistant.components.recorder.auto_repairs.schema import (
     correct_db_schema_precision,
     correct_db_schema_utf8,
     validate_db_schema_precision,
+    validate_table_schema_has_correct_collation,
     validate_table_schema_supports_utf8,
 )
 from homeassistant.components.recorder.db_schema import States
@@ -102,6 +103,48 @@ async def test_validate_db_schema_fix_utf8_issue_with_broken_schema(
     # Now validate the schema again
     schema_errors = await instance.async_add_executor_job(
         validate_table_schema_supports_utf8, instance, States, ("state",)
+    )
+    assert schema_errors == set()
+
+
+async def test_validate_db_schema_fix_incorrect_collation(
+    async_setup_recorder_instance: RecorderInstanceGenerator,
+    hass: HomeAssistant,
+    recorder_db_url: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test validating DB schema with MySQL when the collation is incorrect."""
+    if not recorder_db_url.startswith("mysql://"):
+        # This problem only happens on MySQL
+        return
+    await async_setup_recorder_instance(hass)
+    await async_wait_recording_done(hass)
+    instance = get_instance(hass)
+    session_maker = instance.get_session
+
+    def _break_states_schema():
+        with session_scope(session=session_maker()) as session:
+            session.execute(
+                text(
+                    "ALTER TABLE states CHARACTER SET utf8mb3 COLLATE utf8_general_ci, "
+                    "LOCK=EXCLUSIVE;"
+                )
+            )
+
+    await instance.async_add_executor_job(_break_states_schema)
+    schema_errors = await instance.async_add_executor_job(
+        validate_table_schema_has_correct_collation, instance, States
+    )
+    assert schema_errors == {"states.utf8mb4_unicode_ci"}
+
+    # Now repair the schema
+    await instance.async_add_executor_job(
+        correct_db_schema_utf8, instance, States, schema_errors
+    )
+
+    # Now validate the schema again
+    schema_errors = await instance.async_add_executor_job(
+        validate_table_schema_has_correct_collation, instance, States
     )
     assert schema_errors == set()
 

--- a/tests/components/recorder/auto_repairs/test_schema.py
+++ b/tests/components/recorder/auto_repairs/test_schema.py
@@ -126,7 +126,7 @@ async def test_validate_db_schema_fix_incorrect_collation(
         with session_scope(session=session_maker()) as session:
             session.execute(
                 text(
-                    "ALTER TABLE states CHARACTER SET utf8mb3 COLLATE utf8_general_ci, "
+                    "ALTER TABLE states CHARACTER SET ascii COLLATE ascii_general_ci, "
                     "LOCK=EXCLUSIVE;"
                 )
             )

--- a/tests/components/recorder/auto_repairs/test_schema.py
+++ b/tests/components/recorder/auto_repairs/test_schema.py
@@ -126,7 +126,7 @@ async def test_validate_db_schema_fix_incorrect_collation(
         with session_scope(session=session_maker()) as session:
             session.execute(
                 text(
-                    "ALTER TABLE states CHARACTER SET ascii COLLATE ascii_general_ci, "
+                    "ALTER TABLE states CHARACTER SET utf8mb3 COLLATE utf8_general_ci, "
                     "LOCK=EXCLUSIVE;"
                 )
             )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As we do more union queries in 2023.5.x if there is a mismatch between collations on tables, they will fail with an error that is hard for the user to figure out how to fix

`Error executing query: (MySQLdb.OperationalError) (1271, "Illegal mix of collations for operation UNION")`

This was reported in the #beta channel and by PM from others so the problem is not isolated to a single user. 

Since we never enforced this in earlier versions its likely some tables will have a mix of `utf8mb4_unicode_ci` and `utf8_general_ci`, and `utf8mb4_general_ci` as they were created with whatever the user's system default were.  If they are not all `utf8mb4_unicode_ci` the unions data between tables with non-like collations will fail.

https://discord.com/channels/330944238910963714/427516175237382144/1100908739910963272

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #75126 fixes #74293 fixes #79867 fixes #74634 fixes #74230 fixes #73235
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
