### PR TITLE
Support multiple TLS/SSL configurations on the webserver

### DIFF
--- a/homeassistant/components/analytics/analytics.py
+++ b/homeassistant/components/analytics/analytics.py
@@ -247,7 +247,9 @@ class Analytics:
                     )
 
         if self.preferences.get(ATTR_USAGE, False):
-            payload[ATTR_CERTIFICATE] = self.hass.http.ssl_certificate is not None
+            payload[ATTR_CERTIFICATE] = (
+                self.hass.config.api and self.hass.config.api.use_ssl
+            )
             payload[ATTR_INTEGRATIONS] = integrations
             payload[ATTR_CUSTOM_INTEGRATIONS] = custom_integrations
             if supervisor_info is not None:

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -138,7 +138,7 @@ def _relocated_with_message(key: str, new_location: str) -> Callable[[dict], dic
             )
         if key in config:
             _LOGGER.warning(
-                "The '%s' option %s has moved to '%s', please update your configuration.",
+                "The '%s' option %s has moved to '%s', please update your configuration",
                 key,
                 near,
                 new_location,

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -282,7 +282,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         local_ip,
         primary_host,
         primary_server_conf.server_port,
-        all(site_config.ssl_certificate is not None for site_config in site_configs),
+        primary_server_conf.ssl_certificate is not None,
     )
 
     return True

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -282,7 +282,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         local_ip,
         primary_host,
         primary_server_conf.server_port,
-        primary_server_conf.ssl_certificate is not None,
+        all(site_config.ssl_certificate is not None for site_config in site_configs),
     )
 
     return True
@@ -364,14 +364,8 @@ class HomeAssistantHTTP:
         self.trusted_proxies = trusted_proxies
         self.runner: web.AppRunner | None = None
         self.sites: list[HomeAssistantTCPSite] = []
-        self.ssl_certificate: str | None = None
-        self.server_port: int | None = None
         # For backwards compat
