### PR TITLE
Add helper script to find orphaned translation strings

### DIFF
--- a/script/translations/find_orphaned_strings.py
+++ b/script/translations/find_orphaned_strings.py
@@ -1,0 +1,59 @@
+"""Script to find orphan/unused strings in strings.json for all integrations."""
+
+import glob
+import json
+import os
+
+
+def dig_recursive(dic: dict, keys: list):
+    """Recursively dig into dict looking for key/value = string/string."""
+    for key, val in dic.items():
+        if type(key) is str:
+            if type(val) is str:
+                keys.append(key)
+            elif type(val) is dict:
+                dig_recursive(val, keys)
+
+
+def find_orphan_strings(basedir, ignores):
+    """Find keys referenced in strings.json that aren't used anywhere in code."""
+
+    keys = []  # the keys we're looking for
+    with open(os.path.join(basedir, "strings.json")) as _jfile:
+        _j = json.loads(_jfile.read())
+        dig_recursive(_j, keys)
+
+    sourcelines = []
+    for pythonfile in glob.iglob("%s" % basedir + os.sep + "*.py"):
+        with open(pythonfile) as pfile:
+            for line in pfile:
+                line = line.split("#", 1)[0]
+                line = line.rstrip()
+                sourcelines.append(line)
+
+    _orphans = []  # list of orphans we generate
+    for key in keys:
+        if key not in ignores and not any(key in s for s in sourcelines + ignores):
+            _orphans.append(key)
+    return _orphans
+
+
+if __name__ == "__main__":
+    orphancount = 0
+    ignorelist = ["description", "title", "flow_title", "already_configured"]
+
+    with open("homeassistant/strings.json") as jfile:
+        j = json.loads(jfile.read())
+        dig_recursive(j, ignorelist)
+
+    for path in sorted(glob.glob("homeassistant/components/*/strings.json")):
+        dirname = os.path.dirname(path)
+        if os.path.isfile(os.path.join(dirname, "config_flow.py")):
+            orphans = find_orphan_strings(dirname, ignorelist)
+            if len(orphans) > 0:
+                orphancount += len(orphans)
+                print("%s:" % path)
+                for orphan in orphans:
+                    print(" unused/orphan key '%s'" % orphan)
+
+    print("Total orphan strings = %d" % orphancount)

--- a/script/translations/find_orphaned_strings.py
+++ b/script/translations/find_orphaned_strings.py
@@ -4,6 +4,10 @@ import glob
 import json
 import os
 
+IGNORE_FILES = [
+    "homeassistant/components/scrape/strings.json",
+]
+
 
 def dig_recursive(dic: dict, keys: list):
     """Recursively dig into dict looking for key/value = string/string."""
@@ -47,6 +51,8 @@ if __name__ == "__main__":
         dig_recursive(j, ignorelist)
 
     for path in sorted(glob.glob("homeassistant/components/*/strings.json")):
+        if path in IGNORE_FILES:
+            continue
         dirname = os.path.dirname(path)
         if os.path.isfile(os.path.join(dirname, "config_flow.py")):
             orphans = find_orphan_strings(dirname, ignorelist)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently when an integration is added or updated, the strings.json file must be updated too.  The contents of this file are then translated into many languages.  It could be that some of these are unnecessary.

Since I could not find any tool to check whether the strings are actually in use, I created one.

This script can be run from the root dir of the project e.g.:
`python script/translations/find_orphaned_strings.py`

It outputs a list of orphaned strings and which integrations they are from.

Overall this could possibly be added to a pre-commit hook or test to prevent orphaned strings from being created the first place.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
