### PR TITLE
Prevent pysnmp from being installed as it does not work with newer python

### DIFF
--- a/homeassistant/components/aten_pe/switch.py
+++ b/homeassistant/components/aten_pe/switch.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from atenpdu import AtenPE, AtenPEError
+from atenpdu import AtenPE, AtenPEError  # pylint: disable=import-error
 import voluptuous as vol
 
 from homeassistant.components.switch import (

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -176,3 +176,6 @@ websockets>=11.0.1
 # https://github.com/pysnmp/pysnmp/issues/51
 pyasn1==0.4.8
 pysnmplib==5.0.21
+# pysnmp is no longer maintained and does not work with newer
+# python
+pysnmp==1000000000.0.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -386,7 +386,7 @@ asyncpysupla==0.0.5
 asyncsleepiq==1.3.4
 
 # homeassistant.components.aten_pe
-atenpdu==0.3.2
+# atenpdu==0.3.2
 
 # homeassistant.components.aurora
 auroranoaa==0.0.3

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -180,6 +180,9 @@ websockets>=11.0.1
 # https://github.com/pysnmp/pysnmp/issues/51
 pyasn1==0.4.8
 pysnmplib==5.0.21
+# pysnmp is no longer maintained and does not work with newer
+# python
+pysnmp==1000000000.0.0
 """
 
 IGNORE_PRE_COMMIT_HOOK_ID = (

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -21,6 +21,7 @@ else:
 
 COMMENT_REQUIREMENTS = (
     "Adafruit_BBIO",
+    "atenpdu",  # depends on pysnmp which is not maintained at this time
     "avea",  # depends on bluepy
     "avion",
     "azure-servicebus",  # depends on uamqp, which requires OpenSSL 1.1


### PR DESCRIPTION
blocked by https://github.com/home-assistant/core/pull/92293

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
pysnmplib and pysnmp use the same namespace, but we need pysnmplib since it works with newer python

fixes #92281

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
