### PR TITLE
Pid controller

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -899,6 +899,8 @@ build.json @home-assistant/supervisor
 /tests/components/pi_hole/ @johnluetke @shenxn
 /homeassistant/components/picnic/ @corneyl
 /tests/components/picnic/ @corneyl
+/homeassistant/components/pid_controller/ @antonverburg
+/tests/components/pid_controller/ @antonverburg
 /homeassistant/components/pilight/ @trekky12
 /tests/components/pilight/ @trekky12
 /homeassistant/components/plaato/ @JohNan

--- a/homeassistant/components/pid_controller/__init__.py
+++ b/homeassistant/components/pid_controller/__init__.py
@@ -1,0 +1,207 @@
+"""The PID controller integration."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+import logging
+import math
+from typing import Any
+
+from dvg_pid_controller import Constants as PID_CONST, PID_Controller as PID
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant, ServiceCall, callback
+from homeassistant.helpers import service
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.entity_platform import DATA_ENTITY_PLATFORM
+from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.helpers.typing import ConfigType
+
+from .const import (  # noqa: F401
+    ATTR_CYCLE_TIME,
+    ATTR_LAST_CYCLE_START,
+    ATTR_PID_ENABLE,
+    ATTR_PID_ERROR,
+    ATTR_PID_INPUT,
+    ATTR_PID_KD,
+    ATTR_PID_KI,
+    ATTR_PID_KP,
+    ATTR_PID_OUTPUT,
+    ATTR_VALUE,
+    CONF_CYCLE_TIME,
+    CONF_PID_KD,
+    CONF_PID_KI,
+    CONF_PID_KP,
+    DOMAIN,
+    SERVICE_ENABLE,
+)
+
+PLATFORMS = [Platform.NUMBER]
+_LOGGER = logging.getLogger(__name__)
+
+
+class PidBaseClass(Entity):
+    """Base class for PID entities."""
+
+    # pylint: disable=too-many-arguments
+    def __init__(
+        self, k_p=1, k_i=0.01, k_d=0, direction=PID_CONST.DIRECT, cycle_time="00:00:10"
+    ):
+        """Initialize PID base class."""
+        self._pid = PID(k_p, k_i, k_d, direction)
+        if isinstance(cycle_time, timedelta):
+            self._attr_cycle_time = cycle_time
+        else:
+            self._attr_cycle_time = timedelta(**cycle_time)
+        self._attr_last_cycle_start: str = None
+
+    @property
+    def pid_capability_attributes(self) -> dict[str, Any]:
+        """Return capability attributes."""
+        attr = {}
+        attr[ATTR_CYCLE_TIME] = self.cycle_time
+        attr[ATTR_PID_KP] = str(self.k_p)
+        attr[ATTR_PID_KI] = str(self.k_i)
+        attr[ATTR_PID_KD] = str(self.k_d)
+        attr[ATTR_PID_INPUT] = str(self.pid_input)
+        attr[ATTR_PID_OUTPUT] = str(self.pid_output)
+        attr[ATTR_PID_ERROR] = str(self.pid_error)
+        attr[ATTR_LAST_CYCLE_START] = str((self.last_cycle_start,))
+        attr[ATTR_PID_ENABLE] = str((self.enable_pid,))
+        return attr
+
+    async def _async_start_pid_cycle(self):
+        """Start periodical cycle of PID controller.
+
+        Call this when added to hass, and hass is fully started.
+        """
+        self.async_on_remove(
+            async_track_time_interval(
+                self.hass, self._async_pid_cycle, self._attr_cycle_time
+            )
+        )
+
+    @property
+    def cycle_time(self) -> str:
+        """Return cycle time for PID controller."""
+        return str(self._attr_cycle_time)
+
+    @property
+    def last_cycle_start(self) -> str:
+        """Return last time the PID controller cycle started."""
+        return str(self._attr_last_cycle_start)
+
+    @property
+    def k_p(self) -> float:
+        """Get Kp of the PID regulator."""
+        return self._pid.kp
+
+    @property
+    def k_i(self) -> float:
+        """Ki of the PID regulator."""
+        return self._pid.ki
+
+    @property
+    def k_d(self) -> float:
+        """Kd of the PID regulator."""
+        return self._pid.kd
+
+    @property
+    def enable_pid(self) -> bool:
+        """PID controller enabled."""
+        return self._pid.in_auto
+
+    async def async_enable(self, value: bool):
+        """Enable or disable PID regulator."""
+        # Raise Not Yet implemented error; has to be implemented per controller
+        # Use self._pid.set_mode (mode,
+        #                input_state , output_state, optional:input2_state )
+        raise NotImplementedError()
+
+    def filter_nan(self, value: float):
+        """Filter floats for NAN."""
+        if math.isnan(value):
+            return None
+        return value
+
+    @property
+    def pid_input(self) -> float:
+        """Calculate input value, differential or not."""
+        return self.filter_nan(self._pid.last_input)
+
+    @property
+    def pid_output(self) -> float:
+        """Return PID output value."""
+        return self.filter_nan(self._pid.output)
+
+    @property
+    def pid_error(self) -> float:
+        """Calculate the current error."""
+        return self.filter_nan(self._pid.last_error)
+
+    @callback
+    async def _async_pid_cycle(self, args=None):
+        """Cycle PID regulator.
+
+        Will raise NotImplemented error; should be implemented per controller.
+        Use self._pid.compute(input,optional:input2 ) and self._pid.output to
+        calculate.
+        Read the data from this controllers input and send the result to this
+        controllers output.
+        Don't forget to update last_cycle_start as below:
+        self._attr_last_cycle_start = dt_util.utcnow().replace(microsecond=0)
+        """
+        raise NotImplementedError()
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up slow PID Controller from a config entry."""
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    entry.async_on_unload(entry.add_update_listener(config_entry_update_listener))
+    return True
+
+
+async def config_entry_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Update listener.
+
+    Called when the config entry options are changed.
+    """
+    await hass.config_entries.async_reload(entry.entry_id)
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+
+# pylint: disable=unused-argument
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Register services for PID entities."""
+
+    @service.verify_domain_control(hass, DOMAIN)
+    async def async_service_handle(service_call: ServiceCall) -> None:
+        """Handle services.
+
+        Dispatch the right service call to the right entity.
+        """
+        # Next code will do a service call to all entities in the
+        # current domain that contain the entitiy_id form service_call data
+        # hass.data will get all available platforms in this domain.
+        await service.entity_service_call(
+            hass,
+            list(hass.data[DATA_ENTITY_PLATFORM][DOMAIN]),
+            "async_" + service_call.service,
+            service_call,
+        )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_ENABLE,
+        async_service_handle,
+        cv.make_entity_service_schema({vol.Required(ATTR_VALUE): vol.Coerce(bool)}),
+    )
+    return True

