### PR TITLE
Significantly speed up recorder event listener

### DIFF
--- a/homeassistant/components/recorder/core.py
+++ b/homeassistant/components/recorder/core.py
@@ -1266,27 +1266,6 @@ class Recorder(threading.Thread):
         _LOGGER.debug("Sending keepalive")
         self.event_session.connection().scalar(select(1))
 
-    @callback
-    def _async_event_filter(self, event: Event) -> bool:
-        """Filter events."""
-        if event.event_type in self.exclude_event_types:
-            return False
-
-        if (entity_id := event.data.get(ATTR_ENTITY_ID)) is None:
-            return True
-
-        if isinstance(entity_id, str):
-            return self.entity_filter(entity_id)
-
-        if isinstance(entity_id, list):
-            for eid in entity_id:
-                if self.entity_filter(eid):
-                    return True
-            return False
-
-        # Unknown what it is.
-        return True
-
     async def async_block_till_done(self) -> None:
         """Async version of block_till_done."""
         if self._queue.empty() and not self._event_session_has_pending_writes:

--- a/homeassistant/components/recorder/core.py
+++ b/homeassistant/components/recorder/core.py
@@ -299,9 +299,39 @@ class Recorder(threading.Thread):
     @callback
     def async_initialize(self) -> None:
         """Initialize the recorder."""
+        entity_filter = self.entity_filter
+        exclude_event_types = self.exclude_event_types
+        queue_put = self._queue.put_nowait
+        event_task = EventTask
+
+        @callback
+        def _event_listener(event: Event) -> None:
+            """Listen for new events and put them in the process queue."""
+            if event.event_type in exclude_event_types:
+                return
+
+            if (entity_id := event.data.get(ATTR_ENTITY_ID)) is None:
+                queue_put(event_task(event))
+                return
+
+            if isinstance(entity_id, str):
+                if entity_filter(entity_id):
+                    queue_put(event_task(event))
+                return
+
+            if isinstance(entity_id, list):
+                for eid in entity_id:
+                    if entity_filter(eid):
+                        queue_put(event_task(event))
+                        return
+                return
+
+            # Unknown what it is.
+            queue_put(event_task(event))
+
         self._event_listener = self.hass.bus.async_listen(
             MATCH_ALL,
-            self.event_listener,
+            _event_listener,
             run_immediately=True,
         )
         self._queue_watcher = async_track_time_interval(
@@ -411,27 +441,6 @@ class Recorder(threading.Thread):
         if self._periodic_listener:
             self._periodic_listener()
             self._periodic_listener = None
-
-    @callback
-    def _async_event_filter(self, event: Event) -> bool:
-        """Filter events."""
-        if event.event_type in self.exclude_event_types:
-            return False
-
-        if (entity_id := event.data.get(ATTR_ENTITY_ID)) is None:
-            return True
-
-        if isinstance(entity_id, str):
-            return self.entity_filter(entity_id)
-
-        if isinstance(entity_id, list):
-            for eid in entity_id:
-                if self.entity_filter(eid):
-                    return True
-            return False
-
-        # Unknown what it is.
-        return True
 
     async def _async_close(self, event: Event) -> None:
         """Empty the queue if its still present at close."""
@@ -1258,10 +1267,25 @@ class Recorder(threading.Thread):
         self.event_session.connection().scalar(select(1))
 
     @callback
-    def event_listener(self, event: Event) -> None:
-        """Listen for new events and put them in the process queue."""
-        if self._async_event_filter(event):
-            self.queue_task(EventTask(event))
+    def _async_event_filter(self, event: Event) -> bool:
+        """Filter events."""
+        if event.event_type in self.exclude_event_types:
+            return False
+
+        if (entity_id := event.data.get(ATTR_ENTITY_ID)) is None:
+            return True
+
+        if isinstance(entity_id, str):
+            return self.entity_filter(entity_id)
+
+        if isinstance(entity_id, list):
+            for eid in entity_id:
+                if self.entity_filter(eid):
+                    return True
+            return False
+
+        # Unknown what it is.
+        return True
 
     async def async_block_till_done(self) -> None:
         """Async version of block_till_done."""


### PR DESCRIPTION

I've been working on speeding up the recorder tests a bit since some of them are taking too long.  This is part of a series of changes to improve that.  This one happens to affect production as well so I prioritized it to first in the chain

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This code is called every time an event happens since it subscribes to all events. Its our most frequently called listener out of the box.

It used to have a seperate filter function but it was later combined after core had some previous refactoring.

It was never optimized after that happened.

This change reduces the run time by ~70%

Before
![event_listener_before](https://github.com/home-assistant/core/assets/663432/fce48a71-5472-45f5-98cd-3ef72035a17e)



After
![event_listener_after](https://github.com/home-assistant/core/assets/663432/bede690b-a6c2-4c11-9286-eb9940a6cc0a)



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
