### PR TITLE
Start onvif events later

### DIFF
--- a/homeassistant/components/onvif/device.py
+++ b/homeassistant/components/onvif/device.py
@@ -338,7 +338,13 @@ class ONVIFDevice:
     async def async_get_profiles(self) -> list[Profile]:
         """Obtain media profiles for this device."""
         media_service = self.device.create_media_service()
-        result = await media_service.GetProfiles()
+        try:
+            result = await media_service.GetProfiles()
+        except GET_CAPABILITIES_EXCEPTIONS:
+            LOGGER.debug(
+                "%s: Could not get profiles from ONVIF device", self.name, exc_info=True
+            )
+            raise
         profiles: list[Profile] = []
 
         if not isinstance(result, list):

--- a/homeassistant/components/onvif/device.py
+++ b/homeassistant/components/onvif/device.py
@@ -101,7 +101,6 @@ class ONVIFDevice:
         # Get all device info
         await self.device.update_xaddrs()
         LOGGER.debug("%s: xaddrs = %s", self.name, self.device.xaddrs)
-        LOGGER.debug("%s: services = %s", self.name, self.device.services)
 
         # Get device capabilities
         self.onvif_capabilities = await self.device.get_capabilities()

--- a/homeassistant/components/onvif/device.py
+++ b/homeassistant/components/onvif/device.py
@@ -100,6 +100,8 @@ class ONVIFDevice:
 
         # Get all device info
         await self.device.update_xaddrs()
+        LOGGER.debug("%s: xaddrs = %s", self.name, self.device.xaddrs)
+        LOGGER.debug("%s: services = %s", self.name, self.device.services)
 
         # Get device capabilities
         self.onvif_capabilities = await self.device.get_capabilities()
@@ -112,7 +114,7 @@ class ONVIFDevice:
 
         # Fetch basic device info and capabilities
         self.info = await self.async_get_device_info()
-        LOGGER.debug("Camera %s info = %s", self.name, self.info)
+        LOGGER.debug("%s: camera info = %s", self.name, self.info)
 
         #
         # We need to check capabilities before profiles, because we need the data
@@ -338,6 +340,7 @@ class ONVIFDevice:
     async def async_get_profiles(self) -> list[Profile]:
         """Obtain media profiles for this device."""
         media_service = self.device.create_media_service()
+        LOGGER.debug("%s: xaddr for media_service: %s", self.name, media_service.xaddr)
         try:
             result = await media_service.GetProfiles()
         except GET_CAPABILITIES_EXCEPTIONS:

--- a/homeassistant/components/onvif/device.py
+++ b/homeassistant/components/onvif/device.py
@@ -125,10 +125,6 @@ class ONVIFDevice:
         LOGGER.debug("%s: fetching initial capabilities", self.name)
         self.capabilities = await self.async_get_capabilities()
 
-        if self.capabilities.ptz:
-            LOGGER.debug("%s: creating PTZ service", self.name)
-            self.device.create_ptz_service()
-
         LOGGER.debug("%s: fetching profiles", self.name)
         self.profiles = await self.async_get_profiles()
         LOGGER.debug("Camera %s profiles = %s", self.name, self.profiles)
@@ -136,6 +132,10 @@ class ONVIFDevice:
         # No camera profiles to add
         if not self.profiles:
             raise ONVIFError("No camera profiles found")
