### PR TITLE
Default to MP3 for Wyoming TTS

### DIFF
--- a/homeassistant/components/wyoming/manifest.json
+++ b/homeassistant/components/wyoming/manifest.json
@@ -3,6 +3,7 @@
   "name": "Wyoming Protocol",
   "codeowners": ["@balloob", "@synesthesiam"],
   "config_flow": true,
+  "dependencies": ["ffmpeg"],
   "documentation": "https://www.home-assistant.io/integrations/wyoming",
   "iot_class": "local_push",
   "requirements": ["wyoming==0.0.1"]

--- a/tests/components/wyoming/snapshots/test_tts.ambr
+++ b/tests/components/wyoming/snapshots/test_tts.ambr
@@ -21,7 +21,40 @@
     }),
   ])
 # ---
+# name: test_get_tts_audio_format[raw]
+  list([
+    dict({
+      'data': dict({
+        'text': 'Hello world',
+      }),
+      'payload': None,
+      'type': 'synthesize',
+    }),
+  ])
+# ---
+# name: test_get_tts_audio_format[wav]
+  list([
+    dict({
+      'data': dict({
+        'text': 'Hello world',
+      }),
+      'payload': None,
+      'type': 'synthesize',
+    }),
+  ])
+# ---
 # name: test_get_tts_audio_raw
+  list([
+    dict({
+      'data': dict({
+        'text': 'Hello world',
+      }),
+      'payload': None,
+      'type': 'synthesize',
+    }),
+  ])
+# ---
+# name: test_no_options
   list([
     dict({
       'data': dict({

--- a/tests/components/wyoming/snapshots/test_tts.ambr
+++ b/tests/components/wyoming/snapshots/test_tts.ambr
@@ -10,6 +10,17 @@
     }),
   ])
 # ---
+# name: test_get_tts_audio.1
+  list([
+    dict({
+      'data': dict({
+        'text': 'Hello world',
+      }),
+      'payload': None,
+      'type': 'synthesize',
+    }),
+  ])
+# ---
 # name: test_get_tts_audio_raw
   list([
     dict({

--- a/tests/components/wyoming/test_tts.py
+++ b/tests/components/wyoming/test_tts.py
@@ -54,9 +54,25 @@ async def test_get_tts_audio(hass: HomeAssistant, init_wyoming_tts, snapshot) ->
             tts.generate_media_source_id(hass, "Hello world", "tts.test_tts", "en-US"),
         )
 
-    assert extension == "mp3"
-    assert data is not None
-    assert mock_client.written == snapshot
+        assert extension == "mp3"
+        assert data is not None
+        assert mock_client.written == snapshot
+
+        # Test empty options too
+        extension, data = await tts.async_get_media_source_audio(
+            hass,
+            tts.generate_media_source_id(
+                hass,
+                "Hello world",
+                "tts.test_tts",
+                "en-US",
+                options=None,
+            ),
+        )
+
+        assert extension == "mp3"
+        assert data is not None
+        assert mock_client.written == snapshot
 
 
 async def test_get_tts_audio_raw(

--- a/tests/components/wyoming/test_tts.py
+++ b/tests/components/wyoming/test_tts.py
@@ -89,10 +89,7 @@ async def test_get_tts_audio(hass: HomeAssistant, init_wyoming_tts, snapshot) ->
         assert mock_client.written == snapshot
 
 
-@pytest.mark.parametrize(
-    "audio_format",
-    [("wav",), ("raw",)],
-)
+@pytest.mark.parametrize("audio_format", ("wav", "raw"))
 async def test_get_tts_audio_format(
     hass: HomeAssistant, init_wyoming_tts, snapshot, audio_format: str
 ) -> None:

--- a/tests/components/wyoming/test_tts.py
+++ b/tests/components/wyoming/test_tts.py
@@ -1,9 +1,7 @@
 """Test tts."""
 from __future__ import annotations
 
-import io
 from unittest.mock import patch
-import wave
 
 import pytest
 from wyoming.audio import AudioChunk, AudioStop
@@ -56,14 +54,8 @@ async def test_get_tts_audio(hass: HomeAssistant, init_wyoming_tts, snapshot) ->
             tts.generate_media_source_id(hass, "Hello world", "tts.test_tts", "en-US"),
         )
 
-    assert extension == "wav"
+    assert extension == "mp3"
     assert data is not None
-    with io.BytesIO(data) as wav_io, wave.open(wav_io, "rb") as wav_file:
-        assert wav_file.getframerate() == 16000
-        assert wav_file.getsampwidth() == 2
-        assert wav_file.getnchannels() == 1
-        assert wav_file.readframes(wav_file.getnframes()) == audio
-
     assert mock_client.written == snapshot
 
 

--- a/tests/components/wyoming/test_tts.py
+++ b/tests/components/wyoming/test_tts.py
@@ -30,6 +30,7 @@ async def test_support(hass: HomeAssistant, init_wyoming_tts) -> None:
 
     assert entity.supported_languages == ["en-US"]
     assert entity.supported_options == [tts.ATTR_AUDIO_OUTPUT, tts.ATTR_VOICE]
+    assert entity.default_language == "en-US"
     voices = entity.async_get_supported_voices("en-US")
     assert len(voices) == 1
     assert voices[0].name == "Test Voice"
@@ -52,22 +53,6 @@ async def test_get_tts_audio(hass: HomeAssistant, init_wyoming_tts, snapshot) ->
         extension, data = await tts.async_get_media_source_audio(
             hass,
             tts.generate_media_source_id(hass, "Hello world", "tts.test_tts", "en-US"),
-        )
-
-        assert extension == "mp3"
-        assert data is not None
-        assert mock_client.written == snapshot
-
-        # Test empty options too
-        extension, data = await tts.async_get_media_source_audio(
-            hass,
-            tts.generate_media_source_id(
-                hass,
-                "Hello world",
-                "tts.test_tts",
-                "en-US",
-                options=None,
-            ),
         )
 
         assert extension == "mp3"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The Wyoming integration text to speech system originally produced WAV audio. This PR uses the builtin ffmpeg component to convert this to MP3 for compatibility with existing media players.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # https://github.com/home-assistant/addons/issues/3030
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