--- a/homeassistant/components/pid_controller/config_flow.py
+++ b/homeassistant/components/pid_controller/config_flow.py
@@ -1,0 +1,151 @@
+"""Config flow for pid integration."""
+from collections.abc import Mapping
+import logging
+from typing import Any, cast
+
+import voluptuous as vol
+
+from homeassistant.components.number import (
+    DEFAULT_MAX_VALUE,
+    DEFAULT_MIN_VALUE,
+    DEFAULT_STEP,
+    DOMAIN as NUMBER_DOMAIN,
+)
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.const import CONF_MAXIMUM, CONF_MINIMUM, CONF_MODE, CONF_NAME
+from homeassistant.helpers import selector
+from homeassistant.helpers.schema_config_entry_flow import (
+    SchemaConfigFlowHandler,
+    SchemaFlowFormStep,
+)
+
+from .const import (
+    CONF_CYCLE_TIME,
+    CONF_INPUT1,
+    CONF_INPUT2,
+    CONF_OUTPUT,
+    CONF_PID_DIR,
+    CONF_PID_KD,
+    CONF_PID_KI,
+    CONF_PID_KP,
+    CONF_STEP,
+    DEFAULT_CYCLE_TIME,
+    DEFAULT_MODE,
+    DEFAULT_PID_DIR,
+    DEFAULT_PID_KD,
+    DEFAULT_PID_KI,
+    DEFAULT_PID_KP,
+    DOMAIN,
+    MODE_AUTO,
+    MODE_BOX,
+    MODE_SLIDER,
+    PID_DIR_DIRECT,
+    PID_DIR_REVERSE,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+_MODES = [
+    selector.SelectOptionDict(value=MODE_AUTO, label="Auto"),
+    selector.SelectOptionDict(value=MODE_BOX, label="Box"),
+    selector.SelectOptionDict(value=MODE_SLIDER, label="Slider"),
+]
+
+_PID_DIRECTIONS = [
+    selector.SelectOptionDict(value=PID_DIR_DIRECT, label="Direct"),
+    selector.SelectOptionDict(value=PID_DIR_REVERSE, label="Reverse"),
+]
+
+OPTIONS_BASE_SCHEMA_PART1 = vol.Schema(
+    {
+        vol.Required(CONF_OUTPUT): selector.EntitySelector(
+            selector.EntitySelectorConfig(domain=[NUMBER_DOMAIN]),
+        ),
+        vol.Required(CONF_INPUT1): selector.EntitySelector(
+            selector.EntitySelectorConfig(domain=[SENSOR_DOMAIN]),
+        ),
+    }
+)
+
+
+OPTIONS_BASE_SCHEMA_PART2 = vol.Schema(
+    {
+        vol.Optional(CONF_PID_KI, default=DEFAULT_PID_KI): selector.NumberSelector(
+            selector.NumberSelectorConfig(
+                min=0, step=0.01, mode=selector.NumberSelectorMode.BOX
+            ),
+        ),
+        vol.Optional(CONF_PID_KP, default=DEFAULT_PID_KP): selector.NumberSelector(
+            selector.NumberSelectorConfig(
+                min=0, step=0.001, mode=selector.NumberSelectorMode.BOX
+            ),
+        ),
+        vol.Optional(CONF_PID_KD, default=DEFAULT_PID_KD): selector.NumberSelector(
+            selector.NumberSelectorConfig(
+                min=0, step=0.001, mode=selector.NumberSelectorMode.BOX
+            ),
+        ),
+        vol.Optional(CONF_PID_DIR, default=DEFAULT_PID_DIR): selector.SelectSelector(
+            selector.SelectSelectorConfig(
+                options=_PID_DIRECTIONS, translation_key=CONF_PID_DIR
+            ),
+        ),
+        vol.Optional(CONF_MINIMUM, default=DEFAULT_MIN_VALUE): selector.NumberSelector(
+            selector.NumberSelectorConfig(min=0, mode=selector.NumberSelectorMode.BOX),
+        ),
+        vol.Optional(CONF_MAXIMUM, default=DEFAULT_MAX_VALUE): selector.NumberSelector(
+            selector.NumberSelectorConfig(min=0, mode=selector.NumberSelectorMode.BOX),
+        ),
+        vol.Optional(
+            CONF_CYCLE_TIME, default=DEFAULT_CYCLE_TIME
+        ): selector.DurationSelector(),
+        vol.Optional(CONF_STEP, default=DEFAULT_STEP): selector.NumberSelector(
+            selector.NumberSelectorConfig(
+                min=0.1, mode=selector.NumberSelectorMode.BOX
+            ),
+        ),
+        vol.Optional(CONF_MODE, default=DEFAULT_MODE): selector.SelectSelector(
+            selector.SelectSelectorConfig(options=_MODES),
+        ),
+    }
+)
+
+OPTIONS_BASE_SCHEMA = OPTIONS_BASE_SCHEMA_PART1.extend(OPTIONS_BASE_SCHEMA_PART2.schema)
+
+OPTIONS_PID_SCHEMA = OPTIONS_BASE_SCHEMA_PART1.extend(
+    vol.Schema(
+        {
+            vol.Optional(CONF_INPUT2): selector.EntitySelector(
+                selector.EntitySelectorConfig(domain=[SENSOR_DOMAIN])
+            ),
+        }
+    ).schema
+).extend(OPTIONS_BASE_SCHEMA_PART2.schema)
+
+
+CONFIG_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_NAME): selector.TextSelector(),
+    }
+).extend(OPTIONS_PID_SCHEMA.schema)
+
+
+CONFIG_FLOW = {
+    "user": SchemaFlowFormStep(CONFIG_SCHEMA),
+}
+
+OPTIONS_FLOW = {
+    "init": SchemaFlowFormStep(OPTIONS_PID_SCHEMA),
+}
+
+
+class PIDControllerPWMConfigFlow(SchemaConfigFlowHandler, domain=DOMAIN):
+    """PID regulator Config handler."""
+
+    config_flow = CONFIG_FLOW
+    options_flow = OPTIONS_FLOW
+
+    def async_config_entry_title(self, options: Mapping[str, Any]) -> str:
+        """Return config entry title."""
+        return cast(str, options["name"]) if CONF_NAME in options else ""

--- a/homeassistant/components/pid_controller/const.py
+++ b/homeassistant/components/pid_controller/const.py
@@ -1,0 +1,49 @@
+"""Constants for the PID Controller integration."""
+DOMAIN = "pid_controller"
+PLATFORMS = ["number"]
+
+ATTR_CYCLE_TIME = "cycle_time"
+ATTR_LAST_CYCLE_START = "last_cycle_start"
+ATTR_PID_ERR = "pid_error"
+ATTR_PID_KP = "kp"
+ATTR_PID_KI = "ki"
+ATTR_PID_KD = "kd"
+ATTR_PID_ENABLE = "pid_enable"
+ATTR_PID_INPUT = "pid_input"
+ATTR_PID_OUTPUT = "pid_output"
+ATTR_PID_ERROR = "pid_error"
+ATTR_INPUT1 = "input1"
+ATTR_INPUT2 = "input2"
+ATTR_OUTPUT = "output"
+ATTR_VALUE = "value"
+
+CONF_NUMBERS = "numbers"
+CONF_CYCLE_TIME = "cycle_time"
+CONF_INPUT1 = "input1"
+CONF_INPUT2 = "input2"
+CONF_OUTPUT = "output"
+CONF_STEP = "step"
+CONF_PID_KP = "kp"
+CONF_PID_KI = "ki"
+CONF_PID_KD = "kd"
+CONF_PID_DIR = "direction"
+
+MODE_SLIDER = "slider"
+MODE_BOX = "box"
+MODE_AUTO = "auto"
+
+SERVICE_SET_KI = "set_ki"
+SERVICE_SET_KP = "set_kp"
+SERVICE_SET_KD = "set_kd"
+SERVICE_ENABLE = "enable"
+
+PID_DIR_DIRECT = "direct"
+PID_DIR_REVERSE = "reverse"
+
+DEFAULT_MODE = MODE_SLIDER
+DEFAULT_CYCLE_TIME = {"seconds": 30}
+
+DEFAULT_PID_DIR = PID_DIR_DIRECT
+DEFAULT_PID_KI = 1.0
+DEFAULT_PID_KP = 0.1
+DEFAULT_PID_KD = 0.0

--- a/homeassistant/components/pid_controller/manifest.json
+++ b/homeassistant/components/pid_controller/manifest.json
@@ -1,0 +1,14 @@
+{
+  "domain": "pid_controller",
+  "name": "PID Controller",
+  "codeowners": ["@antonverburg"],
+  "config_flow": true,
+  "dependencies": ["sensor", "number"],
+  "documentation": "https://www.home-assistant.io/integrations/pid_controller",
+  "homekit": {},
+  "iot_class": "calculated",
+  "quality_scale": "platinum",
+  "requirements": ["dvg-pid-controller==2.1.0"],
+  "ssdp": [],
+  "zeroconf": []
+}

