### PR TITLE
Fix a series of bugs due to Notion API changes

### DIFF
--- a/homeassistant/components/notion/__init__.py
+++ b/homeassistant/components/notion/__init__.py
@@ -157,9 +157,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         """Get the latest data from the Notion API."""
         data = NotionData(hass=hass, entry=entry)
         tasks = {
-            "bridge": client.bridge.async_all(),
-            "listener": client.sensor.async_listeners(),
-            "sensor": client.sensor.async_all(),
+            "bridges": client.bridge.async_all(),
+            "listeners": client.sensor.async_listeners(),
+            "sensors": client.sensor.async_all(),
             "user_preferences": client.user.async_preferences(),
         }
 

--- a/homeassistant/components/notion/__init__.py
+++ b/homeassistant/components/notion/__init__.py
@@ -58,11 +58,6 @@ PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR]
 ATTR_SYSTEM_MODE = "system_mode"
 ATTR_SYSTEM_NAME = "system_name"
 
-DATA_KIND_BRIDGE = "bridge"
-DATA_KIND_LISTENER = "listener"
-DATA_KIND_SENSOR = "sensor"
-DATA_KIND_USER_PREFERENCES = "user_preferences"
-
 DEFAULT_SCAN_INTERVAL = timedelta(minutes=1)
 
 CONFIG_SCHEMA = cv.removed(DOMAIN, raise_if_present=False)
@@ -162,10 +157,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         """Get the latest data from the Notion API."""
         data = NotionData(hass=hass, entry=entry)
         tasks = {
-            DATA_KIND_BRIDGE: client.bridge.async_all(),
-            DATA_KIND_LISTENER: client.sensor.async_listeners(),
-            DATA_KIND_SENSOR: client.sensor.async_all(),
-            DATA_KIND_USER_PREFERENCES: client.user.async_preferences(),
+            "bridge": client.bridge.async_all(),
+            "listener": client.sensor.async_listeners(),
+            "sensor": client.sensor.async_all(),
+            "user_preferences": client.user.async_preferences(),
         }
 
         results = await asyncio.gather(*tasks.values(), return_exceptions=True)

--- a/homeassistant/components/notion/__init__.py
+++ b/homeassistant/components/notion/__init__.py
@@ -10,9 +10,16 @@ from typing import Any
 from uuid import UUID
 
 from aionotion import async_get_client
-from aionotion.bridge.models import Bridge
+from aionotion.bridge.models import Bridge, BridgeAllResponse
 from aionotion.errors import InvalidCredentialsError, NotionError
-from aionotion.sensor.models import Listener, ListenerKind, Sensor
+from aionotion.sensor.models import (
+    Listener,
+    ListenerAllResponse,
+    ListenerKind,
+    Sensor,
+    SensorAllResponse,
+)
+from aionotion.user.models import UserPreferences, UserPreferencesResponse
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
@@ -51,6 +58,11 @@ PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR]
 ATTR_SYSTEM_MODE = "system_mode"
 ATTR_SYSTEM_NAME = "system_name"
 
+DATA_KIND_BRIDGE = "bridge"
+DATA_KIND_LISTENER = "listener"
+DATA_KIND_SENSOR = "sensor"
+DATA_KIND_USER_PREFERENCES = "user_preferences"
+
 DEFAULT_SCAN_INTERVAL = timedelta(minutes=1)
 
 CONFIG_SCHEMA = cv.removed(DOMAIN, raise_if_present=False)
@@ -84,6 +96,9 @@ def is_uuid(value: str) -> bool:
 class NotionData:
     """Define a manager class for Notion data."""
 
+    hass: HomeAssistant
+    entry: ConfigEntry
+
     # Define a dict of bridges, indexed by bridge ID (an integer):
     bridges: dict[int, Bridge] = field(default_factory=dict)
 
@@ -92,6 +107,30 @@ class NotionData:
 
     # Define a dict of sensors, indexed by sensor UUID (a string):
     sensors: dict[str, Sensor] = field(default_factory=dict)
