### PR TITLE
Bump ha-av to v10.1.0

### DIFF
--- a/homeassistant/components/generic/manifest.json
+++ b/homeassistant/components/generic/manifest.json
@@ -6,5 +6,5 @@
   "dependencies": ["http"],
   "documentation": "https://www.home-assistant.io/integrations/generic",
   "iot_class": "local_push",
-  "requirements": ["ha-av==10.0.0", "pillow==9.5.0"]
+  "requirements": ["ha-av==10.1.0", "pillow==9.5.0"]
 }

--- a/homeassistant/components/stream/manifest.json
+++ b/homeassistant/components/stream/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "system",
   "iot_class": "local_push",
   "quality_scale": "internal",
-  "requirements": ["PyTurboJPEG==1.6.7", "ha-av==10.0.0", "numpy==1.23.2"]
+  "requirements": ["PyTurboJPEG==1.6.7", "ha-av==10.1.0", "numpy==1.23.2"]
 }

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -21,7 +21,7 @@ ciso8601==2.3.0
 cryptography==40.0.2
 dbus-fast==1.86.0
 fnv-hash-fast==0.3.1
-ha-av==10.0.0
+ha-av==10.1.0
 hass-nabucasa==0.67.1
 hassil==1.0.6
 home-assistant-bluetooth==1.10.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -869,7 +869,7 @@ h2==4.1.0
 
 # homeassistant.components.generic
 # homeassistant.components.stream
-ha-av==10.0.0
+ha-av==10.1.0
 
 # homeassistant.components.ffmpeg
 ha-ffmpeg==3.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -673,7 +673,7 @@ h2==4.1.0
 
 # homeassistant.components.generic
 # homeassistant.components.stream
-ha-av==10.0.0
+ha-av==10.1.0
 
 # homeassistant.components.ffmpeg
 ha-ffmpeg==3.1.0


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bump ha-av to v10.1.0 for FFmpeg 6 compatibility. This version also drops support for FFmpeg 4.3.

ha-av v10.0.0 was based on PyAV v10.0.0: https://github.com/PyAV-Org/PyAV/compare/v10.0.0...uvjustin:PyAV:v10.0.0

ha-av v10.1.0 is based on the main branch of PyAV, so the changes to get there from PyAV v10.0.0 are:
From PyAV v10.0.0 to the current main branch of PyAV: https://github.com/PyAV-Org/PyAV/compare/v10.0.0...PyAV-Org:PyAV:main
From the main branch of PyAV to ha-av v10.1.0:
https://github.com/PyAV-Org/PyAV/compare/main...uvjustin:PyAV:v10.1.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #90994
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
