### PR TITLE
Allow wemo config entry to be unloaded

### DIFF
--- a/homeassistant/components/wemo/__init__.py
+++ b/homeassistant/components/wemo/__init__.py
@@ -113,7 +113,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     wemo_dispatcher = WemoDispatcher(entry)
     wemo_discovery = WemoDiscovery(hass, wemo_dispatcher, static_conf)
 
-    async def async_stop_wemo(event: Event) -> None:
+    async def async_stop_wemo(_: Event | None = None) -> None:
         """Shutdown Wemo subscriptions and subscription thread on exit."""
         _LOGGER.debug("Shutting down WeMo event subscriptions")
         await hass.async_add_executor_job(registry.stop)
@@ -123,6 +123,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     entry.async_on_unload(
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, async_stop_wemo)
     )
+    entry.async_on_unload(async_stop_wemo)
 
     # Need to do this at least once in case statistics are defined and discovery is disabled
     await wemo_discovery.discover_statics()

--- a/homeassistant/components/wemo/__init__.py
+++ b/homeassistant/components/wemo/__init__.py
@@ -133,6 +133,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a wemo config entry."""
+    # This makes sure that `entry.async_on_unload` routines run correctly on unload
+    return True
+
+
 class WemoDispatcher:
     """Dispatch WeMo devices to the correct platform."""
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Linked to #91360
https://github.com/home-assistant/core/actions/runs/4923668065/jobs/8795823449?pr=91360

```console
ERROR tests/components/wemo/test_binary_sensor.py::TestMotion::test_async_update_locked_multiple_updates - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo 12b495322618ea85a7c18f478cf6ec3b HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fc6c5b6ac50>>>
ERROR tests/components/wemo/test_binary_sensor.py::TestMotion::test_async_update_locked_multiple_callbacks - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo 2c0ef4a1e50d6f5ee6713c1dd3af8890 HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fc6c5be05d0>>>
ERROR tests/components/wemo/test_binary_sensor.py::TestMotion::test_async_update_locked_callback_and_update - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo ff7dfa91cf0eb9f339a42e00a451d54a HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fc6c5bd3250>>>
ERROR tests/components/wemo/test_binary_sensor.py::TestMotion::test_binary_sensor_registry_state_callback - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo 8a969d96ea0b02f445e15f9448b5e29d HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fc6c690bd10>>>
ERROR tests/components/wemo/test_binary_sensor.py::TestMotion::test_binary_sensor_update_entity - Failed: Lingering timer after test <TimerHandle when=753.858782848 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:152>
ERROR tests/components/wemo/test_binary_sensor.py::TestMaker::test_async_update_locked_multiple_updates - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo 23f525518a56e03361dc20a2971fa8bb HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fc6c7464710>>>
ERROR tests/components/wemo/test_binary_sensor.py::TestMaker::test_async_update_locked_multiple_callbacks - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo 072ebe41b4a79155b8035f26e315e06e HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fc6c7fe6290>>>
ERROR tests/components/wemo/test_binary_sensor.py::TestMaker::test_async_update_locked_callback_and_update - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo 3e5c0dba71fef1d0b09a10555344dfb3 HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fc6c71bdb50>>>
ERROR tests/components/wemo/test_binary_sensor.py::TestMaker::test_registry_state_callback - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo 625193718946af1c1de76d0d5f8c6fd3 HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fc6c5f26d50>>>
ERROR tests/components/wemo/test_binary_sensor.py::TestInsight::test_async_update_locked_multiple_updates - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo 448025ecb038c8953e7f393c27ad35ff HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fc6c5d738d0>>>
ERROR tests/components/wemo/test_binary_sensor.py::TestInsight::test_async_update_locked_multiple_callbacks - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo f406c1501e32f0d5b82cd39faaca4ef5 HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fc6c7193ad0>>>
ERROR tests/components/wemo/test_device_trigger.py::test_get_triggers - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo 92d0fd9ed0dc5de11e99a38848495641 HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fe35fd15610>>>
ERROR tests/components/wemo/test_binary_sensor.py::TestInsight::test_async_update_locked_callback_and_update - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo c9c50832c1ecc09dff07cdc2382ebff9 HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fc6c813f4d0>>>
ERROR tests/components/wemo/test_binary_sensor.py::TestInsight::test_registry_state_callback - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo 4eba7dbcd14659b57a5901c19bd0412e HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fc6c5ae3050>>>
ERROR tests/components/wemo/test_fan.py::test_async_update_locked_multiple_updates - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo 78b0150cb3b7ad237df95a42319e4872 HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fe35eff0990>>>
ERROR tests/components/wemo/test_fan.py::test_async_update_locked_multiple_callbacks - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo febb3c3f65ff26fdc2dab8b474917fa1 HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fe35fdaca10>>>
ERROR tests/components/wemo/test_init.py::test_static_duplicate_static_entry - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo e8b071ab68298af3a66361d84860b102 HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fc6c6d4b250>>>
ERROR tests/components/wemo/test_fan.py::test_async_update_locked_callback_and_update - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo b2f80ec50e5eb0298cbf31610b83aa33 HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fe3644df3d0>>>
ERROR tests/components/wemo/test_init.py::test_static_config_with_port - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo 37bf14e4415bdfbc119ccf78ae602b01 HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fc6c5d40550>>>
ERROR tests/components/wemo/test_fan.py::test_fan_registry_state_callback - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo df44a800feaf6e3c76aec338e31bed1a HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fe364959090>>>
ERROR tests/components/wemo/test_init.py::test_static_config_without_port - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo 9340286796556f7f9cbd5645ca048ed4 HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fc6c825cb10>>>
ERROR tests/components/wemo/test_fan.py::test_fan_update_entity - Failed: Lingering timer after test <TimerHandle when=757.59890158 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:152>
ERROR tests/components/wemo/test_fan.py::test_available_after_update - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo d05bec5a4ed0ea3b3e9a18fc15a58304 HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fe364ff8e10>>>
ERROR tests/components/wemo/test_init.py::test_discovery - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName_1 Wemo wemo c40f328b20cdb38887da2673a7244a31 HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fc6c5df0590>>>
ERROR tests/components/wemo/test_fan.py::test_turn_off_state - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo 9b9017eea0b82c99156674172a8effe1 HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fe365103190>>>
ERROR tests/components/wemo/test_fan.py::test_fan_reset_filter_service - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo 0c6866c545fe4bfd8ea5253c00954fa5 HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fe365543b90>>>
ERROR tests/components/wemo/test_fan.py::test_fan_set_humidity_service[0-0] - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo 34c4d95f53ab2f19a470361285382f7d HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fe36574ab90>>>
ERROR tests/components/wemo/test_fan.py::test_fan_set_humidity_service[45-0] - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo 6892bfce49f8215ca837eed431fb1323 HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fe365849cd0>>>
ERROR tests/components/wemo/test_fan.py::test_fan_set_humidity_service[50-1] - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo a0aabeb19c782785e000db426cf8c9cc HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fe365b66090>>>
ERROR tests/components/wemo/test_fan.py::test_fan_set_humidity_service[55-2] - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo c0f8aba61686b0d6ffa3f156c13a8767 HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fe365e53990>>>
ERROR tests/components/wemo/test_light_bridge.py::test_async_update_locked_callback_and_update - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo 05df74a7dd114a1e29e5b29b5ca777b0 HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fc6c5e1fa10>>>
ERROR tests/components/wemo/test_fan.py::test_fan_set_humidity_service[60-3] - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo f832c879ea4ec3f1816c6f0bc6242209 HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fe364d1d350>>>
ERROR tests/components/wemo/test_light_bridge.py::test_async_update_locked_multiple_updates - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo c51c06e14b360856e4d4355e99d03c32 HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fc6c6ce5590>>>
ERROR tests/components/wemo/test_fan.py::test_fan_set_humidity_service[100-4] - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo 2f1372e9aeb6016eeba06e03262e0dfe HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fe3672e9cd0>>>
ERROR tests/components/wemo/test_light_bridge.py::test_async_update_locked_multiple_callbacks - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo adf8e5430a72cbb398cdd45951f8ec70 HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fc6c720c850>>>
ERROR tests/components/wemo/test_fan.py::test_fan_set_percentage[0-0] - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo 139f93380d08ff1f5e829f4e361529c2 HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fe3675dabd0>>>
ERROR tests/components/wemo/test_light_bridge.py::test_available_after_update - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo 6bf0ca5982283cdd2688dee3fae28aba HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fc6c808c110>>>
ERROR tests/components/wemo/test_fan.py::test_fan_set_percentage[10-1] - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo 04c7fdd9037a6faea44f21a6c265693a HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fe3676c2e10>>>
ERROR tests/components/wemo/test_light_bridge.py::test_turn_off_state - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo 78b1812a26f983d2d981be5a5d5233f2 HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fc6c5c46ed0>>>
ERROR tests/components/wemo/test_fan.py::test_fan_set_percentage[30-2] - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo 9d92d08a49a2f1e437d01936fae07a8b HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fe36780fd50>>>
ERROR tests/components/wemo/test_light_bridge.py::test_light_update_entity - Failed: Lingering timer after test <TimerHandle when=760.393919932 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:152>
ERROR tests/components/wemo/test_fan.py::test_fan_set_percentage[50-3] - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo 05d27b559a89e24eb4c77aa8ce1be24c HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fe367b43590>>>
ERROR tests/components/wemo/test_fan.py::test_fan_set_percentage[70-4] - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo 4268cef3f10bb8b2a3c94278bebefebd HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fe367e76490>>>
ERROR tests/components/wemo/test_fan.py::test_fan_set_percentage[100-5] - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo 408320054d9d2162d022755e46be5bfe HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fe36c888610>>>
ERROR tests/components/wemo/test_fan.py::test_fan_mode_high_initially - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo 4b400295b4cab2573fc1ee45b891f159 HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fe36ceeb6d0>>>
ERROR tests/components/wemo/test_light_dimmer.py::test_async_update_locked_multiple_updates - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo d0e4833298a7579c6fea63b1d2ea569c HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fc6c73bd210>>>
ERROR tests/components/wemo/test_light_dimmer.py::test_async_update_locked_multiple_callbacks - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo eecf6111d0b666bbb7eaeaa841c70ae4 HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fc6c6939b10>>>
ERROR tests/components/wemo/test_light_dimmer.py::test_async_update_locked_callback_and_update - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo 415ce794a885d984b227373ddb29da37 HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fc6c7810e10>>>
ERROR tests/components/wemo/test_light_dimmer.py::test_available_after_update - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo d020b1c2d56bf68ccfa33a72de10868d HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fc6c7464ed0>>>
ERROR tests/components/wemo/test_light_dimmer.py::test_turn_off_state - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo b2b217dd04dede37a766423495d6d6f1 HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fc6c7117a10>>>
ERROR tests/components/wemo/test_sensor.py::TestInsightCurrentPower::test_async_update_locked_multiple_updates - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo 314ad813f5eb1276c0e1bbf6f376b174 HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fe36cc34410>>>
ERROR tests/components/wemo/test_light_dimmer.py::test_turn_on_brightness - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo b2bd9e9ed66169e28663d8fef6059ddb HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fc6c54663d0>>>
ERROR tests/components/wemo/test_sensor.py::TestInsightCurrentPower::test_async_update_locked_multiple_callbacks - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo 17876cc8b6067a30fb1b5c3169f38788 HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fe367cd1150>>>
ERROR tests/components/wemo/test_light_dimmer.py::test_light_registry_state_callback - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo 5b47a8b58536a9e40161d707076f9352 HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fc6c81d32d0>>>
ERROR tests/components/wemo/test_sensor.py::TestInsightCurrentPower::test_async_update_locked_callback_and_update - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo 85b6de5937fd6b567d2069192934cc08 HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fe3679dddd0>>>
ERROR tests/components/wemo/test_light_dimmer.py::test_light_update_entity - Failed: Lingering timer after test <TimerHandle when=763.177674995 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:152>
ERROR tests/components/wemo/test_sensor.py::TestInsightCurrentPower::test_state - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo a71c65ecdb806fc17aba1ffd4391297c HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fe36770b010>>>
ERROR tests/components/wemo/test_sensor.py::TestInsightTodayEnergy::test_async_update_locked_multiple_updates - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo 45c3bb016246470431ec136c7634fa21 HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fe36772c190>>>
ERROR tests/components/wemo/test_sensor.py::TestInsightTodayEnergy::test_async_update_locked_multiple_callbacks - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo cbbdd9c684ae25a2a86ffc7ff0e74794 HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fe367426950>>>
ERROR tests/components/wemo/test_sensor.py::TestInsightTodayEnergy::test_async_update_locked_callback_and_update - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo 8cf0db7019f5ce8cee8669ea04816fcd HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fe36747f7d0>>>
ERROR tests/components/wemo/test_sensor.py::TestInsightTodayEnergy::test_state - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo 35d93845fc7343a24bec33389aa2f97e HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fe3672e9c10>>>
ERROR tests/components/wemo/test_switch.py::test_async_update_locked_multiple_updates - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo b7d2a6bce1ffc063043e1c0c0f821f0b HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fc6c72bd8d0>>>
ERROR tests/components/wemo/test_switch.py::test_async_update_locked_multiple_callbacks - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo 2b25aa025d0ce7126022fe9a17f1d2bd HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fc6c6f84110>>>
ERROR tests/components/wemo/test_switch.py::test_async_update_locked_callback_and_update - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo 1e7d566217d292eeb99f0e628e18c48d HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fc6c8021950>>>
ERROR tests/components/wemo/test_switch.py::test_switch_registry_state_callback - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo 8bfab9811b6ab09ac25169556cf1b58c HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fc6c8088450>>>
ERROR tests/components/wemo/test_switch.py::test_switch_update_entity - Failed: Lingering timer after test <TimerHandle when=765.280351885 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:152>
ERROR tests/components/wemo/test_wemo_device.py::test_async_register_device_longpress_fails - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo ed72eaaa97e49b6f4041928c5f9bd1bb HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fe36767a550>>>
ERROR tests/components/wemo/test_switch.py::test_available_after_update - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo c23953641b0981ca5e88faa6ac76f774 HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fc6c816c7d0>>>
ERROR tests/components/wemo/test_wemo_device.py::test_long_press_event - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo 3c2aebb26af3535dcfa937f49fa8821f HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fe36774dc10>>>
ERROR tests/components/wemo/test_switch.py::test_turn_off_state - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo db925a94dc814d6f30febf7c82482fd0 HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fc6c8085c90>>>
ERROR tests/components/wemo/test_wemo_device.py::test_subscription_callback - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo f45dddf8082ee3a142ac98c899ec1a92 HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fe3679df3d0>>>
ERROR tests/components/wemo/test_switch.py::test_insight_state_attributes - Failed: Lingering timer after test <TimerHandle when=765.925699481 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:152>
ERROR tests/components/wemo/test_wemo_device.py::test_subscription_update_action_exception - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo f274d8f816e8902e6bb343d699d99e00 HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fe367b38210>>>
ERROR tests/components/wemo/test_switch.py::test_maker_state_attributes - Failed: Lingering timer after test <TimerHandle when=766.149472149 Debouncer._on_debounce() created at /home/runner/work/core/core/homeassistant/helpers/debounce.py:152>
ERROR tests/components/wemo/test_wemo_device.py::test_subscription_update_exception - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo a2b50664ba3d9475f8a58fd6caf41fce HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fe36cc8d350>>>
ERROR tests/components/wemo/test_wemo_device.py::test_async_update_data_subscribed - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo 08224454c9ea374c197c082a4206c548 HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fe36c869390>>>
ERROR tests/components/wemo/test_wemo_device.py::test_device_info - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo 315401d2e114ef25c12c31393c11bc64 HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fe36739d4d0>>>
ERROR tests/components/wemo/test_wemo_device.py::test_dli_device_info - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo 2c3d156de2ad8de81b70507143973704 HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fe3675d85d0>>>
ERROR tests/components/wemo/test_wemo_device.py::TestInsight::test_should_poll[False-0-expected_calls0] - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo c4c2357cd7713d1143d6b26a0627ac02 HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fe364ee3c90>>>
ERROR tests/components/wemo/test_wemo_device.py::TestInsight::test_should_poll[False-1-expected_calls1] - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo ce37f1502c7ad76b79ec9d765e4b74cf HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fe365e33b10>>>
ERROR tests/components/wemo/test_wemo_device.py::TestInsight::test_should_poll[True-0-expected_calls2] - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo daa04ce5bfe21ccbbe2bdf8dded2c943 HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fe365e64a90>>>
ERROR tests/components/wemo/test_wemo_device.py::TestInsight::test_should_poll[True-1-expected_calls3] - Failed: Lingering timer after job <Job DataUpdateCoordinator DeviceCoordinator WemoDeviceName Wemo wemo 2e7b5f6beed75fa015a48213ab067cf5 HassJobType.Coroutinefunction <bound method DataUpdateCoordinator._handle_refresh_interval of <homeassistant.components.wemo.wemo_device.DeviceCoordinator object at 0x7fe365c18250>>>
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
