### PR TITLE
Configurable KNX Telegram history size

### DIFF
--- a/homeassistant/components/knx/__init__.py
+++ b/homeassistant/components/knx/__init__.py
@@ -60,6 +60,7 @@ from .const import (
     CONF_KNX_SECURE_USER_ID,
     CONF_KNX_SECURE_USER_PASSWORD,
     CONF_KNX_STATE_UPDATER,
+    CONF_KNX_TELEGRAM_LOG_SIZE,
     CONF_KNX_TUNNELING,
     CONF_KNX_TUNNELING_TCP,
     CONF_KNX_TUNNELING_TCP_SECURE,
@@ -68,6 +69,7 @@ from .const import (
     DOMAIN,
     KNX_ADDRESS,
     SUPPORTED_PLATFORMS,
+    TELEGRAM_LOG_DEFAULT,
 )
 from .device import KNXInterfaceDevice
 from .expose import KNXExposeSensor, KNXExposeTime, create_knx_exposure
@@ -384,7 +386,12 @@ class KNXModule:
         self.xknx.connection_manager.register_connection_state_changed_cb(
             self.connection_state_changed_cb
         )
-        self.telegrams = Telegrams(hass, self.xknx, self.project)
+        self.telegrams = Telegrams(
+            hass=hass,
+            xknx=self.xknx,
+            project=self.project,
+            log_size=entry.data.get(CONF_KNX_TELEGRAM_LOG_SIZE, TELEGRAM_LOG_DEFAULT),
+        )
         self.interface_device = KNXInterfaceDevice(
             hass=hass, entry=entry, xknx=self.xknx
         )

--- a/homeassistant/components/knx/config_flow.py
+++ b/homeassistant/components/knx/config_flow.py
@@ -49,12 +49,15 @@ from .const import (
     CONF_KNX_SECURE_USER_ID,
     CONF_KNX_SECURE_USER_PASSWORD,
     CONF_KNX_STATE_UPDATER,
+    CONF_KNX_TELEGRAM_LOG_SIZE,
     CONF_KNX_TUNNEL_ENDPOINT_IA,
     CONF_KNX_TUNNELING,
     CONF_KNX_TUNNELING_TCP,
     CONF_KNX_TUNNELING_TCP_SECURE,
     DEFAULT_ROUTING_IA,
     DOMAIN,
+    TELEGRAM_LOG_DEFAULT,
+    TELEGRAM_LOG_MAX,
     KNXConfigEntryData,
 )
 from .schema import ia_validator, ip_v4_validator
@@ -70,6 +73,7 @@ DEFAULT_ENTRY_DATA = KNXConfigEntryData(
     rate_limit=CONF_KNX_DEFAULT_RATE_LIMIT,
     route_back=False,
     state_updater=CONF_KNX_DEFAULT_STATE_UPDATER,
+    telegram_log_size=TELEGRAM_LOG_DEFAULT,
 )
 
 CONF_KEYRING_FILE: Final = "knxkeys_file"
@@ -203,7 +207,11 @@ class KNXCommonFlow(ABC, FlowHandler):
         )
 
     async def async_step_tunnel(self, user_input: dict | None = None) -> FlowResult:
-        """Select a tunnel from a list. Will be skipped if the gateway scan was unsuccessful or if only one gateway was found."""
+        """Select a tunnel from a list.
+
+        Will be skipped if the gateway scan was unsuccessful
+        or if only one gateway was found.
+        """
         if user_input is not None:
             if user_input[CONF_KNX_GATEWAY] == OPTION_MANUAL_TUNNEL:
                 if self._found_tunnels:
@@ -804,6 +812,7 @@ class KNXOptionsFlow(KNXCommonFlow, OptionsFlow):
             self.new_entry_data = KNXConfigEntryData(
                 state_updater=user_input[CONF_KNX_STATE_UPDATER],
                 rate_limit=user_input[CONF_KNX_RATE_LIMIT],
+                telegram_log_size=user_input[CONF_KNX_TELEGRAM_LOG_SIZE],
             )
             return self.finish_flow()
 
