### PR TITLE
Add support for configuring built-in Melnor Bluetooth scheduling system

### DIFF
--- a/homeassistant/components/melnor/manifest.json
+++ b/homeassistant/components/melnor/manifest.json
@@ -12,5 +12,5 @@
   "dependencies": ["bluetooth_adapters"],
   "documentation": "https://www.home-assistant.io/integrations/melnor",
   "iot_class": "local_polling",
-  "requirements": ["melnor-bluetooth==0.0.20"]
+  "requirements": ["melnor-bluetooth==0.0.21"]
 }

--- a/homeassistant/components/melnor/number.py
+++ b/homeassistant/components/melnor/number.py
@@ -8,9 +8,13 @@ from typing import Any
 
 from melnor_bluetooth.device import Valve
 
-from homeassistant.components.number import NumberEntity, NumberEntityDescription
+from homeassistant.components.number import (
+    NumberEntity,
+    NumberEntityDescription,
+    NumberMode,
+)
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EntityCategory
+from homeassistant.const import EntityCategory, UnitOfTime
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -44,10 +48,33 @@ ZONE_ENTITY_DESCRIPTIONS: list[MelnorZoneNumberEntityDescription] = [
         native_min_value=1,
         icon="mdi:timer-cog-outline",
         key="manual_minutes",
-        name="Manual Minutes",
+        name="Manual Duration",
+        native_unit_of_measurement=UnitOfTime.MINUTES,
         set_num_fn=lambda valve, value: valve.set_manual_watering_minutes(value),
         state_fn=lambda valve: valve.manual_watering_minutes,
-    )
+    ),
+    MelnorZoneNumberEntityDescription(
+        entity_category=EntityCategory.CONFIG,
+        native_max_value=168,
+        native_min_value=1,
+        icon="mdi:calendar-refresh-outline",
+        key="frequency_interval_hours",
+        name="Schedule Interval",
+        native_unit_of_measurement=UnitOfTime.HOURS,
+        set_num_fn=lambda valve, value: valve.set_frequency_interval_hours(value),
+        state_fn=lambda valve: valve.frequency.interval_hours,
+    ),
+    MelnorZoneNumberEntityDescription(
+        entity_category=EntityCategory.CONFIG,
+        native_max_value=360,
+        native_min_value=1,
+        icon="mdi:timer-outline",
+        key="frequency_duration_minutes",
+        name="Schedule Duration",
+        native_unit_of_measurement=UnitOfTime.MINUTES,
+        set_num_fn=lambda valve, value: valve.set_frequency_duration_minutes(value),
+        state_fn=lambda valve: valve.frequency.duration_minutes,
+    ),
 ]
 
 
@@ -75,6 +102,7 @@ class MelnorZoneNumber(MelnorZoneEntity, NumberEntity):
     """A number implementation for a melnor device."""
 
     entity_description: MelnorZoneNumberEntityDescription
+    _attr_mode = NumberMode.BOX
 
     def __init__(
         self,
@@ -88,7 +116,7 @@ class MelnorZoneNumber(MelnorZoneEntity, NumberEntity):
     @property
     def native_value(self) -> float | None:
         """Return the current value."""
-        return self._valve.manual_watering_minutes
+        return self.entity_description.state_fn(self._valve)
 
     async def async_set_native_value(self, value: float) -> None:
         """Update the current value."""

--- a/homeassistant/components/melnor/sensor.py
+++ b/homeassistant/components/melnor/sensor.py
@@ -45,6 +45,15 @@ def watering_seconds_left(valve: Valve) -> datetime | None:
     return dt_util.utc_from_timestamp(valve.watering_end_time)
 
 
+def next_cycle(valve: Valve) -> datetime | None:
+    """Return the value of the next_cycle date, only if the cycle is enabled."""
+
+    if valve.schedule_enabled is True:
+        return valve.next_cycle
+
+    return None
+
+
 @dataclass
 class MelnorSensorEntityDescriptionMixin:
     """Mixin for required keys."""
@@ -101,6 +110,12 @@ ZONE_ENTITY_DESCRIPTIONS: list[MelnorZoneSensorEntityDescription] = [
         key="manual_cycle_end",
         name="Manual Cycle End",
         state_fn=watering_seconds_left,
+    ),
+    MelnorZoneSensorEntityDescription(
+        device_class=SensorDeviceClass.TIMESTAMP,
+        key="next_cycle",
+        name="Next Cycle",
+        state_fn=next_cycle,
     ),
 ]
 

