### PR TITLE
Fix race in tracking pending writes in recorder

### DIFF
--- a/homeassistant/components/recorder/core.py
+++ b/homeassistant/components/recorder/core.py
@@ -691,8 +691,8 @@ class Recorder(threading.Thread):
 
     def _add_to_session(self, session: Session, obj: object) -> None:
         """Add an object to the session."""
-        self._event_session_has_pending_writes = True
         session.add(obj)
+        self._event_session_has_pending_writes = True
 
     def _run(self) -> None:
         """Start processing events to save."""
@@ -1048,8 +1048,8 @@ class Recorder(threading.Thread):
             # No matching attributes found, save them in the DB
             dbevent_data = EventData(shared_data=shared_data, hash=hash_)
             event_data_manager.add_pending(dbevent_data)
-            dbevent.event_data_rel = dbevent_data
             self._add_to_session(session, dbevent_data)
+            dbevent.event_data_rel = dbevent_data
 
         self._add_to_session(session, dbevent)
 
@@ -1121,8 +1121,8 @@ class Recorder(threading.Thread):
             # No matching attributes found, save them in the DB
             dbstate_attributes = StateAttributes(shared_attrs=shared_attrs, hash=hash_)
             state_attributes_manager.add_pending(dbstate_attributes)
-            dbstate.state_attributes = dbstate_attributes
             self._add_to_session(session, dbstate_attributes)
+            dbstate.state_attributes = dbstate_attributes
 
         self._add_to_session(session, dbstate)
 

--- a/homeassistant/components/recorder/core.py
+++ b/homeassistant/components/recorder/core.py
@@ -215,6 +215,7 @@ class Recorder(threading.Thread):
 
         self.schema_version = 0
         self._commits_without_expire = 0
+        self._event_session_has_pending_writes = False
 
         self.recorder_runs_manager = RecorderRunsManager()
         self.states_manager = StatesManager()
@@ -322,7 +323,7 @@ class Recorder(threading.Thread):
         if (
             self._event_listener
             and not self._database_lock_task
-            and self._event_session_has_pending_writes()
+            and self._event_session_has_pending_writes
         ):
             self.queue_task(COMMIT_TASK)
 
@@ -688,6 +689,11 @@ class Recorder(threading.Thread):
             # anything goes wrong in the run loop
             self._shutdown()
 
+    def _add_to_session(self, session: Session, obj: object) -> None:
+        """Add an object to the session."""
+        session.add(obj)
+        self._event_session_has_pending_writes = True
+
     def _run(self) -> None:
         """Start processing events to save."""
         self.thread_id = threading.get_ident()
@@ -1016,11 +1022,11 @@ class Recorder(threading.Thread):
         else:
             event_types = EventTypes(event_type=event.event_type)
             event_type_manager.add_pending(event_types)
-            session.add(event_types)
+            self._add_to_session(session, event_types)
             dbevent.event_type_rel = event_types
 
         if not event.data:
-            session.add(dbevent)
+            self._add_to_session(session, dbevent)
             return
 
         event_data_manager = self.event_data_manager
@@ -1042,10 +1048,10 @@ class Recorder(threading.Thread):
             # No matching attributes found, save them in the DB
             dbevent_data = EventData(shared_data=shared_data, hash=hash_)
             event_data_manager.add_pending(dbevent_data)
-            session.add(dbevent_data)
+            self._add_to_session(session, dbevent_data)
             dbevent.event_data_rel = dbevent_data
 
-        session.add(dbevent)
+        self._add_to_session(session, dbevent)
 
     def _process_state_changed_event_into_session(self, event: Event) -> None:
         """Process a state_changed event into the session."""
@@ -1090,7 +1096,7 @@ class Recorder(threading.Thread):
         else:
             states_meta = StatesMeta(entity_id=entity_id)
             states_meta_manager.add_pending(states_meta)
-            session.add(states_meta)
+            self._add_to_session(session, states_meta)
             dbstate.states_meta_rel = states_meta
 
         # Map the event data to the StateAttributes table
@@ -1115,10 +1121,10 @@ class Recorder(threading.Thread):
             # No matching attributes found, save them in the DB
             dbstate_attributes = StateAttributes(shared_attrs=shared_attrs, hash=hash_)
             state_attributes_manager.add_pending(dbstate_attributes)
-            session.add(dbstate_attributes)
+            self._add_to_session(session, dbstate_attributes)
             dbstate.state_attributes = dbstate_attributes
 
