### PR TITLE
Add zeroconf support to roomba

### DIFF
--- a/homeassistant/components/roomba/__init__.py
+++ b/homeassistant/components/roomba/__init__.py
@@ -4,7 +4,6 @@ from functools import partial
 import logging
 
 import async_timeout
-from roombapy import RoombaConnectionError, RoombaFactory
 
 from homeassistant import exceptions
 from homeassistant.config_entries import ConfigEntry
@@ -16,6 +15,7 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STOP,
 )
 from homeassistant.core import HomeAssistant
+from roombapy import RoombaConnectionError, RoombaFactory
 
 from .const import (
     BLID,

--- a/homeassistant/components/roomba/__init__.py
+++ b/homeassistant/components/roomba/__init__.py
@@ -4,6 +4,7 @@ from functools import partial
 import logging
 
 import async_timeout
+from roombapy import RoombaConnectionError, RoombaFactory
 
 from homeassistant import exceptions
 from homeassistant.config_entries import ConfigEntry
@@ -15,7 +16,6 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STOP,
 )
 from homeassistant.core import HomeAssistant
-from roombapy import RoombaConnectionError, RoombaFactory
 
 from .const import (
     BLID,

--- a/homeassistant/components/roomba/config_flow.py
+++ b/homeassistant/components/roomba/config_flow.py
@@ -5,6 +5,9 @@ import asyncio
 from functools import partial
 import logging
 
+from roombapy import RoombaFactory
+from roombapy.discovery import RoombaDiscovery
+from roombapy.getpassword import RoombaPassword
 import voluptuous as vol
 
 from homeassistant import config_entries, core
@@ -12,9 +15,6 @@ from homeassistant.components import dhcp, zeroconf
 from homeassistant.const import CONF_DELAY, CONF_HOST, CONF_NAME, CONF_PASSWORD
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
-from roombapy import RoombaFactory
-from roombapy.discovery import RoombaDiscovery
-from roombapy.getpassword import RoombaPassword
 
 from . import CannotConnect, async_connect_or_timeout, async_disconnect_or_timeout
 from .const import (

--- a/homeassistant/components/roomba/config_flow.py
+++ b/homeassistant/components/roomba/config_flow.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 from functools import partial
+import logging
 
 import voluptuous as vol
 
@@ -36,6 +37,8 @@ MAX_NUM_DEVICES_TO_DISCOVER = 25
 
 AUTH_HELP_URL_KEY = "auth_help_url"
 AUTH_HELP_URL_VALUE = "https://www.home-assistant.io/integrations/roomba/#manually-retrieving-your-credentials"
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def validate_input(hass: core.HomeAssistant, data):
@@ -100,6 +103,14 @@ class RoombaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
     async def _async_step_discovery(self, ip_address: str, hostname: str) -> FlowResult:
+        """Handle any discovery."""
+        _LOGGER.debug(
+            "Roomba discovered at %s (%s) (source=%s) (context=%s)",
+            ip_address,
+            hostname,
+            self.source,
+            self.context,
+        )
         self._async_abort_entries_match({CONF_HOST: ip_address})
 
         if not hostname.startswith(("irobot-", "roomba-")):

--- a/homeassistant/components/roomba/config_flow.py
+++ b/homeassistant/components/roomba/config_flow.py
@@ -93,7 +93,7 @@ class RoombaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> FlowResult:
         """Handle zeroconf discovery."""
         return await self._async_step_discovery(
-            discovery_info.host, discovery_info.hostname.rstrip(".local.")
+            discovery_info.host, discovery_info.hostname.lower().rstrip(".local.")
         )
 
     async def async_step_dhcp(self, discovery_info: dhcp.DhcpServiceInfo) -> FlowResult:
@@ -119,7 +119,7 @@ class RoombaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self.host = ip_address
         self.blid = _async_blid_from_hostname(hostname)
         await self.async_set_unique_id(self.blid)
-        self._abort_if_unique_id_configured(updates={CONF_HOST: self.host})
+        self._abort_if_unique_id_configured(updates={CONF_HOST: ip_address})
 
         # Because the hostname is so long some sources may
         # truncate the hostname since it will be longer than
@@ -127,7 +127,7 @@ class RoombaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         # going for a longer hostname we abort so the user
         # does not see two flows if discovery fails.
         for progress in self._async_in_progress():
-            flow_unique_id = progress["context"]["unique_id"]
+            flow_unique_id: str = progress["context"]["unique_id"]
             if flow_unique_id.startswith(self.blid):
                 return self.async_abort(reason="short_blid")
             if self.blid.startswith(flow_unique_id):

--- a/homeassistant/components/roomba/config_flow.py
+++ b/homeassistant/components/roomba/config_flow.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import asyncio
 from functools import partial
-import logging
 
 from roombapy import RoombaFactory
 from roombapy.discovery import RoombaDiscovery
@@ -37,8 +36,6 @@ MAX_NUM_DEVICES_TO_DISCOVER = 25
 
 AUTH_HELP_URL_KEY = "auth_help_url"
 AUTH_HELP_URL_VALUE = "https://www.home-assistant.io/integrations/roomba/#manually-retrieving-your-credentials"
-
-_LOGGER = logging.getLogger(__name__)
 
 
 async def validate_input(hass: core.HomeAssistant, data):
@@ -104,13 +101,6 @@ class RoombaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def _async_step_discovery(self, ip_address: str, hostname: str) -> FlowResult:
         """Handle any discovery."""
-        _LOGGER.debug(
-            "Roomba discovered at %s (%s) (source=%s) (context=%s)",
-            ip_address,
-            hostname,
-            self.source,
-            self.context,
-        )
         self._async_abort_entries_match({CONF_HOST: ip_address})
 
         if not hostname.startswith(("irobot-", "roomba-")):

--- a/homeassistant/components/roomba/manifest.json
+++ b/homeassistant/components/roomba/manifest.json
@@ -24,5 +24,15 @@
   "documentation": "https://www.home-assistant.io/integrations/roomba",
   "iot_class": "local_push",
   "loggers": ["paho_mqtt", "roombapy"],
-  "requirements": ["roombapy==1.6.8"]
+  "requirements": ["roombapy==1.6.8"],
+  "zeroconf": [
+    {
+      "type": "_amzn-alexa._tcp.local.",
+      "name": "irobot-*"
+    },
+    {
+      "type": "_amzn-alexa._tcp.local.",
+      "name": "roomba-*"
+    }
+  ]
 }

--- a/homeassistant/generated/zeroconf.py
+++ b/homeassistant/generated/zeroconf.py
@@ -279,6 +279,16 @@ ZEROCONF = {
             "domain": "apple_tv",
         },
     ],
