### PR TITLE
Refactor some zwave code and add test coverage

### DIFF
--- a/homeassistant/components/zwave_js/device_action.py
+++ b/homeassistant/components/zwave_js/device_action.py
@@ -186,8 +186,9 @@ async def async_get_actions(
         # underlying value is not being monitored by HA so we shouldn't allow
         # actions against it.
         if (
-            state := hass.states.get(entry.entity_id)
-        ) and state.state == STATE_UNAVAILABLE:
+            not (state := hass.states.get(entry.entity_id))
+            or state.state == STATE_UNAVAILABLE
+        ):
             continue
         entity_action = {**base_action, CONF_ENTITY_ID: entry.entity_id}
         actions.append({**entity_action, CONF_TYPE: SERVICE_REFRESH_VALUE})
@@ -209,9 +210,7 @@ async def async_get_actions(
             # If the value has the meterType CC specific value, we can add a reset_meter
             # action for it
             if CC_SPECIFIC_METER_TYPE in value.metadata.cc_specific:
-                endpoint_idx = value.endpoint
-                if endpoint_idx is None:
-                    endpoint_idx = 0
+                endpoint_idx = value.endpoint or 0
                 meter_endpoints[endpoint_idx].setdefault(
                     CONF_ENTITY_ID, entry.entity_id
                 )

--- a/homeassistant/components/zwave_js/fan.py
+++ b/homeassistant/components/zwave_js/fan.py
@@ -25,7 +25,6 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util.percentage import (
-    int_states_in_range,
     percentage_to_ranged_value,
     ranged_value_to_percentage,
 )
@@ -85,7 +84,9 @@ class ZwaveFan(ZWaveBaseEntity, FanEntity):
     ) -> None:
         """Initialize the fan."""
         super().__init__(config_entry, driver, info)
-        self._target_value = self.get_zwave_value(TARGET_VALUE_PROPERTY)
+        if not (target_value := self.get_zwave_value(TARGET_VALUE_PROPERTY)):
+            raise HomeAssistantError("Missing target value on device.")
+        self._target_value = target_value
 
     async def async_set_percentage(self, percentage: int) -> None:
         """Set the speed percentage of the fan."""
@@ -96,9 +97,7 @@ class ZwaveFan(ZWaveBaseEntity, FanEntity):
                 percentage_to_ranged_value(DEFAULT_SPEED_RANGE, percentage)
             )
 
