### PR TITLE
2023.5.1

### DIFF
--- a/homeassistant/components/bluetooth/manifest.json
+++ b/homeassistant/components/bluetooth/manifest.json
@@ -18,7 +18,7 @@
     "bleak==0.20.2",
     "bleak-retry-connector==3.0.2",
     "bluetooth-adapters==0.15.3",
-    "bluetooth-auto-recovery==1.1.1",
+    "bluetooth-auto-recovery==1.1.2",
     "bluetooth-data-tools==0.4.0",
     "dbus-fast==1.85.0"
   ]

--- a/homeassistant/components/cloud/alexa_config.py
+++ b/homeassistant/components/cloud/alexa_config.py
@@ -24,7 +24,6 @@ from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.homeassistant.exposed_entities import (
     async_expose_entity,
     async_get_assistant_settings,
-    async_get_entity_settings,
     async_listen_entity_updates,
     async_should_expose,
 )
@@ -201,10 +200,6 @@ class CloudAlexaConfig(alexa_config.AbstractConfig):
             return
 
         for state in self.hass.states.async_all():
-            with suppress(HomeAssistantError):
-                entity_settings = async_get_entity_settings(self.hass, state.entity_id)
-                if CLOUD_ALEXA in entity_settings:
-                    continue
             async_expose_entity(
                 self.hass,
                 CLOUD_ALEXA,
@@ -212,10 +207,6 @@ class CloudAlexaConfig(alexa_config.AbstractConfig):
                 self._should_expose_legacy(state.entity_id),
             )
         for entity_id in self._prefs.alexa_entity_configs:
-            with suppress(HomeAssistantError):
-                entity_settings = async_get_entity_settings(self.hass, entity_id)
-                if CLOUD_ALEXA in entity_settings:
-                    continue
             async_expose_entity(
                 self.hass,
                 CLOUD_ALEXA,

--- a/homeassistant/components/cloud/google_config.py
+++ b/homeassistant/components/cloud/google_config.py
@@ -1,6 +1,5 @@
 """Google config for Cloud."""
 import asyncio
-from contextlib import suppress
 from http import HTTPStatus
 import logging
 from typing import Any
@@ -178,10 +177,6 @@ class CloudGoogleConfig(AbstractConfig):
 
         for state in self.hass.states.async_all():
             entity_id = state.entity_id
-            with suppress(HomeAssistantError):
-                entity_settings = async_get_entity_settings(self.hass, entity_id)
-                if CLOUD_GOOGLE in entity_settings:
-                    continue
             async_expose_entity(
                 self.hass,
                 CLOUD_GOOGLE,
@@ -197,10 +192,6 @@ class CloudGoogleConfig(AbstractConfig):
                     _2fa_disabled,
                 )
         for entity_id in self._prefs.google_entity_configs:
-            with suppress(HomeAssistantError):
-                entity_settings = async_get_entity_settings(self.hass, entity_id)
-                if CLOUD_GOOGLE in entity_settings:
-                    continue
             async_expose_entity(
                 self.hass,
                 CLOUD_GOOGLE,

--- a/homeassistant/components/frontend/manifest.json
+++ b/homeassistant/components/frontend/manifest.json
@@ -20,5 +20,5 @@
   "documentation": "https://www.home-assistant.io/integrations/frontend",
   "integration_type": "system",
   "quality_scale": "internal",
-  "requirements": ["home-assistant-frontend==20230503.1"]
+  "requirements": ["home-assistant-frontend==20230503.2"]
 }

--- a/homeassistant/components/lifx/light.py
+++ b/homeassistant/components/lifx/light.py
@@ -382,7 +382,7 @@ class LIFXMultiZone(LIFXColor):
         """Send a color change to the bulb."""
         bulb = self.bulb
         color_zones = bulb.color_zones
-        num_zones = len(color_zones)
+        num_zones = self.coordinator.get_number_of_zones()
 
         # Zone brightness is not reported when powered off
         if not self.is_on and hsbk[HSBK_BRIGHTNESS] is None:

--- a/homeassistant/components/notion/manifest.json
+++ b/homeassistant/components/notion/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "loggers": ["aionotion"],
-  "requirements": ["aionotion==2023.04.2"]
+  "requirements": ["aionotion==2023.05.0"]
 }

--- a/homeassistant/components/onvif/device.py
+++ b/homeassistant/components/onvif/device.py
@@ -12,7 +12,7 @@ from httpx import RequestError
 import onvif
 from onvif import ONVIFCamera
 from onvif.exceptions import ONVIFError
-from zeep.exceptions import Fault, TransportError, XMLParseError
+from zeep.exceptions import Fault, TransportError, XMLParseError, XMLSyntaxError
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -286,7 +286,21 @@ class ONVIFDevice:
     async def async_get_device_info(self) -> DeviceInfo:
         """Obtain information about this device."""
         device_mgmt = self.device.create_devicemgmt_service()