@@ -811,21 +820,34 @@ class KNXOptionsFlow(KNXCommonFlow, OptionsFlow):
             vol.Required(
                 CONF_KNX_STATE_UPDATER,
                 default=self.initial_data.get(
-                    CONF_KNX_STATE_UPDATER,
-                    CONF_KNX_DEFAULT_STATE_UPDATER,
+                    CONF_KNX_STATE_UPDATER, CONF_KNX_DEFAULT_STATE_UPDATER
                 ),
             ): selector.BooleanSelector(),
             vol.Required(
                 CONF_KNX_RATE_LIMIT,
                 default=self.initial_data.get(
-                    CONF_KNX_RATE_LIMIT,
-                    CONF_KNX_DEFAULT_RATE_LIMIT,
+                    CONF_KNX_RATE_LIMIT, CONF_KNX_DEFAULT_RATE_LIMIT
                 ),
             ): vol.All(
                 selector.NumberSelector(
                     selector.NumberSelectorConfig(
                         min=0,
                         max=CONF_MAX_RATE_LIMIT,
+                        mode=selector.NumberSelectorMode.BOX,
+                    ),
+                ),
+                vol.Coerce(int),
+            ),
+            vol.Required(
+                CONF_KNX_TELEGRAM_LOG_SIZE,
+                default=self.initial_data.get(
+                    CONF_KNX_TELEGRAM_LOG_SIZE, TELEGRAM_LOG_DEFAULT
+                ),
+            ): vol.All(
+                selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        min=0,
+                        max=TELEGRAM_LOG_MAX,
                         mode=selector.NumberSelectorMode.BOX,
                     ),
                 ),

--- a/homeassistant/components/knx/config_flow.py
+++ b/homeassistant/components/knx/config_flow.py
@@ -858,4 +858,7 @@ class KNXOptionsFlow(KNXCommonFlow, OptionsFlow):
             step_id="communication_settings",
             data_schema=vol.Schema(data_schema),
             last_step=True,
+            description_placeholders={
+                "telegram_log_size_max": f"{TELEGRAM_LOG_MAX}",
+            },
         )

--- a/homeassistant/components/knx/const.py
+++ b/homeassistant/components/knx/const.py
@@ -52,6 +52,10 @@ CONF_KNX_DEFAULT_RATE_LIMIT: Final = 0
 
 DEFAULT_ROUTING_IA: Final = "0.0.240"
 
+CONF_KNX_TELEGRAM_LOG_SIZE: Final = "telegram_log_size"
+TELEGRAM_LOG_DEFAULT: Final = 50
+TELEGRAM_LOG_MAX: Final = 5000  # ~2 MB or ~5 hours of reasonable bus load
+
 ##
 # Secure constants
 ##
@@ -88,23 +92,26 @@ class KNXConfigEntryData(TypedDict, total=False):
 
     connection_type: str
     individual_address: str
-    local_ip: str | None
+    local_ip: str | None  # not required
     multicast_group: str
     multicast_port: int
-    route_back: bool
+    route_back: bool  # not required
+    host: str  # only required for tunnelling
+    port: int  # only required for tunnelling
+    tunnel_endpoint_ia: str | None
+    # KNX secure
+    user_id: int | None  # not required
+    user_password: str | None  # not required
+    device_authentication: str | None  # not required
+    knxkeys_filename: str  # not required
+    knxkeys_password: str  # not required
+    backbone_key: str | None  # not required
+    sync_latency_tolerance: int | None  # not required
+    # OptionsFlow only
     state_updater: bool
     rate_limit: int
-    host: str
-    port: int
-    tunnel_endpoint_ia: str | None
-
-    user_id: int | None
-    user_password: str | None
-    device_authentication: str | None
-    knxkeys_filename: str
-    knxkeys_password: str
-    backbone_key: str | None
-    sync_latency_tolerance: int | None
+    #   Integration only (not forwarded to xknx)
+    telegram_log_size: int  # not required
 
 
 class KNXBusMonitorMessage(TypedDict):

--- a/homeassistant/components/knx/strings.json
+++ b/homeassistant/components/knx/strings.json
@@ -139,7 +139,7 @@
         "data_description": {
           "state_updater": "Set default for reading states from the KNX Bus. When disabled, Home Assistant will not actively retrieve entity states from the KNX Bus. Can be overridden by `sync_state` entity options.",
           "rate_limit": "Maximum outgoing telegrams per second.\n`0` to disable limit. Recommended: 0 or 20 to 40",
-          "telegram_log_size": "Telegrams to keep in memory for group monitor."
+          "telegram_log_size": "Telegrams to keep in memory for KNX panel group monitor. Maximum: {telegram_log_size_max}"
         }
       },
       "connection_type": {

--- a/homeassistant/components/knx/strings.json
+++ b/homeassistant/components/knx/strings.json
@@ -133,11 +133,13 @@
         "title": "Communication settings",
         "data": {
           "state_updater": "State updater",
-          "rate_limit": "Rate limit"
+          "rate_limit": "Rate limit",
+          "telegram_log_size": "Telegram history limit"
         },
         "data_description": {
           "state_updater": "Set default for reading states from the KNX Bus. When disabled, Home Assistant will not actively retrieve entity states from the KNX Bus. Can be overridden by `sync_state` entity options.",
-          "rate_limit": "Maximum outgoing telegrams per second.\n`0` to disable limit. Recommended: 0 or 20 to 40"
+          "rate_limit": "Maximum outgoing telegrams per second.\n`0` to disable limit. Recommended: 0 or 20 to 40",
+          "telegram_log_size": "Telegrams to keep in memory for group monitor."
         }
       },
       "connection_type": {

--- a/homeassistant/components/knx/telegrams.py
+++ b/homeassistant/components/knx/telegrams.py
@@ -35,7 +35,13 @@ class TelegramDict(TypedDict):
 class Telegrams:
     """Class to handle KNX telegrams."""
 
-    def __init__(self, hass: HomeAssistant, xknx: XKNX, project: KNXProject) -> None:
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        xknx: XKNX,
+        project: KNXProject,
+        log_size: int,
+    ) -> None:
         """Initialize Telegrams class."""
         self.hass = hass
         self.project = project
