### PR TITLE
Add blueprints for template entities

### DIFF
--- a/homeassistant/components/template/blueprints/trigger_template_blueprint_dummy.yaml
+++ b/homeassistant/components/template/blueprints/trigger_template_blueprint_dummy.yaml
@@ -1,0 +1,28 @@
+blueprint:
+  name: Trigger template dummy sensor
+  description: >-
+    An example blueprint to demo re-usable template for template sensors.
+  domain: template
+  author: Home Assistant
+  input:
+    trigger_entity_id:
+      name: "Trigger entity ID"
+      description: "Entity ID of the state trigger to use."
+      selector:
+        entity:
+          multiple: false
+    name:
+      name: "Sensor name"
+      description: "The name of the produced Template Sensor."
+      selector:
+        text:
+
+trigger:
+  - platform: state
+    entity_id: !input trigger_entity_id
+
+sensor:
+  - name: !input name
+    # Yes this could be handled using 'trigger.entity_id', but for demo purposes we use the data passed by the blueprint itself
+    state: >-
+      Source state: {{ states(blueprint.trigger_entity_id) }}

--- a/homeassistant/components/template/config.py
+++ b/homeassistant/components/template/config.py
@@ -92,13 +92,13 @@ async def _async_validate_config_item(hass, config):
     config = CONFIG_SECTION_SCHEMA(config)
     # Add blueprint inputs to entity config
     if blueprint_inputs:
