### PR TITLE
no-ip multihost configuration

### DIFF
--- a/homeassistant/components/no_ip/__init__.py
+++ b/homeassistant/components/no_ip/__init__.py
@@ -8,7 +8,6 @@ import aiohttp
 from aiohttp.hdrs import AUTHORIZATION, USER_AGENT
 import async_timeout
 import voluptuous as vol
-from collections import OrderedDict
 
 from homeassistant.const import CONF_DOMAIN, CONF_PASSWORD, CONF_TIMEOUT, CONF_USERNAME
 from homeassistant.core import HomeAssistant
@@ -27,7 +26,7 @@ DOMAIN = "no_ip"
 # We should set a dedicated address for the user agent.
 EMAIL = "hello@home-assistant.io"
 
-INTERVAL = timedelta(minutes=1)
+INTERVAL = timedelta(minutes=5)
 
 DEFAULT_TIMEOUT = 10
 

--- a/tests/components/no_ip/test_init.py
+++ b/tests/components/no_ip/test_init.py
@@ -11,6 +11,9 @@ from homeassistant.util.dt import utcnow
 from tests.common import async_fire_time_changed
 from tests.test_util.aiohttp import AiohttpClientMocker
 
+import asyncio
+import aiohttp
+
 DOMAIN = "test.example.com"
 
 PASSWORD = "xyz789"
@@ -30,47 +33,49 @@ def setup_no_ip(hass, aioclient_mock):
             hass,
             no_ip.DOMAIN,
             {
-                no_ip.DOMAIN: {
+                no_ip.DOMAIN: [{
                     "domain": DOMAIN,
                     "username": USERNAME,
                     "password": PASSWORD,
-                }
+                }]
             },
         )
     )
 
 
-async def test_setup(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker) -> None:
+async def test_setup_1_domain(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker) -> None:
     """Test setup works if update passes."""
     aioclient_mock.get(UPDATE_URL, params={"hostname": DOMAIN}, text="nochg 0.0.0.0")
 
     result = await async_setup_component(
         hass,
         no_ip.DOMAIN,
-        {no_ip.DOMAIN: {"domain": DOMAIN, "username": USERNAME, "password": PASSWORD}},
+        {no_ip.DOMAIN: [{"domain": DOMAIN, "username": USERNAME, "password": PASSWORD}]},
     )
     assert result
-    assert aioclient_mock.call_count == 1
+    assert aioclient_mock.call_count == 0
 
     async_fire_time_changed(hass, utcnow() + timedelta(minutes=5))
     await hass.async_block_till_done()
-    assert aioclient_mock.call_count == 2
+    assert result
+    assert aioclient_mock.call_count == 1
 
-
-async def test_setup_fails_if_update_fails(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
-) -> None:
-    """Test setup fails if first update fails."""
-    aioclient_mock.get(UPDATE_URL, params={"hostname": DOMAIN}, text="nohost")
+async def test_setup_2_domain(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker) -> None:
+    """Test setup works if update passes."""
+    aioclient_mock.get(UPDATE_URL, params={"hostname": DOMAIN}, text="nochg 0.0.0.0")
 
     result = await async_setup_component(
         hass,
         no_ip.DOMAIN,
-        {no_ip.DOMAIN: {"domain": DOMAIN, "username": USERNAME, "password": PASSWORD}},
+        {no_ip.DOMAIN: [{"domain": DOMAIN, "username": USERNAME, "password": PASSWORD}, {"domain": DOMAIN, "username": USERNAME, "password": PASSWORD}]},
     )
-    assert not result
-    assert aioclient_mock.call_count == 1
+    assert result
+    assert aioclient_mock.call_count == 0
 
+    async_fire_time_changed(hass, utcnow() + timedelta(minutes=5))
+    await hass.async_block_till_done()
+    assert result
+    assert aioclient_mock.call_count == 2
 
 async def test_setup_fails_if_wrong_auth(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
@@ -81,7 +86,50 @@ async def test_setup_fails_if_wrong_auth(
     result = await async_setup_component(
         hass,
         no_ip.DOMAIN,
-        {no_ip.DOMAIN: {"domain": DOMAIN, "username": USERNAME, "password": PASSWORD}},
+        {no_ip.DOMAIN: [{"domain": DOMAIN, "username": USERNAME, "password": PASSWORD}]},
     )
-    assert not result
+    assert result
+    assert aioclient_mock.call_count == 0
+
+    async_fire_time_changed(hass, utcnow() + timedelta(minutes=5))
+    result_block = await hass.async_block_till_done()
+    assert not result_block
+    assert aioclient_mock.call_count == 1
+
+async def test_setup_fails_if_timeout(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Test setup fails if first update fails through wrong authentication."""
+    aioclient_mock.get(UPDATE_URL, params={"hostname": DOMAIN}, text="badauth", exc=asyncio.TimeoutError())
+
+    result = await async_setup_component(
+        hass,
+        no_ip.DOMAIN,
+        {no_ip.DOMAIN: [{"domain": DOMAIN, "username": USERNAME, "password": PASSWORD}]},
+    )
+    assert result
+    assert aioclient_mock.call_count == 0
+
+    async_fire_time_changed(hass, utcnow() + timedelta(minutes=5))
+    result_block = await hass.async_block_till_done()
+    assert not result_block
+    assert aioclient_mock.call_count == 1
+
+async def test_setup_fails_if_client_error(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Test setup fails if first update fails through wrong authentication."""
+    aioclient_mock.get(UPDATE_URL, params={"hostname": DOMAIN}, text="badauth", exc=aiohttp.ClientError())
+
+    result = await async_setup_component(
+        hass,
+        no_ip.DOMAIN,
+        {no_ip.DOMAIN: [{"domain": DOMAIN, "username": USERNAME, "password": PASSWORD}]},
+    )
+    assert result
+    assert aioclient_mock.call_count == 0
+
+    async_fire_time_changed(hass, utcnow() + timedelta(minutes=5))
+    result_block = await hass.async_block_till_done()
+    assert not result_block
     assert aioclient_mock.call_count == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
The no-ip component allow us to configure just only one host in no-ip configuration. For free, NO-IP allow 3 so I develop a modification of the component to allow a multi configuration

## Type of change
Modify the init component to allow array of configuration and modify code to read and prepare the async_track_time_interval for all the configuration in the array

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
