### PR TITLE
Remove unused zwave discovery logic

### DIFF
--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -143,8 +143,6 @@ class ZWaveValueDiscoverySchema(DataclassMustHaveAtLeastOne):
     property_name: set[str] | None = None
     # [optional] the value's property key must match ANY of these values
     property_key: set[str | int | None] | None = None
-    # [optional] the value's property key name must match ANY of these values
-    property_key_name: set[str | None] | None = None
     # [optional] the value's metadata_type must match ANY of these values
     type: set[str] | None = None
     # [optional] the value's states map must include ANY of these key/value pairs
@@ -176,14 +174,10 @@ class ZWaveDiscoverySchema:
     product_type: set[int] | None = None
     # [optional] the node's firmware_version must be within this range
     firmware_version_range: FirmwareVersionRange | None = None
-    # [optional] the node's firmware_version must match ANY of these values
-    firmware_version: set[str] | None = None
-    # [optional] the node's basic device class must match ANY of these values
-    device_class_basic: set[str | int] | None = None
     # [optional] the node's generic device class must match ANY of these values
-    device_class_generic: set[str | int] | None = None
+    device_class_generic: set[str] | None = None
     # [optional] the node's specific device class must match ANY of these values
-    device_class_specific: set[str | int] | None = None
+    device_class_specific: set[str] | None = None
     # [optional] additional values that ALL need to be present
     # on the node for this scheme to pass
     required_values: list[ZWaveValueDiscoverySchema] | None = None
@@ -204,7 +198,6 @@ def get_config_parameter_discovery_schema(
     property_: set[str | int] | None = None,
     property_name: set[str] | None = None,
     property_key: set[str | int | None] | None = None,
-    property_key_name: set[str | None] | None = None,
     **kwargs: Any,
 ) -> ZWaveDiscoverySchema:
     """Return a discovery schema for a config parameter.
@@ -220,7 +213,6 @@ def get_config_parameter_discovery_schema(
             property=property_,
             property_name=property_name,
             property_key=property_key,
-            property_key_name=property_key_name,
             type={ValueType.NUMBER},
         ),
         entity_registry_enabled_default=False,
@@ -928,9 +920,8 @@ def async_discover_node_values(
     """Run discovery on ZWave node and return matching (primary) values."""
     for value in node.values.values():
         # We don't need to rediscover an already processed value_id
-        if value.value_id in discovered_value_ids[device.id]:
-            continue
-        yield from async_discover_single_value(value, device, discovered_value_ids)
+        if value.value_id not in discovered_value_ids[device.id]:
+            yield from async_discover_single_value(value, device, discovered_value_ids)
 
 
 @callback
@@ -940,24 +931,20 @@ def async_discover_single_value(
     """Run discovery on a single ZWave value and return matching schema info."""
     discovered_value_ids[device.id].add(value.value_id)
     for schema in DISCOVERY_SCHEMAS:
-        # check manufacturer_id
+        # check manufacturer_id, product_id, product_type
         if (
-            schema.manufacturer_id is not None
-            and value.node.manufacturer_id not in schema.manufacturer_id
-        ):
-            continue
-
-        # check product_id
-        if (
-            schema.product_id is not None
-            and value.node.product_id not in schema.product_id
-        ):
-            continue
-
-        # check product_type
-        if (
-            schema.product_type is not None
-            and value.node.product_type not in schema.product_type
+            (
+                schema.manufacturer_id is not None
+                and value.node.manufacturer_id not in schema.manufacturer_id
+            )
+            or (
+                schema.product_id is not None
+                and value.node.product_id not in schema.product_id
+            )
+            or (
+                schema.product_type is not None
+                and value.node.product_type not in schema.product_type
+            )
         ):
             continue
 
@@ -973,19 +960,6 @@ def async_discover_single_value(
                 and schema.firmware_version_range.max_ver
                 < AwesomeVersion(value.node.firmware_version)
             )
-        ):
-            continue
-
-        # check firmware_version
-        if (
-            schema.firmware_version is not None
-            and value.node.firmware_version not in schema.firmware_version
-        ):
-            continue
-
-        # check device_class_basic
-        if value.node.device_class and not check_device_class(
-            value.node.device_class.basic, schema.device_class_basic
         ):
             continue
 
@@ -1084,12 +1058,6 @@ def check_value(value: ZwaveValue, schema: ZWaveValueDiscoverySchema) -> bool:
         and value.property_key not in schema.property_key
     ):
         return False
-    # check property_key_name
-    if (
-        schema.property_key_name is not None
-        and value.property_key_name not in schema.property_key_name
-    ):
-        return False
     # check metadata_type
     if schema.type is not None and value.metadata.type not in schema.type:
         return False
@@ -1108,14 +1076,12 @@ def check_value(value: ZwaveValue, schema: ZWaveValueDiscoverySchema) -> bool:
 
 @callback
 def check_device_class(
-    device_class: DeviceClassItem, required_value: set[str | int] | None
+    device_class: DeviceClassItem, required_value: set[str] | None
 ) -> bool:
     """Check if device class id or label matches."""
     if required_value is None:
         return True
     for val in required_value:
-        if isinstance(val, str) and device_class.label == val:
-            return True
-        if isinstance(val, int) and device_class.key == val:
+        if device_class.label == val:
             return True
     return False

--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -1081,7 +1081,6 @@ def check_device_class(
     """Check if device class id or label matches."""
     if required_value is None:
         return True
-    for val in required_value:
-        if device_class.label == val:
-            return True
+    if any(device_class.label == val for val in required_value):
+        return True
     return False

--- a/homeassistant/components/zwave_js/manifest.json
+++ b/homeassistant/components/zwave_js/manifest.json
@@ -8,7 +8,6 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "loggers": ["zwave_js_server"],
-  "quality_scale": "platinum",
   "requirements": ["pyserial==3.5", "zwave-js-server-python==0.48.1"],
   "usb": [
     {

--- a/homeassistant/components/zwave_js/manifest.json
+++ b/homeassistant/components/zwave_js/manifest.json
@@ -8,6 +8,7 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "loggers": ["zwave_js_server"],
+  "quality_scale": "platinum",
   "requirements": ["pyserial==3.5", "zwave-js-server-python==0.48.1"],
   "usb": [
     {


### PR DESCRIPTION
## Proposed change
There were several unused checks that may be useful in the future but we don't need to include logic for them until that comes up. Additionally, manufacturer ID, product ID, and product type are usually used together so I combined the logic into one if statement. I avoided doing that elsewhere - I think it makes sense here.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
