### PR TITLE
Bump `accuweather` to version 1.0.0

### DIFF
--- a/homeassistant/components/accuweather/__init__.py
+++ b/homeassistant/components/accuweather/__init__.py
@@ -125,7 +125,9 @@ class AccuWeatherDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             async with timeout(10):
                 current = await self.accuweather.async_get_current_conditions()
                 forecast = (
-                    await self.accuweather.async_get_forecast() if self.forecast else {}
+                    await self.accuweather.async_get_daily_forecast()
+                    if self.forecast
+                    else {}
                 )
         except (
             ApiError,

--- a/homeassistant/components/accuweather/__init__.py
+++ b/homeassistant/components/accuweather/__init__.py
@@ -121,14 +121,12 @@ class AccuWeatherDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Update data via library."""
+        forecast: list[dict[str, Any]] = []
         try:
             async with timeout(10):
                 current = await self.accuweather.async_get_current_conditions()
-                forecast = (
-                    await self.accuweather.async_get_daily_forecast()
-                    if self.forecast
-                    else {}
-                )
+                if self.forecast:
+                    forecast = await self.accuweather.async_get_daily_forecast()
         except (
             ApiError,
             ClientConnectorError,

--- a/homeassistant/components/accuweather/manifest.json
+++ b/homeassistant/components/accuweather/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["accuweather"],
   "quality_scale": "platinum",
-  "requirements": ["accuweather==0.5.2"]
+  "requirements": ["accuweather==1.0.0"]
 }

--- a/homeassistant/components/accuweather/weather.py
+++ b/homeassistant/components/accuweather/weather.py
@@ -1,8 +1,7 @@
 """Support for the AccuWeather service."""
 from __future__ import annotations
 
-from statistics import mean
-from typing import Any, cast
+from typing import cast
 
 from homeassistant.components.weather import (
     ATTR_FORECAST_CONDITION,
@@ -120,15 +119,10 @@ class AccuWeatherEntity(
                 ATTR_FORECAST_TIME: utc_from_timestamp(item["EpochDate"]).isoformat(),
                 ATTR_FORECAST_NATIVE_TEMP: item["TemperatureMax"]["Value"],
                 ATTR_FORECAST_NATIVE_TEMP_LOW: item["TemperatureMin"]["Value"],
-                ATTR_FORECAST_NATIVE_PRECIPITATION: self._calc_precipitation(item),
-                ATTR_FORECAST_PRECIPITATION_PROBABILITY: round(
-                    mean(
-                        [
-                            item["PrecipitationProbabilityDay"],
-                            item["PrecipitationProbabilityNight"],
-                        ]
-                    )
-                ),
+                ATTR_FORECAST_NATIVE_PRECIPITATION: item["TotalLiquidDay"]["Value"],
+                ATTR_FORECAST_PRECIPITATION_PROBABILITY: item[
+                    "PrecipitationProbabilityDay"
+                ],
                 ATTR_FORECAST_NATIVE_WIND_SPEED: item["WindDay"]["Speed"]["Value"],
                 ATTR_FORECAST_WIND_BEARING: item["WindDay"]["Direction"]["Degrees"],
                 ATTR_FORECAST_CONDITION: [
@@ -137,18 +131,3 @@ class AccuWeatherEntity(
             }
             for item in self.coordinator.data[ATTR_FORECAST]
         ]
-
-    @staticmethod
-    def _calc_precipitation(day: dict[str, Any]) -> float:
-        """Return sum of the precipitation."""
-        precip_sum = 0
-        precip_types = ["Rain", "Snow", "Ice"]
-        for precip in precip_types:
-            precip_sum = sum(
-                [
-                    precip_sum,
-                    day[f"{precip}Day"]["Value"],
-                    day[f"{precip}Night"]["Value"],
-                ]
-            )
-        return round(precip_sum, 1)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -71,7 +71,7 @@ WSDiscovery==2.0.0
 WazeRouteCalculator==0.14
 
 # homeassistant.components.accuweather
-accuweather==0.5.2
+accuweather==1.0.0
 
 # homeassistant.components.adax
 adax==0.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -61,7 +61,7 @@ WSDiscovery==2.0.0
 WazeRouteCalculator==0.14
 
 # homeassistant.components.accuweather
-accuweather==0.5.2
+accuweather==1.0.0
 
 # homeassistant.components.adax
 adax==0.2.0

--- a/tests/components/accuweather/__init__.py
+++ b/tests/components/accuweather/__init__.py
@@ -41,7 +41,7 @@ async def init_integration(
         "homeassistant.components.accuweather.AccuWeather.async_get_current_conditions",
         return_value=current,
     ), patch(
-        "homeassistant.components.accuweather.AccuWeather.async_get_forecast",
+        "homeassistant.components.accuweather.AccuWeather.async_get_daily_forecast",
         return_value=forecast,
     ), patch(
         "homeassistant.components.accuweather.AccuWeather.requests_remaining",

--- a/tests/components/accuweather/fixtures/current_conditions_data.json
+++ b/tests/components/accuweather/fixtures/current_conditions_data.json
@@ -1,4 +1,5 @@
 {
+  "WeatherText": "Sunny",
   "WeatherIcon": 1,
   "HasPrecipitation": false,
   "PrecipitationType": null,

--- a/tests/components/accuweather/fixtures/forecast_data.json
+++ b/tests/components/accuweather/fixtures/forecast_data.json
@@ -137,6 +137,11 @@
     "HoursOfSnowDay": 0.0,
     "HoursOfIceDay": 0.0,
     "CloudCoverDay": 58,
+    "SolarIrradianceDay": {
+      "Value": 7447.1,
+      "Unit": "W/m\u00b2",
+      "UnitType": 33
+    },
     "IconNight": 41,
     "IconPhraseNight": "Partly cloudy w/ t-storms",
     "HasPrecipitationNight": true,
@@ -197,7 +202,12 @@
     "HoursOfRainNight": 1.0,
     "HoursOfSnowNight": 0.0,
     "HoursOfIceNight": 0.0,
-    "CloudCoverNight": 65
+    "CloudCoverNight": 65,
+    "SolarIrradianceNight": {
+      "Value": 271.6,
+      "Unit": "W/m\u00b2",
+      "UnitType": 33
+    }
   },
   {
     "Date": "2020-07-27T07:00:00+02:00",
@@ -335,6 +345,11 @@
     "HoursOfSnowDay": 0.0,
     "HoursOfIceDay": 0.0,
     "CloudCoverDay": 52,
+    "SolarIrradianceDay": {
+      "Value": 7447.1,
+      "Unit": "W/m\u00b2",
+      "UnitType": 33
+    },
     "IconNight": 36,
     "IconPhraseNight": "Intermittent clouds",
     "HasPrecipitationNight": false,
@@ -393,7 +408,12 @@
     "HoursOfRainNight": 0.0,
     "HoursOfSnowNight": 0.0,
     "HoursOfIceNight": 0.0,
-    "CloudCoverNight": 63
+    "CloudCoverNight": 63,
+    "SolarIrradianceNight": {
+      "Value": 271.6,
+      "Unit": "W/m\u00b2",
+      "UnitType": 33
+    }
   },
   {
     "Date": "2020-07-28T07:00:00+02:00",
@@ -531,6 +551,11 @@
     "HoursOfSnowDay": 0.0,
     "HoursOfIceDay": 0.0,
     "CloudCoverDay": 65,
+    "SolarIrradianceDay": {
+      "Value": 7447.1,
+      "Unit": "W/m\u00b2",
+      "UnitType": 33
+    },
     "IconNight": 36,
     "IconPhraseNight": "Intermittent clouds",
     "HasPrecipitationNight": false,
@@ -589,7 +614,12 @@
     "HoursOfRainNight": 0.0,
     "HoursOfSnowNight": 0.0,
     "HoursOfIceNight": 0.0,
-    "CloudCoverNight": 53
+    "CloudCoverNight": 53,
+    "SolarIrradianceNight": {
+      "Value": 271.6,
+      "Unit": "W/m\u00b2",
+      "UnitType": 33
+    }
   },
   {
     "Date": "2020-07-29T07:00:00+02:00",
@@ -727,6 +757,11 @@
     "HoursOfSnowDay": 0.0,
     "HoursOfIceDay": 0.0,
     "CloudCoverDay": 45,
+    "SolarIrradianceDay": {
+      "Value": 7447.1,
+      "Unit": "W/m\u00b2",
+      "UnitType": 33
+    },
     "IconNight": 34,
     "IconPhraseNight": "Mostly clear",
     "HasPrecipitationNight": false,
@@ -785,7 +820,12 @@
     "HoursOfRainNight": 0.0,
     "HoursOfSnowNight": 0.0,
     "HoursOfIceNight": 0.0,
-    "CloudCoverNight": 27
+    "CloudCoverNight": 27,
+    "SolarIrradianceNight": {
+      "Value": 7447.1,
+      "Unit": "W/m\u00b2",
+      "UnitType": 33
+    }
   },
   {
     "Date": "2020-07-30T07:00:00+02:00",
@@ -923,6 +963,11 @@
     "HoursOfSnowDay": 0.0,
     "HoursOfIceDay": 0.0,
     "CloudCoverDay": 50,
+    "SolarIrradianceDay": {
+      "Value": 7447.1,
+      "Unit": "W/m\u00b2",
+      "UnitType": 33
+    },
     "IconNight": 34,
     "IconPhraseNight": "Mostly clear",
     "HasPrecipitationNight": false,
@@ -981,6 +1026,11 @@
     "HoursOfRainNight": 0.0,
     "HoursOfSnowNight": 0.0,
     "HoursOfIceNight": 0.0,
-    "CloudCoverNight": 13
+    "CloudCoverNight": 13,
+    "SolarIrradianceNight": {
+      "Value": 276.1,
+      "Unit": "W/m\u00b2",
+      "UnitType": 33
+    }
   }
 ]

--- a/tests/components/accuweather/test_config_flow.py
+++ b/tests/components/accuweather/test_config_flow.py
@@ -156,7 +156,7 @@ async def test_options_flow(hass: HomeAssistant) -> None:
             "accuweather/current_conditions_data.json"
         ),
     ), patch(
-        "homeassistant.components.accuweather.AccuWeather.async_get_forecast"
+        "homeassistant.components.accuweather.AccuWeather.async_get_daily_forecast"
     ), patch(
         "homeassistant.components.accuweather.AccuWeather.requests_remaining",
         new_callable=PropertyMock,

--- a/tests/components/accuweather/test_diagnostics.py
+++ b/tests/components/accuweather/test_diagnostics.py
@@ -19,7 +19,7 @@ async def test_entry_diagnostics(
         "current_conditions_data.json", "accuweather"
     )
 
-    coordinator_data["forecast"] = {}
+    coordinator_data["forecast"] = []
 
     result = await get_diagnostics_for_config_entry(hass, hass_client, entry)
 

--- a/tests/components/accuweather/test_init.py
+++ b/tests/components/accuweather/test_init.py
@@ -104,7 +104,7 @@ async def test_update_interval_forecast(hass: HomeAssistant) -> None:
         "homeassistant.components.accuweather.AccuWeather.async_get_current_conditions",
         return_value=current,
     ) as mock_current, patch(
-        "homeassistant.components.accuweather.AccuWeather.async_get_forecast",
+        "homeassistant.components.accuweather.AccuWeather.async_get_daily_forecast",
         return_value=forecast,
     ) as mock_forecast:
         assert mock_current.call_count == 0

--- a/tests/components/accuweather/test_sensor.py
+++ b/tests/components/accuweather/test_sensor.py
@@ -717,7 +717,7 @@ async def test_manual_update_entity(hass: HomeAssistant) -> None:
         "homeassistant.components.accuweather.AccuWeather.async_get_current_conditions",
         return_value=current,
     ) as mock_current, patch(
-        "homeassistant.components.accuweather.AccuWeather.async_get_forecast",
+        "homeassistant.components.accuweather.AccuWeather.async_get_daily_forecast",
         return_value=forecast,
     ) as mock_forecast, patch(
         "homeassistant.components.accuweather.AccuWeather.requests_remaining",

--- a/tests/components/accuweather/test_weather.py
+++ b/tests/components/accuweather/test_weather.py
@@ -74,8 +74,8 @@ async def test_weather_with_forecast(hass: HomeAssistant) -> None:
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
     forecast = state.attributes.get(ATTR_FORECAST)[0]
     assert forecast.get(ATTR_FORECAST_CONDITION) == "lightning-rainy"
-    assert forecast.get(ATTR_FORECAST_PRECIPITATION) == 4.8
-    assert forecast.get(ATTR_FORECAST_PRECIPITATION_PROBABILITY) == 58
+    assert forecast.get(ATTR_FORECAST_PRECIPITATION) == 2.5
+    assert forecast.get(ATTR_FORECAST_PRECIPITATION_PROBABILITY) == 60
     assert forecast.get(ATTR_FORECAST_TEMP) == 29.5
     assert forecast.get(ATTR_FORECAST_TEMP_LOW) == 15.4
     assert forecast.get(ATTR_FORECAST_TIME) == "2020-07-26T05:00:00+00:00"
@@ -141,7 +141,7 @@ async def test_manual_update_entity(hass: HomeAssistant) -> None:
         "homeassistant.components.accuweather.AccuWeather.async_get_current_conditions",
         return_value=current,
     ) as mock_current, patch(
-        "homeassistant.components.accuweather.AccuWeather.async_get_forecast",
+        "homeassistant.components.accuweather.AccuWeather.async_get_daily_forecast",
         return_value=forecast,
     ) as mock_forecast, patch(
         "homeassistant.components.accuweather.AccuWeather.requests_remaining",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR bumps `accuweather` library to version `1.0.0`.

Calculation of `native precipitation` and `precipitation probability` is not needed now, the value is taken directly from the API data.

Changelog: https://github.com/bieniu/accuweather/compare/0.5.2...1.0.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
