### PR TITLE
Fix lingering timer in esphome

### DIFF
--- a/homeassistant/components/esphome/dashboard.py
+++ b/homeassistant/components/esphome/dashboard.py
@@ -10,7 +10,8 @@ from awesomeversion import AwesomeVersion
 from esphome_dashboard_api import ConfiguredDevice, ESPHomeDashboardAPI
 
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
@@ -47,6 +48,11 @@ async def async_set_dashboard_info(
         return
 
     hass.data[KEY_DASHBOARD] = dashboard
+
+    async def on_hass_stop(_: Event) -> None:
+        await dashboard.async_shutdown()
+
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, on_hass_stop)
 
     reloads = [
         hass.config_entries.async_reload(entry.entry_id)

--- a/homeassistant/components/esphome/dashboard.py
+++ b/homeassistant/components/esphome/dashboard.py
@@ -32,11 +32,13 @@ async def async_set_dashboard_info(
     """Set the dashboard info."""
     url = f"http://{host}:{port}"
 
-    # Do nothing if we already have this data.
     if cur_dashboard := async_get_dashboard(hass):
         if cur_dashboard.addon_slug == addon_slug and cur_dashboard.url == url:
+            # Do nothing if we already have this data.
             return
+        # Clear and make way for new dashboard
         await cur_dashboard.async_shutdown()
+        del hass.data[KEY_DASHBOARD]
 
     dashboard = ESPHomeDashboard(hass, addon_slug, url, async_get_clientsession(hass))
     try:

--- a/homeassistant/components/esphome/dashboard.py
+++ b/homeassistant/components/esphome/dashboard.py
@@ -33,12 +33,10 @@ async def async_set_dashboard_info(
     url = f"http://{host}:{port}"
 
     # Do nothing if we already have this data.
-    if (
-        (cur_dashboard := hass.data.get(KEY_DASHBOARD))
-        and cur_dashboard.addon_slug == addon_slug
-        and cur_dashboard.url == url
-    ):
-        return
+    if cur_dashboard := async_get_dashboard(hass):
+        if cur_dashboard.addon_slug == addon_slug and cur_dashboard.url == url:
+            return
+        await cur_dashboard.async_shutdown()
 
     dashboard = ESPHomeDashboard(hass, addon_slug, url, async_get_clientsession(hass))
     try:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Linked to https://github.com/home-assistant/core/pull/91360
https://github.com/home-assistant/core/actions/runs/4881750941/jobs/8711209278?pr=91360

```console
ERROR tests/components/esphome/test_dashboard.py::test_new_info_reload_config_entries - Failed: Lingering timer after test <TimerHandle when=1254.230451539 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:152>
ERROR tests/components/esphome/test_dashboard.py::test_new_dashboard_fix_reauth - Failed: Lingering timer after test <TimerHandle when=1254.714376327 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:152>
ERROR tests/components/esphome/test_diagnostics.py::test_diagnostics - Failed: Lingering timer after test <TimerHandle when=1256.98213432 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:152>
ERROR tests/components/esphome/test_config_flow.py::test_reauth_fixed_via_dashboard - Failed: Lingering timer after test <TimerHandle when=1261.874176543 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:152>
ERROR tests/components/esphome/test_config_flow.py::test_reauth_fixed_via_dashboard_add_encryption_remove_password - Failed: Lingering timer after test <TimerHandle when=1262.34223002 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:152>
ERROR tests/components/esphome/test_config_flow.py::test_reauth_fixed_via_remove_password - Failed: Lingering timer after test <TimerHandle when=1262.733089128 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:152>
ERROR tests/components/esphome/test_config_flow.py::test_reauth_fixed_via_dashboard_at_confirm - Failed: Lingering timer after test <TimerHandle when=1263.250772384 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:152>
ERROR tests/components/esphome/test_update.py::test_update_entity[devices_payload0-on-expected_attributes0] - Failed: Lingering timer after test <TimerHandle when=1264.91458648 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:152>
ERROR tests/components/esphome/test_config_flow.py::test_discovery_hassio - Failed: Lingering timer after test <TimerHandle when=1265.230447055 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:152>
ERROR tests/components/esphome/test_update.py::test_update_entity[devices_payload1-off-expected_attributes1] - Failed: Lingering timer after job <Job DataUpdateCoordinator ESPHomeDashboard ESPHome Dashboard HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.esphome.dashboard.ESPHomeDashboard object at 0x7fdd476f1150>>>
ERROR tests/components/esphome/test_config_flow.py::test_zeroconf_encryption_key_via_dashboard - Failed: Lingering timer after test <TimerHandle when=1265.720199273 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:152>
ERROR tests/components/esphome/test_update.py::test_update_entity[devices_payload2-unavailable-expected_attributes2] - Failed: Lingering timer after job <Job DataUpdateCoordinator ESPHomeDashboard ESPHome Dashboard HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.esphome.dashboard.ESPHomeDashboard object at 0x7fdd3baf0d60>>>
ERROR tests/components/esphome/test_config_flow.py::test_zeroconf_no_encryption_key_via_dashboard - Failed: Lingering timer after test <TimerHandle when=1266.177248563 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:152>
ERROR tests/components/esphome/test_update.py::test_update_static_info - Failed: Lingering timer after job <Job DataUpdateCoordinator ESPHomeDashboard ESPHome Dashboard HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.esphome.dashboard.ESPHomeDashboard object at 0x7fdd47900340>>>
ERROR tests/components/esphome/test_update.py::test_update_device_state_for_availability - Failed: Lingering timer after job <Job DataUpdateCoordinator ESPHomeDashboard ESPHome Dashboard HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.esphome.dashboard.ESPHomeDashboard object at 0x7fdd44d001f0>>>
ERROR tests/components/esphome/test_update.py::test_update_entity_dashboard_not_available_startup - Failed: Lingering timer after job <Job DataUpdateCoordinator ESPHomeDashboard ESPHome Dashboard HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.esphome.dashboard.ESPHomeDashboard object at 0x7fdd44e3c130>>
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
