### PR TITLE
Add `silabs_multiprotocol` platform

### DIFF
--- a/homeassistant/components/homeassistant_hardware/silabs_multiprotocol_addon.py
+++ b/homeassistant/components/homeassistant_hardware/silabs_multiprotocol_addon.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 import asyncio
 import dataclasses
 import logging
-from typing import Any
+from typing import Any, Protocol
 
 import voluptuous as vol
 import yarl
@@ -19,12 +19,19 @@ from homeassistant.components.hassio import (
     hostname_from_addon_slug,
     is_hassio,
 )
-from homeassistant.components.zha import DOMAIN as ZHA_DOMAIN
-from homeassistant.components.zha.radio_manager import ZhaMultiPANMigrationHelper
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import AbortFlow, FlowResult
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.integration_platform import (
+    async_process_integration_platforms,
+)
+from homeassistant.helpers.selector import (
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+)
 from homeassistant.helpers.singleton import singleton
+from homeassistant.helpers.storage import Store
 
 from .const import LOGGER, SILABS_MULTIPROTOCOL_ADDON_SLUG
 
@@ -39,17 +46,132 @@ CONF_ADDON_AUTOFLASH_FW = "autoflash_firmware"
 CONF_ADDON_DEVICE = "device"
 CONF_ENABLE_MULTI_PAN = "enable_multi_pan"
 
+DEFAULT_CHANNEL = 15
+
+STORAGE_KEY = "homeassistant_hardware.silabs"
+STORAGE_VERSION_MAJOR = 1
+STORAGE_VERSION_MINOR = 1
+SAVE_DELAY = 10
+
 
 @singleton(DATA_ADDON_MANAGER)
-@callback
-def get_addon_manager(hass: HomeAssistant) -> AddonManager:
+async def get_addon_manager(hass: HomeAssistant) -> MultiprotocolAddonManager:
     """Get the add-on manager."""
-    return AddonManager(
-        hass,
-        LOGGER,
-        "Silicon Labs Multiprotocol",
-        SILABS_MULTIPROTOCOL_ADDON_SLUG,
-    )
+    manager = MultiprotocolAddonManager(hass)
+    await manager.async_setup()
+    return manager
+
+
+class MultiprotocolAddonManager(AddonManager):
+    """Silicon Labs Multiprotocol add-on manager."""
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize the manager."""
+        super().__init__(
+            hass,
+            LOGGER,
+            "Silicon Labs Multiprotocol",
+            SILABS_MULTIPROTOCOL_ADDON_SLUG,
+        )
+        self._channel: int | None = None
+        self._platforms: dict[str, MultipanProtocol] = {}
+        self._store: Store[dict[str, Any]] = Store(
+            hass,
+            STORAGE_VERSION_MAJOR,
+            STORAGE_KEY,
+            atomic_writes=True,
+            minor_version=STORAGE_VERSION_MINOR,
+        )
+
+    async def async_setup(self) -> None:
+        """Set up the manager."""
+        await async_process_integration_platforms(
+            self._hass, "silabs_multiprotocol", self._register_multipan_platform
+        )
+        await self.async_load()
+
+    async def _register_multipan_platform(
+        self, hass: HomeAssistant, integration_domain: str, platform: MultipanProtocol
+    ) -> None:
+        """Register a multipan platform."""
+        self._platforms[integration_domain] = platform
+        if self._channel is not None or not await platform.async_using_multipan(hass):
+            return
+
+        new_channel = await platform.async_get_channel(hass)
+        if new_channel is None:
+            return
+
+        _LOGGER.info(
+            "Setting multipan channel to %s (source: '%s')",
+            new_channel,
+            integration_domain,
+        )
+        self.async_set_channel(new_channel)
+
+    async def async_change_channel(self, channel: int) -> None:
+        """Change the channel and notify platforms."""
+        self.async_set_channel(channel)
+
+        for platform in self._platforms.values():
+            if not await platform.async_using_multipan(self._hass):
+                continue
+            await platform.async_change_channel(self._hass, channel)
+
+    @callback
+    def async_get_channel(self) -> int | None:
+        """Get the channel."""
+        return self._channel
+
+    @callback
+    def async_set_channel(self, channel: int) -> None:
+        """Set the channel without notifying platforms.
+
+        This must only be called when first initializing the manager.
+        """
+        self._channel = channel
+        self.async_schedule_save()
+
+    async def async_load(self) -> None:
+        """Load the store."""
+        data = await self._store.async_load()
+
+        if data is not None:
+            self._channel = data["channel"]
+
+    @callback
+    def async_schedule_save(self) -> None:
+        """Schedule saving the store."""
+        self._store.async_delay_save(self._data_to_save, SAVE_DELAY)
+
+    @callback
+    def _data_to_save(self) -> dict[str, list[dict[str, str | None]]]:
+        """Return data to store in a file."""
+        data: dict[str, Any] = {}
+        data["channel"] = self._channel
+        return data
+
+
+class MultipanProtocol(Protocol):
+    """Define the format of multipan platforms."""
+
+    async def async_change_channel(self, hass: HomeAssistant, channel: int) -> None:
+        """Set the channel to be used.
+
+        Does nothing if not configured or the multiprotocol add-on is not used.
+        """
+
+    async def async_get_channel(self, hass: HomeAssistant) -> int | None:
+        """Return the channel.
+
+        Returns None if not configured or the multiprotocol add-on is not used.
+        """
+
+    async def async_using_multipan(self, hass: HomeAssistant) -> bool:
+        """Return if the multiprotocol device is used.
+
+        Returns False if not configured.
+        """
 
 
 @dataclasses.dataclass
@@ -82,6 +204,11 @@ class OptionsFlowHandler(config_entries.OptionsFlow, ABC):
 
     def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
         """Set up the options flow."""
+        # pylint: disable-next=import-outside-toplevel
+        from homeassistant.components.zha.radio_manager import (
+            ZhaMultiPANMigrationHelper,
+        )
+
         # If we install the add-on we should uninstall it on entry remove.
         self.install_task: asyncio.Task | None = None
         self.start_task: asyncio.Task | None = None
@@ -117,7 +244,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow, ABC):
 
     async def _async_get_addon_info(self) -> AddonInfo:
         """Return and cache Silicon Labs Multiprotocol add-on info."""
-        addon_manager: AddonManager = get_addon_manager(self.hass)
+        addon_manager: AddonManager = await get_addon_manager(self.hass)
         try:
             addon_info: AddonInfo = await addon_manager.async_get_addon_info()
         except AddonError as err:
@@ -128,7 +255,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow, ABC):
 
     async def _async_set_addon_config(self, config: dict) -> None:
         """Set Silicon Labs Multiprotocol add-on config."""
-        addon_manager: AddonManager = get_addon_manager(self.hass)
+        addon_manager: AddonManager = await get_addon_manager(self.hass)
         try:
             await addon_manager.async_set_addon_options(config)
         except AddonError as err:
@@ -137,7 +264,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow, ABC):
 
     async def _async_install_addon(self) -> None:
         """Install the Silicon Labs Multiprotocol add-on."""
-        addon_manager: AddonManager = get_addon_manager(self.hass)
+        addon_manager: AddonManager = await get_addon_manager(self.hass)
         try:
             await addon_manager.async_schedule_install_addon()
         finally:
@@ -213,6 +340,19 @@ class OptionsFlowHandler(config_entries.OptionsFlow, ABC):
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Configure the Silicon Labs Multiprotocol add-on."""
+        # pylint: disable-next=import-outside-toplevel
+        from homeassistant.components.zha import DOMAIN as ZHA_DOMAIN
+
+        # pylint: disable-next=import-outside-toplevel
+        from homeassistant.components.zha.radio_manager import (
+            ZhaMultiPANMigrationHelper,
+        )
+
+        # pylint: disable-next=import-outside-toplevel
+        from homeassistant.components.zha.silabs_multiprotocol import (
+            async_get_channel as async_get_zha_channel,
+        )
+
         addon_info = await self._async_get_addon_info()
 
         addon_config = addon_info.options
@@ -223,6 +363,8 @@ class OptionsFlowHandler(config_entries.OptionsFlow, ABC):
             CONF_ADDON_AUTOFLASH_FW: True,
             **dataclasses.asdict(serial_port_settings),
         }
+
+        multipan_channel = DEFAULT_CHANNEL
 
         # Initiate ZHA migration
         zha_entries = self.hass.config_entries.async_entries(ZHA_DOMAIN)
@@ -246,6 +388,13 @@ class OptionsFlowHandler(config_entries.OptionsFlow, ABC):
             except Exception as err:
                 _LOGGER.exception("Unexpected exception during ZHA migration")
                 raise AbortFlow("zha_migration_failed") from err
+
+            if (zha_channel := await async_get_zha_channel(self.hass)) is not None:
+                multipan_channel = zha_channel
+
+        # Initialize the shared channel
+        multipan_manager = await get_addon_manager(self.hass)
+        multipan_manager.async_set_channel(multipan_channel)
 
         if new_addon_config != addon_config:
             # Copy the add-on config to keep the objects separate.
