### PR TITLE
Update certifi to >=2022.12.07

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ attrs==22.2.0
 atomicwrites-homeassistant==1.4.1
 awesomeversion==22.9.0
 bcrypt==4.0.1
-certifi>=2021.5.30
+certifi>=2022.12.07
 ciso8601==2.3.0
 httpx==0.24.1
 home-assistant-bluetooth==1.10.0


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in certifi 2021.5.30
- [CVE-2022-23491](https://www.oscs1024.com/hd/CVE-2022-23491)


### What did I do？
Upgrade certifi from 2021.5.30 to 2022.12.07 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS