### PR TITLE
Pass OPUS payload ID through VoIP

### DIFF
--- a/homeassistant/components/voip/voip.py
+++ b/homeassistant/components/voip/voip.py
@@ -363,7 +363,7 @@ class PipelineRtpDatagramProtocol(RtpDatagramProtocol):
 
             async with async_timeout.timeout(tts_seconds + self.tts_extra_timeout):
                 # Assume TTS audio is 16Khz 16-bit mono
-                await self._async_send_audio(audio_bytes, **RTP_AUDIO_SETTINGS)
+                await self._async_send_audio(audio_bytes)
         except asyncio.TimeoutError as err:
             _LOGGER.warning("TTS timeout")
             raise err
@@ -374,7 +374,7 @@ class PipelineRtpDatagramProtocol(RtpDatagramProtocol):
     async def _async_send_audio(self, audio_bytes: bytes, **kwargs):
         """Send audio in executor."""
         await self.hass.async_add_executor_job(
-            partial(self.send_audio, audio_bytes, **kwargs)
+            partial(self.send_audio, audio_bytes, **RTP_AUDIO_SETTINGS, **kwargs)
         )
 
     async def _play_listening_tone(self) -> None:
@@ -389,7 +389,6 @@ class PipelineRtpDatagramProtocol(RtpDatagramProtocol):
         await self._async_send_audio(
             self._tone_bytes,
             silence_before=self.tone_delay,
-            **RTP_AUDIO_SETTINGS,
         )
 
     async def _play_processing_tone(self) -> None:
@@ -401,10 +400,7 @@ class PipelineRtpDatagramProtocol(RtpDatagramProtocol):
                 "processing.pcm",
             )
 
-        await self._async_send_audio(
-            self._processing_bytes,
-            **RTP_AUDIO_SETTINGS,
-        )
+        await self._async_send_audio(self._processing_bytes)
 
     async def _play_error_tone(self) -> None:
         """Play a tone to indicate a pipeline error occurred."""
@@ -415,10 +411,7 @@ class PipelineRtpDatagramProtocol(RtpDatagramProtocol):
                 "error.pcm",
             )
 
-        await self._async_send_audio(
-            self._error_bytes,
-            **RTP_AUDIO_SETTINGS,
-        )
+        await self._async_send_audio(self._error_bytes)
 
     def _load_pcm(self, file_name: str) -> bytes:
         """Load raw audio (16Khz, 16-bit mono)."""

--- a/tests/components/voip/test_voip.py
+++ b/tests/components/voip/test_voip.py
@@ -4,6 +4,7 @@ import time
 from unittest.mock import AsyncMock, Mock, patch
 
 import async_timeout
+import pytest
 
 from homeassistant.components import assist_pipeline, voip
 from homeassistant.components.voip.devices import VoIPDevice
@@ -88,6 +89,7 @@ async def test_pipeline(
             hass.config.language,
             voip_device,
             Context(),
+            opus_payload_type=123,
             listening_tone_enabled=False,
             processing_tone_enabled=False,
             error_tone_enabled=False,
@@ -138,6 +140,7 @@ async def test_pipeline_timeout(hass: HomeAssistant, voip_device: VoIPDevice) ->
             hass.config.language,
             voip_device,
             Context(),
+            opus_payload_type=123,
             pipeline_timeout=0.001,
             listening_tone_enabled=False,
             processing_tone_enabled=False,
@@ -178,6 +181,7 @@ async def test_stt_stream_timeout(hass: HomeAssistant, voip_device: VoIPDevice) 
             hass.config.language,
             voip_device,
             Context(),
+            opus_payload_type=123,
             audio_timeout=0.001,
             listening_tone_enabled=False,
             processing_tone_enabled=False,
@@ -247,6 +251,14 @@ async def test_tts_timeout(
         # Block here to force a timeout in _send_tts
         time.sleep(2)
 
+    async def async_send_audio(audio_bytes, **kwargs):
+        if audio_bytes == tone_bytes:
+            # Not TTS
+            return
+
+        # Block here to force a timeout in _send_tts
+        await asyncio.sleep(2)
+
     async def async_get_media_source_audio(
         hass: HomeAssistant,
         media_source_id: str,
@@ -269,6 +281,8 @@ async def test_tts_timeout(
             hass.config.language,
             voip_device,
             Context(),
+            opus_payload_type=123,
+            tts_extra_timeout=0.001,
             listening_tone_enabled=True,
             processing_tone_enabled=True,
             error_tone_enabled=True,
@@ -277,13 +291,18 @@ async def test_tts_timeout(
         rtp_protocol._processing_bytes = tone_bytes
         rtp_protocol._error_bytes = tone_bytes
         rtp_protocol.transport = Mock()
-        rtp_protocol.send_audio = Mock(side_effect=send_audio)
+        rtp_protocol.send_audio = Mock()
+
+        original_send_tts = rtp_protocol._send_tts
 
         async def send_tts(*args, **kwargs):
             # Call original then end test successfully
-            rtp_protocol._send_tts(*args, **kwargs)
+            with pytest.raises(asyncio.TimeoutError):
+                await original_send_tts(*args, **kwargs)
+
             done.set()
 
+        rtp_protocol._async_send_audio = AsyncMock(side_effect=async_send_audio)
         rtp_protocol._send_tts = AsyncMock(side_effect=send_tts)
 
         # silence


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Thread the auto-detected OPUS payload ID from the phone through to the audio input/output in VoIP.
This fixes problems with apps like MizuDroid which uses a payload id different from the Grandstream HT801.

Additionally, a broken test was fixed for VoIP.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
