### PR TITLE
Add always connected option to Yale Access Bluetooth

### DIFF
--- a/homeassistant/components/yalexs_ble/config_flow.py
+++ b/homeassistant/components/yalexs_ble/config_flow.py
@@ -327,7 +327,6 @@ class YaleXSBLEOptionsFlowHandler(config_entries.OptionsFlow):
         """Manage the YaleXSBLE devices options."""
         if user_input is not None:
             return self.async_create_entry(
-                title="",
                 data={CONF_ALWAYS_CONNECTED: user_input[CONF_ALWAYS_CONNECTED]},
             )
 

--- a/homeassistant/components/yalexs_ble/config_flow.py
+++ b/homeassistant/components/yalexs_ble/config_flow.py
@@ -23,10 +23,11 @@ from homeassistant.components.bluetooth import (
     async_discovered_service_info,
 )
 from homeassistant.const import CONF_ADDRESS
+from homeassistant.core import callback
 from homeassistant.data_entry_flow import AbortFlow, FlowResult
 from homeassistant.helpers.typing import DiscoveryInfoType
 
-from .const import CONF_KEY, CONF_LOCAL_NAME, CONF_SLOT, DOMAIN
+from .const import CONF_ALWAYS_CONNECTED, CONF_KEY, CONF_LOCAL_NAME, CONF_SLOT, DOMAIN
 from .util import async_find_existing_service_info, human_readable_name
 
 _LOGGER = logging.getLogger(__name__)
@@ -296,4 +297,48 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="user",
             data_schema=data_schema,
             errors=errors,
+        )
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> YaleXSBLEOptionsFlowHandler:
+        """Get the options flow for this handler."""
+        return YaleXSBLEOptionsFlowHandler(config_entry)
+
+
+class YaleXSBLEOptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle YaleXSBLE options."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        """Initialize YaleXSBLE options flow."""
+        self.entry = config_entry
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Manage the YaleXSBLE options."""
+        return await self.async_step_device_options()
+
+    async def async_step_device_options(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Manage the YaleXSBLE devices options."""
+        if user_input is not None:
+            return self.async_create_entry(
+                title="",
+                data={CONF_ALWAYS_CONNECTED: user_input[CONF_ALWAYS_CONNECTED]},
+            )
+
+        return self.async_show_form(
+            step_id="device_options",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        CONF_ALWAYS_CONNECTED,
+                        default=self.entry.options.get(CONF_ALWAYS_CONNECTED, False),
+                    ): bool,
+                }
+            ),
         )

--- a/homeassistant/components/yalexs_ble/const.py
+++ b/homeassistant/components/yalexs_ble/const.py
@@ -5,5 +5,6 @@ DOMAIN = "yalexs_ble"
 CONF_LOCAL_NAME = "local_name"
 CONF_KEY = "key"
 CONF_SLOT = "slot"
+CONF_ALWAYS_CONNECTED = "always_connected"
 
 DEVICE_TIMEOUT = 55

--- a/homeassistant/components/yalexs_ble/models.py
+++ b/homeassistant/components/yalexs_ble/models.py
@@ -12,3 +12,4 @@ class YaleXSBLEData:
 
     title: str
     lock: PushLock
+    always_connected: bool

--- a/homeassistant/components/yalexs_ble/strings.json
+++ b/homeassistant/components/yalexs_ble/strings.json
@@ -35,5 +35,15 @@
       "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     }
+  },
+  "options": {
+    "step": {
+      "device_options": {
+        "description": "If the lock does not support push updates via advertisements or you want lock operation to be more responsive, you can enable always connected mode. Always connected will cause the lock to stay connected to Home Assistant via Bluetooth, which will use more battery.",
+        "data": {
+          "always_connected": "Always connected"
+        }
+      }
+    }
   }
 }

--- a/tests/components/yalexs_ble/test_config_flow.py
+++ b/tests/components/yalexs_ble/test_config_flow.py
@@ -1,13 +1,14 @@
 """Test the Yale Access Bluetooth config flow."""
 import asyncio
-from unittest.mock import patch
+from unittest.mock import AsyncMock, Mock, patch
 
 from bleak import BleakError
 import pytest
-from yalexs_ble import AuthError
+from yalexs_ble import AuthError, DoorStatus, LockInfo, LockState, LockStatus
 
 from homeassistant import config_entries
 from homeassistant.components.yalexs_ble.const import (
+    CONF_ALWAYS_CONNECTED,
     CONF_KEY,
     CONF_LOCAL_NAME,
     CONF_SLOT,
@@ -25,6 +26,23 @@ from . import (
 )
 
 from tests.common import MockConfigEntry
+
+
+def _get_mock_push_lock():
+    """Return a mock PushLock."""
+    mock_push_lock = Mock()
+    mock_push_lock.start = AsyncMock()
+    mock_push_lock.wait_for_first_update = AsyncMock()
+    mock_push_lock.stop = AsyncMock()
+    mock_push_lock.lock_state = LockState(
+        LockStatus.UNLOCKED, DoorStatus.CLOSED, None, None
+    )
+    mock_push_lock.lock_status = LockStatus.UNLOCKED
+    mock_push_lock.door_status = DoorStatus.CLOSED
+    mock_push_lock.lock_info = LockInfo("Front Door", "M1XXX012LU", "1.0.0", "1.0.0")
+    mock_push_lock.device_info = None
+    mock_push_lock.address = YALE_ACCESS_LOCK_DISCOVERY_INFO.address
+    return mock_push_lock
 
 
 @pytest.mark.parametrize("slot", [0, 1, 66])
@@ -946,4 +964,49 @@ async def test_reauth(hass: HomeAssistant) -> None:
 
     assert result3["type"] == FlowResultType.ABORT
     assert result3["reason"] == "reauth_successful"
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_options(hass: HomeAssistant) -> None:
+    """Test options."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_LOCAL_NAME: YALE_ACCESS_LOCK_DISCOVERY_INFO.name,
+            CONF_ADDRESS: YALE_ACCESS_LOCK_DISCOVERY_INFO.address,
+            CONF_KEY: "2fd51b8621c6a139eaffbedcb846b60f",
+            CONF_SLOT: 66,
+        },
+        unique_id=YALE_ACCESS_LOCK_DISCOVERY_INFO.address,
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.yalexs_ble.PushLock",
+        return_value=_get_mock_push_lock(),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(
+        entry.entry_id,
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "device_options"
+
+    with patch(
+        "homeassistant.components.yalexs_ble.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            {
+                CONF_ALWAYS_CONNECTED: True,
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert entry.options == {CONF_ALWAYS_CONNECTED: True}
     assert len(mock_setup_entry.mock_calls) == 1


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add always connected option to Yale Access Bluetooth

If the lock does not support push updates via advertisements or you want lock operation to be more responsive, you can enable always connected mode. Always connected will cause the lock to stay connected to Home Assistant via Bluetooth, which will use more battery.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/27450

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
