### PR TITLE
Constrain urllib3 to < 2

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -59,7 +59,7 @@ zeroconf==0.62.0
 pycryptodome>=3.6.6
 
 # Constrain urllib3 to ensure we deal with CVE-2020-26137 and CVE-2021-33503
-urllib3>=1.26.5
+urllib3>=1.26.5,<2
 
 # Constrain httplib2 to protect against GHSA-93xj-8mrv-444m
 # https://github.com/advisories/GHSA-93xj-8mrv-444m

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -63,7 +63,7 @@ CONSTRAINT_BASE = """
 pycryptodome>=3.6.6
 
 # Constrain urllib3 to ensure we deal with CVE-2020-26137 and CVE-2021-33503
-urllib3>=1.26.5
+urllib3>=1.26.5,<2
 
 # Constrain httplib2 to protect against GHSA-93xj-8mrv-444m
 # https://github.com/advisories/GHSA-93xj-8mrv-444m


### PR DESCRIPTION
## Proposed change

Constrain urllib3 to < 2.

The currently installed version of requests (2.29.0) has constraint `urllib3>=1.21.1,<1.27`, so this is required to avoid installing urllib3 2, otherwise there is a version conflict.

## Type of change

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #93185
- This PR is related to issue: 
- Link to documentation pull request: 

I ran the core tests (`pytest tests/test_core.py`) which passed, but I cannot run the entire test suite. After running `pip3 install --use-deprecated=legacy-resolver -r requirements_test_all.txt -c homeassistant/package_constraints.txt` as indicated in the docs, an old version of botocore is installed which breaks the test and running HA.

```text
tests/components/cloud/__init__.py:5: in <module>                                                                                                                                                                                from homeassistant.components import cloud                                                                                                                                                                               homeassistant/components/cloud/__init__.py:9: in <module>
    from hass_nabucasa import Cloud
venv/lib/python3.11/site-packages/hass_nabucasa/__init__.py:15: in <module>
    from .auth import CloudError, CognitoAuth
venv/lib/python3.11/site-packages/hass_nabucasa/auth.py:11: in <module>
    import boto3
venv/lib/python3.11/site-packages/boto3/__init__.py:17: in <module>
    from boto3.session import Session
venv/lib/python3.11/site-packages/boto3/session.py:25: in <module>
    from .resources.factory import ResourceFactory
venv/lib/python3.11/site-packages/boto3/resources/factory.py:17: in <module>
    from ..docs import docstring
venv/lib/python3.11/site-packages/boto3/docs/__init__.py:15: in <module>
    from botocore.docs import DEPRECATED_SERVICE_NAMES
E   ImportError: cannot import name 'DEPRECATED_SERVICE_NAMES' from 'botocore.docs' (/home/keith/src/hass/core/venv/lib/python3.11/site-packages/botocore/docs/__init__.py)
```

## Checklist

- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
