### PR TITLE
Make temperature sensor value displayed in Google Home

### DIFF
--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -901,7 +901,7 @@ class TemperatureSettingTrait(_Trait):
     def climate_google_modes(self):
         """Return supported Google modes."""
         if self.state.domain == sensor.DOMAIN:
-            return ["on", "heat"]
+            return ["none"]
 
         modes = []
         attrs = self.state.attributes
@@ -956,8 +956,8 @@ class TemperatureSettingTrait(_Trait):
             preset = attrs.get(climate.ATTR_PRESET_MODE)
             supported = attrs.get(ATTR_SUPPORTED_FEATURES, 0)
         elif self.state.domain == sensor.DOMAIN:
-            operation = "heat"
-            preset = "heat"
+            operation = "none"
+            preset = "none"
 
         if preset in self.preset_to_google:
             response["thermostatMode"] = self.preset_to_google[preset]

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -967,12 +967,15 @@ class TemperatureSettingTrait(_Trait):
         current_temp = (
             attrs.get(climate.ATTR_CURRENT_TEMPERATURE)
             if self.state.domain == climate.DOMAIN
-            else float(self.state.state)
+            else self.state.state
         )
-        if current_temp is not None:
+        if current_temp is not None and current_temp not in (
+            STATE_UNKNOWN,
+            STATE_UNAVAILABLE,
+        ):
             response["thermostatTemperatureAmbient"] = round(
                 TemperatureConverter.convert(
-                    current_temp, unit, UnitOfTemperature.CELSIUS
+                    float(current_temp), unit, UnitOfTemperature.CELSIUS
                 ),
                 1,
             )
@@ -1022,10 +1025,14 @@ class TemperatureSettingTrait(_Trait):
                         ),
                         1,
                     )
-        elif self.state.domain == sensor.DOMAIN:
+        elif (
+            self.state.domain == sensor.DOMAIN
+            and current_temp is not None
+            and current_temp not in (STATE_UNKNOWN, STATE_UNAVAILABLE)
+        ):
             response["thermostatTemperatureSetpoint"] = round(
                 TemperatureConverter.convert(
-                    current_temp, unit, UnitOfTemperature.CELSIUS
+                    float(current_temp), unit, UnitOfTemperature.CELSIUS
                 ),
                 1,
             )

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -901,7 +901,7 @@ class TemperatureSettingTrait(_Trait):
     def climate_google_modes(self):
         """Return supported Google modes."""
         if self.state.domain == sensor.DOMAIN:
-            return ["none"]
+            return ["heat"]
 
         modes = []
         attrs = self.state.attributes
@@ -956,7 +956,7 @@ class TemperatureSettingTrait(_Trait):
             preset = attrs.get(climate.ATTR_PRESET_MODE)
             supported = attrs.get(ATTR_SUPPORTED_FEATURES, 0)
         elif self.state.domain == sensor.DOMAIN:
-            operation = "none"
+            operation = "heat"
             preset = "none"
 
         if preset in self.preset_to_google:

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -1120,7 +1120,7 @@ async def test_temperature_control_and_setting_traits(hass: HomeAssistant) -> No
     )
     assert trt.sync_attributes() == {
         "thermostatTemperatureUnit": "C",
-        "availableThermostatModes": ["on", "heat"],
+        "availableThermostatModes": ["heat"],
         "queryOnlyTemperatureSetting": True,
     }
     assert trt.query_attributes() == {
@@ -3000,7 +3000,7 @@ async def test_temperature_control_and_setting_sensor_data(
 
     assert trt.sync_attributes() == {
         "thermostatTemperatureUnit": "C",
-        "availableThermostatModes": ["on", "heat"],
+        "availableThermostatModes": ["heat"],
         "queryOnlyTemperatureSetting": True,
     }
 

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -1091,7 +1091,7 @@ async def test_temperature_setting_climate_setpoint_auto(hass: HomeAssistant) ->
     assert calls[0].data == {ATTR_ENTITY_ID: "climate.bla", ATTR_TEMPERATURE: 19}
 
 
-async def test_temperature_sensor(hass: HomeAssistant) -> None:
+async def test_temperature_control_and_setting_traits(hass: HomeAssistant) -> None:
     """Test TemperatureControl and TemperatureSetting traits support for sensor domain."""
     hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In Google Home, temperature sensor values are not displayed.
It is because `TemperatureControl` trait does not allow any value to be displayed.
To display the temperature in Google Home, we have to use `TemperatureSetting` treat, like a thermostat.
With `queryOnlyTemperatureSetting` set to `True` no buttons are shown to change any setting which is expected for a sensor.
At last, target temperature must be equal to the ambient one and mode set to heat to have only the temperature announced when asking for the State by voice.
If things are better for Google Home, precision by voice changes.
Before precision was 0.1, with these changes precision is 0.5° as it is for thermostats, which should not really be a regression.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #92242
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
