### PR TITLE
Fix lingering timer in generic_hygrostat

### DIFF
--- a/homeassistant/components/generic_hygrostat/humidifier.py
+++ b/homeassistant/components/generic_hygrostat/humidifier.py
@@ -172,7 +172,11 @@ class GenericHygrostat(HumidifierEntity, RestoreEntity):
         )
 
         if self._keep_alive:
-            async_track_time_interval(self.hass, self._async_operate, self._keep_alive)
+            self.async_on_remove(
+                async_track_time_interval(
+                    self.hass, self._async_operate, self._keep_alive
+                )
+            )
 
         async def _async_startup(event):
             """Init on startup."""
@@ -215,6 +219,12 @@ class GenericHygrostat(HumidifierEntity, RestoreEntity):
             self._state = False
 
         await _async_startup(None)  # init the sensor
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Run when entity will be removed from hass."""
+        if self._remove_stale_tracking:
+            self._remove_stale_tracking()
+        return await super().async_will_remove_from_hass()
 
     @property
     def available(self):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Linked to #91360
https://github.com/home-assistant/core/actions/runs/4885480491/jobs/8719797846?pr=91360

```console
ERROR tests/components/generic_hygrostat/test_humidifier.py::test_humidity_change_dry_trigger_on_long_enough_3 - Failed: Lingering timer after job <Job track time interval 0:10:00 <bound method GenericHygrostat._async_operate of <entity humidifier.test=unavailable>> HassJobType.Callback <function async_track_time_interval.<locals>.interval_listener at 0x7faaab85d2d0>>
ERROR tests/components/generic_hygrostat/test_humidifier.py::test_humidity_change_dry_trigger_off_long_enough_3 - Failed: Lingering timer after job <Job track time interval 0:10:00 <bound method GenericHygrostat._async_operate of <entity humidifier.test=unavailable>> HassJobType.Callback <function async_track_time_interval.<locals>.interval_listener at 0x7faaab87c4c0>>
ERROR tests/components/generic_hygrostat/test_humidifier.py::test_humidity_change_humidifier_trigger_on_long_enough_2 - Failed: Lingering timer after job <Job track time interval 0:10:00 <bound method GenericHygrostat._async_operate of <entity humidifier.test=unavailable>> HassJobType.Callback <function async_track_time_interval.<locals>.interval_listener at 0x7faaab8b03a0>>
ERROR tests/components/generic_hygrostat/test_humidifier.py::test_humidity_change_humidifier_trigger_off_long_enough_2 - Failed: Lingering timer after job <Job track time interval 0:10:00 <bound method GenericHygrostat._async_operate of <entity humidifier.test=unavailable>> HassJobType.Callback <function async_track_time_interval.<locals>.interval_listener at 0x7faaab881750>>
ERROR tests/components/generic_hygrostat/test_humidifier.py::test_sensor_stale_duration - Failed: Lingering timer after job <Job track time interval 0:10:00 <bound method GenericHygrostat._async_sensor_not_responding of <entity humidifier.test=unavailable>> HassJobType.Callback <function async_track_time_interval.<locals>.interval_listener at 0x7faaab645ea0>>
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
