### PR TITLE
Clean up zwave_js.cover

### DIFF
--- a/homeassistant/components/zwave_js/cover.py
+++ b/homeassistant/components/zwave_js/cover.py
@@ -125,11 +125,9 @@ class ZWaveCover(ZWaveBaseEntity, CoverEntity):
 
         # Entity class attributes
         self._attr_device_class = CoverDeviceClass.WINDOW
-        if not self.info.platform_hint:
-            return
-        if self.info.platform_hint.startswith("shutter"):
+        if self.info.platform_hint and self.info.platform_hint.startswith("shutter"):
             self._attr_device_class = CoverDeviceClass.SHUTTER
-        if self.info.platform_hint.startswith("blind"):
+        if self.info.platform_hint and self.info.platform_hint.startswith("blind"):
             self._attr_device_class = CoverDeviceClass.BLIND
 
     @property

--- a/homeassistant/components/zwave_js/cover.py
+++ b/homeassistant/components/zwave_js/cover.py
@@ -208,11 +208,11 @@ class ZWaveTiltCover(ZWaveCover):
 
     async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
         """Move the cover tilt to a specific position."""
-        if self._current_tilt_value:
-            await self.info.node.async_set_value(
-                self._current_tilt_value,
-                percent_to_zwave_tilt(kwargs[ATTR_TILT_POSITION]),
-            )
+        assert self._current_tilt_value
+        await self.info.node.async_set_value(
+            self._current_tilt_value,
+            percent_to_zwave_tilt(kwargs[ATTR_TILT_POSITION]),
+        )
 
     async def async_open_cover_tilt(self, **kwargs: Any) -> None:
         """Open the cover tilt."""

