### PR TITLE
Allow workday sensor to be configured without a country

### DIFF
--- a/homeassistant/components/workday/__init__.py
+++ b/homeassistant/components/workday/__init__.py
@@ -13,12 +13,13 @@ from .const import CONF_COUNTRY, CONF_PROVINCE, PLATFORMS
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Workday from a config entry."""
 
-    country: str = entry.options[CONF_COUNTRY]
+    country: str | None = entry.options.get(CONF_COUNTRY)
     province: str | None = entry.options.get(CONF_PROVINCE)
+
     if country and country not in list_supported_countries():
         raise ConfigEntryError(f"Selected country {country} is not valid")
 
-    if province and province not in list_supported_countries()[country]:
+    if country and province and province not in list_supported_countries()[country]:
         raise ConfigEntryError(
             f"Selected province {province} for country {country} is not valid"
         )

--- a/homeassistant/components/workday/binary_sensor.py
+++ b/homeassistant/components/workday/binary_sensor.py
@@ -138,8 +138,6 @@ async def async_setup_entry(
             years=year,
             language=cls.default_language,
         )
-    elif province:
-        raise ValueError(f"Must not specify a province without a country: {province}")
     else:
         obj_holidays = HolidayBase()
 

--- a/homeassistant/components/workday/binary_sensor.py
+++ b/homeassistant/components/workday/binary_sensor.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 from datetime import date, timedelta
 from typing import Any
 
-import holidays
 from holidays import (
     DateLike,
     HolidayBase,

--- a/homeassistant/components/workday/config_flow.py
+++ b/homeassistant/components/workday/config_flow.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 
 from typing import Any
 
-import holidays
-from holidays import HolidayBase, list_supported_countries
+from holidays import HolidayBase, country_holidays, list_supported_countries
 import voluptuous as vol
 
 from homeassistant.config_entries import (
@@ -53,11 +52,10 @@ def add_province_to_schema(
 ) -> vol.Schema:
     """Update schema with province from country."""
     all_countries = list_supported_countries()
-    all_provinces = all_countries.get(country)
-    if not all_provinces:
+    if not all_countries.get(country):
         return schema
 
-    province_list = [NONE_SENTINEL, *all_provinces]
+    province_list = [NONE_SENTINEL, *all_countries[country]]
     add_schema = {
         vol.Optional(CONF_PROVINCE, default=NONE_SENTINEL): SelectSelector(
             SelectSelectorConfig(
@@ -77,19 +75,17 @@ def validate_custom_dates(user_input: dict[str, Any]) -> None:
         if dt_util.parse_date(add_date) is None:
             raise AddDatesError("Incorrect date")
 
-    country: str = user_input[CONF_COUNTRY]
-    if country is not None:
-        cls: type[HolidayBase] = getattr(holidays, country)
-    else:
-        cls = HolidayBase
-
     year: int = dt_util.now().year
-
-    obj_holidays = cls(
-        subdiv=user_input.get(CONF_PROVINCE),
-        years=year,
-        language=cls.default_language,
-    )
+    if country := user_input[CONF_COUNTRY]:
+        cls = country_holidays(country)
+        obj_holidays = country_holidays(
+            country=country,
+            subdiv=user_input.get(CONF_PROVINCE),
+            years=year,
+            language=cls.default_language,
+        )
+    else:
+        obj_holidays = HolidayBase(years=year)
 
     for remove_date in user_input[CONF_REMOVE_HOLIDAYS]:
         if dt_util.parse_date(remove_date) is None:

--- a/homeassistant/components/workday/strings.json
+++ b/homeassistant/components/workday/strings.json
@@ -66,6 +66,11 @@
     }
   },
   "selector": {
+    "country": {
+      "options": {
+        "none": "No country"
+      }
+    },
     "province": {
       "options": {
         "none": "No subdivision"

--- a/tests/components/workday/__init__.py
+++ b/tests/components/workday/__init__.py
@@ -40,6 +40,31 @@ async def init_integration(
     return config_entry
 
 
+TEST_CONFIG_NO_COUNTRY = {
+    "name": DEFAULT_NAME,
+    "excludes": DEFAULT_EXCLUDES,
+    "days_offset": DEFAULT_OFFSET,
+    "workdays": DEFAULT_WORKDAYS,
+    "add_holidays": [],
+    "remove_holidays": [],
+}
+TEST_CONFIG_NO_COUNTRY_ADD_HOLIDAY = {
+    "name": DEFAULT_NAME,
+    "excludes": DEFAULT_EXCLUDES,
+    "days_offset": DEFAULT_OFFSET,
+    "workdays": DEFAULT_WORKDAYS,
+    "add_holidays": ["2020-02-24"],
+    "remove_holidays": [],
+}
+TEST_CONFIG_NO_COUNTRY_WITH_PROVINCE = {
+    "name": DEFAULT_NAME,
+    "excludes": DEFAULT_EXCLUDES,
+    "days_offset": DEFAULT_OFFSET,
+    "workdays": DEFAULT_WORKDAYS,
+    "add_holidays": [],
+    "remove_holidays": [],
+    "province": "NO",
+}
 TEST_CONFIG_WITH_PROVINCE = {
     "name": DEFAULT_NAME,
     "country": "DE",

--- a/tests/components/workday/__init__.py
+++ b/tests/components/workday/__init__.py
@@ -56,15 +56,6 @@ TEST_CONFIG_NO_COUNTRY_ADD_HOLIDAY = {
     "add_holidays": ["2020-02-24"],
     "remove_holidays": [],
 }
-TEST_CONFIG_NO_COUNTRY_WITH_PROVINCE = {
-    "name": DEFAULT_NAME,
-    "excludes": DEFAULT_EXCLUDES,
-    "days_offset": DEFAULT_OFFSET,
-    "workdays": DEFAULT_WORKDAYS,
-    "add_holidays": [],
-    "remove_holidays": [],
-    "province": "NO",
-}
 TEST_CONFIG_WITH_PROVINCE = {
     "name": DEFAULT_NAME,
     "country": "DE",

--- a/tests/components/workday/test_binary_sensor.py
+++ b/tests/components/workday/test_binary_sensor.py
@@ -21,7 +21,6 @@ from . import (
     TEST_CONFIG_INCORRECT_PROVINCE,
     TEST_CONFIG_NO_COUNTRY,
     TEST_CONFIG_NO_COUNTRY_ADD_HOLIDAY,
-    TEST_CONFIG_NO_COUNTRY_WITH_PROVINCE,
     TEST_CONFIG_NO_PROVINCE,
     TEST_CONFIG_NO_STATE,
     TEST_CONFIG_REMOVE_HOLIDAY,
@@ -247,18 +246,6 @@ async def test_setup_faulty_province(
     assert state is None
 
     assert "Selected province ZZ for country DE is not valid" in caplog.text
-
-
-async def test_setup_no_country_faulty_province(
-    hass: HomeAssistant,
-    freezer: FrozenDateTimeFactory,
-) -> None:
-    """Test setup with no country and faulty province."""
-    freezer.move_to(datetime(2017, 1, 6, 12, tzinfo=UTC))  # Friday
-    await init_integration(hass, TEST_CONFIG_NO_COUNTRY_WITH_PROVINCE)
-
-    state = hass.states.get("binary_sensor.workday_sensor")
-    assert state is None
 
 
 async def test_setup_incorrect_add_remove(

--- a/tests/components/workday/test_config_flow.py
+++ b/tests/components/workday/test_config_flow.py
@@ -72,6 +72,48 @@ async def test_form(hass: HomeAssistant) -> None:
     }
 
 
+async def test_form_no_country(hass: HomeAssistant) -> None:
+    """Test we get the forms correctly without a country."""
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.FORM
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_NAME: "Workday Sensor",
+            CONF_COUNTRY: "none",
+        },
+    )
+    await hass.async_block_till_done()
+    result3 = await hass.config_entries.flow.async_configure(
+        result2["flow_id"],
+        {
+            CONF_EXCLUDES: DEFAULT_EXCLUDES,
+            CONF_OFFSET: DEFAULT_OFFSET,
+            CONF_WORKDAYS: DEFAULT_WORKDAYS,
+            CONF_ADD_HOLIDAYS: [],
+            CONF_REMOVE_HOLIDAYS: [],
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert result3["type"] == FlowResultType.CREATE_ENTRY
+    assert result3["title"] == "Workday Sensor"
+    assert result3["options"] == {
+        "name": "Workday Sensor",
+        "country": None,
+        "excludes": ["sat", "sun", "holiday"],
+        "days_offset": 0,
+        "workdays": ["mon", "tue", "wed", "thu", "fri"],
+        "add_holidays": [],
+        "remove_holidays": [],
+        "province": None,
+    }
+
+
 async def test_form_no_subdivision(hass: HomeAssistant) -> None:
     """Test we get the forms correctly without subdivision."""
 


### PR DESCRIPTION
## Proposed change
Allow the configuration of the workday sensor without a country. This allows for an empty starting slate of holidays that can then be built up with the "Add holidays" option.

This is useful to those (like me) with a holiday schedule that doesn't match well with the official holidays of my region. Instead of having to determine which holidays to remove and which to add, it is easier to simply start with a blank slate and add the holidays I will have from the list provided by HR.


## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #85996
- This PR is related to issue: #85996
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/28641
- Supersedes #87222

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
