### PR TITLE
Improve TTS cache dir mocking

### DIFF
--- a/tests/components/assist_pipeline/conftest.py
+++ b/tests/components/assist_pipeline/conftest.py
@@ -23,13 +23,14 @@ from tests.common import (
     mock_integration,
     mock_platform,
 )
-from tests.components.tts.conftest import (  # noqa: F401, pylint: disable=unused-import
-    init_cache_dir_side_effect,
-    mock_get_cache_files,
-    mock_init_cache_dir,
-)
 
 _TRANSCRIPT = "test transcript"
+
+
+@pytest.fixture(autouse=True)
+def mock_tts_cache_dir_autouse(mock_tts_cache_dir):
+    """Mock the TTS cache dir with empty dir."""
+    return mock_tts_cache_dir
 
 
 class BaseProvider:
@@ -190,9 +191,6 @@ async def init_supporting_components(
     mock_stt_provider_entity: MockSttProviderEntity,
     mock_tts_provider: MockTTSProvider,
     config_flow_fixture,
-    init_cache_dir_side_effect,  # noqa: F811
-    mock_get_cache_files,  # noqa: F811
-    mock_init_cache_dir,  # noqa: F811
 ):
     """Initialize relevant components with empty configs."""
 

--- a/tests/components/cloud/conftest.py
+++ b/tests/components/cloud/conftest.py
@@ -8,12 +8,11 @@ from homeassistant.components.cloud import const, prefs
 
 from . import mock_cloud, mock_cloud_prefs
 
-# Prevent TTS cache from being created
-from tests.components.tts.conftest import (  # noqa: F401, pylint: disable=unused-import
-    init_cache_dir_side_effect,
-    mock_get_cache_files,
-    mock_init_cache_dir,
-)
+
+@pytest.fixture(autouse=True)
+def mock_tts_cache_dir_autouse(mock_tts_cache_dir):
+    """Mock the TTS cache dir with empty dir."""
+    return mock_tts_cache_dir
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -4,6 +4,14 @@ from unittest.mock import patch
 
 import pytest
 
+from tests.components.tts.conftest import (  # noqa: F401, pylint: disable=unused-import
+    init_tts_cache_dir_side_effect_fixture,
+    mock_tts_cache_dir_fixture,
+    mock_tts_get_cache_files_fixture,
+    mock_tts_init_cache_dir_fixture,
+    tts_mutagen_mock_fixture,
+)
+
 
 @pytest.fixture(scope="session", autouse=True)
 def patch_zeroconf_multiple_catcher() -> Generator[None, None, None]:

--- a/tests/components/google_translate/test_tts.py
+++ b/tests/components/google_translate/test_tts.py
@@ -1,6 +1,4 @@
 """The tests for the Google speech platform."""
-import os
-import shutil
 from unittest.mock import patch
 
 from gtts import gTTSError
@@ -18,7 +16,17 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import async_setup_component
 
 from tests.common import async_mock_service
-from tests.components.tts.conftest import mutagen_mock  # noqa: F401
+
+
+@pytest.fixture(autouse=True)
+def tts_mutagen_mock_fixture_autouse(tts_mutagen_mock):
+    """Mock writing tags."""
+
+
+@pytest.fixture(autouse=True)
+def mock_tts_cache_dir_autouse(mock_tts_cache_dir):
+    """Mock the TTS cache dir with empty dir."""
+    return mock_tts_cache_dir
 
 
 async def get_media_source_url(hass, media_content_id):
@@ -28,15 +36,6 @@ async def get_media_source_url(hass, media_content_id):
 
     resolved = await media_source.async_resolve_media(hass, media_content_id, None)
     return resolved.url
-
-
-@pytest.fixture(autouse=True)
-def cleanup_cache(hass):
-    """Clean up TTS cache."""
-    yield
-    default_tts = hass.config.path(tts.DEFAULT_CACHE_DIR)
-    if os.path.isdir(default_tts):
-        shutil.rmtree(default_tts)
 
 
 @pytest.fixture

