### PR TITLE
Support Airzone temperature ranges (HEAT_COOL)

### DIFF
--- a/homeassistant/components/airzone/climate.py
+++ b/homeassistant/components/airzone/climate.py
@@ -5,11 +5,16 @@ from typing import Any, Final
 
 from aioairzone.common import OperationAction, OperationMode
 from aioairzone.const import (
+    API_COOL_SET_POINT,
+    API_HEAT_SET_POINT,
     API_MODE,
     API_ON,
     API_SET_POINT,
     API_SPEED,
     AZD_ACTION,
+    AZD_COOL_TEMP_SET,
+    AZD_DOUBLE_SET_POINT,
+    AZD_HEAT_TEMP_SET,
     AZD_HUMIDITY,
     AZD_MASTER,
     AZD_MODE,
@@ -27,6 +32,8 @@ from aioairzone.const import (
 )
 
 from homeassistant.components.climate import (
+    ATTR_TARGET_TEMP_HIGH,
+    ATTR_TARGET_TEMP_LOW,
     FAN_AUTO,
     FAN_HIGH,
     FAN_LOW,
@@ -137,6 +144,10 @@ class AirzoneClimate(AirzoneZoneEntity, ClimateEntity):
             and self.get_airzone_value(AZD_SPEEDS) is not None
         ):
             self._set_fan_speeds()
+        if self.get_airzone_value(AZD_DOUBLE_SET_POINT):
+            self._attr_supported_features |= (
+                ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+            )
 
         self._async_update_attrs()
 
@@ -201,9 +212,12 @@ class AirzoneClimate(AirzoneZoneEntity, ClimateEntity):
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
-        params = {
-            API_SET_POINT: kwargs.get(ATTR_TEMPERATURE),
-        }
+        params = {}
+        if ATTR_TEMPERATURE in kwargs:
+            params[API_SET_POINT] = kwargs[ATTR_TEMPERATURE]
+        if ATTR_TARGET_TEMP_LOW in kwargs and ATTR_TARGET_TEMP_HIGH in kwargs:
+            params[API_COOL_SET_POINT] = kwargs[ATTR_TARGET_TEMP_LOW]
+            params[API_HEAT_SET_POINT] = kwargs[ATTR_TARGET_TEMP_HIGH]
         await self._async_update_hvac_params(params)
 
     @callback
@@ -229,3 +243,10 @@ class AirzoneClimate(AirzoneZoneEntity, ClimateEntity):
         self._attr_target_temperature = self.get_airzone_value(AZD_TEMP_SET)
         if self.supported_features & ClimateEntityFeature.FAN_MODE:
             self._attr_fan_mode = self._speeds.get(self.get_airzone_value(AZD_SPEED))
+        if self.supported_features & ClimateEntityFeature.TARGET_TEMPERATURE_RANGE:
+            self._attr_target_temperature_high = self.get_airzone_value(
+                AZD_HEAT_TEMP_SET
+            )
+            self._attr_target_temperature_low = self.get_airzone_value(
+                AZD_COOL_TEMP_SET
+            )


### PR DESCRIPTION
## Proposed change
This adds support for temperature ranges in Airzone integration.
Temperature ranges are only available on devices with AUTO mode (Home Assistant's HEAT_COOL climate mode).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
