### PR TITLE
Fix august lock state when API reports locking and locked with the same timestamp

### DIFF
--- a/homeassistant/components/august/activity.py
+++ b/homeassistant/components/august/activity.py
@@ -3,6 +3,7 @@ import asyncio
 import logging
 
 from aiohttp import ClientError
+from yalexs.util import get_latest_activity
 
 from homeassistant.core import callback
 from homeassistant.helpers.debounce import Debouncer
@@ -169,12 +170,11 @@ class ActivityStream(AugustSubscriberMixin):
             device_id = activity.device_id
             activity_type = activity.activity_type
             device_activities = self._latest_activities.setdefault(device_id, {})
-            lastest_activity = device_activities.get(activity_type)
-
-            # Ignore activities that are older than the latest one
+            # Ignore activities that are older than the latest one unless it is a non
+            # locking or unlocking activity with the exact same start time.
             if (
-                lastest_activity
-                and lastest_activity.activity_start_time >= activity.activity_start_time
+                get_latest_activity(activity, device_activities.get(activity_type))
+                != activity
             ):
                 continue
 

--- a/homeassistant/components/august/lock.py
+++ b/homeassistant/components/august/lock.py
@@ -5,7 +5,7 @@ from typing import Any
 from aiohttp import ClientResponseError
 from yalexs.activity import SOURCE_PUBNUB, ActivityType
 from yalexs.lock import LockStatus
-from yalexs.util import update_lock_detail_from_activity
+from yalexs.util import get_latest_activity, update_lock_detail_from_activity
 
 from homeassistant.components.lock import ATTR_CHANGED_BY, LockEntity
 from homeassistant.config_entries import ConfigEntry
@@ -90,17 +90,26 @@ class AugustLock(AugustEntityMixin, RestoreEntity, LockEntity):
     @callback
     def _update_from_data(self):
         """Get the latest state of the sensor and update activity."""
-        lock_activity = self._data.activity_stream.get_latest_device_activity(
-            self._device_id,
-            {ActivityType.LOCK_OPERATION, ActivityType.LOCK_OPERATION_WITHOUT_OPERATOR},
+        activity_stream = self._data.activity_stream
+        device_id = self._device_id
+        if lock_activity := activity_stream.get_latest_device_activity(
+            device_id,
+            {ActivityType.LOCK_OPERATION},
+        ):
+            self._attr_changed_by = lock_activity.operated_by
+
+        lock_activity_without_operator = activity_stream.get_latest_device_activity(
+            device_id,
+            {ActivityType.LOCK_OPERATION_WITHOUT_OPERATOR},
         )
 
-        if lock_activity is not None:
-            self._attr_changed_by = lock_activity.operated_by
-            update_lock_detail_from_activity(self._detail, lock_activity)
-            # If the source is pubnub the lock must be online since its a live update
-            if lock_activity.source == SOURCE_PUBNUB:
+        if latest_activity := get_latest_activity(
+            lock_activity_without_operator, lock_activity
+        ):
+            if latest_activity.source == SOURCE_PUBNUB:
+                # If the source is pubnub the lock must be online since its a live update
                 self._detail.set_online(True)
+            update_lock_detail_from_activity(self._detail, latest_activity)
 
         bridge_activity = self._data.activity_stream.get_latest_device_activity(
             self._device_id, {ActivityType.BRIDGE_OPERATION}

--- a/homeassistant/components/august/manifest.json
+++ b/homeassistant/components/august/manifest.json
@@ -28,5 +28,5 @@
   "documentation": "https://www.home-assistant.io/integrations/august",
   "iot_class": "cloud_push",
   "loggers": ["pubnub", "yalexs"],
-  "requirements": ["yalexs==1.3.2", "yalexs-ble==2.1.16"]
+  "requirements": ["yalexs==1.3.3", "yalexs-ble==2.1.16"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2679,7 +2679,7 @@ yalesmartalarmclient==0.3.9
 yalexs-ble==2.1.16
 
 # homeassistant.components.august
-yalexs==1.3.2
+yalexs==1.3.3
 
 # homeassistant.components.yeelight
 yeelight==0.7.10

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1943,7 +1943,7 @@ yalesmartalarmclient==0.3.9
 yalexs-ble==2.1.16
 
 # homeassistant.components.august
-yalexs==1.3.2
+yalexs==1.3.3
 
 # homeassistant.components.yeelight
 yeelight==0.7.10


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix august lock state when API reports locking and locked with the same timestamap

changelog: https://github.com/bdraco/yalexs/compare/v1.3.2...v1.3.3



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #92274
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
