### PR TITLE
Adjust counter to not restore configuration parameters

### DIFF
--- a/homeassistant/components/counter/__init__.py
+++ b/homeassistant/components/counter/__init__.py
@@ -244,10 +244,6 @@ class Counter(collection.CollectionEntity, RestoreEntity):
             and (state := await self.async_get_last_state()) is not None
         ):
             self._state = self.compute_next_state(int(state.state))
-            self._config[CONF_INITIAL] = state.attributes.get(ATTR_INITIAL)
-            self._config[CONF_MAXIMUM] = state.attributes.get(ATTR_MAXIMUM)
-            self._config[CONF_MINIMUM] = state.attributes.get(ATTR_MINIMUM)
-            self._config[CONF_STEP] = state.attributes.get(ATTR_STEP)
 
     @callback
     def async_decrement(self) -> None:

--- a/tests/components/counter/test_init.py
+++ b/tests/components/counter/test_init.py
@@ -307,14 +307,11 @@ async def test_initial_state_overrules_restore_state(hass: HomeAssistant) -> Non
 async def test_restore_state_overrules_initial_state(hass: HomeAssistant) -> None:
     """Ensure states are restored on startup."""
 
-    attr = {"initial": 6, "minimum": 1, "maximum": 8, "step": 2}
-
     mock_restore_cache(
         hass,
         (
             State("counter.test1", "11"),
             State("counter.test2", "-22"),
-            State("counter.test3", "5", attr),
         ),
     )
 
@@ -331,14 +328,6 @@ async def test_restore_state_overrules_initial_state(hass: HomeAssistant) -> Non
     state = hass.states.get("counter.test2")
     assert state
     assert int(state.state) == -22
-
-    state = hass.states.get("counter.test3")
-    assert state
-    assert int(state.state) == 5
-    assert state.attributes.get("initial") == 6
-    assert state.attributes.get("minimum") == 1
-    assert state.attributes.get("maximum") == 8
-    assert state.attributes.get("step") == 2
 
 
 async def test_no_initial_state_and_no_restore_state(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The `counter` entities no longer restore their previous manually set configuration (using the, now deprecated, `counter.configure` service) on Home Assistant startup. Instead, it will now use the configuration as set in the helper configuration in the UI (or as configured YAML, if that is used).

This behavior is removed, as it caused configuration issues, as the new configuration was never applied again (but forever restored). This behavior was out of the ordinary for Home Assistant and thus now standardized.

The value of the counter is still restored and available across Home Assistant restarts.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

See breaking change section :)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