+    "_amzn-alexa._tcp.local.": [
+        {
+            "domain": "roomba",
+            "name": "irobot-*",
+        },
+        {
+            "domain": "roomba",
+            "name": "roomba-*",
+        },
+    ],
     "_androidtvremote2._tcp.local.": [
         {
             "domain": "androidtv_remote",

--- a/tests/components/roomba/test_config_flow.py
+++ b/tests/components/roomba/test_config_flow.py
@@ -2,6 +2,7 @@
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
+from roombapy import RoombaConnectionError, RoombaInfo
 
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components import dhcp, zeroconf
@@ -9,7 +10,6 @@ from homeassistant.components.roomba import config_flow
 from homeassistant.components.roomba.const import CONF_BLID, CONF_CONTINUOUS, DOMAIN
 from homeassistant.const import CONF_DELAY, CONF_HOST, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
-from roombapy import RoombaConnectionError, RoombaInfo
 
 from tests.common import MockConfigEntry
 

--- a/tests/components/roomba/test_config_flow.py
+++ b/tests/components/roomba/test_config_flow.py
@@ -2,30 +2,60 @@
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
-from roombapy import RoombaConnectionError, RoombaInfo
 
 from homeassistant import config_entries, data_entry_flow
-from homeassistant.components import dhcp
+from homeassistant.components import dhcp, zeroconf
 from homeassistant.components.roomba import config_flow
 from homeassistant.components.roomba.const import CONF_BLID, CONF_CONTINUOUS, DOMAIN
 from homeassistant.const import CONF_DELAY, CONF_HOST, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
+from roombapy import RoombaConnectionError, RoombaInfo
 
 from tests.common import MockConfigEntry
 
 MOCK_IP = "1.2.3.4"
 VALID_CONFIG = {CONF_HOST: MOCK_IP, CONF_BLID: "BLID", CONF_PASSWORD: "password"}
 
-DHCP_DISCOVERY_DEVICES = [
-    dhcp.DhcpServiceInfo(
-        ip=MOCK_IP,
-        macaddress="50:14:79:DD:EE:FF",
-        hostname="irobot-blid",
+DISCOVERY_DEVICES = [
+    (
+        config_entries.SOURCE_DHCP,
+        dhcp.DhcpServiceInfo(
+            ip=MOCK_IP,
+            macaddress="50:14:79:DD:EE:FF",
+            hostname="irobot-blid",
+        ),
     ),
-    dhcp.DhcpServiceInfo(
-        ip=MOCK_IP,
-        macaddress="80:A5:89:DD:EE:FF",
-        hostname="roomba-blid",
+    (
+        config_entries.SOURCE_DHCP,
+        dhcp.DhcpServiceInfo(
+            ip=MOCK_IP,
+            macaddress="80:A5:89:DD:EE:FF",
+            hostname="roomba-blid",
+        ),
+    ),
+    (
+        config_entries.SOURCE_ZEROCONF,
+        zeroconf.ZeroconfServiceInfo(
+            host=MOCK_IP,
+            hostname="irobot-blid.local.",
+            name="irobot-blid._amzn-alexa._tcp.local.",
+            type="_amzn-alexa._tcp.local.",
+            port=443,
+            properties={},
+            addresses=[MOCK_IP],
+        ),
+    ),
+    (
+        config_entries.SOURCE_ZEROCONF,
+        zeroconf.ZeroconfServiceInfo(
+            host=MOCK_IP,
+            hostname="roomba-blid.local.",
+            name="roomba-blid._amzn-alexa._tcp.local.",
+            type="_amzn-alexa._tcp.local.",
+            port=443,
+            properties={},
+            addresses=[MOCK_IP],
+        ),
     ),
 ]
 
@@ -625,9 +655,10 @@ async def test_form_user_discovery_and_password_fetch_gets_connection_refused(
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-@pytest.mark.parametrize("discovery_data", DHCP_DISCOVERY_DEVICES)
+@pytest.mark.parametrize("discovery_data", DISCOVERY_DEVICES)
 async def test_dhcp_discovery_and_roomba_discovery_finds(
-    hass: HomeAssistant, discovery_data
+    hass: HomeAssistant,
+    discovery_data: tuple[str, dhcp.DhcpServiceInfo | zeroconf.ZeroconfServiceInfo],
 ) -> None:
     """Test we can process the discovery from dhcp and roomba discovery matches the device."""
 
@@ -635,14 +666,15 @@ async def test_dhcp_discovery_and_roomba_discovery_finds(
         roomba_connected=True,
         master_state={"state": {"reported": {"name": "myroomba"}}},
     )
+    source, discovery = discovery_data
 
     with patch(
         "homeassistant.components.roomba.config_flow.RoombaDiscovery", _mocked_discovery
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
-            context={"source": config_entries.SOURCE_DHCP},
-            data=discovery_data,
+            context={"source": source},
+            data=discovery,
         )
         await hass.async_block_till_done()
 


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add zeroconf support to roomba.

Roomba recently started advertising via mdns which makes the devices much easier to discover for those who do not have dhcp.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
