### PR TITLE
Fix LaMetric Config Flow for SKY

### DIFF
--- a/homeassistant/components/lametric/config_flow.py
+++ b/homeassistant/components/lametric/config_flow.py
@@ -248,6 +248,12 @@ class LaMetricFlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):
                 updates={CONF_HOST: lametric.host, CONF_API_KEY: lametric.api_key}
             )
 
+        notify_sound: Sound | None
+        if device.model == "sa5":
+            notify_sound = None
+        else:
+            notify_sound = Sound(sound=NotificationSound.WIN)
+
         await lametric.notify(
             notification=Notification(
                 priority=NotificationPriority.CRITICAL,
@@ -255,7 +261,7 @@ class LaMetricFlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):
                 model=Model(
                     cycles=2,
                     frames=[Simple(text="Connected to Home Assistant!", icon=7956)],
-                    sound=Sound(sound=NotificationSound.WIN),
+                    sound=notify_sound,
                 ),
             )
         )

--- a/homeassistant/components/lametric/config_flow.py
+++ b/homeassistant/components/lametric/config_flow.py
@@ -248,10 +248,8 @@ class LaMetricFlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):
                 updates={CONF_HOST: lametric.host, CONF_API_KEY: lametric.api_key}
             )
 
-        notify_sound: Sound | None
-        if device.model == "sa5":
-            notify_sound = None
-        else:
+        notify_sound: Sound | None = None
+        if device.model != "sa5":
             notify_sound = Sound(sound=NotificationSound.WIN)
 
         await lametric.notify(

--- a/tests/components/lametric/conftest.py
+++ b/tests/components/lametric/conftest.py
@@ -67,7 +67,13 @@ def mock_lametric_cloud() -> Generator[MagicMock, None, None]:
 
 
 @pytest.fixture
-def mock_lametric(request) -> Generator[MagicMock, None, None]:
+def device_fixture() -> str:
+    """Return the device fixture for a specific device."""
+    return "device"
+
+
+@pytest.fixture
+def mock_lametric(request, device_fixture: str) -> Generator[MagicMock, None, None]:
     """Return a mocked LaMetric TIME client."""
     with patch(
         "homeassistant.components.lametric.coordinator.LaMetricDevice", autospec=True
@@ -79,25 +85,7 @@ def mock_lametric(request) -> Generator[MagicMock, None, None]:
         lametric.api_key = "mock-api-key"
         lametric.host = "127.0.0.1"
         lametric.device.return_value = Device.parse_raw(
-            load_fixture("device.json", DOMAIN)
-        )
-        yield lametric
-
-
-@pytest.fixture
-def mock_lametric_sky(request) -> Generator[MagicMock, None, None]:
-    """Return a mocked LaMetric SKY client."""
-    with patch(
-        "homeassistant.components.lametric.coordinator.LaMetricDevice", autospec=True
-    ) as lametric_mock, patch(
-        "homeassistant.components.lametric.config_flow.LaMetricDevice",
-        new=lametric_mock,
-    ):
-        lametric = lametric_mock.return_value
-        lametric.api_key = "mock-api-key"
-        lametric.host = "127.0.0.1"
-        lametric.device.return_value = Device.parse_raw(
-            load_fixture("device_sa5.json", DOMAIN)
+            load_fixture(f"{device_fixture}.json", DOMAIN)
         )
         yield lametric
 

--- a/tests/components/lametric/conftest.py
+++ b/tests/components/lametric/conftest.py
@@ -66,8 +66,8 @@ def mock_lametric_cloud() -> Generator[MagicMock, None, None]:
         yield lametric
 
 
-@pytest.fixture
-def mock_lametric() -> Generator[MagicMock, None, None]:
+@pytest.fixture(params=["device.json"])
+def mock_lametric(request) -> Generator[MagicMock, None, None]:
     """Return a mocked LaMetric client."""
     with patch(
         "homeassistant.components.lametric.coordinator.LaMetricDevice", autospec=True
@@ -79,7 +79,7 @@ def mock_lametric() -> Generator[MagicMock, None, None]:
         lametric.api_key = "mock-api-key"
         lametric.host = "127.0.0.1"
         lametric.device.return_value = Device.parse_raw(
-            load_fixture("device.json", DOMAIN)
+            load_fixture(request.param, DOMAIN)
         )
         yield lametric
 

--- a/tests/components/lametric/conftest.py
+++ b/tests/components/lametric/conftest.py
@@ -66,9 +66,9 @@ def mock_lametric_cloud() -> Generator[MagicMock, None, None]:
         yield lametric
 
 
-@pytest.fixture(params=["device.json"])
+@pytest.fixture
 def mock_lametric(request) -> Generator[MagicMock, None, None]:
-    """Return a mocked LaMetric client."""
+    """Return a mocked LaMetric TIME client."""
     with patch(
         "homeassistant.components.lametric.coordinator.LaMetricDevice", autospec=True
     ) as lametric_mock, patch(
@@ -79,7 +79,25 @@ def mock_lametric(request) -> Generator[MagicMock, None, None]:
         lametric.api_key = "mock-api-key"
         lametric.host = "127.0.0.1"
         lametric.device.return_value = Device.parse_raw(
-            load_fixture(request.param, DOMAIN)
+            load_fixture("device.json", DOMAIN)
+        )
+        yield lametric
+
+
+@pytest.fixture
+def mock_lametric_sky(request) -> Generator[MagicMock, None, None]:
+    """Return a mocked LaMetric SKY client."""
+    with patch(
+        "homeassistant.components.lametric.coordinator.LaMetricDevice", autospec=True
+    ) as lametric_mock, patch(
+        "homeassistant.components.lametric.config_flow.LaMetricDevice",
+        new=lametric_mock,
+    ):
+        lametric = lametric_mock.return_value
+        lametric.api_key = "mock-api-key"
+        lametric.host = "127.0.0.1"
+        lametric.device.return_value = Device.parse_raw(
+            load_fixture("device_sa5.json", DOMAIN)
         )
         yield lametric
 

--- a/tests/components/lametric/fixtures/device_sa5.json
+++ b/tests/components/lametric/fixtures/device_sa5.json
@@ -1,0 +1,71 @@
+{
+  "audio": {
+    "volume": 100,
+    "volume_limit": {
+      "max": 100,
+      "min": 0
+    },
+    "volume_range": {
+      "max": 100,
+      "min": 0
+    }
+  },
+  "bluetooth": {
+    "active": true,
+    "address": "AA:BB:CC:DD:EE:FF",
+    "available": true,
+    "discoverable": true,
+    "low_energy": {
+      "active": true,
+      "advertising": true,
+      "connectable": true
+    },
+    "name": "SKY0123",
+    "pairable": false
+  },
+  "display": {
+    "brightness": 66,
+    "brightness_limit": {
+      "max": 100,
+      "min": 2
+    },
+    "brightness_mode": "manual",
+    "brightness_range": {
+      "max": 100,
+      "min": 0
+    },
+    "height": 8,
+    "on": true,
+    "screensaver": {
+      "enabled": true,
+      "modes": {
+        "screen_off": {
+          "enabled": false
+        },
+        "time_based": {
+          "enabled": false
+        }
+      },
+      "widget": ""
+    },
+    "type": "mixed",
+    "width": 64
+  },
+  "id": "12345",
+  "mode": "manual",
+  "model": "sa5",
+  "name": "spyfly's LaMetric SKY",
+  "os_version": "3.0.13",
+  "serial_number": "SA52100000123TBNC",
+  "wifi": {
+    "active": true,
+    "mac": "AA:BB:CC:DD:EE:FF",
+    "available": true,
+    "encryption": "WPA",
+    "ssid": "IoT",
+    "ip": "127.0.0.1",
+    "mode": "dhcp",
+    "netmask": "255.255.255.0",
+    "strength": 58
+  }
+}

--- a/tests/components/lametric/test_config_flow.py
+++ b/tests/components/lametric/test_config_flow.py
@@ -904,9 +904,10 @@ async def test_reauth_manual(
 
 
 @pytest.mark.usefixtures("mock_setup_entry")
+@pytest.mark.parametrize("device_fixture", ["device_sa5"])
 async def test_reauth_manual_sky(
     hass: HomeAssistant,
-    mock_lametric_sky: MagicMock,
+    mock_lametric: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test reauth flow with manual entry for LaMetric Sky."""
@@ -940,10 +941,8 @@ async def test_reauth_manual_sky(
         CONF_MAC: "AA:BB:CC:DD:EE:FF",
     }
 
-    assert len(mock_lametric_sky.device.mock_calls) == 1
-    assert len(mock_lametric_sky.notify.mock_calls) == 1
+    assert len(mock_lametric.device.mock_calls) == 1
+    assert len(mock_lametric.notify.mock_calls) == 1
 
-    notification: Notification = mock_lametric_sky.notify.mock_calls[0][2][
-        "notification"
-    ]
+    notification: Notification = mock_lametric.notify.mock_calls[0][2]["notification"]
     assert notification.model.sound is None

--- a/tests/components/lametric/test_config_flow.py
+++ b/tests/components/lametric/test_config_flow.py
@@ -6,6 +6,9 @@ from demetriek import (
     LaMetricConnectionError,
     LaMetricConnectionTimeoutError,
     LaMetricError,
+    Notification,
+    NotificationSound,
+    Sound,
 )
 import pytest
 
@@ -238,6 +241,10 @@ async def test_full_manual(
 
     assert len(mock_lametric.device.mock_calls) == 1
     assert len(mock_lametric.notify.mock_calls) == 1
+
+    notification: Notification = mock_lametric.notify.mock_calls[0][2]["notification"]
+    assert notification.model.sound == Sound(sound=NotificationSound.WIN)
+
     assert len(mock_setup_entry.mock_calls) == 1
 
 

--- a/tests/components/lametric/test_config_flow.py
+++ b/tests/components/lametric/test_config_flow.py
@@ -904,10 +904,9 @@ async def test_reauth_manual(
 
 
 @pytest.mark.usefixtures("mock_setup_entry")
-@pytest.mark.parametrize("mock_lametric", ["device_sa5.json"], indirect=True)
 async def test_reauth_manual_sky(
     hass: HomeAssistant,
-    mock_lametric: MagicMock,
+    mock_lametric_sky: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test reauth flow with manual entry for LaMetric Sky."""
@@ -941,8 +940,10 @@ async def test_reauth_manual_sky(
         CONF_MAC: "AA:BB:CC:DD:EE:FF",
     }
 
-    assert len(mock_lametric.device.mock_calls) == 1
-    assert len(mock_lametric.notify.mock_calls) == 1
+    assert len(mock_lametric_sky.device.mock_calls) == 1
+    assert len(mock_lametric_sky.notify.mock_calls) == 1
 
-    notification: Notification = mock_lametric.notify.mock_calls[0][2]["notification"]
+    notification: Notification = mock_lametric_sky.notify.mock_calls[0][2][
+        "notification"
+    ]
     assert notification.model.sound is None

--- a/tests/components/lametric/test_config_flow.py
+++ b/tests/components/lametric/test_config_flow.py
@@ -901,3 +901,48 @@ async def test_reauth_manual(
 
     assert len(mock_lametric.device.mock_calls) == 1
     assert len(mock_lametric.notify.mock_calls) == 1
+
+
+@pytest.mark.usefixtures("mock_setup_entry")
+@pytest.mark.parametrize("mock_lametric", ["device_sa5.json"], indirect=True)
+async def test_reauth_manual_sky(
+    hass: HomeAssistant,
+    mock_lametric: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test reauth flow with manual entry for LaMetric Sky."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": SOURCE_REAUTH,
+            "unique_id": mock_config_entry.unique_id,
+            "entry_id": mock_config_entry.entry_id,
+        },
+        data=mock_config_entry.data,
+    )
+
+    flow_id = result["flow_id"]
+
+    await hass.config_entries.flow.async_configure(
+        flow_id, user_input={"next_step_id": "manual_entry"}
+    )
+
+    result2 = await hass.config_entries.flow.async_configure(
+        flow_id, user_input={CONF_API_KEY: "mock-api-key"}
+    )
+
+    assert result2.get("type") == FlowResultType.ABORT
+    assert result2.get("reason") == "reauth_successful"
+    assert mock_config_entry.data == {
+        CONF_HOST: "127.0.0.1",
+        CONF_API_KEY: "mock-api-key",
+        CONF_MAC: "AA:BB:CC:DD:EE:FF",
+    }
+
+    assert len(mock_lametric.device.mock_calls) == 1
+    assert len(mock_lametric.notify.mock_calls) == 1
+
+    notification: Notification = mock_lametric.notify.mock_calls[0][2]["notification"]
+    assert notification.model.sound is None


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes the configuration flow for [LaMetric SKY](https://lametric.com/en-US/sky/overview)

Adds a check for the model type and disables the notification sound for the SKY (["sa5"](https://lametric-documentation.readthedocs.io/en/latest/reference-docs/device-state.html#response)) in the configuration flow.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #92271
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