-        if (target_value := self._target_value) is None:
-            raise HomeAssistantError("Missing target value on device.")
-        await self.info.node.async_set_value(target_value, zwave_speed)
+        await self.info.node.async_set_value(self._target_value, zwave_speed)
 
     async def async_turn_on(
         self,
@@ -112,16 +111,12 @@ class ZwaveFan(ZWaveBaseEntity, FanEntity):
         elif preset_mode is not None:
             await self.async_set_preset_mode(preset_mode)
         else:
-            if (target_value := self._target_value) is None:
-                raise HomeAssistantError("Missing target value on device.")
             # Value 255 tells device to return to previous value
-            await self.info.node.async_set_value(target_value, 255)
+            await self.info.node.async_set_value(self._target_value, 255)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
-        if (target_value := self._target_value) is None:
-            raise HomeAssistantError("Missing target value on device.")
-        await self.info.node.async_set_value(target_value, 0)
+        await self.info.node.async_set_value(self._target_value, 0)
 
     @property
     def is_on(self) -> bool | None:
@@ -146,11 +141,6 @@ class ZwaveFan(ZWaveBaseEntity, FanEntity):
         """Return the step size for percentage."""
         return 1
 
-    @property
-    def speed_count(self) -> int:
-        """Return the number of speeds the fan supports."""
-        return int_states_in_range(DEFAULT_SPEED_RANGE)
-
 
 class ValueMappingZwaveFan(ZwaveFan):
     """A Zwave fan with a value mapping data (e.g., 1-24 is low)."""
@@ -166,18 +156,14 @@ class ValueMappingZwaveFan(ZwaveFan):
 
     async def async_set_percentage(self, percentage: int) -> None:
         """Set the speed percentage of the fan."""
-        if (target_value := self._target_value) is None:
-            raise HomeAssistantError("Missing target value on device.")
         zwave_speed = self.percentage_to_zwave_speed(percentage)
-        await self.info.node.async_set_value(target_value, zwave_speed)
+        await self.info.node.async_set_value(self._target_value, zwave_speed)
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""
-        if (target_value := self._target_value) is None:
-            raise HomeAssistantError("Missing target value on device.")
         for zwave_value, mapped_preset_mode in self.fan_value_mapping.presets.items():
             if preset_mode == mapped_preset_mode:
-                await self.info.node.async_set_value(target_value, zwave_value)
+                await self.info.node.async_set_value(self._target_value, zwave_value)
                 return
 
         raise NotValidPresetModeError(
@@ -277,12 +263,9 @@ class ValueMappingZwaveFan(ZwaveFan):
             assert step_percentage
 
             if percentage <= step_percentage:
-                return max_speed
+                break
 
-        # This shouldn't actually happen; the last entry in
-        # `self.fan_value_mapping.speeds` should map to 100%.
-        (_, last_max_speed) = self.fan_value_mapping.speeds[-1]
-        return last_max_speed
+        return max_speed
 
     def zwave_speed_to_percentage(self, zwave_speed: int) -> int | None:
         """Convert a Zwave speed to a percentage.

--- a/homeassistant/components/zwave_js/light.py
+++ b/homeassistant/components/zwave_js/light.py
@@ -444,8 +444,8 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
 class ZwaveBlackIsOffLight(ZwaveLight):
     """Representation of a Z-Wave light where setting the color to black turns it off.
 
-    Currently only supports lights with RGB, no color temperature,
-    and no white channels.
+    Currently only supports lights with RGB, no color temperature, and no white
+    channels.
     """
 
     def __init__(
@@ -471,13 +471,12 @@ class ZwaveBlackIsOffLight(ZwaveLight):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""
-        await super().async_turn_on(**kwargs)
-
         if (
             kwargs.get(ATTR_RGBW_COLOR) is not None
             or kwargs.get(ATTR_COLOR_TEMP) is not None
             or kwargs.get(ATTR_HS_COLOR) is not None
         ):
+            await super().async_turn_on(**kwargs)
             return
 
         transition = kwargs.get(ATTR_TRANSITION)

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -395,13 +395,6 @@ class ZwaveSensor(ZWaveBaseEntity, SensorEntity):
         self._attr_name = self.generate_name(include_value_name=True)
 
     @property
-    def options(self) -> list[str] | None:
-        """Return options for enum sensor."""
-        if self.device_class == SensorDeviceClass.ENUM:
-            return list(self.info.primary_value.metadata.states.values())
-        return None
-
-    @property
     def native_value(self) -> StateType:
         """Return state of the sensor."""
         key = str(self.info.primary_value.value)
@@ -499,6 +492,13 @@ class ZWaveListSensor(ZwaveSensor):
             return super().device_class
         if self.info.primary_value.metadata.states:
             return SensorDeviceClass.ENUM
+        return None
+
+    @property
+    def options(self) -> list[str] | None:
+        """Return options for enum sensor."""
+        if self.device_class == SensorDeviceClass.ENUM:
+            return list(self.info.primary_value.metadata.states.values())
         return None
 
     @property

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -469,22 +469,6 @@ class ZWaveMeterSensor(ZWaveNumericSensor):
 class ZWaveListSensor(ZwaveSensor):
     """Representation of a Z-Wave Numeric sensor with multiple states."""
 
-    def __init__(
-        self,
-        config_entry: ConfigEntry,
-        driver: Driver,
-        info: ZwaveDiscoveryInfo,
-        entity_description: SensorEntityDescription,
-        unit_of_measurement: str | None = None,
-    ) -> None:
-        """Initialize a ZWaveListSensor entity."""
-        super().__init__(
-            config_entry, driver, info, entity_description, unit_of_measurement
-        )
-
-        # Entity class attributes
-        self._attr_name = self.generate_name(include_value_name=True)
-
     @property
     def device_class(self) -> SensorDeviceClass | None:
         """Return sensor device class."""

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -397,16 +397,10 @@ class ZwaveSensor(ZWaveBaseEntity, SensorEntity):
     @property
     def native_value(self) -> StateType:
         """Return state of the sensor."""
-        if self.info.primary_value.value is None:
-            return None
-        if (
-            str(self.info.primary_value.value)
-            not in self.info.primary_value.metadata.states
-        ):
-            return str(self.info.primary_value.value)
-        return str(
-            self.info.primary_value.metadata.states[str(self.info.primary_value.value)]
-        )
+        key = str(self.info.primary_value.value)
+        if key not in self.info.primary_value.metadata.states:
+            return self.info.primary_value.value
+        return str(self.info.primary_value.metadata.states[key])
 
     @property
     def native_unit_of_measurement(self) -> str | None:

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -447,8 +447,7 @@ class ZWaveMeterSensor(ZWaveNumericSensor):
     ) -> None:
         """Reset meter(s) on device."""
         node = self.info.node
-        primary_value = self.info.primary_value
-        endpoint = primary_value.endpoint or 0
+        endpoint = self.info.primary_value.endpoint or 0
         options = {}
         if meter_type is not None:
             options[RESET_METER_OPTION_TYPE] = meter_type
@@ -461,7 +460,7 @@ class ZWaveMeterSensor(ZWaveNumericSensor):
         LOGGER.debug(
             "Meters on node %s endpoint %s reset with the following options: %s",
             node,
-            primary_value.endpoint,
+            endpoint,
             options,
         )
 

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -395,6 +395,13 @@ class ZwaveSensor(ZWaveBaseEntity, SensorEntity):
         self._attr_name = self.generate_name(include_value_name=True)
 
     @property
+    def options(self) -> list[str] | None:
+        """Return options for enum sensor."""
+        if self.device_class == SensorDeviceClass.ENUM:
+            return list(self.info.primary_value.metadata.states.values())
+        return None
+
+    @property
     def native_value(self) -> StateType:
         """Return state of the sensor."""
         key = str(self.info.primary_value.value)
@@ -495,23 +502,6 @@ class ZWaveListSensor(ZwaveSensor):
         return None
 
     @property
-    def options(self) -> list[str] | None:
-        """Return options for enum sensor."""
-        if self.device_class == SensorDeviceClass.ENUM:
-            return list(self.info.primary_value.metadata.states.values())
-        return None
-
-    @property
-    def native_value(self) -> str | None:
-        """Return state of the sensor."""
-        if self.info.primary_value.value is None:
-            return None
-        key = str(self.info.primary_value.value)
-        if key not in self.info.primary_value.metadata.states:
-            return key
-        return str(self.info.primary_value.metadata.states[key])
-
-    @property
     def extra_state_attributes(self) -> dict[str, str] | None:
         """Return the device specific state attributes."""
         if (value := self.info.primary_value.value) is None:
@@ -555,13 +545,6 @@ class ZWaveConfigParameterSensor(ZwaveSensor):
             == ConfigurationValueType.ENUMERATED
         ):
             return SensorDeviceClass.ENUM
-        return None
-
-    @property
-    def options(self) -> list[str] | None:
-        """Return options for enum sensor."""
-        if self.device_class == SensorDeviceClass.ENUM:
-            return list(self.info.primary_value.metadata.states.values())
         return None
 
     @property

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -531,19 +531,6 @@ class ZWaveConfigParameterSensor(ZwaveSensor):
         return None
 
     @property
-    def native_value(self) -> str | None:
-        """Return state of the sensor."""
-        if self.info.primary_value.value is None:
-            return None
-        key = str(self.info.primary_value.value)
-        if (
-            self._primary_value.configuration_value_type == ConfigurationValueType.RANGE
-            or (key not in self.info.primary_value.metadata.states)
-        ):
-            return key
-        return str(self.info.primary_value.metadata.states[key])
-
-    @property
     def extra_state_attributes(self) -> dict[str, str] | None:
         """Return the device specific state attributes."""
         if (

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -38,10 +38,10 @@ from homeassistant.const import (
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import StateType
 
 from .const import (
     ATTR_METER_TYPE,
@@ -311,11 +311,7 @@ async def async_setup_entry(
 
         entity_description = get_entity_description(data)
 
-        if info.platform_hint == "string_sensor":
-            entities.append(
-                ZWaveStringSensor(config_entry, driver, info, entity_description)
-            )
-        elif info.platform_hint == "numeric_sensor":
+        if info.platform_hint == "numeric_sensor":
             entities.append(
                 ZWaveNumericSensor(
                     config_entry,
@@ -340,12 +336,7 @@ async def async_setup_entry(
                 ZWaveMeterSensor(config_entry, driver, info, entity_description)
             )
         else:
-            LOGGER.warning(
-                "Sensor not implemented for %s/%s",
-                info.platform_hint,
-                info.primary_value.property_name,
-            )
-            return
+            entities.append(ZwaveSensor(config_entry, driver, info, entity_description))
 
         async_add_entities(entities)
 
@@ -383,7 +374,7 @@ async def async_setup_entry(
     )
 
 
-class ZwaveSensorBase(ZWaveBaseEntity, SensorEntity):
+class ZwaveSensor(ZWaveBaseEntity, SensorEntity):
     """Basic Representation of a Z-Wave sensor."""
 
     def __init__(
@@ -403,26 +394,31 @@ class ZwaveSensorBase(ZWaveBaseEntity, SensorEntity):
         self._attr_force_update = True
         self._attr_name = self.generate_name(include_value_name=True)
 
-
-class ZWaveStringSensor(ZwaveSensorBase):
-    """Representation of a Z-Wave String sensor."""
-
     @property
-    def native_value(self) -> str | None:
+    def native_value(self) -> StateType:
         """Return state of the sensor."""
         if self.info.primary_value.value is None:
             return None
-        return str(self.info.primary_value.value)
+        if (
+            str(self.info.primary_value.value)
+            not in self.info.primary_value.metadata.states
+        ):
+            return str(self.info.primary_value.value)
+        return str(
+            self.info.primary_value.metadata.states[str(self.info.primary_value.value)]
+        )
 
     @property
     def native_unit_of_measurement(self) -> str | None:
         """Return unit of measurement the value is expressed in."""
+        if super().native_unit_of_measurement is not None:
+            return super().native_unit_of_measurement
         if self.info.primary_value.metadata.unit is None:
             return None
         return str(self.info.primary_value.metadata.unit)
 
 
-class ZWaveNumericSensor(ZwaveSensorBase):
+class ZWaveNumericSensor(ZwaveSensor):
     """Representation of a Z-Wave Numeric sensor."""
 
     @callback
@@ -439,18 +435,6 @@ class ZWaveNumericSensor(ZwaveSensorBase):
             return 0
         return round(float(self.info.primary_value.value), 2)
 
-    @property
-    def native_unit_of_measurement(self) -> str | None:
-        """Return unit of measurement the value is expressed in."""
-        if self.entity_description.native_unit_of_measurement is not None:
-            return self.entity_description.native_unit_of_measurement
-        if self._attr_native_unit_of_measurement is not None:
-            return self._attr_native_unit_of_measurement
-        if self.info.primary_value.metadata.unit is None:
-            return None
-
-        return str(self.info.primary_value.metadata.unit)
-
 
 class ZWaveMeterSensor(ZWaveNumericSensor):
     """Representation of a Z-Wave Meter CC sensor."""
@@ -458,12 +442,11 @@ class ZWaveMeterSensor(ZWaveNumericSensor):
     @property
     def extra_state_attributes(self) -> Mapping[str, int | str] | None:
         """Return extra state attributes."""
-        if meter_type := get_meter_type(self.info.primary_value):
-            return {
-                ATTR_METER_TYPE: meter_type.value,
-                ATTR_METER_TYPE_NAME: meter_type.name,
-            }
-        return None
+        meter_type = get_meter_type(self.info.primary_value)
+        return {
+            ATTR_METER_TYPE: meter_type.value,
+            ATTR_METER_TYPE_NAME: meter_type.name,
+        }
 
     async def async_reset_meter(
         self, meter_type: int | None = None, value: int | None = None
@@ -471,8 +454,7 @@ class ZWaveMeterSensor(ZWaveNumericSensor):
         """Reset meter(s) on device."""
         node = self.info.node
         primary_value = self.info.primary_value
-        if (endpoint := primary_value.endpoint) is None:
-            raise HomeAssistantError("Missing endpoint on device.")
+        endpoint = primary_value.endpoint or 0
         options = {}
         if meter_type is not None:
             options[RESET_METER_OPTION_TYPE] = meter_type
@@ -490,8 +472,8 @@ class ZWaveMeterSensor(ZWaveNumericSensor):
         )
 
 
-class ZWaveListSensor(ZwaveSensorBase):
-    """Representation of a Z-Wave List sensor with multiple states."""
+class ZWaveListSensor(ZwaveSensor):
+    """Representation of a Z-Wave Numeric sensor with multiple states."""
 
     def __init__(
         self,
@@ -544,7 +526,7 @@ class ZWaveListSensor(ZwaveSensorBase):
         return {ATTR_VALUE: value}
 
 
-class ZWaveConfigParameterSensor(ZwaveSensorBase):
+class ZWaveConfigParameterSensor(ZwaveSensor):
     """Representation of a Z-Wave config parameter sensor."""
 
     def __init__(

--- a/homeassistant/components/zwave_js/trigger.py
+++ b/homeassistant/components/zwave_js/trigger.py
@@ -1,8 +1,6 @@
 """Z-Wave JS trigger dispatcher."""
 from __future__ import annotations
 
-from typing import cast
-
 from homeassistant.const import CONF_PLATFORM
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant
 from homeassistant.helpers.trigger import (
@@ -33,10 +31,7 @@ async def async_validate_trigger_config(
 ) -> ConfigType:
     """Validate config."""
     platform = _get_trigger_platform(config)
-    if hasattr(platform, "async_validate_trigger_config"):
-        return await platform.async_validate_trigger_config(hass, config)
-
-    return cast(ConfigType, platform.TRIGGER_SCHEMA(config))
+    return await platform.async_validate_trigger_config(hass, config)
 
 
 async def async_attach_trigger(

--- a/tests/components/zwave_js/test_fan.py
+++ b/tests/components/zwave_js/test_fan.py
@@ -13,6 +13,7 @@ from homeassistant.components.fan import (
     ATTR_PRESET_MODE,
     ATTR_PRESET_MODES,
     DOMAIN as FAN_DOMAIN,
+    SERVICE_SET_PERCENTAGE,
     SERVICE_SET_PRESET_MODE,
     FanEntityFeature,
     NotValidPresetModeError,
@@ -166,6 +167,50 @@ async def test_generic_fan(
     state = hass.states.get(entity_id)
     assert state.state == "off"
     assert state.attributes[ATTR_PERCENTAGE] == 0
+
+    client.async_send_command.reset_mock()
+
+    # Test setting percentage to 0
+    await hass.services.async_call(
+        "fan",
+        SERVICE_SET_PERCENTAGE,
+        {"entity_id": entity_id, "percentage": 0},
+        blocking=True,
+    )
+
+    assert len(client.async_send_command.call_args_list) == 1
+    args = client.async_send_command.call_args[0][0]
+    assert args["command"] == "node.set_value"
+    assert args["nodeId"] == 17
+    assert args["valueId"] == {
+        "commandClass": 38,
+        "endpoint": 0,
+        "property": "targetValue",
+    }
+    assert args["value"] == 0
+
+    # Test value is None
+    event = Event(
+        type="value updated",
+        data={
+            "source": "node",
+            "event": "value updated",
+            "nodeId": 17,
+            "args": {
+                "commandClassName": "Multilevel Switch",
+                "commandClass": 38,
+                "endpoint": 0,
+                "property": "currentValue",
+                "newValue": None,
+                "prevValue": 0,
+                "propertyName": "currentValue",
+            },
+        },
+    )
+    node.receive_event(event)
+
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_UNKNOWN
 
 
 async def test_configurable_speeds_fan(
@@ -360,6 +405,29 @@ async def test_ge_12730_fan(hass: HomeAssistant, client, ge_12730, integration) 
     state = hass.states.get(entity_id)
     assert state.attributes[ATTR_PERCENTAGE_STEP] == pytest.approx(33.3333, rel=1e-3)
     assert state.attributes[ATTR_PRESET_MODES] == []
+
+    # Test value is None
+    event = Event(
+        type="value updated",
+        data={
+            "source": "node",
+            "event": "value updated",
+            "nodeId": node_id,
+            "args": {
+                "commandClassName": "Multilevel Switch",
+                "commandClass": 38,
+                "endpoint": 0,
+                "property": "currentValue",
+                "newValue": None,
+                "prevValue": 0,
+                "propertyName": "currentValue",
+            },
+        },
+    )
+    node.receive_event(event)
+
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_UNKNOWN
 
 
 async def test_inovelli_lzw36(

--- a/tests/components/zwave_js/test_helpers.py
+++ b/tests/components/zwave_js/test_helpers.py
@@ -1,0 +1,24 @@
+"""Test the Z-Wave JS helpers module."""
+from homeassistant.components.zwave_js.helpers import (
+    async_get_node_status_sensor_entity_id,
+    async_get_nodes_from_area_id,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import area_registry as ar, device_registry as dr
+
+
+async def test_async_get_node_status_sensor_entity_id(hass: HomeAssistant) -> None:
+    """Test async_get_node_status_sensor_entity_id for non zwave_js device."""
+    dev_reg = dr.async_get(hass)
+    device = dev_reg.async_get_or_create(
+        config_entry_id="123",
+        identifiers={("test", "test")},
+    )
+    assert async_get_node_status_sensor_entity_id(hass, device.id) is None
+
+
+async def test_async_get_nodes_from_area_id(hass: HomeAssistant) -> None:
+    """Test async_get_nodes_from_area_id."""
+    area_reg = ar.async_get(hass)
+    area = area_reg.async_create("test")
+    assert not async_get_nodes_from_area_id(hass, area.id)

--- a/tests/components/zwave_js/test_light.py
+++ b/tests/components/zwave_js/test_light.py
@@ -23,6 +23,7 @@ from homeassistant.const import (
     SERVICE_TURN_ON,
     STATE_OFF,
     STATE_ON,
+    STATE_UNKNOWN,
 )
 from homeassistant.core import HomeAssistant
 
@@ -397,6 +398,33 @@ async def test_light(
     }
     assert args["value"] == 0
 
+    client.async_send_command.reset_mock()
+
+    # Test brightness update to None from value updated event
+    event = Event(
+        type="value updated",
+        data={
+            "source": "node",
+            "event": "value updated",
+            "nodeId": 39,
+            "args": {
+                "commandClassName": "Multilevel Switch",
+                "commandClass": 38,
+                "endpoint": 0,
+                "property": "currentValue",
+                "newValue": None,
+                "prevValue": 99,
+                "propertyName": "currentValue",
+            },
+        },
+    )
+    node.receive_event(event)
+
+    state = hass.states.get(BULB_6_MULTI_COLOR_LIGHT_ENTITY)
+    assert state.state == STATE_UNKNOWN
+    assert ATTR_COLOR_MODE not in state.attributes
+    assert ATTR_BRIGHTNESS not in state.attributes
+
 
 async def test_v4_dimmer_light(
     hass: HomeAssistant, client, eaton_rf9640_dimmer, integration
@@ -599,3 +627,50 @@ async def test_black_is_off(
     assert args["value"] == {"red": 0, "green": 255, "blue": 0}
 
     client.async_send_command.reset_mock()
+
+    # Force the light to turn on
+    event = Event(
+        type="value updated",
+        data={
+            "source": "node",
+            "event": "value updated",
+            "nodeId": node.node_id,
+            "args": {
+                "commandClassName": "Color Switch",
+                "commandClass": 51,
+                "endpoint": 0,
+                "property": "currentColor",
+                "newValue": None,
+                "prevValue": {
+                    "red": 0,
+                    "green": 255,
+                    "blue": 0,
+                },
+                "propertyName": "currentColor",
+            },
+        },
+    )
+    node.receive_event(event)
+    await hass.async_block_till_done()
+    state = hass.states.get(HSM200_V1_ENTITY)
+    assert state.state == STATE_UNKNOWN
+
+    client.async_send_command.reset_mock()
+
+    # Assert that call fails if attribute is added to service call
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: HSM200_V1_ENTITY, ATTR_RGBW_COLOR: (255, 76, 255, 0)},
+        blocking=True,
+    )
+    assert len(client.async_send_command.call_args_list) == 1
+    args = client.async_send_command.call_args_list[0][0][0]
+    assert args["command"] == "node.set_value"
+    assert args["nodeId"] == node.node_id
+    assert args["valueId"] == {
+        "commandClass": 51,
+        "endpoint": 0,
+        "property": "targetColor",
+    }
+    assert args["value"] == {"red": 255, "green": 76, "blue": 255}

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -27,6 +27,7 @@ from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT,
     PERCENTAGE,
     STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
     EntityCategory,
     UnitOfElectricCurrent,
     UnitOfElectricPotential,
@@ -103,6 +104,30 @@ async def test_numeric_sensor(
     assert ATTR_DEVICE_CLASS not in state.attributes
     assert state.attributes[ATTR_STATE_CLASS] == SensorStateClass.MEASUREMENT
 
+    event = Event(
+        "value updated",
+        {
+            "source": "node",
+            "event": "value updated",
+            "nodeId": express_controls_ezmultipli.node_id,
+            "args": {
+                "commandClassName": "Multilevel Sensor",
+                "commandClass": 49,
+                "endpoint": 0,
+                "property": "Illuminance",
+                "propertyName": "Illuminance",
+                "newValue": None,
+                "prevValue": 61,
+            },
+        },
+    )
+
+    express_controls_ezmultipli.receive_event(event)
+    await hass.async_block_till_done()
+    state = hass.states.get("sensor.hsm200_illuminance")
+    assert state
+    assert state.state == "0"
+
 
 async def test_energy_sensors(
     hass: HomeAssistant, hank_binary_switch, integration
@@ -165,6 +190,32 @@ async def test_disabled_notification_sensor(
     assert state.state == "Motion detection"
     assert state.attributes["value"] == 8
 
+    event = Event(
+        "value updated",
+        {
+            "source": "node",
+            "event": "value updated",
+            "nodeId": multisensor_6.node_id,
+            "args": {
+                "commandClassName": "Notification",
+                "commandClass": 113,
+                "endpoint": 0,
+                "property": "Home Security",
+                "propertyKey": "Motion sensor status",
+                "newValue": None,
+                "prevValue": 0,
+                "propertyName": "Home Security",
+                "propertyKeyName": "Motion sensor status",
+            },
+        },
+    )
+
+    multisensor_6.receive_event(event)
+    await hass.async_block_till_done()
+    state = hass.states.get(NOTIFICATION_MOTION_SENSOR)
+    assert state
+    assert state.state == STATE_UNKNOWN
+
 
 async def test_disabled_indcator_sensor(
     hass: HomeAssistant, climate_radio_thermostat_ct100_plus, integration
@@ -186,6 +237,46 @@ async def test_config_parameter_sensor(
     entity_entry = ent_reg.async_get(ID_LOCK_CONFIG_PARAMETER_SENSOR)
     assert entity_entry
     assert entity_entry.disabled
+
+    updated_entry = ent_reg.async_update_entity(
+        entity_entry.entity_id, **{"disabled_by": None}
+    )
+    assert updated_entry != entity_entry
+    assert updated_entry.disabled is False
+
+    # reload integration and check if entity is correctly there
+    await hass.config_entries.async_reload(integration.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ID_LOCK_CONFIG_PARAMETER_SENSOR)
+    assert state
+    assert state.state == "Disable Away Manual Lock"
+    assert state.attributes[ATTR_VALUE] == 0
+
+    event = Event(
+        "value updated",
+        {
+            "source": "node",
+            "event": "value updated",
+            "nodeId": lock_id_lock_as_id150.node_id,
+            "args": {
+                "commandClassName": "Configuration",
+                "commandClass": 112,
+                "endpoint": 0,
+                "property": 1,
+                "newValue": None,
+                "prevValue": 0,
+                "propertyName": "Door lock mode",
+            },
+        },
+    )
+
+    lock_id_lock_as_id150.receive_event(event)
+    await hass.async_block_till_done()
+    state = hass.states.get(ID_LOCK_CONFIG_PARAMETER_SENSOR)
+    assert state
+    assert state.state == STATE_UNKNOWN
+    assert ATTR_VALUE not in state.attributes
 
 
 async def test_node_status_sensor(

--- a/tests/components/zwave_js/test_trigger.py
+++ b/tests/components/zwave_js/test_trigger.py
@@ -10,11 +10,14 @@ from zwave_js_server.model.node import Node
 from homeassistant.components import automation
 from homeassistant.components.zwave_js import DOMAIN
 from homeassistant.components.zwave_js.helpers import get_device_id
-from homeassistant.components.zwave_js.trigger import async_validate_trigger_config
+from homeassistant.components.zwave_js.trigger import (
+    _get_trigger_platform,
+    async_validate_trigger_config,
+)
 from homeassistant.components.zwave_js.triggers.trigger_helpers import (
     async_bypass_dynamic_config_validation,
 )
-from homeassistant.const import SERVICE_RELOAD
+from homeassistant.const import CONF_PLATFORM, SERVICE_RELOAD
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import async_get as async_get_dev_reg
 from homeassistant.setup import async_setup_component
@@ -1100,3 +1103,9 @@ async def test_zwave_js_trigger_config_entry_unloaded(
             "event": "nvm convert progress",
         },
     )
+
+
+def test_get_trigger_platform_failure() -> None:
+    """Test _get_trigger_platform."""
+    with pytest.raises(ValueError):
+        _get_trigger_platform({CONF_PLATFORM: "zwave_js.invalid"})

--- a/tests/components/zwave_js/test_update.py
+++ b/tests/components/zwave_js/test_update.py
@@ -776,3 +776,20 @@ async def test_update_entity_full_restore_data_no_update_available(
     assert state.state == STATE_OFF
     assert state.attributes[ATTR_SKIPPED_VERSION] is None
     assert state.attributes[ATTR_LATEST_VERSION] == "10.7"
+
+
+async def test_update_entity_unload_asleep_node(
+    hass: HomeAssistant, client, wallmote_central_scene, integration
+) -> None:
+    """Test unloading config entry after attempting an update for an asleep node."""
+    assert len(client.async_send_command.call_args_list) == 0
+
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5, days=1))
+    await hass.async_block_till_done()
+
+    assert len(client.async_send_command.call_args_list) == 0
+    assert len(wallmote_central_scene._listeners["wake up"]) == 2
+
+    await hass.config_entries.async_unload(integration.entry_id)
+    # await hass.async_block_till_done()
+    assert len(wallmote_central_scene._listeners["wake up"]) == 0


### PR DESCRIPTION
## Proposed change
Slowly working on improving test coverage. You'll notice that I made some changes to the code of the modules. These changes should be no-op from a user perspective as described below. Note that this should probably be merged before https://github.com/home-assistant/core/pull/92223 and https://github.com/home-assistant/core/pull/90248 so I can rebase those to accommodate the logic changes in the sensor platform.

device_action:
- The if statement logic was wrong so corrected (we want to skip an entity if it doesn't have a state so it is disabled or gone, or it's state is unknown)
- Combined statements

fan:
- Rather than guarding for no target value in each service, we guard during initialization since a fan without a target value is not controllable.
- Removed `speed_count` property. It is unused in `ZwaveFan` because `percentage_step` is hardcoded to 1 (`speed_count` is used in `FanEntity` to calculate percentage_step)
- Refactored `ValueMappingZwaveFan.percentage_to_zwave_speed` to accomplish the same thing while reducing code branches

light:
- fixed turn_on logic for `ZwaveBlackIsOffLight` to only set the colors to turn on the light if colors are sent in the service call.

sensor:
- The classes were built for specific use cases but there was a way to combine them into a single base sensor class so we can eliminate the number of different class types
- Removed dupe/redundant logic across classes
- Meter sensor state attributes were unnecessarily guarded
- If endpoint is missing for meter sensor, default to 0

trigger:
- Currently all trigger platforms have `async_validate_trigger_config` so there is no need for conditional logic, we can add it back in later if/when needed


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