-        device_info = await device_mgmt.GetDeviceInformation()
+        manufacturer = None
+        model = None
+        firmware_version = None
+        serial_number = None
+        try:
+            device_info = await device_mgmt.GetDeviceInformation()
+        except (XMLParseError, XMLSyntaxError, TransportError) as ex:
+            # Some cameras have invalid UTF-8 in their device information (TransportError)
+            # and others have completely invalid XML (XMLParseError, XMLSyntaxError)
+            LOGGER.warning("%s: Failed to fetch device information: %s", self.name, ex)
+        else:
+            manufacturer = device_info.Manufacturer
+            model = device_info.Model
+            firmware_version = device_info.FirmwareVersion
+            serial_number = device_info.SerialNumber
 
         # Grab the last MAC address for backwards compatibility
         mac = None
@@ -306,10 +320,10 @@ class ONVIFDevice:
             )
 
         return DeviceInfo(
-            device_info.Manufacturer,
-            device_info.Model,
-            device_info.FirmwareVersion,
-            device_info.SerialNumber,
+            manufacturer,
+            model,
+            firmware_version,
+            serial_number,
             mac,
         )
 

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -8,7 +8,7 @@ from .backports.enum import StrEnum
 APPLICATION_NAME: Final = "HomeAssistant"
 MAJOR_VERSION: Final = 2023
 MINOR_VERSION: Final = 5
-PATCH_VERSION: Final = "0"
+PATCH_VERSION: Final = "1"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 10, 0)

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -14,7 +14,7 @@ bcrypt==4.0.1
 bleak-retry-connector==3.0.2
 bleak==0.20.2
 bluetooth-adapters==0.15.3
-bluetooth-auto-recovery==1.1.1
+bluetooth-auto-recovery==1.1.2
 bluetooth-data-tools==0.4.0
 certifi>=2021.5.30
 ciso8601==2.3.0

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -25,7 +25,7 @@ ha-av==10.0.0
 hass-nabucasa==0.66.2
 hassil==1.0.6
 home-assistant-bluetooth==1.10.0
-home-assistant-frontend==20230503.1
+home-assistant-frontend==20230503.2
 home-assistant-intents==2023.4.26
 httpx==0.24.0
 ifaddr==0.1.7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name        = "homeassistant"
-version     = "2023.5.0"
+version     = "2023.5.1"
 license     = {text = "Apache-2.0"}
 description = "Open-source home automation platform running on Python 3."
 readme      = "README.rst"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -223,7 +223,7 @@ aionanoleaf==0.2.1
 aionotify==0.2.0
 
 # homeassistant.components.notion
-aionotion==2023.04.2
+aionotion==2023.05.0
 
 # homeassistant.components.oncue
 aiooncue==0.3.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -465,7 +465,7 @@ bluemaestro-ble==0.2.3
 bluetooth-adapters==0.15.3
 
 # homeassistant.components.bluetooth
-bluetooth-auto-recovery==1.1.1
+bluetooth-auto-recovery==1.1.2
 
 # homeassistant.components.bluetooth
 # homeassistant.components.esphome

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -911,7 +911,7 @@ hole==0.8.0
 holidays==0.21.13
 
 # homeassistant.components.frontend
-home-assistant-frontend==20230503.1
+home-assistant-frontend==20230503.2
 
 # homeassistant.components.conversation
 home-assistant-intents==2023.4.26

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -204,7 +204,7 @@ aiomusiccast==0.14.8
 aionanoleaf==0.2.1
 
 # homeassistant.components.notion
-aionotion==2023.04.2
+aionotion==2023.05.0
 
 # homeassistant.components.oncue
 aiooncue==0.3.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -385,7 +385,7 @@ bluemaestro-ble==0.2.3
 bluetooth-adapters==0.15.3
 
 # homeassistant.components.bluetooth
-bluetooth-auto-recovery==1.1.1
+bluetooth-auto-recovery==1.1.2
 
 # homeassistant.components.bluetooth
 # homeassistant.components.esphome

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -700,7 +700,7 @@ hole==0.8.0
 holidays==0.21.13
 
 # homeassistant.components.frontend
-home-assistant-frontend==20230503.1
+home-assistant-frontend==20230503.2
 
 # homeassistant.components.conversation
 home-assistant-intents==2023.4.26