@@ -283,7 +432,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow, ABC):
 
     async def _async_start_addon(self) -> None:
         """Start Silicon Labs Multiprotocol add-on."""
-        addon_manager: AddonManager = get_addon_manager(self.hass)
+        addon_manager: AddonManager = await get_addon_manager(self.hass)
         try:
             await addon_manager.async_schedule_start_addon()
         finally:
@@ -319,8 +468,57 @@ class OptionsFlowHandler(config_entries.OptionsFlow, ABC):
 
         serial_device = (await self._async_serial_port_settings()).device
         if addon_info.options.get(CONF_ADDON_DEVICE) == serial_device:
-            return await self.async_step_show_revert_guide()
+            return await self.async_step_show_addon_menu()
         return await self.async_step_addon_installed_other_device()
+
+    async def async_step_show_addon_menu(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Show menu options for the addon."""
+        return self.async_show_menu(
+            step_id="addon_menu",
+            menu_options=[
+                "reconfigure_addon",
+                "uninstall_addon",
+            ],
+        )
+
+    async def async_step_reconfigure_addon(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Reconfigure the addon."""
+        multipan_manager = await get_addon_manager(self.hass)
+
+        if user_input is None:
+            channels = [str(x) for x in range(11, 27)]
+            suggested_channel = DEFAULT_CHANNEL
+            if (channel := multipan_manager.async_get_channel()) is not None:
+                suggested_channel = channel
+            data_schema = vol.Schema(
+                {
+                    vol.Required(
+                        "channel",
+                        description={"suggested_value": str(suggested_channel)},
+                    ): SelectSelector(
+                        SelectSelectorConfig(
+                            options=channels, mode=SelectSelectorMode.DROPDOWN
+                        )
+                    )
+                }
+            )
+            return self.async_show_form(
+                step_id="reconfigure_addon", data_schema=data_schema
+            )
+
+        # Change the shared channel
+        await multipan_manager.async_change_channel(int(user_input["channel"]))
+        return self.async_create_entry(title="", data={})
+
+    async def async_step_uninstall_addon(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Uninstall the addon (not implemented)."""
+        return await self.async_step_show_revert_guide()
 
     async def async_step_show_revert_guide(
         self, user_input: dict[str, Any] | None = None
@@ -348,7 +546,7 @@ async def check_multi_pan_addon(hass: HomeAssistant) -> None:
     if not is_hassio(hass):
         return
 
-    addon_manager: AddonManager = get_addon_manager(hass)
+    addon_manager: AddonManager = await get_addon_manager(hass)
     try:
         addon_info: AddonInfo = await addon_manager.async_get_addon_info()
     except AddonError as err:
@@ -375,7 +573,7 @@ async def multi_pan_addon_using_device(hass: HomeAssistant, device_path: str) ->
     if not is_hassio(hass):
         return False
 
-    addon_manager: AddonManager = get_addon_manager(hass)
+    addon_manager: AddonManager = await get_addon_manager(hass)
     addon_info: AddonInfo = await addon_manager.async_get_addon_info()
 
     if addon_info.state != AddonState.RUNNING:

--- a/homeassistant/components/homeassistant_hardware/silabs_multiprotocol_addon.py
+++ b/homeassistant/components/homeassistant_hardware/silabs_multiprotocol_addon.py
@@ -111,7 +111,7 @@ class MultiprotocolAddonManager(AddonManager):
         self.async_set_channel(new_channel)
 
     async def async_change_channel(
-        self, channel: int, delay: float = DEFAULT_CHANNEL_CHANGE_DELAY
+        self, channel: int, delay: float
     ) -> list[asyncio.Task]:
         """Change the channel and notify platforms."""
         self.async_set_channel(channel)
@@ -523,7 +523,22 @@ class OptionsFlowHandler(config_entries.OptionsFlow, ABC):
             )
 
         # Change the shared channel
-        await multipan_manager.async_change_channel(int(user_input["channel"]))
+        await multipan_manager.async_change_channel(
+            int(user_input["channel"]), DEFAULT_CHANNEL_CHANGE_DELAY
+        )
+        return await self.async_step_notify_channel_change()
+
+    async def async_step_notify_channel_change(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Notify that the channel change will take about five minutes."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="notify_channel_change",
+                description_placeholders={
+                    "delay_minutes": str(DEFAULT_CHANNEL_CHANGE_DELAY // 60)
+                },
+            )
         return self.async_create_entry(title="", data={})
 
     async def async_step_uninstall_addon(

--- a/homeassistant/components/homeassistant_hardware/silabs_multiprotocol_addon.py
+++ b/homeassistant/components/homeassistant_hardware/silabs_multiprotocol_addon.py
@@ -47,6 +47,7 @@ CONF_ADDON_DEVICE = "device"
 CONF_ENABLE_MULTI_PAN = "enable_multi_pan"
 
 DEFAULT_CHANNEL = 15
+DEFAULT_CHANNEL_CHANGE_DELAY = 5 * 60  # Thread recommendation
 
 STORAGE_KEY = "homeassistant_hardware.silabs"
 STORAGE_VERSION_MAJOR = 1
@@ -109,14 +110,16 @@ class MultiprotocolAddonManager(AddonManager):
         )
         self.async_set_channel(new_channel)
 
-    async def async_change_channel(self, channel: int) -> None:
+    async def async_change_channel(
+        self, channel: int, delay: float = DEFAULT_CHANNEL_CHANGE_DELAY
+    ) -> None:
         """Change the channel and notify platforms."""
         self.async_set_channel(channel)
 
         for platform in self._platforms.values():
             if not await platform.async_using_multipan(self._hass):
                 continue
-            await platform.async_change_channel(self._hass, channel)
+            await platform.async_change_channel(self._hass, channel, delay)
 
     @callback
     def async_get_channel(self) -> int | None:
@@ -155,7 +158,9 @@ class MultiprotocolAddonManager(AddonManager):
 class MultipanProtocol(Protocol):
     """Define the format of multipan platforms."""
 
-    async def async_change_channel(self, hass: HomeAssistant, channel: int) -> None:
+    async def async_change_channel(
+        self, hass: HomeAssistant, channel: int, delay: float
+    ) -> None:
         """Set the channel to be used.
 
         Does nothing if not configured or the multiprotocol add-on is not used.

--- a/homeassistant/components/homeassistant_hardware/strings.json
+++ b/homeassistant/components/homeassistant_hardware/strings.json
@@ -12,8 +12,20 @@
         "addon_installed_other_device": {
           "title": "Multiprotocol support is already enabled for another device"
         },
+        "addon_menu": {
+          "menu_options": {
+            "reconfigure_addon": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::reconfigure_addon::title%]",
+            "uninstall_addon": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::uninstall_addon::title%]"
+          }
+        },
         "install_addon": {
           "title": "The Silicon Labs Multiprotocol add-on installation has started"
+        },
+        "reconfigure_addon": {
+          "title": "Reconfigure IEEE 802.15.4 radio multiprotocol support",
+          "data": {
+            "channel": "Channel"
+          }
         },
         "show_revert_guide": {
           "title": "Multiprotocol support is enabled for this device",
@@ -21,6 +33,9 @@
         },
         "start_addon": {
           "title": "The Silicon Labs Multiprotocol add-on is starting."
+        },
+        "uninstall_addon": {
+          "title": "Remove IEEE 802.15.4 radio multiprotocol support."
         }
       },
       "error": {

--- a/homeassistant/components/homeassistant_hardware/strings.json
+++ b/homeassistant/components/homeassistant_hardware/strings.json
@@ -21,6 +21,10 @@
         "install_addon": {
           "title": "The Silicon Labs Multiprotocol add-on installation has started"
         },
+        "notify_channel_change": {
+          "title": "Channel change initiated",
+          "description": "A Zigbee and Thread channel change has been initiated and will finish in {delay_minutes} minutes."
+        },
         "reconfigure_addon": {
           "title": "Reconfigure IEEE 802.15.4 radio multiprotocol support",
           "data": {

--- a/homeassistant/components/homeassistant_sky_connect/strings.json
+++ b/homeassistant/components/homeassistant_sky_connect/strings.json
@@ -11,8 +11,20 @@
       "addon_installed_other_device": {
         "title": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::addon_installed_other_device::title%]"
       },
+      "addon_menu": {
+        "menu_options": {
+          "reconfigure_addon": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::addon_menu::menu_options::reconfigure_addon%]",
+          "uninstall_addon": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::addon_menu::menu_options::uninstall_addon%]"
+        }
+      },
       "install_addon": {
         "title": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::install_addon::title%]"
+      },
+      "reconfigure_addon": {
+        "title": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::reconfigure_addon::title%]",
+        "data": {
+          "channel": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::reconfigure_addon::data::channel%]"
+        }
       },
       "show_revert_guide": {
         "title": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::show_revert_guide::title%]",
@@ -20,6 +32,9 @@
       },
       "start_addon": {
         "title": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::start_addon::title%]"
