### PR TITLE
Don't inherit SensorEntity/NumberEntity and RestoreEntity in Shelly integration

### DIFF
--- a/homeassistant/components/shelly/binary_sensor.py
+++ b/homeassistant/components/shelly/binary_sensor.py
@@ -315,10 +315,17 @@ class BlockSleepingBinarySensor(
         return self.last_state.state == STATE_ON
 
 
-class RpcSleepingBinarySensor(ShellySleepingRpcAttributeEntity, BinarySensorEntity):
+class RpcSleepingBinarySensor(
+    ShellySleepingRpcAttributeEntity, BinarySensorEntity, RestoreEntity
+):
     """Represent a RPC sleeping binary sensor entity."""
 
     entity_description: RpcBinarySensorDescription
+
+    async def async_added_to_hass(self) -> None:
+        """Handle entity which will be added."""
+        await super().async_added_to_hass()
+        self.last_state = await self.async_get_last_state()
 
     @property
     def is_on(self) -> bool | None:

--- a/homeassistant/components/shelly/binary_sensor.py
+++ b/homeassistant/components/shelly/binary_sensor.py
@@ -14,6 +14,7 @@ from homeassistant.const import STATE_ON, EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.entity_registry import RegistryEntry
+from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import CONF_SLEEP_PERIOD
 from .entity import (
@@ -290,10 +291,17 @@ class RpcBinarySensor(ShellyRpcAttributeEntity, BinarySensorEntity):
         return bool(self.attribute_value)
 
 
-class BlockSleepingBinarySensor(ShellySleepingBlockAttributeEntity, BinarySensorEntity):
+class BlockSleepingBinarySensor(
+    ShellySleepingBlockAttributeEntity, BinarySensorEntity, RestoreEntity
+):
     """Represent a block sleeping binary sensor."""
 
     entity_description: BlockBinarySensorDescription
+
+    async def async_added_to_hass(self) -> None:
+        """Handle entity which will be added."""
+        await super().async_added_to_hass()
+        self.last_state = await self.async_get_last_state()
 
     @property
     def is_on(self) -> bool | None:

--- a/homeassistant/components/shelly/entity.py
+++ b/homeassistant/components/shelly/entity.py
@@ -19,7 +19,6 @@ from homeassistant.helpers.entity_registry import (
     async_entries_for_config_entry,
     async_get as er_async_get,
 )
-from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -624,7 +623,7 @@ class ShellySleepingBlockAttributeEntity(ShellyBlockAttributeEntity):
                 return
 
 
-class ShellySleepingRpcAttributeEntity(ShellyRpcAttributeEntity, RestoreEntity):
+class ShellySleepingRpcAttributeEntity(ShellyRpcAttributeEntity):
     """Helper class to represent a sleeping rpc attribute."""
 
     entity_description: RpcEntityDescription
@@ -660,8 +659,3 @@ class ShellySleepingRpcAttributeEntity(ShellyRpcAttributeEntity, RestoreEntity):
             )
         elif entry is not None:
             self._attr_name = cast(str, entry.original_name)
-
-    async def async_added_to_hass(self) -> None:
-        """Handle entity which will be added."""
-        await super().async_added_to_hass()
-        self.last_state = await self.async_get_last_state()

--- a/homeassistant/components/shelly/entity.py
+++ b/homeassistant/components/shelly/entity.py
@@ -552,7 +552,7 @@ class ShellyRpcAttributeEntity(ShellyRpcEntity, Entity):
         return self.entity_description.available(self.sub_status)
 
 
-class ShellySleepingBlockAttributeEntity(ShellyBlockAttributeEntity, RestoreEntity):
+class ShellySleepingBlockAttributeEntity(ShellyBlockAttributeEntity):
     """Represent a shelly sleeping block attribute entity."""
 
     # pylint: disable=super-init-not-called
@@ -588,11 +588,6 @@ class ShellySleepingBlockAttributeEntity(ShellyBlockAttributeEntity, RestoreEnti
         elif entry is not None:
             self._attr_unique_id = entry.unique_id
             self._attr_name = cast(str, entry.original_name)
-
-    async def async_added_to_hass(self) -> None:
-        """Handle entity which will be added."""
-        await super().async_added_to_hass()
-        self.last_state = await self.async_get_last_state()
 
     @callback
     def _update_callback(self) -> None:

--- a/homeassistant/components/shelly/number.py
+++ b/homeassistant/components/shelly/number.py
@@ -1,15 +1,18 @@
 """Number for Shelly."""
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, Final, cast
 
+from aioshelly.block_device import Block
 from aioshelly.exceptions import DeviceConnectionError, InvalidAuthError
 
 from homeassistant.components.number import (
-    NumberEntity,
     NumberEntityDescription,
+    NumberExtraStoredData,
     NumberMode,
+    RestoreNumber,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import PERCENTAGE, EntityCategory
@@ -19,6 +22,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.entity_registry import RegistryEntry
 
 from .const import CONF_SLEEP_PERIOD, LOGGER
+from .coordinator import ShellyBlockCoordinator
 from .entity import (
     BlockEntityDescription,
     ShellySleepingBlockAttributeEntity,
@@ -85,11 +89,28 @@ async def async_setup_entry(
         )
 
 
-# pylint: disable-next=hass-invalid-inheritance # needs fixing
-class BlockSleepingNumber(ShellySleepingBlockAttributeEntity, NumberEntity):
+class BlockSleepingNumber(ShellySleepingBlockAttributeEntity, RestoreNumber):
     """Represent a block sleeping number."""
 
     entity_description: BlockNumberDescription
+
+    def __init__(
+        self,
+        coordinator: ShellyBlockCoordinator,
+        block: Block | None,
+        attribute: str,
+        description: BlockNumberDescription,
+        entry: RegistryEntry | None = None,
+        sensors: Mapping[tuple[str, str], BlockNumberDescription] | None = None,
+    ) -> None:
+        """Initialize the sleeping sensor."""
+        self.restored_data: NumberExtraStoredData | None = None
+        super().__init__(coordinator, block, attribute, description, entry, sensors)
+
+    async def async_added_to_hass(self) -> None:
+        """Handle entity which will be added."""
+        await super().async_added_to_hass()
+        self.restored_data = await self.async_get_last_number_data()
 
     @property
     def native_value(self) -> float | None:
@@ -97,10 +118,10 @@ class BlockSleepingNumber(ShellySleepingBlockAttributeEntity, NumberEntity):
         if self.block is not None:
             return cast(float, self.attribute_value)
 
-        if self.last_state is None:
+        if self.restored_data is None:
             return None
 
-        return cast(float, self.last_state.state)
+        return cast(float, self.restored_data.native_value)
 
     async def async_set_native_value(self, value: float) -> None:
         """Set value."""

--- a/homeassistant/components/shelly/update.py
+++ b/homeassistant/components/shelly/update.py
@@ -21,6 +21,7 @@ from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import CONF_SLEEP_PERIOD
 from .coordinator import ShellyBlockCoordinator, ShellyRpcCoordinator
@@ -282,10 +283,17 @@ class RpcUpdateEntity(ShellyRpcAttributeEntity, UpdateEntity):
             LOGGER.debug("OTA update call successful")
 
 
-class RpcSleepingUpdateEntity(ShellySleepingRpcAttributeEntity, UpdateEntity):
+class RpcSleepingUpdateEntity(
+    ShellySleepingRpcAttributeEntity, UpdateEntity, RestoreEntity
+):
     """Represent a RPC sleeping update entity."""
 
     entity_description: RpcUpdateDescription
+
+    async def async_added_to_hass(self) -> None:
+        """Handle entity which will be added."""
+        await super().async_added_to_hass()
+        self.last_state = await self.async_get_last_state()
 
     @property
     def installed_version(self) -> str | None:

--- a/tests/components/shelly/test_number.py
+++ b/tests/components/shelly/test_number.py
@@ -62,9 +62,14 @@ async def test_block_restored_number(
         entry,
         capabilities,
     )
-    mock_restore_cache_with_extra_data(
-        hass, ((State(entity_id, ""), {"native_value": "40"}),)
-    )
+    extra_data = {
+        "native_max_value": 100,
+        "native_min_value": 0,
+        "native_step": 1,
+        "native_unit_of_measurement": "%",
+        "native_value": "40",
+    }
+    mock_restore_cache_with_extra_data(hass, ((State(entity_id, ""), extra_data),))
 
     monkeypatch.setattr(mock_block_device, "initialized", False)
     await hass.config_entries.async_setup(entry.entry_id)

--- a/tests/components/shelly/test_number.py
+++ b/tests/components/shelly/test_number.py
@@ -17,7 +17,7 @@ from homeassistant.exceptions import HomeAssistantError
 
 from . import init_integration, register_device, register_entity
 
-from tests.common import mock_restore_cache
+from tests.common import mock_restore_cache_with_extra_data
 
 DEVICE_BLOCK_ID = 4
 
@@ -62,7 +62,9 @@ async def test_block_restored_number(
         entry,
         capabilities,
     )
-    mock_restore_cache(hass, [State(entity_id, "40")])
+    mock_restore_cache_with_extra_data(
+        hass, ((State(entity_id, "40"), {"native_value": "40"}),)
+    )
 
     monkeypatch.setattr(mock_block_device, "initialized", False)
     await hass.config_entries.async_setup(entry.entry_id)

--- a/tests/components/shelly/test_number.py
+++ b/tests/components/shelly/test_number.py
@@ -63,7 +63,7 @@ async def test_block_restored_number(
         capabilities,
     )
     mock_restore_cache_with_extra_data(
-        hass, ((State(entity_id, "40"), {"native_value": "40"}),)
+        hass, ((State(entity_id, ""), {"native_value": "40"}),)
     )
 
     monkeypatch.setattr(mock_block_device, "initialized", False)

--- a/tests/components/shelly/test_sensor.py
+++ b/tests/components/shelly/test_sensor.py
@@ -20,7 +20,7 @@ from . import (
     register_entity,
 )
 
-from tests.common import mock_restore_cache
+from tests.common import mock_restore_cache, mock_restore_cache_with_extra_data
 
 RELAY_BLOCK_ID = 0
 SENSOR_BLOCK_ID = 3
@@ -137,7 +137,15 @@ async def test_block_restored_sleeping_sensor(
     entity_id = register_entity(
         hass, SENSOR_DOMAIN, "test_name_temperature", "sensor_0-temp", entry
     )
-    mock_restore_cache(hass, [State(entity_id, "20.4")])
+    mock_restore_cache_with_extra_data(
+        hass,
+        (
+            (
+                State(entity_id, "20.4"),
+                {"native_value": "20.4", "native_unit_of_measurement": "°C"},
+            ),
+        ),
+    )
     monkeypatch.setattr(mock_block_device, "initialized", False)
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
@@ -216,7 +224,15 @@ async def test_block_not_matched_restored_sleeping_sensor(
     entity_id = register_entity(
         hass, SENSOR_DOMAIN, "test_name_temperature", "sensor_0-temp", entry
     )
-    mock_restore_cache(hass, [State(entity_id, "20.4")])
+    mock_restore_cache_with_extra_data(
+        hass,
+        (
+            (
+                State(entity_id, "20.4"),
+                {"native_value": "20.4", "native_unit_of_measurement": "°C"},
+            ),
+        ),
+    )
     monkeypatch.setattr(mock_block_device, "initialized", False)
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()

--- a/tests/components/shelly/test_sensor.py
+++ b/tests/components/shelly/test_sensor.py
@@ -20,7 +20,7 @@ from . import (
     register_entity,
 )
 
-from tests.common import mock_restore_cache, mock_restore_cache_with_extra_data
+from tests.common import mock_restore_cache_with_extra_data
 
 RELAY_BLOCK_ID = 0
 SENSOR_BLOCK_ID = 3
@@ -137,15 +137,9 @@ async def test_block_restored_sleeping_sensor(
     entity_id = register_entity(
         hass, SENSOR_DOMAIN, "test_name_temperature", "sensor_0-temp", entry
     )
-    mock_restore_cache_with_extra_data(
-        hass,
-        (
-            (
-                State(entity_id, "20.4"),
-                {"native_value": "20.4", "native_unit_of_measurement": "°C"},
-            ),
-        ),
-    )
+    extra_data = {"native_value": "20.4", "native_unit_of_measurement": "°C"}
+
+    mock_restore_cache_with_extra_data(hass, ((State(entity_id, ""), extra_data),))
     monkeypatch.setattr(mock_block_device, "initialized", False)
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
@@ -224,15 +218,9 @@ async def test_block_not_matched_restored_sleeping_sensor(
     entity_id = register_entity(
         hass, SENSOR_DOMAIN, "test_name_temperature", "sensor_0-temp", entry
     )
-    mock_restore_cache_with_extra_data(
-        hass,
-        (
-            (
-                State(entity_id, "20.4"),
-                {"native_value": "20.4", "native_unit_of_measurement": "°C"},
-            ),
-        ),
-    )
+    extra_data = {"native_value": "20.4", "native_unit_of_measurement": "°C"}
+
+    mock_restore_cache_with_extra_data(hass, ((State(entity_id, ""), extra_data),))
     monkeypatch.setattr(mock_block_device, "initialized", False)
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
@@ -373,8 +361,9 @@ async def test_rpc_restored_sleeping_sensor(
         "temperature:0-temperature_0",
         entry,
     )
+    extra_data = {"native_value": "21.0", "native_unit_of_measurement": "°C"}
 
-    mock_restore_cache(hass, [State(entity_id, "21.0")])
+    mock_restore_cache_with_extra_data(hass, ((State(entity_id, ""), extra_data),))
     monkeypatch.setattr(mock_rpc_device, "initialized", False)
 
     await hass.config_entries.async_setup(entry.entry_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Inherit SensorEntity/NumberEntity and RestoreEntity is not allowed. This change uses RestoreSensor and RestoreNumber for Shelly sleeping devices.

I tested the change with H&T (gen1), Valve (gen1) and Plus H&T (gen2).

Related to https://github.com/home-assistant/core/pull/93467 and https://github.com/home-assistant/core/pull/88971

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
