### PR TITLE
Roborock continue on failed mqtt disconnect

### DIFF
--- a/homeassistant/components/roborock/__init__.py
+++ b/homeassistant/components/roborock/__init__.py
@@ -8,6 +8,7 @@ import logging
 from roborock.api import RoborockApiClient
 from roborock.cloud_api import RoborockMqttClient
 from roborock.containers import HomeDataDevice, RoborockDeviceInfo, UserData
+from roborock.exceptions import RoborockException
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_USERNAME
@@ -44,7 +45,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         for device, result in zip(devices, network_results)
         if result is not None
     }
-    await mqtt_client.async_disconnect()
+    try:
+        await mqtt_client.async_disconnect()
+    except RoborockException as err:
+        _LOGGER.warning("Failed disconnecting from the mqtt server %s", err)
     if not network_info:
         raise ConfigEntryNotReady(
             "Could not get network information about your devices"

--- a/tests/components/roborock/mock_data.py
+++ b/tests/components/roborock/mock_data.py
@@ -7,6 +7,7 @@ from roborock.containers import (
     Consumable,
     DNDTimer,
     HomeData,
+    NetworkInfo,
     Status,
     UserData,
 )
@@ -368,3 +369,7 @@ STATUS = Status.from_dict(
 )
 
 PROP = DeviceProp(STATUS, DND_TIMER, CLEAN_SUMMARY, CONSUMABLE, CLEAN_RECORD)
+
+NETWORK_INFO = NetworkInfo(
+    ip="123.232.12.1", ssid="wifi", mac="ac:cc:cc:cc:cc", bssid="bssid", rssi=90
+)

--- a/tests/components/roborock/test_init.py
+++ b/tests/components/roborock/test_init.py
@@ -1,6 +1,8 @@
 """Test for Roborock init."""
 from unittest.mock import patch
 
+from roborock.exceptions import RoborockTimeout
+
 from homeassistant.components.roborock.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
@@ -8,6 +10,7 @@ from homeassistant.helpers.update_coordinator import UpdateFailed
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
+from tests.components.roborock.mock_data import HOME_DATA, NETWORK_INFO
 
 
 async def test_unload_entry(
@@ -38,3 +41,23 @@ async def test_config_entry_not_ready(
     ):
         await async_setup_component(hass, DOMAIN, {})
         assert mock_roborock_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_continue_setup_mqtt_disconnect_fail(
+    hass: HomeAssistant, mock_roborock_entry: MockConfigEntry
+):
+    """Test that if disconnect fails, we still continue setting up."""
+    with patch(
+        "homeassistant.components.roborock.RoborockApiClient.get_home_data",
+        return_value=HOME_DATA,
+    ), patch(
+        "homeassistant.components.roborock.RoborockMqttClient.get_networking",
+        return_value=NETWORK_INFO,
+    ), patch(
+        "homeassistant.components.roborock.RoborockMqttClient.async_disconnect",
+        side_effect=RoborockTimeout(),
+    ), patch(
+        "homeassistant.components.roborock.RoborockDataUpdateCoordinator.async_config_entry_first_refresh"
+    ):
+        await async_setup_component(hass, DOMAIN, {})
+    assert mock_roborock_entry.state is ConfigEntryState.LOADED


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
We disconnect from the mqtt client when are are done using it, but sometimes disconnect can fail, and we don't want that to stop us from continuing through with the setup.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #92268 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
