### PR TITLE
Add option to disable webhooks in ONVIF

### DIFF
--- a/homeassistant/components/onvif/__init__.py
+++ b/homeassistant/components/onvif/__init__.py
@@ -20,7 +20,13 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 
-from .const import CONF_SNAPSHOT_AUTH, DEFAULT_ARGUMENTS, DOMAIN
+from .const import (
+    CONF_ENABLE_WEBHOOKS,
+    CONF_SNAPSHOT_AUTH,
+    DEFAULT_ARGUMENTS,
+    DEFAULT_ENABLE_WEBHOOKS,
+    DOMAIN,
+)
 from .device import ONVIFDevice
 
 LOGGER = logging.getLogger(__name__)
@@ -143,6 +149,7 @@ async def async_populate_options(hass, entry):
     options = {
         CONF_EXTRA_ARGUMENTS: DEFAULT_ARGUMENTS,
         CONF_RTSP_TRANSPORT: next(iter(RTSP_TRANSPORTS)),
+        CONF_ENABLE_WEBHOOKS: DEFAULT_ENABLE_WEBHOOKS,
     }
 
     hass.config_entries.async_update_entry(entry, options=options)

--- a/homeassistant/components/onvif/config_flow.py
+++ b/homeassistant/components/onvif/config_flow.py
@@ -34,7 +34,9 @@ from homeassistant.helpers import device_registry as dr
 
 from .const import (
     CONF_DEVICE_ID,
+    CONF_ENABLE_WEBHOOKS,
     DEFAULT_ARGUMENTS,
+    DEFAULT_ENABLE_WEBHOOKS,
     DEFAULT_PORT,
     DOMAIN,
     GET_CAPABILITIES_EXCEPTIONS,
@@ -387,6 +389,12 @@ class OnvifOptionsFlowHandler(config_entries.OptionsFlow):
                 CONF_USE_WALLCLOCK_AS_TIMESTAMPS,
                 self.config_entry.options.get(CONF_USE_WALLCLOCK_AS_TIMESTAMPS, False),
             )
+            self.options[CONF_ENABLE_WEBHOOKS] = user_input.get(
+                CONF_ENABLE_WEBHOOKS,
+                self.config_entry.options.get(
+                    CONF_ENABLE_WEBHOOKS, DEFAULT_ENABLE_WEBHOOKS
+                ),
+            )
             return self.async_create_entry(title="", data=self.options)
 
         advanced_options = {}
@@ -415,6 +423,12 @@ class OnvifOptionsFlowHandler(config_entries.OptionsFlow):
                             CONF_RTSP_TRANSPORT, next(iter(RTSP_TRANSPORTS))
                         ),
                     ): vol.In(RTSP_TRANSPORTS),
+                    vol.Optional(
+                        CONF_ENABLE_WEBHOOKS,
+                        default=self.config_entry.options.get(
+                            CONF_ENABLE_WEBHOOKS, DEFAULT_ENABLE_WEBHOOKS
+                        ),
+                    ): bool,
                     **advanced_options,
                 }
             ),

--- a/homeassistant/components/onvif/const.py
+++ b/homeassistant/components/onvif/const.py
@@ -14,6 +14,8 @@ DEFAULT_ARGUMENTS = "-pred 1"
 
 CONF_DEVICE_ID = "deviceid"
 CONF_SNAPSHOT_AUTH = "snapshot_auth"
+CONF_ENABLE_WEBHOOKS = "enable_webhooks"
+DEFAULT_ENABLE_WEBHOOKS = True
 
 ATTR_PAN = "pan"
 ATTR_TILT = "tilt"

--- a/homeassistant/components/onvif/strings.json
+++ b/homeassistant/components/onvif/strings.json
@@ -61,7 +61,8 @@
         "data": {
           "extra_arguments": "Extra FFMPEG arguments",
           "rtsp_transport": "RTSP transport mechanism",
-          "use_wallclock_as_timestamps": "Use wall clock as timestamps"
+          "use_wallclock_as_timestamps": "Use wall clock as timestamps",
+          "enable_webhooks": "Enable Webhooks"
         },
         "title": "ONVIF Device Options"
       }

--- a/tests/components/onvif/test_config_flow.py
+++ b/tests/components/onvif/test_config_flow.py
@@ -1,6 +1,8 @@
 """Test ONVIF config flow."""
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components import dhcp
 from homeassistant.components.onvif import DOMAIN, config_flow
@@ -597,7 +599,8 @@ async def test_flow_manual_entry_wrong_password(hass: HomeAssistant) -> None:
         }
 
 
-async def test_option_flow(hass: HomeAssistant) -> None:
+@pytest.mark.parametrize("option_value", [True, False])
+async def test_option_flow(hass: HomeAssistant, option_value: bool) -> None:
     """Test config flow options."""
     entry, _, _ = await setup_onvif_integration(hass)
 
@@ -613,7 +616,8 @@ async def test_option_flow(hass: HomeAssistant) -> None:
         user_input={
             config_flow.CONF_EXTRA_ARGUMENTS: "",
             config_flow.CONF_RTSP_TRANSPORT: list(config_flow.RTSP_TRANSPORTS)[1],
-            config_flow.CONF_USE_WALLCLOCK_AS_TIMESTAMPS: True,
+            config_flow.CONF_USE_WALLCLOCK_AS_TIMESTAMPS: option_value,
+            config_flow.CONF_ENABLE_WEBHOOKS: option_value,
         },
     )
 
@@ -621,7 +625,8 @@ async def test_option_flow(hass: HomeAssistant) -> None:
     assert result["data"] == {
         config_flow.CONF_EXTRA_ARGUMENTS: "",
         config_flow.CONF_RTSP_TRANSPORT: list(config_flow.RTSP_TRANSPORTS)[1],
-        config_flow.CONF_USE_WALLCLOCK_AS_TIMESTAMPS: True,
+        config_flow.CONF_USE_WALLCLOCK_AS_TIMESTAMPS: option_value,
+        config_flow.CONF_ENABLE_WEBHOOKS: option_value,
     }
 
 

--- a/tests/components/onvif/test_diagnostics.py
+++ b/tests/components/onvif/test_diagnostics.py
@@ -39,7 +39,11 @@ async def test_diagnostics(
                 "password": "**REDACTED**",
                 "snapshot_auth": "digest",
             },
-            "options": {"extra_arguments": "-pred 1", "rtsp_transport": "tcp"},
+            "options": {
+                "extra_arguments": "-pred 1",
+                "rtsp_transport": "tcp",
+                "enable_webhooks": True,
+            },
             "pref_disable_new_entities": False,
             "pref_disable_polling": False,
             "source": "user",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
feature request: https://community.home-assistant.io/t/disable-webhooks-on-cameras-that-have-old-firmwares-after-2023-5-x-some-old-onvif-cams-stopped-working/571854

https://github.com/home-assistant/core/pull/92711 fixed a lot of the cameras that had buffer overflows when the url was too long, and https://github.com/home-assistant/core/pull/93104 will fix cameras where the url changes, but we can't fix all the problems with firmwares so there needs to be a way to turn this off for cameras that have buggy firmwares that crash when notifications are enabled.

related issues: #92892 #93043 #92943

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/27431

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


TODO: 

- [x] options flow tests
- [x] more manual testing
