### PR TITLE
Fix lingering timer in history_stats

### DIFF
--- a/homeassistant/components/history_stats/sensor.py
+++ b/homeassistant/components/history_stats/sensor.py
@@ -17,10 +17,11 @@ from homeassistant.const import (
     CONF_NAME,
     CONF_STATE,
     CONF_TYPE,
+    EVENT_HOMEASSISTANT_STOP,
     PERCENTAGE,
     UnitOfTime,
 )
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -105,6 +106,13 @@ async def async_setup_platform(
     await coordinator.async_refresh()
     if not coordinator.last_update_success:
         raise PlatformNotReady from coordinator.last_exception
+
+    async def _on_hass_stop(_: Event) -> None:
+        """Shutdown coordinator on HomeAssistant stop."""
+        await coordinator.async_shutdown()
+
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _on_hass_stop)
+
     async_add_entities([HistoryStatsSensor(coordinator, sensor_type, name)])
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Linked to #91360
https://github.com/home-assistant/core/actions/runs/4885480491/jobs/8719797846?pr=91360

```console
ERROR tests/components/history_stats/test_sensor.py::test_setup - Failed: Lingering timer after job <Job DataUpdateCoordinator HistoryStatsUpdateCoordinator Test HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.history_stats.coordinator.HistoryStatsUpdateCoordinator object at 0x7f2583774b20>>>
ERROR tests/components/history_stats/test_sensor.py::test_setup_multiple_states - Failed: Lingering timer after job <Job DataUpdateCoordinator HistoryStatsUpdateCoordinator Test HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.history_stats.coordinator.HistoryStatsUpdateCoordinator object at 0x7f2583877c40>>>
ERROR tests/components/history_stats/test_sensor.py::test_reload - Failed: Lingering timer after job <Job DataUpdateCoordinator HistoryStatsUpdateCoordinator second_test HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.history_stats.coordinator.HistoryStatsUpdateCoordinator object at 0x7f2583aef580>>>
ERROR tests/components/history_stats/test_sensor.py::test_measure_multiple - Failed: Lingering timer after test <TimerHandle when=999.785599538 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:152>
ERROR tests/components/history_stats/test_sensor.py::test_measure - Failed: Lingering timer after test <TimerHandle when=1000.151560023 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:152>
ERROR tests/components/history_stats/test_sensor.py::test_async_on_entire_period - Failed: Lingering timer after test <TimerHandle when=1000.508457291 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:152>
ERROR tests/components/history_stats/test_sensor.py::test_async_off_entire_period - Failed: Lingering timer after test <TimerHandle when=1000.87702231 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:152>
ERROR tests/components/history_stats/test_sensor.py::test_async_start_from_history_and_switch_to_watching_state_changes_single - Failed: Lingering timer after job <Job DataUpdateCoordinator HistoryStatsUpdateCoordinator sensor1 HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.history_stats.coordinator.HistoryStatsUpdateCoordinator object at 0x7f25833c7460>>>
ERROR tests/components/history_stats/test_sensor.py::test_async_start_from_history_and_switch_to_watching_state_changes_single_expanding_window - Failed: Lingering timer after job <Job DataUpdateCoordinator HistoryStatsUpdateCoordinator sensor1 HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.history_stats.coordinator.HistoryStatsUpdateCoordinator object at 0x7f258221d660>>>
ERROR tests/components/history_stats/test_sensor.py::test_async_start_from_history_and_switch_to_watching_state_changes_multiple - Failed: Lingering timer after job <Job DataUpdateCoordinator HistoryStatsUpdateCoordinator sensor4 HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.history_stats.coordinator.HistoryStatsUpdateCoordinator object at 0x7f2583622740>>>
ERROR tests/components/history_stats/test_sensor.py::test_does_not_work_into_the_future - Failed: Lingering timer after job <Job DataUpdateCoordinator HistoryStatsUpdateCoordinator sensor1 HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.history_stats.coordinator.HistoryStatsUpdateCoordinator object at 0x7f2582626ce0>>>
ERROR tests/components/history_stats/test_sensor.py::test_reload_before_start_event - Failed: Lingering timer after job <Job DataUpdateCoordinator HistoryStatsUpdateCoordinator second_test HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.history_stats.coordinator.HistoryStatsUpdateCoordinator object at 0x7f2583620a00>>>
ERROR tests/components/history_stats/test_sensor.py::test_measure_sliding_window - Failed: Lingering timer after job <Job DataUpdateCoordinator HistoryStatsUpdateCoordinator sensor4 HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.history_stats.coordinator.HistoryStatsUpdateCoordinator object at 0x7f25829ca500>>>
ERROR tests/components/history_stats/test_sensor.py::test_measure_from_end_going_backwards - Failed: Lingering timer after job <Job DataUpdateCoordinator HistoryStatsUpdateCoordinator sensor3 HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.history_stats.coordinator.HistoryStatsUpdateCoordinator object at 0x7f25919fcd90>>>
ERROR tests/components/history_stats/test_sensor.py::test_measure_cet - Failed: Lingering timer after test <TimerHandle when=1011.811953019 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:152>
ERROR tests/components/history_stats/test_sensor.py::test_end_time_with_microseconds_zeroed[Europe/Berlin] - Failed: Lingering timer after job <Job DataUpdateCoordinator HistoryStatsUpdateCoordinator heatpump_compressor_today HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.history_stats.coordinator.HistoryStatsUpdateCoordinator object at 0x7f2583139c90>>>
ERROR tests/components/history_stats/test_sensor.py::test_end_time_with_microseconds_zeroed[America/Chicago] - Failed: Lingering timer after job <Job DataUpdateCoordinator HistoryStatsUpdateCoordinator heatpump_compressor_today HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.history_stats.coordinator.HistoryStatsUpdateCoordinator object at 0x7f2582a03190>>>
ERROR tests/components/history_stats/test_sensor.py::test_end_time_with_microseconds_zeroed[US/Hawaii] - Failed: Lingering timer after job <Job DataUpdateCoordinator HistoryStatsUpdateCoordinator heatpump_compressor_today HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.history_stats.coordinator.HistoryStatsUpdateCoordinator object at 0x7f2591bf2d40>>>
ERROR tests/components/history_stats/test_sensor.py::test_device_classes - Failed: Lingering timer after job <Job DataUpdateCoordinator HistoryStatsUpdateCoordinator time HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.history_stats.coordinator.HistoryStatsUpdateCoordinator object at 0x7f2582e16350>>>
ERROR tests/components/history_stats/test_sensor.py::test_history_stats_handles_floored_timestamps - Failed: Lingering timer after test <TimerHandle when=1683158410.0 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:152>
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
