### PR TITLE
Fix blocking I/O in the event loop when starting ONVIF

### DIFF
--- a/homeassistant/components/onvif/button.py
+++ b/homeassistant/components/onvif/button.py
@@ -34,7 +34,7 @@ class RebootButton(ONVIFBaseEntity, ButtonEntity):
 
     async def async_press(self) -> None:
         """Send out a SystemReboot command."""
-        device_mgmt = self.device.device.create_devicemgmt_service()
+        device_mgmt = await self.device.device.create_devicemgmt_service()
         await device_mgmt.SystemReboot()
 
 

--- a/homeassistant/components/onvif/config_flow.py
+++ b/homeassistant/components/onvif/config_flow.py
@@ -275,7 +275,7 @@ class OnvifFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         try:
             await device.update_xaddrs()
-            device_mgmt = device.create_devicemgmt_service()
+            device_mgmt = await device.create_devicemgmt_service()
             # Get the MAC address to use as the unique ID for the config flow
             if not self.device_id:
                 try:
@@ -314,7 +314,7 @@ class OnvifFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     }
                 )
             # Verify there is an H264 profile
-            media_service = device.create_media_service()
+            media_service = await device.create_media_service()
             profiles = await media_service.GetProfiles()
         except AttributeError:  # Likely an empty document or 404 from the wrong port
             LOGGER.debug(

--- a/homeassistant/components/onvif/device.py
+++ b/homeassistant/components/onvif/device.py
@@ -136,7 +136,7 @@ class ONVIFDevice:
 
         if self.capabilities.ptz:
             LOGGER.debug("%s: creating PTZ service", self.name)
-            self.device.create_ptz_service()
+            await self.device.create_ptz_service()
 
         # Determine max resolution from profiles
         self.max_resolution = max(
@@ -159,7 +159,7 @@ class ONVIFDevice:
 
     async def async_manually_set_date_and_time(self) -> None:
         """Set Date and Time Manually using SetSystemDateAndTime command."""
-        device_mgmt = self.device.create_devicemgmt_service()
+        device_mgmt = await self.device.create_devicemgmt_service()
 
         # Retrieve DateTime object from camera to use as template for Set operation
         device_time = await device_mgmt.GetSystemDateAndTime()
@@ -202,7 +202,7 @@ class ONVIFDevice:
     async def async_check_date_and_time(self) -> None:
         """Warns if device and system date not synced."""
         LOGGER.debug("%s: Setting up the ONVIF device management service", self.name)
-        device_mgmt = self.device.create_devicemgmt_service()
+        device_mgmt = await self.device.create_devicemgmt_service()
         system_date = dt_util.utcnow()
 
         LOGGER.debug("%s: Retrieving current device date/time", self.name)
@@ -285,7 +285,7 @@ class ONVIFDevice:
 
     async def async_get_device_info(self) -> DeviceInfo:
         """Obtain information about this device."""
-        device_mgmt = self.device.create_devicemgmt_service()
+        device_mgmt = await self.device.create_devicemgmt_service()
         manufacturer = None
         model = None
         firmware_version = None
@@ -331,7 +331,7 @@ class ONVIFDevice:
         """Obtain information about the available services on the device."""
         snapshot = False
         with suppress(*GET_CAPABILITIES_EXCEPTIONS):
-            media_service = self.device.create_media_service()
+            media_service = await self.device.create_media_service()
             media_capabilities = await media_service.GetServiceCapabilities()
             snapshot = media_capabilities and media_capabilities.SnapshotUri
 
@@ -342,7 +342,7 @@ class ONVIFDevice:
 
         imaging = False
         with suppress(*GET_CAPABILITIES_EXCEPTIONS):
-            self.device.create_imaging_service()
+            await self.device.create_imaging_service()
             imaging = True
 
         return Capabilities(snapshot=snapshot, ptz=ptz, imaging=imaging)
@@ -361,7 +361,7 @@ class ONVIFDevice:
 
     async def async_get_profiles(self) -> list[Profile]:
         """Obtain media profiles for this device."""
-        media_service = self.device.create_media_service()
+        media_service = await self.device.create_media_service()
         LOGGER.debug("%s: xaddr for media_service: %s", self.name, media_service.xaddr)
         try:
             result = await media_service.GetProfiles()
@@ -408,7 +408,7 @@ class ONVIFDevice:
                 )
 
                 try:
-                    ptz_service = self.device.create_ptz_service()
+                    ptz_service = await self.device.create_ptz_service()
                     presets = await ptz_service.GetPresets(profile.token)
                     profile.ptz.presets = [preset.token for preset in presets if preset]
                 except GET_CAPABILITIES_EXCEPTIONS:
@@ -427,7 +427,7 @@ class ONVIFDevice:
 
     async def async_get_stream_uri(self, profile: Profile) -> str:
         """Get the stream URI for a specified profile."""
-        media_service = self.device.create_media_service()
+        media_service = await self.device.create_media_service()
         req = media_service.create_type("GetStreamUri")
         req.ProfileToken = profile.token
         req.StreamSetup = {
@@ -454,7 +454,7 @@ class ONVIFDevice:
             LOGGER.warning("PTZ actions are not supported on device '%s'", self.name)
             return
 
-        ptz_service = self.device.create_ptz_service()
+        ptz_service = await self.device.create_ptz_service()
 
         pan_val = distance * PAN_FACTOR.get(pan, 0)
         tilt_val = distance * TILT_FACTOR.get(tilt, 0)
@@ -576,7 +576,7 @@ class ONVIFDevice:
             LOGGER.warning("PTZ actions are not supported on device '%s'", self.name)
             return
 
-        ptz_service = self.device.create_ptz_service()
+        ptz_service = await self.device.create_ptz_service()
 
         LOGGER.debug(
             "Running Aux Command | Cmd = %s",
@@ -607,7 +607,7 @@ class ONVIFDevice:
             )
             return
 
-        imaging_service = self.device.create_imaging_service()
+        imaging_service = await self.device.create_imaging_service()
 
         LOGGER.debug("Setting Imaging Setting | Settings = %s", settings)
         try:

--- a/homeassistant/components/onvif/event.py
+++ b/homeassistant/components/onvif/event.py
@@ -392,12 +392,12 @@ class PullPointManager:
             return False
 
         # Create subscription manager
-        self._pullpoint_subscription = self._device.create_subscription_service(
+        self._pullpoint_subscription = await self._device.create_subscription_service(
             "PullPointSubscription"
         )
 
         # Create the service that will be used to pull messages from the device.
-        self._pullpoint_service = self._device.create_pullpoint_service()
+        self._pullpoint_service = await self._device.create_pullpoint_service()
 
         # Initialize events
         with suppress(*SET_SYNCHRONIZATION_POINT_ERRORS):

--- a/homeassistant/components/onvif/manifest.json
+++ b/homeassistant/components/onvif/manifest.json
@@ -8,5 +8,5 @@
   "documentation": "https://www.home-assistant.io/integrations/onvif",
   "iot_class": "local_push",
   "loggers": ["onvif", "wsdiscovery", "zeep"],
-  "requirements": ["onvif-zeep-async==1.3.1", "WSDiscovery==2.0.0"]
+  "requirements": ["onvif-zeep-async==2.0.0", "WSDiscovery==2.0.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1258,7 +1258,7 @@ ondilo==0.2.0
 onkyo-eiscp==1.2.7
 
 # homeassistant.components.onvif
-onvif-zeep-async==1.3.1
+onvif-zeep-async==2.0.0
 
 # homeassistant.components.opengarage
 open-garage==0.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -945,7 +945,7 @@ omnilogic==0.4.5
 ondilo==0.2.0
 
 # homeassistant.components.onvif
-onvif-zeep-async==1.3.1
+onvif-zeep-async==2.0.0
 
 # homeassistant.components.opengarage
 open-garage==0.2.0

--- a/tests/components/onvif/__init__.py
+++ b/tests/components/onvif/__init__.py
@@ -98,8 +98,8 @@ def setup_mock_onvif_camera(
         )
     else:
         mock_onvif_camera.update_xaddrs = AsyncMock(return_value=True)
-    mock_onvif_camera.create_devicemgmt_service = MagicMock(return_value=devicemgmt)
-    mock_onvif_camera.create_media_service = MagicMock(return_value=media_service)
+    mock_onvif_camera.create_devicemgmt_service = AsyncMock(return_value=devicemgmt)
+    mock_onvif_camera.create_media_service = AsyncMock(return_value=media_service)
     mock_onvif_camera.close = AsyncMock(return_value=None)
 
     def mock_constructor(

--- a/tests/components/onvif/test_button.py
+++ b/tests/components/onvif/test_button.py
@@ -27,7 +27,7 @@ async def test_reboot_button(hass: HomeAssistant) -> None:
 async def test_reboot_button_press(hass: HomeAssistant) -> None:
     """Test Reboot button press."""
     _, camera, _ = await setup_onvif_integration(hass)
-    devicemgmt = camera.create_devicemgmt_service()
+    devicemgmt = await camera.create_devicemgmt_service()
     devicemgmt.SystemReboot = AsyncMock(return_value=True)
 
     await hass.services.async_call(


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update to onvif-zeep-async to 2.0.0 which makes the service creation calls coroutines so they can load the wsdl files from disk in the executor.

cc @JurajNyiri as this is going to cause some breakage for you

changelog: https://github.com/hunterjm/python-onvif-zeep-async/compare/v1.3.1...v2.0.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