+
+        if self.capabilities.ptz:
+            LOGGER.debug("%s: creating PTZ service", self.name)
+            self.device.create_ptz_service()
 
         # Determine max resolution from profiles
         self.max_resolution = max(

--- a/homeassistant/components/onvif/device.py
+++ b/homeassistant/components/onvif/device.py
@@ -122,17 +122,20 @@ class ONVIFDevice:
         # where cameras become slow to respond for a bit after starting events, and
         # instead we start events last and than update capabilities.
         #
+        LOGGER.debug("%s: fetching initial capabilities", self.name)
         self.capabilities = await self.async_get_capabilities()
 
+        if self.capabilities.ptz:
+            LOGGER.debug("%s: creating PTZ service", self.name)
+            self.device.create_ptz_service()
+
+        LOGGER.debug("%s: fetching profiles", self.name)
         self.profiles = await self.async_get_profiles()
         LOGGER.debug("Camera %s profiles = %s", self.name, self.profiles)
 
         # No camera profiles to add
         if not self.profiles:
             raise ONVIFError("No camera profiles found")
-
-        if self.capabilities.ptz:
-            self.device.create_ptz_service()
 
         # Determine max resolution from profiles
         self.max_resolution = max(
@@ -143,6 +146,7 @@ class ONVIFDevice:
 
         # Start events last since some cameras become slow to respond
         # for a bit after starting events
+        LOGGER.debug("%s: starting events", self.name)
         self.capabilities.events = await self.async_start_events()
         LOGGER.debug("Camera %s capabilities = %s", self.name, self.capabilities)
 

--- a/homeassistant/components/onvif/device.py
+++ b/homeassistant/components/onvif/device.py
@@ -144,8 +144,7 @@ class ONVIFDevice:
 
         # Start events last since some cameras become slow to respond
         # for a bit after starting events
-        if await self.async_start_events():
-            self.capabilities.events = True
+        self.capabilities.events = await self.async_start_events()
 
     async def async_stop(self, event=None):
         """Shut it all down."""

--- a/homeassistant/components/onvif/device.py
+++ b/homeassistant/components/onvif/device.py
@@ -123,7 +123,6 @@ class ONVIFDevice:
         # instead we start events last and than update capabilities.
         #
         self.capabilities = await self.async_get_capabilities()
-        LOGGER.debug("Camera %s capabilities = %s", self.name, self.capabilities)
 
         self.profiles = await self.async_get_profiles()
         LOGGER.debug("Camera %s profiles = %s", self.name, self.profiles)
@@ -145,6 +144,7 @@ class ONVIFDevice:
         # Start events last since some cameras become slow to respond
         # for a bit after starting events
         self.capabilities.events = await self.async_start_events()
+        LOGGER.debug("Camera %s capabilities = %s", self.name, self.capabilities)
 
     async def async_stop(self, event=None):
         """Shut it all down."""

--- a/homeassistant/components/onvif/device.py
+++ b/homeassistant/components/onvif/device.py
@@ -120,7 +120,7 @@ class ONVIFDevice:
         #
         # We no longer initialize events in capabilities to avoid the problem
         # where cameras become slow to respond for a bit after starting events, and
-        # instead we start events last and update capabilities after starting events.
+        # instead we start events last and than update capabilities.
         #
         self.capabilities = await self.async_get_capabilities()
         LOGGER.debug("Camera %s capabilities = %s", self.name, self.capabilities)

--- a/homeassistant/components/onvif/device.py
+++ b/homeassistant/components/onvif/device.py
@@ -114,6 +114,11 @@ class ONVIFDevice:
         self.info = await self.async_get_device_info()
         LOGGER.debug("Camera %s info = %s", self.name, self.info)
 
+        # We need to check capabilities before profiles, because some cameras
+        # because we need the data from capabilities to determine profiles correctly.
+        # We no longer initialize events in capabilities to avoid the problem
+        # where cameras become slow to respond for a bit after starting events, and
+        # instead we start events last and update capabilities after starting events.
         self.capabilities = await self.async_get_capabilities()
         LOGGER.debug("Camera %s capabilities = %s", self.name, self.capabilities)
 
@@ -320,8 +325,7 @@ class ONVIFDevice:
                 "WSPullPointSupport"
             )
             LOGGER.debug("%s: WSPullPointSupport: %s", self.name, pull_point_support)
-            await self.events.async_start(pull_point_support is not False, True)
-            return True
+            return await self.events.async_start(pull_point_support is not False, True)
 
         return False
 

--- a/homeassistant/components/onvif/device.py
+++ b/homeassistant/components/onvif/device.py
@@ -114,11 +114,14 @@ class ONVIFDevice:
         self.info = await self.async_get_device_info()
         LOGGER.debug("Camera %s info = %s", self.name, self.info)
 
-        # We need to check capabilities before profiles, because some cameras
-        # because we need the data from capabilities to determine profiles correctly.
+        #
+        # We need to check capabilities before profiles, because we need the data
+        # from capabilities to determine profiles correctly.
+        #
         # We no longer initialize events in capabilities to avoid the problem
         # where cameras become slow to respond for a bit after starting events, and
         # instead we start events last and update capabilities after starting events.
+        #
         self.capabilities = await self.async_get_capabilities()
         LOGGER.debug("Camera %s capabilities = %s", self.name, self.capabilities)
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
reverts the order change in #92333 since it caused collateral breakage with ptz https://github.com/home-assistant/core/issues/92308#issuecomment-1530922775

pulls out starting events into a new function so we can still start them last without the unintended side effects

I also added a bit more logging since it was discovered in https://github.com/home-assistant/core/issues/92308#issuecomment-1531067676 that some cameras reflect the wrong xaddr back so we try to connect to the wrong host. We now log the xaddrs. The only way I was able to fix that was to factory reset the camera.   In the future we may rewrite the xaddrs when we detect this, but I'm not sure its safe to do this and we are just about out of beta runway so I'm leaving that as-is at this time and will do some additional testing for 2023.6.x

partial fix for #92308

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