--- a/homeassistant/components/pid_controller/number.py
+++ b/homeassistant/components/pid_controller/number.py
@@ -1,0 +1,315 @@
+"""Number entity containing a PID regulator."""
+from __future__ import annotations
+
+import logging
+import math
+from typing import Any
+
+from dvg_pid_controller import Constants as PID_CONST
+import voluptuous as vol
+
+from homeassistant.components.number import (
+    DEFAULT_MAX_VALUE,
+    DEFAULT_MIN_VALUE,
+    DEFAULT_STEP,
+    PLATFORM_SCHEMA,
+    RestoreNumber,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    CONF_MAXIMUM,
+    CONF_MINIMUM,
+    CONF_MODE,
+    CONF_NAME,
+    CONF_UNIQUE_ID,
+    EVENT_HOMEASSISTANT_START,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+)
+from homeassistant.core import CoreState, HomeAssistant, callback
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.reload import async_setup_reload_service
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+import homeassistant.util.dt as dt_util
+
+from . import PLATFORMS, PidBaseClass
+from .const import (
+    ATTR_INPUT1,
+    ATTR_INPUT2,
+    ATTR_OUTPUT,
+    ATTR_PID_ENABLE,
+    CONF_CYCLE_TIME,
+    CONF_INPUT1,
+    CONF_INPUT2,
+    CONF_OUTPUT,
+    CONF_PID_DIR,
+    CONF_PID_KD,
+    CONF_PID_KI,
+    CONF_PID_KP,
+    CONF_STEP,
+    DEFAULT_CYCLE_TIME,
+    DEFAULT_MODE,
+    DEFAULT_PID_DIR,
+    DEFAULT_PID_KD,
+    DEFAULT_PID_KI,
+    DEFAULT_PID_KP,
+    DOMAIN,
+    MODE_AUTO,
+    MODE_BOX,
+    MODE_SLIDER,
+    PID_DIR_DIRECT,
+    PID_DIR_REVERSE,
+)
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Required(CONF_NAME): cv.string,
+        vol.Optional(CONF_CYCLE_TIME, default=DEFAULT_CYCLE_TIME): cv.time_period_dict,
+        vol.Required(CONF_INPUT1): cv.entity_id,
+        vol.Optional(CONF_INPUT2, default=""): cv.string,
+        vol.Required(CONF_OUTPUT): cv.entity_id,
+        vol.Optional(CONF_PID_KP, default=DEFAULT_PID_KP): vol.Coerce(float),
+        vol.Optional(CONF_PID_KI, default=DEFAULT_PID_KI): vol.Coerce(float),
+        vol.Optional(CONF_PID_KD, default=DEFAULT_PID_KD): vol.Coerce(float),
+        vol.Optional(CONF_PID_DIR, default=DEFAULT_PID_DIR): vol.In(
+            [PID_DIR_DIRECT, PID_DIR_REVERSE]
+        ),
+        vol.Optional(CONF_MINIMUM, default=DEFAULT_MIN_VALUE): vol.Coerce(float),
+        vol.Optional(CONF_MAXIMUM, default=DEFAULT_MAX_VALUE): vol.Coerce(float),
+        vol.Optional(CONF_STEP, default=DEFAULT_STEP): cv.positive_float,
+        vol.Optional(CONF_MODE, default=DEFAULT_MODE): vol.In(
+            [MODE_BOX, MODE_SLIDER, MODE_AUTO]
+        ),
+        vol.Optional(CONF_UNIQUE_ID): cv.string,
+    }
+)
+
+_LOGGER = logging.getLogger(__name__)
+DEBUG_PID = False
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Initialize PID Controller config entry."""
+    async_add_entities([PidEntity(config_entry.options, config_entry.entry_id)])
+
+
+async def async_setup_platform(
+    hass: HomeAssistant,
+    config: ConfigType,
+    async_add_entities: AddEntitiesCallback,
+    discovery_info: DiscoveryInfoType | None = None,
+) -> None:
+    """Set up the number platform."""
+    await async_setup_reload_service(hass, DOMAIN, PLATFORMS)
+    async_add_entities([PidEntity(config, config.get(CONF_UNIQUE_ID))])
+
+
+class PidEntity(RestoreNumber, PidBaseClass):
+    """Representation of a PID Controller number."""
+
+    # pylint: disable=too-many-instance-attributes
+    def __init__(self, config, unique_id: str | None) -> None:
+        """Initialize the PID Controller number."""
+        self._config = config
+        self._attr_native_min_value = config.get(CONF_MINIMUM, DEFAULT_MIN_VALUE)
+        self._attr_native_max_value = config.get(CONF_MAXIMUM, DEFAULT_MAX_VALUE)
+        self._attr_native_step = config.get(CONF_STEP, DEFAULT_STEP)
+        self._attr_mode = config.get(CONF_MODE, DEFAULT_MODE)
+        self._attr_last_cycle_start = str(dt_util.utcnow().replace(microsecond=0))
+        self._attr_timed_output = ("", 0.0)
+        self._output = config[CONF_OUTPUT]
+        self._input_1 = config[CONF_INPUT1]
+        self._input_2 = config.get(CONF_INPUT2, "")
+        self._attr_unique_id = unique_id
+        self._output_step = 0.01
+        # Use super to create _pid
+        super().__init__(
+            config.get(CONF_PID_KP, DEFAULT_PID_KP),
+            config.get(CONF_PID_KI, DEFAULT_PID_KI),
+            config.get(CONF_PID_KD, DEFAULT_PID_KD),
+            PID_CONST.DIRECT
+            if config.get(CONF_PID_DIR, DEFAULT_PID_DIR) == PID_DIR_DIRECT
+            else PID_CONST.REVERSE,
+            config.get(CONF_CYCLE_TIME, DEFAULT_CYCLE_TIME),
+        )
+        # setpoint initial to minimum value
+        self._pid.setpoint = self._attr_native_min_value
+        self._attr_native_value = self._pid.setpoint
+
+    async def async_added_to_hass(self):
+        """Handle entity about to be added to hass event."""
+        await super().async_added_to_hass()
+        start_pid_controller = False
+        # Restore state and cycle timer info
+        if last_state := await self.async_get_last_state():
+            try:
+                # restore the enabled state
+                start_pid_controller = last_state.attributes.get(ATTR_PID_ENABLE, False)
+                await self.async_set_native_value(float(last_state.state))
+            except (ValueError, TypeError) as ex:
+                _LOGGER.warning(
+                    "Failed to restore last state for %s: %s!", self.name, ex
+                )
+
+        # After full startup, set outputs and timers & communicate
+        # states to the physical outputs
+        @callback
+        async def _async_startup(*_):
+            # Request min- and max values from HA, and clip the output
+            # of the PID regulator to that
+            entity = self.hass.states.get(self._output)
+            if entity:
+                attr_min = entity.attributes.get("min", 0.0)
+                attr_max = entity.attributes.get("max", 100.0)
+                self._output_step = entity.attributes.get("step", 0.01)
+                # Set min/max for output
+                self._pid.set_output_limits(attr_min, attr_max)
+            # Start PID controller cycles
+            await self._async_start_pid_cycle()
+            if start_pid_controller:
+                await self.async_enable(True)
+
+        if self.hass.state == CoreState.running:
+            await _async_startup()
+        else:
+            self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, _async_startup)
+
+    @property
+    def name(self) -> str:
+        """Return the name of the sensor."""
+        return self._config[CONF_NAME]
+
+    @property
+    def should_poll(self):
+        """No polling needed."""
+        return False
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set new value."""
+        if math.isnan(value):
+            _LOGGER.warning(
+                "PID controller %s received invalid value: %s!", self.name, value
+            )
+        else:
+            self._pid.setpoint = value
+            self._attr_native_value = self._pid.setpoint
+            self.schedule_update_ha_state()
+
+    @property
+    def capability_attributes(self) -> dict[str, Any]:
+        """Return capability attributes."""
+        attr = super().capability_attributes
+        attr.update(super().pid_capability_attributes)
+        attr[ATTR_INPUT1] = self.input_1
+        attr[ATTR_INPUT2] = self.input_2
+        attr[ATTR_OUTPUT] = self.output
+        return attr
+
+    @property
+    def unique_id(self):
+        """Return the unique id of the device."""
+        return self._attr_unique_id
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info for this device."""
+        attr_id = self._attr_unique_id or ""
+        return DeviceInfo(
+            identifiers={(DOMAIN, attr_id)},
+            name=self.name,
+        )
+
+    async def async_enable(self, value: bool):
+        """Enable or disable PID regulator."""
+        mode = PID_CONST.MANUAL
+        if value:
+            mode = PID_CONST.AUTOMATIC
+        input_2 = math.nan
+        if self._input_2:
+            state_i2 = self.hass.states.get(self._input_2)
+            if state_i2:
+                input_2 = float(state_i2.state)
+        state_i1 = self.hass.states.get(self._input_1)
+        state_o = self.hass.states.get(self._output)
+        if state_i1 and state_o:
+            self._pid.set_mode(
+                mode,
+                float(state_i1.state),
+                float(state_o.state),
+                input_2,
+            )
+
+    @property
+    def input_1(self) -> str:
+        """Return input 1 entity name."""
+        return self._input_1
+
+    @property
+    def input_2(self) -> str:
+        """Return input 2 entity name."""
+        return self._input_2
+
+    @property
+    def output(self) -> str:
+        """Return output entity name."""
+        return self._output
+
+    @callback
+    async def _async_pid_cycle(self, args=None):
+        """Cycle for PWM timed output."""
+        input_1_state = self.hass.states.get(self._input_1)
+        if input_1_state in (
+            STATE_UNAVAILABLE,
+            STATE_UNKNOWN,
+        ):
+            _LOGGER.warning(
+                "Cannot fetch state of input %s for %s", self._input_1, self.name
+            )
+        else:
+            input_1 = float(input_1_state.state)
+
+            input_2 = math.nan
+            if self._input_2:
+                input_2_state = self.hass.states.get(self._input_2)
+                if input_2_state in (
+                    STATE_UNAVAILABLE,
+                    STATE_UNKNOWN,
+                ):
+                    _LOGGER.warning(
+                        "Cannot fetch state of input %s for %s",
+                        self._input_2,
+                        self.name,
+                    )
+                else:
+                    input_2 = float(input_2_state.state)
+            if not self._pid.compute(input_1, input_2):
+                if self._pid.in_auto:
+                    _LOGGER.warning(
+                        "Something wrong with PID regulator"
+                        "%s when calculating from inputs %s and %s!",
+                        self.name,
+                        input_1,
+                        input_2,
+                    )
+            else:
+                pid_val = (
+                    round(self._pid.output / self._output_step) * self._output_step
+                )  # Round off to step
+                state = self.hass.states.get(
+                    self._output
+                )  # Copy attributes when writing new state (required for UI)
+                attr = {}
+                if state:
+                    attr = state.attributes.copy()
+                self.hass.states.async_set(
+                    self._output, pid_val, attr
+                )  # Use set-state to be as much type-independent as possible
+
+        self._attr_last_cycle_start = dt_util.utcnow().replace(microsecond=0)
+        self.async_write_ha_state()

--- a/homeassistant/components/pid_controller/services.yaml
+++ b/homeassistant/components/pid_controller/services.yaml
@@ -1,0 +1,14 @@
+# Describes the format for available Number entity services
+enable:
+  name: Enable PID controller
+  description: Enable the PID controller.
+  target:
+    entity:
+      integration: pid_controller
+  fields:
+    value:
+      name: Value
+      description: True to enable, False to disable the controller.
+      example: true
+      selector:
+        text:

--- a/homeassistant/components/pid_controller/strings.json
+++ b/homeassistant/components/pid_controller/strings.json
@@ -24,12 +24,12 @@
           "kp": "Proportional gain factor, directly gaining the error to compensate the fault (Kp).",
           "ki": "Integration factor, reducing offset fault over time (Ki).",
           "kd": "Differential factor, damping the overshoot (Kd).",
-          "direction": "When direct, output will increase to decrease fault, when reverse output will decrease to decrease fault",
+          "direction": "When direct, output will increase to decrease fault, when reverse output will decrease to decrease fault.",
           "input2": "Secondary input sensor. If selected, the regulator will work in differential mode.",
           "minimum": "Minimum regulation setpoint value.",
           "maximum": "Maximum regulation setpoint value.",
           "step": "Step size of the number.",
-          "mode": "Mode of user interface elements"
+          "mode": "Mode of user interface elements."
         }
       }
     }

--- a/homeassistant/components/pid_controller/strings.json
+++ b/homeassistant/components/pid_controller/strings.json
@@ -1,0 +1,76 @@
+{
+  "title": "PID controller",
+  "config": {
+    "step": {
+      "user": {
+        "title": "PID controller",
+        "description": "Number that functions as PID regulator, using one or two sensor inputs and a number output.",
+        "data": {
+          "name": "Name",
+          "output": "Output number entity",
+          "input1": "Input sensor entity",
+          "input2": "Optional secondary input sensor entity",
+          "kp": "Proportional gain factor (Kp)",
+          "ki": "Integration factor (Ki)",
+          "kd": "Differential factor (Kd)",
+          "direction": "Controller direction",
+          "minimum": "Minimum",
+          "maximum": "Maximum",
+          "cycle_time": "Duration between controller cycles",
+          "step": "Step size",
+          "mode": "Mode"
+        },
+        "data_description": {
+          "kp": "Proportional gain factor, directly gaining the error to compensate the fault (Kp).",
+          "ki": "Integration factor, reducing offset fault over time (Ki).",
+          "kd": "Differential factor, damping the overshoot (Kd).",
+          "direction": "When direct, output will increase to decrease fault, when reverse output will decrease to decrease fault",
+          "input2": "Secondary input sensor. If selected, the regulator will work in differential mode.",
+          "minimum": "Minimum regulation setpoint value.",
+          "maximum": "Maximum regulation setpoint value.",
+          "step": "Step size of the number.",
+          "mode": "Mode of user interface elements"
+        }
+      }
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "output": "[%key:component::pid_controller::config::step::user::data::output%]",
+          "input1": "[%key:component::pid_controller::config::step::user::data::input1%]",
+          "input2": "[%key:component::pid_controller::config::step::user::data::input2%]",
+          "kp": "[%key:component::pid_controller::config::step::user::data::kp%]",
+          "ki": "[%key:component::pid_controller::config::step::user::data::ki%]",
+          "kd": "[%key:component::pid_controller::config::step::user::data::kd%]",
+          "direction": "[%key:component::pid_controller::config::step::user::data::direction%]",
+          "minimum": "[%key:component::pid_controller::config::step::user::data::minimum%]",
+          "maximum": "[%key:component::pid_controller::config::step::user::data::maximum%]",
+          "cycle_time": "[%key:component::pid_controller::config::step::user::data::cycle_time%]",
+          "step": "[%key:component::pid_controller::config::step::user::data::step%]",
+          "mode": "[%key:component::pid_controller::config::step::user::data::mode%]"
+        },
+        "data_description": {
+          "kp": "[%key:component::pid_controller::config::step::user::data_description::kd%]",
+          "ki": "[%key:component::pid_controller::config::step::user::data_description::ki%]",
+          "kd": "[%key:component::pid_controller::config::step::user::data_description::kd%]",
+          "direction": "[%key:component::pid_controller::config::step::user::data_description::direction%]",
+          "input2": "[%key:component::pid_controller::config::step::user::data_description::input2%]",
+          "minimum": "[%key:component::pid_controller::config::step::user::data_description::minimum%]",
+          "maximum": "[%key:component::pid_controller::config::step::user::data_description::maximum%]",
+          "step": "[%key:component::pid_controller::config::step::user::data_description::step%]",
+          "mode": "[%key:component::pid_controller::config::step::user::data_description::mode%]"
+        }
+      }
+    }
+  },
+  "selector": {
+    "direction": {
+      "options": {
+        "direct": "Direct",
+        "reverse": "Reverse"
+      }
+    }
+  }
+}

--- a/homeassistant/components/pid_controller/strings.json
+++ b/homeassistant/components/pid_controller/strings.json
@@ -22,9 +22,9 @@
         },
         "data_description": {
           "kp": "Proportional gain factor, directly gaining the error to compensate the fault (Kp).",
-          "ki": "Integration factor, reducing offset fault over time (Ki).",
+          "ki": "Integration factor, reducing the offset fault over time (Ki).",
           "kd": "Differential factor, damping the overshoot (Kd).",
-          "direction": "When direct, output will increase to decrease fault, when reverse output will decrease to decrease fault.",
+          "direction": "When direct, the output will increase to decrease fault. When reverse, the output will decrease to decrease fault.",
           "input2": "Secondary input sensor. If selected, the regulator will work in differential mode.",
           "minimum": "Minimum regulation setpoint value.",
           "maximum": "Maximum regulation setpoint value.",

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -326,6 +326,7 @@ FLOWS = {
         "philips_js",
         "pi_hole",
         "picnic",
+        "pid_controller",
         "plaato",
         "plex",
         "plugwise",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -4132,6 +4132,11 @@
       "config_flow": false,
       "iot_class": "local_push"
     },
+    "pid_controller": {
+      "integration_type": "hub",
+      "config_flow": true,
+      "iot_class": "calculated"
+    },
     "pilight": {
       "name": "Pilight",
       "integration_type": "hub",
@@ -6620,6 +6625,7 @@
     "moehlenhoff_alpha2",
     "moon",
     "nmap_tracker",
+    "pid_controller",
     "plant",
     "proximity",
     "rpi_power",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -616,6 +616,9 @@ dovado==0.4.1
 # homeassistant.components.dsmr
 dsmr_parser==0.33
 
+# homeassistant.components.pid_controller
+dvg-pid-controller==2.1.0
+
 # homeassistant.components.dwd_weather_warnings
 dwdwfsapi==1.0.6
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -493,6 +493,9 @@ doorbirdpy==2.1.0
 # homeassistant.components.dsmr
 dsmr_parser==0.33
 
+# homeassistant.components.pid_controller
+dvg-pid-controller==2.1.0
+
 # homeassistant.components.dwd_weather_warnings
 dwdwfsapi==1.0.6
 

--- a/tests/components/pid_controller/__init__.py
+++ b/tests/components/pid_controller/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the pid_controller component."""

