### PR TITLE
Improve test coverage for zwave_js

### DIFF
--- a/tests/components/zwave_js/test_helpers.py
+++ b/tests/components/zwave_js/test_helpers.py
@@ -1,0 +1,24 @@
+"""Test the Z-Wave JS helpers module."""
+from homeassistant.components.zwave_js.helpers import (
+    async_get_node_status_sensor_entity_id,
+    async_get_nodes_from_area_id,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import area_registry as ar, device_registry as dr
+
+
+async def test_async_get_node_status_sensor_entity_id(hass: HomeAssistant) -> None:
+    """Test async_get_node_status_sensor_entity_id for non zwave_js device."""
+    dev_reg = dr.async_get(hass)
+    device = dev_reg.async_get_or_create(
+        config_entry_id="123",
+        identifiers={("test", "test")},
+    )
+    assert async_get_node_status_sensor_entity_id(hass, device.id) is None
+
+
+async def test_async_get_nodes_from_area_id(hass: HomeAssistant) -> None:
+    """Test async_get_nodes_from_area_id."""
+    area_reg = ar.async_get(hass)
+    area = area_reg.async_create("test")
+    assert not async_get_nodes_from_area_id(hass, area.id)

--- a/tests/components/zwave_js/test_update.py
+++ b/tests/components/zwave_js/test_update.py
@@ -776,3 +776,20 @@ async def test_update_entity_full_restore_data_no_update_available(
     assert state.state == STATE_OFF
     assert state.attributes[ATTR_SKIPPED_VERSION] is None
     assert state.attributes[ATTR_LATEST_VERSION] == "10.7"
+
+
+async def test_update_entity_unload_asleep_node(
+    hass: HomeAssistant, client, wallmote_central_scene, integration
+) -> None:
+    """Test unloading config entry after attempting an update for an asleep node."""
+    assert len(client.async_send_command.call_args_list) == 0
+
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5, days=1))
+    await hass.async_block_till_done()
+
+    assert len(client.async_send_command.call_args_list) == 0
+    assert len(wallmote_central_scene._listeners["wake up"]) == 2
+
+    await hass.config_entries.async_unload(integration.entry_id)
+    # await hass.async_block_till_done()
+    assert len(wallmote_central_scene._listeners["wake up"]) == 0

--- a/tests/components/zwave_js/test_update.py
+++ b/tests/components/zwave_js/test_update.py
@@ -791,5 +791,4 @@ async def test_update_entity_unload_asleep_node(
     assert len(wallmote_central_scene._listeners["wake up"]) == 2
 
     await hass.config_entries.async_unload(integration.entry_id)
-    # await hass.async_block_till_done()
     assert len(wallmote_central_scene._listeners["wake up"]) == 0


### PR DESCRIPTION
## Proposed change
Added some coverage here and there


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