--- a/tests/components/marytts/test_tts.py
+++ b/tests/components/marytts/test_tts.py
@@ -1,6 +1,4 @@
 """The tests for the MaryTTS speech platform."""
-import os
-import shutil
 from unittest.mock import patch
 
 import pytest
@@ -27,12 +25,9 @@ async def get_media_source_url(hass, media_content_id):
 
 
 @pytest.fixture(autouse=True)
-def cleanup_cache(hass):
-    """Prevent TTS writing."""
-    yield
-    default_tts = hass.config.path(tts.DEFAULT_CACHE_DIR)
-    if os.path.isdir(default_tts):
-        shutil.rmtree(default_tts)
+def mock_tts_cache_dir_autouse(mock_tts_cache_dir):
+    """Mock the TTS cache dir with empty dir."""
+    return mock_tts_cache_dir
 
 
 async def test_setup_component(hass: HomeAssistant) -> None:

--- a/tests/components/microsoft/test_tts.py
+++ b/tests/components/microsoft/test_tts.py
@@ -1,6 +1,4 @@
 """Tests for Microsoft Text-to-Speech."""
-import os
-import shutil
 from unittest.mock import patch
 
 from pycsspeechtts import pycsspeechtts
@@ -32,12 +30,9 @@ async def get_media_source_url(hass: HomeAssistant, media_content_id):
 
 
 @pytest.fixture(autouse=True)
-def cleanup_cache(hass: HomeAssistant):
-    """Clean up TTS cache."""
-    yield
-    default_tts = hass.config.path(tts.DEFAULT_CACHE_DIR)
-    if os.path.isdir(default_tts):
-        shutil.rmtree(default_tts)
+def mock_tts_cache_dir_autouse(mock_tts_cache_dir):
+    """Mock the TTS cache dir with empty dir."""
+    return mock_tts_cache_dir
 
 
 @pytest.fixture

--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -148,12 +148,12 @@ async def test_setup_component(hass: HomeAssistant, setup: str) -> None:
     assert f"{tts.DOMAIN}.test" in hass.config.components
 
 
-@pytest.mark.parametrize("init_cache_dir_side_effect", [OSError(2, "No access")])
+@pytest.mark.parametrize("init_tts_cache_dir_side_effect", [OSError(2, "No access")])
 @pytest.mark.parametrize(
     "setup", ["mock_setup", "mock_config_entry_setup"], indirect=True
 )
 async def test_setup_component_no_access_cache_folder(
-    hass: HomeAssistant, mock_init_cache_dir: MagicMock, setup: str
+    hass: HomeAssistant, mock_tts_init_cache_dir: MagicMock, setup: str
 ) -> None:
     """Set up a TTS platform with defaults."""
     assert not hass.services.has_service(tts.DOMAIN, "test_say")