-        for dom in [
+        for dom in (
             BINARY_SENSOR_DOMAIN,
             BUTTON_DOMAIN,
             NUMBER_DOMAIN,
             SELECT_DOMAIN,
             SENSOR_DOMAIN,
-        ]:
+        ):
             if dom in config:
                 for idx in range(len(config[dom])):
                     config[dom][idx][CONF_BLUEPRINT_INPUTS] = {

--- a/homeassistant/components/template/const.py
+++ b/homeassistant/components/template/const.py
@@ -1,7 +1,8 @@
 """Constants for the Template Platform Components."""
 
-from homeassistant.const import Platform
 import logging
+
+from homeassistant.const import Platform
 
 CONF_AVAILABILITY_TEMPLATE = "availability_template"
 CONF_ATTRIBUTE_TEMPLATES = "attribute_templates"
@@ -30,6 +31,7 @@ PLATFORMS = [
 CONF_AVAILABILITY = "availability"
 CONF_ATTRIBUTES = "attributes"
 CONF_ATTRIBUTE_TEMPLATES = "attribute_templates"
+CONF_BLUEPRINT_INPUTS = "BLUEPRINT_INPUTS"
 CONF_PICTURE = "picture"
 CONF_OBJECT_ID = "object_id"
 

--- a/homeassistant/components/template/const.py
+++ b/homeassistant/components/template/const.py
@@ -1,6 +1,7 @@
 """Constants for the Template Platform Components."""
 
 from homeassistant.const import Platform
+import logging
 
 CONF_AVAILABILITY_TEMPLATE = "availability_template"
 CONF_ATTRIBUTE_TEMPLATES = "attribute_templates"
@@ -31,3 +32,5 @@ CONF_ATTRIBUTES = "attributes"
 CONF_ATTRIBUTE_TEMPLATES = "attribute_templates"
 CONF_PICTURE = "picture"
 CONF_OBJECT_ID = "object_id"
+
+LOGGER = logging.getLogger(__package__)

--- a/homeassistant/components/template/helpers.py
+++ b/homeassistant/components/template/helpers.py
@@ -1,0 +1,38 @@
+"""Helpers for template integration."""
+from homeassistant.components.blueprint import DomainBlueprints
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.helpers.singleton import singleton
+from homeassistant.helpers.template_entity import TemplateEntity
+
+from .const import DOMAIN, LOGGER
+
+DATA_BLUEPRINTS = "template_blueprints"
+
+
+@callback
+def templates_with_blueprint(hass: HomeAssistant, blueprint_path: str) -> list[str]:
+    """Return all templates that reference the blueprint."""
+    if DOMAIN not in hass.data:
+        return []
+
+    component: EntityComponent[TemplateEntity] = hass.data[DOMAIN]
+
+    return [
+        template_entity.entity_id
+        for template_entity in component.entities
+        if template_entity.referenced_blueprint == blueprint_path
+    ]
+
+
+def _blueprint_in_use(hass: HomeAssistant, blueprint_path: str) -> bool:
+    """Return True if any template references the blueprint."""
+
+    return len(templates_with_blueprint(hass, blueprint_path)) > 0
+
+
+@singleton(DATA_BLUEPRINTS)
+@callback
+def async_get_blueprints(hass: HomeAssistant) -> DomainBlueprints:
+    """Get script blueprints."""
+    return DomainBlueprints(hass, DOMAIN, LOGGER, _blueprint_in_use)

--- a/homeassistant/components/template/manifest.json
+++ b/homeassistant/components/template/manifest.json
@@ -3,6 +3,7 @@
   "name": "Template",
   "after_dependencies": ["group"],
   "codeowners": ["@PhracturedBlue", "@tetienne", "@home-assistant/core"],
+  "dependencies": ["blueprint"],
   "documentation": "https://www.home-assistant.io/integrations/template",
   "iot_class": "local_push",
   "quality_scale": "internal"

--- a/homeassistant/components/template/trigger_entity.py
+++ b/homeassistant/components/template/trigger_entity.py
@@ -43,7 +43,11 @@ class TriggerEntity(TriggerBaseEntity, CoordinatorEntity[TriggerUpdateCoordinato
         if state := self.hass.states.get(self.entity_id):
             this = state.as_dict()
         run_variables = self.coordinator.data["run_variables"]
-        variables = {"this": this, **(run_variables or {})}
+        variables = {
+            "this": this,
+            **(self._blueprint_inputs or {}),
+            **(run_variables or {}),
+        }
 
         self._render_templates(variables)
 

--- a/tests/components/template/test_blueprint.py
+++ b/tests/components/template/test_blueprint.py
@@ -1,0 +1,92 @@
+"""Test template blueprints."""
+import asyncio
+import contextlib
+import pathlib
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components import template
+from homeassistant.components.blueprint import models
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.setup import async_setup_component
+from homeassistant.util import yaml
+
+BUILTIN_BLUEPRINT_FOLDER = pathlib.Path(template.__file__).parent / "blueprints"
+
+
+@contextlib.contextmanager
+def patch_blueprint(blueprint_path: str, data_path):
+    """Patch blueprint loading from a different source."""
+    orig_load = models.DomainBlueprints._load_blueprint
+
+    @callback
+    def mock_load_blueprint(self, path):
+        if path != blueprint_path:
+            pytest.fail(f"Unexpected blueprint {path}")
+            return orig_load(self, path)
+
+        return models.Blueprint(
+            yaml.load_yaml(data_path), expected_domain=self.domain, path=path
+        )
+
+    with patch(
+        "homeassistant.components.blueprint.models.DomainBlueprints._load_blueprint",
+        mock_load_blueprint,
+    ):
+        yield
+
+
+async def test_trigger_blueprint_sensor(hass: HomeAssistant) -> None:
+    """Test trigger sensor blueprint."""
+    hass.states.async_set("binary_sensor.kitchen", "off")
+
+    with patch_blueprint(
+        "trigger_template_blueprint_dummy.yaml",
+        BUILTIN_BLUEPRINT_FOLDER / "trigger_template_blueprint_dummy.yaml",
+    ):
+        assert await async_setup_component(
+            hass,
+            "template",
+            {
+                "template": {
+                    "use_blueprint": {
+                        "path": "trigger_template_blueprint_dummy.yaml",
+                        "input": {
+                            "trigger_entity_id": "binary_sensor.kitchen",
+                            "name": "Blueprint trigger template sensor TEST",
+                        },
+                    }
+                }
+            },
+        )
+
+    await hass.async_block_till_done()
+
+    # Turn on motion
+    hass.states.async_set("binary_sensor.kitchen", "on")
+    # Can't block till done because delay is active
+    # So wait 10 event loop iterations to process script
+    for _ in range(10):
+        await asyncio.sleep(0)
+
+    # Validate entity creation:
+    assert hass.states.get("sensor.blueprint_trigger_template_sensor_test") is not None
+    # Validate entity name:
+    assert (
+        hass.states.get("sensor.blueprint_trigger_template_sensor_test").name
+        == "Blueprint trigger template sensor TEST"
+    )
+
+    # Turn off motion
+    hass.states.async_set("binary_sensor.kitchen", "off")
+    # Can't block till done because delay is active
+    # So wait 10 event loop iterations to process script
+    for _ in range(10):
+        await asyncio.sleep(0)
+
+    # Validate state update:
+    assert (
+        hass.states.get("sensor.blueprint_trigger_template_sensor_test").state
+        == "Source state: off"
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Blueprints for scripts and automations are amazing, as it allows us to create a template for **reuse** and sharing. This PR aims to provide similar functionality for [template](https://www.home-assistant.io/integrations/template/) entities. 

(Backend only, need help with dashboard integration!)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

**Example config:**
A toy example showing how / where injected _blueprint_ data can be used.

`config.yaml`
```yaml

...
template:
  - use_blueprint:
      path: count_enabled.yaml
      input:
        name: Number of enabled devices
        unique_id: number_of_enabled_devices_
        toggle_entities:
          - input_boolean.test_toggle
          - switch.kitchen_lights
          - binary_sensor.motion_detected
```

`blueprints/template/count_enabled.yaml`
```yaml
blueprint:
  name: Count enabled entities
  description: Count the number of enabled entities
  domain: template
  author: RoboMagus
  input:
    name:
      name: name
      selector:
        text:
    unique_id:
      name: unique_id
      selector:
        text:
    toggle_entities:
      name: Toggle entity Trigger
      selector:
        entity:
          multiple: true

sensor:
  - name: !input name
    unique_id: !input unique_id
    state: >-
        {% set ns = namespace(count=0) %}
        {% for entity_id in blueprint.toggle_entities %}
          {% if is_state(entity_id, 'on') %}
            {% set ns.count = ns.count + 1 %}
          {% endif %}
        {% endfor %}
        {{ ns.count }}
    attributes:
      toggle_entities: >-
        {% set ns = namespace(_dict=[]) %}
        {% for entity_id in blueprint.toggle_entities %}
          {% set ns._dict = ns._dict + [(entity_id, states(entity_id))] %}
        {% endfor %}
        {{ dict(ns._dict) }}
```

I'm personally a heavy YAML user and not at all familiar with frontend programming. For feature completeness it would be nice to have a functional template blueprint import dialog as well. Hope there's someone up for that task! :innocent:


- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: `t.b.d.`

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
