### PR TITLE
Plugwise prepare typing for binary_sensor

### DIFF
--- a/homeassistant/components/plugwise/binary_sensor.py
+++ b/homeassistant/components/plugwise/binary_sensor.py
@@ -5,7 +5,7 @@ from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from typing import Any
 
-from plugwise import DeviceData
+from plugwise import SmileBinarySensors
 
 from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
@@ -27,7 +27,7 @@ SEVERITIES = ["other", "info", "warning", "error"]
 class PlugwiseBinarySensorMixin:
     """Mixin for required Plugwise binary sensor base description keys."""
 
-    value_fn: Callable[[DeviceData], bool]
+    value_fn: Callable[[SmileBinarySensors], bool]
 
 
 @dataclass
@@ -46,14 +46,14 @@ BINARY_SENSORS: tuple[PlugwiseBinarySensorEntityDescription, ...] = (
         icon="mdi:hvac",
         icon_off="mdi:hvac-off",
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda data: data["binary_sensors"]["compressor_state"],
+        value_fn=lambda data: data["compressor_state"],
     ),
     PlugwiseBinarySensorEntityDescription(
         key="cooling_enabled",
         translation_key="cooling_enabled",
         icon="mdi:snowflake-thermometer",
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda data: data["binary_sensors"]["cooling_enabled"],
+        value_fn=lambda data: data["cooling_enabled"],
     ),
     PlugwiseBinarySensorEntityDescription(
         key="dhw_state",
@@ -61,7 +61,7 @@ BINARY_SENSORS: tuple[PlugwiseBinarySensorEntityDescription, ...] = (
         icon="mdi:water-pump",
         icon_off="mdi:water-pump-off",
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda data: data["binary_sensors"]["dhw_state"],
+        value_fn=lambda data: data["dhw_state"],
     ),
     PlugwiseBinarySensorEntityDescription(
         key="flame_state",
@@ -70,7 +70,7 @@ BINARY_SENSORS: tuple[PlugwiseBinarySensorEntityDescription, ...] = (
         icon="mdi:fire",
         icon_off="mdi:fire-off",
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda data: data["binary_sensors"]["flame_state"],
+        value_fn=lambda data: data["flame_state"],
     ),
     PlugwiseBinarySensorEntityDescription(
         key="heating_state",
@@ -78,7 +78,7 @@ BINARY_SENSORS: tuple[PlugwiseBinarySensorEntityDescription, ...] = (
         icon="mdi:radiator",
         icon_off="mdi:radiator-off",
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda data: data["binary_sensors"]["heating_state"],
+        value_fn=lambda data: data["heating_state"],
     ),
     PlugwiseBinarySensorEntityDescription(
         key="cooling_state",
@@ -86,7 +86,7 @@ BINARY_SENSORS: tuple[PlugwiseBinarySensorEntityDescription, ...] = (
         icon="mdi:snowflake",
         icon_off="mdi:snowflake-off",
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda data: data["binary_sensors"]["cooling_state"],
+        value_fn=lambda data: data["cooling_state"],
     ),
     PlugwiseBinarySensorEntityDescription(
         key="slave_boiler_state",
@@ -94,7 +94,7 @@ BINARY_SENSORS: tuple[PlugwiseBinarySensorEntityDescription, ...] = (
         icon="mdi:fire",
         icon_off="mdi:circle-off-outline",
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda data: data["binary_sensors"]["slave_boiler_state"],
+        value_fn=lambda data: data["slave_boiler_state"],
     ),
     PlugwiseBinarySensorEntityDescription(
         key="plugwise_notification",
@@ -102,7 +102,7 @@ BINARY_SENSORS: tuple[PlugwiseBinarySensorEntityDescription, ...] = (
         icon="mdi:mailbox-up-outline",
         icon_off="mdi:mailbox-outline",
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda data: data["binary_sensors"]["plugwise_notification"],
+        value_fn=lambda data: data["plugwise_notification"],
     ),
 )
 
@@ -119,10 +119,10 @@ async def async_setup_entry(
 
     entities: list[PlugwiseBinarySensorEntity] = []
     for device_id, device in coordinator.data.devices.items():
-        if "binary_sensors" not in device:
+        if not (binary_sensors := device.get("binary_sensors")):
             continue
         for description in BINARY_SENSORS:
-            if description.key not in device["binary_sensors"]:
+            if description.key not in binary_sensors:
                 continue
 
             entities.append(
@@ -154,7 +154,7 @@ class PlugwiseBinarySensorEntity(PlugwiseEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool | None:
         """Return true if the binary sensor is on."""
-        return self.entity_description.value_fn(self.device)
+        return self.entity_description.value_fn(self.device["binary_sensors"])
 
     @property
     def icon(self) -> str | None:

--- a/homeassistant/components/plugwise/binary_sensor.py
+++ b/homeassistant/components/plugwise/binary_sensor.py
@@ -1,9 +1,11 @@
 """Plugwise Binary Sensor component for Home Assistant."""
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from typing import Any
+
+from plugwise import DeviceData
 
 from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
@@ -22,7 +24,16 @@ SEVERITIES = ["other", "info", "warning", "error"]
 
 
 @dataclass
-class PlugwiseBinarySensorEntityDescription(BinarySensorEntityDescription):
+class PlugwiseBinarySensorMixin:
+    """Mixin for required Plugwise binary sensor base description keys."""
+
+    value_fn: Callable[[DeviceData], bool]
+
+
+@dataclass
+class PlugwiseBinarySensorEntityDescription(
+    BinarySensorEntityDescription, PlugwiseBinarySensorMixin
+):
     """Describes a Plugwise binary sensor entity."""
 
     icon_off: str | None = None
@@ -35,12 +46,14 @@ BINARY_SENSORS: tuple[PlugwiseBinarySensorEntityDescription, ...] = (
         icon="mdi:hvac",
         icon_off="mdi:hvac-off",
         entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: data["binary_sensors"]["compressor_state"],
     ),
     PlugwiseBinarySensorEntityDescription(
         key="cooling_enabled",
         translation_key="cooling_enabled",
         icon="mdi:snowflake-thermometer",
         entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: data["binary_sensors"]["cooling_enabled"],
     ),
     PlugwiseBinarySensorEntityDescription(
         key="dhw_state",
@@ -48,6 +61,7 @@ BINARY_SENSORS: tuple[PlugwiseBinarySensorEntityDescription, ...] = (
         icon="mdi:water-pump",
         icon_off="mdi:water-pump-off",
         entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: data["binary_sensors"]["dhw_state"],
     ),
     PlugwiseBinarySensorEntityDescription(
         key="flame_state",
@@ -56,6 +70,7 @@ BINARY_SENSORS: tuple[PlugwiseBinarySensorEntityDescription, ...] = (
         icon="mdi:fire",
         icon_off="mdi:fire-off",
         entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: data["binary_sensors"]["flame_state"],
     ),
     PlugwiseBinarySensorEntityDescription(
         key="heating_state",
@@ -63,6 +78,7 @@ BINARY_SENSORS: tuple[PlugwiseBinarySensorEntityDescription, ...] = (
         icon="mdi:radiator",
         icon_off="mdi:radiator-off",
         entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: data["binary_sensors"]["heating_state"],
     ),
     PlugwiseBinarySensorEntityDescription(
         key="cooling_state",
@@ -70,6 +86,7 @@ BINARY_SENSORS: tuple[PlugwiseBinarySensorEntityDescription, ...] = (
         icon="mdi:snowflake",
         icon_off="mdi:snowflake-off",
         entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: data["binary_sensors"]["cooling_state"],
     ),
     PlugwiseBinarySensorEntityDescription(
         key="slave_boiler_state",
@@ -77,6 +94,7 @@ BINARY_SENSORS: tuple[PlugwiseBinarySensorEntityDescription, ...] = (
         icon="mdi:fire",
         icon_off="mdi:circle-off-outline",
         entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: data["binary_sensors"]["slave_boiler_state"],
     ),
     PlugwiseBinarySensorEntityDescription(
         key="plugwise_notification",
@@ -84,6 +102,7 @@ BINARY_SENSORS: tuple[PlugwiseBinarySensorEntityDescription, ...] = (
         icon="mdi:mailbox-up-outline",
         icon_off="mdi:mailbox-outline",
         entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: data["binary_sensors"]["plugwise_notification"],
     ),
 )
 
@@ -100,11 +119,10 @@ async def async_setup_entry(
 
     entities: list[PlugwiseBinarySensorEntity] = []
     for device_id, device in coordinator.data.devices.items():
+        if "binary_sensors" not in device:
+            continue
         for description in BINARY_SENSORS:
-            if description.key not in device and (
-                "binary_sensors" not in device
-                or description.key not in device["binary_sensors"]
-            ):
+            if description.key not in device["binary_sensors"]:
                 continue
 
             entities.append(
@@ -136,9 +154,7 @@ class PlugwiseBinarySensorEntity(PlugwiseEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool | None:
         """Return true if the binary sensor is on."""
-        if self.entity_description.key in self.device:
-            return self.device[self.entity_description.key]
-        return self.device["binary_sensors"].get(self.entity_description.key)
+        return self.entity_description.value_fn(self.device)
 
     @property
     def icon(self) -> str | None:


### PR DESCRIPTION
## Proposed change
Change entitydescription approach for `binary_sensor` preparing for upcoming strict typing and module version bump PRs. Decreasing PR size as per #92253 / #93088

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #92253 #93155
- Link to documentation pull request: 

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.