--- a/tests/components/pid_controller/fixtures/configuration.yaml
+++ b/tests/components/pid_controller/fixtures/configuration.yaml
@@ -1,0 +1,5 @@
+number:
+  - platform: pid_controller
+    output: number.output
+    input1: sensor.input1
+    name: second_test

--- a/tests/components/pid_controller/test_config_flow.py
+++ b/tests/components/pid_controller/test_config_flow.py
@@ -1,0 +1,172 @@
+"""Test the PID Controller config flow."""
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant import config_entries
+from homeassistant.components.number import (
+    DEFAULT_MAX_VALUE,
+    DEFAULT_MIN_VALUE,
+    DEFAULT_STEP,
+)
+from homeassistant.components.pid_controller.const import (
+    CONF_CYCLE_TIME,
+    CONF_INPUT1,
+    CONF_OUTPUT,
+    CONF_PID_DIR,
+    CONF_PID_KD,
+    CONF_PID_KI,
+    CONF_PID_KP,
+    CONF_STEP,
+    DEFAULT_CYCLE_TIME,
+    DEFAULT_MODE,
+    DEFAULT_PID_DIR,
+    DEFAULT_PID_KD,
+    DEFAULT_PID_KI,
+    DEFAULT_PID_KP,
+    DOMAIN,
+)
+from homeassistant.const import CONF_MAXIMUM, CONF_MINIMUM, CONF_MODE, CONF_NAME
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from tests.common import MockConfigEntry
+
+
+@pytest.mark.parametrize("platform", ("number",))
+async def test_config_flow(
+    hass: HomeAssistant, platform: str
+) -> None:  # pylint: disable=W0613
+    """Test the config flow."""
+    output = "number.output"
+    input = "sensor.input1"
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] is None
+
+    with patch(
+        "homeassistant.components.pid_controller.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"name": "My PID Controller", CONF_OUTPUT: output, CONF_INPUT1: input},
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == "My PID Controller"
+    assert result["data"] == {}
+    expected_config = {
+        CONF_NAME: "My PID Controller",
+        CONF_CYCLE_TIME: DEFAULT_CYCLE_TIME,
+        CONF_INPUT1: input,
+        #        CONF_INPUT2: "",
+        CONF_OUTPUT: output,
+        CONF_PID_KP: DEFAULT_PID_KP,
+        CONF_PID_KI: DEFAULT_PID_KI,
+        CONF_PID_KD: DEFAULT_PID_KD,
+        CONF_PID_DIR: DEFAULT_PID_DIR,
+        CONF_MINIMUM: DEFAULT_MIN_VALUE,
+        CONF_MAXIMUM: DEFAULT_MAX_VALUE,
+        CONF_STEP: DEFAULT_STEP,
+        CONF_MODE: DEFAULT_MODE,
+        #        CONF_UNIQUE_ID: None
+    }
+
+    assert result["options"] == expected_config
+    assert len(mock_setup_entry.mock_calls) == 1
+
+    config_entry = hass.config_entries.async_entries(DOMAIN)[0]
+    assert config_entry.data == {}
+    assert config_entry.options == expected_config
+    assert config_entry.title == "My PID Controller"
+
+
+def get_suggested(schema, key):
+    """Get suggested value for key in voluptuous schema."""
+    for k in schema:
+        if k == key:
+            if k.description is None or "suggested_value" not in k.description:
+                return None
+            return k.description["suggested_value"]
+    # Wanted key absent from schema
+    raise Exception
+
+
+@pytest.mark.parametrize("platform", ("number",))
+async def test_options(hass: HomeAssistant, platform: str) -> None:
+    """Test reconfiguring."""
+    output_1 = "number.output_1"
+    output_2 = "number.output_2"
+    input = "sensor.input"
+
+    # Setup the config entry
+    config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            CONF_NAME: "My PID Controller",
+            CONF_OUTPUT: output_1,
+            CONF_INPUT1: input,
+        },
+        title="My PID Controller",
+    )
+
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "init"
+    schema = result["data_schema"].schema
+    assert get_suggested(schema, CONF_OUTPUT) == output_1
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={CONF_OUTPUT: output_2, CONF_INPUT1: input}
+    )
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["data"] == {
+        CONF_NAME: "My PID Controller",
+        CONF_CYCLE_TIME: DEFAULT_CYCLE_TIME,
+        CONF_INPUT1: input,
+        CONF_OUTPUT: output_2,
+        CONF_PID_KP: DEFAULT_PID_KP,
+        CONF_PID_KI: DEFAULT_PID_KI,
+        CONF_PID_KD: DEFAULT_PID_KD,
+        CONF_PID_DIR: DEFAULT_PID_DIR,
+        CONF_MINIMUM: DEFAULT_MIN_VALUE,
+        CONF_MAXIMUM: DEFAULT_MAX_VALUE,
+        CONF_STEP: DEFAULT_STEP,
+        CONF_MODE: DEFAULT_MODE,
+    }
+    assert config_entry.data == {}
+    assert config_entry.options == {
+        CONF_NAME: "My PID Controller",
+        CONF_CYCLE_TIME: DEFAULT_CYCLE_TIME,
+        CONF_INPUT1: input,
+        CONF_OUTPUT: output_2,
+        CONF_PID_KP: DEFAULT_PID_KP,
+        CONF_PID_KI: DEFAULT_PID_KI,
+        CONF_PID_KD: DEFAULT_PID_KD,
+        CONF_PID_DIR: DEFAULT_PID_DIR,
+        CONF_MINIMUM: DEFAULT_MIN_VALUE,
+        CONF_MAXIMUM: DEFAULT_MAX_VALUE,
+        CONF_STEP: DEFAULT_STEP,
+        CONF_MODE: DEFAULT_MODE,
+    }
+    assert config_entry.title == "My PID Controller"
+
+    # Check config entry is reloaded with new options
+    await hass.async_block_till_done()
+
+    # Check the entity was updated, no new entity was created
+    assert len(hass.states.async_all()) == 1
+
+    # Check the state of the entity has changed as expected
+    state = hass.states.get(f"{platform}.my_pid_controller")
+    assert state.state == "0.0"