--- a/tests/components/cloud/test_alexa_config.py
+++ b/tests/components/cloud/test_alexa_config.py
@@ -628,7 +628,7 @@ async def test_alexa_config_migrate_expose_entity_prefs(
         "cloud.alexa": {"should_expose": True}
     }
     assert async_get_entity_settings(hass, entity_migrated.entity_id) == {
-        "cloud.alexa": {"should_expose": False}
+        "cloud.alexa": {"should_expose": True}
     }
     assert async_get_entity_settings(hass, entity_config.entity_id) == {
         "cloud.alexa": {"should_expose": False}

--- a/tests/components/cloud/test_google_config.py
+++ b/tests/components/cloud/test_google_config.py
@@ -580,7 +580,7 @@ async def test_google_config_migrate_expose_entity_prefs(
         "cloud.google_assistant": {"should_expose": True}
     }
     assert async_get_entity_settings(hass, entity_migrated.entity_id) == {
-        "cloud.google_assistant": {"should_expose": False}
+        "cloud.google_assistant": {"should_expose": True}
     }
     assert async_get_entity_settings(hass, entity_no_2fa_exposed.entity_id) == {
         "cloud.google_assistant": {"disable_2fa": True, "should_expose": True}

--- a/tests/components/lifx/test_light.py
+++ b/tests/components/lifx/test_light.py
@@ -36,6 +36,7 @@ from homeassistant.components.light import (
     ATTR_TRANSITION,
     ATTR_XY_COLOR,
     DOMAIN as LIGHT_DOMAIN,
+    SERVICE_TURN_ON,
     ColorMode,
 )
 from homeassistant.const import (
@@ -1741,3 +1742,46 @@ async def test_set_hev_cycle_state_fails_for_color_bulb(hass: HomeAssistant) -> 
             {ATTR_ENTITY_ID: entity_id, ATTR_POWER: True},
             blocking=True,
         )
+
+
+async def test_light_strip_zones_not_populated_yet(hass: HomeAssistant) -> None:
+    """Test a light strip were zones are not populated initially."""
+    already_migrated_config_entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_HOST: "127.0.0.1"}, unique_id=SERIAL
+    )
+    already_migrated_config_entry.add_to_hass(hass)
+    bulb = _mocked_light_strip()
+    bulb.power_level = 65535
+    bulb.color_zones = None
+    bulb.color = [65535, 65535, 65535, 65535]
+    with _patch_discovery(device=bulb), _patch_config_flow_try_connect(
+        device=bulb
+    ), _patch_device(device=bulb):
+        await async_setup_component(hass, lifx.DOMAIN, {lifx.DOMAIN: {}})
+        await hass.async_block_till_done()
+
+    entity_id = "light.my_bulb"
+
+    state = hass.states.get(entity_id)
+    assert state.state == "on"
+    attributes = state.attributes
+    assert attributes[ATTR_BRIGHTNESS] == 255
+    assert attributes[ATTR_COLOR_MODE] == ColorMode.HS
+    assert attributes[ATTR_SUPPORTED_COLOR_MODES] == [
+        ColorMode.COLOR_TEMP,
+        ColorMode.HS,
+    ]
+    assert attributes[ATTR_HS_COLOR] == (360.0, 100.0)
+    assert attributes[ATTR_RGB_COLOR] == (255, 0, 0)
+    assert attributes[ATTR_XY_COLOR] == (0.701, 0.299)
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: entity_id}, blocking=True
+    )
+    assert bulb.set_power.calls[0][0][0] is True
+    bulb.set_power.reset_mock()
+
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=30))
+    await hass.async_block_till_done()
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ON


### PR DESCRIPTION
- Fix onvif setup when time set service is not functional ([@bdraco] - [#92447]) ([onvif docs])
- Fix onvif cameras with invalid encodings in device info ([@bdraco] - [#92450]) ([onvif docs])
- Bump `aionotion` to 2023.05.0 ([@bachya] - [#92451]) ([notion docs])
- Fix lifx light strips when color zones are not initially populated ([@bdraco] - [#92487]) ([lifx docs])
- Bump bluetooth-auto-recovery 1.1.2 ([@bdraco] - [#92495]) ([bluetooth docs])
- Force migration of cloud settings to exposed_entities ([@emontnemery] - [#92499]) ([cloud docs])
- Update frontend to 20230503.2 ([@bramkragten] - [#92508]) ([frontend docs])

[#92422]: https://github.com/home-assistant/core/pull/92422
[#92447]: https://github.com/home-assistant/core/pull/92447
[#92450]: https://github.com/home-assistant/core/pull/92450
[#92451]: https://github.com/home-assistant/core/pull/92451
[#92487]: https://github.com/home-assistant/core/pull/92487
[#92495]: https://github.com/home-assistant/core/pull/92495
[#92499]: https://github.com/home-assistant/core/pull/92499
[#92508]: https://github.com/home-assistant/core/pull/92508
[@bachya]: https://github.com/bachya
[@bdraco]: https://github.com/bdraco
[@bramkragten]: https://github.com/bramkragten
[@emontnemery]: https://github.com/emontnemery
[@frenck]: https://github.com/frenck
[accuweather docs]: https://www.home-assistant.io/integrations/accuweather/
[advantage_air docs]: https://www.home-assistant.io/integrations/advantage_air/
[bluetooth docs]: https://www.home-assistant.io/integrations/bluetooth/
[cloud docs]: https://www.home-assistant.io/integrations/cloud/
[frontend docs]: https://www.home-assistant.io/integrations/frontend/
[lifx docs]: https://www.home-assistant.io/integrations/lifx/
[notion docs]: https://www.home-assistant.io/integrations/notion/
[onvif docs]: https://www.home-assistant.io/integrations/onvif/
