### PR TITLE
Improve hydrawise typing

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -169,6 +169,7 @@ homeassistant.components.homekit_controller.utils
 homeassistant.components.homewizard.*
 homeassistant.components.http.*
 homeassistant.components.huawei_lte.*
+homeassistant.components.hydrawise.*
 homeassistant.components.hyperion.*
 homeassistant.components.ibeacon.*
 homeassistant.components.image_processing.*

--- a/homeassistant/components/hydrawise/__init__.py
+++ b/homeassistant/components/hydrawise/__init__.py
@@ -53,7 +53,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
-def _show_failure_notification(hass: HomeAssistant, error: str):
+def _show_failure_notification(hass: HomeAssistant, error: str) -> None:
     persistent_notification.create(
         hass,
         f"Error: {error}<br />You will need to restart hass after fixing.",

--- a/homeassistant/components/hydrawise/__init__.py
+++ b/homeassistant/components/hydrawise/__init__.py
@@ -60,11 +60,3 @@ def _show_failure_notification(hass: HomeAssistant, error: str) -> None:
         title=NOTIFICATION_TITLE,
         notification_id=NOTIFICATION_ID,
     )
-
-
-class HydrawiseHub:
-    """Representation of a base Hydrawise device."""
-
-    def __init__(self, data):
-        """Initialize the entity."""
-        self.data = data

--- a/homeassistant/components/hydrawise/entity.py
+++ b/homeassistant/components/hydrawise/entity.py
@@ -28,6 +28,6 @@ class HydrawiseEntity(CoordinatorEntity[HydrawiseDataUpdateCoordinator]):
         self._attr_name = f"{self.data['name']} {description.name}"
 
     @property
-    def extra_state_attributes(self):
+    def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes."""
         return {"identifier": self.data.get("relay")}

--- a/homeassistant/components/hydrawise/entity.py
+++ b/homeassistant/components/hydrawise/entity.py
@@ -1,15 +1,15 @@
 """Base classes for Hydrawise entities."""
+from __future__ import annotations
 
 from typing import Any
 
 from homeassistant.helpers.entity import EntityDescription
-from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
-    DataUpdateCoordinator,
-)
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .coordinator import HydrawiseDataUpdateCoordinator
 
 
-class HydrawiseEntity(CoordinatorEntity):
+class HydrawiseEntity(CoordinatorEntity[HydrawiseDataUpdateCoordinator]):
     """Entity class for Hydrawise devices."""
 
     _attr_attribution = "Data provided by hydrawise.com"
@@ -18,7 +18,7 @@ class HydrawiseEntity(CoordinatorEntity):
         self,
         *,
         data: dict[str, Any],
-        coordinator: DataUpdateCoordinator,
+        coordinator: HydrawiseDataUpdateCoordinator,
         description: EntityDescription,
     ) -> None:
         """Initialize the Hydrawise entity."""

--- a/homeassistant/components/hydrawise/switch.py
+++ b/homeassistant/components/hydrawise/switch.py
@@ -17,7 +17,6 @@ from homeassistant.core import HomeAssistant, callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import (
     ALLOWED_WATERING_TIME,
@@ -90,7 +89,7 @@ class HydrawiseSwitch(HydrawiseEntity, SwitchEntity):
         self,
         *,
         data: dict[str, Any],
-        coordinator: DataUpdateCoordinator,
+        coordinator: HydrawiseDataUpdateCoordinator,
         description: SwitchEntityDescription,
         default_watering_timer: int,
     ) -> None:

--- a/mypy.ini
+++ b/mypy.ini
@@ -1452,6 +1452,16 @@ disallow_untyped_defs = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.hydrawise.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.hyperion.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true


### PR DESCRIPTION
## Proposed change
* Improve generic typing for `HydrawiseEntity[CoordinatorEntity]`
* Enable strict typing as only two returns types were missing
* Remove some unused code
(Maybe missed in #93223? /cc: @dknowles2)

If needed, I can split this up into separate PRs. However, since the changes are quite small and at least somewhat related to typing, I felt that wasn't necessary here.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
