### PR TITLE
Skip unexposed entities in intent handlers

### DIFF
--- a/homeassistant/components/conversation/default_agent.py
+++ b/homeassistant/components/conversation/default_agent.py
@@ -201,6 +201,7 @@ class DefaultAgent(AbstractConversationAgent):
                 user_input.text,
                 user_input.context,
                 language,
+                assistant=DOMAIN,
             )
         except intent.IntentHandleError:
             _LOGGER.exception("Intent handling error")

--- a/homeassistant/components/intent/__init__.py
+++ b/homeassistant/components/intent/__init__.py
@@ -140,16 +140,18 @@ class GetStateIntentHandler(intent.IntentHandler):
                 area=area,
                 domains=domains,
                 device_classes=device_classes,
+                assistant=intent_obj.assistant,
             )
         )
 
         _LOGGER.debug(
-            "Found %s state(s) that matched: name=%s, area=%s, domains=%s, device_classes=%s",
+            "Found %s state(s) that matched: name=%s, area=%s, domains=%s, device_classes=%s, assistant=%s",
             len(states),
             name,
             area,
             domains,
             device_classes,
+            intent_obj.assistant,
         )
 
         # Create response

--- a/homeassistant/helpers/intent.py
+++ b/homeassistant/helpers/intent.py
@@ -11,6 +11,7 @@ from typing import Any, TypeVar
 
 import voluptuous as vol
 
+from homeassistant.components.homeassistant.exposed_entities import async_should_expose
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_ENTITY_ID,
@@ -65,6 +66,7 @@ async def async_handle(
     text_input: str | None = None,
     context: Context | None = None,
     language: str | None = None,
+    assistant: str | None = None,
 ) -> IntentResponse:
     """Handle an intent."""
     handler: IntentHandler = hass.data.get(DATA_KEY, {}).get(intent_type)
@@ -79,7 +81,14 @@ async def async_handle(
         language = hass.config.language
 
     intent = Intent(
-        hass, platform, intent_type, slots or {}, text_input, context, language
+        hass,
+        platform=platform,
+        intent_type=intent_type,
+        slots=slots or {},
+        text_input=text_input,
+        context=context,
+        language=language,
+        assistant=assistant,
     )
 
     try:
@@ -208,6 +217,7 @@ def async_match_states(
     entities: entity_registry.EntityRegistry | None = None,
     areas: area_registry.AreaRegistry | None = None,
     devices: device_registry.DeviceRegistry | None = None,
+    assistant: str | None = None,
 ) -> Iterable[State]:
     """Find states that match the constraints."""
     if states is None:
@@ -257,6 +267,14 @@ def async_match_states(
             devices = device_registry.async_get(hass)
 
         states_and_entities = list(_filter_by_area(states_and_entities, area, devices))
+
+    if assistant is not None:
+        # Filter by exposure
+        states_and_entities = [
+            (state, entity)
+            for state, entity in states_and_entities
+            if async_should_expose(hass, assistant, state.entity_id)
+        ]
 
     if name is not None:
         if devices is None:
@@ -387,6 +405,7 @@ class ServiceIntentHandler(IntentHandler):
                 area=area,
                 domains=domains,
                 device_classes=device_classes,
+                assistant=intent_obj.assistant,
             )
         )
 
@@ -496,6 +515,7 @@ class Intent:
         "context",
         "language",
         "category",
+        "assistant",
     ]
 
     def __init__(
@@ -508,6 +528,7 @@ class Intent:
         context: Context,
         language: str,
         category: IntentCategory | None = None,
+        assistant: str | None = None,
     ) -> None:
         """Initialize an intent."""
         self.hass = hass
@@ -518,6 +539,7 @@ class Intent:
         self.context = context
         self.language = language
         self.category = category
+        self.assistant = assistant
 
     @callback
     def create_response(self) -> IntentResponse:

--- a/tests/components/conversation/test_default_agent.py
+++ b/tests/components/conversation/test_default_agent.py
@@ -174,3 +174,52 @@ async def test_expose_flag_automatically_set(
         new_light: {"should_expose": True},
         test.entity_id: {"should_expose": False},
     }
+
+
+async def test_unexposed_entities_skipped(
+    hass: HomeAssistant,
+    init_components,
+    area_registry: ar.AreaRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test that unexposed entities are skipped in exposed areas."""
+    area_kitchen = area_registry.async_get_or_create("kitchen")
+
+    # Both lights are in the kitchen
+    exposed_light = entity_registry.async_get_or_create("light", "demo", "1234")
+    entity_registry.async_update_entity(
+        exposed_light.entity_id,
+        area_id=area_kitchen.id,
+    )
+    hass.states.async_set(exposed_light.entity_id, "off")
+
+    unexposed_light = entity_registry.async_get_or_create("light", "demo", "5678")
+    entity_registry.async_update_entity(
+        unexposed_light.entity_id,
+        area_id=area_kitchen.id,
+    )
+    hass.states.async_set(unexposed_light.entity_id, "off")
+
+    # On light is exposed, the other is not
+    expose_entity(hass, exposed_light.entity_id, True)
+    expose_entity(hass, unexposed_light.entity_id, False)
+
+    # Only one light should be turned on
+    calls = async_mock_service(hass, "light", "turn_on")
+    result = await conversation.async_converse(
+        hass, "turn on kitchen lights", None, Context(), None
+    )
+
+    assert len(calls) == 1
+    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+
+    # Only one light should be returned
+    hass.states.async_set(exposed_light.entity_id, "on")
+    hass.states.async_set(unexposed_light.entity_id, "on")
+    result = await conversation.async_converse(
+        hass, "how many lights are on in the kitchen", None, Context(), None
+    )
+
+    assert result.response.response_type == intent.IntentResponseType.QUERY_ANSWER
+    assert len(result.response.matched_states) == 1
+    assert result.response.matched_states[0].entity_id == exposed_light.entity_id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Intent handlers were not aware of which assistant they were being called from and consider unexposed entities with input like "turn on all lights in the bedroom" or "which lights are on in the office".

This PR passes in the assistant for the default conversation agent, and modifies the intent entity filtering to take assistant into account.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