-        session.add(dbstate)
+        self._add_to_session(session, dbstate)
 
     def _handle_database_error(self, err: Exception) -> bool:
         """Handle a database error that may result in moving away the corrupt db."""
@@ -1130,14 +1136,9 @@ class Recorder(threading.Thread):
             return True
         return False
 
-    def _event_session_has_pending_writes(self) -> bool:
-        """Return True if there are pending writes in the event session."""
-        session = self.event_session
-        return bool(session and (session.new or session.dirty))
-
     def _commit_event_session_or_retry(self) -> None:
         """Commit the event session if there is work to do."""
-        if not self._event_session_has_pending_writes():
+        if not self._event_session_has_pending_writes:
             return
         tries = 1
         while tries <= self.db_max_retries:
@@ -1163,6 +1164,7 @@ class Recorder(threading.Thread):
         self._commits_without_expire += 1
 
         session.commit()
+        self._event_session_has_pending_writes = False
         # We just committed the state attributes to the database
         # and we now know the attributes_ids.  We can save
         # many selects for matching attributes by loading them
@@ -1263,7 +1265,7 @@ class Recorder(threading.Thread):
 
     async def async_block_till_done(self) -> None:
         """Async version of block_till_done."""
-        if self._queue.empty() and not self._event_session_has_pending_writes():
+        if self._queue.empty() and not self._event_session_has_pending_writes:
             return
         event = asyncio.Event()
         self.queue_task(SynchronizeTask(event))

--- a/homeassistant/components/recorder/core.py
+++ b/homeassistant/components/recorder/core.py
@@ -1419,6 +1419,8 @@ class Recorder(threading.Thread):
         if self.event_session is None:
             return
         if self.recorder_runs_manager.active:
+            # .end will add to the event session
+            self._event_session_has_pending_writes = True
             self.recorder_runs_manager.end(self.event_session)
         try:
             self._commit_event_session_or_retry()

--- a/homeassistant/components/recorder/core.py
+++ b/homeassistant/components/recorder/core.py
@@ -691,8 +691,8 @@ class Recorder(threading.Thread):
 
     def _add_to_session(self, session: Session, obj: object) -> None:
         """Add an object to the session."""
-        session.add(obj)
         self._event_session_has_pending_writes = True
+        session.add(obj)
 
     def _run(self) -> None:
         """Start processing events to save."""
@@ -1048,8 +1048,8 @@ class Recorder(threading.Thread):
             # No matching attributes found, save them in the DB
             dbevent_data = EventData(shared_data=shared_data, hash=hash_)
             event_data_manager.add_pending(dbevent_data)
-            self._add_to_session(session, dbevent_data)
             dbevent.event_data_rel = dbevent_data
+            self._add_to_session(session, dbevent_data)
 
         self._add_to_session(session, dbevent)
 
@@ -1121,8 +1121,8 @@ class Recorder(threading.Thread):
             # No matching attributes found, save them in the DB
             dbstate_attributes = StateAttributes(shared_attrs=shared_attrs, hash=hash_)
             state_attributes_manager.add_pending(dbstate_attributes)
-            self._add_to_session(session, dbstate_attributes)
             dbstate.state_attributes = dbstate_attributes
+            self._add_to_session(session, dbstate_attributes)
 
         self._add_to_session(session, dbstate)
 

--- a/homeassistant/components/recorder/core.py
+++ b/homeassistant/components/recorder/core.py
@@ -691,8 +691,8 @@ class Recorder(threading.Thread):
 
     def _add_to_session(self, session: Session, obj: object) -> None:
         """Add an object to the session."""
-        session.add(obj)
         self._event_session_has_pending_writes = True
+        session.add(obj)
 
     def _run(self) -> None:
         """Start processing events to save."""


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix a long standing race bug where the `commit_before` flag for `RecorderTask`s did not always work as intended because another session could be opened by another task that did a `flush` but does not `commit` the event session which would cause the `.new` flag to unexpectedly be flipped to `False` which means we would not commit and the table managers would not move objects out of a pending state which would result in conflicts.

The race here could be triggered by the following order of tasks:

- `EventTask` that adds a new `event_type_id`
- `EventsContextIDMigrationTask` -- always creates a new session and does a `flush` 
- `EventTypeIDMigrationTask` (the `commit_before` would not happen here because when the `StatesContextIDMigrationTask` opened a new session `session.new` would be false)

To solve this all the `session.add`s are now wrapped into a function which flips a flag that we track internally so we no longer rely on sqlalchemy internals.

fixes #92650


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
