### PR TITLE
Move naming of entities in Rituals Perfume Genie

### DIFF
--- a/homeassistant/components/rituals_perfume_genie/binary_sensor.py
+++ b/homeassistant/components/rituals_perfume_genie/binary_sensor.py
@@ -14,8 +14,6 @@ from .const import DOMAIN
 from .coordinator import RitualsDataUpdateCoordinator
 from .entity import DiffuserEntity
 
-CHARGING_SUFFIX = " Battery Charging"
-
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -42,8 +40,9 @@ class DiffuserBatteryChargingBinarySensor(DiffuserEntity, BinarySensorEntity):
 
     def __init__(self, coordinator: RitualsDataUpdateCoordinator) -> None:
         """Initialize the battery charging binary sensor."""
-        super().__init__(coordinator, CHARGING_SUFFIX)
+        super().__init__(coordinator)
         self._attr_unique_id = f"{coordinator.diffuser.hublot}-charging"
+        self._attr_name = f"{coordinator.diffuser.name} Battery Charging"
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/rituals_perfume_genie/entity.py
+++ b/homeassistant/components/rituals_perfume_genie/entity.py
@@ -18,19 +18,14 @@ class DiffuserEntity(CoordinatorEntity[RitualsDataUpdateCoordinator]):
     def __init__(
         self,
         coordinator: RitualsDataUpdateCoordinator,
-        entity_suffix: str,
     ) -> None:
         """Init from config, hookup diffuser and coordinator."""
         super().__init__(coordinator)
-        hublot = coordinator.diffuser.hublot
-        hubname = coordinator.diffuser.name
-
-        self._attr_name = f"{hubname}{entity_suffix}"
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, hublot)},
+            identifiers={(DOMAIN, coordinator.diffuser.hublot)},
             manufacturer=MANUFACTURER,
             model=MODEL if coordinator.diffuser.has_battery else MODEL2,
-            name=hubname,
+            name=coordinator.diffuser.name,
             sw_version=coordinator.diffuser.version,
         )
 

--- a/homeassistant/components/rituals_perfume_genie/number.py
+++ b/homeassistant/components/rituals_perfume_genie/number.py
@@ -13,8 +13,6 @@ from .entity import DiffuserEntity
 MIN_PERFUME_AMOUNT = 1
 MAX_PERFUME_AMOUNT = 3
 
-PERFUME_AMOUNT_SUFFIX = " Perfume Amount"
-
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -39,8 +37,9 @@ class DiffuserPerfumeAmount(DiffuserEntity, NumberEntity):
 
     def __init__(self, coordinator: RitualsDataUpdateCoordinator) -> None:
         """Initialize the diffuser perfume amount number."""
-        super().__init__(coordinator, PERFUME_AMOUNT_SUFFIX)
+        super().__init__(coordinator)
         self._attr_unique_id = f"{coordinator.diffuser.hublot}-perfume_amount"
+        self._attr_name = f"{coordinator.diffuser.name} Perfume Amount"
 
     @property
     def native_value(self) -> int:

--- a/homeassistant/components/rituals_perfume_genie/select.py
+++ b/homeassistant/components/rituals_perfume_genie/select.py
@@ -11,8 +11,6 @@ from .const import DOMAIN
 from .coordinator import RitualsDataUpdateCoordinator
 from .entity import DiffuserEntity
 
-ROOM_SIZE_SUFFIX = " Room Size"
-
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -39,11 +37,12 @@ class DiffuserRoomSize(DiffuserEntity, SelectEntity):
 
     def __init__(self, coordinator: RitualsDataUpdateCoordinator) -> None:
         """Initialize the diffuser room size select entity."""
-        super().__init__(coordinator, ROOM_SIZE_SUFFIX)
+        super().__init__(coordinator)
         self._attr_entity_registry_enabled_default = (
             self.coordinator.diffuser.has_battery
         )
         self._attr_unique_id = f"{coordinator.diffuser.hublot}-room_size_square_meter"
