### PR TITLE
Fix lookin falling back to polling too quickly

### DIFF
--- a/homeassistant/components/lookin/__init__.py
+++ b/homeassistant/components/lookin/__init__.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable, Coroutine
-from datetime import timedelta
 import logging
 from typing import Any
 
@@ -26,7 +25,13 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import DOMAIN, PLATFORMS, TYPE_TO_PLATFORM
+from .const import (
+    DOMAIN,
+    METEO_UPDATE_INTERVAL,
+    PLATFORMS,
+    REMOTE_UPDATE_INTERVAL,
+    TYPE_TO_PLATFORM,
+)
 from .coordinator import LookinDataUpdateCoordinator, LookinPushCoordinator
 from .models import LookinData
 
@@ -107,9 +112,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             push_coordinator,
             name=entry.title,
             update_method=lookin_protocol.get_meteo_sensor,
-            update_interval=timedelta(
-                minutes=5
-            ),  # Updates are pushed (fallback is polling)
+            update_interval=METEO_UPDATE_INTERVAL,  # Updates are pushed (fallback is polling)
         )
         await meteo_coordinator.async_config_entry_first_refresh()
 
@@ -127,9 +130,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             push_coordinator,
             name=f"{entry.title} {uuid}",
             update_method=updater,
-            update_interval=timedelta(
-                seconds=60
-            ),  # Updates are pushed (fallback is polling)
+            update_interval=REMOTE_UPDATE_INTERVAL,  # Updates are pushed (fallback is polling)
         )
         await coordinator.async_config_entry_first_refresh()
         device_coordinators[uuid] = coordinator

--- a/homeassistant/components/lookin/const.py
+++ b/homeassistant/components/lookin/const.py
@@ -1,6 +1,7 @@
 """The lookin integration constants."""
 from __future__ import annotations
 
+from datetime import timedelta
 from typing import Final
 
 from homeassistant.const import Platform
@@ -22,3 +23,11 @@ TYPE_TO_PLATFORM = {
     "03": Platform.LIGHT,
     "EF": Platform.CLIMATE,
 }
+
+ACTIVE_UPDATES_INTERVAL = 4  # Consider active for 3x the update interval
+METEO_UPDATE_INTERVAL = timedelta(minutes=5)
+REMOTE_UPDATE_INTERVAL = timedelta(seconds=60)
+POLLING_FALLBACK_SECONDS = (
+    max(REMOTE_UPDATE_INTERVAL, METEO_UPDATE_INTERVAL).total_seconds()
+    * ACTIVE_UPDATES_INTERVAL
+)

--- a/homeassistant/components/lookin/const.py
+++ b/homeassistant/components/lookin/const.py
@@ -24,6 +24,7 @@ TYPE_TO_PLATFORM = {
     "EF": Platform.CLIMATE,
 }
 
+NEVER_TIME = -120.0  # Time that will never match time.monotonic()
 ACTIVE_UPDATES_INTERVAL = 4  # Consider active for 4x the update interval
 METEO_UPDATE_INTERVAL = timedelta(minutes=5)
 REMOTE_UPDATE_INTERVAL = timedelta(seconds=60)

--- a/homeassistant/components/lookin/const.py
+++ b/homeassistant/components/lookin/const.py
@@ -24,7 +24,7 @@ TYPE_TO_PLATFORM = {
     "EF": Platform.CLIMATE,
 }
 
-ACTIVE_UPDATES_INTERVAL = 4  # Consider active for 3x the update interval
+ACTIVE_UPDATES_INTERVAL = 4  # Consider active for 4x the update interval
 METEO_UPDATE_INTERVAL = timedelta(minutes=5)
 REMOTE_UPDATE_INTERVAL = timedelta(seconds=60)
 POLLING_FALLBACK_SECONDS = (

--- a/homeassistant/components/lookin/coordinator.py
+++ b/homeassistant/components/lookin/coordinator.py
@@ -10,12 +10,10 @@ from typing import TypeVar
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import POLLING_FALLBACK_SECONDS
+from .const import NEVER_TIME, POLLING_FALLBACK_SECONDS
 
 _LOGGER = logging.getLogger(__name__)
 _DataT = TypeVar("_DataT")
-
-NEVER_TIME = -120.0  # Time that will never match time.monotonic()
 
 
 class LookinPushCoordinator:

--- a/homeassistant/components/lookin/coordinator.py
+++ b/homeassistant/components/lookin/coordinator.py
@@ -10,11 +10,12 @@ from typing import TypeVar
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
+from .const import POLLING_FALLBACK_SECONDS
+
 _LOGGER = logging.getLogger(__name__)
 _DataT = TypeVar("_DataT")
 
 NEVER_TIME = -120.0  # Time that will never match time.monotonic()
-ACTIVE_UPDATES_INTERVAL = 3  # Consider active for 3x the update interval
 
 
 class LookinPushCoordinator:
@@ -32,9 +33,7 @@ class LookinPushCoordinator:
     def active(self, interval: timedelta) -> bool:
         """Check if the last push update was recently."""
         time_since_last_update = time.monotonic() - self.last_update
-        is_active = (
-            time_since_last_update < interval.total_seconds() * ACTIVE_UPDATES_INTERVAL
-        )
+        is_active = time_since_last_update < POLLING_FALLBACK_SECONDS
         _LOGGER.debug(
             "%s: push updates active: %s (time_since_last_update=%s)",
             self.name,


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If the meteo sensor was quiet, we would fallback to polling to quickly because the integration would
prematurely believe push updates were no longer working

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
