### PR TITLE
Add support for setting NumberMode using NumberEntityDescription

### DIFF
--- a/homeassistant/components/baf/number.py
+++ b/homeassistant/components/baf/number.py
@@ -27,7 +27,6 @@ class BAFNumberDescriptionMixin:
     """Required values for BAF sensors."""
 
     value_fn: Callable[[Device], int | None]
-    mode: NumberMode
 
 
 @dataclass
@@ -147,7 +146,6 @@ class BAFNumber(BAFEntity, NumberEntity):
         self.entity_description = description
         super().__init__(device, f"{device.name} {description.name}")
         self._attr_unique_id = f"{self._device.mac_address}-{description.key}"
-        self._attr_mode = description.mode
 
     @callback
     def _async_update_attrs(self) -> None:

--- a/homeassistant/components/bmw_connected_drive/number.py
+++ b/homeassistant/components/bmw_connected_drive/number.py
@@ -40,7 +40,6 @@ class BMWNumberEntityDescription(NumberEntityDescription, BMWRequiredKeysMixin):
 
     is_available: Callable[[MyBMWVehicle], bool] = lambda _: False
     dynamic_options: Callable[[MyBMWVehicle], list[str]] | None = None
-    mode: NumberMode = NumberMode.AUTO
 
 
 NUMBER_TYPES: list[BMWNumberEntityDescription] = [
@@ -99,7 +98,6 @@ class BMWNumber(BMWBaseEntity, NumberEntity):
         super().__init__(coordinator, vehicle)
         self.entity_description = description
         self._attr_unique_id = f"{vehicle.vin}-{description.key}"
-        self._attr_mode = description.mode
 
     @property
     def native_value(self) -> float | None:

--- a/homeassistant/components/number/__init__.py
+++ b/homeassistant/components/number/__init__.py
@@ -130,8 +130,8 @@ class NumberEntityDescription(EntityDescription):
     mode: NumberMode | None = None
     native_max_value: float | None = None
     native_min_value: float | None = None
-    native_unit_of_measurement: str | None = None
     native_step: float | None = None
+    native_unit_of_measurement: str | None = None
     step: None = None
     unit_of_measurement: None = None  # Type override, use native_unit_of_measurement
 
@@ -202,8 +202,8 @@ class NumberEntity(Entity):
     _attr_native_max_value: float
     _attr_native_min_value: float
     _attr_native_step: float
-    _attr_native_value: float | None = None
     _attr_native_unit_of_measurement: str | None
+    _attr_native_value: float | None = None
     _deprecated_number_entity_reported = False
     _number_option_unit_of_measurement: str | None = None
 

--- a/homeassistant/components/number/__init__.py
+++ b/homeassistant/components/number/__init__.py
@@ -127,13 +127,13 @@ class NumberEntityDescription(EntityDescription):
     device_class: NumberDeviceClass | None = None
     max_value: None = None
     min_value: None = None
+    mode: NumberMode | None = None
     native_max_value: float | None = None
     native_min_value: float | None = None
     native_unit_of_measurement: str | None = None
     native_step: float | None = None
     step: None = None
     unit_of_measurement: None = None  # Type override, use native_unit_of_measurement
-    mode: NumberMode | None = None
 
     def __post_init__(self) -> None:
         """Post initialisation processing."""

--- a/homeassistant/components/number/__init__.py
+++ b/homeassistant/components/number/__init__.py
@@ -133,6 +133,7 @@ class NumberEntityDescription(EntityDescription):
     native_step: float | None = None
     step: None = None
     unit_of_measurement: None = None  # Type override, use native_unit_of_measurement
+    mode: NumberMode | None = None
 
     def __post_init__(self) -> None:
         """Post initialisation processing."""
@@ -193,7 +194,7 @@ class NumberEntity(Entity):
     _attr_device_class: NumberDeviceClass | None
     _attr_max_value: None
     _attr_min_value: None
-    _attr_mode: NumberMode = NumberMode.AUTO
+    _attr_mode: NumberMode
     _attr_state: None = None
     _attr_step: None
     _attr_unit_of_measurement: None  # Subclasses of NumberEntity should not set this
@@ -357,7 +358,14 @@ class NumberEntity(Entity):
     @property
     def mode(self) -> NumberMode:
         """Return the mode of the entity."""
-        return self._attr_mode
+        if hasattr(self, "_attr_mode"):
+            return self._attr_mode
+        if (
+            hasattr(self, "entity_description")
+            and self.entity_description.mode is not None
+        ):
+            return self.entity_description.mode
+        return NumberMode.AUTO
 
     @property
     @final

--- a/homeassistant/components/shelly/number.py
+++ b/homeassistant/components/shelly/number.py
@@ -30,7 +30,6 @@ from .entity import (
 class BlockNumberDescription(BlockEntityDescription, NumberEntityDescription):
     """Class to describe a BLOCK sensor."""
 
-    mode: NumberMode = NumberMode("slider")
     rest_path: str = ""
     rest_arg: str = ""
 
@@ -46,7 +45,7 @@ NUMBERS: Final = {
         native_min_value=0,
         native_max_value=100,
         native_step=1,
-        mode=NumberMode("slider"),
+        mode=NumberMode.SLIDER,
         rest_path="thermostat/0",
         rest_arg="pos",
     ),


### PR DESCRIPTION
## Breaking change
FOR CUSTOM COMPONENTS ONLY:

As of Home Assistant Core 2023.6, `mode` is available as a standard property of `NumberEntityDescription`.
This may cause issues in custom components if a custom `mode` property was previously implemented.

Please adjust the custom component by either dropping or renaming the custom `mode` property.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add the ability to set the number mode (auto, box, slider) using the NumberEntityDescription. The original behaviour, mode auto when no mode is set, is maintained.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #92423
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
