### PR TITLE
Better handling of source sensor unavailability in Riemman Integration

### DIFF
--- a/homeassistant/components/integration/sensor.py
+++ b/homeassistant/components/integration/sensor.py
@@ -197,25 +197,23 @@ class IntegrationSensor(RestoreEntity, SensorEntity):
             old_state: State | None = event.data.get("old_state")
             new_state: State | None = event.data.get("new_state")
 
-            if (
-                source_state := self.hass.states.get(self._sensor_source_id)
-            ) is None or source_state.state == STATE_UNAVAILABLE:
-                self._attr_available = False
-                self.async_write_ha_state()
-                return
-
-            self._attr_available = True
-
-            if new_state is None or new_state.state in (
-                STATE_UNKNOWN,
-                STATE_UNAVAILABLE,
-            ):
-                return
-
             # We may want to update our state before an early return,
             # based on the source sensor's unit_of_measurement
             # or device_class.
             update_state = False
+
+            if (
+                source_state := self.hass.states.get(self._sensor_source_id)
+            ) is None or source_state.state == STATE_UNAVAILABLE:
+                self._attr_available = False
+                update_state = True
+            else:
+                self._attr_available = True
+
+            if old_state is None or new_state is None:
+                # we can't calculate the elapsed time, so we can't calculate the integral
+                return
+
             unit = new_state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
             if unit is not None:
                 new_unit_of_measurement = self._unit(unit)
@@ -235,31 +233,53 @@ class IntegrationSensor(RestoreEntity, SensorEntity):
             if update_state:
                 self.async_write_ha_state()
 
-            if old_state is None or old_state.state in (
-                STATE_UNKNOWN,
-                STATE_UNAVAILABLE,
-            ):
-                return
-
             try:
                 # integration as the Riemann integral of previous measures.
-                area = Decimal(0)
                 elapsed_time = (
                     new_state.last_updated - old_state.last_updated
                 ).total_seconds()
 
-                if self._method == METHOD_TRAPEZOIDAL:
+                if (
+                    self._method == METHOD_TRAPEZOIDAL
+                    and new_state.state
+                    not in (
+                        STATE_UNKNOWN,
+                        STATE_UNAVAILABLE,
+                    )
+                    and old_state.state
+                    not in (
+                        STATE_UNKNOWN,
+                        STATE_UNAVAILABLE,
+                    )
+                ):
                     area = (
                         (Decimal(new_state.state) + Decimal(old_state.state))
                         * Decimal(elapsed_time)
                         / 2
                     )
-                elif self._method == METHOD_LEFT:
+                elif self._method == METHOD_LEFT and old_state.state not in (
+                    STATE_UNKNOWN,
+                    STATE_UNAVAILABLE,
+                ):
                     area = Decimal(old_state.state) * Decimal(elapsed_time)
-                elif self._method == METHOD_RIGHT:
+                elif self._method == METHOD_RIGHT and new_state.state not in (
+                    STATE_UNKNOWN,
+                    STATE_UNAVAILABLE,
+                ):
                     area = Decimal(new_state.state) * Decimal(elapsed_time)
+                else:
+                    _LOGGER.debug(
+                        "Could not apply method %s to %s -> %s",
+                        self._method,
+                        new_state.state,
+                        old_state.state,
+                    )
+                    return
 
                 integral = area / (self._unit_prefix * self._unit_time)
+                _LOGGER.debug(
+                    "area = %s, integral = %s state = %s", area, integral, self._state
+                )
                 assert isinstance(integral, Decimal)
             except ValueError as err:
                 _LOGGER.warning("While calculating integration: %s", err)

--- a/homeassistant/components/integration/sensor.py
+++ b/homeassistant/components/integration/sensor.py
@@ -271,8 +271,8 @@ class IntegrationSensor(RestoreEntity, SensorEntity):
                     _LOGGER.debug(
                         "Could not apply method %s to %s -> %s",
                         self._method,
-                        new_state.state,
                         old_state.state,
+                        new_state.state,
                     )
                     return
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is a code refactor that attempts (Can't reproduce situation locally) to better handle limit situations (when sensors go unavailable or unknown and come back) in order to fix #92529, #92912
To help close the issues it Increases coverage (testing all integration methods) and adds debug messages.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #92529, #92912
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
