### PR TITLE
Bump azure-servicebus to 7.10.0

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -141,7 +141,6 @@ jobs:
         run: |
           requirement_files="requirements_all.txt requirements_diff.txt"
           for requirement_file in ${requirement_files}; do
-            sed -i "s|# azure-servicebus|azure-servicebus|g" ${requirement_file}
             sed -i "s|# pybluez|pybluez|g" ${requirement_file}
             sed -i "s|# beacontools|beacontools|g" ${requirement_file}
             sed -i "s|# fritzconnection|fritzconnection|g" ${requirement_file}
@@ -263,12 +262,6 @@ jobs:
 
             # beacontools requires PyBluez.
             # sed -i "s|# beacontools|beacontools|g" ${requirement_file}
-
-            # azure-servicebus requires uamqp, which requires OpenSSL 1.1 to
-            # compile/build. This is not available on Alpine 3.17. The compat
-            # layer offered by Alpine conflicts, so we have no way to build
-            # this package.
-            # sed -i "s|# azure-servicebus|azure-servicebus|g" ${requirement_file}
 
             # It doesn't build for some reason, so we skip it for now.
             # Bumping to the latest version (4.7.0.72) supporting Python 3.11

--- a/homeassistant/components/azure_event_hub/__init__.py
+++ b/homeassistant/components/azure_event_hub/__init__.py
@@ -155,7 +155,6 @@ class AzureEventHub:
         Suppress the INFO and below logging on the underlying packages,
         they are very verbose, even at INFO.
         """
-        logging.getLogger("uamqp").setLevel(logging.WARNING)
         logging.getLogger("azure.eventhub").setLevel(logging.WARNING)
         self._listener_remover = self.hass.bus.async_listen(
             MATCH_ALL, self.async_listen

--- a/homeassistant/components/azure_service_bus/manifest.json
+++ b/homeassistant/components/azure_service_bus/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "https://www.home-assistant.io/integrations/azure_service_bus",
   "iot_class": "cloud_push",
   "loggers": ["azure"],
-  "requirements": ["azure-servicebus==7.8.0"]
+  "requirements": ["azure-servicebus==7.10.0"]
 }

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -152,10 +152,6 @@ matplotlib==3.6.1
 # cryptography 40.0.1 is installed with botocore
 pyOpenSSL>=23.1.0
 
-# uamqp newer versions we currently can't build for armv7/armhf
-# Limit this to Python 3.10, to not block Python 3.11 dev for now
-uamqp==1.6.0;python_version<'3.11'
-
 # protobuf must be in package constraints for the wheel
 # builder to build binary wheels
 protobuf==4.22.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -407,7 +407,7 @@ axis==48
 azure-eventhub==5.11.1
 
 # homeassistant.components.azure_service_bus
-# azure-servicebus==7.8.0
+azure-servicebus==7.10.0
 
 # homeassistant.components.baidu
 baidu-aip==1.6.6

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -24,7 +24,6 @@ COMMENT_REQUIREMENTS = (
     "atenpdu",  # depends on pysnmp which is not maintained at this time
     "avea",  # depends on bluepy
     "avion",
-    "azure-servicebus",  # depends on uamqp, which requires OpenSSL 1.1
     "beacontools",
     "beewi_smartclim",  # depends on bluepy
     "bluepy",

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -157,10 +157,6 @@ matplotlib==3.6.1
 # cryptography 40.0.1 is installed with botocore
 pyOpenSSL>=23.1.0
 
-# uamqp newer versions we currently can't build for armv7/armhf
-# Limit this to Python 3.10, to not block Python 3.11 dev for now
-uamqp==1.6.0;python_version<'3.11'
-
 # protobuf must be in package constraints for the wheel
 # builder to build binary wheels
 protobuf==4.22.3


### PR DESCRIPTION
## Proposed change
Update the Azure Service Bus package to 7.10.0, which is now also on the python implemented AMQP stack.  This release drops the requirement for uamqp, allowing yall to run this extension on arm64, alpine etc and removes a blocker from bumping up python versions for the project overall. You will no longer need to build uamqp as well 🙂

Please let me know if there are other changes I need to do. 

CC @hfurubotten (codeowner of the azure_service_bus integration)

## Type of change
- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
