### PR TITLE
Clamp last legacy lifx zone request when zones are not a multiple of 8

### DIFF
--- a/homeassistant/components/lifx/coordinator.py
+++ b/homeassistant/components/lifx/coordinator.py
@@ -238,9 +238,6 @@ class LIFXUpdateCoordinator(DataUpdateCoordinator[None]):
                 ) -> None:
                     # We need to call resp_set_multizonemultizone to populate
                     # the color_zones attribute before calling the callback
-                    _LOGGER.warning(
-                        "Calling resp_set_multizonemultizone with %s", response
-                    )
                     device.resp_set_multizonemultizone(response)
                     # Now call the original callback
                     callb(bulb, response, **kwargs)

--- a/tests/components/lifx/test_light.py
+++ b/tests/components/lifx/test_light.py
@@ -1,7 +1,7 @@
 """Tests for the lifx integration light platform."""
 
 from datetime import timedelta
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import aiolifx_effects
 import pytest
@@ -1771,6 +1771,56 @@ async def test_light_strip_zones_not_populated_yet(hass: HomeAssistant) -> None:
     # Again once we know the number of zones
     assert bulb.get_color_zones.calls[1][1]["start_index"] == 0
     assert bulb.get_color_zones.calls[2][1]["start_index"] == 8
+
+    state = hass.states.get(entity_id)
+    assert state.state == "on"
+    attributes = state.attributes
+    assert attributes[ATTR_BRIGHTNESS] == 255
+    assert attributes[ATTR_COLOR_MODE] == ColorMode.HS
+    assert attributes[ATTR_SUPPORTED_COLOR_MODES] == [
+        ColorMode.COLOR_TEMP,
+        ColorMode.HS,
+    ]
+    assert attributes[ATTR_HS_COLOR] == (360.0, 100.0)
+    assert attributes[ATTR_RGB_COLOR] == (255, 0, 0)
+    assert attributes[ATTR_XY_COLOR] == (0.701, 0.299)
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: entity_id}, blocking=True
+    )
+    assert bulb.set_power.calls[0][0][0] is True
+    bulb.set_power.reset_mock()
+
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=30))
+    await hass.async_block_till_done()
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ON
+
+
+async def test_light_strip_zones_not_multiple_of_eight(hass: HomeAssistant) -> None:
+    """Test a light strip where the zones are not a multiple of 8."""
+    already_migrated_config_entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_HOST: "127.0.0.1"}, unique_id=SERIAL
+    )
+    already_migrated_config_entry.add_to_hass(hass)
+    bulb = _mocked_light_strip()
+    bulb.power_level = 65535
+    bulb.color_zones = [MagicMock()] * 7
+    bulb.color = [65535, 65535, 65535, 65535]
+    assert bulb.get_color_zones.calls == []
+
+    with _patch_discovery(device=bulb), _patch_config_flow_try_connect(
+        device=bulb
+    ), _patch_device(device=bulb):
+        await async_setup_component(hass, lifx.DOMAIN, {lifx.DOMAIN: {}})
+        await hass.async_block_till_done()
+
+    entity_id = "light.my_bulb"
+    assert len(bulb.get_color_zones.calls) == 1
+    # Once since we already know the number of zones
+    assert bulb.get_color_zones.calls[0][1]["start_index"] == 0
+    # And we do not fetch any more zones than we need
+    assert bulb.get_color_zones.calls[0][1]["end_index"] == 6
 
     state = hass.states.get(entity_id)
     assert state.state == "on"

--- a/tests/components/lifx/test_light.py
+++ b/tests/components/lifx/test_light.py
@@ -1768,9 +1768,13 @@ async def test_light_strip_zones_not_populated_yet(hass: HomeAssistant) -> None:
     assert len(bulb.get_color_zones.calls) == 3
     # Once to populate the number of zones
     assert bulb.get_color_zones.calls[0][1]["start_index"] == 0
+    assert bulb.get_color_zones.calls[0][1]["end_index"] == 0
+
     # Again once we know the number of zones
     assert bulb.get_color_zones.calls[1][1]["start_index"] == 0
+    assert bulb.get_color_zones.calls[1][1]["end_index"] == 7
     assert bulb.get_color_zones.calls[2][1]["start_index"] == 8
+    assert bulb.get_color_zones.calls[2][1]["end_index"] == 8
 
     state = hass.states.get(entity_id)
     assert state.state == "on"


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
fixes #93225


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
