### PR TITLE
Fix shutdown being delayed for cancelling tasks

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -83,7 +83,7 @@ from .helpers.aiohttp_compat import restore_original_aiohttp_cancel_behavior
 from .helpers.json import json_dumps
 from .util import dt as dt_util, location, ulid as ulid_util
 from .util.async_ import (
-    done_or_cancelling,
+    cancelling,
     run_callback_threadsafe,
     shutdown_run_callback_threadsafe,
 )
@@ -685,7 +685,7 @@ class HomeAssistant:
         while tasks := [
             task
             for task in self._tasks
-            if task is not current_task and not done_or_cancelling(task)
+            if task is not current_task and not cancelling(task)
         ]:
             await self._await_and_log_pending(tasks)
 
@@ -799,7 +799,7 @@ class HomeAssistant:
         # while we are awaiting canceled tasks to get their result
         # which will result in the set size changing during iteration
         for task in list(running_tasks):
-            if done_or_cancelling(task):
+            if task.done() or cancelling(task):
                 # Since we made a copy we need to check
                 # to see if the task finished while we
                 # were awaiting another task

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -82,7 +82,11 @@ from .exceptions import (
 from .helpers.aiohttp_compat import restore_original_aiohttp_cancel_behavior
 from .helpers.json import json_dumps
 from .util import dt as dt_util, location, ulid as ulid_util
-from .util.async_ import run_callback_threadsafe, shutdown_run_callback_threadsafe
+from .util.async_ import (
+    done_or_cancelling,
+    run_callback_threadsafe,
+    shutdown_run_callback_threadsafe,
+)
 from .util.read_only_dict import ReadOnlyDict
 from .util.timeout import TimeoutManager
 from .util.unit_system import (
@@ -678,7 +682,11 @@ class HomeAssistant:
         start_time: float | None = None
         current_task = asyncio.current_task()
 
-        while tasks := [task for task in self._tasks if task is not current_task]:
+        while tasks := [
+            task
+            for task in self._tasks
+            if task is not current_task and not done_or_cancelling(task)
+        ]:
             await self._await_and_log_pending(tasks)
 
             if start_time is None:
@@ -791,7 +799,7 @@ class HomeAssistant:
         # while we are awaiting canceled tasks to get their result
         # which will result in the set size changing during iteration
         for task in list(running_tasks):
-            if task.done():
+            if done_or_cancelling(task):
                 # Since we made a copy we need to check
                 # to see if the task finished while we
                 # were awaiting another task

--- a/homeassistant/util/async_.py
+++ b/homeassistant/util/async_.py
@@ -1,7 +1,7 @@
 """Asyncio utilities."""
 from __future__ import annotations
 
-from asyncio import Semaphore, gather, get_running_loop
+from asyncio import Future, Semaphore, gather, get_running_loop
 from asyncio.events import AbstractEventLoop
 from collections.abc import Awaitable, Callable
 import concurrent.futures
@@ -18,6 +18,16 @@ _SHUTDOWN_RUN_CALLBACK_THREADSAFE = "_shutdown_run_callback_threadsafe"
 _T = TypeVar("_T")
 _R = TypeVar("_R")
 _P = ParamSpec("_P")
+
+
+def done_or_cancelling(task: Future[Any]) -> bool:
+    """Return True if task is done or cancelling."""
+    # https://docs.python.org/3/library/asyncio-task.html#asyncio.Task.cancelling
+    # is new in Python 3.11
+    return bool(
+        task.done()
+        or ((cancelling := getattr(task, "cancelling", None)) and cancelling())
+    )
 
 
 def run_callback_threadsafe(

--- a/homeassistant/util/async_.py
+++ b/homeassistant/util/async_.py
@@ -24,7 +24,7 @@ def cancelling(task: Future[Any]) -> bool:
     """Return True if task is done or cancelling."""
     # https://docs.python.org/3/library/asyncio-task.html#asyncio.Task.cancelling
     # is new in Python 3.11
-    return bool((cancelling := getattr(task, "cancelling", None)) and cancelling())
+    return bool((cancelling_ := getattr(task, "cancelling", None)) and cancelling_())
 
 
 def run_callback_threadsafe(

--- a/homeassistant/util/async_.py
+++ b/homeassistant/util/async_.py
@@ -20,14 +20,11 @@ _R = TypeVar("_R")
 _P = ParamSpec("_P")
 
 
-def done_or_cancelling(task: Future[Any]) -> bool:
+def cancelling(task: Future[Any]) -> bool:
     """Return True if task is done or cancelling."""
     # https://docs.python.org/3/library/asyncio-task.html#asyncio.Task.cancelling
     # is new in Python 3.11
-    return bool(
-        task.done()
-        or ((cancelling := getattr(task, "cancelling", None)) and cancelling())
-    )
+    return bool((cancelling := getattr(task, "cancelling", None)) and cancelling())
 
 
 def run_callback_threadsafe(


### PR DESCRIPTION
## Breaking change

Home Assistant will no longer wait for cancelling tasks at shutdown when running with cpython 3.11 or later.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
cpython 3.11 introduced the concept of cancelling
https://docs.python.org/3/library/asyncio-task.html#asyncio.Task.cancelling

Once a task is being cancelled we should no longer block waiting for it since we can end up waiting multiple minutes for a long polling http request, udp discovery, etc that has already received cancellation but cancellation has not fully propagated to full stack.  This is common with `anyio` since it won't finish the cancellation until the timeout expires.

Fixes
```
2023-05-19 18:52:49.856 WARNING (MainThread) [homeassistant.core] Shutdown stage 0: still running: <Task cancelling name='c200 background pull messages' coro=<PullPointManager._async_pull_messages() running at /usr/src/homeassistant/homeassistant/components/onvif/event.py:354> wait_for=<Future cancelled> cb=[set.remove(), set.remove()]>
2023-05-19 18:52:49.858 WARNING (MainThread) [homeassistant.core] Shutdown stage 0: still running: <Task cancelling name='HD-IPC background pull messages' coro=<PullPointManager._async_pull_messages() running at /usr/src/homeassistant/homeassistant/components/onvif/event.py:354> wait_for=<Future cancelled> cb=[set.remove(), set.remove()]>
2023-05-19 18:52:49.859 WARNING (MainThread) [homeassistant.core] Shutdown stage 0: still running: <Task cancelling name='e1 reolink background pull messages' coro=<PullPointManager._async_pull_messages() running at /usr/src/homeassistant/homeassistant/components/onvif/event.py:354> wait_for=<Future cancelled> cb=[set.remove(), set.remove()]>
2023-05-19 18:52:49.860 WARNING (MainThread) [homeassistant.core] Shutdown stage 0: still running: <Task cancelling name='Amcrest background pull messages' coro=<PullPointManager._async_pull_messages() running at /usr/src/homeassistant/homeassistant/components/onvif/event.py:354> wait_for=<Future cancelled> cb=[set.remove(), set.remove()]>
2023-05-19 18:52:49.860 WARNING (MainThread) [homeassistant.core] Shutdown stage 0: still running: <Task cancelling name='LC background pull messages' coro=<PullPointManager._async_pull_messages() running at /usr/src/homeassistant/homeassistant/components/onvif/event.py:354> wait_for=<Future cancelled> cb=[set.remove(), set.remove()]>
2023-05-19 18:52:49.861 WARNING (MainThread) [homeassistant.core] Shutdown stage 0: still running: <Task cancelling name='flux_led-discovery' coro=<async_setup.<locals>._async_discovery() running at /usr/src/homeassistant/homeassistant/components/flux_led/__init__.py:97> wait_for=<_GatheringFuture pending cb=[Task.task_wakeup()]> cb=[set.remove(), set.remove()]>
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
