### PR TITLE
Fix lingering timer in iaqualink

### DIFF
--- a/homeassistant/components/iaqualink/__init__.py
+++ b/homeassistant/components/iaqualink/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Awaitable, Callable, Coroutine
+from datetime import datetime
 from functools import wraps
 import logging
 from typing import Any, Concatenate, ParamSpec, TypeVar
@@ -139,7 +140,7 @@ async def async_setup_entry(  # noqa: C901
 
     await hass.config_entries.async_forward_entry_setups(entry, platforms)
 
-    async def _async_systems_update(now):
+    async def _async_systems_update(_: datetime) -> None:
         """Refresh internal state for all systems."""
         for system in systems:
             prev = system.online
@@ -161,7 +162,9 @@ async def async_setup_entry(  # noqa: C901
 
             async_dispatcher_send(hass, DOMAIN)
 
-    async_track_time_interval(hass, _async_systems_update, UPDATE_INTERVAL)
+    entry.async_on_unload(
+        async_track_time_interval(hass, _async_systems_update, UPDATE_INTERVAL)
+    )
 
     return True
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Linked to #91360
https://github.com/home-assistant/core/actions/runs/4923668065/jobs/8795822324?pr=91360

```console
ERROR tests/components/iaqualink/test_init.py::test_setup_all_good_no_recognized_devices - Failed: Lingering timer after job <Job track time interval 0:00:15 <function async_setup_entry.<locals>._async_systems_update at 0x7f53cfd789d0> HassJobType.Callback <function async_track_time_interval.<locals>.interval_listener at 0x7f53cfd79870>>
ERROR tests/components/iaqualink/test_init.py::test_setup_all_good_all_device_types - Failed: Lingering timer after job <Job track time interval 0:00:15 <function async_setup_entry.<locals>._async_systems_update at 0x7f53cfd7bd90> HassJobType.Callback <function async_track_time_interval.<locals>.interval_listener at 0x7f53cffb28c0>>
ERROR tests/components/iaqualink/test_init.py::test_multiple_updates - Failed: Lingering timer after job <Job track time interval 0:00:15 <function async_setup_entry.<locals>._async_systems_update at 0x7f53d42ab490> HassJobType.Callback <function async_track_time_interval.<locals>.interval_listener at 0x7f53d42aa290>>
ERROR tests/components/iaqualink/test_init.py::test_entity_assumed_and_available - Failed: Lingering timer after job <Job track time interval 0:00:15 <function async_setup_entry.<locals>._async_systems_update at 0x7f53d42aa4d0> HassJobType.Callback <function async_track_time_interval.<locals>.interval_listener at 0x7f53d4248a60>>
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