+        self._attr_name = f"{coordinator.diffuser.name} Room Size"
 
     @property
     def current_option(self) -> str:

--- a/homeassistant/components/rituals_perfume_genie/sensor.py
+++ b/homeassistant/components/rituals_perfume_genie/sensor.py
@@ -11,11 +11,6 @@ from .const import DOMAIN
 from .coordinator import RitualsDataUpdateCoordinator
 from .entity import DiffuserEntity
 
-BATTERY_SUFFIX = " Battery"
-PERFUME_SUFFIX = " Perfume"
-FILL_SUFFIX = " Fill"
-WIFI_SUFFIX = " Wifi"
-
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -47,8 +42,9 @@ class DiffuserPerfumeSensor(DiffuserEntity, SensorEntity):
 
     def __init__(self, coordinator: RitualsDataUpdateCoordinator) -> None:
         """Initialize the perfume sensor."""
-        super().__init__(coordinator, PERFUME_SUFFIX)
+        super().__init__(coordinator)
         self._attr_unique_id = f"{coordinator.diffuser.hublot}-perfume"
+        self._attr_name = f"{coordinator.diffuser.name} Perfume"
 
     @property
     def icon(self) -> str:
@@ -68,8 +64,9 @@ class DiffuserFillSensor(DiffuserEntity, SensorEntity):
 
     def __init__(self, coordinator: RitualsDataUpdateCoordinator) -> None:
         """Initialize the fill sensor."""
-        super().__init__(coordinator, FILL_SUFFIX)
+        super().__init__(coordinator)
         self._attr_unique_id = f"{coordinator.diffuser.hublot}-fill"
+        self._attr_name = f"{coordinator.diffuser.name} Fill"
 
     @property
     def icon(self) -> str:
@@ -93,8 +90,9 @@ class DiffuserBatterySensor(DiffuserEntity, SensorEntity):
 
     def __init__(self, coordinator: RitualsDataUpdateCoordinator) -> None:
         """Initialize the battery sensor."""
-        super().__init__(coordinator, BATTERY_SUFFIX)
+        super().__init__(coordinator)
         self._attr_unique_id = f"{coordinator.diffuser.hublot}-battery_percentage"
+        self._attr_name = f"{coordinator.diffuser.name} Battery"
 
     @property
     def native_value(self) -> int:
@@ -110,8 +108,9 @@ class DiffuserWifiSensor(DiffuserEntity, SensorEntity):
 
     def __init__(self, coordinator: RitualsDataUpdateCoordinator) -> None:
         """Initialize the wifi sensor."""
-        super().__init__(coordinator, WIFI_SUFFIX)
+        super().__init__(coordinator)
         self._attr_unique_id = f"{coordinator.diffuser.hublot}-wifi_percentage"
+        self._attr_name = f"{coordinator.diffuser.name} Wifi"
 
     @property
     def native_value(self) -> int:

--- a/homeassistant/components/rituals_perfume_genie/switch.py
+++ b/homeassistant/components/rituals_perfume_genie/switch.py
@@ -35,9 +35,10 @@ class DiffuserSwitch(DiffuserEntity, SwitchEntity):
 
     def __init__(self, coordinator: RitualsDataUpdateCoordinator) -> None:
         """Initialize the diffuser switch."""
-        super().__init__(coordinator, "")
+        super().__init__(coordinator)
         self._attr_is_on = self.coordinator.diffuser.is_on
         self._attr_unique_id = f"{coordinator.diffuser.hublot}-is_on"
+        self._attr_name = coordinator.diffuser.name
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This is a small pre-refactor step towards more refactoring to come.

Currently, the names of entities are defined in the base entity. This moves it to each individual entity class (out of the base entity).

This enables the ability to refactor each platform to entity descriptions in individual follow-up PRs (this is a step in keeping follow-ups smaller).

PS: Yes, entity names and such should be possible by now, and so are translations, will do that in follow-up PRs (just like entity descriptions).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