-        for site in site_configs:
-            if self.ssl_certificate is None and site.ssl_certificate:
-                self.ssl_certificate = site.ssl_certificate
-            if self.server_port is None and site.server_port:
-                self.server_port = site.server_port
+        self.server_port: int = site_configs[0].server_port
 
     async def async_initialize(
         self,

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -89,6 +89,7 @@ STORAGE_VERSION: Final = 1
 SAVE_DELAY: Final = 180
 
 CONF_SERVERS = "servers"
+SERVERS_GROUP = "servers"
 
 SERVER_SCHEMA_WITHOUT_PORT = {
     vol.Optional(CONF_SERVER_HOST): vol.All(
@@ -104,7 +105,7 @@ SERVER_SCHEMA_WITHOUT_PORT = {
 
 OPTIONAL_PORT = {vol.Optional(CONF_SERVER_PORT, default=SERVER_PORT): cv.port}
 
-_EXCLUSIVE_PORT_KEY = vol.Exclusive(CONF_SERVER_PORT, "server")
+_EXCLUSIVE_PORT_KEY = vol.Exclusive(CONF_SERVER_PORT, SERVERS_GROUP)
 _EXCLUSIVE_PORT_KEY.default = vol.default_factory(SERVER_PORT)
 
 EXCLUSIVE_PORT = {_EXCLUSIVE_PORT_KEY: cv.port}
@@ -138,7 +139,7 @@ HTTP_SCHEMA: Final = vol.All(
             **EXCLUSIVE_PORT,
             vol.Optional(CONF_BASE_URL): cv.string,
             vol.Exclusive(
-                CONF_SERVERS, "servers", msg=SERVERS_EXCLUSIVE_MESSAGE
+                CONF_SERVERS, SERVERS_GROUP, msg=SERVERS_EXCLUSIVE_MESSAGE
             ): vol.All(
                 cv.ensure_list,
                 [vol.Schema({**SERVER_SCHEMA_WITHOUT_PORT, **OPTIONAL_PORT})],

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -124,6 +124,12 @@ SERVERS_EXCLUSIVE_MESSAGE = (
 
 HTTP_SCHEMA: Final = vol.All(
     cv.deprecated(CONF_BASE_URL),
+    cv.deprecated(CONF_SERVER_HOST),
+    cv.deprecated(CONF_SERVER_PORT),
+    cv.deprecated(CONF_SSL_CERTIFICATE),
+    cv.deprecated(CONF_SSL_PEER_CERTIFICATE),
+    cv.deprecated(CONF_SSL_KEY),
+    cv.deprecated(CONF_SSL_PROFILE),
     vol.Schema(
         {
             **SERVER_SCHEMA_WITHOUT_PORT,

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -124,12 +124,14 @@ SERVERS_EXCLUSIVE_MESSAGE = (
 
 HTTP_SCHEMA: Final = vol.All(
     cv.deprecated(CONF_BASE_URL),
-    cv.deprecated(CONF_SERVER_HOST),
-    cv.deprecated(CONF_SERVER_PORT),
-    cv.deprecated(CONF_SSL_CERTIFICATE),
-    cv.deprecated(CONF_SSL_PEER_CERTIFICATE),
-    cv.deprecated(CONF_SSL_KEY),
-    cv.deprecated(CONF_SSL_PROFILE),
+    cv.deprecated(CONF_SERVER_HOST, replacement_key="servers[0].server_host"),
+    cv.deprecated(CONF_SERVER_PORT, replacement_key="servers[0].server_port"),
+    cv.deprecated(CONF_SSL_CERTIFICATE, replacement_key="servers[0].ssl_certificate"),
+    cv.deprecated(
+        CONF_SSL_PEER_CERTIFICATE, replacement_key="servers[0].ssl_peer_certificate"
+    ),
+    cv.deprecated(CONF_SSL_KEY, replacement_key="servers[0].ssl_key"),
+    cv.deprecated(CONF_SSL_PROFILE, replacement_key="servers[0].ssl_profile"),
     vol.Schema(
         {
             **SERVER_SCHEMA_WITHOUT_PORT,

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -200,7 +200,7 @@ class ApiConfig:
 class SiteServerConfig:
     """Configuration for a single TCPSite."""
 
-    server_host: list[str]
+    server_host: list[str] | None
     server_port: int
     ssl_certificate: str | None
     ssl_peer_certificate: str | None
@@ -212,7 +212,7 @@ class SiteServerConfig:
 def _create_site_server_config_from_dict(conf: ConfData) -> SiteServerConfig:
     """Create a SiteServerConfig from a dict."""
     return SiteServerConfig(
-        server_host=conf.get(CONF_SERVER_HOST) or [],
+        server_host=conf.get(CONF_SERVER_HOST),
         server_port=conf[CONF_SERVER_PORT],
         ssl_certificate=conf.get(CONF_SSL_CERTIFICATE),
         ssl_peer_certificate=conf.get(CONF_SSL_PEER_CERTIFICATE),

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -282,7 +282,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         local_ip,
         primary_host,
         primary_server_conf.server_port,
-        primary_server_conf.ssl_certificate is not None,
+        all(site_config.ssl_certificate is not None for site_config in site_configs),
     )
 
     return True

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -468,7 +468,8 @@ class HomeAssistantHTTP:
     def _create_ssl_contexts(self) -> None:
         for site in self.site_configs:
             context: ssl.SSLContext | None = None
-            assert site.ssl_certificate is not None
+            if site.ssl_certificate is None:
+                continue
             try:
                 if site.ssl_profile == SSL_INTERMEDIATE:
                     context = ssl_util.server_context_intermediate()

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -125,7 +125,7 @@ SERVERS_EXCLUSIVE_MESSAGE = (
 )
 
 
-def _relocated_with_message(key: str, new_location: str) -> Callable[[dict], dict]:
+def _relocated_with_message(key: str, new_location: str) -> Callable[[ConfigType], ConfigType]:
     """Log key as relocated with a message."""
 
     def validator(config: ConfigType) -> ConfigType:

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -193,12 +193,10 @@ class SiteServerConfig:
     ssl_context: ssl.SSLContext | None = None
 
 
-def _create_site_server_config_from_dict(
-    conf: ConfData | dict[str, Any]
-) -> SiteServerConfig:
+def _create_site_server_config_from_dict(conf: ConfData) -> SiteServerConfig:
     """Create a SiteServerConfig from a dict."""
     return SiteServerConfig(
-        server_host=conf[CONF_SERVER_HOST],
+        server_host=conf.get(CONF_SERVER_HOST) or [],
         server_port=conf[CONF_SERVER_PORT],
         ssl_certificate=conf.get(CONF_SSL_CERTIFICATE),
         ssl_peer_certificate=conf.get(CONF_SSL_PEER_CERTIFICATE),
@@ -223,11 +221,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     site_configs: list[SiteServerConfig] = []
 
-    if CONF_SERVERS in config[DOMAIN]:
-        site_configs = [
-            _create_site_server_config_from_dict(conf)
-            for conf in config[DOMAIN][CONF_SERVERS]
-        ]
+    if server_cfg := conf.get(CONF_SERVERS):
+        servers = cast(list[ConfData], server_cfg)
+        site_configs = [_create_site_server_config_from_dict(cfg) for cfg in servers]
     else:
         site_configs = [_create_site_server_config_from_dict(conf)]
 

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -364,6 +364,14 @@ class HomeAssistantHTTP:
         self.trusted_proxies = trusted_proxies
         self.runner: web.AppRunner | None = None
         self.sites: list[HomeAssistantTCPSite] = []
+        self.ssl_certificate: str | None = None
+        self.server_port: int | None = None
+        # For backwards compat
+        for site in site_configs:
+            if self.ssl_certificate is None and site.ssl_certificate:
+                self.ssl_certificate = site.ssl_certificate
+            if self.server_port is None and site.server_port:
+                self.server_port = site.server_port
 
     async def async_initialize(
         self,

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -605,14 +605,19 @@ class HomeAssistantHTTP:
 
             if isinstance(result, Exception):
                 _LOGGER.error(
-                    "Failed to create HTTP server at port %d: %s",
+                    "Failed to create HTTP server at port %s:%d: %s",
+                    site_config.server_host,
                     site_config.server_port,
                     result,
                 )
                 continue
 
             self.sites.append(sites[idx])
-            _LOGGER.info("Now listening on port %d", site_config.server_port)
+            _LOGGER.info(
+                "Now listening on %s:%d",
+                site_config.server_host,
+                site_config.server_port,
+            )
 
     async def stop(self) -> None:
         """Stop the aiohttp server."""

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -622,7 +622,7 @@ class HomeAssistantHTTP:
     async def stop(self) -> None:
         """Stop the aiohttp server."""
         if self.sites:
-            await asyncio.gather(*[site.stop() for site in self.sites])
+            await asyncio.gather(*(site.stop() for site in self.sites))
         if self.runner is not None:
             await self.runner.cleanup()
 

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -125,7 +125,9 @@ SERVERS_EXCLUSIVE_MESSAGE = (
 )
 
 
-def _relocated_with_message(key: str, new_location: str) -> Callable[[ConfigType], ConfigType]:
+def _relocated_with_message(
+    key: str, new_location: str
+) -> Callable[[ConfigType], ConfigType]:
     """Log key as relocated with a message."""
 
     def validator(config: ConfigType) -> ConfigType:

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -128,7 +128,7 @@ SERVERS_EXCLUSIVE_MESSAGE = (
 def _relocated_with_message(key: str, new_location: str) -> Callable[[dict], dict]:
     """Log key as relocated with a message."""
 
-    def validator(config: dict) -> dict:
+    def validator(config: ConfigType) -> ConfigType:
         """Check if key is in config and log the new location."""
         near = ""
         with contextlib.suppress(AttributeError):

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -113,7 +113,7 @@ _EXCLUSIVE_PORT_KEY.default = vol.default_factory(SERVER_PORT)
 EXCLUSIVE_PORT = {_EXCLUSIVE_PORT_KEY: cv.port}
 
 
-def _has_all_unique_ports(servers: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def _has_all_unique_ports(servers: list[ConfigType]) -> list[ConfigType]:
     """Validate that each http service has a unique port."""
     ports = [list[CONF_SERVER_PORT] for list in servers]
     vol.Schema(vol.Unique())(ports)

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -15,7 +15,6 @@ import sys
 from typing import Any, Final, cast
 
 import voluptuous as vol
-from yarl import URL
 from zeroconf import (
     BadTypeInNameException,
     InterfaceChoice,
@@ -268,16 +267,14 @@ async def _async_register_hass_zc_service(
     }
 
     # Get instance URL's
-    external_url: str | None = None
     with suppress(NoURLAvailableError):
-        params["external_url"] = external_url = get_url(hass, allow_internal=False)
+        params["external_url"] = get_url(hass, allow_internal=False)
 
-    internal_url: str | None = None
     with suppress(NoURLAvailableError):
-        params["internal_url"] = internal_url = get_url(hass, allow_external=False)
+        params["internal_url"] = get_url(hass, allow_external=False)
 
     # Set old base URL based on external or internal
-    params["base_url"] = external_url or internal_url
+    params["base_url"] = params["external_url"] or params["internal_url"]
 
     adapters = await network.async_get_adapters(hass)
 
@@ -292,19 +289,12 @@ async def _async_register_hass_zc_service(
 
     _suppress_invalid_properties(params)
 
-    server_port: int | None = None
-    with contextlib.suppress(ValueError):
-        if (preferred_url := (internal_url or external_url)) and (
-            url_host := URL(preferred_url).host
-        ):
-            server_port = int(url_host.partition(":")[1])
-
     info = AsyncServiceInfo(
         ZEROCONF_TYPE,
         name=f"{valid_location_name}.{ZEROCONF_TYPE}",
         server=f"{uuid}.local.",
         addresses=address_list,
-        port=server_port or hass.http.server_port,
+        port=hass.http.server_port,
         properties=params,
     )
 

--- a/tests/components/analytics/test_analytics.py
+++ b/tests/components/analytics/test_analytics.py
@@ -199,7 +199,7 @@ async def test_send_usage(
     """Test send usage preferences are defined."""
     aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=200)
     analytics = Analytics(hass)
-    hass.http = Mock(ssl_certificate=None)
+    hass.config.api = Mock(use_ssl=False)
     await analytics.save_preferences({ATTR_BASE: True, ATTR_USAGE: True})
 
     assert analytics.preferences[ATTR_BASE]
@@ -222,7 +222,7 @@ async def test_send_usage_with_supervisor(
     """Test send usage with supervisor preferences are defined."""
     aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=200)
     analytics = Analytics(hass)
-    hass.http = Mock(ssl_certificate=None)
+    hass.config.api = Mock(use_ssl=False)
     await analytics.save_preferences({ATTR_BASE: True, ATTR_USAGE: True})
     assert analytics.preferences[ATTR_BASE]
     assert analytics.preferences[ATTR_USAGE]
@@ -417,7 +417,7 @@ async def test_custom_integrations(
     """Test sending custom integrations."""
     aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=200)
     analytics = Analytics(hass)
-    hass.http = Mock(ssl_certificate=None)
+    hass.config.api = Mock(use_ssl=False)
     assert await async_setup_component(hass, "test_package", {"test_package": {}})
     await analytics.save_preferences({ATTR_BASE: True, ATTR_USAGE: True})
 
@@ -491,7 +491,7 @@ async def test_send_with_no_energy(
     """Test send base preferences are defined."""
     aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=200)
     analytics = Analytics(hass)
-    hass.http = Mock(ssl_certificate=None)
+    hass.config.api = Mock(use_ssl=False)
 
     await analytics.save_preferences({ATTR_BASE: True, ATTR_USAGE: True})
 
@@ -565,7 +565,8 @@ async def test_send_usage_with_certificate(
     """Test send usage preferences with certificate."""
     aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=200)
     analytics = Analytics(hass)
-    hass.http = Mock(ssl_certificate="/some/path/to/cert.pem")
+
+    hass.config.api = Mock(use_ssl=True)
     await analytics.save_preferences({ATTR_BASE: True, ATTR_USAGE: True})
 
     assert analytics.preferences[ATTR_BASE]
@@ -586,7 +587,7 @@ async def test_send_with_recorder(
     """Test recorder information."""
     aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=200)
     analytics = Analytics(hass)
-    hass.http = Mock(ssl_certificate="/some/path/to/cert.pem")
+    hass.config.api = Mock(use_ssl=True)
 
     await analytics.save_preferences({ATTR_BASE: True, ATTR_USAGE: True})
 

--- a/tests/components/http/test_init.py
+++ b/tests/components/http/test_init.py
@@ -567,6 +567,9 @@ async def test_multiple_ssl_profiles(hass: HomeAssistant, tmp_path: Path) -> Non
     assert len(mock_server_context_intermediate.mock_calls) == 1
     assert len(hass.http.sites) == 2
     assert len(mock_create_server.mock_calls) == 2
+    # If all sites are using ssl use_ssl should be True
+    # for backwards compatibility
+    assert hass.config.api.use_ssl is True
 
 
 async def test_ssl_for_external_no_ssl_internal(
@@ -610,3 +613,6 @@ async def test_ssl_for_external_no_ssl_internal(
     assert len(mock_server_context_modern.mock_calls) == 1
     assert len(mock_create_server.mock_calls) == 2
     assert len(hass.http.sites) == 2
+    # If there is at least one site not using ssl, use_ssl
+    # should be False for backwards compatibility
+    assert hass.config.api.use_ssl is False

--- a/tests/components/http/test_init.py
+++ b/tests/components/http/test_init.py
@@ -306,7 +306,7 @@ async def test_emergency_ssl_certificate_when_invalid(
         in caplog.text
     )
 
-    assert hass.http.site is not None
+    assert len(hass.http.sites) == 1
 
 
 async def test_emergency_ssl_certificate_not_used_when_not_safe_mode(
@@ -360,7 +360,7 @@ async def test_emergency_ssl_certificate_when_invalid_get_url_fails(
         in caplog.text
     )
 
-    assert hass.http.site is not None
+    assert len(hass.http.sites) == 1
 
 
 async def test_invalid_ssl_and_cannot_create_emergency_cert(
@@ -391,7 +391,7 @@ async def test_invalid_ssl_and_cannot_create_emergency_cert(
     assert "Could not create an emergency self signed ssl certificate" in caplog.text
     assert len(mock_builder.mock_calls) == 1
 
-    assert hass.http.site is not None
+    assert len(hass.http.sites) == 1
 
 
 async def test_invalid_ssl_and_cannot_create_emergency_cert_with_ssl_peer_cert(
@@ -425,11 +425,12 @@ async def test_invalid_ssl_and_cannot_create_emergency_cert_with_ssl_peer_cert(
                     },
                 },
             )
-            is False
+            is True
         )
         await hass.async_start()
         await hass.async_block_till_done()
     assert "Could not create an emergency self signed ssl certificate" in caplog.text
+    # We should fallback to non-ssl so they can still access the system
     assert len(mock_builder.mock_calls) == 1
 
 

--- a/tests/components/http/test_init.py
+++ b/tests/components/http/test_init.py
@@ -536,7 +536,7 @@ async def test_multiple_ssl_profiles(hass: HomeAssistant, tmp_path: Path) -> Non
         side_effect=server_context_intermediate,
     ) as mock_server_context_intermediate, patch.object(
         hass.loop, "create_server"
-    ):
+    ) as mock_create_server:
         assert (
             await async_setup_component(
                 hass,
@@ -566,6 +566,7 @@ async def test_multiple_ssl_profiles(hass: HomeAssistant, tmp_path: Path) -> Non
     assert len(mock_server_context_modern.mock_calls) == 1
     assert len(mock_server_context_intermediate.mock_calls) == 1
     assert len(hass.http.sites) == 2
+    assert len(mock_create_server.mock_calls) == 2
 
 
 async def test_ssl_for_external_no_ssl_internal(
@@ -580,7 +581,9 @@ async def test_ssl_for_external_no_ssl_internal(
     with patch("ssl.SSLContext.load_cert_chain"), patch(
         "homeassistant.util.ssl.server_context_modern",
         side_effect=server_context_modern,
-    ) as mock_server_context_modern, patch.object(hass.loop, "create_server"):
+    ) as mock_server_context_modern, patch.object(
+        hass.loop, "create_server"
+    ) as mock_create_server:
         assert (
             await async_setup_component(
                 hass,
@@ -605,5 +608,5 @@ async def test_ssl_for_external_no_ssl_internal(
         await hass.async_block_till_done()
 
     assert len(mock_server_context_modern.mock_calls) == 1
-
+    assert len(mock_create_server.mock_calls) == 2
     assert len(hass.http.sites) == 2


### PR DESCRIPTION
~~TODO~~:

- [x] Manually test safe mode
- [x] see if anything on the frontend needs to be adjusted
- [x] review cloud code to see if this has an impact - I don't think it does since its attaching to the app runner directly

## Breaking change

Configuring `server_host`, `server_port`, `ssl_certificate`, `ssl_peer_certificate`, `ssl_key`, and `ssl_profile` has moved under the `servers` key to allow for multiple TLS configurations.  While the top level keys will continue to work, they are now deprecated and will be removed in a future version.

To migrate your configuration, move the values under the `servers` key:

Example old configuration:

```yaml
http:
    ssl_certificate: /config/ssl/cert.pem
    ssl_key: /config/ssl/key.pem
```

Example new configuration:

```yaml
http:
    servers:
       - ssl_certificate: /config/ssl/cert.pem
         ssl_key: /config/ssl/key.pem
```

Example new configuration with multiple ports; TLS on port 8123, and no TLS on port 8124:

```yaml
http:
    servers:
       - ssl_certificate: /config/ssl/cert.pem
         ssl_key: /config/ssl/key.pem
       - server_port: 8124
```


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
aiohttp already supports multiple `TCPSite`s for a single server

This allows Home Assistant to listen on multiple ports with different ssl configuration per port so that devices that need a less secure configuration can be isolated to a single port.

Motivation:
 - No need downgrade entire ssl configuration for a single device that needs a less secure configuration
 - Make external access require a client certificate but internal access allowed without it
 - Support an ONVIF camera that does not do SSL
 - Webhooks that do not work with SSL (ie Reolink)
 - Enable TLS/SSL on another so assist works without breaking no ssl on the primary port
 - Makes setups that use a TLS/SSL external url and a non-TLS/SSL internal url possible which seems to keep coming up over and over and over again for ONVIF / Reolink / Doorbird / anything using webhooks / etc users


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/27460

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