@@ -46,7 +52,7 @@ class Telegrams:
                 match_for_outgoing=True,
             )
         )
-        self.recent_telegrams: deque[TelegramDict] = deque(maxlen=50)
+        self.recent_telegrams: deque[TelegramDict] = deque(maxlen=log_size)
 
     async def _xknx_telegram_cb(self, telegram: Telegram) -> None:
         """Handle incoming and outgoing telegrams from xknx."""

--- a/tests/components/knx/test_config_flow.py
+++ b/tests/components/knx/test_config_flow.py
@@ -37,6 +37,7 @@ from homeassistant.components.knx.const import (
     CONF_KNX_SECURE_USER_ID,
     CONF_KNX_SECURE_USER_PASSWORD,
     CONF_KNX_STATE_UPDATER,
+    CONF_KNX_TELEGRAM_LOG_SIZE,
     CONF_KNX_TUNNEL_ENDPOINT_IA,
     CONF_KNX_TUNNELING,
     CONF_KNX_TUNNELING_TCP,
@@ -820,7 +821,6 @@ async def test_tunneling_setup_for_multiple_found_gateways(
         CONF_PORT: 3675,
         CONF_KNX_INDIVIDUAL_ADDRESS: "0.0.240",
         CONF_KNX_ROUTE_BACK: False,
-        CONF_KNX_LOCAL_IP: None,
         CONF_KNX_TUNNEL_ENDPOINT_IA: None,
         CONF_KNX_SECURE_DEVICE_AUTHENTICATION: None,
         CONF_KNX_SECURE_USER_ID: None,
@@ -900,9 +900,17 @@ async def test_form_with_automatic_connection_handling(
     assert result2["type"] == FlowResultType.CREATE_ENTRY
     assert result2["title"] == CONF_KNX_AUTOMATIC.capitalize()
     assert result2["data"] == {
-        **DEFAULT_ENTRY_DATA,
+        # don't use **DEFAULT_ENTRY_DATA here to check for correct usage of defaults
         CONF_KNX_CONNECTION_TYPE: CONF_KNX_AUTOMATIC,
+        CONF_KNX_INDIVIDUAL_ADDRESS: "0.0.240",
+        CONF_KNX_LOCAL_IP: None,
+        CONF_KNX_MCAST_PORT: DEFAULT_MCAST_PORT,
+        CONF_KNX_MCAST_GRP: DEFAULT_MCAST_GRP,
+        CONF_KNX_RATE_LIMIT: 0,
+        CONF_KNX_ROUTE_BACK: False,
         CONF_KNX_TUNNEL_ENDPOINT_IA: None,
+        CONF_KNX_STATE_UPDATER: True,
+        CONF_KNX_TELEGRAM_LOG_SIZE: 50,
     }
     knx_setup.assert_called_once()
 
@@ -1202,6 +1210,7 @@ async def test_options_flow_connection_type(
             CONF_KNX_SECURE_DEVICE_AUTHENTICATION: None,
             CONF_KNX_SECURE_USER_ID: None,
             CONF_KNX_SECURE_USER_PASSWORD: None,
+            CONF_KNX_TELEGRAM_LOG_SIZE: 50,
         }
 
 
@@ -1331,6 +1340,7 @@ async def test_options_communication_settings(
         user_input={
             CONF_KNX_STATE_UPDATER: False,
             CONF_KNX_RATE_LIMIT: 40,
+            CONF_KNX_TELEGRAM_LOG_SIZE: 3000,
         },
     )
     await hass.async_block_till_done()
@@ -1341,6 +1351,7 @@ async def test_options_communication_settings(
         CONF_KNX_CONNECTION_TYPE: CONF_KNX_AUTOMATIC,
         CONF_KNX_STATE_UPDATER: False,
         CONF_KNX_RATE_LIMIT: 40,
+        CONF_KNX_TELEGRAM_LOG_SIZE: 3000,
     }
     knx_setup.assert_called_once()
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Make KNX Telegram history size configurable. This is loaded whenever the KNX Panels GroupMonitor is opened.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