--- a/homeassistant/components/zwave_js/cover.py
+++ b/homeassistant/components/zwave_js/cover.py
@@ -51,7 +51,7 @@ async def async_setup_entry(
         entities: list[ZWaveBaseEntity] = []
         if info.platform_hint == "motorized_barrier":
             entities.append(ZwaveMotorizedBarrier(config_entry, driver, info))
-        elif info.platform_hint == "window_shutter_tilt":
+        elif info.platform_hint and info.platform_hint.endswith("tilt"):
             entities.append(ZWaveTiltCover(config_entry, driver, info))
         else:
             entities.append(ZWaveCover(config_entry, driver, info))
@@ -99,6 +99,12 @@ def zwave_tilt_to_percent(value: int) -> int:
 class ZWaveCover(ZWaveBaseEntity, CoverEntity):
     """Representation of a Z-Wave Cover device."""
 
+    _attr_supported_features = (
+        CoverEntityFeature.OPEN
+        | CoverEntityFeature.CLOSE
+        | CoverEntityFeature.SET_POSITION
+    )
+
     def __init__(
         self,
         config_entry: ConfigEntry,
@@ -108,11 +114,22 @@ class ZWaveCover(ZWaveBaseEntity, CoverEntity):
         """Initialize a ZWaveCover entity."""
         super().__init__(config_entry, driver, info)
 
+        self._stop_cover_value = (
+            self.get_zwave_value(COVER_OPEN_PROPERTY)
+            or self.get_zwave_value(COVER_UP_PROPERTY)
+            or self.get_zwave_value(COVER_ON_PROPERTY)
+        )
+
+        if self._stop_cover_value:
+            self._attr_supported_features |= CoverEntityFeature.STOP
+
         # Entity class attributes
         self._attr_device_class = CoverDeviceClass.WINDOW
-        if self.info.platform_hint in ("window_shutter", "window_shutter_tilt"):
+        if not self.info.platform_hint:
+            return
+        if self.info.platform_hint.startswith("shutter"):
             self._attr_device_class = CoverDeviceClass.SHUTTER
-        if self.info.platform_hint == "window_blind":
+        if self.info.platform_hint.startswith("blind"):
             self._attr_device_class = CoverDeviceClass.BLIND
 
     @property
@@ -153,28 +170,13 @@ class ZWaveCover(ZWaveBaseEntity, CoverEntity):
 
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop cover."""
-        cover_property = (
-            self.get_zwave_value(COVER_OPEN_PROPERTY)
-            or self.get_zwave_value(COVER_UP_PROPERTY)
-            or self.get_zwave_value(COVER_ON_PROPERTY)
-        )
-        if cover_property:
-            # Stop the cover, will stop regardless of the actual direction of travel.
-            await self.info.node.async_set_value(cover_property, False)
+        assert self._stop_cover_value
+        # Stop the cover, will stop regardless of the actual direction of travel.
+        await self.info.node.async_set_value(self._stop_cover_value, False)
 
 
 class ZWaveTiltCover(ZWaveCover):
-    """Representation of a Z-Wave Cover device with tilt."""
-
-    _attr_supported_features = (
-        CoverEntityFeature.OPEN
-        | CoverEntityFeature.CLOSE
-        | CoverEntityFeature.STOP
-        | CoverEntityFeature.SET_POSITION
-        | CoverEntityFeature.OPEN_TILT
-        | CoverEntityFeature.CLOSE_TILT
-        | CoverEntityFeature.SET_TILT_POSITION
-    )
+    """Representation of a Z-Wave cover device with tilt."""
 
     def __init__(
         self,
@@ -184,8 +186,15 @@ class ZWaveTiltCover(ZWaveCover):
     ) -> None:
         """Initialize a ZWaveCover entity."""
         super().__init__(config_entry, driver, info)
-        self.data_template = cast(
+
+        self._current_tilt_value = cast(
             CoverTiltDataTemplate, self.info.platform_data_template
+        ).current_tilt_value(self.info.platform_data)
+
+        self._attr_supported_features |= (
+            CoverEntityFeature.OPEN_TILT
+            | CoverEntityFeature.CLOSE_TILT
+            | CoverEntityFeature.SET_TILT_POSITION
         )
 
     @property
@@ -194,17 +203,16 @@ class ZWaveTiltCover(ZWaveCover):
 
         None is unknown, 0 is closed, 100 is fully open.
         """
-        value = self.data_template.current_tilt_value(self.info.platform_data)
+        value = self._current_tilt_value
         if value is None or value.value is None:
             return None
         return zwave_tilt_to_percent(int(value.value))
 
     async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
         """Move the cover tilt to a specific position."""
-        tilt_value = self.data_template.current_tilt_value(self.info.platform_data)
-        if tilt_value:
+        if self._current_tilt_value:
             await self.info.node.async_set_value(
-                tilt_value,
+                self._current_tilt_value,
                 percent_to_zwave_tilt(kwargs[ATTR_TILT_POSITION]),
             )
 

--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -347,7 +347,7 @@ DISCOVERY_SCHEMAS = [
     # Fibaro Shutter Fibaro FGR222
     ZWaveDiscoverySchema(
         platform=Platform.COVER,
-        hint="window_shutter_tilt",
+        hint="shutter_tilt",
         manufacturer_id={0x010F},
         product_id={0x1000, 0x1001},
         product_type={0x0301, 0x0302},
@@ -371,7 +371,7 @@ DISCOVERY_SCHEMAS = [
     # Qubino flush shutter
     ZWaveDiscoverySchema(
         platform=Platform.COVER,
-        hint="window_shutter",
+        hint="shutter",
         manufacturer_id={0x0159},
         product_id={0x0052, 0x0053},
         product_type={0x0003},
@@ -380,7 +380,7 @@ DISCOVERY_SCHEMAS = [
     # Graber/Bali/Spring Fashion Covers
     ZWaveDiscoverySchema(
         platform=Platform.COVER,
-        hint="window_blind",
+        hint="blind",
         manufacturer_id={0x026E},
         product_id={0x5A31},
         product_type={0x4353},
@@ -389,7 +389,7 @@ DISCOVERY_SCHEMAS = [
     # iBlinds v2 window blind motor
     ZWaveDiscoverySchema(
         platform=Platform.COVER,
-        hint="window_blind",
+        hint="blind",
         manufacturer_id={0x0287},
         product_id={0x000D},
         product_type={0x0003},
@@ -398,7 +398,7 @@ DISCOVERY_SCHEMAS = [
     # Merten 507801 Connect Roller Shutter
     ZWaveDiscoverySchema(
         platform=Platform.COVER,
-        hint="window_shutter",
+        hint="shutter",
         manufacturer_id={0x007A},
         product_id={0x0001},
         product_type={0x8003},
@@ -414,7 +414,7 @@ DISCOVERY_SCHEMAS = [
     # Disable endpoint 2, as it has no practical function. CC: Switch_Multilevel
     ZWaveDiscoverySchema(
         platform=Platform.COVER,
-        hint="window_shutter",
+        hint="shutter",
         manufacturer_id={0x007A},
         product_id={0x0001},
         product_type={0x8003},
@@ -807,7 +807,7 @@ DISCOVERY_SCHEMAS = [
     # window coverings
     ZWaveDiscoverySchema(
         platform=Platform.COVER,
-        hint="window_cover",
+        hint="cover",
         device_class_generic={"Multilevel Switch"},
         device_class_specific={
             "Motor Control Class A",


### PR DESCRIPTION
## Proposed change
While looking into the Window Covering CC, I noticed that supported features were not properly being set for entities using the `ZWaveCover` class. To be completely honest, I am not sure how the services were even working for those entities because of a lack of supported features.

I cleaned up some other code along the way just to make things a little easier to understand (at least IMO).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
