### PR TITLE
Add counter.set_value service

### DIFF
--- a/homeassistant/components/counter/__init__.py
+++ b/homeassistant/components/counter/__init__.py
@@ -270,11 +270,11 @@ class Counter(collection.CollectionEntity, RestoreEntity):
     @callback
     def async_set_value(self, value: int) -> None:
         """Set counter to value."""
-        if (maximum := self._config.get(CONF_MAXIMUM) is not None) and value > maximum:
+        if (maximum := self._config.get(CONF_MAXIMUM)) is not None and value > maximum:
             raise ValueError(
                 f"Value {value} for {self.entity_id} exceeding the maximum value of {maximum}"
             )
-        if (minimum := self._config.get(CONF_MAXIMUM) is not None) and value < minimum:
+        if (minimum := self._config.get(CONF_MINIMUM)) is not None and value < minimum:
             raise ValueError(
                 f"Value {value} for {self.entity_id} exceeding the minimum value of {minimum}"
             )

--- a/homeassistant/components/counter/__init__.py
+++ b/homeassistant/components/counter/__init__.py
@@ -274,10 +274,17 @@ class Counter(collection.CollectionEntity, RestoreEntity):
             raise ValueError(
                 f"Value {value} for {self.entity_id} exceeding the maximum value of {maximum}"
             )
+
         if (minimum := self._config.get(CONF_MINIMUM)) is not None and value < minimum:
             raise ValueError(
                 f"Value {value} for {self.entity_id} exceeding the minimum value of {minimum}"
             )
+
+        if (step := self._config.get(CONF_STEP)) is not None and value % step != 0:
+            raise ValueError(
+                f"Value {value} for {self.entity_id} is not a multiple of the step size {step}"
+            )
+
         self._state = value
         self.async_write_ha_state()
 

--- a/homeassistant/components/counter/__init__.py
+++ b/homeassistant/components/counter/__init__.py
@@ -44,6 +44,7 @@ SERVICE_DECREMENT = "decrement"
 SERVICE_INCREMENT = "increment"
 SERVICE_RESET = "reset"
 SERVICE_CONFIGURE = "configure"
+SERVICE_SET_VALUE = "set_value"
 
 STORAGE_KEY = DOMAIN
 STORAGE_VERSION = 1
@@ -124,6 +125,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     component.async_register_entity_service(SERVICE_INCREMENT, {}, "async_increment")
     component.async_register_entity_service(SERVICE_DECREMENT, {}, "async_decrement")
     component.async_register_entity_service(SERVICE_RESET, {}, "async_reset")
+    component.async_register_entity_service(
+        SERVICE_SET_VALUE,
+        {vol.Required(VALUE): cv.positive_int},
+        "async_set_value",
+    )
     component.async_register_entity_service(
         SERVICE_CONFIGURE,
         {
@@ -259,6 +265,20 @@ class Counter(collection.CollectionEntity, RestoreEntity):
     def async_reset(self) -> None:
         """Reset a counter."""
         self._state = self.compute_next_state(self._config[CONF_INITIAL])
+        self.async_write_ha_state()
+
+    @callback
+    def async_set_value(self, value: int) -> None:
+        """Set counter to value."""
+        if (maximum := self._config.get(CONF_MAXIMUM) is not None) and value > maximum:
+            raise ValueError(
+                f"Value {value} for {self.entity_id} exceeding the maximum value of {maximum}"
+            )
+        if (minimum := self._config.get(CONF_MAXIMUM) is not None) and value < minimum:
+            raise ValueError(
+                f"Value {value} for {self.entity_id} exceeding the minimum value of {minimum}"
+            )
+        self._state = value
         self.async_write_ha_state()
 
     @callback

--- a/homeassistant/components/counter/services.yaml
+++ b/homeassistant/components/counter/services.yaml
@@ -21,6 +21,23 @@ reset:
     entity:
       domain: counter
 
+set_value:
+  name: Set
+  description: Set the counter value
+  target:
+    entity:
+      domain: counter
+  fields:
+    value:
+      name: Value
+      required: true
+      description: The new counter value the entity should be set to.
+      selector:
+        number:
+          min: 0
+          max: 9223372036854775807
+          mode: box
+
 configure:
   name: Configure
   description: Change counter parameters.

--- a/tests/components/counter/test_init.py
+++ b/tests/components/counter/test_init.py
@@ -17,8 +17,10 @@ from homeassistant.components.counter import (
     DEFAULT_INITIAL,
     DEFAULT_STEP,
     DOMAIN,
+    SERVICE_SET_VALUE,
+    VALUE,
 )
-from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_ICON, ATTR_NAME
+from homeassistant.const import ATTR_ENTITY_ID, ATTR_FRIENDLY_NAME, ATTR_ICON, ATTR_NAME
 from homeassistant.core import Context, CoreState, HomeAssistant, State
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
@@ -124,7 +126,7 @@ async def test_config_options(hass: HomeAssistant) -> None:
 
 
 async def test_methods(hass: HomeAssistant) -> None:
-    """Test increment, decrement, and reset methods."""
+    """Test increment, decrement, set value, and reset methods."""
     config = {DOMAIN: {"test_1": {}}}
 
     assert await async_setup_component(hass, "counter", config)
@@ -158,6 +160,18 @@ async def test_methods(hass: HomeAssistant) -> None:
     state = hass.states.get(entity_id)
     assert int(state.state) == 0
 
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_VALUE,
+        {
+            ATTR_ENTITY_ID: entity_id,
+            VALUE: 5,
+        },
+        blocking=True,
+    )
+    state = hass.states.get(entity_id)
+    assert state.state == "5"
+
 
 async def test_methods_with_config(hass: HomeAssistant) -> None:
     """Test increment, decrement, and reset methods with configuration."""
@@ -189,6 +203,18 @@ async def test_methods_with_config(hass: HomeAssistant) -> None:
 
     state = hass.states.get(entity_id)
     assert int(state.state) == 15
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_VALUE,
+        {
+            ATTR_ENTITY_ID: entity_id,
+            VALUE: 5,
+        },
+        blocking=True,
+    )
+    state = hass.states.get(entity_id)
+    assert state.state == "5"
 
 
 async def test_initial_state_overrules_restore_state(hass: HomeAssistant) -> None:

--- a/tests/components/counter/test_init.py
+++ b/tests/components/counter/test_init.py
@@ -243,14 +243,31 @@ async def test_methods_with_config(hass: HomeAssistant) -> None:
     assert state.state == "5"
 
     with pytest.raises(
-        ValueError, match=r"Value 1 for counter.test exceeding the minimum value of 5"
+        ValueError, match=r"Value 0 for counter.test exceeding the minimum value of 5"
     ):
         await hass.services.async_call(
             DOMAIN,
             SERVICE_SET_VALUE,
             {
                 ATTR_ENTITY_ID: entity_id,
-                VALUE: 1,
+                VALUE: 0,
+            },
+            blocking=True,
+        )
+
+    state = hass.states.get(entity_id)
+    assert state.state == "5"
+
+    with pytest.raises(
+        ValueError,
+        match=r"Value 6 for counter.test is not a multiple of the step size 5",
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_VALUE,
+            {
+                ATTR_ENTITY_ID: entity_id,
+                VALUE: 6,
             },
             blocking=True,
         )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds a `counter.set_value` service.

This service is similar to what we have available on other entities. Setting the value of the `counter` entity can already be done using the `counter.configure` service, however, we want to deprecate it.

Before starting a deprecation PR, I'm adding this new service that provides the part of the functionality we want to keep.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/27345

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
