### PR TITLE
Plugwise add value_fn for select

### DIFF
--- a/homeassistant/components/plugwise/select.py
+++ b/homeassistant/components/plugwise/select.py
@@ -83,7 +83,7 @@ async def async_setup_entry(
         for description in SELECT_TYPES:
             if (
                 description.options_key in device
-                and len(device[description.options_key]) > 1  # type: ignore [literal-required]
+                and len(device[description.options_key]) > 1
             ):
                 entities.append(
                     PlugwiseSelectEntity(coordinator, device_id, description)

--- a/homeassistant/components/plugwise/select.py
+++ b/homeassistant/components/plugwise/select.py
@@ -41,9 +41,8 @@ SELECT_TYPES = (
         translation_key="select_schedule",
         icon="mdi:calendar-clock",
         command=lambda api, loc, opt: api.set_schedule_state(loc, opt, STATE_ON),
-        options_key="available_schedules",
         value_fn=lambda data: data["selected_schedule"],
-        values_fn=lambda data: data["available_schedules"],
+        options_fn=lambda data: data.get("available_schedules"),
     ),
     PlugwiseSelectEntityDescription(
         key="select_regulation_mode",
@@ -51,9 +50,8 @@ SELECT_TYPES = (
         icon="mdi:hvac",
         entity_category=EntityCategory.CONFIG,
         command=lambda api, loc, opt: api.set_regulation_mode(opt),
-        options_key="regulation_modes",
         value_fn=lambda data: data["regulation_mode"],
-        values_fn=lambda data: data["regulation_modes"],
+        options_fn=lambda data: data.get("regulation_modes"),
     ),
     PlugwiseSelectEntityDescription(
         key="select_dhw_mode",
@@ -61,9 +59,8 @@ SELECT_TYPES = (
         icon="mdi:shower",
         entity_category=EntityCategory.CONFIG,
         command=lambda api, loc, opt: api.set_dhw_mode(opt),
-        options_key="dhw_modes",
         value_fn=lambda data: data["dhw_mode"],
-        values_fn=lambda data: data["dhw_modes"],
+        options_fn=lambda data: data.get("dhw_modes"),
     ),
 )
 
@@ -81,10 +78,7 @@ async def async_setup_entry(
     entities: list[PlugwiseSelectEntity] = []
     for device_id, device in coordinator.data.devices.items():
         for description in SELECT_TYPES:
-            if (
-                description.options_key in device
-                and len(device[description.options_key]) > 1
-            ):
+            if (options := description.options_fn(device)) and len(options) > 1:
                 entities.append(
                     PlugwiseSelectEntity(coordinator, device_id, description)
                 )
@@ -116,7 +110,7 @@ class PlugwiseSelectEntity(PlugwiseEntity, SelectEntity):
     @property
     def options(self) -> list[str]:
         """Return the selectable entity options."""
-        return self.entity_description.values_fn(self.device)
+        return self.entity_description.options_fn(self.device)
 
     async def async_select_option(self, option: str) -> None:
         """Change to the selected entity option."""

--- a/homeassistant/components/plugwise/select.py
+++ b/homeassistant/components/plugwise/select.py
@@ -23,9 +23,8 @@ class PlugwiseSelectDescriptionMixin:
     """Mixin values for Plugwise Select entities."""
 
     command: Callable[[Smile, str, str], Awaitable[Any]]
-    options_key: str
     value_fn: Callable[[DeviceData], str]
-    values_fn: Callable[[DeviceData], list[str]]
+    options_fn: Callable[[DeviceData], list[str]]
 
 
 @dataclass

--- a/homeassistant/components/plugwise/select.py
+++ b/homeassistant/components/plugwise/select.py
@@ -5,7 +5,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any
 
-from plugwise import Smile
+from plugwise import DeviceData, Smile
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.config_entries import ConfigEntry
@@ -23,8 +23,9 @@ class PlugwiseSelectDescriptionMixin:
     """Mixin values for Plugwise Select entities."""
 
     command: Callable[[Smile, str, str], Awaitable[Any]]
-    current_option_key: str
     options_key: str
+    value_fn: Callable[[DeviceData], str]
+    values_fn: Callable[[DeviceData], list[str]]
 
 
 @dataclass
@@ -40,8 +41,9 @@ SELECT_TYPES = (
         translation_key="select_schedule",
         icon="mdi:calendar-clock",
         command=lambda api, loc, opt: api.set_schedule_state(loc, opt, STATE_ON),
-        current_option_key="selected_schedule",
         options_key="available_schedules",
+        value_fn=lambda data: data["selected_schedule"],
+        values_fn=lambda data: data["available_schedules"],
     ),
     PlugwiseSelectEntityDescription(
         key="select_regulation_mode",
@@ -49,8 +51,9 @@ SELECT_TYPES = (
         icon="mdi:hvac",
         entity_category=EntityCategory.CONFIG,
         command=lambda api, loc, opt: api.set_regulation_mode(opt),
-        current_option_key="regulation_mode",
         options_key="regulation_modes",
+        value_fn=lambda data: data["regulation_mode"],
+        values_fn=lambda data: data["regulation_modes"],
     ),
     PlugwiseSelectEntityDescription(
         key="select_dhw_mode",
@@ -58,8 +61,9 @@ SELECT_TYPES = (
         icon="mdi:shower",
         entity_category=EntityCategory.CONFIG,
         command=lambda api, loc, opt: api.set_dhw_mode(opt),
-        current_option_key="dhw_mode",
         options_key="dhw_modes",
+        value_fn=lambda data: data["dhw_mode"],
+        values_fn=lambda data: data["dhw_modes"],
     ),
 )
 
@@ -79,7 +83,7 @@ async def async_setup_entry(
         for description in SELECT_TYPES:
             if (
                 description.options_key in device
-                and len(device[description.options_key]) > 1
+                and len(device[description.options_key]) > 1  # type: ignore [literal-required]
             ):
                 entities.append(
                     PlugwiseSelectEntity(coordinator, device_id, description)
@@ -107,12 +111,12 @@ class PlugwiseSelectEntity(PlugwiseEntity, SelectEntity):
     @property
     def current_option(self) -> str:
         """Return the selected entity option to represent the entity state."""
-        return self.device[self.entity_description.current_option_key]
+        return self.entity_description.value_fn(self.device)
 
     @property
     def options(self) -> list[str]:
         """Return the selectable entity options."""
-        return self.device[self.entity_description.options_key]
+        return self.entity_description.values_fn(self.device)
 
     async def async_select_option(self, option: str) -> None:
         """Change to the selected entity option."""


### PR DESCRIPTION
## Proposed change
Change entitydescription approach for select preparing for upcoming strict typing and module version bump PRs.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
Walking our platforms as outlined in #93088 leading up to dependency bump and strict typing.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

