### PR TITLE
Introduce DEVICE_NAME constant for entities which don't have their own name

### DIFF
--- a/homeassistant/components/aranet/sensor.py
+++ b/homeassistant/components/aranet/sensor.py
@@ -28,7 +28,7 @@ from homeassistant.const import (
     UnitOfTime,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DEVICE_CLASS_NAME, DeviceInfo
+from homeassistant.helpers.entity import DEVICE_CLASS_NAME, DEVICE_NAME, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
@@ -107,10 +107,11 @@ def sensor_update_to_bluetooth_data_update(
     """Convert a sensor update to a Bluetooth data update."""
     entity_names: dict[PassiveBluetoothEntityKey, str | None] = {}
     for key, desc in SENSOR_DESCRIPTIONS.items():
-        # PassiveBluetoothDataUpdate does not support DEVICE_CLASS_NAME
-        # the assert satisfies the type checker and will catch attempts
-        # to use DEVICE_CLASS_NAME in the entity descriptions.
+        # PassiveBluetoothDataUpdate does not support DEVICE_CLASS_NAME or DEVICE_NAME.
+        # The asserts satisfy the type checker and will catch attempts
+        # to use DEVICE_CLASS_NAME or DEVICE_NAME in the entity descriptions.
         assert desc.name is not DEVICE_CLASS_NAME
+        assert desc.name is not DEVICE_NAME
         entity_names[_device_key_to_bluetooth_entity_key(adv.device, key)] = desc.name
     return PassiveBluetoothDataUpdate(
         devices={adv.device.address: _sensor_device_info_to_hass(adv)},

--- a/homeassistant/components/balboa/binary_sensor.py
+++ b/homeassistant/components/balboa/binary_sensor.py
@@ -13,6 +13,7 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DEVICE_NAME
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
@@ -83,6 +84,9 @@ class BalboaBinarySensorEntity(BalboaEntity, BinarySensorEntity):
         self, spa: SpaClient, description: BalboaBinarySensorEntityDescription
     ) -> None:
         """Initialize a Balboa binary sensor entity."""
+        # The assert satisfies the type checker and will catch attempts
+        # to use DEVICE_NAME in the entity descriptions.
+        assert description.name is not DEVICE_NAME
         super().__init__(spa, description.name)
         self.entity_description = description
 

--- a/homeassistant/components/modbus/binary_sensor.py
+++ b/homeassistant/components/modbus/binary_sensor.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
     STATE_ON,
 )
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.entity import DEVICE_CLASS_NAME
+from homeassistant.helpers.entity import DEVICE_CLASS_NAME, DEVICE_NAME
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
@@ -75,10 +75,11 @@ class ModbusBinarySensor(BasePlatform, RestoreEntity, BinarySensorEntity):
         # polling is done with the base class
         name = self._attr_name if self._attr_name else "modbus_sensor"
 
-        # DataUpdateCoordinator does not support DEVICE_CLASS_NAME
-        # the assert satisfies the type checker and will catch attempts
-        # to use DEVICE_CLASS_NAME in _attr_name.
+        # DataUpdateCoordinator does not support DEVICE_CLASS_NAME or DEVICE_NAME
+        # The asserts satisfy the type checker and will catch attempts
+        # to use DEVICE_CLASS_NAME or DEVICE_NAME in _attr_name.
         assert name is not DEVICE_CLASS_NAME
+        assert name is not DEVICE_NAME
         self._coordinator = DataUpdateCoordinator(
             hass,
             _LOGGER,

--- a/homeassistant/components/modbus/sensor.py
+++ b/homeassistant/components/modbus/sensor.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
     CONF_UNIT_OF_MEASUREMENT,
 )
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.entity import DEVICE_CLASS_NAME
+from homeassistant.helpers.entity import DEVICE_CLASS_NAME, DEVICE_NAME
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.helpers.update_coordinator import (
@@ -81,10 +81,11 @@ class ModbusRegisterSensor(BaseStructPlatform, RestoreSensor, SensorEntity):
         # polling is done with the base class
         name = self._attr_name if self._attr_name else "modbus_sensor"
 
-        # DataUpdateCoordinator does not support DEVICE_CLASS_NAME
-        # the assert satisfies the type checker and will catch attempts
-        # to use DEVICE_CLASS_NAME in _attr_name.
+        # DataUpdateCoordinator does not support DEVICE_CLASS_NAME or DEVICE_NAME
+        # The asserts satisfy the type checker and will catch attempts
+        # to use DEVICE_CLASS_NAME or DEVICE_NAME in _attr_name.
         assert name is not DEVICE_CLASS_NAME
+        assert name is not DEVICE_NAME
         self._coordinator = DataUpdateCoordinator(
             hass,
             _LOGGER,

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -19,7 +19,12 @@ from homeassistant.helpers.device_registry import (
     async_get as dr_async_get,
     format_mac,
 )
-from homeassistant.helpers.entity import DEVICE_CLASS_NAME, DeviceClassName
+from homeassistant.helpers.entity import (
+    DEVICE_CLASS_NAME,
+    DEVICE_NAME,
+    DeviceClassName,
+    DeviceName,
+)
 from homeassistant.helpers.entity_registry import async_get as er_async_get
 from homeassistant.helpers.typing import EventType
 from homeassistant.util.dt import utcnow
@@ -73,16 +78,17 @@ def get_number_of_channels(device: BlockDevice, block: Block) -> int:
 def get_block_entity_name(
     device: BlockDevice,
     block: Block | None,
-    description: str | DeviceClassName | None = None,
+    description: str | DeviceClassName | DeviceName | None = None,
 ) -> str:
     """Naming for block based switch and sensors."""
     channel_name = get_block_channel_name(device, block)
 
     if description:
-        # It's not possible to do string manipulations on DEVICE_CLASS_NAME
-        # the assert satisfies the type checker and will catch attempts
-        # to use DEVICE_CLASS_NAME as description.
+        # It's not possible to do string manipulations on DEVICE_CLASS_NAME or
+        # DEVICE_NAME. The asserts satisfy the type checker and will catch attempts
+        # to use DEVICE_CLASS_NAME or DEVICE_NAME as descriptions.
         assert description is not DEVICE_CLASS_NAME
+        assert description is not DEVICE_NAME
         return f"{channel_name} {description.lower()}"
 
     return channel_name
@@ -306,16 +312,19 @@ def get_rpc_channel_name(device: RpcDevice, key: str) -> str:
 
 
 def get_rpc_entity_name(
-    device: RpcDevice, key: str, description: str | DeviceClassName | None = None
+    device: RpcDevice,
+    key: str,
+    description: str | DeviceClassName | DeviceName | None = None,
 ) -> str:
     """Naming for RPC based switch and sensors."""
     channel_name = get_rpc_channel_name(device, key)
 
     if description:
-        # It's not possible to do string manipulations on DEVICE_CLASS_NAME
-        # the assert satisfies the type checker and will catch attempts
-        # to use DEVICE_CLASS_NAME as description.
+        # It's not possible to do string manipulations on DEVICE_CLASS_NAME or
+        # DEVICE_NAME. The asserts satisfy the type checker and will catch attempts
+        # to use DEVICE_CLASS_NAME or DEVICE_NAME as descriptions.
         assert description is not DEVICE_CLASS_NAME
+        assert description is not DEVICE_NAME
         return f"{channel_name} {description.lower()}"
 
     return channel_name

--- a/homeassistant/components/system_bridge/__init__.py
+++ b/homeassistant/components/system_bridge/__init__.py
@@ -30,7 +30,13 @@ from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.entity import DEVICE_CLASS_NAME, DeviceClassName, DeviceInfo
+from homeassistant.helpers.entity import (
+    DEVICE_CLASS_NAME,
+    DEVICE_NAME,
+    DeviceClassName,
+    DeviceInfo,
+    DeviceName,
+)
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, MODULES
@@ -279,17 +285,18 @@ class SystemBridgeEntity(CoordinatorEntity[SystemBridgeDataUpdateCoordinator]):
         coordinator: SystemBridgeDataUpdateCoordinator,
         api_port: int,
         key: str,
-        name: str | DeviceClassName | None,
+        name: str | DeviceClassName | DeviceName | None,
     ) -> None:
         """Initialize the System Bridge entity."""
         super().__init__(coordinator)
 
         self._hostname = coordinator.data.system.hostname
         self._key = f"{self._hostname}_{key}"
-        # It's not possible to do string manipulations on DEVICE_CLASS_NAME
-        # the assert satisfies the type checker and will catch attempts
-        # to use DEVICE_CLASS_NAME as name.
+        # It's not possible to do string manipulations on DEVICE_CLASS_NAME or
+        # DEVICE_NAME. The asserts satisfy the type checker and will catch attempts
+        # to use DEVICE_CLASS_NAME or DEVICE_NAME as name.
         assert name is not DEVICE_CLASS_NAME
+        assert name is not DEVICE_NAME
         self._name = f"{self._hostname} {name}"
         self._configuration_url = (
             f"http://{self._hostname}:{api_port}/app/settings.html"

--- a/homeassistant/components/tomorrowio/sensor.py
+++ b/homeassistant/components/tomorrowio/sensor.py
@@ -32,7 +32,7 @@ from homeassistant.const import (
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DEVICE_CLASS_NAME
+from homeassistant.helpers.entity import DEVICE_CLASS_NAME, DEVICE_NAME
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util import slugify
 from homeassistant.util.unit_conversion import DistanceConverter, SpeedConverter
@@ -350,10 +350,11 @@ class BaseTomorrowioSensorEntity(TomorrowioEntity, SensorEntity):
         """Initialize Tomorrow.io Sensor Entity."""
         super().__init__(config_entry, coordinator, api_version)
         self.entity_description = description
-        # It's not possible to do string manipulations on DEVICE_CLASS_NAME
-        # the assert satisfies the type checker and will catch attempts
-        # to use DEVICE_CLASS_NAME in the entity descriptions.
+        # It's not possible to do string manipulations on DEVICE_CLASS_NAME or
+        # DEVICE_NAME. The asserts satisfy the type checker and will catch attempts
+        # to use DEVICE_CLASS_NAME or DEVICE_NAME in the entity descriptions.
         assert description.name is not DEVICE_CLASS_NAME
+        assert description.name is not DEVICE_NAME
         self._attr_name = f"{self._config_entry.data[CONF_NAME]} - {description.name}"
         self._attr_unique_id = (
             f"{self._config_entry.unique_id}_{slugify(description.name)}"

--- a/homeassistant/components/unifiprotect/entity.py
+++ b/homeassistant/components/unifiprotect/entity.py
@@ -24,6 +24,7 @@ from homeassistant.core import callback
 import homeassistant.helpers.device_registry as dr
 from homeassistant.helpers.entity import (
     DEVICE_CLASS_NAME,
+    DEVICE_NAME,
     DeviceInfo,
     Entity,
     EntityDescription,
@@ -204,10 +205,11 @@ class ProtectDeviceEntity(Entity):
             self.entity_description = description
             self._attr_unique_id = f"{self.device.mac}_{description.key}"
             name = description.name or ""
-            # It's not possible to do string manipulations on DEVICE_CLASS_NAME
-            # the assert satisfies the type checker and will catch attempts
-            # to use DEVICE_CLASS_NAME in the entity descriptions.
+            # It's not possible to do string manipulations on DEVICE_CLASS_NAME or
+            # DEVICE_NAME. The asserts satisfy the type checker and will catch attempts
+            # to use DEVICE_CLASS_NAME or DEVICE_NAME in the entity descriptions.
             assert name is not DEVICE_CLASS_NAME
+            assert name is not DEVICE_NAME
             self._attr_name = f"{self.device.display_name} {name.title()}"
 
         self._attr_attribution = DEFAULT_ATTRIBUTION

--- a/homeassistant/components/zwave_js/entity.py
+++ b/homeassistant/components/zwave_js/entity.py
@@ -8,7 +8,12 @@ from zwave_js_server.model.value import Value as ZwaveValue, get_value_id_str
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.entity import DEVICE_CLASS_NAME, DeviceInfo, Entity
+from homeassistant.helpers.entity import (
+    DEVICE_CLASS_NAME,
+    DEVICE_NAME,
+    DeviceInfo,
+    Entity,
+)
 
 from .const import DOMAIN, LOGGER
 from .discovery import ZwaveDiscoveryInfo
@@ -136,10 +141,11 @@ class ZWaveBaseEntity(Entity):
             and self.entity_description
             and self.entity_description.name
         ):
-            # It's not possible to do string manipulations on DEVICE_CLASS_NAME
-            # the assert satisfies the type checker and will catch attempts
-            # to use DEVICE_CLASS_NAME in the entity descriptions.
+            # It's not possible to do string manipulations on DEVICE_CLASS_NAME or
+            # DEVICE_NAME. The asserts satisfy the type checker and will catch attempts
+            # to use DEVICE_CLASS_NAME or DEVICE_NAME in the entity descriptions.
             assert self.entity_description.name is not DEVICE_CLASS_NAME
+            assert self.entity_description.name is not DEVICE_NAME
             name = self.entity_description.name
 
         if name_prefix:

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -367,6 +367,12 @@ class Entity(ABC):
                 report_implicit_device_name()
                 return True
             return False
+
+        if name_translation_key := self.__name_translation_key():
+            assert self.platform
+            if name_translation_key in self.platform.platform_translations:
+                return False
+
         if hasattr(self, "entity_description"):
             if (name := self.entity_description.name) is DEVICE_NAME:
                 return True
@@ -406,6 +412,16 @@ class Entity(ABC):
         )
         return self.platform.component_translations.get(name_translation_key)
 
+    def __name_translation_key(self) -> str | None:
+        """Return translation key for entity name."""
+        if self.translation_key is None:
+            return None
+        assert self.platform
+        return (
+            f"component.{self.platform.platform_name}.entity.{self.platform.domain}"
+            f".{self.translation_key}.name"
+        )
+
     @property
     def name(self) -> str | None:
         """Return the name of the entity.
@@ -418,12 +434,10 @@ class Entity(ABC):
             if name is DEVICE_NAME:
                 return None
             return name
-        if self.translation_key is not None and self.has_entity_name:
+        if self.has_entity_name and (
+            name_translation_key := self.__name_translation_key()
+        ):
             assert self.platform
-            name_translation_key = (
-                f"component.{self.platform.platform_name}.entity.{self.platform.domain}"
-                f".{self.translation_key}.name"
-            )
             if name_translation_key in self.platform.platform_translations:
                 name = self.platform.platform_translations[name_translation_key]
                 return name

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -125,8 +125,8 @@ class EntityPlatform:
         self.entity_namespace = entity_namespace
         self.config_entry: config_entries.ConfigEntry | None = None
         self.entities: dict[str, Entity] = {}
-        self.component_translations: dict[str, Any] = {}
-        self.platform_translations: dict[str, Any] = {}
+        self.component_translations: dict[str, str] = {}
+        self.platform_translations: dict[str, str] = {}
         self._tasks: list[asyncio.Task[None]] = []
         # Stop tracking tasks after setup is completed
         self._setup_complete = False
@@ -627,7 +627,7 @@ class EntityPlatform:
             else:
                 if device and entity.has_entity_name:  # type: ignore[unreachable]
                     device_name = device.name_by_user or device.name
-                    if not entity.name:
+                    if entity.use_device_name:
                         suggested_object_id = device_name
                     else:
                         suggested_object_id = f"{device_name} {entity.name}"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Introduce `DEVICE_NAME` constant for entities which don't have their own name

This replaces setting the name to `None` to implicitly signal that the entity does not have its own name.

The motivation for the change is that it is unwanted to let `None` have a special meaning when we introduce new features, such as translating entity names.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
