### PR TITLE
Fix august configuration url with Yale Home brand

### DIFF
--- a/homeassistant/components/august/__init__.py
+++ b/homeassistant/components/august/__init__.py
@@ -142,6 +142,11 @@ class AugustData(AugustSubscriberMixin):
         self._house_ids: set[str] = set()
         self._pubnub_unsub: CALLBACK_TYPE | None = None
 
+    @property
+    def brand(self) -> str:
+        """Brand of the device."""
+        return self._config_entry.data.get(CONF_BRAND, DEFAULT_BRAND)
+
     async def async_setup(self):
         """Async setup of august device data and activities."""
         token = self._august_gateway.access_token
@@ -194,7 +199,7 @@ class AugustData(AugustSubscriberMixin):
         self._pubnub_unsub = async_create_pubnub(
             user_data["UserID"],
             pubnub,
-            self._config_entry.data.get(CONF_BRAND, DEFAULT_BRAND),
+            self.brand,
         )
 
         if self._locks_by_id:

--- a/homeassistant/components/august/entity.py
+++ b/homeassistant/components/august/entity.py
@@ -3,6 +3,7 @@ from abc import abstractmethod
 
 from yalexs.doorbell import Doorbell
 from yalexs.lock import Lock
+from yalexs.util import get_configuration_url
 
 from homeassistant.core import callback
 from homeassistant.helpers.entity import DeviceInfo, Entity
@@ -30,7 +31,7 @@ class AugustEntityMixin(Entity):
             name=device.device_name,
             sw_version=self._detail.firmware_version,
             suggested_area=_remove_device_types(device.device_name, DEVICE_TYPES),
-            configuration_url="https://account.august.com",
+            configuration_url=get_configuration_url(data.brand),
         )
 
     @property

--- a/homeassistant/components/august/manifest.json
+++ b/homeassistant/components/august/manifest.json
@@ -28,5 +28,5 @@
   "documentation": "https://www.home-assistant.io/integrations/august",
   "iot_class": "cloud_push",
   "loggers": ["pubnub", "yalexs"],
-  "requirements": ["yalexs==1.5.0", "yalexs-ble==2.1.17"]
+  "requirements": ["yalexs==1.5.1", "yalexs-ble==2.1.17"]
 }

--- a/homeassistant/components/august/manifest.json
+++ b/homeassistant/components/august/manifest.json
@@ -28,5 +28,5 @@
   "documentation": "https://www.home-assistant.io/integrations/august",
   "iot_class": "cloud_push",
   "loggers": ["pubnub", "yalexs"],
-  "requirements": ["yalexs==1.4.6", "yalexs-ble==2.1.17"]
+  "requirements": ["yalexs==1.5.0", "yalexs-ble==2.1.17"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2697,7 +2697,7 @@ yalesmartalarmclient==0.3.9
 yalexs-ble==2.1.17
 
 # homeassistant.components.august
-yalexs==1.5.0
+yalexs==1.5.1
 
 # homeassistant.components.yeelight
 yeelight==0.7.10

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2697,7 +2697,7 @@ yalesmartalarmclient==0.3.9
 yalexs-ble==2.1.17
 
 # homeassistant.components.august
-yalexs==1.4.6
+yalexs==1.5.0
 
 # homeassistant.components.yeelight
 yeelight==0.7.10

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1964,7 +1964,7 @@ yalesmartalarmclient==0.3.9
 yalexs-ble==2.1.17
 
 # homeassistant.components.august
-yalexs==1.5.0
+yalexs==1.5.1
 
 # homeassistant.components.yeelight
 yeelight==0.7.10

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1964,7 +1964,7 @@ yalesmartalarmclient==0.3.9
 yalexs-ble==2.1.17
 
 # homeassistant.components.august
-yalexs==1.4.6
+yalexs==1.5.0
 
 # homeassistant.components.yeelight
 yeelight==0.7.10


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
changelog: https://github.com/bdraco/yalexs/compare/v1.4.6...v1.5.1


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
