### PR TITLE
Matter cover position improvements

### DIFF
--- a/homeassistant/components/matter/cover.py
+++ b/homeassistant/components/matter/cover.py
@@ -59,9 +59,18 @@ class MatterCover(MatterEntity, CoverEntity):
     entity_description: CoverEntityDescription
 
     @property
-    def is_closed(self) -> bool:
-        """Return true if cover is closed, else False."""
-        return self.current_cover_position == 0
+    def is_closed(self) -> bool | None:
+        """Return true if cover is closed, if there is no position report, return None."""
+        if not self._entity_info.endpoint.has_attribute(
+            None, clusters.WindowCovering.Attributes.CurrentPositionLiftPercentage
+        ):
+            return None
+
+        return (
+            self.current_cover_position == 0
+            if self.current_cover_position is not None
+            else None
+        )
 
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover movement."""

--- a/homeassistant/components/matter/cover.py
+++ b/homeassistant/components/matter/cover.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from enum import IntEnum
+from math import floor
 from typing import Any
 
 from chip.clusters import Objects as clusters
@@ -62,7 +63,7 @@ class MatterCover(MatterEntity, CoverEntity):
     def is_closed(self) -> bool | None:
         """Return true if cover is closed, if there is no position report, return None."""
         if not self._entity_info.endpoint.has_attribute(
-            None, clusters.WindowCovering.Attributes.CurrentPositionLiftPercentage
+            None, clusters.WindowCovering.Attributes.CurrentPositionLiftPercent100ths
         ):
             return None
 
@@ -137,10 +138,12 @@ class MatterCover(MatterEntity, CoverEntity):
 
         # current position is inverted in matter (100 is closed, 0 is open)
         current_cover_position = self.get_matter_attribute_value(
-            clusters.WindowCovering.Attributes.CurrentPositionLiftPercentage
+            clusters.WindowCovering.Attributes.CurrentPositionLiftPercent100ths
         )
         self._attr_current_cover_position = (
-            100 - current_cover_position if current_cover_position is not None else None
+            100 - floor(current_cover_position / 100)
+            if current_cover_position is not None
+            else None
         )
 
         LOGGER.debug(
@@ -152,10 +155,10 @@ class MatterCover(MatterEntity, CoverEntity):
 
         # current tilt position is inverted in matter (100 is closed, 0 is open)
         current_cover_tilt_position = self.get_matter_attribute_value(
-            clusters.WindowCovering.Attributes.CurrentPositionTiltPercentage
+            clusters.WindowCovering.Attributes.CurrentPositionTiltPercent100ths
         )
         self._attr_current_cover_tilt_position = (
-            100 - current_cover_tilt_position
+            100 - floor(current_cover_tilt_position / 100)
             if current_cover_tilt_position is not None
             else None
         )
@@ -197,8 +200,8 @@ DISCOVERY_SCHEMAS = [
             clusters.WindowCovering.Attributes.Type,
         ),
         absent_attributes=(
-            clusters.WindowCovering.Attributes.CurrentPositionLiftPercentage,
-            clusters.WindowCovering.Attributes.CurrentPositionTiltPercentage,
+            clusters.WindowCovering.Attributes.CurrentPositionLiftPercent100ths,
+            clusters.WindowCovering.Attributes.CurrentPositionTiltPercent100ths,
         ),
     ),
     MatterDiscoverySchema(
@@ -208,10 +211,10 @@ DISCOVERY_SCHEMAS = [
         required_attributes=(
             clusters.WindowCovering.Attributes.OperationalStatus,
             clusters.WindowCovering.Attributes.Type,
-            clusters.WindowCovering.Attributes.CurrentPositionLiftPercentage,
+            clusters.WindowCovering.Attributes.CurrentPositionLiftPercent100ths,
         ),
         absent_attributes=(
-            clusters.WindowCovering.Attributes.CurrentPositionTiltPercentage,
+            clusters.WindowCovering.Attributes.CurrentPositionTiltPercent100ths,
         ),
     ),
     MatterDiscoverySchema(
@@ -221,10 +224,10 @@ DISCOVERY_SCHEMAS = [
         required_attributes=(
             clusters.WindowCovering.Attributes.OperationalStatus,
             clusters.WindowCovering.Attributes.Type,
-            clusters.WindowCovering.Attributes.CurrentPositionTiltPercentage,
+            clusters.WindowCovering.Attributes.CurrentPositionTiltPercent100ths,
         ),
         absent_attributes=(
-            clusters.WindowCovering.Attributes.CurrentPositionLiftPercentage,
+            clusters.WindowCovering.Attributes.CurrentPositionLiftPercent100ths,
         ),
     ),
     MatterDiscoverySchema(
@@ -236,8 +239,8 @@ DISCOVERY_SCHEMAS = [
         required_attributes=(
             clusters.WindowCovering.Attributes.OperationalStatus,
             clusters.WindowCovering.Attributes.Type,
-            clusters.WindowCovering.Attributes.CurrentPositionLiftPercentage,
-            clusters.WindowCovering.Attributes.CurrentPositionTiltPercentage,
+            clusters.WindowCovering.Attributes.CurrentPositionLiftPercent100ths,
+            clusters.WindowCovering.Attributes.CurrentPositionTiltPercent100ths,
         ),
     ),
 ]

--- a/homeassistant/components/matter/cover.py
+++ b/homeassistant/components/matter/cover.py
@@ -136,39 +136,45 @@ class MatterCover(MatterEntity, CoverEntity):
                 self._attr_is_opening = False
                 self._attr_is_closing = False
 
-        # current position is inverted in matter (100 is closed, 0 is open)
-        current_cover_position = self.get_matter_attribute_value(
-            clusters.WindowCovering.Attributes.CurrentPositionLiftPercent100ths
-        )
-        self._attr_current_cover_position = (
-            100 - floor(current_cover_position / 100)
-            if current_cover_position is not None
-            else None
-        )
+        if self._entity_info.endpoint.has_attribute(
+            None, clusters.WindowCovering.Attributes.CurrentPositionLiftPercent100ths
+        ):
+            # current position is inverted in matter (100 is closed, 0 is open)
+            current_cover_position = self.get_matter_attribute_value(
+                clusters.WindowCovering.Attributes.CurrentPositionLiftPercent100ths
+            )
+            self._attr_current_cover_position = (
+                100 - floor(current_cover_position / 100)
+                if current_cover_position is not None
+                else None
+            )
 
-        LOGGER.debug(
-            "Current position for %s - raw: %s - corrected: %s",
-            self.entity_id,
-            current_cover_position,
-            self.current_cover_position,
-        )
+            LOGGER.debug(
+                "Current position for %s - raw: %s - corrected: %s",
+                self.entity_id,
+                current_cover_position,
+                self.current_cover_position,
+            )
 
-        # current tilt position is inverted in matter (100 is closed, 0 is open)
-        current_cover_tilt_position = self.get_matter_attribute_value(
-            clusters.WindowCovering.Attributes.CurrentPositionTiltPercent100ths
-        )
-        self._attr_current_cover_tilt_position = (
-            100 - floor(current_cover_tilt_position / 100)
-            if current_cover_tilt_position is not None
-            else None
-        )
+        if self._entity_info.endpoint.has_attribute(
+            None, clusters.WindowCovering.Attributes.CurrentPositionTiltPercent100ths
+        ):
+            # current tilt position is inverted in matter (100 is closed, 0 is open)
+            current_cover_tilt_position = self.get_matter_attribute_value(
+                clusters.WindowCovering.Attributes.CurrentPositionTiltPercent100ths
+            )
+            self._attr_current_cover_tilt_position = (
+                100 - floor(current_cover_tilt_position / 100)
+                if current_cover_tilt_position is not None
+                else None
+            )
 
-        LOGGER.debug(
-            "Current tilt position for %s - raw: %s - corrected: %s",
-            self.entity_id,
-            current_cover_tilt_position,
-            self.current_cover_tilt_position,
-        )
+            LOGGER.debug(
+                "Current tilt position for %s - raw: %s - corrected: %s",
+                self.entity_id,
+                current_cover_tilt_position,
+                self.current_cover_tilt_position,
+            )
 
         # map matter type to HA deviceclass
         device_type: clusters.WindowCovering.Enums.Type = (

--- a/tests/components/matter/test_cover.py
+++ b/tests/components/matter/test_cover.py
@@ -177,6 +177,14 @@ async def test_cover_lift_only(
         matter_client,
     )
 
+    set_node_attribute(window_covering, 1, 258, 8, None)
+    set_node_attribute(window_covering, 1, 258, 10, 0b000000)
+    await trigger_subscription_callback(hass, matter_client)
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == "unknown"
+
     set_node_attribute(window_covering, 1, 258, 65529, [0, 1, 2])
     await trigger_subscription_callback(hass, matter_client)
 
@@ -437,3 +445,43 @@ async def test_cover_full_features(
     state = hass.states.get(entity_id)
     assert state
     assert state.state == STATE_CLOSED
+
+    set_node_attribute(window_covering, 1, 258, 8, 50)
+    set_node_attribute(window_covering, 1, 258, 9, None)
+    set_node_attribute(window_covering, 1, 258, 10, 0b000000)
+    await trigger_subscription_callback(hass, matter_client)
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == STATE_OPEN
+
+    set_node_attribute(window_covering, 1, 258, 8, None)
+    set_node_attribute(window_covering, 1, 258, 9, 50)
+    set_node_attribute(window_covering, 1, 258, 10, 0b000000)
+    await trigger_subscription_callback(hass, matter_client)
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == "unknown"
+
+    set_node_attribute(window_covering, 1, 258, 8, 100)
+    set_node_attribute(window_covering, 1, 258, 9, None)
+    set_node_attribute(window_covering, 1, 258, 10, 0b000000)
+    await trigger_subscription_callback(hass, matter_client)
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == STATE_CLOSED
+
+    set_node_attribute(window_covering, 1, 258, 8, None)
+    set_node_attribute(window_covering, 1, 258, 9, 100)
+    set_node_attribute(window_covering, 1, 258, 10, 0b000000)
+    await trigger_subscription_callback(hass, matter_client)
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == "unknown"
+
+    set_node_attribute(window_covering, 1, 258, 8, None)
+    set_node_attribute(window_covering, 1, 258, 9, None)
+    set_node_attribute(window_covering, 1, 258, 10, 0b000000)
+    await trigger_subscription_callback(hass, matter_client)
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == "unknown"

--- a/tests/components/matter/test_cover.py
+++ b/tests/components/matter/test_cover.py
@@ -397,6 +397,7 @@ async def test_cover_position_aware_tilt(
             tilt_position / 100
         )
 
+
 async def test_cover_full_features(
     hass: HomeAssistant,
     matter_client: MagicMock,
@@ -447,6 +448,15 @@ async def test_cover_full_features(
     state = hass.states.get(entity_id)
     assert state
     assert state.state == STATE_CLOSED
+
+    set_node_attribute(window_covering, 1, 258, 14, 5000)
+    set_node_attribute(window_covering, 1, 258, 15, 5000)
+    set_node_attribute(window_covering, 1, 258, 10, 0b000000)
+    await trigger_subscription_callback(hass, matter_client)
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == STATE_OPEN
 
     set_node_attribute(window_covering, 1, 258, 14, 5000)
     set_node_attribute(window_covering, 1, 258, 15, None)

--- a/tests/components/matter/test_cover.py
+++ b/tests/components/matter/test_cover.py
@@ -1,4 +1,5 @@
 """Test Matter covers."""
+from math import floor
 from unittest.mock import MagicMock, call
 
 from chip.clusters import Objects as clusters
@@ -177,7 +178,7 @@ async def test_cover_lift_only(
         matter_client,
     )
 
-    set_node_attribute(window_covering, 1, 258, 8, None)
+    set_node_attribute(window_covering, 1, 258, 14, None)
     set_node_attribute(window_covering, 1, 258, 10, 0b000000)
     await trigger_subscription_callback(hass, matter_client)
 
@@ -232,17 +233,17 @@ async def test_cover_position_aware_lift(
     )
     assert state.attributes["supported_features"] & mask == mask
 
-    for position in (0, 99):
-        set_node_attribute(window_covering, 1, 258, 8, position)
+    for position in (0, 9999):
+        set_node_attribute(window_covering, 1, 258, 14, position)
         set_node_attribute(window_covering, 1, 258, 10, 0b000000)
         await trigger_subscription_callback(hass, matter_client)
 
         state = hass.states.get(entity_id)
         assert state
-        assert state.attributes["current_position"] == 100 - position
+        assert state.attributes["current_position"] == 100 - floor(position / 100)
         assert state.state == STATE_OPEN
 
-    set_node_attribute(window_covering, 1, 258, 8, 100)
+    set_node_attribute(window_covering, 1, 258, 14, 10000)
     set_node_attribute(window_covering, 1, 258, 10, 0b000000)
     await trigger_subscription_callback(hass, matter_client)
 
@@ -385,15 +386,16 @@ async def test_cover_position_aware_tilt(
     )
     assert state.attributes["supported_features"] & mask == mask
 
-    for tilt_position in (0, 99, 100):
-        set_node_attribute(window_covering, 1, 258, 9, tilt_position)
+    for tilt_position in (0, 9999, 10000):
+        set_node_attribute(window_covering, 1, 258, 15, tilt_position)
         set_node_attribute(window_covering, 1, 258, 10, 0b000000)
         await trigger_subscription_callback(hass, matter_client)
 
         state = hass.states.get(entity_id)
         assert state
-        assert state.attributes["current_tilt_position"] == 100 - tilt_position
-
+        assert state.attributes["current_tilt_position"] == 100 - floor(
+            tilt_position / 100
+        )
 
 async def test_cover_full_features(
     hass: HomeAssistant,
@@ -419,8 +421,8 @@ async def test_cover_full_features(
     )
     assert state.attributes["supported_features"] & mask == mask
 
-    set_node_attribute(window_covering, 1, 258, 8, 100)
-    set_node_attribute(window_covering, 1, 258, 9, 100)
+    set_node_attribute(window_covering, 1, 258, 14, 10000)
+    set_node_attribute(window_covering, 1, 258, 15, 10000)
     set_node_attribute(window_covering, 1, 258, 10, 0b000000)
     await trigger_subscription_callback(hass, matter_client)
 
@@ -428,8 +430,8 @@ async def test_cover_full_features(
     assert state
     assert state.state == STATE_CLOSED
 
-    set_node_attribute(window_covering, 1, 258, 8, 50)
-    set_node_attribute(window_covering, 1, 258, 9, 100)
+    set_node_attribute(window_covering, 1, 258, 14, 5000)
+    set_node_attribute(window_covering, 1, 258, 15, 10000)
     set_node_attribute(window_covering, 1, 258, 10, 0b000000)
     await trigger_subscription_callback(hass, matter_client)
 
@@ -437,8 +439,8 @@ async def test_cover_full_features(
     assert state
     assert state.state == STATE_OPEN
 
-    set_node_attribute(window_covering, 1, 258, 8, 100)
-    set_node_attribute(window_covering, 1, 258, 9, 50)
+    set_node_attribute(window_covering, 1, 258, 14, 10000)
+    set_node_attribute(window_covering, 1, 258, 15, 5000)
     set_node_attribute(window_covering, 1, 258, 10, 0b000000)
     await trigger_subscription_callback(hass, matter_client)
 
@@ -446,40 +448,40 @@ async def test_cover_full_features(
     assert state
     assert state.state == STATE_CLOSED
 
-    set_node_attribute(window_covering, 1, 258, 8, 50)
-    set_node_attribute(window_covering, 1, 258, 9, None)
+    set_node_attribute(window_covering, 1, 258, 14, 5000)
+    set_node_attribute(window_covering, 1, 258, 15, None)
     set_node_attribute(window_covering, 1, 258, 10, 0b000000)
     await trigger_subscription_callback(hass, matter_client)
     state = hass.states.get(entity_id)
     assert state
     assert state.state == STATE_OPEN
 
-    set_node_attribute(window_covering, 1, 258, 8, None)
-    set_node_attribute(window_covering, 1, 258, 9, 50)
+    set_node_attribute(window_covering, 1, 258, 14, None)
+    set_node_attribute(window_covering, 1, 258, 15, 5000)
     set_node_attribute(window_covering, 1, 258, 10, 0b000000)
     await trigger_subscription_callback(hass, matter_client)
     state = hass.states.get(entity_id)
     assert state
     assert state.state == "unknown"
 
-    set_node_attribute(window_covering, 1, 258, 8, 100)
-    set_node_attribute(window_covering, 1, 258, 9, None)
+    set_node_attribute(window_covering, 1, 258, 14, 10000)
+    set_node_attribute(window_covering, 1, 258, 15, None)
     set_node_attribute(window_covering, 1, 258, 10, 0b000000)
     await trigger_subscription_callback(hass, matter_client)
     state = hass.states.get(entity_id)
     assert state
     assert state.state == STATE_CLOSED
 
-    set_node_attribute(window_covering, 1, 258, 8, None)
-    set_node_attribute(window_covering, 1, 258, 9, 100)
+    set_node_attribute(window_covering, 1, 258, 14, None)
+    set_node_attribute(window_covering, 1, 258, 15, 10000)
     set_node_attribute(window_covering, 1, 258, 10, 0b000000)
     await trigger_subscription_callback(hass, matter_client)
     state = hass.states.get(entity_id)
     assert state
     assert state.state == "unknown"
 
-    set_node_attribute(window_covering, 1, 258, 8, None)
-    set_node_attribute(window_covering, 1, 258, 9, None)
+    set_node_attribute(window_covering, 1, 258, 14, None)
+    set_node_attribute(window_covering, 1, 258, 15, None)
     set_node_attribute(window_covering, 1, 258, 10, 0b000000)
     await trigger_subscription_callback(hass, matter_client)
     state = hass.states.get(entity_id)


### PR DESCRIPTION
⚠️ **This PR is the second part of a set of changes, first part: #92256** ⚠️
<s>This would be the comparation between first and second pr: [diff](https://github.com/home-assistant/core/compare/Diegorro98:matter_cover_add_functionality...Diegorro98:hass-core:matter_cover_position_improvements)</s>
## Proposed change
+ Position will be updated only if the endpoint has the position attributes
+ Changed the attribute in which is based the position from `CurrentPositionLiftPercentage` and `CurrentPositionTiltPercentage` to `CurrentPositionLiftPercent100ths` and `CurrentPositionTiltPercent100ths`
  + This change has been done because at the matter specs, the old ones are optional and the new ones are mandatory.
  + Position is rounded to the ceiling (in fact is rounded to the floor but then is subtracted to 100, so it is like is rounded to the ceiling) because 0.01% open is near to be closed, but it stills open.
+ Updated tests and added more tests

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR does not fix or close any issue
- This PR is not related to issue
- There is no link to documentation pull request

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