--- a/tests/components/pid_controller/test_init.py
+++ b/tests/components/pid_controller/test_init.py
@@ -1,0 +1,56 @@
+"""Test the PID controller integration."""
+import pytest
+
+from homeassistant.components.pid_controller.const import (
+    CONF_INPUT1,
+    CONF_OUTPUT,
+    DOMAIN,
+)
+from homeassistant.const import CONF_NAME
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from tests.common import MockConfigEntry
+
+
+@pytest.mark.parametrize("platform", ("number",))
+async def test_setup_and_remove_config_entry(
+    hass: HomeAssistant,
+    platform: str,
+) -> None:
+    """Test setting up and removing a config entry."""
+    input = "sensor.input"
+    output = "number.output"
+
+    registry = er.async_get(hass)
+    pid_controller_entity_id = f"{platform}.my_pid_controller"
+
+    # Setup the config entry
+    config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            CONF_OUTPUT: output,
+            CONF_INPUT1: input,
+            CONF_NAME: "My pid_controller",
+        },
+        title="My pid_controller",
+    )
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Check the entity is registered in the entity registry
+    assert registry.async_get(pid_controller_entity_id) is not None
+
+    # Check the platform is setup correctly
+    state = hass.states.get(pid_controller_entity_id)
+    assert state.state == "0.0"
+
+    # Remove the config entry
+    assert await hass.config_entries.async_remove(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Check the state and entity registry entry are removed
+    assert hass.states.get(pid_controller_entity_id) is None
+    assert registry.async_get(pid_controller_entity_id) is None

--- a/tests/components/pid_controller/test_number.py
+++ b/tests/components/pid_controller/test_number.py
@@ -1,0 +1,650 @@
+"""The test for the pid_controller number platform."""
+import asyncio
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant import config as hass_config
+from homeassistant.components.number import ATTR_VALUE, SERVICE_SET_VALUE
+from homeassistant.components.pid_controller.const import (
+    CONF_CYCLE_TIME,
+    CONF_INPUT1,
+    CONF_INPUT2,
+    CONF_OUTPUT,
+    CONF_PID_DIR,
+    CONF_PID_KD,
+    CONF_PID_KI,
+    CONF_PID_KP,
+    DOMAIN,
+    PID_DIR_REVERSE,
+    SERVICE_ENABLE,
+)
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    CONF_MAXIMUM,
+    CONF_MINIMUM,
+    CONF_NAME,
+    CONF_PLATFORM,
+    SERVICE_RELOAD,
+    Platform,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+from homeassistant.util.unit_system import METRIC_SYSTEM
+
+from tests.common import get_fixture_path
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@pytest.fixture(name="setup_comp")
+async def fixture_setup_comp(hass):
+    """Initialize components."""
+    hass.config.units = METRIC_SYSTEM
+    assert await async_setup_component(hass, "homeassistant", {})
+    await hass.async_block_till_done()
+
+
+async def _setup_controller(hass, config, input, output, input_value, output_value):
+    """Setupfunctions for the controller.
+
+    The input and output device do really exist, only set state.
+    """
+    hass.states.async_set(input, input_value)
+    if output:
+        hass.states.async_set(output, output_value)
+    assert await async_setup_component(hass, Platform.NUMBER, config)
+    await hass.async_block_till_done()
+
+
+async def test_pid_controller_kp(hass: HomeAssistant, setup_comp) -> None:
+    """Test function Kp for normal pid controller (number): output should equal error."""
+    input = "sensor.input1"
+    output = "number.output"
+    pid = f"{Platform.NUMBER}.pid"
+
+    cycle_time = 0.01  # Cycle time in seconds
+    config = {
+        Platform.NUMBER: {
+            CONF_PLATFORM: DOMAIN,
+            CONF_NAME: "pid",
+            CONF_INPUT1: input,
+            CONF_OUTPUT: output,
+            CONF_PID_KP: 1,
+            CONF_PID_KI: 0,
+            CONF_PID_KD: 0,
+            CONF_CYCLE_TIME: {"seconds": cycle_time},
+        }
+    }
+    await _setup_controller(hass, config, input, output, 10.0, 0.0)
+
+    # On initialize value is 0, so output should be off. Check all states.
+    assert hass.states.get(pid).state == "0.0"
+    assert hass.states.get(input).state == "10.0"
+    assert hass.states.get(output).state == "0.0"
+
+    # Now set pid setpoint to value 20. Input remains 10, but pid is not yet enabled,
+    # so output state should remain 0.
+    assert await hass.services.async_call(
+        Platform.NUMBER,
+        SERVICE_SET_VALUE,
+        {ATTR_VALUE: 20, ATTR_ENTITY_ID: pid},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get(pid).state == "20.0"
+    assert hass.states.get(output).state == "0.0"
+
+    # Enable PID controller. Output should run up after a while to 10
+    assert await hass.services.async_call(
+        "pid_controller",
+        SERVICE_ENABLE,
+        {ATTR_VALUE: True, ATTR_ENTITY_ID: pid},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    # Sleep some cyles.
+    await asyncio.sleep(cycle_time * 3)
+    # Check if output is equal to 10, as Kp=1
+    # and difference between in- and output is 10.
+    assert hass.states.get(output).state == "10.0"
+    assert await hass.services.async_call(
+        "homeassistant",
+        "stop",
+        None,
+        blocking=True,
+    )
+
+
+async def test_pid_controller_kp_reverse(hass: HomeAssistant, setup_comp) -> None:
+    """Test function Kp for normal pid controller (number): output should equal error."""
+    input = "sensor.input1"
+    output = "number.output"
+    pid = f"{Platform.NUMBER}.pid"
+
+    # Min/max of the controller are set up by output limits, so assign
+    hass.states.async_set(output, 0.0)
+    state = hass.states.get(output)
+    attr = state.attributes.copy()
+    attr["min"] = -100.0
+    attr["max"] = 100.0
+    hass.states.async_set(output, 0.0, attr)
+
+    cycle_time = 0.01  # Cycle time in seconds
+    config = {
+        Platform.NUMBER: {
+            CONF_PLATFORM: DOMAIN,
+            CONF_NAME: "pid",
+            CONF_INPUT1: input,
+            CONF_OUTPUT: output,
+            CONF_PID_KP: 1,
+            CONF_PID_KI: 0,
+            CONF_PID_KD: 0,
+            CONF_PID_DIR: PID_DIR_REVERSE,
+            CONF_CYCLE_TIME: {"seconds": cycle_time},
+        }
+    }
+    await _setup_controller(hass, config, input, None, 10.0, 0.0)
+
+    # On initialize value is 0, so output should be off. Check all states.
+    assert hass.states.get(pid).state == "0.0"
+    assert hass.states.get(input).state == "10.0"
+    assert hass.states.get(output).state == "0.0"
+
+    # Now set pid setpoint to value 20. Input remains 10, but pid is not yet enabled,
+    # so output state should remain 0.
+    assert await hass.services.async_call(
+        Platform.NUMBER,
+        SERVICE_SET_VALUE,
+        {ATTR_VALUE: 20, ATTR_ENTITY_ID: pid},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get(pid).state == "20.0"
+    assert hass.states.get(output).state == "0.0"
+
+    # Enable PID controller. Output should run down after a while to -10
+    assert await hass.services.async_call(
+        "pid_controller",
+        SERVICE_ENABLE,
+        {ATTR_VALUE: True, ATTR_ENTITY_ID: pid},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    # Sleep some cyles.
+    await asyncio.sleep(cycle_time * 3)
+    # Check if output is equal to -10, as Kp=1
+    # and difference between in- and output is 10.
+    assert hass.states.get(output).state == "-10.0"
+    # Now invert in- and output; output state should
+    # change polarity.
+    # Set pid setpoint to value 10.
+    assert await hass.services.async_call(
+        Platform.NUMBER,
+        SERVICE_SET_VALUE,
+        {ATTR_VALUE: 10, ATTR_ENTITY_ID: pid},
+        blocking=True,
+    )
+    # Set input to value 20
+    hass.states.async_set(input, 20.0)
+    # Sleep some cyles.
+    await asyncio.sleep(cycle_time * 3)
+    # Check if output is equal to 10, as Kp=1
+    # and difference between in- and output is -10.
+    assert hass.states.get(output).state == "10.0"
+
+    assert await hass.services.async_call(
+        "homeassistant",
+        "stop",
+        None,
+        blocking=True,
+    )
+
+
+async def test_pid_controller_kp_differential(hass: HomeAssistant, setup_comp) -> None:
+    """Test function Kp for normal pid controller (number): output should equal error."""
+    input = "sensor.input1"
+    input2 = "sensor.input2"
+    output = "number.output"
+    pid = f"{Platform.NUMBER}.pid"
+
+    cycle_time = 0.01  # Cycle time in seconds
+    config = {
+        Platform.NUMBER: {
+            CONF_PLATFORM: DOMAIN,
+            CONF_NAME: "pid",
+            CONF_INPUT1: input,
+            CONF_INPUT2: input2,
+            CONF_OUTPUT: output,
+            CONF_PID_KP: 1,
+            CONF_PID_KI: 0,
+            CONF_PID_KD: 0,
+            CONF_CYCLE_TIME: {"seconds": cycle_time},
+        }
+    }
+    await _setup_controller(hass, config, input, output, 10.0, 0.0)
+    # Assign input2 value
+    hass.states.async_set(input2, 12.0)
+
+    # On initialize value is 0, so output should be off. Check all states.
+    assert hass.states.get(pid).state == "0.0"
+    assert hass.states.get(input).state == "10.0"
+    assert hass.states.get(input2).state == "12.0"
+    assert hass.states.get(output).state == "0.0"
+
+    # Now set pid setpoint to value 20. Input remains 10, but pid is not yet enabled,
+    # so output state should remain 0.
+    assert await hass.services.async_call(
+        Platform.NUMBER,
+        SERVICE_SET_VALUE,
+        {ATTR_VALUE: 20, ATTR_ENTITY_ID: pid},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get(pid).state == "20.0"
+    assert hass.states.get(output).state == "0.0"
+
+    # Enable PID controller. Output should run down after a while to -10
+    assert await hass.services.async_call(
+        "pid_controller",
+        SERVICE_ENABLE,
+        {ATTR_VALUE: True, ATTR_ENTITY_ID: pid},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    # Sleep some cyles.
+    await asyncio.sleep(cycle_time * 3)
+    # Check if output is equal to 2, as Kp=1
+    # and difference between in- two inputs is 2.
+    assert hass.states.get(output).state == "18.0"
+    assert await hass.services.async_call(
+        "homeassistant",
+        "stop",
+        None,
+        blocking=True,
+    )
+
+
+async def test_pid_controller_ki(hass: HomeAssistant, setup_comp) -> None:
+    """Test Ki function for normal pid controller (number): output should run to max."""
+    input = "sensor.input1"
+    output = "number.output"
+    pid = f"{Platform.NUMBER}.pid"
+    cycle_time = 0.01  # Cycle time in seconds
+
+    config = {
+        Platform.NUMBER: {
+            CONF_PLATFORM: DOMAIN,
+            CONF_NAME: "pid",
+            CONF_INPUT1: input,
+            CONF_OUTPUT: output,
+            CONF_PID_KP: 0,
+            CONF_PID_KI: 100,
+            CONF_PID_KD: 0,
+            CONF_CYCLE_TIME: {"seconds": cycle_time},
+        }
+    }
+    await _setup_controller(hass, config, input, output, 10.0, 0.0)
+
+    # On initialize value is 0, so output should be off. Check all states.
+    assert hass.states.get(pid).state == "0.0"
+    assert hass.states.get(input).state == "10.0"
+    assert hass.states.get(output).state == "0.0"
+
+    # Now set pid setpoint to value 20. Input remains 10, but pid is not yet enabled,
+    # so output state should remain 0.
+    assert await hass.services.async_call(
+        Platform.NUMBER,
+        SERVICE_SET_VALUE,
+        {ATTR_VALUE: 20, ATTR_ENTITY_ID: pid},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get(pid).state == "20.0"
+    assert hass.states.get(output).state == "0.0"
+
+    # Enable PID controller. Output should run up after a while to 100
+    # (as that's the max of the output)
+    assert await hass.services.async_call(
+        "pid_controller",
+        SERVICE_ENABLE,
+        {ATTR_VALUE: True, ATTR_ENTITY_ID: pid},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    # Sleep some cyles.
+    await asyncio.sleep(cycle_time * 10)
+    # Check if output is equal to 100, as Ki=100
+    # and difference between in- and output is 10.
+    assert hass.states.get(output).state == "100.0"
+    assert await hass.services.async_call(
+        "homeassistant",
+        "stop",
+        None,
+        blocking=True,
+    )
+
+
+async def test_pid_controller_kd(hass: HomeAssistant, setup_comp) -> None:
+    """Test Kd function for normal pid controller (number): output should stay 0."""
+    input = "sensor.input1"
+    output = "number.output"
+    pid = f"{Platform.NUMBER}.pid"
+    cycle_time = 0.01  # Cycle time in seconds
+
+    config = {
+        Platform.NUMBER: {
+            CONF_PLATFORM: DOMAIN,
+            CONF_NAME: "pid",
+            CONF_INPUT1: input,
+            CONF_OUTPUT: output,
+            CONF_PID_KP: 0,
+            CONF_PID_KI: 0,
+            CONF_PID_KD: 100,
+            CONF_CYCLE_TIME: {"seconds": cycle_time},
+        }
+    }
+    await _setup_controller(hass, config, input, output, 10.0, 0.0)
+
+    # On initialize value is 0, so output should be off. Check all states.
+    assert hass.states.get(pid).state == "0.0"
+    assert hass.states.get(input).state == "10.0"
+    assert hass.states.get(output).state == "0.0"
+
+    # Now set pid setpoint to value 20. Input remains 10, but pid is not yet enabled,
+    # so output state should remain 0.
+    assert await hass.services.async_call(
+        Platform.NUMBER,
+        SERVICE_SET_VALUE,
+        {ATTR_VALUE: 20, ATTR_ENTITY_ID: pid},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get(pid).state == "20.0"
+    assert hass.states.get(output).state == "0.0"
+
+    # Enable PID controller. Output should run up after a while to 100
+    # (as that's the max of the output)
+    assert await hass.services.async_call(
+        "pid_controller",
+        SERVICE_ENABLE,
+        {ATTR_VALUE: True, ATTR_ENTITY_ID: pid},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    # Sleep some cyles.
+    await asyncio.sleep(cycle_time * 10)
+    # Check if output is equal to 0, as we only have a Kd100
+    # and  input remains always 10.0
+    assert hass.states.get(output).state == "0.0"
+    assert await hass.services.async_call(
+        "homeassistant",
+        "stop",
+        None,
+        blocking=True,
+    )
+
+
+async def test_output_does_not_exist(hass: HomeAssistant, setup_comp, caplog) -> None:
+    """Test output does not exist."""
+    input = "sensor.input1"
+    output = "number.output"
+    cycle_time = 0.01  # Cycle time in seconds
+
+    # clear logging
+    caplog.clear()
+    config = {
+        Platform.NUMBER: {
+            CONF_PLATFORM: DOMAIN,
+            CONF_NAME: "pid",
+            CONF_INPUT1: input,
+            CONF_OUTPUT: "DoesNotExist",
+            CONF_PID_KP: 1,
+            CONF_PID_KI: 0,
+            CONF_PID_KD: 0,
+            CONF_CYCLE_TIME: {"seconds": cycle_time},
+        }
+    }
+    await _setup_controller(hass, config, input, output, 10.0, 0.0)
+
+    # test if an error was generated
+    assert "ERROR" in caplog.text
+    assert await hass.services.async_call(
+        "homeassistant",
+        "stop",
+        None,
+        blocking=True,
+    )
+
+
+async def test_outside_range(hass: HomeAssistant, setup_comp) -> None:
+    """Test what happens if we write a value outside the range."""
+    input = "sensor.input1"
+    output = "number.output"
+    pid = f"{Platform.NUMBER}.pid"
+    cycle_time = 0.01  # Cycle time in seconds
+    minimum = 20.0
+    maximum = 30.0
+
+    config = {
+        Platform.NUMBER: {
+            CONF_PLATFORM: DOMAIN,
+            CONF_NAME: "pid",
+            CONF_INPUT1: input,
+            CONF_OUTPUT: output,
+            CONF_PID_KP: 1,
+            CONF_PID_KI: 0,
+            CONF_PID_KD: 0,
+            CONF_CYCLE_TIME: {"seconds": cycle_time},
+            CONF_MINIMUM: minimum,
+            CONF_MAXIMUM: maximum,
+        }
+    }
+    await _setup_controller(hass, config, input, output, 10.0, 0.0)
+
+    # On initialize value is 0, so output should be off. Check all states.
+    assert hass.states.get(pid).state == "20.0"
+    assert hass.states.get(input).state == "10.0"
+    assert hass.states.get(output).state == "0.0"
+
+    # Set value to 5. This should generate a ValueError in the number component
+    with pytest.raises(Exception):
+        await hass.services.async_call(
+            Platform.NUMBER,
+            SERVICE_SET_VALUE,
+            {ATTR_VALUE: 5, ATTR_ENTITY_ID: pid},
+            blocking=True,
+        )
+
+    await hass.async_block_till_done()
+    # Value should not be changed
+    assert hass.states.get(pid).state == "20.0"
+    assert hass.states.get(output).state == "0.0"
+
+    # Set value to 50. This should generate a ValueError in the number component
+    with pytest.raises(Exception):
+        await hass.services.async_call(
+            Platform.NUMBER,
+            SERVICE_SET_VALUE,
+            {ATTR_VALUE: 50, ATTR_ENTITY_ID: pid},
+            blocking=True,
+        )
+
+    await hass.async_block_till_done()
+    # Value should not be changed
+    assert hass.states.get(pid).state == "20.0"
+    assert hass.states.get(output).state == "0.0"
+
+    # Enable PID controller and repeat
+    assert await hass.services.async_call(
+        "pid_controller",
+        SERVICE_ENABLE,
+        {ATTR_VALUE: True, ATTR_ENTITY_ID: pid},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    # Set value to 5. This should generate a ValueError in the number component
+    with pytest.raises(Exception):
+        await hass.services.async_call(
+            Platform.NUMBER,
+            SERVICE_SET_VALUE,
+            {ATTR_VALUE: 5, ATTR_ENTITY_ID: pid},
+            blocking=True,
+        )
+    await hass.async_block_till_done()
+    await asyncio.sleep(cycle_time * 3)
+    # Value should not be changed, except output should regulate to 10 now.
+    assert hass.states.get(pid).state == "20.0"
+    assert hass.states.get(output).state == "10.0"
+
+    # Set value to 50. This should generate a ValueError in the number component
+    with pytest.raises(Exception):
+        await hass.services.async_call(
+            Platform.NUMBER,
+            SERVICE_SET_VALUE,
+            {ATTR_VALUE: 50, ATTR_ENTITY_ID: pid},
+            blocking=True,
+        )
+
+    await hass.async_block_till_done()
+    await asyncio.sleep(cycle_time * 3)
+    # Value should not be changed, except output still regulated to 10 now.
+    assert hass.states.get(pid).state == "20.0"
+    assert hass.states.get(output).state == "10.0"
+    # Stop hass
+    assert await hass.services.async_call(
+        "homeassistant",
+        "stop",
+        None,
+        blocking=True,
+    )
+
+
+async def test_bad_value(hass: HomeAssistant, setup_comp, caplog) -> None:
+    """Test what happens if we send a bad value."""
+    input = "sensor.input1"
+    output = "number.output"
+    pid = f"{Platform.NUMBER}.pid"
+    cycle_time = 0.01  # Cycle time in seconds
+
+    config = {
+        Platform.NUMBER: {
+            CONF_PLATFORM: DOMAIN,
+            CONF_NAME: "pid",
+            CONF_INPUT1: input,
+            CONF_OUTPUT: output,
+            CONF_PID_KP: 1,
+            CONF_PID_KI: 0,
+            CONF_PID_KD: 0,
+            CONF_CYCLE_TIME: {"seconds": cycle_time},
+        }
+    }
+    await _setup_controller(hass, config, input, output, 10.0, 0.0)
+
+    # On initialize value is 0, so output should be off. Check all states.
+    assert hass.states.get(pid).state == "0.0"
+    assert hass.states.get(input).state == "10.0"
+    assert hass.states.get(output).state == "0.0"
+
+    # Set value to "infinity". This should generate an exception, value should remain what it was
+    with pytest.raises(Exception):
+        await hass.services.async_call(
+            Platform.NUMBER,
+            SERVICE_SET_VALUE,
+            {ATTR_VALUE: "inf", ATTR_ENTITY_ID: pid},
+            blocking=True,
+        )
+    assert hass.states.get(pid).state == "0.0"
+
+    # Set value to "nan". This should generate a warning, value should remain what it was
+    caplog.clear()
+    await hass.services.async_call(
+        Platform.NUMBER,
+        SERVICE_SET_VALUE,
+        {ATTR_VALUE: "nan", ATTR_ENTITY_ID: pid},
+        blocking=True,
+    )
+    assert hass.states.get(pid).state == "0.0"
+    # test if a warning was generated
+    assert "WARNING" in caplog.text
+
+    # Now repeat with controller enabled
+    # Enable PID controller and repeat
+    assert await hass.services.async_call(
+        "pid_controller",
+        SERVICE_ENABLE,
+        {ATTR_VALUE: True, ATTR_ENTITY_ID: pid},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    # Set value to "infinity". This should generate an exception, value should remain what it was
+    with pytest.raises(Exception):
+        await hass.services.async_call(
+            Platform.NUMBER,
+            SERVICE_SET_VALUE,
+            {ATTR_VALUE: "inf", ATTR_ENTITY_ID: pid},
+            blocking=True,
+        )
+    assert hass.states.get(pid).state == "0.0"
+
+    # Set value to "nan". This should generate a warning, value should remain what it was
+    caplog.clear()
+    await hass.services.async_call(
+        Platform.NUMBER,
+        SERVICE_SET_VALUE,
+        {ATTR_VALUE: "nan", ATTR_ENTITY_ID: pid},
+        blocking=True,
+    )
+    assert hass.states.get(pid).state == "0.0"
+
+    assert await hass.services.async_call(
+        "homeassistant",
+        "stop",
+        None,
+        blocking=True,
+    )
+
+
+async def test_reload(hass: HomeAssistant, setup_comp) -> None:
+    """Verify we can reload pid_controller from yaml file."""
+    input = "sensor.input1"
+    output = "number.output"
+    pid = f"{Platform.NUMBER}.pid"
+    cycle_time = 0.01  # Cycle time in seconds
+
+    config = {
+        Platform.NUMBER: {
+            CONF_PLATFORM: DOMAIN,
+            CONF_NAME: "pid",
+            CONF_INPUT1: input,
+            CONF_OUTPUT: output,
+            CONF_PID_KP: 1,
+            CONF_PID_KI: 0,
+            CONF_PID_KD: 0,
+            CONF_CYCLE_TIME: {"seconds": cycle_time},
+        }
+    }
+    await _setup_controller(hass, config, input, output, 10.0, 0.0)
+
+    # On initialize value is 0, so output should be off. Check all states.
+    assert hass.states.get(pid).state == "0.0"
+    assert hass.states.get(input).state == "10.0"
+    assert hass.states.get(output).state == "0.0"
+    assert len(hass.states.async_all()) == 3
+
+    yaml_path = get_fixture_path("configuration.yaml", "pid_controller")
+    with patch.object(hass_config, "YAML_CONFIG_FILE", yaml_path):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_RELOAD,
+            {},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    assert len(hass.states.async_all()) == 3
+    assert hass.states.get(pid) is None
+    assert hass.states.get("number.second_test")

--- a/tests/components/pid_controller/test_number.py
+++ b/tests/components/pid_controller/test_number.py
@@ -115,6 +115,8 @@ async def test_pid_controller_kp(hass: HomeAssistant, setup_comp) -> None:
         None,
         blocking=True,
     )
+    # Sleep some cyles.
+    await asyncio.sleep(cycle_time * 10)
 
 
 async def test_pid_controller_kp_reverse(hass: HomeAssistant, setup_comp) -> None:
@@ -200,6 +202,8 @@ async def test_pid_controller_kp_reverse(hass: HomeAssistant, setup_comp) -> Non
         None,
         blocking=True,
     )
+    # Sleep some cyles.
+    await asyncio.sleep(cycle_time * 10)
 
 
 async def test_pid_controller_kp_differential(hass: HomeAssistant, setup_comp) -> None:
@@ -264,6 +268,8 @@ async def test_pid_controller_kp_differential(hass: HomeAssistant, setup_comp) -
         None,
         blocking=True,
     )
+    # Sleep some cyles.
+    await asyncio.sleep(cycle_time * 10)
 
 
 async def test_pid_controller_ki(hass: HomeAssistant, setup_comp) -> None:
@@ -324,6 +330,8 @@ async def test_pid_controller_ki(hass: HomeAssistant, setup_comp) -> None:
         None,
         blocking=True,
     )
+    # Sleep some cyles.
+    await asyncio.sleep(cycle_time * 10)
 
 
 async def test_pid_controller_kd(hass: HomeAssistant, setup_comp) -> None:
@@ -416,6 +424,8 @@ async def test_output_does_not_exist(hass: HomeAssistant, setup_comp, caplog) ->
         None,
         blocking=True,
     )
+    # Sleep some cyles.
+    await asyncio.sleep(cycle_time * 10)
 
 
 async def test_outside_range(hass: HomeAssistant, setup_comp) -> None:
@@ -520,6 +530,8 @@ async def test_outside_range(hass: HomeAssistant, setup_comp) -> None:
         None,
         blocking=True,
     )
+    # Sleep some cyles.
+    await asyncio.sleep(cycle_time * 10)
 
 
 async def test_bad_value(hass: HomeAssistant, setup_comp, caplog) -> None:
@@ -606,6 +618,8 @@ async def test_bad_value(hass: HomeAssistant, setup_comp, caplog) -> None:
         None,
         blocking=True,
     )
+    # Sleep some cyles.
+    await asyncio.sleep(cycle_time * 10)
 
 
 async def test_reload(hass: HomeAssistant, setup_comp) -> None:


### PR DESCRIPTION
## Proposed change
Add a number integration that functions as a PID regulator. It will use a sensor as input, and another number for output.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ X] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/home-assistant.io/pull/27380
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/27381

## Checklist
- [ X] The code change is tested and works locally.
- [ X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X ] There is no commented out code in this PR.
- [X ] I have followed the [development checklist][dev-checklist]
- [X ] I have followed the [perfect PR recommendations][perfect-pr]
- [ X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure


[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
