### PR TITLE
Add Slack thread/reply support

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1142,8 +1142,8 @@ build.json @home-assistant/supervisor
 /homeassistant/components/sky_hub/ @rogerselwyn
 /homeassistant/components/skybell/ @tkdrob
 /tests/components/skybell/ @tkdrob
-/homeassistant/components/slack/ @tkdrob
-/tests/components/slack/ @tkdrob
+/homeassistant/components/slack/ @tkdrob @fletcherau
+/tests/components/slack/ @tkdrob @fletcherau
 /homeassistant/components/sleepiq/ @mfugate1 @kbickar
 /tests/components/sleepiq/ @mfugate1 @kbickar
 /homeassistant/components/slide/ @ualex73

--- a/homeassistant/components/slack/const.py
+++ b/homeassistant/components/slack/const.py
@@ -10,6 +10,7 @@ ATTR_SNOOZE = "snooze_endtime"
 ATTR_URL = "url"
 ATTR_USERNAME = "username"
 ATTR_USER_ID = "user_id"
+ATTR_THREAD_TS = "thread_ts"
 
 CONF_DEFAULT_CHANNEL = "default_channel"
 

--- a/homeassistant/components/slack/manifest.json
+++ b/homeassistant/components/slack/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "slack",
   "name": "Slack",
-  "codeowners": ["@tkdrob"],
+  "codeowners": ["@tkdrob", "@fletcherau"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/slack",
   "integration_type": "service",

--- a/homeassistant/components/slack/notify.py
+++ b/homeassistant/components/slack/notify.py
@@ -30,6 +30,7 @@ from .const import (
     ATTR_FILE,
     ATTR_PASSWORD,
     ATTR_PATH,
+    ATTR_THREAD_TS,
     ATTR_URL,
     ATTR_USERNAME,
     CONF_DEFAULT_CHANNEL,
@@ -50,7 +51,10 @@ FILE_URL_SCHEMA = vol.Schema(
 )
 
 DATA_FILE_SCHEMA = vol.Schema(
-    {vol.Required(ATTR_FILE): vol.Any(FILE_PATH_SCHEMA, FILE_URL_SCHEMA)}
+    {
+        vol.Required(ATTR_FILE): vol.Any(FILE_PATH_SCHEMA, FILE_URL_SCHEMA),
+        vol.Optional(ATTR_THREAD_TS): cv.string,
+    }
 )
 
 DATA_TEXT_ONLY_SCHEMA = vol.Schema(
@@ -59,6 +63,7 @@ DATA_TEXT_ONLY_SCHEMA = vol.Schema(
         vol.Optional(ATTR_ICON): cv.string,
         vol.Optional(ATTR_BLOCKS): list,
         vol.Optional(ATTR_BLOCKS_TEMPLATE): list,
+        vol.Optional(ATTR_THREAD_TS): cv.string,
     }
 )
 
@@ -73,7 +78,7 @@ class AuthDictT(TypedDict, total=False):
     auth: BasicAuth
 
 
-class FormDataT(TypedDict):
+class FormDataT(TypedDict, total=False):
     """Type for form data, file upload."""
 
     channels: str
@@ -81,6 +86,7 @@ class FormDataT(TypedDict):
     initial_comment: str
     title: str
     token: str
+    thread_ts: str  # Optional key
 
 
 class MessageT(TypedDict, total=False):
@@ -92,6 +98,7 @@ class MessageT(TypedDict, total=False):
     icon_url: str  # Optional key
     icon_emoji: str  # Optional key
     blocks: list[Any]  # Optional key
+    thread_ts: str  # Optional key
 
 
 async def async_get_service(
@@ -142,6 +149,7 @@ class SlackNotificationService(BaseNotificationService):
         targets: list[str],
         message: str,
         title: str | None,
+        thread_ts: str | None,
     ) -> None:
         """Upload a local file (with message) to Slack."""
         if not self._hass.config.is_allowed_path(path):
@@ -158,6 +166,7 @@ class SlackNotificationService(BaseNotificationService):
                 filename=filename,
                 initial_comment=message,
                 title=title or filename,
+                thread_ts=thread_ts,
             )
         except (SlackApiError, ClientError) as err:
             _LOGGER.error("Error while uploading file-based message: %r", err)
@@ -168,6 +177,7 @@ class SlackNotificationService(BaseNotificationService):
         targets: list[str],
         message: str,
         title: str | None,
+        thread_ts: str | None,
         *,
         username: str | None = None,
         password: str | None = None,
@@ -205,6 +215,9 @@ class SlackNotificationService(BaseNotificationService):
             "token": self._client.token,
         }
 