+
+    # Define a user preferences response object:
+    user_preferences: UserPreferences | None = field(default=None)
+
+    def update_data_from_response(
+        self,
+        response: BridgeAllResponse
+        | ListenerAllResponse
+        | SensorAllResponse
+        | UserPreferencesResponse,
+    ) -> None:
+        """Update data from an aionotion response."""
+        if isinstance(response, BridgeAllResponse):
+            for bridge in response.bridges:
+                # If a new bridge is discovered, register it:
+                if bridge.id not in self.bridges:
+                    _async_register_new_bridge(self.hass, self.entry, bridge)
+                self.bridges[bridge.id] = bridge
+        elif isinstance(response, ListenerAllResponse):
+            self.listeners = {listener.id: listener for listener in response.listeners}
+        elif isinstance(response, SensorAllResponse):
+            self.sensors = {sensor.uuid: sensor for sensor in response.sensors}
+        elif isinstance(response, UserPreferencesResponse):
+            self.user_preferences = response.user_preferences
 
     def asdict(self) -> dict[str, Any]:
         """Represent this dataclass (and its Pydantic contents) as a dict."""
@@ -121,11 +160,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     async def async_update() -> NotionData:
         """Get the latest data from the Notion API."""
-        data = NotionData()
+        data = NotionData(hass=hass, entry=entry)
         tasks = {
-            "bridges": client.bridge.async_all(),
-            "listeners": client.sensor.async_listeners(),
-            "sensors": client.sensor.async_all(),
+            DATA_KIND_BRIDGE: client.bridge.async_all(),
+            DATA_KIND_LISTENER: client.sensor.async_listeners(),
+            DATA_KIND_SENSOR: client.sensor.async_all(),
+            DATA_KIND_USER_PREFERENCES: client.user.async_preferences(),
         }
 
         results = await asyncio.gather(*tasks.values(), return_exceptions=True)
@@ -145,16 +185,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     f"There was an unknown error while updating {attr}: {result}"
                 ) from result
 
-            for item in result:
-                if attr == "bridges":
-                    # If a new bridge is discovered, register it:
-                    if item.id not in data.bridges:
-                        _async_register_new_bridge(hass, item, entry)
-                    data.bridges[item.id] = item
-                elif attr == "listeners":
-                    data.listeners[item.id] = item
-                else:
-                    data.sensors[item.uuid] = item
+            data.update_data_from_response(result)
 
         return data
 
@@ -216,7 +247,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 @callback
 def _async_register_new_bridge(
-    hass: HomeAssistant, bridge: Bridge, entry: ConfigEntry
+    hass: HomeAssistant, entry: ConfigEntry, bridge: Bridge
 ) -> None:
     """Register a new bridge."""
     if name := bridge.name:
@@ -279,6 +310,11 @@ class NotionEntity(CoordinatorEntity[DataUpdateCoordinator[NotionData]]):
             and self._listener_id in self.coordinator.data.listeners
         )
 
+    @property
+    def listener(self) -> Listener:
+        """Return the listener related to this entity."""
+        return self.coordinator.data.listeners[self._listener_id]
+
     @callback
     def _async_update_bridge_id(self) -> None:
         """Update the entity's bridge ID if it has changed.
@@ -311,20 +347,8 @@ class NotionEntity(CoordinatorEntity[DataUpdateCoordinator[NotionData]]):
         )
 
     @callback
-    def _async_update_from_latest_data(self) -> None:
-        """Update the entity from the latest data."""
-        raise NotImplementedError
-
-    @callback
     def _handle_coordinator_update(self) -> None:
         """Respond to a DataUpdateCoordinator update."""
         if self._listener_id in self.coordinator.data.listeners:
             self._async_update_bridge_id()
-            self._async_update_from_latest_data()
-
-        self.async_write_ha_state()
-
-    async def async_added_to_hass(self) -> None:
-        """Handle entity which will be added."""
-        await super().async_added_to_hass()
-        self._async_update_from_latest_data()
+        super()._handle_coordinator_update()

--- a/homeassistant/components/notion/diagnostics.py
+++ b/homeassistant/components/notion/diagnostics.py
@@ -16,6 +16,7 @@ CONF_DEVICE_KEY = "device_key"
 CONF_HARDWARE_ID = "hardware_id"
 CONF_LAST_BRIDGE_HARDWARE_ID = "last_bridge_hardware_id"
 CONF_TITLE = "title"
+CONF_USER_ID = "user_id"
 
 TO_REDACT = {
     CONF_DEVICE_KEY,
@@ -27,6 +28,7 @@ TO_REDACT = {
     CONF_TITLE,
     CONF_UNIQUE_ID,
     CONF_USERNAME,
+    CONF_USER_ID,
 }
 
 

--- a/homeassistant/components/notion/manifest.json
+++ b/homeassistant/components/notion/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "loggers": ["aionotion"],
-  "requirements": ["aionotion==2023.05.1"]
+  "requirements": ["aionotion==2023.05.4"]
 }

--- a/homeassistant/components/notion/sensor.py
+++ b/homeassistant/components/notion/sensor.py
@@ -78,9 +78,9 @@ class NotionSensor(NotionEntity, SensorEntity):
     def native_value(self) -> str | None:
         """Return the value reported by the sensor.
 
