### PR TITLE
Fix lingering timer in hue light tests

### DIFF
--- a/tests/components/hue/test_light_v1.py
+++ b/tests/components/hue/test_light_v1.py
@@ -8,6 +8,7 @@ from homeassistant.components import hue
 from homeassistant.components.hue.const import CONF_ALLOW_HUE_GROUPS
 from homeassistant.components.hue.v1 import light as hue_light
 from homeassistant.components.light import ColorMode
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.util import color
@@ -178,6 +179,8 @@ async def setup_bridge(hass, mock_bridge_v1):
     """Load the Hue light platform with the provided bridge."""
     hass.config.components.add(hue.DOMAIN)
     config_entry = create_config_entry()
+    config_entry.add_to_hass(hass)
+    config_entry.state = ConfigEntryState.LOADED
     config_entry.options = {CONF_ALLOW_HUE_GROUPS: True}
     mock_bridge_v1.config_entry = config_entry
     hass.data[hue.DOMAIN] = {config_entry.entry_id: mock_bridge_v1}


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Linked to #91360
https://github.com/home-assistant/core/actions/runs/4923668065/jobs/8795822324?pr=91360

```console
ERROR tests/components/hue/test_light_v1.py::test_not_load_groups_if_old_bridge - Failed: Lingering timer after job <Job DataUpdateCoordinator light Mock bridge 1 hue 0d8af528eb721916bdf4ffa192db4dc1 HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.helpers.update_coordinator.DataUpdateCoordinator object at 0x7febf017f550>>>
ERROR tests/components/hue/test_light_v1.py::test_no_lights_or_groups - Failed: Lingering timer after job <Job DataUpdateCoordinator group Mock bridge 1 hue 88eed292b0a78ccb326ad420e7fa4d7e HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.helpers.update_coordinator.DataUpdateCoordinator object at 0x7febf025cfd0>>>
ERROR tests/components/hue/test_light_v1.py::test_lights - Failed: Lingering timer after job <Job DataUpdateCoordinator group Mock bridge 1 hue b4af73cc02d2b5e395c2c3af3aa1e1ca HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.helpers.update_coordinator.DataUpdateCoordinator object at 0x7febf14720b0>>>
ERROR tests/components/hue/test_light_v1.py::test_lights_color_mode - Failed: Lingering timer after test <TimerHandle when=987.829626491 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:152>
ERROR tests/components/hue/test_light_v1.py::test_groups - Failed: Lingering timer after job <Job DataUpdateCoordinator group Mock bridge 1 hue e59363652a5b40b83042e9689c87ac73 HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.helpers.update_coordinator.DataUpdateCoordinator object at 0x7febf04b3b20>>>
ERROR tests/components/hue/test_light_v1.py::test_new_group_discovered - Failed: Lingering timer after test <TimerHandle when=988.1050725059999 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:152>
ERROR tests/components/hue/test_light_v1.py::test_new_light_discovered - Failed: Lingering timer after test <TimerHandle when=988.2478577539999 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:152>
ERROR tests/components/hue/test_light_v1.py::test_group_removed - Failed: Lingering timer after test <TimerHandle when=988.389761695 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:152>
ERROR tests/components/hue/test_light_v1.py::test_light_removed - Failed: Lingering timer after test <TimerHandle when=988.537713285 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:152>
ERROR tests/components/hue/test_light_v1.py::test_other_group_update - Failed: Lingering timer after test <TimerHandle when=988.6803061319999 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:152>
ERROR tests/components/hue/test_light_v1.py::test_other_light_update - Failed: Lingering timer after test <TimerHandle when=988.8210239629999 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:152>
ERROR tests/components/hue/test_light_v1.py::test_light_turn_on_service - Failed: Lingering timer after test <TimerHandle when=989.140704834 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:152>
ERROR tests/components/hue/test_light_v1.py::test_light_turn_off_service - Failed: Lingering timer after test <TimerHandle when=989.292712256 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:152>
ERROR tests/components/hue/test_light_v1.py::test_group_features - Failed: Lingering timer after job <Job DataUpdateCoordinator group Mock bridge 1 hue 5c488e09d51a3378a13b0e493ac792ef HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.helpers.update_coordinator.DataUpdateCoordinator object at 0x7febf0733520>>>
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