+      },
+      "uninstall_addon": {
+        "title": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::uninstall_addon::title%]"
       }
     },
     "error": {

--- a/homeassistant/components/homeassistant_sky_connect/strings.json
+++ b/homeassistant/components/homeassistant_sky_connect/strings.json
@@ -20,6 +20,10 @@
       "install_addon": {
         "title": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::install_addon::title%]"
       },
+      "notify_channel_change": {
+        "title": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::notify_channel_change::title%]",
+        "description": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::notify_channel_change::description%]"
+      },
       "reconfigure_addon": {
         "title": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::reconfigure_addon::title%]",
         "data": {

--- a/homeassistant/components/homeassistant_yellow/strings.json
+++ b/homeassistant/components/homeassistant_yellow/strings.json
@@ -11,6 +11,12 @@
       "addon_installed_other_device": {
         "title": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::addon_installed_other_device::title%]"
       },
+      "addon_menu": {
+        "menu_options": {
+          "reconfigure_addon": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::addon_menu::menu_options::reconfigure_addon%]",
+          "uninstall_addon": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::addon_menu::menu_options::uninstall_addon%]"
+        }
+      },
       "hardware_settings": {
         "title": "Configure hardware settings",
         "data": {
@@ -36,12 +42,21 @@
           "reboot_now": "Reboot now"
         }
       },
+      "reconfigure_addon": {
+        "title": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::reconfigure_addon::title%]",
+        "data": {
+          "channel": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::reconfigure_addon::data::channel%]"
+        }
+      },
       "show_revert_guide": {
         "title": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::show_revert_guide::title%]",
         "description": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::show_revert_guide::description%]"
       },
       "start_addon": {
         "title": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::start_addon::title%]"
+      },
+      "uninstall_addon": {
+        "title": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::uninstall_addon::title%]"
       }
     },
     "error": {

--- a/homeassistant/components/homeassistant_yellow/strings.json
+++ b/homeassistant/components/homeassistant_yellow/strings.json
@@ -28,6 +28,10 @@
       "install_addon": {
         "title": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::install_addon::title%]"
       },