+        if thread_ts:
+            form_data["thread_ts"] = thread_ts
+
         data = FormData(form_data, charset="utf-8")
         data.add_field("file", resp.content, filename=filename)
 
@@ -218,6 +231,7 @@ class SlackNotificationService(BaseNotificationService):
         targets: list[str],
         message: str,
         title: str | None,
+        thread_ts: str | None,
         *,
         username: str | None = None,
         icon: str | None = None,
@@ -237,6 +251,9 @@ class SlackNotificationService(BaseNotificationService):
 
         if blocks:
             message_dict["blocks"] = blocks
+
+        if thread_ts:
+            message_dict["thread_ts"] = thread_ts
 
         tasks = {
             target: self._client.chat_postMessage(**message_dict, channel=target)
@@ -286,6 +303,7 @@ class SlackNotificationService(BaseNotificationService):
                 title,
                 username=data.get(ATTR_USERNAME, self._config.get(ATTR_USERNAME)),
                 icon=data.get(ATTR_ICON, self._config.get(ATTR_ICON)),
+                thread_ts=data.get(ATTR_THREAD_TS),
                 blocks=blocks,
             )
 
@@ -296,11 +314,16 @@ class SlackNotificationService(BaseNotificationService):
                 targets,
                 message,
                 title,
+                thread_ts=data.get(ATTR_THREAD_TS),
                 username=data[ATTR_FILE].get(ATTR_USERNAME),
                 password=data[ATTR_FILE].get(ATTR_PASSWORD),
             )
 
         # Message Type 3: A message that uploads a local file
         return await self._async_send_local_file_message(
-            data[ATTR_FILE][ATTR_PATH], targets, message, title
+            data[ATTR_FILE][ATTR_PATH],
+            targets,
+            message,
+            title,
+            thread_ts=data.get(ATTR_THREAD_TS),
         )

--- a/tests/components/slack/test_notify.py
+++ b/tests/components/slack/test_notify.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, Mock
 from homeassistant.components import notify
 from homeassistant.components.slack import DOMAIN
 from homeassistant.components.slack.notify import (
+    ATTR_THREAD_TS,
     CONF_DEFAULT_CHANNEL,
     SlackNotificationService,
 )
@@ -93,3 +94,18 @@ async def test_message_icon_url_overrides_default() -> None:
     mock_fn.assert_called_once()
     _, kwargs = mock_fn.call_args
     assert kwargs["icon_url"] == expected_icon
+
+
+async def test_message_as_reply() -> None:
+    """Tests that a message pointer will be passed to Slack if specified."""
+    mock_client = Mock()
+    mock_client.chat_postMessage = AsyncMock()
+    service = SlackNotificationService(None, mock_client, CONF_DATA)
+
+    expected_ts = "1624146685.064129"
+    await service.async_send_message("test", data={ATTR_THREAD_TS: expected_ts})
+
+    mock_fn = mock_client.chat_postMessage
+    mock_fn.assert_called_once()
+    _, kwargs = mock_fn.call_args
+    assert kwargs["thread_ts"] == expected_ts


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Adds support for sending Slack messages as replies to existing messages by specifying a pointer to an existing message. (`thread_ts`)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/27490

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
