### PR TITLE
Add unique id to entities for envisalink integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -291,7 +291,8 @@ omit =
     homeassistant/components/environment_canada/camera.py
     homeassistant/components/environment_canada/sensor.py
     homeassistant/components/environment_canada/weather.py
-    homeassistant/components/envisalink/*
+    homeassistant/components/envisalink/__init__.py
+    homeassistant/components/envisalink/switch.py
     homeassistant/components/ephember/climate.py
     homeassistant/components/epson/__init__.py
     homeassistant/components/epson/media_player.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -337,6 +337,7 @@ build.json @home-assistant/supervisor
 /homeassistant/components/environment_canada/ @gwww @michaeldavie
 /tests/components/environment_canada/ @gwww @michaeldavie
 /homeassistant/components/envisalink/ @ufodone
+/tests/components/envisalink/ @ufodone
 /homeassistant/components/ephember/ @ttroy50
 /homeassistant/components/epson/ @pszafer
 /tests/components/epson/ @pszafer

--- a/homeassistant/components/envisalink/__init__.py
+++ b/homeassistant/components/envisalink/__init__.py
@@ -1,6 +1,7 @@
 """Support for Envisalink devices."""
 import asyncio
 import logging
+from typing import Any
 
 from pyenvisalink import EnvisalinkAlarmPanel
 import voluptuous as vol
@@ -250,12 +251,14 @@ class EnvisalinkDevice(Entity):
 
     _attr_should_poll = False
 
-    def __init__(self, name, info, controller, unique_id):
+    def __init__(
+        self, name: str, info: Any, idx: int, controller: EnvisalinkAlarmPanel
+    ) -> None:
         """Initialize the device."""
         self._controller = controller
         self._info = info
         self._name = name
-        self._attr_unique_id = unique_id
+        self._attr_unique_id = f"{idx}"
 
     @property
     def name(self):

--- a/homeassistant/components/envisalink/__init__.py
+++ b/homeassistant/components/envisalink/__init__.py
@@ -250,11 +250,12 @@ class EnvisalinkDevice(Entity):
 
     _attr_should_poll = False
 
-    def __init__(self, name, info, controller):
+    def __init__(self, name, info, controller, unique_id):
         """Initialize the device."""
         self._controller = controller
         self._info = info
         self._name = name
+        self._attr_unique_id = unique_id
 
     @property
     def name(self):

--- a/homeassistant/components/envisalink/alarm_control_panel.py
+++ b/homeassistant/components/envisalink/alarm_control_panel.py
@@ -66,7 +66,6 @@ async def async_setup_platform(
     entities = []
     for part_num in configured_partitions:
         entity_config_data = PARTITION_SCHEMA(configured_partitions[part_num])
-        unique_id = f"envisalink-acp-{part_num}"
         entity = EnvisalinkAlarm(
             hass,
             part_num,
@@ -75,7 +74,6 @@ async def async_setup_platform(
             panic_type,
             hass.data[DATA_EVL].alarm_state["partition"][part_num],
             hass.data[DATA_EVL],
-            unique_id,
         )
         entities.append(entity)
 
@@ -113,15 +111,7 @@ class EnvisalinkAlarm(EnvisalinkDevice, AlarmControlPanelEntity):
     )
 
     def __init__(
-        self,
-        hass,
-        partition_number,
-        alarm_name,
-        code,
-        panic_type,
-        info,
-        controller,
-        unique_id,
+        self, hass, partition_number, alarm_name, code, panic_type, info, controller
     ):
         """Initialize the alarm panel."""
         self._partition_number = partition_number
@@ -129,7 +119,7 @@ class EnvisalinkAlarm(EnvisalinkDevice, AlarmControlPanelEntity):
         self._panic_type = panic_type
 
         _LOGGER.debug("Setting up alarm: %s", alarm_name)
-        super().__init__(alarm_name, info, controller, unique_id=unique_id)
+        super().__init__(alarm_name, info, partition_number, controller)
 
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""

--- a/homeassistant/components/envisalink/alarm_control_panel.py
+++ b/homeassistant/components/envisalink/alarm_control_panel.py
@@ -66,6 +66,7 @@ async def async_setup_platform(
     entities = []
     for part_num in configured_partitions:
         entity_config_data = PARTITION_SCHEMA(configured_partitions[part_num])
+        unique_id = f"envisalink-acp-{part_num}"
         entity = EnvisalinkAlarm(
             hass,
             part_num,
@@ -74,6 +75,7 @@ async def async_setup_platform(
             panic_type,
             hass.data[DATA_EVL].alarm_state["partition"][part_num],
             hass.data[DATA_EVL],
+            unique_id,
         )
         entities.append(entity)
 
@@ -111,7 +113,15 @@ class EnvisalinkAlarm(EnvisalinkDevice, AlarmControlPanelEntity):
     )
 
     def __init__(
-        self, hass, partition_number, alarm_name, code, panic_type, info, controller
+        self,
+        hass,
+        partition_number,
+        alarm_name,
+        code,
+        panic_type,
+        info,
+        controller,
+        unique_id,
     ):
         """Initialize the alarm panel."""
         self._partition_number = partition_number
@@ -119,7 +129,7 @@ class EnvisalinkAlarm(EnvisalinkDevice, AlarmControlPanelEntity):
         self._panic_type = panic_type
 
         _LOGGER.debug("Setting up alarm: %s", alarm_name)
-        super().__init__(alarm_name, info, controller)
+        super().__init__(alarm_name, info, controller, unique_id=unique_id)
 
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""

--- a/homeassistant/components/envisalink/binary_sensor.py
+++ b/homeassistant/components/envisalink/binary_sensor.py
@@ -38,7 +38,6 @@ async def async_setup_platform(
     entities = []
     for zone_num in configured_zones:
         entity_config_data = ZONE_SCHEMA(configured_zones[zone_num])
-        unique_id = f"envisalink-bs-{zone_num}"
         entity = EnvisalinkBinarySensor(
             hass,
             zone_num,
@@ -46,7 +45,6 @@ async def async_setup_platform(
             entity_config_data[CONF_ZONETYPE],
             hass.data[DATA_EVL].alarm_state["zone"][zone_num],
             hass.data[DATA_EVL],
-            unique_id,
         )
         entities.append(entity)
 
@@ -56,15 +54,13 @@ async def async_setup_platform(
 class EnvisalinkBinarySensor(EnvisalinkDevice, BinarySensorEntity):
     """Representation of an Envisalink binary sensor."""
 
-    def __init__(
-        self, hass, zone_number, zone_name, zone_type, info, controller, unique_id
-    ):
+    def __init__(self, hass, zone_number, zone_name, zone_type, info, controller):
         """Initialize the binary_sensor."""
         self._zone_type = zone_type
         self._zone_number = zone_number
 
         _LOGGER.debug("Setting up zone: %s", zone_name)
-        super().__init__(zone_name, info, controller, unique_id=unique_id)
+        super().__init__(zone_name, info, zone_number, controller)
 
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""

--- a/homeassistant/components/envisalink/binary_sensor.py
+++ b/homeassistant/components/envisalink/binary_sensor.py
@@ -38,6 +38,7 @@ async def async_setup_platform(
     entities = []
     for zone_num in configured_zones:
         entity_config_data = ZONE_SCHEMA(configured_zones[zone_num])
+        unique_id = f"envisalink-bs-{zone_num}"
         entity = EnvisalinkBinarySensor(
             hass,
             zone_num,
@@ -45,6 +46,7 @@ async def async_setup_platform(
             entity_config_data[CONF_ZONETYPE],
             hass.data[DATA_EVL].alarm_state["zone"][zone_num],
             hass.data[DATA_EVL],
+            unique_id,
         )
         entities.append(entity)
 
@@ -54,13 +56,15 @@ async def async_setup_platform(
 class EnvisalinkBinarySensor(EnvisalinkDevice, BinarySensorEntity):
     """Representation of an Envisalink binary sensor."""
 
-    def __init__(self, hass, zone_number, zone_name, zone_type, info, controller):
+    def __init__(
+        self, hass, zone_number, zone_name, zone_type, info, controller, unique_id
+    ):
         """Initialize the binary_sensor."""
         self._zone_type = zone_type
         self._zone_number = zone_number
 
         _LOGGER.debug("Setting up zone: %s", zone_name)
-        super().__init__(zone_name, info, controller)
+        super().__init__(zone_name, info, controller, unique_id=unique_id)
 
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""

--- a/homeassistant/components/envisalink/sensor.py
+++ b/homeassistant/components/envisalink/sensor.py
@@ -35,14 +35,12 @@ async def async_setup_platform(
     entities = []
     for part_num in configured_partitions:
         entity_config_data = PARTITION_SCHEMA(configured_partitions[part_num])
-        unique_id = f"envisalink-s-{part_num}"
         entity = EnvisalinkSensor(
             hass,
             entity_config_data[CONF_PARTITIONNAME],
             part_num,
             hass.data[DATA_EVL].alarm_state["partition"][part_num],
             hass.data[DATA_EVL],
-            unique_id,
         )
 
         entities.append(entity)
@@ -53,17 +51,13 @@ async def async_setup_platform(
 class EnvisalinkSensor(EnvisalinkDevice, SensorEntity):
     """Representation of an Envisalink keypad."""
 
-    def __init__(
-        self, hass, partition_name, partition_number, info, controller, unique_id
-    ):
+    def __init__(self, hass, partition_name, partition_number, info, controller):
         """Initialize the sensor."""
         self._icon = "mdi:alarm"
         self._partition_number = partition_number
 
         _LOGGER.debug("Setting up sensor for partition: %s", partition_name)
-        super().__init__(
-            f"{partition_name} Keypad", info, controller, unique_id=unique_id
-        )
+        super().__init__(f"{partition_name} Keypad", info, partition_number, controller)
 
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""

--- a/homeassistant/components/envisalink/sensor.py
+++ b/homeassistant/components/envisalink/sensor.py
@@ -35,12 +35,14 @@ async def async_setup_platform(
     entities = []
     for part_num in configured_partitions:
         entity_config_data = PARTITION_SCHEMA(configured_partitions[part_num])
+        unique_id = f"envisalink-s-{part_num}"
         entity = EnvisalinkSensor(
             hass,
             entity_config_data[CONF_PARTITIONNAME],
             part_num,
             hass.data[DATA_EVL].alarm_state["partition"][part_num],
             hass.data[DATA_EVL],
+            unique_id,
         )
 
         entities.append(entity)
@@ -51,13 +53,17 @@ async def async_setup_platform(
 class EnvisalinkSensor(EnvisalinkDevice, SensorEntity):
     """Representation of an Envisalink keypad."""
 
-    def __init__(self, hass, partition_name, partition_number, info, controller):
+    def __init__(
+        self, hass, partition_name, partition_number, info, controller, unique_id
+    ):
         """Initialize the sensor."""
         self._icon = "mdi:alarm"
         self._partition_number = partition_number
 
         _LOGGER.debug("Setting up sensor for partition: %s", partition_name)
-        super().__init__(f"{partition_name} Keypad", info, controller)
+        super().__init__(
+            f"{partition_name} Keypad", info, controller, unique_id=unique_id
+        )
 
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""

--- a/homeassistant/components/envisalink/switch.py
+++ b/homeassistant/components/envisalink/switch.py
@@ -38,14 +38,12 @@ async def async_setup_platform(
         zone_name = f"{entity_config_data[CONF_ZONENAME]}_bypass"
         _LOGGER.debug("Setting up zone_bypass switch: %s", zone_name)
 
-        unique_id = f"envisalink-sw-{zone_num}"
         entity = EnvisalinkSwitch(
             hass,
             zone_num,
             zone_name,
             hass.data[DATA_EVL].alarm_state["zone"][zone_num],
             hass.data[DATA_EVL],
-            unique_id,
         )
         entities.append(entity)
 
@@ -55,11 +53,11 @@ async def async_setup_platform(
 class EnvisalinkSwitch(EnvisalinkDevice, SwitchEntity):
     """Representation of an Envisalink switch."""
 
-    def __init__(self, hass, zone_number, zone_name, info, controller, unique_id):
+    def __init__(self, hass, zone_number, zone_name, info, controller):
         """Initialize the switch."""
         self._zone_number = zone_number
 
-        super().__init__(zone_name, info, controller, unique_id=unique_id)
+        super().__init__(zone_name, info, zone_number, controller)
 
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""

--- a/homeassistant/components/envisalink/switch.py
+++ b/homeassistant/components/envisalink/switch.py
@@ -38,12 +38,14 @@ async def async_setup_platform(
         zone_name = f"{entity_config_data[CONF_ZONENAME]}_bypass"
         _LOGGER.debug("Setting up zone_bypass switch: %s", zone_name)
 
+        unique_id = f"envisalink-sw-{zone_num}"
         entity = EnvisalinkSwitch(
             hass,
             zone_num,
             zone_name,
             hass.data[DATA_EVL].alarm_state["zone"][zone_num],
             hass.data[DATA_EVL],
+            unique_id,
         )
         entities.append(entity)
 
@@ -53,11 +55,11 @@ async def async_setup_platform(
 class EnvisalinkSwitch(EnvisalinkDevice, SwitchEntity):
     """Representation of an Envisalink switch."""
 
-    def __init__(self, hass, zone_number, zone_name, info, controller):
+    def __init__(self, hass, zone_number, zone_name, info, controller, unique_id):
         """Initialize the switch."""
         self._zone_number = zone_number
 
-        super().__init__(zone_name, info, controller)
+        super().__init__(zone_name, info, controller, unique_id=unique_id)
 
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1168,6 +1168,9 @@ pyefergy==22.1.1
 # homeassistant.components.eight_sleep
 pyeight==0.3.2
 
+# homeassistant.components.envisalink
+pyenvisalink==4.6
+
 # homeassistant.components.everlights
 pyeverlights==0.1.0
 

--- a/tests/components/envisalink/__init__.py
+++ b/tests/components/envisalink/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the envisalink component."""

--- a/tests/components/envisalink/common.py
+++ b/tests/components/envisalink/common.py
@@ -4,6 +4,10 @@ from homeassistant.components.envisalink import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
+KEEP_ALIVE_PATCH = "pyenvisalink.DSCClient.keep_alive"
+PERIODIC_PATCH = "pyenvisalink.DSCClient.periodic_zone_timer_dump"
+RECONNECT_PATCH = "pyenvisalink.EnvisalinkClient.reconnect"
+
 PARTITIONS = {1: {"name": "Partition 1"}, 2: {"name": "Partition 2"}}
 
 ZONES = {

--- a/tests/components/envisalink/common.py
+++ b/tests/components/envisalink/common.py
@@ -1,0 +1,31 @@
+"""Common methods used across tests for envisalink."""
+
+from homeassistant.components.envisalink import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+PARTITIONS = {1: {"name": "Partition 1"}, 2: {"name": "Partition 2"}}
+
+ZONES = {
+    1: {"name": "Zone 1", "type": "door"},
+    2: {"name": "Zone 2", "type": "window"},
+    3: {"name": "Zone 3", "type": "motion"},
+    4: {"name": "Zone 4", "type": "smoke"},
+}
+
+CONFIG = {
+    "envisalink": {
+        "host": "127.0.0.1",
+        "panel_type": "DSC",
+        "user_name": "user",
+        "password": "user",
+        "partitions": PARTITIONS,
+        "zones": ZONES,
+    }
+}
+
+
+async def setup_platform(hass: HomeAssistant):
+    """Set up the envisalink platform."""
+    assert await async_setup_component(hass, DOMAIN, CONFIG)
+    await hass.async_block_till_done()

--- a/tests/components/envisalink/test_alarm_control_panel.py
+++ b/tests/components/envisalink/test_alarm_control_panel.py
@@ -18,4 +18,4 @@ async def test_alarm_control_panel_entity_registry(hass: HomeAssistant) -> None:
         partition_name = partition_info["name"]
         entity_id = f"alarm_control_panel.{slugify(partition_name)}"
         entity = entity_registry.async_get(entity_id)
-        assert entity.unique_id == f"envisalink-acp-{partition_id}"
+        assert entity.unique_id == f"{partition_id}"

--- a/tests/components/envisalink/test_alarm_control_panel.py
+++ b/tests/components/envisalink/test_alarm_control_panel.py
@@ -1,21 +1,30 @@
 """Tests for envisalink alarm control panel."""
 
-import pytest
+
+from unittest.mock import patch
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util import slugify
 
-from .common import PARTITIONS, setup_platform
+from .common import (
+    KEEP_ALIVE_PATCH,
+    PARTITIONS,
+    PERIODIC_PATCH,
+    RECONNECT_PATCH,
+    setup_platform,
+)
 
 
-@pytest.mark.parametrize("expected_lingering_tasks", [True])
 async def test_alarm_control_panel_entity_registry(hass: HomeAssistant) -> None:
     """Test the sensors are registered in entity registry."""
-    await setup_platform(hass)
-    entity_registry = er.async_get(hass)
-    for partition_id, partition_info in PARTITIONS.items():
-        partition_name = partition_info["name"]
-        entity_id = f"alarm_control_panel.{slugify(partition_name)}"
-        entity = entity_registry.async_get(entity_id)
-        assert entity.unique_id == f"{partition_id}"
+    with patch(KEEP_ALIVE_PATCH, return_value=None), patch(
+        PERIODIC_PATCH, return_value=None
+    ), patch(RECONNECT_PATCH, return_value=None):
+        await setup_platform(hass)
+        entity_registry = er.async_get(hass)
+        for partition_id, partition_info in PARTITIONS.items():
+            partition_name = partition_info["name"]
+            entity_id = f"alarm_control_panel.{slugify(partition_name)}"
+            entity = entity_registry.async_get(entity_id)
+            assert entity.unique_id == f"{partition_id}"

--- a/tests/components/envisalink/test_alarm_control_panel.py
+++ b/tests/components/envisalink/test_alarm_control_panel.py
@@ -1,0 +1,21 @@
+"""Tests for envisalink alarm control panel."""
+
+import pytest
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.util import slugify
+
+from .common import PARTITIONS, setup_platform
+
+
+@pytest.mark.parametrize("expected_lingering_tasks", [True])
+async def test_alarm_control_panel_entity_registry(hass: HomeAssistant) -> None:
+    """Test the sensors are registered in entity registry."""
+    await setup_platform(hass)
+    entity_registry = er.async_get(hass)
+    for partition_id, partition_info in PARTITIONS.items():
+        partition_name = partition_info["name"]
+        entity_id = f"alarm_control_panel.{slugify(partition_name)}"
+        entity = entity_registry.async_get(entity_id)
+        assert entity.unique_id == f"envisalink-acp-{partition_id}"

--- a/tests/components/envisalink/test_binary_sensor.py
+++ b/tests/components/envisalink/test_binary_sensor.py
@@ -19,5 +19,5 @@ async def test_binary_sensor_entity_registry(hass: HomeAssistant) -> None:
         zone_type = zone_info["type"]
         entity_id = f"binary_sensor.{slugify(zone_name)}"
         entity = entity_registry.async_get(entity_id)
-        assert entity.unique_id == f"envisalink-bs-{zone_id}"
+        assert entity.unique_id == f"{zone_id}"
         assert entity.original_device_class == zone_type

--- a/tests/components/envisalink/test_binary_sensor.py
+++ b/tests/components/envisalink/test_binary_sensor.py
@@ -1,23 +1,31 @@
 """Tests for envisalink binary_sensor."""
 
-import pytest
+from unittest.mock import patch
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util import slugify
 
-from .common import ZONES, setup_platform
+from .common import (
+    KEEP_ALIVE_PATCH,
+    PERIODIC_PATCH,
+    RECONNECT_PATCH,
+    ZONES,
+    setup_platform,
+)
 
 
-@pytest.mark.parametrize("expected_lingering_tasks", [True])
 async def test_binary_sensor_entity_registry(hass: HomeAssistant) -> None:
     """Test the binary sensors are registered in entity registry."""
-    await setup_platform(hass)
-    entity_registry = er.async_get(hass)
-    for zone_id, zone_info in ZONES.items():
-        zone_name = zone_info["name"]
-        zone_type = zone_info["type"]
-        entity_id = f"binary_sensor.{slugify(zone_name)}"
-        entity = entity_registry.async_get(entity_id)
-        assert entity.unique_id == f"{zone_id}"
-        assert entity.original_device_class == zone_type
+    with patch(KEEP_ALIVE_PATCH, return_value=None), patch(
+        PERIODIC_PATCH, return_value=None
+    ), patch(RECONNECT_PATCH, return_value=None):
+        await setup_platform(hass)
+        entity_registry = er.async_get(hass)
+        for zone_id, zone_info in ZONES.items():
+            zone_name = zone_info["name"]
+            zone_type = zone_info["type"]
+            entity_id = f"binary_sensor.{slugify(zone_name)}"
+            entity = entity_registry.async_get(entity_id)
+            assert entity.unique_id == f"{zone_id}"
+            assert entity.original_device_class == zone_type

--- a/tests/components/envisalink/test_binary_sensor.py
+++ b/tests/components/envisalink/test_binary_sensor.py
@@ -1,0 +1,23 @@
+"""Tests for envisalink binary_sensor."""
+
+import pytest
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.util import slugify
+
+from .common import ZONES, setup_platform
+
+
+@pytest.mark.parametrize("expected_lingering_tasks", [True])
+async def test_binary_sensor_entity_registry(hass: HomeAssistant) -> None:
+    """Test the binary sensors are registered in entity registry."""
+    await setup_platform(hass)
+    entity_registry = er.async_get(hass)
+    for zone_id, zone_info in ZONES.items():
+        zone_name = zone_info["name"]
+        zone_type = zone_info["type"]
+        entity_id = f"binary_sensor.{slugify(zone_name)}"
+        entity = entity_registry.async_get(entity_id)
+        assert entity.unique_id == f"envisalink-bs-{zone_id}"
+        assert entity.original_device_class == zone_type

--- a/tests/components/envisalink/test_sensor.py
+++ b/tests/components/envisalink/test_sensor.py
@@ -18,4 +18,4 @@ async def test_sensor_entity_registry(hass: HomeAssistant) -> None:
         partition_name = partition_info["name"]
         entity_id = f"sensor.{slugify(partition_name)}_keypad"
         entity = entity_registry.async_get(entity_id)
-        assert entity.unique_id == f"envisalink-s-{partition_id}"
+        assert entity.unique_id == f"{partition_id}"

--- a/tests/components/envisalink/test_sensor.py
+++ b/tests/components/envisalink/test_sensor.py
@@ -1,21 +1,30 @@
 """Tests for envisalink sensor."""
 
-import pytest
+
+from unittest.mock import patch
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util import slugify
 
-from .common import PARTITIONS, setup_platform
+from .common import (
+    KEEP_ALIVE_PATCH,
+    PARTITIONS,
+    PERIODIC_PATCH,
+    RECONNECT_PATCH,
+    setup_platform,
+)
 
 
-@pytest.mark.parametrize("expected_lingering_tasks", [True])
 async def test_sensor_entity_registry(hass: HomeAssistant) -> None:
     """Test the sensors are registered in entity registry."""
-    await setup_platform(hass)
-    entity_registry = er.async_get(hass)
-    for partition_id, partition_info in PARTITIONS.items():
-        partition_name = partition_info["name"]
-        entity_id = f"sensor.{slugify(partition_name)}_keypad"
-        entity = entity_registry.async_get(entity_id)
-        assert entity.unique_id == f"{partition_id}"
+    with patch(KEEP_ALIVE_PATCH, return_value=None), patch(
+        PERIODIC_PATCH, return_value=None
+    ), patch(RECONNECT_PATCH, return_value=None):
+        await setup_platform(hass)
+        entity_registry = er.async_get(hass)
+        for partition_id, partition_info in PARTITIONS.items():
+            partition_name = partition_info["name"]
+            entity_id = f"sensor.{slugify(partition_name)}_keypad"
+            entity = entity_registry.async_get(entity_id)
+            assert entity.unique_id == f"{partition_id}"

--- a/tests/components/envisalink/test_sensor.py
+++ b/tests/components/envisalink/test_sensor.py
@@ -1,0 +1,21 @@
+"""Tests for envisalink sensor."""
+
+import pytest
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.util import slugify
+
+from .common import PARTITIONS, setup_platform
+
+
+@pytest.mark.parametrize("expected_lingering_tasks", [True])
+async def test_sensor_entity_registry(hass: HomeAssistant) -> None:
+    """Test the sensors are registered in entity registry."""
+    await setup_platform(hass)
+    entity_registry = er.async_get(hass)
+    for partition_id, partition_info in PARTITIONS.items():
+        partition_name = partition_info["name"]
+        entity_id = f"sensor.{slugify(partition_name)}_keypad"
+        entity = entity_registry.async_get(entity_id)
+        assert entity.unique_id == f"envisalink-s-{partition_id}"


### PR DESCRIPTION
## Proposed change
Add unique id to all the entities created by the envisalink integration:
- alarm_control_panel
- sensor
- binary_sensor

This allows the user to move these entities into an approriate room.

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
