### PR TITLE
Fix lingering timer in hassio

### DIFF
--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -596,7 +596,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:  # noqa:
             # os info not yet fetched from supervisor, retry later
             async_track_point_in_utc_time(
                 hass,
-                _async_setup_hardware_integration,
+                async_setup_hardware_integration_job,
                 utcnow() + HASSIO_UPDATE_INTERVAL,
             )
             return
@@ -609,6 +609,10 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:  # noqa:
                 hw_integration, context={"source": "system"}
             )
         )
+
+    async_setup_hardware_integration_job = HassJob(
+        _async_setup_hardware_integration, cancel_on_shutdown=True
+    )
 
     await _async_setup_hardware_integration()
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Linked to #91360
https://github.com/home-assistant/core/actions/runs/4923668065/jobs/8795822120?pr=91360

```console
ERROR tests/components/hassio/test_init.py::test_service_calls_core - Failed: Lingering timer after job <Job track point in utc time 2023-05-09 08:22:43.939535+00:00 HassJobType.Coroutinefunction <function async_setup.<locals>._async_setup_hardware_integration at 0x7f26ef03c5e0>>
ERROR tests/components/hassio/test_http.py::test_backup_upload_headers - Failed: Lingering timer after job <Job track point in utc time 2023-05-09 08:22:44.240802+00:00 HassJobType.Coroutinefunction <function async_setup.<locals>._async_setup_hardware_integration at 0x7f47bbbe3e20>>
ERROR tests/components/hassio/test_http.py::test_backup_download_headers - Failed: Lingering timer after job <Job track point in utc time 2023-05-09 08:22:44.484740+00:00 HassJobType.Coroutinefunction <function async_setup.<locals>._async_setup_hardware_integration at 0x7f47bbeb0040>>
ERROR tests/components/hassio/test_http.py::test_stream - Failed: Lingering timer after job <Job track point in utc time 2023-05-09 08:22:44.716496+00:00 HassJobType.Coroutinefunction <function async_setup.<locals>._async_setup_hardware_integration at 0x7f47c12d36d0>>
ERROR tests/components/hassio/test_http.py::test_entrypoint_cache_control - Failed: Lingering timer after job <Job track point in utc time 2023-05-09 08:22:44.957199+00:00 HassJobType.Coroutinefunction <function async_setup.<locals>._async_setup_hardware_integration at 0x7f47bb64a290>>
ERROR tests/components/hassio/test_init.py::test_get_store_addon_info - Failed: Lingering timer after job <Job track point in utc time 2023-05-09 08:22:47.695233+00:00 HassJobType.Coroutinefunction <function async_setup.<locals>._async_setup_hardware_integration at 0x7f26eeaba560>>
ERROR tests/components/hassio/test_websocket_api.py::test_ws_subscription - Failed: Lingering timer after job <Job track point in utc time 2023-05-09 08:22:55.915066+00:00 HassJobType.Coroutinefunction <function async_setup.<locals>._async_setup_hardware_integration at 0x7f47bbac1f30>>
ERROR tests/components/hassio/test_websocket_api.py::test_websocket_supervisor_api - Failed: Lingering timer after job <Job track point in utc time 2023-05-09 08:22:56.152181+00:00 HassJobType.Coroutinefunction <function async_setup.<locals>._async_setup_hardware_integration at 0x7f47bbf79510>>
ERROR tests/components/hassio/test_websocket_api.py::test_websocket_supervisor_api_error - Failed: Lingering timer after job <Job track point in utc time 2023-05-09 08:22:56.381096+00:00 HassJobType.Coroutinefunction <function async_setup.<locals>._async_setup_hardware_integration at 0x7f47bbcb4700>>
ERROR tests/components/hassio/test_websocket_api.py::test_websocket_non_admin_user - Failed: Lingering timer after job <Job track point in utc time 2023-05-09 08:22:56.613986+00:00 HassJobType.Coroutinefunction <function async_setup.<locals>._async_setup_hardware_integration at 0x7f47c12b8a60>>
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
