### PR TITLE
Plugwise add value_fn for switch

### DIFF
--- a/homeassistant/components/plugwise/switch.py
+++ b/homeassistant/components/plugwise/switch.py
@@ -101,7 +101,7 @@ class PlugwiseSwitchEntity(PlugwiseEntity, SwitchEntity):
         self._attr_unique_id = f"{device_id}-{description.key}"
 
     @property
-    def is_on(self) -> bool | None:
+    def is_on(self) -> bool:
         """Return True if entity is on."""
         return self.entity_description.value_fn(self.device["switches"])
 

--- a/homeassistant/components/plugwise/switch.py
+++ b/homeassistant/components/plugwise/switch.py
@@ -1,7 +1,11 @@
 """Plugwise Switch component for HomeAssistant."""
 from __future__ import annotations
 
+from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any
+
+from plugwise import SmileSwitches
 
 from homeassistant.components.switch import (
     SwitchDeviceClass,
@@ -18,29 +22,46 @@ from .coordinator import PlugwiseDataUpdateCoordinator
 from .entity import PlugwiseEntity
 from .util import plugwise_command
 
-SWITCHES: tuple[SwitchEntityDescription, ...] = (
-    SwitchEntityDescription(
+
+@dataclass
+class PlugwiseSwitchBaseMixin:
+    """Mixin for required Plugwise switch description keys."""
+
+    value_fn: Callable[[SmileSwitches], bool]
+
+
+@dataclass
+class PlugwiseSwitchEntityDescription(SwitchEntityDescription, PlugwiseSwitchBaseMixin):
+    """Describes Plugwise switch entity."""
+
+
+SWITCHES: tuple[PlugwiseSwitchEntityDescription, ...] = (
+    PlugwiseSwitchEntityDescription(
         key="dhw_cm_switch",
         translation_key="dhw_cm_switch",
         icon="mdi:water-plus",
         entity_category=EntityCategory.CONFIG,
+        value_fn=lambda data: data["dhw_cm_switch"],
     ),
-    SwitchEntityDescription(
+    PlugwiseSwitchEntityDescription(
         key="lock",
         translation_key="lock",
         icon="mdi:lock",
         entity_category=EntityCategory.CONFIG,
+        value_fn=lambda data: data["lock"],
     ),
-    SwitchEntityDescription(
+    PlugwiseSwitchEntityDescription(
         key="relay",
         translation_key="relay",
         device_class=SwitchDeviceClass.SWITCH,
+        value_fn=lambda data: data["relay"],
     ),
-    SwitchEntityDescription(
+    PlugwiseSwitchEntityDescription(
         key="cooling_ena_switch",
         name="Cooling",
         icon="mdi:snowflake-thermometer",
         entity_category=EntityCategory.CONFIG,
+        value_fn=lambda data: data["cooling_ena_switch"],
     ),
 )
 
@@ -54,8 +75,10 @@ async def async_setup_entry(
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
     entities: list[PlugwiseSwitchEntity] = []
     for device_id, device in coordinator.data.devices.items():
+        if not (switches := device.get("switches")):
+            continue
         for description in SWITCHES:
-            if "switches" not in device or description.key not in device["switches"]:
+            if description.key not in switches:
                 continue
             entities.append(PlugwiseSwitchEntity(coordinator, device_id, description))
     async_add_entities(entities)
@@ -64,11 +87,13 @@ async def async_setup_entry(
 class PlugwiseSwitchEntity(PlugwiseEntity, SwitchEntity):
     """Representation of a Plugwise plug."""
 
+    entity_description: PlugwiseSwitchEntityDescription
+
     def __init__(
         self,
         coordinator: PlugwiseDataUpdateCoordinator,
         device_id: str,
-        description: SwitchEntityDescription,
+        description: PlugwiseSwitchEntityDescription,
     ) -> None:
         """Set up the Plugwise API."""
         super().__init__(coordinator, device_id)
@@ -78,7 +103,7 @@ class PlugwiseSwitchEntity(PlugwiseEntity, SwitchEntity):
     @property
     def is_on(self) -> bool | None:
         """Return True if entity is on."""
-        return self.device["switches"].get(self.entity_description.key)
+        return self.entity_description.value_fn(self.device["switches"])
 
     @plugwise_command
     async def async_turn_on(self, **kwargs: Any) -> None:


### PR DESCRIPTION
## Proposed change
Change entitydescription approach for switch preparing for upcoming strict typing and module version bump PRs.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #93162 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
