### PR TITLE
Fix last imap message is not reset on empty search

### DIFF
--- a/homeassistant/components/imap/coordinator.py
+++ b/homeassistant/components/imap/coordinator.py
@@ -201,7 +201,9 @@ class ImapDataUpdateCoordinator(DataUpdateCoordinator[int | None]):
             raise UpdateFailed(
                 f"Invalid response for search '{self.config_entry.data[CONF_SEARCH]}': {result} / {lines[0]}"
             )
-        count: int = len(message_ids := lines[0].split())
+        if not (count := len(message_ids := lines[0].split())):
+            self._last_message_id = None
+            return 0
         last_message_id = (
             str(message_ids[-1:][0], encoding=self.config_entry.data[CONF_CHARSET])
             if count

--- a/tests/components/imap/test_init.py
+++ b/tests/components/imap/test_init.py
@@ -15,6 +15,7 @@ from homeassistant.util.dt import utcnow
 
 from .const import (
     BAD_RESPONSE,
+    EMPTY_SEARCH_RESPONSE,
     TEST_FETCH_RESPONSE_BINARY,
     TEST_FETCH_RESPONSE_HTML,
     TEST_FETCH_RESPONSE_INVALID_DATE,
@@ -347,3 +348,101 @@ async def test_fetch_number_of_messages(
     # we should have an entity with an unavailable state
     assert state is not None
     assert state.state == STATE_UNAVAILABLE
+
+
+@pytest.mark.parametrize("imap_search", [TEST_SEARCH_RESPONSE])
+@pytest.mark.parametrize(
+    ("imap_fetch", "valid_date"),
+    [(TEST_FETCH_RESPONSE_TEXT_PLAIN, True)],
+    ids=["plain"],
+)
+@pytest.mark.parametrize("imap_has_capability", [True, False], ids=["push", "poll"])
+async def test_reset_last_message(
+    hass: HomeAssistant, mock_imap_protocol: MagicMock, valid_date: bool
+) -> None:
+    """Test receiving a message successfully."""
+    event = asyncio.Event()  # needed for pushed coordinator to make a new loop
+
+    async def _sleep_till_event() -> None:
+        """Simulate imap server waiting for pushes message and keep the push loop going.
+
+        Needed for pushed coordinator only.
+        """
+        nonlocal event
+        await event.wait()
+        event = asyncio.Event()
+        mock_imap_protocol.idle_start.return_value = AsyncMock()()
+
+    # Make sure we make another cycle (needed for pushed coordinator)
+    mock_imap_protocol.idle_start.return_value = AsyncMock()()
+    # Mock we wait till we push an update (needed for pushed coordinator)
+    mock_imap_protocol.wait_server_push.side_effect = _sleep_till_event
+
+    event_called = async_capture_events(hass, "imap_content")
+
+    config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG)
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    # Make sure we have had one update (when polling)
+    async_fire_time_changed(hass, utcnow() + timedelta(seconds=5))
+    await hass.async_block_till_done()
+    state = hass.states.get("sensor.imap_email_email_com")
+    # We should have received one message
+    assert state is not None
+    assert state.state == "1"
+
+    # We should have received one event
+    assert len(event_called) == 1
+    data: dict[str, Any] = event_called[0].data
+    assert data["server"] == "imap.server.com"
+    assert data["username"] == "email@email.com"
+    assert data["search"] == "UnSeen UnDeleted"
+    assert data["folder"] == "INBOX"
+    assert data["sender"] == "john.doe@example.com"
+    assert data["subject"] == "Test subject"
+    assert data["text"]
+    assert (
+        valid_date
+        and isinstance(data["date"], datetime)
+        or not valid_date
+        and data["date"] is None
+    )
+
+    # Simulate an update where no messages are found (needed for pushed coordinator)
+    mock_imap_protocol.search.return_value = Response(*EMPTY_SEARCH_RESPONSE)
+
+    # Make sure we have an update
+    async_fire_time_changed(hass, utcnow() + timedelta(seconds=30))
+
+    # Awake loop (needed for pushed coordinator)
+    event.set()
+
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.imap_email_email_com")
+    # We should have message
+    assert state is not None
+    assert state.state == "0"
+    # No new events should be called
+    assert len(event_called) == 1
+
+    # Simulate an update where with the original message
+    mock_imap_protocol.search.return_value = Response(*TEST_SEARCH_RESPONSE)
+    # Make sure we have an update again with the same UID
+    async_fire_time_changed(hass, utcnow() + timedelta(seconds=30))
+
+    # Awake loop (needed for pushed coordinator)
+    event.set()
+
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.imap_email_email_com")
+    # We should have received one message
+    assert state is not None
+    assert state.state == "1"
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+
+    # One new event
+    assert len(event_called) == 2

--- a/tests/components/imap/test_init.py
+++ b/tests/components/imap/test_init.py
@@ -370,7 +370,7 @@ async def test_reset_last_message(
         """
         nonlocal event
         await event.wait()
-        event = asyncio.Event()
+        event.clear()
         mock_imap_protocol.idle_start.return_value = AsyncMock()()
 
     # Make sure we make another cycle (needed for pushed coordinator)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Reset the last message id no `None` when there are no messages in the search.
As the UID could start renumbering the UID could be reused (e.g. gmail shows this behavior).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #93092
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
