### PR TITLE
Fix lingering timer in jewish_calendar

### DIFF
--- a/homeassistant/components/jewish_calendar/binary_sensor.py
+++ b/homeassistant/components/jewish_calendar/binary_sensor.py
@@ -116,6 +116,13 @@ class JewishCalendarBinarySensor(BinarySensorEntity):
         await super().async_added_to_hass()
         self._schedule_update()
 
+    async def async_will_remove_from_hass(self) -> None:
+        """Run when entity will be removed from hass."""
+        if self._update_unsub:
+            self._update_unsub()
+            self._update_unsub = None
+        return await super().async_will_remove_from_hass()
+
     @callback
     def _update(self, now: datetime | None = None) -> None:
         """Update the state of the sensor."""


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Linked to #91360
https://github.com/home-assistant/core/actions/runs/4879928151/jobs/8707050076?pr=91360

```console
ERROR tests/components/jewish_calendar/test_sensor.py::test_shabbat_times_sensor[currently_third_day_of_three_day_type2_yomtov_in_israel-hebrew] - Failed: Lingering timer after job <Job track point in time 2017-09-23 19:11:00+03:00 UTC converter HassJobType.Callback <function async_track_point_in_time.<locals>.utc_converter at 0x7fd1ae943600>>
ERROR tests/components/jewish_calendar/test_sensor.py::test_omer_sensor[first_day_of_omer] - Failed: Lingering timer after job <Job track point in time 2019-04-22 06:13:00-07:00 UTC converter HassJobType.Callback <function async_track_point_in_time.<locals>.utc_converter at 0x7fd1aedf1d00>>
ERROR tests/components/jewish_calendar/test_sensor.py::test_omer_sensor[first_day_of_omer_after_tzeit] - Failed: Lingering timer after job <Job track point in time 2019-04-22 06:13:00-07:00 UTC converter HassJobType.Callback <function async_track_point_in_time.<locals>.utc_converter at 0x7fd1ae4a0e00>>
ERROR tests/components/jewish_calendar/test_sensor.py::test_omer_sensor[lag_baomer] - Failed: Lingering timer after job <Job track point in time 2019-05-24 05:45:00-07:00 UTC converter HassJobType.Callback <function async_track_point_in_time.<locals>.utc_converter at 0x7fd1ae6fbe20>>
ERROR tests/components/jewish_calendar/test_sensor.py::test_omer_sensor[last_day_of_omer] - Failed: Lingering timer after job <Job track point in time 2019-06-08 20:39:00-07:00 UTC converter HassJobType.Callback <function async_track_point_in_time.<locals>.utc_converter at 0x7fd1ae635f80>>
ERROR tests/components/jewish_calendar/test_sensor.py::test_omer_sensor[shavuot_no_omer] - Failed: Lingering timer after job <Job track point in time 2019-06-09 20:39:00-07:00 UTC converter HassJobType.Callback <function async_track_point_in_time.<locals>.utc_converter at 0x7fd1ae4be480>>
ERROR tests/components/jewish_calendar/test_sensor.py::test_omer_sensor[jan_1st_no_omer] - Failed: Lingering timer after job <Job track point in time 2019-01-02 06:52:00-08:00 UTC converter HassJobType.Callback <function async_track_point_in_time.<locals>.utc_converter at 0x7fd1ae401c60>>
ERROR tests/components/jewish_calendar/test_sensor.py::test_dafyomi_sensor[randomly_picked_date] - Failed: Lingering timer after job <Job track point in time 2014-04-29 06:05:00-07:00 UTC converter HassJobType.Callback <function async_track_point_in_time.<locals>.utc_converter at 0x7fd1ae8ea660>>
ERROR tests/components/jewish_calendar/test_sensor.py::test_dafyomi_sensor[end_of_cycle13] - Failed: Lingering timer after job <Job track point in time 2020-01-04 17:36:00-08:00 UTC converter HassJobType.Callback <function async_track_point_in_time.<locals>.utc_converter at 0x7fd1aecba7a0>>
ERROR tests/components/jewish_calendar/test_sensor.py::test_dafyomi_sensor[start_of_cycle14] - Failed: Lingering timer after job <Job track point in time 2020-01-06 06:52:00-08:00 UTC converter HassJobType.Callback <function async_track_point_in_time.<locals>.utc_converter at 0x7fd1b420a0c0>>
ERROR tests/components/jewish_calendar/test_sensor.py::test_dafyomi_sensor[cycle14_end_of_berachos] - Failed: Lingering timer after job <Job track point in time 2020-03-07 18:28:00-08:00 UTC converter HassJobType.Callback <function async_track_point_in_time.<locals>.utc_converter at 0x7fd1aecd94e0>>
ERROR tests/components/jewish_calendar/test_sensor.py::test_dafyomi_sensor[cycle14_start_of_shabbos] - Failed: Lingering timer after job <Job track point in time 2020-03-09 07:08:00-07:00 UTC converter HassJobType.Callback <function async_track_point_in_time.<locals>.utc_converter at 0x7fd1ae73d760>>
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
