### PR TITLE
Fix lingering timer in flux

### DIFF
--- a/homeassistant/components/flux/switch.py
+++ b/homeassistant/components/flux/switch.py
@@ -226,6 +226,12 @@ class FluxSwitch(SwitchEntity, RestoreEntity):
         if last_state and last_state.state == STATE_ON:
             await self.async_turn_on()
 
+    async def async_will_remove_from_hass(self) -> None:
+        """Run when entity will be removed from hass."""
+        if self.unsub_tracker:
+            self.unsub_tracker()
+        return await super().async_will_remove_from_hass()
+
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on flux."""
         if self.is_on:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Linked to #91360
https://github.com/home-assistant/core/actions/runs/4885480491/jobs/8719797846?pr=91360

```console
ERROR tests/components/flux/test_switch.py::test_restore_state_last_on - Failed: Lingering timer after job <Job track time interval 0:00:30 <bound method FluxSwitch.async_flux_update of <entity switch.flux=off>> HassJobType.Callback <function async_track_time_interval.<locals>.interval_listener at 0x7f2594301fc0>>
ERROR tests/components/flux/test_switch.py::test_flux_before_sunrise - Failed: Lingering timer after job <Job track time interval 0:00:30 <bound method FluxSwitch.async_flux_update of <entity switch.flux=off>> HassJobType.Callback <function async_track_time_interval.<locals>.interval_listener at 0x7f25928f7d00>>
ERROR tests/components/flux/test_switch.py::test_flux_before_sunrise_known_location - Failed: Lingering timer after job <Job track time interval 0:00:30 <bound method FluxSwitch.async_flux_update of <entity switch.flux=off>> HassJobType.Callback <function async_track_time_interval.<locals>.interval_listener at 0x7f25923831c0>>
ERROR tests/components/flux/test_switch.py::test_flux_after_sunrise_before_sunset - Failed: Lingering timer after job <Job track time interval 0:00:30 <bound method FluxSwitch.async_flux_update of <entity switch.flux=off>> HassJobType.Callback <function async_track_time_interval.<locals>.interval_listener at 0x7f25923be8c0>>
ERROR tests/components/flux/test_switch.py::test_flux_after_sunset_before_stop - Failed: Lingering timer after job <Job track time interval 0:00:30 <bound method FluxSwitch.async_flux_update of <entity switch.flux=off>> HassJobType.Callback <function async_track_time_interval.<locals>.interval_listener at 0x7f2592405ea0>>
ERROR tests/components/flux/test_switch.py::test_flux_after_stop_before_sunrise - Failed: Lingering timer after job <Job track time interval 0:00:30 <bound method FluxSwitch.async_flux_update of <entity switch.flux=off>> HassJobType.Callback <function async_track_time_interval.<locals>.interval_listener at 0x7f259243d510>>
ERROR tests/components/flux/test_switch.py::test_flux_with_custom_start_stop_times - Failed: Lingering timer after job <Job track time interval 0:00:30 <bound method FluxSwitch.async_flux_update of <entity switch.flux=off>> HassJobType.Callback <function async_track_time_interval.<locals>.interval_listener at 0x7f2592458a60>>
ERROR tests/components/flux/test_switch.py::test_flux_before_sunrise_stop_next_day - Failed: Lingering timer after job <Job track time interval 0:00:30 <bound method FluxSwitch.async_flux_update of <entity switch.flux=off>> HassJobType.Callback <function async_track_time_interval.<locals>.interval_listener at 0x7f259241c040>>
ERROR tests/components/flux/test_switch.py::test_flux_after_sunrise_before_sunset_stop_next_day - Failed: Lingering timer after job <Job track time interval 0:00:30 <bound method FluxSwitch.async_flux_update of <entity switch.flux=off>> HassJobType.Callback <function async_track_time_interval.<locals>.interval_listener at 0x7f25923c7760>>
ERROR tests/components/flux/test_switch.py::test_flux_after_sunset_before_midnight_stop_next_day[0] - Failed: Lingering timer after job <Job track time interval 0:00:30 <bound method FluxSwitch.async_flux_update of <entity switch.flux=off>> HassJobType.Callback <function async_track_time_interval.<locals>.interval_listener at 0x7f25940c6e60>>
ERROR tests/components/flux/test_switch.py::test_flux_after_sunset_before_midnight_stop_next_day[1] - Failed: Lingering timer after job <Job track time interval 0:00:30 <bound method FluxSwitch.async_flux_update of <entity switch.flux=off>> HassJobType.Callback <function async_track_time_interval.<locals>.interval_listener at 0x7f2594116440>>
ERROR tests/components/flux/test_switch.py::test_flux_after_sunset_after_midnight_stop_next_day - Failed: Lingering timer after job <Job track time interval 0:00:30 <bound method FluxSwitch.async_flux_update of <entity switch.flux=off>> HassJobType.Callback <function async_track_time_interval.<locals>.interval_listener at 0x7f259415d900>>
ERROR tests/components/flux/test_switch.py::test_flux_after_stop_before_sunrise_stop_next_day - Failed: Lingering timer after job <Job track time interval 0:00:30 <bound method FluxSwitch.async_flux_update of <entity switch.flux=off>> HassJobType.Callback <function async_track_time_interval.<locals>.interval_listener at 0x7f25940c8e50>>
ERROR tests/components/flux/test_switch.py::test_flux_with_custom_colortemps - Failed: Lingering timer after job <Job track time interval 0:00:30 <bound method FluxSwitch.async_flux_update of <entity switch.flux=off>> HassJobType.Callback <function async_track_time_interval.<locals>.interval_listener at 0x7f2594024550>>
ERROR tests/components/flux/test_switch.py::test_flux_with_custom_brightness - Failed: Lingering timer after job <Job track time interval 0:00:30 <bound method FluxSwitch.async_flux_update of <entity switch.flux=off>> HassJobType.Callback <function async_track_time_interval.<locals>.interval_listener at 0x7f2593fb7ac0>>
ERROR tests/components/flux/test_switch.py::test_flux_with_multiple_lights - Failed: Lingering timer after job <Job track time interval 0:00:30 <bound method FluxSwitch.async_flux_update of <entity switch.flux=off>> HassJobType.Callback <function async_track_time_interval.<locals>.interval_listener at 0x7f2593ff6f80>>
ERROR tests/components/flux/test_switch.py::test_flux_with_mired - Failed: Lingering timer after job <Job track time interval 0:00:30 <bound method FluxSwitch.async_flux_update of <entity switch.flux=off>> HassJobType.Callback <function async_track_time_interval.<locals>.interval_listener at 0x7f2593eba680>>
ERROR tests/components/flux/test_switch.py::test_flux_with_rgb - Failed: Lingering timer after job <Job track time interval 0:00:30 <bound method FluxSwitch.async_flux_update of <entity switch.flux=off>> HassJobType.Callback <function async_track_time_interval.<locals>.interval_listener at 0x7f2593f95d80>>
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
