### PR TITLE
Add climate on/off for supported BMW vehicles

### DIFF
--- a/homeassistant/components/bmw_connected_drive/__init__.py
+++ b/homeassistant/components/bmw_connected_drive/__init__.py
@@ -44,6 +44,7 @@ PLATFORMS = [
     Platform.NUMBER,
     Platform.SELECT,
     Platform.SENSOR,
+    Platform.SWITCH,
 ]
 
 SERVICE_UPDATE_STATE = "update_state"

--- a/homeassistant/components/bmw_connected_drive/button.py
+++ b/homeassistant/components/bmw_connected_drive/button.py
@@ -54,12 +54,6 @@ BUTTON_TYPES: tuple[BMWButtonEntityDescription, ...] = (
         remote_function=lambda vehicle: vehicle.remote_services.trigger_remote_air_conditioning(),
     ),
     BMWButtonEntityDescription(
-        key="deactivate_air_conditioning",
-        icon="mdi:hvac-off",
-        name="Deactivate air conditioning",
-        remote_function=lambda vehicle: vehicle.remote_services.trigger_remote_air_conditioning_stop(),
-    ),
-    BMWButtonEntityDescription(
         key="find_vehicle",
         icon="mdi:crosshairs-question",
         name="Find vehicle",

--- a/homeassistant/components/bmw_connected_drive/switch.py
+++ b/homeassistant/components/bmw_connected_drive/switch.py
@@ -1,0 +1,109 @@
+"""Switch platform for BMW."""
+
+from collections.abc import Callable, Coroutine
+from dataclasses import dataclass
+import logging
+from typing import Any
+
+from bimmer_connected.models import MyBMWAPIError
+from bimmer_connected.vehicle import MyBMWVehicle
+
+from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import BMWBaseEntity
+from .const import DOMAIN
+from .coordinator import BMWDataUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class BMWRequiredKeysMixin:
+    """Mixin for required keys."""
+
+    value_fn: Callable[[MyBMWVehicle], bool]
+    remote_service_on: Callable[[MyBMWVehicle], Coroutine[Any, Any, Any]]
+    remote_service_off: Callable[[MyBMWVehicle], Coroutine[Any, Any, Any]]
+
+
+@dataclass
+class BMWSwitchEntityDescription(SwitchEntityDescription, BMWRequiredKeysMixin):
+    """Describes BMW switch entity."""
+
+    is_available: Callable[[MyBMWVehicle], bool] = lambda _: False
+    dynamic_options: Callable[[MyBMWVehicle], list[str]] | None = None
+
+
+NUMBER_TYPES: list[BMWSwitchEntityDescription] = [
+    BMWSwitchEntityDescription(
+        key="climate",
+        name="Climate",
+        is_available=lambda v: v.is_remote_climate_stop_enabled,
+        value_fn=lambda v: v.climate.is_climate_on,
+        remote_service_on=lambda v: v.remote_services.trigger_remote_air_conditioning(),
+        remote_service_off=lambda v: v.remote_services.trigger_remote_air_conditioning_stop(),
+        icon="mdi:fan",
+    ),
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the MyBMW switch from config entry."""
+    coordinator: BMWDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+
+    entities: list[BMWSwitch] = []
+
+    for vehicle in coordinator.account.vehicles:
+        if not coordinator.read_only:
+            entities.extend(
+                [
+                    BMWSwitch(coordinator, vehicle, description)
+                    for description in NUMBER_TYPES
+                    if description.is_available(vehicle)
+                ]
+            )
+    async_add_entities(entities)
+
+
+class BMWSwitch(BMWBaseEntity, SwitchEntity):
+    """Representation of BMW Switch entity."""
+
+    entity_description: BMWSwitchEntityDescription
+
+    def __init__(
+        self,
+        coordinator: BMWDataUpdateCoordinator,
+        vehicle: MyBMWVehicle,
+        description: BMWSwitchEntityDescription,
+    ) -> None:
+        """Initialize an BMW Switch."""
+        super().__init__(coordinator, vehicle)
+        self.entity_description = description
+        self._attr_unique_id = f"{vehicle.vin}-{description.key}"
+
+    @property
+    def is_on(self) -> bool:
+        """Return the entity value to represent the entity state."""
+        return self.entity_description.value_fn(self.vehicle)
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the switch on."""
+        try:
+            await self.entity_description.remote_service_on(self.vehicle)
+        except MyBMWAPIError as ex:
+            raise HomeAssistantError(ex) from ex
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the switch off."""
+        try:
+            await self.entity_description.remote_service_off(self.vehicle)
+        except MyBMWAPIError as ex:
+            raise HomeAssistantError(ex) from ex

--- a/tests/components/bmw_connected_drive/snapshots/test_switch.ambr
+++ b/tests/components/bmw_connected_drive/snapshots/test_switch.ambr
@@ -1,0 +1,17 @@
+# serializer version: 1
+# name: test_entity_state_attrs
+  list([
+    StateSnapshot({
+      'attributes': ReadOnlyDict({
+        'attribution': 'Data provided by MyBMW',
+        'friendly_name': 'i4 eDrive40 Climate',
+        'icon': 'mdi:fan',
+      }),
+      'context': <ANY>,
+      'entity_id': 'switch.i4_edrive40_climate',
+      'last_changed': <ANY>,
+      'last_updated': <ANY>,
+      'state': 'off',
+    }),
+  ])
+# ---

--- a/tests/components/bmw_connected_drive/test_switch.py
+++ b/tests/components/bmw_connected_drive/test_switch.py
@@ -86,8 +86,15 @@ async def test_update_triggers_exceptions(
     with pytest.raises(expected):
         await hass.services.async_call(
             "switch",
-            "toggle",
+            "turn_on",
             blocking=True,
             target={"entity_id": "switch.i4_edrive40_climate"},
         )
-    assert RemoteServices.trigger_remote_service.call_count == 1
+    with pytest.raises(expected):
+        await hass.services.async_call(
+            "switch",
+            "turn_off",
+            blocking=True,
+            target={"entity_id": "switch.i4_edrive40_climate"},
+        )
+    assert RemoteServices.trigger_remote_service.call_count == 2

--- a/tests/components/bmw_connected_drive/test_switch.py
+++ b/tests/components/bmw_connected_drive/test_switch.py
@@ -1,0 +1,93 @@
+"""Test BMW switches."""
+from unittest.mock import AsyncMock
+
+from bimmer_connected.models import MyBMWAPIError, MyBMWRemoteServiceError
+from bimmer_connected.vehicle.remote_services import RemoteServices
+import pytest
+import respx
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+
+from . import setup_mocked_integration
+
+
+async def test_entity_state_attrs(
+    hass: HomeAssistant,
+    bmw_fixture: respx.Router,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test switch options and values.."""
+
+    # Setup component
+    assert await setup_mocked_integration(hass)
+
+    # Get all switch entities
+    assert hass.states.async_all("switch") == snapshot
+
+
+@pytest.mark.parametrize(
+    ("entity_id", "value"),
+    [
+        ("switch.i4_edrive40_climate", "ON"),
+        ("switch.i4_edrive40_climate", "OFF"),
+    ],
+)
+async def test_update_triggers_success(
+    hass: HomeAssistant,
+    entity_id: str,
+    value: str,
+    bmw_fixture: respx.Router,
+) -> None:
+    """Test allowed values for switch inputs."""
+
+    # Setup component
+    assert await setup_mocked_integration(hass)
+
+    # Test
+    await hass.services.async_call(
+        "switch",
+        f"turn_{value.lower()}",
+        blocking=True,
+        target={"entity_id": entity_id},
+    )
+    assert RemoteServices.trigger_remote_service.call_count == 1
+
+
+@pytest.mark.parametrize(
+    ("raised", "expected"),
+    [
+        (MyBMWRemoteServiceError, HomeAssistantError),
+        (MyBMWAPIError, HomeAssistantError),
+        (ValueError, ValueError),
+    ],
+)
+async def test_update_triggers_exceptions(
+    hass: HomeAssistant,
+    raised: Exception,
+    expected: Exception,
+    bmw_fixture: respx.Router,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test not allowed values for switch inputs."""
+
+    # Setup component
+    assert await setup_mocked_integration(hass)
+
+    # Setup exception
+    monkeypatch.setattr(
+        RemoteServices,
+        "trigger_remote_service",
+        AsyncMock(side_effect=raised),
+    )
+
+    # Test
+    with pytest.raises(expected):
+        await hass.services.async_call(
+            "switch",
+            "toggle",
+            blocking=True,
+            target={"entity_id": "switch.i4_edrive40_climate"},
+        )
+    assert RemoteServices.trigger_remote_service.call_count == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
`button.<vehicle>_deactivate_air_conditioning` is removed in favor of `switch.<vehicle>_climate`. If the new entity does not appear, turning off climate is not supported by your vehicle.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add the `switch` platform to support on/off toggling of vehicle climatization if the vehicle supports it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/bimmerconnected/bimmer_connected/discussions/521
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/27365

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