+      "notify_channel_change": {
+        "title": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::notify_channel_change::title%]",
+        "description": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::notify_channel_change::description%]"
+      },
       "main_menu": {
         "menu_options": {
           "hardware_settings": "[%key:component::homeassistant_yellow::options::step::hardware_settings::title%]",

--- a/homeassistant/components/otbr/silabs_multiprotocol.py
+++ b/homeassistant/components/otbr/silabs_multiprotocol.py
@@ -1,0 +1,69 @@
+"""Silicon Labs Multiprotocol support."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import aiohttp
+
+from homeassistant.components.homeassistant_hardware.silabs_multiprotocol_addon import (
+    is_multiprotocol_url,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+
+from . import DOMAIN
+from .util import OTBRData
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_change_channel(hass: HomeAssistant, channel: int) -> None:
+    """Set the channel to be used.
+
+    Does nothing if not configured.
+    """
+    if DOMAIN not in hass.data:
+        return
+
+    data: OTBRData = hass.data[DOMAIN]
+    await data.set_channel(channel)
+
+
+async def async_get_channel(hass: HomeAssistant) -> int | None:
+    """Return the channel.
+
+    Returns None if not configured.
+    """
+    if DOMAIN not in hass.data:
+        return None
+
+    data: OTBRData = hass.data[DOMAIN]
+
+    try:
+        dataset = await data.get_active_dataset()
+    except (
+        HomeAssistantError,
+        aiohttp.ClientError,
+        asyncio.TimeoutError,
+    ) as err:
+        _LOGGER.warning("Failed to communicate with OTBR %s", err)
+        return None
+
+    if dataset is None:
+        return None
+
+    return dataset.channel
+
+
+async def async_using_multipan(hass: HomeAssistant) -> bool:
+    """Return if the multiprotocol device is used.
+
+    Returns False if not configured.
+    """
+    if DOMAIN not in hass.data:
+        return False
+
+    data: OTBRData = hass.data[DOMAIN]
+    return is_multiprotocol_url(data.url)

--- a/homeassistant/components/otbr/silabs_multiprotocol.py
+++ b/homeassistant/components/otbr/silabs_multiprotocol.py
@@ -6,10 +6,13 @@ import asyncio
 import logging
 
 import aiohttp
+from python_otbr_api import tlv_parser
+from python_otbr_api.tlv_parser import MeshcopTLVType
 
 from homeassistant.components.homeassistant_hardware.silabs_multiprotocol_addon import (
     is_multiprotocol_url,
 )
+from homeassistant.components.thread import async_add_dataset
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 
@@ -29,6 +32,21 @@ async def async_change_channel(hass: HomeAssistant, channel: int, delay: float) 
 
     data: OTBRData = hass.data[DOMAIN]
     await data.set_channel(channel, delay)
+
+    # Import the new dataset
+    dataset_tlvs = await data.get_pending_dataset_tlvs()
+    if dataset_tlvs is None:
+        # The activation timer may have expired already
+        dataset_tlvs = await data.get_active_dataset_tlvs()
+    if dataset_tlvs is None:
+        # Don't try to import a None dataset
+        return
+
+    dataset = tlv_parser.parse_tlv(dataset_tlvs.hex())
+    dataset.pop(MeshcopTLVType.DELAYTIMER, None)
+    dataset.pop(MeshcopTLVType.PENDINGTIMESTAMP, None)
+    dataset_tlvs_str = tlv_parser.encode_tlv(dataset)
+    await async_add_dataset(hass, DOMAIN, dataset_tlvs_str)
 
 
 async def async_get_channel(hass: HomeAssistant) -> int | None:

--- a/homeassistant/components/otbr/silabs_multiprotocol.py
+++ b/homeassistant/components/otbr/silabs_multiprotocol.py
@@ -19,7 +19,7 @@ from .util import OTBRData
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_change_channel(hass: HomeAssistant, channel: int) -> None:
+async def async_change_channel(hass: HomeAssistant, channel: int, delay: float) -> None:
     """Set the channel to be used.
 
     Does nothing if not configured.
@@ -28,7 +28,7 @@ async def async_change_channel(hass: HomeAssistant, channel: int) -> None:
         return
 
     data: OTBRData = hass.data[DOMAIN]
-    await data.set_channel(channel)
+    await data.set_channel(channel, delay)
 
 
 async def async_get_channel(hass: HomeAssistant) -> int | None:

--- a/homeassistant/components/otbr/util.py
+++ b/homeassistant/components/otbr/util.py
@@ -84,6 +84,11 @@ class OTBRData:
         return await self.api.get_active_dataset_tlvs()
 
     @_handle_otbr_error
+    async def get_pending_dataset_tlvs(self) -> bytes | None:
+        """Get current pending operational dataset in TLVS format, or None."""
+        return await self.api.get_pending_dataset_tlvs()
+
+    @_handle_otbr_error
     async def create_active_dataset(
         self, dataset: python_otbr_api.ActiveDataSet
     ) -> None:

--- a/homeassistant/components/otbr/util.py
+++ b/homeassistant/components/otbr/util.py
@@ -7,7 +7,7 @@ from functools import wraps
 from typing import Any, Concatenate, ParamSpec, TypeVar, cast
 
 import python_otbr_api
-from python_otbr_api import tlv_parser
+from python_otbr_api import PENDING_DATASET_DELAY_TIMER, tlv_parser
 from python_otbr_api.pskc import compute_pskc
 from python_otbr_api.tlv_parser import MeshcopTLVType
 
@@ -96,9 +96,11 @@ class OTBRData:
         await self.api.set_active_dataset_tlvs(dataset)
 
     @_handle_otbr_error
-    async def set_channel(self, channel: int) -> None:
-        """Set current active operational dataset in TLVS format."""
-        await self.api.set_channel(channel)
+    async def set_channel(
+        self, channel: int, delay: float = PENDING_DATASET_DELAY_TIMER / 1000
+    ) -> None:
+        """Set current channel."""
+        await self.api.set_channel(channel, delay=int(delay * 1000))
 
     @_handle_otbr_error
     async def get_extended_address(self) -> bytes:

--- a/homeassistant/components/otbr/util.py
+++ b/homeassistant/components/otbr/util.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Coroutine
-import contextlib
 import dataclasses
 from functools import wraps
 from typing import Any, Concatenate, ParamSpec, TypeVar, cast
@@ -13,11 +12,12 @@ from python_otbr_api.pskc import compute_pskc
 from python_otbr_api.tlv_parser import MeshcopTLVType
 
 from homeassistant.components.homeassistant_hardware.silabs_multiprotocol_addon import (
+    MultiprotocolAddonManager,
+    get_addon_manager,
     is_multiprotocol_url,
     multi_pan_addon_using_device,
 )
 from homeassistant.components.homeassistant_yellow import RADIO_DEVICE as YELLOW_RADIO
-from homeassistant.components.zha import api as zha_api
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import issue_registry as ir
@@ -74,6 +74,11 @@ class OTBRData:
         return await self.api.set_enabled(enabled)
 
     @_handle_otbr_error
+    async def get_active_dataset(self) -> python_otbr_api.ActiveDataSet | None:
+        """Get current active operational dataset, or None."""
+        return await self.api.get_active_dataset()
+
+    @_handle_otbr_error
     async def get_active_dataset_tlvs(self) -> bytes | None:
         """Get current active operational dataset in TLVS format, or None."""
         return await self.api.get_active_dataset_tlvs()
@@ -91,28 +96,14 @@ class OTBRData:
         await self.api.set_active_dataset_tlvs(dataset)
 
     @_handle_otbr_error
+    async def set_channel(self, channel: int) -> None:
+        """Set current active operational dataset in TLVS format."""
+        await self.api.set_channel(channel)
+
+    @_handle_otbr_error
     async def get_extended_address(self) -> bytes:
         """Get extended address (EUI-64)."""
         return await self.api.get_extended_address()
-
-
-def _get_zha_url(hass: HomeAssistant) -> str | None:
-    """Get ZHA radio path, or None if there's no ZHA config entry."""
-    with contextlib.suppress(ValueError):
-        return zha_api.async_get_radio_path(hass)
-    return None
-
-
-async def _get_zha_channel(hass: HomeAssistant) -> int | None:
-    """Get ZHA channel, or None if there's no ZHA config entry."""
-    zha_network_settings: zha_api.NetworkBackup | None
-    with contextlib.suppress(ValueError):
-        zha_network_settings = await zha_api.async_get_network_settings(hass)
-    if not zha_network_settings:
-        return None
-    channel: int = zha_network_settings.network_info.channel
-    # ZHA uses channel 0 when no channel is set
-    return channel or None
 
 
 async def get_allowed_channel(hass: HomeAssistant, otbr_url: str) -> int | None:
@@ -121,12 +112,8 @@ async def get_allowed_channel(hass: HomeAssistant, otbr_url: str) -> int | None:
         # The OTBR is not sharing the radio, no restriction
         return None
 
-    zha_url = _get_zha_url(hass)
-    if not zha_url or not is_multiprotocol_url(zha_url):
-        # ZHA is not configured or not sharing the radio with this OTBR, no restriction
-        return None
-
-    return await _get_zha_channel(hass)
+    addon_manager: MultiprotocolAddonManager = await get_addon_manager(hass)
+    return addon_manager.async_get_channel()
 
 
 async def _warn_on_channel_collision(

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -96,7 +96,7 @@ async def list_serial_ports(hass: HomeAssistant) -> list[ListPortInfo]:
         yellow_radio.manufacturer = "Nabu Casa"
 
     # Present the multi-PAN addon as a setup option, if it's available
-    addon_manager = silabs_multiprotocol_addon.get_addon_manager(hass)
+    addon_manager = await silabs_multiprotocol_addon.get_addon_manager(hass)
 
     try:
         addon_info = await addon_manager.async_get_addon_info()

--- a/homeassistant/components/zha/silabs_multiprotocol.py
+++ b/homeassistant/components/zha/silabs_multiprotocol.py
@@ -1,0 +1,70 @@
+"""Silicon Labs Multiprotocol support."""
+
+from __future__ import annotations
+
+import contextlib
+
+from homeassistant.components.homeassistant_hardware.silabs_multiprotocol_addon import (
+    is_multiprotocol_url,
+)
+from homeassistant.core import HomeAssistant
+
+from . import api
+
+
+def _get_zha_url(hass: HomeAssistant) -> str | None:
+    """Return the ZHA radio path, or None if there's no ZHA config entry."""
+    with contextlib.suppress(ValueError):
+        return api.async_get_radio_path(hass)
+    return None
+
+
+async def _get_zha_channel(hass: HomeAssistant) -> int | None:
+    """Get ZHA channel, or None if there's no ZHA config entry."""
+    zha_network_settings: api.NetworkBackup | None
+    with contextlib.suppress(ValueError):
+        zha_network_settings = await api.async_get_network_settings(hass)
+    if not zha_network_settings:
+        return None
+    channel: int = zha_network_settings.network_info.channel
+    # ZHA uses channel 0 when no channel is set
+    return channel or None
+
+
+async def async_change_channel(hass: HomeAssistant, channel: int) -> None:
+    """Set the channel to be used.
+
+    Does nothing if not configured.
+    """
+    zha_url = _get_zha_url(hass)
+    if not zha_url:
+        # ZHA is not configured
+        return None
+
+    return await api.async_change_channel(hass, channel)
+
+
+async def async_get_channel(hass: HomeAssistant) -> int | None:
+    """Return the channel.
+
+    Returns None if not configured.
+    """
+    zha_url = _get_zha_url(hass)
+    if not zha_url:
+        # ZHA is not configured
+        return None
+
+    return await _get_zha_channel(hass)
+
+
+async def async_using_multipan(hass: HomeAssistant) -> bool:
+    """Return if the multiprotocol device is used.
+
+    Returns False if not configured.
+    """
+    zha_url = _get_zha_url(hass)
+    if not zha_url:
+        # ZHA is not configured
+        return False
+
+    return is_multiprotocol_url(zha_url)

--- a/homeassistant/components/zha/silabs_multiprotocol.py
+++ b/homeassistant/components/zha/silabs_multiprotocol.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 
 from homeassistant.components.homeassistant_hardware.silabs_multiprotocol_addon import (
@@ -10,6 +11,9 @@ from homeassistant.components.homeassistant_hardware.silabs_multiprotocol_addon 
 from homeassistant.core import HomeAssistant
 
 from . import api
+
+# The approximate time it takes ZHA to change channels on SiLabs coordinators
+ZHA_CHANNEL_CHANGE_TIME_S = 10.27
 
 
 def _get_zha_url(hass: HomeAssistant) -> str | None:
@@ -31,7 +35,9 @@ async def _get_zha_channel(hass: HomeAssistant) -> int | None:
     return channel or None
 
 
-async def async_change_channel(hass: HomeAssistant, channel: int) -> None:
+async def async_change_channel(
+    hass: HomeAssistant, channel: int, delay: float = 0
+) -> None:
     """Set the channel to be used.
 
     Does nothing if not configured.
@@ -40,6 +46,8 @@ async def async_change_channel(hass: HomeAssistant, channel: int) -> None:
     if not zha_url:
         # ZHA is not configured
         return None
+
+    await asyncio.sleep(max(0, delay - ZHA_CHANNEL_CHANGE_TIME_S))
 
     return await api.async_change_channel(hass, channel)
 

--- a/homeassistant/components/zha/silabs_multiprotocol.py
+++ b/homeassistant/components/zha/silabs_multiprotocol.py
@@ -37,7 +37,7 @@ async def _get_zha_channel(hass: HomeAssistant) -> int | None:
 
 async def async_change_channel(
     hass: HomeAssistant, channel: int, delay: float = 0
-) -> None:
+) -> asyncio.Task | None:
     """Set the channel to be used.
 
     Does nothing if not configured.
@@ -47,9 +47,12 @@ async def async_change_channel(
         # ZHA is not configured
         return None
 
-    await asyncio.sleep(max(0, delay - ZHA_CHANNEL_CHANGE_TIME_S))
+    async def finish_migration() -> None:
+        """Finish the channel migration."""
+        await asyncio.sleep(max(0, delay - ZHA_CHANNEL_CHANGE_TIME_S))
+        return await api.async_change_channel(hass, channel)
 
-    return await api.async_change_channel(hass, channel)
+    return hass.async_create_task(finish_migration())
 
 
 async def async_get_channel(hass: HomeAssistant) -> int | None:

--- a/tests/components/homeassistant_hardware/conftest.py
+++ b/tests/components/homeassistant_hardware/conftest.py
@@ -1,7 +1,7 @@
 """Test fixtures for the Home Assistant Hardware integration."""
 from collections.abc import Generator
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -28,6 +28,17 @@ def mock_zha_config_flow_setup() -> Generator[None, None, None]:
     ), patch(
         "homeassistant.components.zha.async_setup_entry",
         return_value=True,
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def mock_zha_get_last_network_settings() -> Generator[None, None, None]:
+    """Mock zha.api.async_get_last_network_settings."""
+
+    with patch(
+        "homeassistant.components.zha.api.async_get_last_network_settings",
+        AsyncMock(return_value=None),
     ):
         yield
 

--- a/tests/components/homeassistant_hardware/test_silabs_multiprotocol_addon.py
+++ b/tests/components/homeassistant_hardware/test_silabs_multiprotocol_addon.py
@@ -11,12 +11,16 @@ from homeassistant.components.hassio.handler import HassioAPIError
 from homeassistant.components.homeassistant_hardware import silabs_multiprotocol_addon
 from homeassistant.components.zha.core.const import DOMAIN as ZHA_DOMAIN
 from homeassistant.config_entries import ConfigEntry, ConfigFlow
+from homeassistant.const import EVENT_COMPONENT_LOADED
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult, FlowResultType
+from homeassistant.setup import ATTR_COMPONENT
 
 from tests.common import (
     MockConfigEntry,
     MockModule,
+    MockPlatform,
+    flush_store,
     mock_config_flow,
     mock_integration,
     mock_platform,
@@ -94,6 +98,52 @@ def config_flow_handler(
     mock_platform(hass, f"{TEST_DOMAIN}.config_flow")
     with mock_config_flow(TEST_DOMAIN, FakeConfigFlow):
         yield
+
+
+class MockMultiprotocolPlatform(MockPlatform):
+    """A mock multiprotocol platform."""
+
+    channel = 15
+    using_multipan = True
+
+    def __init__(self, **kwargs: Any) -> None:
+        """Initialize."""
+        super().__init__(**kwargs)
+        self.change_channel_calls = []
+
+    async def async_change_channel(self, hass: HomeAssistant, channel: int) -> None:
+        """Set the channel to be used."""
+        self.change_channel_calls.append(channel)
+
+    async def async_get_channel(self, hass: HomeAssistant) -> int | None:
+        """Return the channel."""
+        return self.channel
+
+    async def async_using_multipan(self, hass: HomeAssistant) -> bool:
+        """Return if the multiprotocol device is used."""
+        return self.using_multipan
+
+
+@pytest.fixture
+def mock_multiprotocol_platform(
+    hass: HomeAssistant,
+) -> Generator[FakeConfigFlow, None, None]:
+    """Fixture for a test silabs multiprotocol platform."""
+    hass.config.components.add(TEST_DOMAIN)
+    platform = MockMultiprotocolPlatform()
+    mock_platform(hass, f"{TEST_DOMAIN}.silabs_multiprotocol", platform)
+    return platform
+
+
+def get_suggested(schema, key):
+    """Get suggested value for key in voluptuous schema."""
+    for k in schema:
+        if k == key:
+            if k.description is None or "suggested_value" not in k.description:
+                return None
+            return k.description["suggested_value"]
+    # Wanted key absent from schema
+    raise Exception
 
 
 async def test_option_flow_install_multi_pan_addon(
@@ -215,7 +265,13 @@ async def test_option_flow_install_multi_pan_addon_zha(
     assert result["step_id"] == "configure_addon"
     install_addon.assert_called_once_with(hass, "core_silabs_multiprotocol")
 
-    result = await hass.config_entries.options.async_configure(result["flow_id"])
+    multipan_manager = await silabs_multiprotocol_addon.get_addon_manager(hass)
+    assert multipan_manager._channel is None
+    with patch(
+        "homeassistant.components.zha.silabs_multiprotocol.async_get_channel",
+        return_value=11,
+    ):
+        result = await hass.config_entries.options.async_configure(result["flow_id"])
     assert result["type"] == FlowResultType.SHOW_PROGRESS
     assert result["step_id"] == "start_addon"
     set_addon_options.assert_called_once_with(
@@ -230,6 +286,8 @@ async def test_option_flow_install_multi_pan_addon_zha(
             }
         },
     )
+    # Check the channel is initialized from ZHA
+    assert multipan_manager._channel == 11
     # Check the ZHA config entry data is updated
     assert zha_config_entry.data == {
         "device": {
@@ -393,7 +451,59 @@ async def test_option_flow_addon_installed_other_device(
     assert result["type"] == FlowResultType.CREATE_ENTRY
 
 
-async def test_option_flow_addon_installed_same_device(
+@pytest.mark.parametrize(
+    ("configured_channel", "suggested_channel"), [(None, "15"), (11, "11")]
+)
+async def test_option_flow_addon_installed_same_device_reconfigure(
+    hass: HomeAssistant,
+    addon_info,
+    addon_store_info,
+    addon_installed,
+    mock_multiprotocol_platform: MockMultiprotocolPlatform,
+    configured_channel: int | None,
+    suggested_channel: int,
+) -> None:
+    """Test installing the multi pan addon."""
+    mock_integration(hass, MockModule("hassio"))
+    addon_info.return_value["options"]["device"] = "/dev/ttyTEST123"
+
+    multipan_manager = await silabs_multiprotocol_addon.get_addon_manager(hass)
+    multipan_manager._channel = configured_channel
+
+    # Setup the config entry
+    config_entry = MockConfigEntry(
+        data={},
+        domain=TEST_DOMAIN,
+        options={},
+        title="Test HW",
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.homeassistant_hardware.silabs_multiprotocol_addon.is_hassio",
+        side_effect=Mock(return_value=True),
+    ):
+        result = await hass.config_entries.options.async_init(config_entry.entry_id)
+        assert result["type"] == FlowResultType.MENU
+        assert result["step_id"] == "addon_menu"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {"next_step_id": "reconfigure_addon"},
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "reconfigure_addon"
+    assert get_suggested(result["data_schema"].schema, "channel") == suggested_channel
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], {"channel": "14"}
+    )
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+
+    assert mock_multiprotocol_platform.change_channel_calls == [14]
+
+
+async def test_option_flow_addon_installed_same_device_uninstall(
     hass: HomeAssistant,
     addon_info,
     addon_store_info,
@@ -417,8 +527,15 @@ async def test_option_flow_addon_installed_same_device(
         side_effect=Mock(return_value=True),
     ):
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
-        assert result["type"] == FlowResultType.FORM
-        assert result["step_id"] == "show_revert_guide"
+        assert result["type"] == FlowResultType.MENU
+        assert result["step_id"] == "addon_menu"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {"next_step_id": "uninstall_addon"},
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "show_revert_guide"
 
     result = await hass.config_entries.options.async_configure(result["flow_id"], {})
     assert result["type"] == FlowResultType.CREATE_ENTRY
@@ -806,3 +923,80 @@ def test_is_multiprotocol_url() -> None:
         "http://core-silabs-multiprotocol:8081"
     )
     assert not silabs_multiprotocol_addon.is_multiprotocol_url("/dev/ttyAMA1")
+
+
+@pytest.mark.parametrize(
+    (
+        "initial_multipan_channel",
+        "platform_using_multipan",
+        "platform_channel",
+        "new_multipan_channel",
+    ),
+    [
+        (None, True, 15, 15),
+        (None, False, 15, None),
+        (11, True, 15, 11),
+        (None, True, None, None),
+    ],
+)
+async def test_import_channel(
+    hass: HomeAssistant,
+    initial_multipan_channel: int | None,
+    platform_using_multipan: bool,
+    platform_channel: int | None,
+    new_multipan_channel: int | None,
+) -> None:
+    """Test channel is initialized from first platform."""
+    multipan_manager = await silabs_multiprotocol_addon.get_addon_manager(hass)
+    multipan_manager._channel = initial_multipan_channel
+
+    mock_multiprotocol_platform = MockMultiprotocolPlatform()
+    mock_multiprotocol_platform.channel = platform_channel
+    mock_multiprotocol_platform.using_multipan = platform_using_multipan
+
+    hass.config.components.add(TEST_DOMAIN)
+    mock_platform(
+        hass, f"{TEST_DOMAIN}.silabs_multiprotocol", mock_multiprotocol_platform
+    )
+    hass.bus.async_fire(EVENT_COMPONENT_LOADED, {ATTR_COMPONENT: TEST_DOMAIN})
+    await hass.async_block_till_done()
+
+    assert multipan_manager.async_get_channel() == new_multipan_channel
+
+
+@pytest.mark.parametrize(
+    (
+        "platform_using_multipan",
+        "expected_calls",
+    ),
+    [
+        (True, [15]),
+        (False, []),
+    ],
+)
+async def test_change_channel(
+    hass: HomeAssistant,
+    mock_multiprotocol_platform: MockMultiprotocolPlatform,
+    platform_using_multipan: bool,
+    expected_calls: list[int],
+) -> None:
+    """Test channel is initialized from first platform."""
+    multipan_manager = await silabs_multiprotocol_addon.get_addon_manager(hass)
+    mock_multiprotocol_platform.using_multipan = platform_using_multipan
+
+    await multipan_manager.async_change_channel(15)
+    assert mock_multiprotocol_platform.change_channel_calls == expected_calls
+
+
+async def test_load_preferences(hass: HomeAssistant) -> None:
+    """Make sure that we can load/save data correctly."""
+    multipan_manager = await silabs_multiprotocol_addon.get_addon_manager(hass)
+    assert multipan_manager._channel != 11
+    multipan_manager.async_set_channel(11)
+
+    await flush_store(multipan_manager._store)
+
+    multipan_manager2 = silabs_multiprotocol_addon.MultiprotocolAddonManager(hass)
+    await multipan_manager2.async_setup()
+
+    assert multipan_manager._channel == multipan_manager2._channel

--- a/tests/components/homeassistant_hardware/test_silabs_multiprotocol_addon.py
+++ b/tests/components/homeassistant_hardware/test_silabs_multiprotocol_addon.py
@@ -111,7 +111,9 @@ class MockMultiprotocolPlatform(MockPlatform):
         super().__init__(**kwargs)
         self.change_channel_calls = []
 
-    async def async_change_channel(self, hass: HomeAssistant, channel: int) -> None:
+    async def async_change_channel(
+        self, hass: HomeAssistant, channel: int, delay: float
+    ) -> None:
         """Set the channel to be used."""
         self.change_channel_calls.append(channel)
 

--- a/tests/components/homeassistant_sky_connect/conftest.py
+++ b/tests/components/homeassistant_sky_connect/conftest.py
@@ -1,6 +1,6 @@
 """Test fixtures for the Home Assistant SkyConnect integration."""
 from collections.abc import Generator
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -30,6 +30,17 @@ def mock_zha():
     ), patch(
         "homeassistant.components.zha.async_setup_entry",
         return_value=True,
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def mock_zha_get_last_network_settings() -> Generator[None, None, None]:
+    """Mock zha.api.async_get_last_network_settings."""
+
+    with patch(
+        "homeassistant.components.zha.api.async_get_last_network_settings",
+        AsyncMock(return_value=None),
     ):
         yield
 

--- a/tests/components/homeassistant_yellow/conftest.py
+++ b/tests/components/homeassistant_yellow/conftest.py
@@ -1,7 +1,7 @@
 """Test fixtures for the Home Assistant Yellow integration."""
 from collections.abc import Generator
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -28,6 +28,17 @@ def mock_zha_config_flow_setup() -> Generator[None, None, None]:
     ), patch(
         "homeassistant.components.zha.async_setup_entry",
         return_value=True,
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def mock_zha_get_last_network_settings() -> Generator[None, None, None]:
+    """Mock zha.api.async_get_last_network_settings."""
+
+    with patch(
+        "homeassistant.components.zha.api.async_get_last_network_settings",
+        AsyncMock(return_value=None),
     ):
         yield
 

--- a/tests/components/otbr/conftest.py
+++ b/tests/components/otbr/conftest.py
@@ -1,9 +1,10 @@
 """Test fixtures for the Open Thread Border Router integration."""
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
 from homeassistant.components import otbr
+from homeassistant.core import HomeAssistant
 
 from . import CONFIG_ENTRY_DATA, DATASET_CH16
 
@@ -31,3 +32,12 @@ async def otbr_config_entry_fixture(hass):
 @pytest.fixture(autouse=True)
 def use_mocked_zeroconf(mock_async_zeroconf):
     """Mock zeroconf in all tests."""
+
+
+@pytest.fixture(name="multiprotocol_addon_manager_mock")
+def multiprotocol_addon_manager_mock_fixture(hass: HomeAssistant):
+    """Mock the Silicon Labs Multiprotocol add-on manager."""
+    mock_manager = Mock()
+    mock_manager.async_get_channel = Mock(return_value=None)
+    with patch.dict(hass.data, {"silabs_multiprotocol_addon_manager": mock_manager}):
+        yield mock_manager

--- a/tests/components/otbr/test_config_flow.py
+++ b/tests/components/otbr/test_config_flow.py
@@ -2,7 +2,7 @@
 import asyncio
 from http import HTTPStatus
 from typing import Any
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import aiohttp
 import pytest
@@ -309,7 +309,9 @@ async def test_hassio_discovery_flow_router_not_setup_has_preferred(
 
 
 async def test_hassio_discovery_flow_router_not_setup_has_preferred_2(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    multiprotocol_addon_manager_mock,
 ) -> None:
     """Test the hassio discovery flow when the border router has no dataset.
 
@@ -321,8 +323,7 @@ async def test_hassio_discovery_flow_router_not_setup_has_preferred_2(
     aioclient_mock.put(f"{url}/node/dataset/active", status=HTTPStatus.CREATED)
     aioclient_mock.put(f"{url}/node/state", status=HTTPStatus.OK)
 
-    networksettings = Mock()
-    networksettings.network_info.channel = 15
+    multiprotocol_addon_manager_mock.async_get_channel.return_value = 15
 
     with patch(
         "homeassistant.components.otbr.config_flow.async_get_preferred_dataset",
@@ -330,13 +331,7 @@ async def test_hassio_discovery_flow_router_not_setup_has_preferred_2(
     ), patch(
         "homeassistant.components.otbr.async_setup_entry",
         return_value=True,
-    ) as mock_setup_entry, patch(
-        "homeassistant.components.otbr.util.zha_api.async_get_radio_path",
-        return_value="socket://core-silabs-multiprotocol:9999",
-    ), patch(
-        "homeassistant.components.otbr.util.zha_api.async_get_network_settings",
-        return_value=networksettings,
-    ):
+    ) as mock_setup_entry:
         result = await hass.config_entries.flow.async_init(
             otbr.DOMAIN, context={"source": "hassio"}, data=HASSIO_DATA
         )

--- a/tests/components/otbr/test_silabs_multiprotocol.py
+++ b/tests/components/otbr/test_silabs_multiprotocol.py
@@ -2,25 +2,106 @@
 from unittest.mock import patch
 
 import pytest
-from python_otbr_api import ActiveDataSet
+from python_otbr_api import ActiveDataSet, tlv_parser
 
 from homeassistant.components import otbr
 from homeassistant.components.otbr import (
     silabs_multiprotocol as otbr_silabs_multiprotocol,
 )
+from homeassistant.components.thread import dataset_store
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 
+from . import DATASET_CH16
+
 OTBR_MULTIPAN_URL = "http://core-silabs-multiprotocol:8081"
 OTBR_NON_MULTIPAN_URL = "/dev/ttyAMA1"
+DATASET_CH16_PENDING = (
+    "0E080000000000020000"  # ACTIVETIMESTAMP
+    "340400006699"  # DELAYTIMER
+    "000300000F"  # CHANNEL
+    "35060004001FFFE0"  # CHANNELMASK
+    "0208F642646DA209B1C0"  # EXTPANID
+    "0708FDF57B5A0FE2AAF6"  # MESHLOCALPREFIX
+    "0510DE98B5BA1A528FEE049D4B4B01835375"  # NETWORKKEY
+    "030D4F70656E546872656164204841"  # NETWORKNAME
+    "010225A4"  # PANID
+    "0410F5DD18371BFD29E1A601EF6FFAD94C03"  # PSKC
+    "0C0402A0F7F8"  # SECURITYPOLICY
+)
 
 
 async def test_async_change_channel(hass: HomeAssistant, otbr_config_entry) -> None:
     """Test test_async_change_channel."""
 
-    with patch("python_otbr_api.OTBR.set_channel") as mock_set_channel:
-        await otbr_silabs_multiprotocol.async_change_channel(hass, 16, delay=5 * 300)
-    mock_set_channel.assert_awaited_once_with(16, delay=5 * 300 * 1000)
+    store = await dataset_store.async_get_store(hass)
+    assert len(store.datasets) == 1
+    assert list(store.datasets.values())[0].tlv == DATASET_CH16.hex()
+
+    with patch("python_otbr_api.OTBR.set_channel") as mock_set_channel, patch(
+        "python_otbr_api.OTBR.get_pending_dataset_tlvs",
+        return_value=bytes.fromhex(DATASET_CH16_PENDING),
+    ):
+        await otbr_silabs_multiprotocol.async_change_channel(hass, 15, delay=5 * 300)
+    mock_set_channel.assert_awaited_once_with(15, delay=5 * 300 * 1000)
+
+    pending_dataset = tlv_parser.parse_tlv(DATASET_CH16_PENDING)
+    pending_dataset.pop(tlv_parser.MeshcopTLVType.DELAYTIMER)
+
+    assert len(store.datasets) == 1
+    assert list(store.datasets.values())[0].tlv == tlv_parser.encode_tlv(
+        pending_dataset
+    )
+
+
+async def test_async_change_channel_no_pending(
+    hass: HomeAssistant, otbr_config_entry
+) -> None:
+    """Test test_async_change_channel when the pending dataset already expired."""
+
+    store = await dataset_store.async_get_store(hass)
+    assert len(store.datasets) == 1
+    assert list(store.datasets.values())[0].tlv == DATASET_CH16.hex()
+
+    with patch("python_otbr_api.OTBR.set_channel") as mock_set_channel, patch(
+        "python_otbr_api.OTBR.get_active_dataset_tlvs",
+        return_value=bytes.fromhex(DATASET_CH16_PENDING),
+    ), patch(
+        "python_otbr_api.OTBR.get_pending_dataset_tlvs",
+        return_value=None,
+    ):
+        await otbr_silabs_multiprotocol.async_change_channel(hass, 15, delay=5 * 300)
+    mock_set_channel.assert_awaited_once_with(15, delay=5 * 300 * 1000)
+
+    pending_dataset = tlv_parser.parse_tlv(DATASET_CH16_PENDING)
+    pending_dataset.pop(tlv_parser.MeshcopTLVType.DELAYTIMER)
+
+    assert len(store.datasets) == 1
+    assert list(store.datasets.values())[0].tlv == tlv_parser.encode_tlv(
+        pending_dataset
+    )
+
+
+async def test_async_change_channel_no_update(
+    hass: HomeAssistant, otbr_config_entry
+) -> None:
+    """Test test_async_change_channel when we didn't get a dataset from the OTBR."""
+
+    store = await dataset_store.async_get_store(hass)
+    assert len(store.datasets) == 1
+    assert list(store.datasets.values())[0].tlv == DATASET_CH16.hex()
+
+    with patch("python_otbr_api.OTBR.set_channel") as mock_set_channel, patch(
+        "python_otbr_api.OTBR.get_active_dataset_tlvs",
+        return_value=None,
+    ), patch(
+        "python_otbr_api.OTBR.get_pending_dataset_tlvs",
+        return_value=None,
+    ):
+        await otbr_silabs_multiprotocol.async_change_channel(hass, 15, delay=5 * 300)
+    mock_set_channel.assert_awaited_once_with(15, delay=5 * 300 * 1000)
+
+    assert list(store.datasets.values())[0].tlv == DATASET_CH16.hex()
 
 
 async def test_async_change_channel_no_otbr(hass: HomeAssistant) -> None:

--- a/tests/components/otbr/test_silabs_multiprotocol.py
+++ b/tests/components/otbr/test_silabs_multiprotocol.py
@@ -19,15 +19,15 @@ async def test_async_change_channel(hass: HomeAssistant, otbr_config_entry) -> N
     """Test test_async_change_channel."""
 
     with patch("python_otbr_api.OTBR.set_channel") as mock_set_channel:
-        await otbr_silabs_multiprotocol.async_change_channel(hass, 16)
-    mock_set_channel.assert_awaited_once_with(16)
+        await otbr_silabs_multiprotocol.async_change_channel(hass, 16, delay=5 * 300)
+    mock_set_channel.assert_awaited_once_with(16, delay=5 * 300 * 1000)
 
 
 async def test_async_change_channel_no_otbr(hass: HomeAssistant) -> None:
     """Test async_change_channel when otbr is not configured."""
 
     with patch("python_otbr_api.OTBR.set_channel") as mock_set_channel:
-        await otbr_silabs_multiprotocol.async_change_channel(hass, 16)
+        await otbr_silabs_multiprotocol.async_change_channel(hass, 16, delay=0)
     mock_set_channel.assert_not_awaited()
 
 

--- a/tests/components/otbr/test_silabs_multiprotocol.py
+++ b/tests/components/otbr/test_silabs_multiprotocol.py
@@ -1,0 +1,94 @@
+"""Test OTBR Silicon Labs Multiprotocol support."""
+from unittest.mock import patch
+
+import pytest
+from python_otbr_api import ActiveDataSet
+
+from homeassistant.components import otbr
+from homeassistant.components.otbr import (
+    silabs_multiprotocol as otbr_silabs_multiprotocol,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+
+OTBR_MULTIPAN_URL = "http://core-silabs-multiprotocol:8081"
+OTBR_NON_MULTIPAN_URL = "/dev/ttyAMA1"
+
+
+async def test_async_change_channel(hass: HomeAssistant, otbr_config_entry) -> None:
+    """Test test_async_change_channel."""
+
+    with patch("python_otbr_api.OTBR.set_channel") as mock_set_channel:
+        await otbr_silabs_multiprotocol.async_change_channel(hass, 16)
+    mock_set_channel.assert_awaited_once_with(16)
+
+
+async def test_async_change_channel_no_otbr(hass: HomeAssistant) -> None:
+    """Test async_change_channel when otbr is not configured."""
+
+    with patch("python_otbr_api.OTBR.set_channel") as mock_set_channel:
+        await otbr_silabs_multiprotocol.async_change_channel(hass, 16)
+    mock_set_channel.assert_not_awaited()
+
+
+async def test_async_get_channel(hass: HomeAssistant, otbr_config_entry) -> None:
+    """Test test_async_get_channel."""
+
+    with patch(
+        "python_otbr_api.OTBR.get_active_dataset",
+        return_value=ActiveDataSet(channel=11),
+    ) as mock_get_active_dataset:
+        assert await otbr_silabs_multiprotocol.async_get_channel(hass) == 11
+    mock_get_active_dataset.assert_awaited_once_with()
+
+
+async def test_async_get_channel_no_dataset(
+    hass: HomeAssistant, otbr_config_entry
+) -> None:
+    """Test test_async_get_channel."""
+
+    with patch(
+        "python_otbr_api.OTBR.get_active_dataset",
+        return_value=None,
+    ) as mock_get_active_dataset:
+        assert await otbr_silabs_multiprotocol.async_get_channel(hass) is None
+    mock_get_active_dataset.assert_awaited_once_with()
+
+
+async def test_async_get_channel_error(hass: HomeAssistant, otbr_config_entry) -> None:
+    """Test test_async_get_channel."""
+
+    with patch(
+        "python_otbr_api.OTBR.get_active_dataset",
+        side_effect=HomeAssistantError,
+    ) as mock_get_active_dataset:
+        assert await otbr_silabs_multiprotocol.async_get_channel(hass) is None
+    mock_get_active_dataset.assert_awaited_once_with()
+
+
+async def test_async_get_channel_no_otbr(hass: HomeAssistant) -> None:
+    """Test test_async_get_channel when otbr is not configured."""
+
+    with patch("python_otbr_api.OTBR.get_active_dataset") as mock_get_active_dataset:
+        await otbr_silabs_multiprotocol.async_get_channel(hass)
+    mock_get_active_dataset.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [(OTBR_MULTIPAN_URL, True), (OTBR_NON_MULTIPAN_URL, False)],
+)
+async def test_async_using_multipan(
+    hass: HomeAssistant, otbr_config_entry, url: str, expected: bool
+) -> None:
+    """Test async_change_channel when otbr is not configured."""
+    data: otbr.OTBRData = hass.data[otbr.DOMAIN]
+    data.url = url
+
+    assert await otbr_silabs_multiprotocol.async_using_multipan(hass) is expected
+
+
+async def test_async_using_multipan_no_otbr(hass: HomeAssistant) -> None:
+    """Test async_change_channel when otbr is not configured."""
+
+    assert await otbr_silabs_multiprotocol.async_using_multipan(hass) is False

--- a/tests/components/otbr/test_util.py
+++ b/tests/components/otbr/test_util.py
@@ -1,5 +1,4 @@
 """Test OTBR Utility functions."""
-from unittest.mock import Mock, patch
 
 from homeassistant.components import otbr
 from homeassistant.core import HomeAssistant
@@ -8,51 +7,19 @@ OTBR_MULTIPAN_URL = "http://core-silabs-multiprotocol:8081"
 OTBR_NON_MULTIPAN_URL = "/dev/ttyAMA1"
 
 
-async def test_get_allowed_channel(hass: HomeAssistant) -> None:
+async def test_get_allowed_channel(
+    hass: HomeAssistant, multiprotocol_addon_manager_mock
+) -> None:
     """Test get_allowed_channel."""
 
-    zha_networksettings = Mock()
-    zha_networksettings.network_info.channel = 15
-
-    # OTBR multipan + No ZHA -> no restriction
+    # OTBR multipan + No configured channel -> no restriction
+    multiprotocol_addon_manager_mock.async_get_channel.return_value = None
     assert await otbr.util.get_allowed_channel(hass, OTBR_MULTIPAN_URL) is None
 
-    # OTBR multipan + ZHA multipan empty settings -> no restriction
-    with patch(
-        "homeassistant.components.otbr.util.zha_api.async_get_radio_path",
-        return_value="socket://core-silabs-multiprotocol:9999",
-    ), patch(
-        "homeassistant.components.otbr.util.zha_api.async_get_network_settings",
-        return_value=None,
-    ):
-        assert await otbr.util.get_allowed_channel(hass, OTBR_MULTIPAN_URL) is None
+    # OTBR multipan + multipan using channel 15 -> 15
+    multiprotocol_addon_manager_mock.async_get_channel.return_value = 15
+    assert await otbr.util.get_allowed_channel(hass, OTBR_MULTIPAN_URL) == 15
 
-    # OTBR multipan + ZHA not multipan using channel 15 -> no restriction
-    with patch(
-        "homeassistant.components.otbr.util.zha_api.async_get_radio_path",
-        return_value="/dev/ttyAMA1",
-    ), patch(
-        "homeassistant.components.otbr.util.zha_api.async_get_network_settings",
-        return_value=zha_networksettings,
-    ):
-        assert await otbr.util.get_allowed_channel(hass, OTBR_MULTIPAN_URL) is None
-
-    # OTBR multipan + ZHA multipan using channel 15 -> 15
-    with patch(
-        "homeassistant.components.otbr.util.zha_api.async_get_radio_path",
-        return_value="socket://core-silabs-multiprotocol:9999",
-    ), patch(
-        "homeassistant.components.otbr.util.zha_api.async_get_network_settings",
-        return_value=zha_networksettings,
-    ):
-        assert await otbr.util.get_allowed_channel(hass, OTBR_MULTIPAN_URL) == 15
-
-    # OTBR not multipan + ZHA multipan using channel 15 -> no restriction
-    with patch(
-        "homeassistant.components.otbr.util.zha_api.async_get_radio_path",
-        return_value="socket://core-silabs-multiprotocol:9999",
-    ), patch(
-        "homeassistant.components.otbr.util.zha_api.async_get_network_settings",
-        return_value=zha_networksettings,
-    ):
-        assert await otbr.util.get_allowed_channel(hass, OTBR_NON_MULTIPAN_URL) is None
+    # OTBR no multipan + multipan using channel 15 -> no restriction
+    multiprotocol_addon_manager_mock.async_get_channel.return_value = 15
+    assert await otbr.util.get_allowed_channel(hass, OTBR_NON_MULTIPAN_URL) is None

--- a/tests/components/otbr/test_websocket_api.py
+++ b/tests/components/otbr/test_websocket_api.py
@@ -1,5 +1,5 @@
 """Test OTBR Websocket API."""
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import pytest
 import python_otbr_api
@@ -273,6 +273,7 @@ async def test_set_network_no_entry(
 async def test_set_network_channel_conflict(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
+    multiprotocol_addon_manager_mock,
     otbr_config_entry,
     websocket_client,
 ) -> None:
@@ -281,24 +282,16 @@ async def test_set_network_channel_conflict(
     dataset_store = await thread.dataset_store.async_get_store(hass)
     dataset_id = list(dataset_store.datasets)[0]
 
-    networksettings = Mock()
-    networksettings.network_info.channel = 15
+    multiprotocol_addon_manager_mock.async_get_channel.return_value = 15
 
-    with patch(
-        "homeassistant.components.otbr.util.zha_api.async_get_radio_path",
-        return_value="socket://core-silabs-multiprotocol:9999",
-    ), patch(
-        "homeassistant.components.otbr.util.zha_api.async_get_network_settings",
-        return_value=networksettings,
-    ):
-        await websocket_client.send_json_auto_id(
-            {
-                "type": "otbr/set_network",
-                "dataset_id": dataset_id,
-            }
-        )
+    await websocket_client.send_json_auto_id(
+        {
+            "type": "otbr/set_network",
+            "dataset_id": dataset_id,
+        }
+    )
 
-        msg = await websocket_client.receive_json()
+    msg = await websocket_client.receive_json()
 
     assert not msg["success"]
     assert msg["error"]["code"] == "channel_conflict"

--- a/tests/components/zha/test_silabs_multiprotocol.py
+++ b/tests/components/zha/test_silabs_multiprotocol.py
@@ -1,0 +1,93 @@
+"""Test ZHA Silicon Labs Multiprotocol support."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import call, patch
+
+import pytest
+import zigpy.backups
+import zigpy.state
+
+from homeassistant.components import zha
+from homeassistant.components.zha import api, silabs_multiprotocol
+from homeassistant.core import HomeAssistant
+
+if TYPE_CHECKING:
+    from zigpy.application import ControllerApplication
+
+
+@pytest.fixture(autouse=True)
+def required_platform_only():
+    """Only set up the required and required base platforms to speed up tests."""
+    with patch("homeassistant.components.zha.PLATFORMS", ()):
+        yield
+
+
+async def test_async_get_channel_active(hass: HomeAssistant, setup_zha) -> None:
+    """Test reading channel with an active ZHA installation."""
+    await setup_zha()
+
+    assert await silabs_multiprotocol.async_get_channel(hass) == 15
+
+
+async def test_async_get_channel_missing(
+    hass: HomeAssistant, setup_zha, zigpy_app_controller: ControllerApplication
+) -> None:
+    """Test reading channel with an inactive ZHA installation, no valid channel."""
+    await setup_zha()
+
+    gateway = api._get_gateway(hass)
+    await zha.async_unload_entry(hass, gateway.config_entry)
+
+    # Network settings were never loaded for whatever reason
+    zigpy_app_controller.state.network_info = zigpy.state.NetworkInfo()
+    zigpy_app_controller.state.node_info = zigpy.state.NodeInfo()
+
+    with patch(
+        "bellows.zigbee.application.ControllerApplication.__new__",
+        return_value=zigpy_app_controller,
+    ):
+        assert await silabs_multiprotocol.async_get_channel(hass) is None
+
+
+async def test_async_get_channel_no_zha(hass: HomeAssistant) -> None:
+    """Test reading channel with no ZHA config entries and no database."""
+    assert await silabs_multiprotocol.async_get_channel(hass) is None
+
+
+async def test_async_using_multipan_active(hass: HomeAssistant, setup_zha) -> None:
+    """Test async_using_multipan with an active ZHA installation."""
+    await setup_zha()
+
+    assert await silabs_multiprotocol.async_using_multipan(hass) is False
+
+
+async def test_async_using_multipan_no_zha(hass: HomeAssistant) -> None:
+    """Test async_using_multipan with no ZHA config entries and no database."""
+    assert await silabs_multiprotocol.async_using_multipan(hass) is False
+
+
+async def test_change_channel(
+    hass: HomeAssistant, setup_zha, zigpy_app_controller: ControllerApplication
+) -> None:
+    """Test changing the channel."""
+    await setup_zha()
+
+    with patch.object(
+        zigpy_app_controller, "move_network_to_channel", autospec=True
+    ) as mock_move_network_to_channel:
+        await silabs_multiprotocol.async_change_channel(hass, 20)
+
+    assert mock_move_network_to_channel.mock_calls == [call(20)]
+
+
+async def test_change_channel_no_zha(
+    hass: HomeAssistant, zigpy_app_controller: ControllerApplication
+) -> None:
+    """Test changing the channel with no ZHA config entries and no database."""
+    with patch.object(
+        zigpy_app_controller, "move_network_to_channel", autospec=True
+    ) as mock_move_network_to_channel:
+        await silabs_multiprotocol.async_change_channel(hass, 20)
+
+    assert mock_move_network_to_channel.mock_calls == []

--- a/tests/components/zha/test_silabs_multiprotocol.py
+++ b/tests/components/zha/test_silabs_multiprotocol.py
@@ -91,3 +91,25 @@ async def test_change_channel_no_zha(
         await silabs_multiprotocol.async_change_channel(hass, 20)
 
     assert mock_move_network_to_channel.mock_calls == []
+
+
+@pytest.mark.parametrize(("delay", "sleep"), [(0, 0), (5, 0), (15, 15 - 10.27)])
+async def test_change_channel_delay(
+    hass: HomeAssistant,
+    setup_zha,
+    zigpy_app_controller: ControllerApplication,
+    delay: float,
+    sleep: float,
+) -> None:
+    """Test changing the channel with a delay."""
+    await setup_zha()
+
+    with patch.object(
+        zigpy_app_controller, "move_network_to_channel", autospec=True
+    ) as mock_move_network_to_channel, patch(
+        "homeassistant.components.zha.silabs_multiprotocol.asyncio.sleep", autospec=True
+    ) as mock_sleep:
+        await silabs_multiprotocol.async_change_channel(hass, 20, delay=delay)
+
+    assert mock_move_network_to_channel.mock_calls == [call(20)]
+    assert mock_sleep.mock_calls == [call(sleep)]

--- a/tests/components/zha/test_silabs_multiprotocol.py
+++ b/tests/components/zha/test_silabs_multiprotocol.py
@@ -76,7 +76,8 @@ async def test_change_channel(
     with patch.object(
         zigpy_app_controller, "move_network_to_channel", autospec=True
     ) as mock_move_network_to_channel:
-        await silabs_multiprotocol.async_change_channel(hass, 20)
+        task = await silabs_multiprotocol.async_change_channel(hass, 20)
+        await task
 
     assert mock_move_network_to_channel.mock_calls == [call(20)]
 
@@ -88,7 +89,8 @@ async def test_change_channel_no_zha(
     with patch.object(
         zigpy_app_controller, "move_network_to_channel", autospec=True
     ) as mock_move_network_to_channel:
-        await silabs_multiprotocol.async_change_channel(hass, 20)
+        task = await silabs_multiprotocol.async_change_channel(hass, 20)
+    assert task is None
 
     assert mock_move_network_to_channel.mock_calls == []
 
@@ -109,7 +111,8 @@ async def test_change_channel_delay(
     ) as mock_move_network_to_channel, patch(
         "homeassistant.components.zha.silabs_multiprotocol.asyncio.sleep", autospec=True
     ) as mock_sleep:
-        await silabs_multiprotocol.async_change_channel(hass, 20, delay=delay)
+        task = await silabs_multiprotocol.async_change_channel(hass, 20, delay=delay)
+        await task
 
     assert mock_move_network_to_channel.mock_calls == [call(20)]
     assert mock_sleep.mock_calls == [call(sleep)]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add `silabs_multiprotocol` platform

Integrations which support using an IEEE 802.15.4 radio with multiprotocol support, currently ZHA and OTBR, can implement a `silabs_multiprotocol` platform which supports changing the channel.

The motivation is that the Silicon labs radio used in the Home Assistant Yellow and Home Assistant Sky Connect requires both Thread/Matter on Zigbee to be on the same channel when in multiprotocol mode.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
