### PR TITLE
Speed up reconnects by caching state serialize

### DIFF
--- a/homeassistant/components/websocket_api/messages.py
+++ b/homeassistant/components/websocket_api/messages.py
@@ -44,7 +44,7 @@ ENTITY_EVENT_REMOVE = "r"
 ENTITY_EVENT_CHANGE = "c"
 
 
-def result_message(iden: int, result: Any = None) -> dict[str, Any]:
+def result_message(iden: JSON_TYPE | int, result: Any = None) -> dict[str, Any]:
     """Return a success result message."""
     return {"id": iden, "type": const.TYPE_RESULT, "success": True, "result": result}
 

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1300,13 +1300,7 @@ class State:
         return self._as_dict
 
     def as_dict_json(self) -> str:
-        """Return a JSON string of the State.
-
-        Async friendly.
-
-        To be used for JSON serialization.
-        Ensures: state == State.from_dict(state.as_dict())
-        """
+        """Return a JSON string of the State."""
         if not self._as_dict_json:
             self._as_dict_json = json_dumps(self.as_dict())
         return self._as_dict_json
@@ -1339,18 +1333,16 @@ class State:
         return compressed_state
 
     def as_compressed_state_json(self) -> str:
-        """Build a compressed dict of a state for adds.
+        """Build a compressed JSON key value pair of a state for adds.
 
-        Omits the lu (last_updated) if it matches (lc) last_changed.
+        The JSON string is a key value pair of the entity_id and the compressed state.
 
-        Sends c (context) as a string if it only contains an id.
+        It is used for sending multiple states in a single message.
         """
         if not self._as_compressed_state_json:
-            self._as_compressed_state_json = (
-                json_dumps(self.entity_id)
-                + ":"
-                + json_dumps(self.as_compressed_state())
-            )
+            self._as_compressed_state_json = json_dumps(
+                {self.entity_id: self.as_compressed_state()}
+            )[1:-1]
         return self._as_compressed_state_json
 
     @classmethod

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -80,6 +80,7 @@ from .exceptions import (
     Unauthorized,
 )
 from .helpers.aiohttp_compat import restore_original_aiohttp_cancel_behavior
+from .helpers.json import json_dumps
 from .util import dt as dt_util, location, ulid as ulid_util
 from .util.async_ import run_callback_threadsafe, shutdown_run_callback_threadsafe
 from .util.read_only_dict import ReadOnlyDict
@@ -1224,6 +1225,8 @@ class State:
         "object_id",
         "_as_dict",
         "_as_compressed_state",
+        "_as_dict_json",
+        "_as_compressed_state_json",
     )
 
     def __init__(
@@ -1260,6 +1263,8 @@ class State:
         self.domain, self.object_id = split_entity_id(self.entity_id)
         self._as_dict: ReadOnlyDict[str, Collection[Any]] | None = None
         self._as_compressed_state: dict[str, Any] | None = None
+        self._as_dict_json: str | None = None
+        self._as_compressed_state_json: str | None = None
 
     @property
     def name(self) -> str:
@@ -1294,6 +1299,18 @@ class State:
             )
         return self._as_dict
 
+    def as_dict_json(self) -> str:
+        """Return a JSON string of the State.
+
+        Async friendly.
+
+        To be used for JSON serialization.
+        Ensures: state == State.from_dict(state.as_dict())
+        """
+        if not self._as_dict_json:
+            self._as_dict_json = json_dumps(self.as_dict())
+        return self._as_dict_json
+
     def as_compressed_state(self) -> dict[str, Any]:
         """Build a compressed dict of a state for adds.
 
@@ -1320,6 +1337,21 @@ class State:
             )
         self._as_compressed_state = compressed_state
         return compressed_state
+
+    def as_compressed_state_json(self) -> str:
+        """Build a compressed dict of a state for adds.
+
+        Omits the lu (last_updated) if it matches (lc) last_changed.
+
+        Sends c (context) as a string if it only contains an id.
+        """
+        if not self._as_compressed_state_json:
+            self._as_compressed_state_json = (
+                json_dumps(self.entity_id)
+                + ":"
+                + json_dumps(self.as_compressed_state())
+            )
+        return self._as_compressed_state_json
 
     @classmethod
     def from_dict(cls, json_dict: dict[str, Any]) -> Self | None:

--- a/homeassistant/helpers/json.py
+++ b/homeassistant/helpers/json.py
@@ -9,7 +9,6 @@ from typing import Any, Final
 
 import orjson
 
