### PR TITLE
Add entity descriptions to numbers of Rituals Perfume Genie

### DIFF
--- a/homeassistant/components/rituals_perfume_genie/number.py
+++ b/homeassistant/components/rituals_perfume_genie/number.py
@@ -1,7 +1,13 @@
 """Support for Rituals Perfume Genie numbers."""
 from __future__ import annotations
 
-from homeassistant.components.number import NumberEntity
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+from pyrituals import Diffuser
+
+from homeassistant.components.number import NumberEntity, NumberEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -10,8 +16,33 @@ from .const import DOMAIN
 from .coordinator import RitualsDataUpdateCoordinator
 from .entity import DiffuserEntity
 
-MIN_PERFUME_AMOUNT = 1
-MAX_PERFUME_AMOUNT = 3
+
+@dataclass
+class RitualsNumberEntityDescriptionMixin:
+    """Mixin for required keys."""
+
+    value_fn: Callable[[Diffuser], int]
+    set_value_fn: Callable[[Diffuser, int], Awaitable[Any]]
+
+
+@dataclass
+class RitualsNumberEntityDescription(
+    NumberEntityDescription, RitualsNumberEntityDescriptionMixin
+):
+    """Class describing Rituals number entities."""
+
+
+ENTITY_DESCRIPTIONS = (
+    RitualsNumberEntityDescription(
+        key="perfume_amount",
+        name="Perfume Amount",
+        icon="mdi:gauge",
+        native_min_value=1,
+        native_max_value=3,
+        value_fn=lambda diffuser: diffuser.perfume_amount,
+        set_value_fn=lambda diffuser, value: diffuser.set_perfume_amount(value),
+    ),
+)
 
 
 async def async_setup_entry(
@@ -24,33 +55,37 @@ async def async_setup_entry(
         config_entry.entry_id
     ]
     async_add_entities(
-        DiffuserPerfumeAmount(coordinator) for coordinator in coordinators.values()
+        RitualsNumberEntity(coordinator, description)
+        for coordinator in coordinators.values()
+        for description in ENTITY_DESCRIPTIONS
     )
 
 
-class DiffuserPerfumeAmount(DiffuserEntity, NumberEntity):
-    """Representation of a diffuser perfume amount number."""
+class RitualsNumberEntity(DiffuserEntity, NumberEntity):
+    """Representation of a diffuser number entity."""
 
-    _attr_icon = "mdi:gauge"
-    _attr_native_max_value = MAX_PERFUME_AMOUNT
-    _attr_native_min_value = MIN_PERFUME_AMOUNT
+    entity_description: RitualsNumberEntityDescription
 
-    def __init__(self, coordinator: RitualsDataUpdateCoordinator) -> None:
+    def __init__(
+        self,
+        coordinator: RitualsDataUpdateCoordinator,
+        description: RitualsNumberEntityDescription,
+    ) -> None:
         """Initialize the diffuser perfume amount number."""
         super().__init__(coordinator)
-        self._attr_unique_id = f"{coordinator.diffuser.hublot}-perfume_amount"
-        self._attr_name = f"{coordinator.diffuser.name} Perfume Amount"
+        self.entity_description = description
+        self._attr_unique_id = f"{coordinator.diffuser.hublot}-{description.key}"
+        self._attr_name = f"{coordinator.diffuser.name} {description.name}"
 
     @property
     def native_value(self) -> int:
-        """Return the current perfume amount."""
-        return self.coordinator.diffuser.perfume_amount
+        """Return the number value."""
+        return self.entity_description.value_fn(self.coordinator.diffuser)
 
     async def async_set_native_value(self, value: float) -> None:
-        """Set the perfume amount."""
+        """Change to new number value."""
         if not value.is_integer():
-            raise ValueError(
-                f"Can't set the perfume amount to {value}. Perfume amount must be an"
-                " integer."
-            )
-        await self.coordinator.diffuser.set_perfume_amount(int(value))
+            raise ValueError(f"Can't set value to {value}. Value must be an integer.")
+        await self.entity_description.set_value_fn(
+            self.coordinator.diffuser, int(value)
+        )

--- a/tests/components/rituals_perfume_genie/test_number.py
+++ b/tests/components/rituals_perfume_genie/test_number.py
@@ -11,10 +11,6 @@ from homeassistant.components.number import (
     DOMAIN as NUMBER_DOMAIN,
     SERVICE_SET_VALUE,
 )
-from homeassistant.components.rituals_perfume_genie.number import (
-    MAX_PERFUME_AMOUNT,
-    MIN_PERFUME_AMOUNT,
-)
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_ICON
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -40,8 +36,8 @@ async def test_number_entity(
     assert state
     assert state.state == str(diffuser.perfume_amount)
     assert state.attributes[ATTR_ICON] == "mdi:gauge"
-    assert state.attributes[ATTR_MIN] == MIN_PERFUME_AMOUNT
-    assert state.attributes[ATTR_MAX] == MAX_PERFUME_AMOUNT
+    assert state.attributes[ATTR_MIN] == 1
+    assert state.attributes[ATTR_MAX] == 3
 
     entry = entity_registry.async_get("number.genie_perfume_amount")
     assert entry


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds entity descriptions to the number entities of the Rituals Perfume Genie integration.

This PR focusses on just that, no other changes at this point. Things like entity naming and translations will happen in follow-up PRs (trying to keep the PRs minimal).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
