### PR TITLE
Fix radio_id can be unavailable

### DIFF
--- a/homeassistant/components/frontier_silicon/config_flow.py
+++ b/homeassistant/components/frontier_silicon/config_flow.py
@@ -6,7 +6,12 @@ import logging
 from typing import Any
 from urllib.parse import urlparse
 
-from afsapi import AFSAPI, ConnectionError as FSConnectionError, InvalidPinException
+from afsapi import (
+    AFSAPI,
+    ConnectionError as FSConnectionError,
+    InvalidPinException,
+    NotImplementedException,
+)
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -68,10 +73,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             _LOGGER.exception(exception)
             return self.async_abort(reason="unknown")
 
+        afsapi = AFSAPI(webfsapi_url, import_info[CONF_PIN])
         try:
-            afsapi = AFSAPI(webfsapi_url, import_info[CONF_PIN])
-
             unique_id = await afsapi.get_radio_id()
+        except NotImplementedException:
+            unique_id = None  # Not all radios have this call implemented
         except FSConnectionError:
             return self.async_abort(reason="cannot_connect")
         except InvalidPinException:
@@ -141,13 +147,17 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             _LOGGER.debug(exception)
             return self.async_abort(reason="unknown")
 
+        # try to login with default pin
+        afsapi = AFSAPI(self._webfsapi_url, DEFAULT_PIN)
         try:
-            # try to login with default pin
-            afsapi = AFSAPI(self._webfsapi_url, DEFAULT_PIN)
-
-            unique_id = await afsapi.get_radio_id()
+            await afsapi.get_friendly_name()
         except InvalidPinException:
             return self.async_abort(reason="invalid_auth")
+
+        try:
+            unique_id = await afsapi.get_radio_id()
+        except NotImplementedException:
+            unique_id = None
 
         await self.async_set_unique_id(unique_id)
         self._abort_if_unique_id_configured(
@@ -175,7 +185,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         self.context["title_placeholders"] = {"name": self._name}
 
-        unique_id = await afsapi.get_radio_id()
+        try:
+            unique_id = await afsapi.get_radio_id()
+        except NotImplementedException:
+            unique_id = None
         await self.async_set_unique_id(unique_id)
         self._abort_if_unique_id_configured()
 
@@ -240,7 +253,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 await self.hass.config_entries.async_reload(self._reauth_entry.entry_id)
                 return self.async_abort(reason="reauth_successful")
 
-            unique_id = await afsapi.get_radio_id()
+            try:
+                unique_id = await afsapi.get_radio_id()
+            except NotImplementedException:
+                unique_id = None
             await self.async_set_unique_id(unique_id, raise_on_progress=False)
             self._abort_if_unique_id_configured()
             return await self._async_create_entry(user_input[CONF_PIN])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Not all frontier_silicon radio's implement the `get_radio_id()` API call. We implement support for this method throwing a `NotImplementedException`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #92645
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
