### PR TITLE
Glances: Add error handling for invalid sensor data

### DIFF
--- a/homeassistant/components/glances/sensor.py
+++ b/homeassistant/components/glances/sensor.py
@@ -329,6 +329,18 @@ class GlancesSensor(CoordinatorEntity[GlancesDataUpdateCoordinator], SensorEntit
         self._attr_unique_id = f"{coordinator.config_entry.entry_id}-{sensor_name_prefix}-{description.key}"
 
     @property
+    def available(self) -> bool:
+        """Set sensor unavailable when native value is invalid."""
+        if super().available:
+            return (
+                not self._numeric_state_expected
+                or isinstance(self.native_value, (int, float))
+                or isinstance(self.native_value, str)
+                and self.native_value.isnumeric()
+            )
+        return False
+
+    @property
     def native_value(self) -> StateType:
         """Return the state of the resources."""
         value = self.coordinator.data[self.entity_description.type]

--- a/tests/components/glances/__init__.py
+++ b/tests/components/glances/__init__.py
@@ -109,7 +109,25 @@ MOCK_DATA = {
             "unit": "C",
             "type": "temperature_core",
             "key": "label",
-        }
+        },
+        {
+            "label": "err_temp",
+            "value": "ERR",
+            "warning": None,
+            "critical": None,
+            "unit": "C",
+            "type": "temperature_hdd",
+            "key": "label",
+        },
+        {
+            "label": "na_temp",
+            "value": "NA",
+            "warning": None,
+            "critical": None,
+            "unit": "C",
+            "type": "temperature_hdd",
+            "key": "label",
+        },
     ],
     "system": {
         "os_name": "Linux",
@@ -127,7 +145,11 @@ HA_SENSOR_DATA: dict[str, Any] = {
         "/ssl": {"disk_use": 30.7, "disk_use_percent": 6.7, "disk_free": 426.5},
         "/media": {"disk_use": 30.7, "disk_use_percent": 6.7, "disk_free": 426.5},
     },
-    "sensors": {"cpu_thermal 1": {"temperature_core": 59}},
+    "sensors": {
+        "cpu_thermal 1": {"temperature_core": 59},
+        "err_temp": {"temperature_hdd": "Unavailable"},
+        "na_temp": {"temperature_hdd": "Unavailable"},
+    },
     "mem": {
         "memory_use_percent": 27.6,
         "memory_use": 1047.1,

--- a/tests/components/glances/test_sensor.py
+++ b/tests/components/glances/test_sensor.py
@@ -21,9 +21,20 @@ async def test_sensor_states(hass: HomeAssistant) -> None:
 
     if state := hass.states.get("sensor.0_0_0_0_ssl_disk_use"):
         assert state.state == HA_SENSOR_DATA["fs"]["/ssl"]["disk_use"]
-
     if state := hass.states.get("sensor.0_0_0_0_cpu_thermal_1"):
         assert state.state == HA_SENSOR_DATA["sensors"]["cpu_thermal 1"]
+    if state := hass.states.get("sensor.0_0_0_0_err_temp"):
+        assert state.state == HA_SENSOR_DATA["sensors"]["err_temp"]
+    if state := hass.states.get("sensor.0_0_0_0_na_temp"):
+        assert state.state == HA_SENSOR_DATA["sensors"]["na_temp"]
+    if state := hass.states.get("sensor.0_0_0_0_memory_use_percent"):
+        assert state.state == HA_SENSOR_DATA["mem"]["memory_use_percent"]
+    if state := hass.states.get("sensor.0_0_0_0_docker_active"):
+        assert state.state == HA_SENSOR_DATA["docker"]["docker_active"]
+    if state := hass.states.get("sensor.0_0_0_0_docker_cpu_use"):
+        assert state.state == HA_SENSOR_DATA["docker"]["docker_cpu_use"]
+    if state := hass.states.get("sensor.0_0_0_0_docker_memory_use"):
+        assert state.state == HA_SENSOR_DATA["docker"]["docker_memory_use"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Added error handling by setting sensor state to `Unavailable` when the received data from glances does not match the expected type.

Background:
When glances sensor plugin is used, it creates a `temperature_hdd` sensor for every hdd entity discovered by the plugin.
This sensor is configured with device_class `temperature`, which expects a numerical value.
When the hdd's discovered by glances do not provide temperature information, the native value is set to strings such aus `NA`, `SLP` or `UNK`.
This leads to HA throwing an error, because the type mismatches, which prevents all glances sensors from updating (see #93417 ).

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #93417
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