@@ -187,7 +187,7 @@ async def test_setup_component_no_access_cache_folder(
 )
 async def test_service(
     hass: HomeAssistant,
-    empty_cache_dir,
+    mock_tts_cache_dir,
     setup: str,
     tts_service: str,
     service_data: dict[str, Any],
@@ -212,7 +212,7 @@ async def test_service(
     )
     await hass.async_block_till_done()
     assert (
-        empty_cache_dir
+        mock_tts_cache_dir
         / f"42f18378fd4393d18c8dd11d03fa9563c1e54491_en-us_-_{expected_url_suffix}.mp3"
     ).is_file()
 
@@ -248,7 +248,7 @@ async def test_service(
 )
 async def test_service_default_language(
     hass: HomeAssistant,
-    empty_cache_dir,
+    mock_tts_cache_dir,
     setup: str,
     tts_service: str,
     service_data: dict[str, Any],
@@ -271,7 +271,7 @@ async def test_service_default_language(
     )
     await hass.async_block_till_done()
     assert (
-        empty_cache_dir
+        mock_tts_cache_dir
         / (
             f"42f18378fd4393d18c8dd11d03fa9563c1e54491_de-de_-_{expected_url_suffix}.mp3"
         )
@@ -309,7 +309,7 @@ async def test_service_default_language(
 )
 async def test_service_default_special_language(
     hass: HomeAssistant,
-    empty_cache_dir,
+    mock_tts_cache_dir,
     setup: str,
     tts_service: str,
     service_data: dict[str, Any],
@@ -332,7 +332,7 @@ async def test_service_default_special_language(
     )
     await hass.async_block_till_done()
     assert (
-        empty_cache_dir
+        mock_tts_cache_dir
         / f"42f18378fd4393d18c8dd11d03fa9563c1e54491_en-us_-_{expected_url_suffix}.mp3"
     ).is_file()
 
@@ -366,7 +366,7 @@ async def test_service_default_special_language(
 )
 async def test_service_language(
     hass: HomeAssistant,
-    empty_cache_dir,
+    mock_tts_cache_dir,
     setup: str,
     tts_service: str,
     service_data: dict[str, Any],
@@ -389,7 +389,7 @@ async def test_service_language(
     )
     await hass.async_block_till_done()
     assert (
-        empty_cache_dir
+        mock_tts_cache_dir
         / f"42f18378fd4393d18c8dd11d03fa9563c1e54491_de-de_-_{expected_url_suffix}.mp3"
     ).is_file()
 
@@ -423,7 +423,7 @@ async def test_service_language(
 )
 async def test_service_wrong_language(
     hass: HomeAssistant,
-    empty_cache_dir,
+    mock_tts_cache_dir,
     setup: str,
     tts_service: str,
     service_data: dict[str, Any],
@@ -441,7 +441,7 @@ async def test_service_wrong_language(
         )
     assert len(calls) == 0
     assert not (
-        empty_cache_dir
+        mock_tts_cache_dir
         / f"42f18378fd4393d18c8dd11d03fa9563c1e54491_lang_-_{expected_url_suffix}.mp3"
     ).is_file()
 
@@ -477,7 +477,7 @@ async def test_service_wrong_language(
 )
 async def test_service_options(
     hass: HomeAssistant,
-    empty_cache_dir,
+    mock_tts_cache_dir,
     setup: str,
     tts_service: str,
     service_data: dict[str, Any],
@@ -502,7 +502,7 @@ async def test_service_options(
     )
     await hass.async_block_till_done()
     assert (
-        empty_cache_dir
+        mock_tts_cache_dir
         / (
             "42f18378fd4393d18c8dd11d03fa9563c1e54491"
             f"_de-de_{opt_hash}_{expected_url_suffix}.mp3"
@@ -561,7 +561,7 @@ class MockEntityWithDefaults(MockTTSEntity):
 )
 async def test_service_default_options(
     hass: HomeAssistant,
-    empty_cache_dir,
+    mock_tts_cache_dir,
     setup: str,
     tts_service: str,
     service_data: dict[str, Any],
@@ -586,7 +586,7 @@ async def test_service_default_options(
     )
     await hass.async_block_till_done()
     assert (
-        empty_cache_dir
+        mock_tts_cache_dir
         / (
             "42f18378fd4393d18c8dd11d03fa9563c1e54491"
             f"_de-de_{opt_hash}_{expected_url_suffix}.mp3"
@@ -629,7 +629,7 @@ async def test_service_default_options(
 )
 async def test_merge_default_service_options(
     hass: HomeAssistant,
-    empty_cache_dir,
+    mock_tts_cache_dir,
     setup: str,
     tts_service: str,
     service_data: dict[str, Any],
@@ -657,7 +657,7 @@ async def test_merge_default_service_options(
     )
     await hass.async_block_till_done()
     assert (
-        empty_cache_dir
+        mock_tts_cache_dir
         / (
             "42f18378fd4393d18c8dd11d03fa9563c1e54491"
             f"_de-de_{opt_hash}_{expected_url_suffix}.mp3"
@@ -696,7 +696,7 @@ async def test_merge_default_service_options(
 )
 async def test_service_wrong_options(
     hass: HomeAssistant,
-    empty_cache_dir,
+    mock_tts_cache_dir,
     setup: str,
     tts_service: str,
     service_data: dict[str, Any],
@@ -717,7 +717,7 @@ async def test_service_wrong_options(
     assert len(calls) == 0
     await hass.async_block_till_done()
     assert not (
-        empty_cache_dir
+        mock_tts_cache_dir
         / (
             "42f18378fd4393d18c8dd11d03fa9563c1e54491"
             f"_de-de_{opt_hash}_{expected_url_suffix}.mp3"
@@ -752,7 +752,7 @@ async def test_service_wrong_options(
 )
 async def test_service_clear_cache(
     hass: HomeAssistant,
-    empty_cache_dir,
+    mock_tts_cache_dir,
     setup: str,
     tts_service: str,
     service_data: dict[str, Any],
@@ -772,7 +772,7 @@ async def test_service_clear_cache(
     await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
     await hass.async_block_till_done()
     assert (
-        empty_cache_dir
+        mock_tts_cache_dir
         / f"42f18378fd4393d18c8dd11d03fa9563c1e54491_en-us_-_{expected_url_suffix}.mp3"
     ).is_file()
 
@@ -781,7 +781,7 @@ async def test_service_clear_cache(
     )
 
     assert not (
-        empty_cache_dir
+        mock_tts_cache_dir
         / f"42f18378fd4393d18c8dd11d03fa9563c1e54491_en-us_-_{expected_url_suffix}.mp3"
     ).is_file()
 
@@ -814,7 +814,7 @@ async def test_service_clear_cache(
 async def test_service_receive_voice(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
-    empty_cache_dir,
+    mock_tts_cache_dir,
     setup: str,
     tts_service: str,
     service_data: dict[str, Any],
@@ -886,7 +886,7 @@ async def test_service_receive_voice(
 async def test_service_receive_voice_german(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
-    empty_cache_dir,
+    mock_tts_cache_dir,
     setup: str,
     tts_service: str,
     service_data: dict[str, Any],
@@ -994,7 +994,7 @@ async def test_web_view_wrong_filename(
 )
 async def test_service_without_cache(
     hass: HomeAssistant,
-    empty_cache_dir,
+    mock_tts_cache_dir,
     setup: str,
     tts_service: str,
     service_data: dict[str, Any],
@@ -1012,7 +1012,7 @@ async def test_service_without_cache(
     await hass.async_block_till_done()
     assert len(calls) == 1
     assert not (
-        empty_cache_dir
+        mock_tts_cache_dir
         / f"42f18378fd4393d18c8dd11d03fa9563c1e54491_en-us_-_{expected_url_suffix}.mp3"
     ).is_file()
 
@@ -1042,7 +1042,7 @@ class MockEntityBoom(MockTTSEntity):
 @pytest.mark.parametrize("mock_provider", [MockProviderBoom(DEFAULT_LANG)])
 async def test_setup_legacy_cache_dir(
     hass: HomeAssistant,
-    empty_cache_dir,
+    mock_tts_cache_dir,
     mock_provider: MockProvider,
 ) -> None:
     """Set up a TTS platform with cache and call service without cache."""
@@ -1050,7 +1050,7 @@ async def test_setup_legacy_cache_dir(
 
     tts_data = b""
     cache_file = (
-        empty_cache_dir / "42f18378fd4393d18c8dd11d03fa9563c1e54491_en-us_-_test.mp3"
+        mock_tts_cache_dir / "42f18378fd4393d18c8dd11d03fa9563c1e54491_en-us_-_test.mp3"
     )
 
     with open(cache_file, "wb") as voice_file:
@@ -1078,14 +1078,14 @@ async def test_setup_legacy_cache_dir(
 @pytest.mark.parametrize("mock_tts_entity", [MockEntityBoom(DEFAULT_LANG)])
 async def test_setup_cache_dir(
     hass: HomeAssistant,
-    empty_cache_dir,
+    mock_tts_cache_dir,
     mock_tts_entity: MockTTSEntity,
 ) -> None:
     """Set up a TTS platform with cache and call service without cache."""
     calls = async_mock_service(hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 
     tts_data = b""
-    cache_file = empty_cache_dir / (
+    cache_file = mock_tts_cache_dir / (
         "42f18378fd4393d18c8dd11d03fa9563c1e54491_en-us_-_tts.test.mp3"
     )
 
@@ -1182,13 +1182,13 @@ async def test_service_get_tts_error(
 async def test_load_cache_legacy_retrieve_without_mem_cache(
     hass: HomeAssistant,
     mock_provider: MockProvider,
-    empty_cache_dir,
+    mock_tts_cache_dir,
     hass_client: ClientSessionGenerator,
 ) -> None:
     """Set up component and load cache and get without mem cache."""
     tts_data = b""
     cache_file = (
-        empty_cache_dir / "42f18378fd4393d18c8dd11d03fa9563c1e54491_en_-_test.mp3"
+        mock_tts_cache_dir / "42f18378fd4393d18c8dd11d03fa9563c1e54491_en_-_test.mp3"
     )
 
     with open(cache_file, "wb") as voice_file:
@@ -1208,12 +1208,12 @@ async def test_load_cache_legacy_retrieve_without_mem_cache(
 async def test_load_cache_retrieve_without_mem_cache(
     hass: HomeAssistant,
     mock_tts_entity: MockTTSEntity,
-    empty_cache_dir,
+    mock_tts_cache_dir,
     hass_client: ClientSessionGenerator,
 ) -> None:
     """Set up component and load cache and get without mem cache."""
     tts_data = b""
-    cache_file = empty_cache_dir / (
+    cache_file = mock_tts_cache_dir / (
         "42f18378fd4393d18c8dd11d03fa9563c1e54491_en-us_-_tts.test.mp3"
     )
 

--- a/tests/components/tts/test_legacy.py
+++ b/tests/components/tts/test_legacy.py
@@ -169,7 +169,7 @@ async def test_service_base_url_set(hass: HomeAssistant, mock_tts) -> None:
 
 
 async def test_service_without_cache_config(
-    hass: HomeAssistant, empty_cache_dir, mock_tts
+    hass: HomeAssistant, mock_tts_cache_dir, mock_tts
 ) -> None:
     """Set up a TTS platform without cache."""
     calls = async_mock_service(hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
@@ -191,5 +191,5 @@ async def test_service_without_cache_config(
     assert len(calls) == 1
     await hass.async_block_till_done()
     assert not (
-        empty_cache_dir / "42f18378fd4393d18c8dd11d03fa9563c1e54491_en-us_-_test.mp3"
+        mock_tts_cache_dir / "42f18378fd4393d18c8dd11d03fa9563c1e54491_en-us_-_test.mp3"
     ).is_file()

--- a/tests/components/voicerss/test_tts.py
+++ b/tests/components/voicerss/test_tts.py
@@ -1,8 +1,6 @@
 """The tests for the VoiceRSS speech platform."""
 import asyncio
 from http import HTTPStatus
-import os
-import shutil
 
 import pytest
 
@@ -17,7 +15,6 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import async_setup_component
 
 from tests.common import assert_setup_component, async_mock_service
-from tests.components.tts.conftest import mutagen_mock  # noqa: F401
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 URL = "https://api.voicerss.org/"
@@ -30,6 +27,17 @@ FORM_DATA = {
 }
 
 
+@pytest.fixture(autouse=True)
+def tts_mutagen_mock_fixture_autouse(tts_mutagen_mock):
+    """Mock writing tags."""
+
+
+@pytest.fixture(autouse=True)
+def mock_tts_cache_dir_autouse(mock_tts_cache_dir):
+    """Mock the TTS cache dir with empty dir."""
+    return mock_tts_cache_dir
+
+
 async def get_media_source_url(hass, media_content_id):
     """Get the media source url."""
     if media_source.DOMAIN not in hass.config.components:
@@ -37,15 +45,6 @@ async def get_media_source_url(hass, media_content_id):
 
     resolved = await media_source.async_resolve_media(hass, media_content_id, None)
     return resolved.url
-
-
-@pytest.fixture(autouse=True)
-def cleanup_cache(hass):
-    """Prevent TTS writing."""
-    yield
-    default_tts = hass.config.path(tts.DEFAULT_CACHE_DIR)
-    if os.path.isdir(default_tts):
-        shutil.rmtree(default_tts)
 
 
 async def test_setup_component(hass: HomeAssistant) -> None:

--- a/tests/components/wyoming/test_tts.py
+++ b/tests/components/wyoming/test_tts.py
@@ -15,11 +15,11 @@ from homeassistant.helpers.entity_component import DATA_INSTANCES
 
 from . import MockAsyncTcpClient
 
-from tests.components.tts.conftest import (  # noqa: F401, pylint: disable=unused-import
-    init_cache_dir_side_effect,
-    mock_get_cache_files,
-    mock_init_cache_dir,
-)
+
+@pytest.fixture(autouse=True)
+def mock_tts_cache_dir_autouse(mock_tts_cache_dir):
+    """Mock the TTS cache dir with empty dir."""
+    return mock_tts_cache_dir
 
 
 async def test_support(hass: HomeAssistant, init_wyoming_tts) -> None:

--- a/tests/components/yandextts/test_tts.py
+++ b/tests/components/yandextts/test_tts.py
@@ -1,8 +1,6 @@
 """The tests for the Yandex SpeechKit speech platform."""
 import asyncio
 from http import HTTPStatus
-import os
-import shutil
 
 import pytest
 
@@ -16,12 +14,20 @@ from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import assert_setup_component, async_mock_service
-from tests.components.tts.conftest import (  # noqa: F401, pylint: disable=unused-import
-    mutagen_mock,
-)
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 URL = "https://tts.voicetech.yandex.net/generate?"
+
+
+@pytest.fixture(autouse=True)
+def tts_mutagen_mock_fixture_autouse(tts_mutagen_mock):
+    """Mock writing tags."""
+
+
+@pytest.fixture(autouse=True)
+def mock_tts_cache_dir_autouse(mock_tts_cache_dir):
+    """Mock the TTS cache dir with empty dir."""
+    return mock_tts_cache_dir
 
 
 async def get_media_source_url(hass, media_content_id):
@@ -31,15 +37,6 @@ async def get_media_source_url(hass, media_content_id):
 
     resolved = await media_source.async_resolve_media(hass, media_content_id, None)
     return resolved.url
-
-
-@pytest.fixture(autouse=True)
-def cleanup_cache(hass):
-    """Prevent TTS writing."""
-    yield
-    default_tts = hass.config.path(tts.DEFAULT_CACHE_DIR)
-    if os.path.isdir(default_tts):
-        shutil.rmtree(default_tts)
 
 
 async def test_setup_component(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve TTS cache dir mocking:
- Import some fixtures from `tests/components/tts/conftest.py` to `tests/components/conftest.py` so they can be used by other integrations without importing
  - We could maybe move the fixtures which should be exposed to other integrations to a separate file?
- Remove fixtures which would wipe the TTS cache directory after the test ran, those fixtures caused tests to be flaky if multiple tts tests ran in parallell

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
