### PR TITLE
Move HydrawiseEntity into entity.py

### DIFF
--- a/homeassistant/components/hydrawise/__init__.py
+++ b/homeassistant/components/hydrawise/__init__.py
@@ -6,10 +6,9 @@ import voluptuous as vol
 
 from homeassistant.components import persistent_notification
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_SCAN_INTERVAL
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.dispatcher import async_dispatcher_connect, dispatcher_send
-from homeassistant.helpers.entity import Entity, EntityDescription
+from homeassistant.helpers.dispatcher import dispatcher_send
 from homeassistant.helpers.event import track_time_interval
 from homeassistant.helpers.typing import ConfigType
 
@@ -73,33 +72,3 @@ class HydrawiseHub:
     def __init__(self, data):
         """Initialize the entity."""
         self.data = data
-
-
-class HydrawiseEntity(Entity):
-    """Entity class for Hydrawise devices."""
-
-    _attr_attribution = "Data provided by hydrawise.com"
-
-    def __init__(self, data, description: EntityDescription) -> None:
-        """Initialize the Hydrawise entity."""
-        self.entity_description = description
-        self.data = data
-        self._attr_name = f"{self.data['name']} {description.name}"
-
-    async def async_added_to_hass(self):
-        """Register callbacks."""
-        self.async_on_remove(
-            async_dispatcher_connect(
-                self.hass, SIGNAL_UPDATE_HYDRAWISE, self._update_callback
-            )
-        )
-
-    @callback
-    def _update_callback(self):
-        """Call update method."""
-        self.async_schedule_update_ha_state(True)
-
-    @property
-    def extra_state_attributes(self):
-        """Return the state attributes."""
-        return {"identifier": self.data.get("relay")}

--- a/homeassistant/components/hydrawise/binary_sensor.py
+++ b/homeassistant/components/hydrawise/binary_sensor.py
@@ -15,8 +15,8 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import HydrawiseEntity
 from .const import DATA_HYDRAWISE, LOGGER
+from .entity import HydrawiseEntity
 
 BINARY_SENSOR_STATUS = BinarySensorEntityDescription(
     key="status",

--- a/homeassistant/components/hydrawise/entity.py
+++ b/homeassistant/components/hydrawise/entity.py
@@ -1,0 +1,37 @@
+"""Base classes for Hydrawise entities."""
+
+from homeassistant.core import callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity import Entity, EntityDescription
+
+from .const import SIGNAL_UPDATE_HYDRAWISE
+
+
+class HydrawiseEntity(Entity):
+    """Entity class for Hydrawise devices."""
+
+    _attr_attribution = "Data provided by hydrawise.com"
+
+    def __init__(self, data, description: EntityDescription) -> None:
+        """Initialize the Hydrawise entity."""
+        self.entity_description = description
+        self.data = data
+        self._attr_name = f"{self.data['name']} {description.name}"
+
+    async def async_added_to_hass(self):
+        """Register callbacks."""
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass, SIGNAL_UPDATE_HYDRAWISE, self._update_callback
+            )
+        )
+
+    @callback
+    def _update_callback(self):
+        """Call update method."""
+        self.async_schedule_update_ha_state(True)
+
+    @property
+    def extra_state_attributes(self):
+        """Return the state attributes."""
+        return {"identifier": self.data.get("relay")}

--- a/homeassistant/components/hydrawise/sensor.py
+++ b/homeassistant/components/hydrawise/sensor.py
@@ -16,8 +16,8 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util import dt
 
-from . import HydrawiseEntity
 from .const import DATA_HYDRAWISE, LOGGER
+from .entity import HydrawiseEntity
 
 SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
     SensorEntityDescription(

--- a/homeassistant/components/hydrawise/switch.py
+++ b/homeassistant/components/hydrawise/switch.py
@@ -17,7 +17,6 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import HydrawiseEntity
 from .const import (
     ALLOWED_WATERING_TIME,
     CONF_WATERING_TIME,
@@ -25,6 +24,7 @@ from .const import (
     DEFAULT_WATERING_TIME,
     LOGGER,
 )
+from .entity import HydrawiseEntity
 
 SWITCH_TYPES: tuple[SwitchEntityDescription, ...] = (
     SwitchEntityDescription(


### PR DESCRIPTION
## Proposed change
Move HydrawiseEntity into entity.py, as suggested in https://github.com/home-assistant/core/pull/93223

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