-        The Notion API only returns a localized string for temperature (like "70°" or
-        "70°F"); in this case, we extract just the digits.
+        The Notion API only returns a localized string for temperature (e.g. "70°"); we
+        simply remove the degree symbol:
         """
         if not self.listener.status_localized:
             return None
-        return "".join(c for c in self.listener.status_localized.state if c.isdigit())
+        return self.listener.status_localized.state[:-1]

--- a/homeassistant/components/notion/sensor.py
+++ b/homeassistant/components/notion/sensor.py
@@ -11,11 +11,11 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfTemperature
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import NotionEntity
-from .const import DOMAIN, LOGGER, SENSOR_TEMPERATURE
+from .const import DOMAIN, SENSOR_TEMPERATURE
 from .model import NotionEntityDescriptionMixin
 
 
@@ -63,15 +63,24 @@ async def async_setup_entry(
 class NotionSensor(NotionEntity, SensorEntity):
     """Define a Notion sensor."""
 
-    @callback
-    def _async_update_from_latest_data(self) -> None:
-        """Fetch new state data for the sensor."""
-        listener = self.coordinator.data.listeners[self._listener_id]
+    @property
+    def native_unit_of_measurement(self) -> str | None:
+        """Return the unit of measurement of the sensor."""
+        if self.listener.listener_kind == ListenerKind.TEMPERATURE:
+            if not self.coordinator.data.user_preferences:
+                return None
+            if self.coordinator.data.user_preferences.celsius_enabled:
+                return UnitOfTemperature.CELSIUS
+            return UnitOfTemperature.FAHRENHEIT
+        return None
 
-        if listener.listener_kind == ListenerKind.TEMPERATURE:
-            self._attr_native_value = round(listener.status.temperature, 1)  # type: ignore[attr-defined]
-        else:
-            LOGGER.error(
-                "Unknown listener type for sensor %s",
-                self.coordinator.data.sensors[self._sensor_id],
-            )
+    @property
+    def native_value(self) -> str | None:
+        """Return the value reported by the sensor.
+
+        The Notion API only returns a localized string for temperature (like "70°" or
+        "70°F"); in this case, we extract just the digits.
+        """
+        if not self.listener.status_localized:
+            return None
+        return "".join(c for c in self.listener.status_localized.state if c.isdigit())

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -223,7 +223,7 @@ aionanoleaf==0.2.1
 aionotify==0.2.0
 
 # homeassistant.components.notion
-aionotion==2023.05.1
+aionotion==2023.05.4
 
 # homeassistant.components.oncue
 aiooncue==0.3.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -204,7 +204,7 @@ aiomusiccast==0.14.8
 aionanoleaf==0.2.1
 
 # homeassistant.components.notion
-aionotion==2023.05.1
+aionotion==2023.05.4
 
 # homeassistant.components.oncue
 aiooncue==0.3.4

--- a/tests/components/notion/conftest.py
+++ b/tests/components/notion/conftest.py
@@ -3,8 +3,9 @@ from collections.abc import Generator
 import json
 from unittest.mock import AsyncMock, Mock, patch
 
-from aionotion.bridge.models import Bridge
-from aionotion.sensor.models import Listener, Sensor
+from aionotion.bridge.models import BridgeAllResponse
+from aionotion.sensor.models import ListenerAllResponse, SensorAllResponse
+from aionotion.user.models import UserPreferencesResponse
 import pytest
 
 from homeassistant.components.notion import DOMAIN
@@ -27,23 +28,22 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture(name="client")
-def client_fixture(data_bridge, data_listener, data_sensor):
+def client_fixture(data_bridge, data_listener, data_sensor, data_user_preferences):
     """Define a fixture for an aionotion client."""
     return Mock(
         bridge=Mock(
-            async_all=AsyncMock(
-                return_value=[Bridge.parse_obj(bridge) for bridge in data_bridge]
-            )
+            async_all=AsyncMock(return_value=BridgeAllResponse.parse_obj(data_bridge))
         ),
         sensor=Mock(
-            async_all=AsyncMock(
-                return_value=[Sensor.parse_obj(sensor) for sensor in data_sensor]
-            ),
+            async_all=AsyncMock(return_value=SensorAllResponse.parse_obj(data_sensor)),
             async_listeners=AsyncMock(
-                return_value=[
-                    Listener.parse_obj(listener) for listener in data_listener
-                ]
+                return_value=ListenerAllResponse.parse_obj(data_listener)
             ),
+        ),
+        user=Mock(
+            async_preferences=AsyncMock(
+                return_value=UserPreferencesResponse.parse_obj(data_user_preferences)
+            )
         ),
     )
 
@@ -81,6 +81,12 @@ def data_listener_fixture():
 def data_sensor_fixture():
     """Define sensor data."""
     return json.loads(load_fixture("sensor_data.json", "notion"))
+
+
+@pytest.fixture(name="data_user_preferences", scope="package")
+def data_user_preferences_fixture():
+    """Define user preferences data."""
+    return json.loads(load_fixture("user_preferences_data.json", "notion"))
 
 
 @pytest.fixture(name="get_client")

--- a/tests/components/notion/fixtures/bridge_data.json
+++ b/tests/components/notion/fixtures/bridge_data.json
@@ -1,50 +1,52 @@
-[
-  {
-    "id": 12345,
-    "name": "Bridge 1",
-    "mode": "home",
-    "hardware_id": "0x0000000000000000",
-    "hardware_revision": 4,
-    "firmware_version": {
-      "silabs": "1.1.2",
-      "wifi": "0.121.0",
-      "wifi_app": "3.3.0"
+{
+  "base_stations": [
+    {
+      "id": 12345,
+      "name": "Bridge 1",
+      "mode": "home",
+      "hardware_id": "0x0000000000000000",
+      "hardware_revision": 4,
+      "firmware_version": {
+        "silabs": "1.1.2",
+        "wifi": "0.121.0",
+        "wifi_app": "3.3.0"
+      },
+      "missing_at": null,
+      "created_at": "2019-06-27T00:18:44.337Z",
+      "updated_at": "2023-03-19T03:20:16.061Z",
+      "system_id": 11111,
+      "firmware": {
+        "silabs": "1.1.2",
+        "wifi": "0.121.0",
+        "wifi_app": "3.3.0"
+      },
+      "links": {
+        "system": 11111
+      }
     },
-    "missing_at": null,
-    "created_at": "2019-06-27T00:18:44.337Z",
-    "updated_at": "2023-03-19T03:20:16.061Z",
-    "system_id": 11111,
-    "firmware": {
-      "silabs": "1.1.2",
-      "wifi": "0.121.0",
-      "wifi_app": "3.3.0"
-    },
-    "links": {
-      "system": 11111
+    {
+      "id": 67890,
+      "name": "Bridge 2",
+      "mode": "home",
+      "hardware_id": "0x0000000000000000",
+      "hardware_revision": 4,
+      "firmware_version": {
+        "wifi": "0.121.0",
+        "wifi_app": "3.3.0",
+        "silabs": "1.1.2"
+      },
+      "missing_at": null,
+      "created_at": "2019-04-30T01:43:50.497Z",
+      "updated_at": "2023-01-02T19:09:58.251Z",
+      "system_id": 11111,
+      "firmware": {
+        "wifi": "0.121.0",
+        "wifi_app": "3.3.0",
+        "silabs": "1.1.2"
+      },
+      "links": {
+        "system": 11111
+      }
     }
-  },
-  {
-    "id": 67890,
-    "name": "Bridge 2",
-    "mode": "home",
-    "hardware_id": "0x0000000000000000",
-    "hardware_revision": 4,
-    "firmware_version": {
-      "wifi": "0.121.0",
-      "wifi_app": "3.3.0",
-      "silabs": "1.1.2"
-    },
-    "missing_at": null,
-    "created_at": "2019-04-30T01:43:50.497Z",
-    "updated_at": "2023-01-02T19:09:58.251Z",
-    "system_id": 11111,
-    "firmware": {
-      "wifi": "0.121.0",
-      "wifi_app": "3.3.0",
-      "silabs": "1.1.2"
-    },
-    "links": {
-      "system": 11111
-    }
-  }
-]
+  ]
+}

--- a/tests/components/notion/fixtures/listener_data.json
+++ b/tests/components/notion/fixtures/listener_data.json
@@ -1,55 +1,57 @@
-[
-  {
-    "id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-    "definition_id": 4,
-    "created_at": "2019-06-28T22:12:49.651Z",
-    "type": "sensor",
-    "model_version": "2.1",
-    "sensor_id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-    "status": {
-      "trigger_value": "no_leak",
-      "data_received_at": "2022-03-20T08:00:29.763Z"
-    },
-    "status_localized": {
-      "state": "No Leak",
-      "description": "Mar 20 at 2:00am"
-    },
-    "insights": {
-      "primary": {
-        "origin": {
-          "type": "Sensor",
-          "id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-        },
-        "value": "no_leak",
+{
+  "listeners": [
+    {
+      "id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+      "definition_id": 4,
+      "created_at": "2019-06-28T22:12:49.651Z",
+      "type": "sensor",
+      "model_version": "2.1",
+      "sensor_id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+      "status": {
+        "trigger_value": "no_leak",
         "data_received_at": "2022-03-20T08:00:29.763Z"
-      }
+      },
+      "status_localized": {
+        "state": "No Leak",
+        "description": "Mar 20 at 2:00am"
+      },
+      "insights": {
+        "primary": {
+          "origin": {
+            "type": "Sensor",
+            "id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+          },
+          "value": "no_leak",
+          "data_received_at": "2022-03-20T08:00:29.763Z"
+        }
+      },
+      "configuration": {},
+      "pro_monitoring_status": "eligible"
     },
-    "configuration": {},
-    "pro_monitoring_status": "eligible"
-  },
-  {
-    "id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-    "definition_id": 7,
-    "created_at": "2019-07-10T22:40:48.847Z",
-    "type": "sensor",
-    "model_version": "3.1",
-    "sensor_id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-    "status": {
-      "trigger_value": "no_alarm",
-      "data_received_at": "2019-06-28T22:12:49.516Z"
-    },
-    "status_localized": {
-      "state": "No Sound",
-      "description": "Jun 28 at 4:12pm"
-    },
-    "insights": {
-      "primary": {
-        "origin": {},
-        "value": "no_alarm",
+    {
+      "id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+      "definition_id": 7,
+      "created_at": "2019-07-10T22:40:48.847Z",
+      "type": "sensor",
+      "model_version": "3.1",
+      "sensor_id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+      "status": {
+        "trigger_value": "no_alarm",
         "data_received_at": "2019-06-28T22:12:49.516Z"
-      }
-    },
-    "configuration": {},
-    "pro_monitoring_status": "eligible"
-  }
-]
+      },
+      "status_localized": {
+        "state": "No Sound",
+        "description": "Jun 28 at 4:12pm"
+      },
+      "insights": {
+        "primary": {
+          "origin": {},
+          "value": "no_alarm",
+          "data_received_at": "2019-06-28T22:12:49.516Z"
+        }
+      },
+      "configuration": {},
+      "pro_monitoring_status": "eligible"
+    }
+  ]
+}

--- a/tests/components/notion/fixtures/sensor_data.json
+++ b/tests/components/notion/fixtures/sensor_data.json
@@ -1,34 +1,36 @@
-[
-  {
-    "id": 123456,
-    "uuid": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-    "user": {
-      "id": 12345,
-      "email": "user@email.com"
-    },
-    "bridge": {
-      "id": 67890,
-      "hardware_id": "0x0000000000000000"
-    },
-    "last_bridge_hardware_id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-    "name": "Sensor 1",
-    "location_id": 123456,
-    "system_id": 12345,
-    "hardware_id": "0x0000000000000000",
-    "hardware_revision": 5,
-    "firmware_version": "1.1.2",
-    "device_key": "0x0000000000000000",
-    "encryption_key": true,
-    "installed_at": "2019-06-28T22:12:51.209Z",
-    "calibrated_at": "2023-03-07T19:51:56.838Z",
-    "last_reported_at": "2023-04-19T18:09:40.479Z",
-    "missing_at": null,
-    "updated_at": "2023-03-28T13:33:33.801Z",
-    "created_at": "2019-06-28T22:12:20.256Z",
-    "signal_strength": 4,
-    "firmware": {
-      "status": "valid"
-    },
-    "surface_type": null
-  }
-]
+{
+  "sensors": [
+    {
+      "id": 123456,
+      "uuid": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+      "user": {
+        "id": 12345,
+        "email": "user@email.com"
+      },
+      "bridge": {
+        "id": 67890,
+        "hardware_id": "0x0000000000000000"
+      },
+      "last_bridge_hardware_id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+      "name": "Sensor 1",
+      "location_id": 123456,
+      "system_id": 12345,
+      "hardware_id": "0x0000000000000000",
+      "hardware_revision": 5,
+      "firmware_version": "1.1.2",
+      "device_key": "0x0000000000000000",
+      "encryption_key": true,
+      "installed_at": "2019-06-28T22:12:51.209Z",
+      "calibrated_at": "2023-03-07T19:51:56.838Z",
+      "last_reported_at": "2023-04-19T18:09:40.479Z",
+      "missing_at": null,
+      "updated_at": "2023-03-28T13:33:33.801Z",
+      "created_at": "2019-06-28T22:12:20.256Z",
+      "signal_strength": 4,
+      "firmware": {
+        "status": "valid"
+      },
+      "surface_type": null
+    }
+  ]
+}

--- a/tests/components/notion/fixtures/user_preferences_data.json
+++ b/tests/components/notion/fixtures/user_preferences_data.json
@@ -1,0 +1,10 @@
+{
+  "user_preferences": {
+    "user_id": 12345,
+    "military_time_enabled": false,
+    "celsius_enabled": false,
+    "disconnect_alerts_enabled": true,
+    "home_away_alerts_enabled": false,
+    "battery_alerts_enabled": true
+  }
+}

--- a/tests/components/notion/test_diagnostics.py
+++ b/tests/components/notion/test_diagnostics.py
@@ -86,14 +86,6 @@ async def test_entry_diagnostics(
                     "device_type": "sensor",
                     "model_version": "3.1",
                     "sensor_id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-                    "status": {
-                        "trigger_value": "no_alarm",
-                        "data_received_at": "2019-06-28T22:12:49.516000+00:00",
-                    },
-                    "status_localized": {
-                        "state": "No Sound",
-                        "description": "Jun 28 at 4:12pm",
-                    },
                     "insights": {
                         "primary": {
                             "origin": {"type": None, "id": None},
@@ -103,6 +95,14 @@ async def test_entry_diagnostics(
                     },
                     "configuration": {},
                     "pro_monitoring_status": "eligible",
+                    "status": {
+                        "trigger_value": "no_alarm",
+                        "data_received_at": "2019-06-28T22:12:49.516000+00:00",
+                    },
+                    "status_localized": {
+                        "state": "No Sound",
+                        "description": "Jun 28 at 4:12pm",
+                    },
                 }
             ],
             "sensors": [
@@ -131,5 +131,13 @@ async def test_entry_diagnostics(
                     "surface_type": None,
                 }
             ],
+            "user_preferences": {
+                "user_id": REDACTED,
+                "military_time_enabled": False,
+                "celsius_enabled": False,
+                "disconnect_alerts_enabled": True,
+                "home_away_alerts_enabled": False,
+                "battery_alerts_enabled": True,
+            },
         },
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Following up on https://github.com/home-assistant/core/pull/91786, this PR fixes some integration bugs introduced by the new Notion API—in particular:

1. Fixes erroneous temperature values by taking the user's preferred unit into account
2. Handles missing data keys that the integration previously relied on
3. Fixes an incorrect check for battery binary sensor state
4. Bumps `aionotion` to 2023.05.4 to address differing data formats

Changelog: https://github.com/bachya/aionotion/releases/tag/2023.05.4
Diff: https://github.com/bachya/aionotion/compare/2023.05.1...2023.05.4

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/92692
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
