### PR TITLE
Improve IoTaWatt refresh rate, Change hard-coded times to single variable, fix missing sensor data

### DIFF
--- a/homeassistant/components/iotawatt/coordinator.py
+++ b/homeassistant/components/iotawatt/coordinator.py
@@ -18,7 +18,7 @@ from .const import CONNECTION_ERRORS
 _LOGGER = logging.getLogger(__name__)
 
 # Desired refresh rate (min 5 sec)
-REFRESH_RATE=5
+REFRESH_RATE = 5
 
 # Matches iotwatt data log interval
 REQUEST_REFRESH_DEFAULT_COOLDOWN = 5

--- a/homeassistant/components/iotawatt/coordinator.py
+++ b/homeassistant/components/iotawatt/coordinator.py
@@ -17,6 +17,9 @@ from .const import CONNECTION_ERRORS
 
 _LOGGER = logging.getLogger(__name__)
 
+# Desired refresh rate (min 5 sec)
+REFRESH_RATE=5
+
 # Matches iotwatt data log interval
 REQUEST_REFRESH_DEFAULT_COOLDOWN = 5
 
@@ -33,7 +36,7 @@ class IotawattUpdater(DataUpdateCoordinator):
             hass=hass,
             logger=_LOGGER,
             name=entry.title,
-            update_interval=timedelta(seconds=30),
+            update_interval=timedelta(seconds=REFRESH_RATE),
             request_refresh_debouncer=Debouncer(
                 hass,
                 _LOGGER,
@@ -73,6 +76,6 @@ class IotawattUpdater(DataUpdateCoordinator):
 
             self.api = api
 
-        await self.api.update(lastUpdate=self._last_run)
+        await self.api.update(lastUpdate=self._last_run, timespan=REFRESH_RATE)
         self._last_run = None
         return self.api.getSensors()

--- a/homeassistant/components/iotawatt/manifest.json
+++ b/homeassistant/components/iotawatt/manifest.json
@@ -1,10 +1,10 @@
 {
-  "domain": "iotawatt",
-  "name": "IoTaWatt",
-  "codeowners": ["@gtdiehl", "@jyavenard"],
-  "config_flow": true,
-  "documentation": "https://www.home-assistant.io/integrations/iotawatt",
-  "iot_class": "local_polling",
-  "loggers": ["iotawattpy"],
-  "requirements": ["iotawattpy==0.1.0"]
+    "domain": "iotawatt",
+    "name": "IoTaWatt",
+    "codeowners": ["@gtdiehl", "@jyavenard"],
+    "config_flow": true,
+    "documentation": "https://www.home-assistant.io/integrations/iotawatt",
+    "iot_class": "local_polling",
+    "loggers": ["iotawattpy"],
+    "requirements": ["iotawattpy==0.1.0"],
 }

--- a/homeassistant/components/iotawatt/sensor.py
+++ b/homeassistant/components/iotawatt/sensor.py
@@ -170,7 +170,9 @@ class IotaWattSensor(CoordinatorEntity[IotawattUpdater], SensorEntity):
                 f"{data.hub_mac_address}-input-{data.getChannel()}-{data.getUnit()}"
             )
         elif data.getType() == "Output":
-            self._attr_unique_id = f"{data.hub_mac_address}-output-{data.getSourceName()}"
+            self._attr_unique_id = (
+                f"{data.hub_mac_address}-output-{data.getSourceName()}"
+            )
         self.entity_description = entity_description
 
     @property

--- a/homeassistant/components/iotawatt/sensor.py
+++ b/homeassistant/components/iotawatt/sensor.py
@@ -169,6 +169,8 @@ class IotaWattSensor(CoordinatorEntity[IotawattUpdater], SensorEntity):
             self._attr_unique_id = (
                 f"{data.hub_mac_address}-input-{data.getChannel()}-{data.getUnit()}"
             )
+        elif data.getType() == "Output":
+            self._attr_unique_id = f"{data.hub_mac_address}-output-{data.getSourceName()}"
         self.entity_description = entity_description
 
     @property

--- a/homeassistant/components/iotawatt/strings.json
+++ b/homeassistant/components/iotawatt/strings.json
@@ -1,23 +1,19 @@
 {
-  "config": {
-    "step": {
-      "user": {
-        "data": {
-          "host": "[%key:common::config_flow::data::host%]"
-        }
-      },
-      "auth": {
-        "data": {
-          "username": "[%key:common::config_flow::data::username%]",
-          "password": "[%key:common::config_flow::data::password%]"
+    "config": {
+        "step": {
+            "user": {"data": {"host": "[%key:common::config_flow::data::host%]"}},
+            "auth": {
+                "data": {
+                    "username": "[%key:common::config_flow::data::username%]",
+                    "password": "[%key:common::config_flow::data::password%]",
+                },
+                "description": "The IoTawatt device requires authentication. Please enter the username and password and click the Submit button.",
+            },
         },
-        "description": "The IoTawatt device requires authentication. Please enter the username and password and click the Submit button."
-      }
-    },
-    "error": {
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
+        "error": {
+            "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+            "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+            "unknown": "[%key:common::config_flow::error::unknown%]",
+        },
     }
-  }
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Presently the IoTaWatt integration has a long hard-coded update interval and was inconsistent in when it passed the hard-coded parameter to the iotawattpy library vs default implied options.  This brings the rate interval out as a variable and passes it into all the required calls for custom rate intervals.  Future enhancement could also expose update interval variable as integration GUI configuration setting.  For now, I have set the interval to the minimum supported by the IoTaWatt.

Additionally this corrects the bug where the output-sensors are missing from Home Assistant resulting in missing data from the IotaWatt.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

Depends on bugfix applied to iotawattpy libraries, see pull request https://github.com/home-assistant-libs/iotawattpy/pull/8#issue-1699079627

- This PR fixes or closes issue: fixes # (none)
- This PR is related to issue: https://github.com/home-assistant-libs/iotawattpy/pull/8#issue-1699079627
- Link to documentation pull request: (no documentation changes required)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->


- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