--- a/homeassistant/components/melnor/switch.py
+++ b/homeassistant/components/melnor/switch.py
@@ -47,7 +47,15 @@ ZONE_ENTITY_DESCRIPTIONS = [
         key="manual",
         on_off_fn=lambda valve, bool: valve.set_is_watering(bool),
         state_fn=lambda valve: valve.is_watering,
-    )
+    ),
+    MelnorSwitchEntityDescription(
+        device_class=SwitchDeviceClass.SWITCH,
+        icon="mdi:calendar-sync-outline",
+        key="frequency",
+        name="Schedule",
+        on_off_fn=lambda valve, bool: valve.set_frequency_enabled(bool),
+        state_fn=lambda valve: valve.schedule_enabled,
+    ),
 ]
 
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1118,7 +1118,7 @@ mcstatus==6.0.0
 meater-python==0.0.8
 
 # homeassistant.components.melnor
-melnor-bluetooth==0.0.20
+melnor-bluetooth==0.0.21
 
 # homeassistant.components.message_bird
 messagebird==1.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -844,7 +844,7 @@ mcstatus==6.0.0
 meater-python==0.0.8
 
 # homeassistant.components.melnor
-melnor-bluetooth==0.0.20
+melnor-bluetooth==0.0.21
 
 # homeassistant.components.meteo_france
 meteofrance-api==1.2.0

