### PR TITLE
Don't poll ZHA electrical measurement sensors unnecessarily

### DIFF
--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -248,13 +248,16 @@ class Battery(Sensor):
         return state_attrs
 
 
-@MULTI_MATCH(cluster_handler_names=CLUSTER_HANDLER_ELECTRICAL_MEASUREMENT)
+@MULTI_MATCH(
+    cluster_handler_names=CLUSTER_HANDLER_ELECTRICAL_MEASUREMENT,
+    stop_on_match_group=CLUSTER_HANDLER_ELECTRICAL_MEASUREMENT,
+    models={"VZM31-SN", "SP 234", "outletv4"},
+)
 class ElectricalMeasurement(Sensor):
     """Active power measurement."""
 
     SENSOR_ATTR = "active_power"
     _attr_device_class: SensorDeviceClass = SensorDeviceClass.POWER
-    _attr_should_poll = True  # BaseZhaEntity defaults to False
     _attr_state_class: SensorStateClass = SensorStateClass.MEASUREMENT
     _attr_name: str = "Active power"
     _attr_native_unit_of_measurement: str = UnitOfPower.WATT
@@ -284,6 +287,16 @@ class ElectricalMeasurement(Sensor):
             return round(value, self._decimals)
         return round(value)
 
+
+@MULTI_MATCH(
+    cluster_handler_names=CLUSTER_HANDLER_ELECTRICAL_MEASUREMENT,
+    stop_on_match_group=CLUSTER_HANDLER_ELECTRICAL_MEASUREMENT,
+)
+class PolledElectricalMeasurement(Sensor):
+    """Polled active power measurement."""
+
+    _attr_should_poll = True  # BaseZhaEntity defaults to False
+
     async def async_update(self) -> None:
         """Retrieve latest state."""
         if not self.available:
