### PR TITLE
Bump volvooncall to 0.10.3 to fix sensor type error

### DIFF
--- a/homeassistant/components/volvooncall/manifest.json
+++ b/homeassistant/components/volvooncall/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/volvooncall",
   "iot_class": "cloud_polling",
   "loggers": ["geopy", "hbmqtt", "volvooncall"],
-  "requirements": ["volvooncall==0.10.2"]
+  "requirements": ["volvooncall==0.10.3"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2594,7 +2594,7 @@ voip-utils==0.0.7
 volkszaehler==0.4.0
 
 # homeassistant.components.volvooncall
-volvooncall==0.10.2
+volvooncall==0.10.3
 
 # homeassistant.components.verisure
 vsure==2.6.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1879,7 +1879,7 @@ vilfo-api-client==0.3.2
 voip-utils==0.0.7
 
 # homeassistant.components.volvooncall
-volvooncall==0.10.2
+volvooncall==0.10.3
 
 # homeassistant.components.verisure
 vsure==2.6.1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR bump `volvooncall` module to fix a sensor type error starting in 2023.4. The changes in #87013 lead to the Last Trip sensor being treated as numeric even though it is actually a date. This is because the `volvooncall` library was erroneously setting its unit to `""` instead of `None`. Version 0.10.3 fixes this issue in the underlying library.

Library changes are here: https://github.com/molobrakos/volvooncall/compare/c468574893e5cc0204583a59220adcb816a63b00..HEAD

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #92746 and fixes #91113
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.

> I no longer own a Volvo, so I cannot test this locally. Perhaps someone who owns such a vehicle can manually patch their HA install and verify this.

- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
