### PR TITLE
Move Hydrawise constants into const.py

### DIFF
--- a/homeassistant/components/hydrawise/__init__.py
+++ b/homeassistant/components/hydrawise/__init__.py
@@ -1,6 +1,4 @@
 """Support for Hydrawise cloud."""
-from datetime import timedelta
-import logging
 
 from hydrawiser.core import Hydrawiser
 from requests.exceptions import ConnectTimeout, HTTPError
@@ -15,22 +13,15 @@ from homeassistant.helpers.entity import Entity, EntityDescription
 from homeassistant.helpers.event import track_time_interval
 from homeassistant.helpers.typing import ConfigType
 
-_LOGGER = logging.getLogger(__name__)
-
-ALLOWED_WATERING_TIME = [5, 10, 15, 30, 45, 60]
-
-CONF_WATERING_TIME = "watering_minutes"
-
-NOTIFICATION_ID = "hydrawise_notification"
-NOTIFICATION_TITLE = "Hydrawise Setup"
-
-DATA_HYDRAWISE = "hydrawise"
-DOMAIN = "hydrawise"
-DEFAULT_WATERING_TIME = 15
-
-SCAN_INTERVAL = timedelta(seconds=120)
-
-SIGNAL_UPDATE_HYDRAWISE = "hydrawise_update"
+from .const import (
+    DATA_HYDRAWISE,
+    DOMAIN,
+    LOGGER,
+    NOTIFICATION_ID,
+    NOTIFICATION_TITLE,
+    SCAN_INTERVAL,
+    SIGNAL_UPDATE_HYDRAWISE,
+)
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -55,7 +46,7 @@ def setup(hass: HomeAssistant, config: ConfigType) -> bool:
         hydrawise = Hydrawiser(user_token=access_token)
         hass.data[DATA_HYDRAWISE] = HydrawiseHub(hydrawise)
     except (ConnectTimeout, HTTPError) as ex:
-        _LOGGER.error("Unable to connect to Hydrawise cloud service: %s", str(ex))
+        LOGGER.error("Unable to connect to Hydrawise cloud service: %s", str(ex))
         persistent_notification.create(
             hass,
             f"Error: {ex}<br />You will need to restart hass after fixing.",
@@ -66,7 +57,7 @@ def setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     def hub_refresh(event_time):
         """Call Hydrawise hub to refresh information."""
-        _LOGGER.debug("Updating Hydrawise Hub component")
+        LOGGER.debug("Updating Hydrawise Hub component")
         hass.data[DATA_HYDRAWISE].data.update_controller_info()
         dispatcher_send(hass, SIGNAL_UPDATE_HYDRAWISE)
 

--- a/homeassistant/components/hydrawise/binary_sensor.py
+++ b/homeassistant/components/hydrawise/binary_sensor.py
@@ -1,8 +1,6 @@
 """Support for Hydrawise sprinkler binary sensors."""
 from __future__ import annotations
 
-import logging
-
 import voluptuous as vol
 
 from homeassistant.components.binary_sensor import (
@@ -17,9 +15,8 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import DATA_HYDRAWISE, HydrawiseEntity
-
-_LOGGER = logging.getLogger(__name__)
+from . import HydrawiseEntity
+from .const import DATA_HYDRAWISE, LOGGER
 
 BINARY_SENSOR_STATUS = BinarySensorEntityDescription(
     key="status",
@@ -82,7 +79,7 @@ class HydrawiseBinarySensor(HydrawiseEntity, BinarySensorEntity):
 
     def update(self) -> None:
         """Get the latest data and updates the state."""
-        _LOGGER.debug("Updating Hydrawise binary sensor: %s", self.name)
+        LOGGER.debug("Updating Hydrawise binary sensor: %s", self.name)
         mydata = self.hass.data[DATA_HYDRAWISE].data
         if self.entity_description.key == "status":
             self._attr_is_on = mydata.status == "All good!"

--- a/homeassistant/components/hydrawise/const.py
+++ b/homeassistant/components/hydrawise/const.py
@@ -1,0 +1,20 @@
+"""Constants for the Hydrawise integration."""
+
+from datetime import timedelta
+import logging
+
+LOGGER = logging.getLogger(__package__)
+
+ALLOWED_WATERING_TIME = [5, 10, 15, 30, 45, 60]
+CONF_WATERING_TIME = "watering_minutes"
+
+NOTIFICATION_ID = "hydrawise_notification"
+NOTIFICATION_TITLE = "Hydrawise Setup"
+
+DATA_HYDRAWISE = "hydrawise"
+DOMAIN = "hydrawise"
+DEFAULT_WATERING_TIME = 15
+
+SCAN_INTERVAL = timedelta(seconds=120)
+
+SIGNAL_UPDATE_HYDRAWISE = "hydrawise_update"

--- a/homeassistant/components/hydrawise/sensor.py
+++ b/homeassistant/components/hydrawise/sensor.py
@@ -1,8 +1,6 @@
 """Support for Hydrawise sprinkler sensors."""
 from __future__ import annotations
 
-import logging
-
 import voluptuous as vol
 
 from homeassistant.components.sensor import (
@@ -18,9 +16,8 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util import dt
 
-from . import DATA_HYDRAWISE, HydrawiseEntity
-
-_LOGGER = logging.getLogger(__name__)
+from . import HydrawiseEntity
+from .const import DATA_HYDRAWISE, LOGGER
 
 SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
     SensorEntityDescription(
@@ -76,7 +73,7 @@ class HydrawiseSensor(HydrawiseEntity, SensorEntity):
     def update(self) -> None:
         """Get the latest data and updates the states."""
         mydata = self.hass.data[DATA_HYDRAWISE].data
-        _LOGGER.debug("Updating Hydrawise sensor: %s", self.name)
+        LOGGER.debug("Updating Hydrawise sensor: %s", self.name)
         relay_data = mydata.relays[self.data["relay"] - 1]
         if self.entity_description.key == "watering_time":
             if relay_data["timestr"] == "Now":
@@ -85,7 +82,7 @@ class HydrawiseSensor(HydrawiseEntity, SensorEntity):
                 self._attr_native_value = 0
         else:  # _sensor_type == 'next_cycle'
             next_cycle = min(relay_data["time"], TWO_YEAR_SECONDS)
-            _LOGGER.debug("New cycle time: %s", next_cycle)
+            LOGGER.debug("New cycle time: %s", next_cycle)
             self._attr_native_value = dt.utc_from_timestamp(
                 dt.as_timestamp(dt.now()) + next_cycle
             )

--- a/homeassistant/components/hydrawise/switch.py
+++ b/homeassistant/components/hydrawise/switch.py
@@ -1,7 +1,6 @@
 """Support for Hydrawise cloud switches."""
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 import voluptuous as vol
@@ -18,15 +17,14 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import (
+from . import HydrawiseEntity
+from .const import (
     ALLOWED_WATERING_TIME,
     CONF_WATERING_TIME,
     DATA_HYDRAWISE,
     DEFAULT_WATERING_TIME,
-    HydrawiseEntity,
+    LOGGER,
 )
-
-_LOGGER = logging.getLogger(__name__)
 
 SWITCH_TYPES: tuple[SwitchEntityDescription, ...] = (
     SwitchEntityDescription(
@@ -108,7 +106,7 @@ class HydrawiseSwitch(HydrawiseEntity, SwitchEntity):
         """Update device state."""
         relay_data = self.data["relay"] - 1
         mydata = self.hass.data[DATA_HYDRAWISE].data
-        _LOGGER.debug("Updating Hydrawise switch: %s", self.name)
+        LOGGER.debug("Updating Hydrawise switch: %s", self.name)
         if self.entity_description.key == "manual_watering":
             self._attr_is_on = mydata.relays[relay_data]["timestr"] == "Now"
         elif self.entity_description.key == "auto_watering":


### PR DESCRIPTION
## Proposed change
Move constants for the Hydrawise integration into `const.py`.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure