### PR TITLE
Add QNAP QSW firmware update support

### DIFF
--- a/homeassistant/components/qnap_qsw/update.py
+++ b/homeassistant/components/qnap_qsw/update.py
@@ -1,7 +1,7 @@
 """Support for the QNAP QSW update."""
 from __future__ import annotations
 
-from typing import Final
+from typing import Any, Final
 
 from aioqsw.const import (
     QSD_DESCRIPTION,
@@ -16,6 +16,7 @@ from homeassistant.components.update import (
     UpdateDeviceClass,
     UpdateEntity,
     UpdateEntityDescription,
+    UpdateEntityFeature,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
@@ -51,6 +52,7 @@ async def async_setup_entry(
 class QswUpdate(QswFirmwareEntity, UpdateEntity):
     """Define a QNAP QSW update."""
 
+    _attr_supported_features = UpdateEntityFeature.INSTALL
     entity_description: UpdateEntityDescription
 
     def __init__(
@@ -87,3 +89,13 @@ class QswUpdate(QswFirmwareEntity, UpdateEntity):
         self._attr_release_summary = self.get_device_value(
             QSD_FIRMWARE_CHECK, QSD_DESCRIPTION
         )
+
+    async def async_install(
+        self, version: str | None, backup: bool, **kwargs: Any
+    ) -> None:
+        """Install an update."""
+        await self.coordinator.async_refresh()
+        await self.coordinator.qsw.live_update()
+
+        self._attr_installed_version = self.latest_version
+        self.async_write_ha_state()

--- a/tests/components/qnap_qsw/test_update.py
+++ b/tests/components/qnap_qsw/test_update.py
@@ -1,6 +1,6 @@
 """The sensor tests for the QNAP QSW platform."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from aioqsw.const import API_ERROR_CODE, API_ERROR_MESSAGE, API_RESULT, API_VERSION
 
@@ -47,9 +47,7 @@ async def test_qnap_qsw_update(hass: HomeAssistant) -> None:
     )
     assert update.attributes[ATTR_IN_PROGRESS] is False
 
-    with patch("tarfile.open", MagicMock()), patch(
-        "pathlib.Path.mkdir", MagicMock()
-    ), patch(
+    with patch(
         "homeassistant.components.qnap_qsw.QnapQswApi.get_firmware_update_check",
         return_value=FIRMWARE_UPDATE_CHECK_MOCK,
     ) as mock_firmware_update_check, patch(

--- a/tests/components/qnap_qsw/test_update.py
+++ b/tests/components/qnap_qsw/test_update.py
@@ -53,9 +53,6 @@ async def test_qnap_qsw_update(hass: HomeAssistant) -> None:
         "homeassistant.components.qnap_qsw.QnapQswApi.get_firmware_update_check",
         return_value=FIRMWARE_UPDATE_CHECK_MOCK,
     ) as mock_firmware_update_check, patch(
-        "homeassistant.components.qnap_qsw.QnapQswApi.get_system_config",
-        return_value=bytearray(b"\xff"),
-    ), patch(
         "homeassistant.components.qnap_qsw.QnapQswApi.get_users_verification",
         return_value=USERS_VERIFICATION_MOCK,
     ) as mock_users_verification, patch(

--- a/tests/components/qnap_qsw/test_update.py
+++ b/tests/components/qnap_qsw/test_update.py
@@ -1,11 +1,32 @@
 """The sensor tests for the QNAP QSW platform."""
 
-from aioqsw.const import API_RESULT, API_VERSION
+from unittest.mock import MagicMock, patch
 
-from homeassistant.const import STATE_OFF
+from aioqsw.const import API_ERROR_CODE, API_ERROR_MESSAGE, API_RESULT, API_VERSION
+
+from homeassistant.components.update import (
+    ATTR_BACKUP,
+    ATTR_IN_PROGRESS,
+    ATTR_INSTALLED_VERSION,
+    ATTR_LATEST_VERSION,
+    DOMAIN as UPDATE_DOMAIN,
+    SERVICE_INSTALL,
+)
+from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 
-from .util import FIRMWARE_INFO_MOCK, FIRMWARE_UPDATE_CHECK_MOCK, async_init_integration
+from .util import (
+    FIRMWARE_INFO_MOCK,
+    FIRMWARE_UPDATE_CHECK_MOCK,
+    USERS_VERIFICATION_MOCK,
+    async_init_integration,
+)
+
+FIRMWARE_UPDATE_LIVE_MOCK = {
+    API_ERROR_CODE: 200,
+    API_ERROR_MESSAGE: "OK",
+    API_RESULT: "None",
+}
 
 
 async def test_qnap_qsw_update(hass: HomeAssistant) -> None:
@@ -15,12 +36,55 @@ async def test_qnap_qsw_update(hass: HomeAssistant) -> None:
 
     update = hass.states.get("update.qsw_m408_4c_firmware_update")
     assert update is not None
-    assert update.state == STATE_OFF
+    assert update.state == STATE_ON
     assert (
-        update.attributes.get("installed_version")
+        update.attributes[ATTR_INSTALLED_VERSION]
         == FIRMWARE_INFO_MOCK[API_RESULT][API_VERSION]
     )
     assert (
-        update.attributes.get("latest_version")
+        update.attributes[ATTR_LATEST_VERSION]
         == FIRMWARE_UPDATE_CHECK_MOCK[API_RESULT][API_VERSION]
     )
+    assert update.attributes[ATTR_IN_PROGRESS] is False
+
+    with patch("tarfile.open", MagicMock()), patch(
+        "pathlib.Path.mkdir", MagicMock()
+    ), patch(
+        "homeassistant.components.qnap_qsw.QnapQswApi.get_firmware_update_check",
+        return_value=FIRMWARE_UPDATE_CHECK_MOCK,
+    ) as mock_firmware_update_check, patch(
+        "homeassistant.components.qnap_qsw.QnapQswApi.get_system_config",
+        return_value=bytearray(b"\xff"),
+    ), patch(
+        "homeassistant.components.qnap_qsw.QnapQswApi.get_users_verification",
+        return_value=USERS_VERIFICATION_MOCK,
+    ) as mock_users_verification, patch(
+        "homeassistant.components.qnap_qsw.QnapQswApi.post_firmware_update_live",
+        return_value=FIRMWARE_UPDATE_LIVE_MOCK,
+    ) as mock_firmware_update_live:
+        await hass.services.async_call(
+            UPDATE_DOMAIN,
+            SERVICE_INSTALL,
+            {
+                ATTR_BACKUP: False,
+                ATTR_ENTITY_ID: "update.qsw_m408_4c_firmware_update",
+            },
+            blocking=True,
+        )
+
+        mock_firmware_update_check.assert_called_once()
+        mock_firmware_update_live.assert_called_once()
+        mock_users_verification.assert_called()
+
+    update = hass.states.get("update.qsw_m408_4c_firmware_update")
+    assert update is not None
+    assert update.state == STATE_OFF
+    assert (
+        update.attributes[ATTR_INSTALLED_VERSION]
+        == FIRMWARE_UPDATE_CHECK_MOCK[API_RESULT][API_VERSION]
+    )
+    assert (
+        update.attributes[ATTR_LATEST_VERSION]
+        == FIRMWARE_UPDATE_CHECK_MOCK[API_RESULT][API_VERSION]
+    )
+    assert update.attributes[ATTR_IN_PROGRESS] is False

--- a/tests/components/qnap_qsw/util.py
+++ b/tests/components/qnap_qsw/util.py
@@ -109,17 +109,17 @@ FIRMWARE_UPDATE_CHECK_MOCK = {
     API_ERROR_CODE: 200,
     API_ERROR_MESSAGE: "OK",
     API_RESULT: {
-        API_VERSION: "1.2.0",
-        API_NUMBER: "29649",
-        API_BUILD_NUMBER: "20220128",
-        API_DATE: "Fri, 28 Jan 2022 01:17:39 +0800",
+        API_VERSION: "1.3.0",
+        API_NUMBER: "527638",
+        API_BUILD_NUMBER: "20221123",
+        API_DATE: "Wed, 07, Dec 2022 16:30:00 +0800",
         API_DESCRIPTION: "",
         API_DOWNLOAD_URL: [
-            "https://download.qnap.com/Storage/Networking/QSW408FW/QSW-M408AC3-FW.v1.2.0_S20220128_29649.img",
-            "https://eu1.qnap.com/Storage/Networking/QSW408FW/QSW-M408AC3-FW.v1.2.0_S20220128_29649.img",
-            "https://us1.qnap.com/Storage/Networking/QSW408FW/QSW-M408AC3-FW.v1.2.0_S20220128_29649.img",
+            "https://download.qnap.com/Storage/Networking/QSW408FW/QSW-M408AC3-FW.v1.3.0_S20221123_527638.img",
+            "https://eu1.qnap.com/Storage/Networking/QSW408FW/QSW-M408AC3-FW.v1.3.0_S20221123_527638.img",
+            "https://us1.qnap.com/Storage/Networking/QSW408FW/QSW-M408AC3-FW.v1.3.0_S20221123_527638.img",
         ],
-        API_NEWER: False,
+        API_NEWER: True,
     },
 }
 


### PR DESCRIPTION
## Proposed change
Add QNAP QSW firmware update support.
As my previous PR adding firmware update (with config backup) support has been unreviewed for 6 months now, this PR only adds the firmware update functionality, hoping that it will be reviewed faster:
https://github.com/home-assistant/core/pull/83844

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/pull/83844
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
