### PR TITLE
Allow "no" to match "nb" in language util

### DIFF
--- a/homeassistant/util/language.py
+++ b/homeassistant/util/language.py
@@ -56,12 +56,16 @@ def is_region(language: str, region: str | None) -> bool:
 
 def is_language_match(lang_1: str, lang_2: str) -> bool:
     """Return true if two languages are considered the same."""
-    if {lang_1, lang_2} == {"no", "nb"}:
-        # no = spoken Norwegian
-        # nb = written Norwegian (Bokmål )
+    if lang_1 == lang_2:
+        # Exact match
         return True
 
-    return lang_1 == lang_2
+    if {lang_1, lang_2} == {"no", "nb"}:
+        # no = spoken Norwegian
+        # nb = written Norwegian (Bokmål)
+        return True
+
+    return False
 
 
 @dataclass

--- a/homeassistant/util/language.py
+++ b/homeassistant/util/language.py
@@ -54,6 +54,16 @@ def is_region(language: str, region: str | None) -> bool:
     return True
 
 
+def is_language_match(lang_1: str, lang_2: str) -> bool:
+    """Return true if two languages are considered the same."""
+    if {lang_1, lang_2} == {"no", "nb"}:
+        # no = spoken Norwegian
+        # nb = written Norwegian (Bokmål )
+        return True
+
+    return lang_1 == lang_2
+
+
 @dataclass
 class Dialect:
     """Language with optional region and script/code."""
@@ -71,26 +81,35 @@ class Dialect:
             # Regions are upper-cased
             self.region = self.region.upper()
 
-    def score(self, dialect: Dialect, country: str | None = None) -> float:
+    def score(
+        self, dialect: Dialect, country: str | None = None
+    ) -> tuple[float, float]:
         """Return score for match with another dialect where higher is better.
 
         Score < 0 indicates a failure to match.
         """
-        if self.language != dialect.language:
+        if not is_language_match(self.language, dialect.language):
             # Not a match
-            return -1
+            return (-1, 0)
+
+        is_exact_language = self.language == dialect.language
 
         if (self.region is None) and (dialect.region is None):
             # Weak match with no region constraint
-            return 1
+            # Prefer exact language match
+            return (2 if is_exact_language else 1, 0)
 
         if (self.region is not None) and (dialect.region is not None):
             if self.region == dialect.region:
-                # Exact language + region match
-                return math.inf
+                # Same language + region match
+                # Prefer exact language match
+                return (
+                    math.inf,
+                    1 if is_exact_language else 0,
+                )
 
             # Regions are both set, but don't match
-            return 0
+            return (0, 0)
 
         # Generate ordered list of preferred regions
         pref_regions = list(
@@ -113,13 +132,13 @@ class Dialect:
 
             # More preferred regions are at the front.
             # Add 1 to boost above a weak match where no regions are set.
-            return 1 + (len(pref_regions) - region_idx)
+            return (1 + (len(pref_regions) - region_idx), 0)
         except ValueError:
             # Region was not in preferred list
             pass
 
         # Not a preferred region
-        return 0
+        return (0, 0)
 
     @staticmethod
     def parse(tag: str) -> Dialect:
@@ -169,4 +188,4 @@ def matches(
     )
 
     # Score < 0 is not a match
-    return [tag for _dialect, score, tag in scored if score >= 0]
+    return [tag for _dialect, score, tag in scored if score[0] >= 0]

--- a/tests/util/test_language.py
+++ b/tests/util/test_language.py
@@ -190,3 +190,39 @@ def test_sr_latn() -> None:
         "sr-CS",
         "sr-RS",
     ]
+
+
+def test_no_nb_same() -> None:
+    """Test that the no/nb are interchangeable."""
+    assert language.matches(
+        "no",
+        ["en-US", "en-GB", "nb"],
+    ) == ["nb"]
+    assert language.matches(
+        "nb",
+        ["en-US", "en-GB", "no"],
+    ) == ["no"]
+
+
+def test_no_nb_prefer_exact() -> None:
+    """Test that the exact language is preferred even if an interchangeable language is available."""
+    assert language.matches(
+        "no",
+        ["en-US", "en-GB", "nb", "no"],
+    ) == ["no", "nb"]
+    assert language.matches(
+        "no",
+        ["en-US", "en-GB", "no", "nb"],
+    ) == ["no", "nb"]
+
+
+def test_no_nb_prefer_exact_regions() -> None:
+    """Test that the exact language/region is preferred."""
+    assert language.matches(
+        "no-AA",
+        ["en-US", "en-GB", "nb-AA", "no-AA"],
+    ) == ["no-AA", "nb-AA"]
+    assert language.matches(
+        "no-AA",
+        ["en-US", "en-GB", "no-AA", "nb-AA"],
+    ) == ["no-AA", "nb-AA"]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The language code "no" refers to the spoken Norwegian language while "nb" refers to the written Norwegian Bokmål.
For voice, we need pipelines to be able to contain both language codes since they span audio and text. Specifically, Whisper uses "no" while Piper and Azure use "nb".

This PR extends the language util scoring to include two numbers so that "no" and "nb" can match, but the *exact* language target will always be preferred (e.g., "no" > "nb" when "no" is available).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # https://github.com/home-assistant/core/issues/92440
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
