### PR TITLE
Fully Kiosk: Truncate long URLs

### DIFF
--- a/homeassistant/components/fully_kiosk/__init__.py
+++ b/homeassistant/components/fully_kiosk/__init__.py
@@ -26,6 +26,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    coordinator.async_update_listeners()
 
     await async_setup_services(hass)
 

--- a/homeassistant/components/fully_kiosk/sensor.py
+++ b/homeassistant/components/fully_kiosk/sensor.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import Any
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -26,11 +27,25 @@ def round_storage(value: int) -> float:
     return round(value * 0.000001, 1)
 
 
+def truncate_url(value: StateType) -> tuple[StateType, dict[str, Any]]:
+    """Truncate URL if longer than 256."""
+    url = str(value)
+    truncated = len(url) > 256
+    extra_state_attributes = {
+        "full_url": url,
+        "truncated": truncated,
+    }
+    if truncated:
+        return (url[0:255], extra_state_attributes)
+    return (url, extra_state_attributes)
+
+
 @dataclass
 class FullySensorEntityDescription(SensorEntityDescription):
     """Fully Kiosk Browser sensor description."""
 
-    state_fn: Callable[[int], float] | None = None
+    round_state_value: bool = False
+    state_fn: Callable[[StateType], tuple[StateType, dict[str, Any]]] | None = None
 
 
 SENSORS: tuple[FullySensorEntityDescription, ...] = (
@@ -41,6 +56,12 @@ SENSORS: tuple[FullySensorEntityDescription, ...] = (
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    FullySensorEntityDescription(
+        key="currentPage",
+        name="Current page",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        state_fn=truncate_url,
     ),
     FullySensorEntityDescription(
         key="screenOrientation",
@@ -59,7 +80,7 @@ SENSORS: tuple[FullySensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfInformation.MEGABYTES,
         device_class=SensorDeviceClass.DATA_SIZE,
         state_class=SensorStateClass.MEASUREMENT,
-        state_fn=round_storage,
+        round_state_value=True,
     ),
     FullySensorEntityDescription(
         key="internalStorageTotalSpace",
@@ -68,7 +89,7 @@ SENSORS: tuple[FullySensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfInformation.MEGABYTES,
         device_class=SensorDeviceClass.DATA_SIZE,
         state_class=SensorStateClass.MEASUREMENT,
-        state_fn=round_storage,
+        round_state_value=True,
     ),
     FullySensorEntityDescription(
         key="ramFreeMemory",
@@ -77,7 +98,7 @@ SENSORS: tuple[FullySensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfInformation.MEGABYTES,
         device_class=SensorDeviceClass.DATA_SIZE,
         state_class=SensorStateClass.MEASUREMENT,
-        state_fn=round_storage,
+        round_state_value=True,
     ),
     FullySensorEntityDescription(
         key="ramTotalMemory",
@@ -86,15 +107,7 @@ SENSORS: tuple[FullySensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfInformation.MEGABYTES,
         device_class=SensorDeviceClass.DATA_SIZE,
         state_class=SensorStateClass.MEASUREMENT,
-        state_fn=round_storage,
-    ),
-)
-
-URL_SENSORS: tuple[FullySensorEntityDescription, ...] = (
-    FullySensorEntityDescription(
-        key="currentPage",
-        name="Current page",
-        entity_category=EntityCategory.DIAGNOSTIC,
+        round_state_value=True,
     ),
 )
 
@@ -111,11 +124,6 @@ async def async_setup_entry(
     async_add_entities(
         FullySensor(coordinator, description)
         for description in SENSORS
-        if description.key in coordinator.data
-    )
-    async_add_entities(
-        FullyUrlSensor(coordinator, description)
-        for description in URL_SENSORS
         if description.key in coordinator.data
     )
 
@@ -139,38 +147,17 @@ class FullySensor(FullyKioskEntity, SensorEntity):
 
     @callback
     def _handle_coordinator_update(self) -> None:
-        self._attr_native_value = self._value()
-        self.async_write_ha_state()
+        extra_state_attributes: dict[str, Any] = {}
+        value = self.coordinator.data.get(self.entity_description.key)
 
-    def _value(self) -> StateType:
-        """Return the state of the sensor."""
-        if (value := self.coordinator.data.get(self.entity_description.key)) is None:
-            return None
+        if value is not None:
+            if self.entity_description.state_fn is not None:
+                value, extra_state_attributes = self.entity_description.state_fn(value)
 
-        if self.entity_description.state_fn is not None:
-            return self.entity_description.state_fn(value)
+            if self.entity_description.round_state_value:
+                value = round_storage(value)
 
-        return value  # type: ignore[no-any-return]
+        self._attr_native_value = value
+        self._attr_extra_state_attributes = extra_state_attributes
 
-
-class FullyUrlSensor(FullySensor):
-    """Representation of a Fully Kiosk Browser URL sensor."""
-
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        value = self._value()
-        if value is None:
-            truncated = False
-            self._attr_native_value = None
-        else:
-            value = str(value)
-            truncated = len(value) > 256
-            if truncated:
-                self._attr_native_value = value[0:255]
-            else:
-                self._attr_native_value = value
-        self._attr_extra_state_attributes = {
-            "full_url": value,
-            "truncated": truncated,
-        }
         self.async_write_ha_state()


### PR DESCRIPTION
URL's longer than 256 characters will result in a
`homeassistant.exceptions.InvalidStateError`. This fixes that problem and adds 2 extra_state_attributes: `full_url`, and `truncated`.

Fixes #89249

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #89249
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
