### PR TITLE
Add allow_legacy_insecure_renegotiation option to SSL util and httpx helper

### DIFF
--- a/homeassistant/helpers/httpx_client.py
+++ b/homeassistant/helpers/httpx_client.py
@@ -12,6 +12,7 @@ from homeassistant.const import APPLICATION_NAME, EVENT_HOMEASSISTANT_CLOSE, __v
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.loader import bind_hass
 from homeassistant.util.ssl import (
+    CONF_SSL_ALLOW_UNSAFE_RENEGOTIATION,
     SSLCipherList,
     client_context,
     create_no_verify_ssl_context,
@@ -71,12 +72,13 @@ def create_async_httpx_client(
 
     This method must be run in the event loop.
     """
+    ssl_args = {
+        CONF_SSL_ALLOW_UNSAFE_RENEGOTIATION: allow_legacy_insecure_renegotiation
+    }
     ssl_context = (
-        client_context(ssl_cipher_list, allow_legacy_insecure_renegotiation)
+        client_context(ssl_cipher_list, **ssl_args)
         if verify_ssl
-        else create_no_verify_ssl_context(
-            ssl_cipher_list, allow_legacy_insecure_renegotiation
-        )
+        else create_no_verify_ssl_context(ssl_cipher_list, **ssl_args)
     )
     client = HassHttpXAsyncClient(
         verify=ssl_context,

--- a/homeassistant/helpers/httpx_client.py
+++ b/homeassistant/helpers/httpx_client.py
@@ -61,6 +61,7 @@ def create_async_httpx_client(
     verify_ssl: bool = True,
     auto_cleanup: bool = True,
     ssl_cipher_list: SSLCipherList = SSLCipherList.PYTHON_DEFAULT,
+    allow_legacy_insecure_renegotiation: bool = False,
     **kwargs: Any,
 ) -> httpx.AsyncClient:
     """Create a new httpx.AsyncClient with kwargs, i.e. for cookies.
@@ -71,9 +72,11 @@ def create_async_httpx_client(
     This method must be run in the event loop.
     """
     ssl_context = (
-        client_context(ssl_cipher_list)
+        client_context(ssl_cipher_list, allow_legacy_insecure_renegotiation)
         if verify_ssl
-        else create_no_verify_ssl_context(ssl_cipher_list)
+        else create_no_verify_ssl_context(
+            ssl_cipher_list, allow_legacy_insecure_renegotiation
+        )
     )
     client = HassHttpXAsyncClient(
         verify=ssl_context,

--- a/homeassistant/util/ssl.py
+++ b/homeassistant/util/ssl.py
@@ -3,6 +3,7 @@ import contextlib
 from functools import cache
 from os import environ
 import ssl
+from typing import Any
 
 import certifi
 
@@ -16,6 +17,8 @@ class SSLCipherList(StrEnum):
     INTERMEDIATE = "intermediate"
     MODERN = "modern"
 
+
+CONF_SSL_ALLOW_UNSAFE_RENEGOTIATION = "ssl_allow_unsafe_renegotiation"
 
 SSL_CIPHER_LISTS = {
     SSLCipherList.INTERMEDIATE: (
@@ -64,7 +67,7 @@ SSL_CIPHER_LISTS = {
 @cache
 def create_no_verify_ssl_context(
     ssl_cipher_list: SSLCipherList = SSLCipherList.PYTHON_DEFAULT,
-    allow_legacy_insecure_renegotiation: bool = False,
+    **kwargs: dict[str, Any],
 ) -> ssl.SSLContext:
     """Return an SSL context that does not verify the server certificate.
 
@@ -75,7 +78,7 @@ def create_no_verify_ssl_context(
     """
     sslcontext = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
 
-    if allow_legacy_insecure_renegotiation:
+    if kwargs.get(CONF_SSL_ALLOW_UNSAFE_RENEGOTIATION):
         # ssl.OP_LEGACY_SERVER_CONNECT is only available in Python 3.12a4+
         sslcontext.options |= getattr(ssl, "OP_LEGACY_SERVER_CONNECT", 0x4)
 
@@ -94,7 +97,7 @@ def create_no_verify_ssl_context(
 @cache
 def client_context(
     ssl_cipher_list: SSLCipherList = SSLCipherList.PYTHON_DEFAULT,
-    allow_legacy_insecure_renegotiation: bool = False,
+    **kwargs: dict[str, Any],
 ) -> ssl.SSLContext:
     """Return an SSL context for making requests."""
 
@@ -107,7 +110,7 @@ def client_context(
         purpose=ssl.Purpose.SERVER_AUTH, cafile=cafile
     )
 
-    if allow_legacy_insecure_renegotiation:
+    if kwargs.get(CONF_SSL_ALLOW_UNSAFE_RENEGOTIATION):
         # ssl.OP_LEGACY_SERVER_CONNECT is only available in Python 3.12a4+
         sslcontext.options |= getattr(ssl, "OP_LEGACY_SERVER_CONNECT", 0x4)
 

--- a/tests/util/test_ssl.py
+++ b/tests/util/test_ssl.py
@@ -1,5 +1,6 @@
 """Test Home Assistant ssl utility functions."""
 
+import ssl
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -15,7 +16,7 @@ from homeassistant.util.ssl import (
 @pytest.fixture
 def mock_sslcontext():
     """Mock the ssl lib."""
-    ssl_mock = MagicMock(set_ciphers=Mock(return_value=True))
+    ssl_mock = MagicMock(set_ciphers=Mock(return_value=True), options=0)
     return ssl_mock
 
 
@@ -35,6 +36,10 @@ def test_client_context(mock_sslcontext) -> None:
             SSL_CIPHER_LISTS[SSLCipherList.INTERMEDIATE]
         )
 
+        client_context(allow_legacy_insecure_renegotiation=True)
+        # ssl.OP_LEGACY_SERVER_CONNECT is only available in Python 3.12a4+
+        assert mock_sslcontext.options & getattr(ssl, "OP_LEGACY_SERVER_CONNECT", 0x4)
+
 
 def test_no_verify_ssl_context(mock_sslcontext) -> None:
     """Test no verify ssl context."""
@@ -51,3 +56,7 @@ def test_no_verify_ssl_context(mock_sslcontext) -> None:
         mock_sslcontext.set_ciphers.assert_called_with(
             SSL_CIPHER_LISTS[SSLCipherList.INTERMEDIATE]
         )
+
+        create_no_verify_ssl_context(allow_legacy_insecure_renegotiation=True)
+        # ssl.OP_LEGACY_SERVER_CONNECT is only available in Python 3.12a4+
+        assert mock_sslcontext.options & getattr(ssl, "OP_LEGACY_SERVER_CONNECT", 0x4)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
With bumping our container to alpine 3.17, openssl 3.0 gets in.
Unsafe legacy renegotiation has been disabled with OpenSSL 3.0.0 (_see https://github.com/openssl/openssl/commit/72d2670bd21becfa6a64bb03fa55ad82d6d0c0f3_)
With this an option is added to still allow unsafe legacy renegotiation.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #92500
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