--- a/tests/components/melnor/test_number.py
+++ b/tests/components/melnor/test_number.py
@@ -12,7 +12,7 @@ from .conftest import (
 
 
 async def test_manual_watering_minutes(hass: HomeAssistant) -> None:
-    """Test the manual watering switch."""
+    """Test the manual watering duration number."""
 
     entry = mock_config_entry(hass)
 
@@ -22,8 +22,9 @@ async def test_manual_watering_minutes(hass: HomeAssistant) -> None:
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-        number = hass.states.get("number.zone_1_manual_minutes")
+        number = hass.states.get("number.zone_1_manual_duration")
 
+        assert number is not None
         assert number.state == "0"
         assert number.attributes["max"] == 360
         assert number.attributes["min"] == 1
@@ -35,11 +36,84 @@ async def test_manual_watering_minutes(hass: HomeAssistant) -> None:
         await hass.services.async_call(
             "number",
             "set_value",
-            {"entity_id": "number.zone_1_manual_minutes", "value": 10},
+            {"entity_id": "number.zone_1_manual_duration", "value": 10},
             blocking=True,
         )
 
-        number = hass.states.get("number.zone_1_manual_minutes")
+        number = hass.states.get("number.zone_1_manual_duration")
 
+        assert number is not None
         assert number.state == "10"
         assert device.zone1.manual_watering_minutes == 10
+
+
+async def test_frequency_interval_hours(hass: HomeAssistant) -> None:
+    """Test the interval hours number."""
+
+    entry = mock_config_entry(hass)
+
+    with patch_async_ble_device_from_address(), patch_melnor_device() as device_patch, patch_async_register_callback():
+        device = device_patch.return_value
+
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        number = hass.states.get("number.zone_1_schedule_interval")
+
+        assert number is not None
+        assert number.state == "0"
+        assert number.attributes["max"] == 168
+        assert number.attributes["min"] == 1
+        assert number.attributes["step"] == 1.0
+        assert number.attributes["icon"] == "mdi:calendar-refresh-outline"
+
+        assert device.zone1.frequency.interval_hours == 0
+
+        await hass.services.async_call(
+            "number",
+            "set_value",
+            {"entity_id": "number.zone_1_schedule_interval", "value": 10},
+            blocking=True,
+        )
+
+        number = hass.states.get("number.zone_1_schedule_interval")
+
+        assert number is not None
+        assert number.state == "10"
+        assert device.zone1.frequency.interval_hours == 10
+
+
+async def test_frequency_duration_minutes(hass: HomeAssistant) -> None:
+    """Test the duration minutes number."""
+
+    entry = mock_config_entry(hass)
+
+    with patch_async_ble_device_from_address(), patch_melnor_device() as device_patch, patch_async_register_callback():
+        device = device_patch.return_value
+
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        number = hass.states.get("number.zone_1_schedule_duration")
+
+        assert number is not None
+        assert number.state == "0"
+        assert number.attributes["max"] == 360
+        assert number.attributes["min"] == 1
+        assert number.attributes["step"] == 1.0
+        assert number.attributes["icon"] == "mdi:timer-outline"
+
+        assert device.zone1.frequency.duration_minutes == 0
+
+        await hass.services.async_call(
+            "number",
+            "set_value",
+            {"entity_id": "number.zone_1_schedule_duration", "value": 10},
+            blocking=True,
+        )
+
+        number = hass.states.get("number.zone_1_schedule_duration")
+
+        assert number is not None
+        assert number.state == "10"
+        assert device.zone1.frequency.duration_minutes == 10

--- a/tests/components/melnor/test_sensor.py
+++ b/tests/components/melnor/test_sensor.py
@@ -30,6 +30,8 @@ async def test_battery_sensor(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
         battery_sensor = hass.states.get("sensor.test_melnor_battery")
+
+        assert battery_sensor is not None
         assert battery_sensor.state == "80"
         assert battery_sensor.attributes["unit_of_measurement"] == PERCENTAGE
         assert battery_sensor.attributes["device_class"] == SensorDeviceClass.BATTERY
@@ -58,6 +60,8 @@ async def test_minutes_remaining_sensor(hass: HomeAssistant) -> None:
 
         # Valve is off, report 0
         minutes_sensor = hass.states.get("sensor.zone_1_manual_cycle_end")
+
+        assert minutes_sensor is not None
         assert minutes_sensor.state == "unknown"
         assert minutes_sensor.attributes["device_class"] == SensorDeviceClass.TIMESTAMP
 
@@ -69,7 +73,48 @@ async def test_minutes_remaining_sensor(hass: HomeAssistant) -> None:
 
         # Valve is on, report 10
         minutes_remaining_sensor = hass.states.get("sensor.zone_1_manual_cycle_end")
+
+        assert minutes_remaining_sensor is not None
         assert minutes_remaining_sensor.state == end_time.isoformat(timespec="seconds")
+
+
+async def test_schedule_next_cycle_sensor(hass: HomeAssistant) -> None:
+    """Test the frequency next_cycle sensor."""
+
+    now = dt_util.utcnow()
+
+    entry = mock_config_entry(hass)
+    device = mock_melnor_device()
+
+    next_cycle = now + dt_util.dt.timedelta(minutes=10)
+
+    # we control this mock
+    device.zone1.frequency._next_run_time = next_cycle
+
+    with freeze_time(now), patch_async_ble_device_from_address(), patch_melnor_device(
+        device
+    ), patch_async_register_callback():
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        # Valve is off, report 0
+        minutes_sensor = hass.states.get("sensor.zone_1_next_cycle")
+
+        assert minutes_sensor is not None
+        assert minutes_sensor.state == "unknown"
+        assert minutes_sensor.attributes["device_class"] == SensorDeviceClass.TIMESTAMP
+
+        # Turn valve on
+        device.zone1._schedule_enabled = True
+
+        async_fire_time_changed(hass, now + dt_util.dt.timedelta(seconds=10))
+        await hass.async_block_till_done()
+
+        # Valve is on, report 10
+        next_cycle_sensor = hass.states.get("sensor.zone_1_next_cycle")
+
+        assert next_cycle_sensor is not None
+        assert next_cycle_sensor.state == next_cycle.isoformat(timespec="seconds")
 
 
 async def test_rssi_sensor(
@@ -104,6 +149,7 @@ async def test_rssi_sensor(
 
         rssi = hass.states.get(entity_id)
 
+        assert rssi is not None
         assert (
             rssi.attributes["unit_of_measurement"] == SIGNAL_STRENGTH_DECIBELS_MILLIWATT
         )

--- a/tests/components/melnor/test_switch.py
+++ b/tests/components/melnor/test_switch.py
@@ -23,6 +23,8 @@ async def test_manual_watering_switch_metadata(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
         switch = hass.states.get("switch.zone_1")
+
+        assert switch is not None
         assert switch.attributes["device_class"] == SwitchDeviceClass.SWITCH
         assert switch.attributes["icon"] == "mdi:sprinkler"
 
@@ -39,6 +41,8 @@ async def test_manual_watering_switch_on_off(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
         switch = hass.states.get("switch.zone_1")
+
+        assert switch is not None
         assert switch.state is STATE_OFF
 
         await hass.services.async_call(
@@ -49,6 +53,8 @@ async def test_manual_watering_switch_on_off(hass: HomeAssistant) -> None:
         )
 
         switch = hass.states.get("switch.zone_1")
+
+        assert switch is not None
         assert switch.state is STATE_ON
         assert device.zone1.is_watering is True
 
@@ -60,5 +66,38 @@ async def test_manual_watering_switch_on_off(hass: HomeAssistant) -> None:
         )
 
         switch = hass.states.get("switch.zone_1")
+
+        assert switch is not None
         assert switch.state is STATE_OFF
         assert device.zone1.is_watering is False
+
+
+async def test_schedule_enabled_switch_on_off(hass: HomeAssistant) -> None:
+    """Test the schedule enabled switch."""
+
+    entry = mock_config_entry(hass)
+
+    with patch_async_ble_device_from_address(), patch_melnor_device() as device_patch, patch_async_register_callback():
+        device = device_patch.return_value
+
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        switch = hass.states.get("switch.zone_1_schedule")
+
+        assert switch is not None
+        assert switch.state is STATE_OFF
+        assert device.zone1.schedule_enabled is False
+
+        await hass.services.async_call(
+            "switch",
+            "turn_on",
+            {"entity_id": "switch.zone_1_schedule"},
+            blocking=True,
+        )
+
+        switch = hass.states.get("switch.zone_1_schedule")
+
+        assert switch is not None
+        assert switch.state is STATE_ON
+        assert device.zone1.schedule_enabled is True


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The bluetooth Melnor devices support their own internal scheduling system. I'd always planned on implementing this after supporting the basic on/off functionality last year but it's become more pressing as I realize just how terrible the bluetooth radios in these devices are. They'll regularly disconnect or downright refuse to connect, even if the device itself still responds to physical interactions with it's buttons.

Supporting the built-in frequency-based schedules will help guarantee that the irrigation schedules defined by the end user _always_ work even if the device has dropped off from the connection with Home Assistant.

To that end, I've added support for the 3 of the 4 scheduling entities exposed by the device:
- `duration` - number of minutes to open the watering valve
- `interval` - how often does the schedule repeat
- a switch to enable/disable the schedule from running

In a future PR, I'll add support for `start_time` (imagine my excitement when I saw the new `time` entity show up in HA _as I was working on this_ 🎉)


Part of adding this support involved bumping `melnor-bluetooth` to `0.0.21` https://github.com/vanstinator/melnor-bluetooth/releases/tag/v0.0.21

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
