### PR TITLE
Use entity translation in dsmr

### DIFF
--- a/homeassistant/components/dsmr/sensor.py
+++ b/homeassistant/components/dsmr/sensor.py
@@ -80,7 +80,7 @@ class DSMRSensorEntityDescription(
 SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     DSMRSensorEntityDescription(
         key="current_electricity_usage",
-        name="Power consumption",
+        translation_key="current_electricity_usage",
         obis_reference=obis_references.CURRENT_ELECTRICITY_USAGE,
         device_class=SensorDeviceClass.POWER,
         force_update=True,
@@ -88,7 +88,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="current_electricity_delivery",
-        name="Power production",
+        translation_key="current_electricity_delivery",
         obis_reference=obis_references.CURRENT_ELECTRICITY_DELIVERY,
         device_class=SensorDeviceClass.POWER,
         force_update=True,
@@ -96,17 +96,16 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="electricity_active_tariff",
-        name="Active tariff",
+        translation_key="electricity_active_tariff",
         obis_reference=obis_references.ELECTRICITY_ACTIVE_TARIFF,
         dsmr_versions={"2.2", "4", "5", "5B", "5L"},
         device_class=SensorDeviceClass.ENUM,
         options=["low", "normal"],
-        translation_key="electricity_tariff",
         icon="mdi:flash",
     ),
     DSMRSensorEntityDescription(
         key="electricity_used_tariff_1",
-        name="Energy consumption (tarif 1)",
+        translation_key="electricity_used_tariff_1",
         obis_reference=obis_references.ELECTRICITY_USED_TARIFF_1,
         dsmr_versions={"2.2", "4", "5", "5B", "5L"},
         device_class=SensorDeviceClass.ENERGY,
@@ -115,7 +114,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="electricity_used_tariff_2",
-        name="Energy consumption (tarif 2)",
+        translation_key="electricity_used_tariff_2",
         obis_reference=obis_references.ELECTRICITY_USED_TARIFF_2,
         dsmr_versions={"2.2", "4", "5", "5B", "5L"},
         force_update=True,
@@ -124,7 +123,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="electricity_delivered_tariff_1",
-        name="Energy production (tarif 1)",
+        translation_key="electricity_delivered_tariff_1",
         obis_reference=obis_references.ELECTRICITY_DELIVERED_TARIFF_1,
         dsmr_versions={"2.2", "4", "5", "5B", "5L"},
         force_update=True,
@@ -133,7 +132,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="electricity_delivered_tariff_2",
-        name="Energy production (tarif 2)",
+        translation_key="electricity_delivered_tariff_2",
         obis_reference=obis_references.ELECTRICITY_DELIVERED_TARIFF_2,
         dsmr_versions={"2.2", "4", "5", "5B", "5L"},
         force_update=True,
@@ -142,7 +141,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="instantaneous_active_power_l1_positive",
-        name="Power consumption phase L1",
+        translation_key="instantaneous_active_power_l1_positive",
         obis_reference=obis_references.INSTANTANEOUS_ACTIVE_POWER_L1_POSITIVE,
         device_class=SensorDeviceClass.POWER,
         entity_registry_enabled_default=False,
@@ -150,7 +149,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="instantaneous_active_power_l2_positive",
-        name="Power consumption phase L2",
+        translation_key="instantaneous_active_power_l2_positive",
         obis_reference=obis_references.INSTANTANEOUS_ACTIVE_POWER_L2_POSITIVE,
         device_class=SensorDeviceClass.POWER,
         entity_registry_enabled_default=False,
@@ -158,7 +157,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="instantaneous_active_power_l3_positive",
-        name="Power consumption phase L3",
+        translation_key="instantaneous_active_power_l3_positive",
         obis_reference=obis_references.INSTANTANEOUS_ACTIVE_POWER_L3_POSITIVE,
         device_class=SensorDeviceClass.POWER,
         entity_registry_enabled_default=False,
@@ -166,7 +165,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="instantaneous_active_power_l1_negative",
-        name="Power production phase L1",
+        translation_key="instantaneous_active_power_l1_negative",
         obis_reference=obis_references.INSTANTANEOUS_ACTIVE_POWER_L1_NEGATIVE,
         device_class=SensorDeviceClass.POWER,
         entity_registry_enabled_default=False,
@@ -174,7 +173,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="instantaneous_active_power_l2_negative",
-        name="Power production phase L2",
+        translation_key="instantaneous_active_power_l2_negative",
         obis_reference=obis_references.INSTANTANEOUS_ACTIVE_POWER_L2_NEGATIVE,
         device_class=SensorDeviceClass.POWER,
         entity_registry_enabled_default=False,
@@ -182,7 +181,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="instantaneous_active_power_l3_negative",
-        name="Power production phase L3",
+        translation_key="instantaneous_active_power_l3_negative",
         obis_reference=obis_references.INSTANTANEOUS_ACTIVE_POWER_L3_NEGATIVE,
         device_class=SensorDeviceClass.POWER,
         entity_registry_enabled_default=False,
@@ -190,7 +189,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="short_power_failure_count",
-        name="Short power failure count",
+        translation_key="short_power_failure_count",
         obis_reference=obis_references.SHORT_POWER_FAILURE_COUNT,
         dsmr_versions={"2.2", "4", "5", "5B", "5L"},
         entity_registry_enabled_default=False,
@@ -199,7 +198,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="long_power_failure_count",
-        name="Long power failure count",
+        translation_key="long_power_failure_count",
         obis_reference=obis_references.LONG_POWER_FAILURE_COUNT,
         dsmr_versions={"2.2", "4", "5", "5B", "5L"},
         entity_registry_enabled_default=False,
@@ -208,7 +207,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="voltage_sag_l1_count",
-        name="Voltage sags phase L1",
+        translation_key="voltage_sag_l1_count",
         obis_reference=obis_references.VOLTAGE_SAG_L1_COUNT,
         dsmr_versions={"2.2", "4", "5", "5B", "5L"},
         entity_registry_enabled_default=False,
@@ -216,7 +215,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="voltage_sag_l2_count",
-        name="Voltage sags phase L2",
+        translation_key="voltage_sag_l2_count",
         obis_reference=obis_references.VOLTAGE_SAG_L2_COUNT,
         dsmr_versions={"2.2", "4", "5", "5B", "5L"},
         entity_registry_enabled_default=False,
@@ -224,7 +223,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="voltage_sag_l3_count",
-        name="Voltage sags phase L3",
+        translation_key="voltage_sag_l3_count",
         obis_reference=obis_references.VOLTAGE_SAG_L3_COUNT,
         dsmr_versions={"2.2", "4", "5", "5B", "5L"},
         entity_registry_enabled_default=False,
@@ -232,7 +231,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="voltage_swell_l1_count",
-        name="Voltage swells phase L1",
+        translation_key="voltage_swell_l1_count",
         obis_reference=obis_references.VOLTAGE_SWELL_L1_COUNT,
         dsmr_versions={"2.2", "4", "5", "5B", "5L"},
         entity_registry_enabled_default=False,
@@ -241,7 +240,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="voltage_swell_l2_count",
-        name="Voltage swells phase L2",
+        translation_key="voltage_swell_l2_count",
         obis_reference=obis_references.VOLTAGE_SWELL_L2_COUNT,
         dsmr_versions={"2.2", "4", "5", "5B", "5L"},
         entity_registry_enabled_default=False,
@@ -250,7 +249,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="voltage_swell_l3_count",
-        name="Voltage swells phase L3",
+        translation_key="voltage_swell_l3_count",
         obis_reference=obis_references.VOLTAGE_SWELL_L3_COUNT,
         dsmr_versions={"2.2", "4", "5", "5B", "5L"},
         entity_registry_enabled_default=False,
@@ -259,7 +258,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="instantaneous_voltage_l1",
-        name="Voltage phase L1",
+        translation_key="instantaneous_voltage_l1",
         obis_reference=obis_references.INSTANTANEOUS_VOLTAGE_L1,
         device_class=SensorDeviceClass.VOLTAGE,
         entity_registry_enabled_default=False,
@@ -268,7 +267,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="instantaneous_voltage_l2",
-        name="Voltage phase L2",
+        translation_key="instantaneous_voltage_l2",
         obis_reference=obis_references.INSTANTANEOUS_VOLTAGE_L2,
         device_class=SensorDeviceClass.VOLTAGE,
         entity_registry_enabled_default=False,
@@ -277,7 +276,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="instantaneous_voltage_l3",
-        name="Voltage phase L3",
+        translation_key="instantaneous_voltage_l3",
         obis_reference=obis_references.INSTANTANEOUS_VOLTAGE_L3,
         device_class=SensorDeviceClass.VOLTAGE,
         entity_registry_enabled_default=False,
@@ -286,7 +285,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="instantaneous_current_l1",
-        name="Current phase L1",
+        translation_key="instantaneous_current_l1",
         obis_reference=obis_references.INSTANTANEOUS_CURRENT_L1,
         device_class=SensorDeviceClass.CURRENT,
         entity_registry_enabled_default=False,
@@ -295,7 +294,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="instantaneous_current_l2",
-        name="Current phase L2",
+        translation_key="instantaneous_current_l2",
         obis_reference=obis_references.INSTANTANEOUS_CURRENT_L2,
         device_class=SensorDeviceClass.CURRENT,
         entity_registry_enabled_default=False,
@@ -304,7 +303,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="instantaneous_current_l3",
-        name="Current phase L3",
+        translation_key="instantaneous_current_l3",
         obis_reference=obis_references.INSTANTANEOUS_CURRENT_L3,
         device_class=SensorDeviceClass.CURRENT,
         entity_registry_enabled_default=False,
@@ -313,7 +312,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="belgium_max_power_per_phase",
-        name="Max power per phase",
+        translation_key="belgium_max_power_per_phase",
         obis_reference=obis_references.BELGIUM_MAX_POWER_PER_PHASE,
         dsmr_versions={"5B"},
         device_class=SensorDeviceClass.POWER,
@@ -323,7 +322,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="belgium_max_current_per_phase",
-        name="Max current per phase",
+        translation_key="belgium_max_current_per_phase",
         obis_reference=obis_references.BELGIUM_MAX_CURRENT_PER_PHASE,
         dsmr_versions={"5B"},
         device_class=SensorDeviceClass.POWER,
@@ -333,7 +332,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="electricity_imported_total",
-        name="Energy consumption (total)",
+        translation_key="electricity_imported_total",
         obis_reference=obis_references.ELECTRICITY_IMPORTED_TOTAL,
         dsmr_versions={"5L", "5S", "Q3D"},
         force_update=True,
@@ -342,7 +341,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="electricity_exported_total",
-        name="Energy production (total)",
+        translation_key="electricity_exported_total",
         obis_reference=obis_references.ELECTRICITY_EXPORTED_TOTAL,
         dsmr_versions={"5L", "5S", "Q3D"},
         force_update=True,
@@ -351,7 +350,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="hourly_gas_meter_reading",
-        name="Gas consumption",
+        translation_key="hourly_gas_meter_reading",
         obis_reference=obis_references.HOURLY_GAS_METER_READING,
         dsmr_versions={"4", "5", "5L"},
         is_gas=True,
@@ -361,7 +360,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="belgium_5min_gas_meter_reading",
-        name="Gas consumption",
+        translation_key="belgium_5min_gas_meter_reading",
         obis_reference=obis_references.BELGIUM_5MIN_GAS_METER_READING,
         dsmr_versions={"5B"},
         is_gas=True,
@@ -371,7 +370,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="gas_meter_reading",
-        name="Gas consumption",
+        translation_key="gas_meter_reading",
         obis_reference=obis_references.GAS_METER_READING,
         dsmr_versions={"2.2"},
         is_gas=True,

--- a/homeassistant/components/dsmr/sensor.py
+++ b/homeassistant/components/dsmr/sensor.py
@@ -312,7 +312,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="belgium_max_power_per_phase",
-        translation_key="belgium_max_power_per_phase",
+        translation_key="max_power_per_phase",
         obis_reference=obis_references.BELGIUM_MAX_POWER_PER_PHASE,
         dsmr_versions={"5B"},
         device_class=SensorDeviceClass.POWER,
@@ -322,7 +322,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="belgium_max_current_per_phase",
-        translation_key="belgium_max_current_per_phase",
+        translation_key="max_current_per_phase",
         obis_reference=obis_references.BELGIUM_MAX_CURRENT_PER_PHASE,
         dsmr_versions={"5B"},
         device_class=SensorDeviceClass.POWER,
@@ -350,7 +350,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="hourly_gas_meter_reading",
-        translation_key="hourly_gas_meter_reading",
+        translation_key="gas_meter_reading",
         obis_reference=obis_references.HOURLY_GAS_METER_READING,
         dsmr_versions={"4", "5", "5L"},
         is_gas=True,
@@ -360,7 +360,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     ),
     DSMRSensorEntityDescription(
         key="belgium_5min_gas_meter_reading",
-        translation_key="belgium_5min_gas_meter_reading",
+        translation_key="gas_meter_reading",
         obis_reference=obis_references.BELGIUM_5MIN_GAS_METER_READING,
         dsmr_versions={"5B"},
         is_gas=True,

--- a/homeassistant/components/dsmr/strings.json
+++ b/homeassistant/components/dsmr/strings.json
@@ -42,11 +42,111 @@
   },
   "entity": {
     "sensor": {
-      "electricity_tariff": {
+      "belgium_5min_gas_meter_reading": {
+        "name": "Gas consumption"
+      },
+      "belgium_max_current_per_phase": {
+        "name": "Max current per phase"
+      },
+      "belgium_max_power_per_phase": {
+        "name": "Max power per phase"
+      },
+      "current_electricity_delivery": {
+        "name": "Power production"
+      },
+      "current_electricity_usage": {
+        "name": "Power consumption"
+      },
+      "electricity_active_tariff": {
+        "name": "Active tariff",
         "state": {
           "low": "Low",
           "normal": "Normal"
         }
+      },
+      "electricity_delivered_tariff_1": {
+        "name": "Energy production (tarif 1)"
+      },
+      "electricity_delivered_tariff_2": {
+        "name": "Energy production (tarif 2)"
+      },
+      "electricity_exported_total": {
+        "name": "Energy production (total)"
+      },
+      "electricity_imported_total": {
+        "name": "Energy consumption (total)"
+      },
+      "electricity_used_tariff_1": {
+        "name": "Energy consumption (tarif 1)"
+      },
+      "electricity_used_tariff_2": {
+        "name": "Energy consumption (tarif 2)"
+      },
+      "gas_meter_reading": {
+        "name": "Gas consumption"
+      },
+      "hourly_gas_meter_reading": {
+        "name": "Gas consumption"
+      },
+      "instantaneous_active_power_l1_negative": {
+        "name": "Power production phase L1"
+      },
+      "instantaneous_active_power_l1_positive": {
+        "name": "Power consumption phase L1"
+      },
+      "instantaneous_active_power_l2_negative": {
+        "name": "Power production phase L2"
+      },
+      "instantaneous_active_power_l2_positive": {
+        "name": "Power consumption phase L2"
+      },
+      "instantaneous_active_power_l3_negative": {
+        "name": "Power production phase L3"
+      },
+      "instantaneous_active_power_l3_positive": {
+        "name": "Power consumption phase L3"
+      },
+      "instantaneous_current_l1": {
+        "name": "Current phase L1"
+      },
+      "instantaneous_current_l2": {
+        "name": "Current phase L2"
+      },
+      "instantaneous_current_l3": {
+        "name": "Current phase L3"
+      },
+      "instantaneous_voltage_l1": {
+        "name": "Voltage phase L1"
+      },
+      "instantaneous_voltage_l2": {
+        "name": "Voltage phase L2"
+      },
+      "instantaneous_voltage_l3": {
+        "name": "Voltage phase L3"
+      },
+      "long_power_failure_count": {
+        "name": "Long power failure count"
+      },
+      "short_power_failure_count": {
+        "name": "Short power failure count"
+      },
+      "voltage_sag_l1_count": {
+        "name": "Voltage sags phase L1"
+      },
+      "voltage_sag_l2_count": {
+        "name": "Voltage sags phase L2"
+      },
+      "voltage_sag_l3_count": {
+        "name": "Voltage sags phase L3"
+      },
+      "voltage_swell_l1_count": {
+        "name": "Voltage swells phase L1"
+      },
+      "voltage_swell_l2_count": {
+        "name": "Voltage swells phase L2"
+      },
+      "voltage_swell_l3_count": {
+        "name": "Voltage swells phase L3"
       }
     }
   },

--- a/homeassistant/components/dsmr/strings.json
+++ b/homeassistant/components/dsmr/strings.json
@@ -42,15 +42,6 @@
   },
   "entity": {
     "sensor": {
-      "belgium_5min_gas_meter_reading": {
-        "name": "Gas consumption"
-      },
-      "belgium_max_current_per_phase": {
-        "name": "Max current per phase"
-      },
-      "belgium_max_power_per_phase": {
-        "name": "Max power per phase"
-      },
       "current_electricity_delivery": {
         "name": "Power production"
       },
@@ -83,9 +74,6 @@
         "name": "Energy consumption (tarif 2)"
       },
       "gas_meter_reading": {
-        "name": "Gas consumption"
-      },
-      "hourly_gas_meter_reading": {
         "name": "Gas consumption"
       },
       "instantaneous_active_power_l1_negative": {
@@ -126,6 +114,12 @@
       },
       "long_power_failure_count": {
         "name": "Long power failure count"
+      },
+      "max_current_per_phase": {
+        "name": "Max current per phase"
+      },
+      "max_power_per_phase": {
+        "name": "Max power per phase"
       },
       "short_power_failure_count": {
         "name": "Short power failure count"

--- a/tests/components/dsmr/test_sensor.py
+++ b/tests/components/dsmr/test_sensor.py
@@ -19,6 +19,7 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
+    ATTR_FRIENDLY_NAME,
     ATTR_ICON,
     ATTR_UNIT_OF_MEASUREMENT,
     STATE_UNAVAILABLE,
@@ -119,6 +120,10 @@ async def test_default_setup(hass: HomeAssistant, dsmr_connection_fixture) -> No
     assert active_tariff.state == "low"
     assert active_tariff.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.ENUM
     assert active_tariff.attributes.get(ATTR_ICON) == "mdi:flash"
+    assert (
+        active_tariff.attributes.get(ATTR_FRIENDLY_NAME)
+        == "Electricity Meter Active tariff"
+    )
     assert active_tariff.attributes.get(ATTR_OPTIONS) == ["low", "normal"]
     assert active_tariff.attributes.get(ATTR_STATE_CLASS) is None
     assert active_tariff.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == ""
@@ -127,6 +132,10 @@ async def test_default_setup(hass: HomeAssistant, dsmr_connection_fixture) -> No
     gas_consumption = hass.states.get("sensor.gas_meter_gas_consumption")
     assert gas_consumption.state == "745.695"
     assert gas_consumption.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.GAS
+    assert (
+        gas_consumption.attributes.get(ATTR_FRIENDLY_NAME)
+        == "Gas Meter Gas consumption"
+    )
     assert (
         gas_consumption.attributes.get(ATTR_STATE_CLASS)
         == SensorStateClass.TOTAL_INCREASING


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Switch to entity translations for dsmr

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