-from homeassistant.core import Event, State
 from homeassistant.util.file import write_utf8_file, write_utf8_file_atomic
 from homeassistant.util.json import (  # pylint: disable=unused-import # noqa: F401
     JSON_DECODE_EXCEPTIONS,
@@ -189,6 +188,11 @@ def find_paths_unserializable_data(
 
     This method is slow! Only use for error handling.
     """
+    from homeassistant.core import (  # pylint: disable=import-outside-toplevel
+        Event,
+        State,
+    )
+
     to_process = deque([(bad_data, "$")])
     invalid = {}
 

--- a/tests/components/websocket_api/test_http.py
+++ b/tests/components/websocket_api/test_http.py
@@ -187,10 +187,9 @@ async def test_non_json_message(
     assert msg["type"] == const.TYPE_RESULT
     assert msg["success"]
     assert msg["result"] == []
-    assert (
-        f"Unable to serialize to JSON. Bad data found at $.result[0](State: test_domain.entity).attributes.bad={bad_data}(<class 'object'>"
-        in caplog.text
-    )
+    assert "Unable to serialize to JSON. Bad data found" in caplog.text
+    assert "State: test_domain.entity" in caplog.text
+    assert "bad=<object" in caplog.text
 
 
 async def test_prepare_fail(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -466,6 +466,29 @@ def test_state_as_dict() -> None:
     assert state.as_dict() is as_dict_1
 
 
+def test_state_as_dict_json() -> None:
+    """Test a State as JSON."""
+    last_time = datetime(1984, 12, 8, 12, 0, 0)
+    state = ha.State(
+        "happy.happy",
+        "on",
+        {"pig": "dog"},
+        last_updated=last_time,
+        last_changed=last_time,
+        context=ha.Context(id="01H0D6K3RFJAYAV2093ZW30PCW"),
+    )
+    expected = (
+        '{"entity_id":"happy.happy","state":"on","attributes":{"pig":"dog"},'
+        '"last_changed":"1984-12-08T12:00:00","last_updated":"1984-12-08T12:00:00",'
+        '"context":{"id":"01H0D6K3RFJAYAV2093ZW30PCW","parent_id":null,"user_id":null}}'
+    )
+    as_dict_json_1 = state.as_dict_json()
+    assert as_dict_json_1 == expected
+    # 2nd time to verify cache
+    assert state.as_dict_json() == expected
+    assert state.as_dict_json() is as_dict_json_1
+
+
 def test_state_as_compressed_state() -> None:
     """Test a State as compressed state."""
     last_time = datetime(1984, 12, 8, 12, 0, 0, tzinfo=dt_util.UTC)
@@ -516,6 +539,27 @@ def test_state_as_compressed_state_unique_last_updated() -> None:
     # 2nd time to verify cache
     assert state.as_compressed_state() == expected
     assert state.as_compressed_state() is as_compressed_state
+
+
+def test_state_as_compressed_state_json() -> None:
+    """Test a State as a JSON compressed state."""
+    last_time = datetime(1984, 12, 8, 12, 0, 0, tzinfo=dt_util.UTC)
+    state = ha.State(
+        "happy.happy",
+        "on",
+        {"pig": "dog"},
+        last_updated=last_time,
+        last_changed=last_time,
+        context=ha.Context(id="01H0D6H5K3SZJ3XGDHED1TJ79N"),
+    )
+    expected = '"happy.happy":{"s":"on","a":{"pig":"dog"},"c":"01H0D6H5K3SZJ3XGDHED1TJ79N","lc":471355200.0}'
+    as_compressed_state = state.as_compressed_state_json()
+    # We are not too concerned about these being ReadOnlyDict
+    # since we don't expect them to be called by external callers
+    assert as_compressed_state == expected
+    # 2nd time to verify cache
+    assert state.as_compressed_state_json() == expected
+    assert state.as_compressed_state_json() is as_compressed_state
 
 
 async def test_eventbus_add_remove_listener(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This will help with:
- mobile app reconnects (still uses get_states)
- frontend reconnects (using subscribe_entities)
- third party reconnects (most still using get_states)

This solves one of the last performance bottlenecks on the list.  This makes a noticeable difference on how fast the frontend can be usable on reconnects.  The goal is to be able to load the frontend as fast as possible from phone pickup / unlock / control device.  The bulk of the waiting is now on the frontend code (this continues to improve)

This is what the flame graph looks like for restoring a frontend connection before:
<img width="1165" alt="Screenshot 2023-05-14 at 1 52 20 AM" src="https://github.com/home-assistant/core/assets/663432/c26148f2-5185-46b4-bd9f-e9be4eca0aa4">

After
<img width="1166" alt="Screenshot 2023-05-14 at 1 56 08 AM" src="https://github.com/home-assistant/core/assets/663432/e59e328b-3ef4-409a-9228-8fb490091cea">



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