@@ -299,7 +312,6 @@ class ElectricalMeasurementApparentPower(
 
     SENSOR_ATTR = "apparent_power"
     _attr_device_class: SensorDeviceClass = SensorDeviceClass.APPARENT_POWER
-    _attr_should_poll = False  # Poll indirectly by ElectricalMeasurementSensor
     _attr_name: str = "Apparent power"
     _attr_native_unit_of_measurement = UnitOfApparentPower.VOLT_AMPERE
     _div_mul_prefix = "ac_power"
@@ -311,7 +323,6 @@ class ElectricalMeasurementRMSCurrent(ElectricalMeasurement, id_suffix="rms_curr
 
     SENSOR_ATTR = "rms_current"
     _attr_device_class: SensorDeviceClass = SensorDeviceClass.CURRENT
-    _attr_should_poll = False  # Poll indirectly by ElectricalMeasurementSensor
     _attr_name: str = "RMS current"
     _attr_native_unit_of_measurement = UnitOfElectricCurrent.AMPERE
     _div_mul_prefix = "ac_current"
@@ -323,7 +334,6 @@ class ElectricalMeasurementRMSVoltage(ElectricalMeasurement, id_suffix="rms_volt
 
     SENSOR_ATTR = "rms_voltage"
     _attr_device_class: SensorDeviceClass = SensorDeviceClass.VOLTAGE
-    _attr_should_poll = False  # Poll indirectly by ElectricalMeasurementSensor
     _attr_name: str = "RMS voltage"
     _attr_native_unit_of_measurement = UnitOfElectricPotential.VOLT
     _div_mul_prefix = "ac_voltage"
@@ -335,7 +345,6 @@ class ElectricalMeasurementFrequency(ElectricalMeasurement, id_suffix="ac_freque
 
     SENSOR_ATTR = "ac_frequency"
     _attr_device_class: SensorDeviceClass = SensorDeviceClass.FREQUENCY
-    _attr_should_poll = False  # Poll indirectly by ElectricalMeasurementSensor
     _attr_name: str = "AC frequency"
     _attr_native_unit_of_measurement = UnitOfFrequency.HERTZ
     _div_mul_prefix = "ac_frequency"
@@ -347,7 +356,6 @@ class ElectricalMeasurementPowerFactor(ElectricalMeasurement, id_suffix="power_f
 
     SENSOR_ATTR = "power_factor"
     _attr_device_class: SensorDeviceClass = SensorDeviceClass.POWER_FACTOR
-    _attr_should_poll = False  # Poll indirectly by ElectricalMeasurementSensor
     _attr_name: str = "Power factor"
     _attr_native_unit_of_measurement = PERCENTAGE
 

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -292,7 +292,7 @@ class ElectricalMeasurement(Sensor):
     cluster_handler_names=CLUSTER_HANDLER_ELECTRICAL_MEASUREMENT,
     stop_on_match_group=CLUSTER_HANDLER_ELECTRICAL_MEASUREMENT,
 )
-class PolledElectricalMeasurement(Sensor):
+class PolledElectricalMeasurement(ElectricalMeasurement):
     """Polled active power measurement."""
 
     _attr_should_poll = True  # BaseZhaEntity defaults to False

--- a/tests/components/zha/test_sensor.py
+++ b/tests/components/zha/test_sensor.py
@@ -1,6 +1,6 @@
 """Test ZHA sensor."""
 import math
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import zigpy.profiles.zha
@@ -586,6 +586,10 @@ async def test_temp_uom(
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == uom
 
 
+@patch(
+    "zigpy.zcl.ClusterPersistingListener",
+    MagicMock(),
+)
 async def test_electrical_measurement_init(
     hass: HomeAssistant,
     zigpy_device_mock,
@@ -605,7 +609,9 @@ async def test_electrical_measurement_init(
     )
     cluster = zigpy_device.endpoints[1].in_clusters[cluster_id]
     zha_device = await zha_device_joined(zigpy_device)
-    entity_id = await find_entity_id(Platform.SENSOR, zha_device, hass)
+    entity_id = await find_entity_id(
+        Platform.SENSOR, zha_device, hass, qualifier="active_power"
+    )
 
     # allow traffic to flow through the gateway and devices
     await async_enable_traffic(hass, [zha_device])

--- a/tests/components/zha/zha_devices_list.py
+++ b/tests/components/zha/zha_devices_list.py
@@ -195,7 +195,7 @@ DEVICES = [
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-2820"): {
                 DEV_SIG_CLUSTER_HANDLERS: ["electrical_measurement"],
-                DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurement",
+                DEV_SIG_ENT_MAP_CLASS: "PolledElectricalMeasurement",
                 DEV_SIG_ENT_MAP_ID: "sensor.centralite_3210_l_active_power",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-2820-apparent_power"): {
@@ -2080,7 +2080,7 @@ DEVICES = [
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-2820"): {
                 DEV_SIG_CLUSTER_HANDLERS: ["electrical_measurement"],
-                DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurement",
+                DEV_SIG_ENT_MAP_CLASS: "PolledElectricalMeasurement",
                 DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_plug_maus01_active_power",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-2820-rms_voltage"): {
@@ -2155,7 +2155,7 @@ DEVICES = [
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-2820"): {
                 DEV_SIG_CLUSTER_HANDLERS: ["electrical_measurement"],
-                DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurement",
+                DEV_SIG_ENT_MAP_CLASS: "PolledElectricalMeasurement",
                 DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_relay_c2acn01_active_power",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-2820-apparent_power"): {
@@ -3633,7 +3633,7 @@ DEVICES = [
             },
             ("sensor", "00:11:22:33:44:55:66:77-3-2820"): {
                 DEV_SIG_CLUSTER_HANDLERS: ["electrical_measurement"],
-                DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurement",
+                DEV_SIG_ENT_MAP_CLASS: "PolledElectricalMeasurement",
                 DEV_SIG_ENT_MAP_ID: (
                     "sensor.osram_lightify_rt_tunable_white_active_power"
                 ),
@@ -4039,7 +4039,7 @@ DEVICES = [
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-2820"): {
                 DEV_SIG_CLUSTER_HANDLERS: ["electrical_measurement"],
-                DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurement",
+                DEV_SIG_ENT_MAP_CLASS: "PolledElectricalMeasurement",
                 DEV_SIG_ENT_MAP_ID: "sensor.securifi_ltd_unk_model_active_power",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-2820-apparent_power"): {
@@ -4167,7 +4167,7 @@ DEVICES = [
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-2820"): {
                 DEV_SIG_CLUSTER_HANDLERS: ["electrical_measurement"],
-                DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurement",
+                DEV_SIG_ENT_MAP_CLASS: "PolledElectricalMeasurement",
                 DEV_SIG_ENT_MAP_ID: "sensor.sercomm_corp_sz_esw01_active_power",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-2820-apparent_power"): {
@@ -4293,7 +4293,7 @@ DEVICES = [
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-2820"): {
                 DEV_SIG_CLUSTER_HANDLERS: ["electrical_measurement"],
-                DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurement",
+                DEV_SIG_ENT_MAP_CLASS: "PolledElectricalMeasurement",
                 DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_rm3250zb_active_power",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-2820-apparent_power"): {
@@ -4378,7 +4378,7 @@ DEVICES = [
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-2820"): {
                 DEV_SIG_CLUSTER_HANDLERS: ["electrical_measurement"],
-                DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurement",
+                DEV_SIG_ENT_MAP_CLASS: "PolledElectricalMeasurement",
                 DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_th1123zb_active_power",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-2820-apparent_power"): {
@@ -4468,7 +4468,7 @@ DEVICES = [
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-2820"): {
                 DEV_SIG_CLUSTER_HANDLERS: ["electrical_measurement"],
-                DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurement",
+                DEV_SIG_ENT_MAP_CLASS: "PolledElectricalMeasurement",
                 DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_th1124zb_active_power",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-2820-apparent_power"): {


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR prevents the polling of electrical measurement sensors in ZHA for devices that support attribute reporting. This can be extended as we discover devices that fall into this category. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
