### PR TITLE
Remove nextcloud YAML configuration

### DIFF
--- a/homeassistant/components/nextcloud/__init__.py
+++ b/homeassistant/components/nextcloud/__init__.py
@@ -1,5 +1,4 @@
 """The Nextcloud integration."""
-import logging
 
 from nextcloudmonitor import (
     NextcloudMonitor,
@@ -7,12 +6,10 @@ from nextcloudmonitor import (
     NextcloudMonitorConnectionError,
     NextcloudMonitorRequestError,
 )
-import voluptuous as vol
 
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_PASSWORD,
-    CONF_SCAN_INTERVAL,
     CONF_URL,
     CONF_USERNAME,
     CONF_VERIFY_SSL,
@@ -20,59 +17,11 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
-from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
-from homeassistant.helpers.typing import ConfigType
 
-from .const import DEFAULT_SCAN_INTERVAL, DOMAIN
+from .const import DOMAIN
 from .coordinator import NextcloudDataUpdateCoordinator
 
-_LOGGER = logging.getLogger(__name__)
 PLATFORMS = (Platform.SENSOR, Platform.BINARY_SENSOR)
-
-# Validate user configuration
-CONFIG_SCHEMA = vol.Schema(
-    vol.All(
-        cv.deprecated(DOMAIN),
-        {
-            DOMAIN: vol.Schema(
-                {
-                    vol.Required(CONF_URL): cv.url,
-                    vol.Required(CONF_USERNAME): cv.string,
-                    vol.Required(CONF_PASSWORD): cv.string,
-                    vol.Optional(
-                        CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL
-                    ): cv.time_period,
-                },
-            )
-        },
-    ),
-    extra=vol.ALLOW_EXTRA,
-)
-
-
-async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up the Nextcloud integration."""
-    if DOMAIN in config:
-        async_create_issue(
-            hass,
-            DOMAIN,
-            "deprecated_yaml",
-            breaks_in_ha_version="2023.6.0",
-            is_fixable=False,
-            severity=IssueSeverity.WARNING,
-            translation_key="deprecated_yaml",
-        )
-
-        hass.async_create_task(
-            hass.config_entries.flow.async_init(
-                DOMAIN,
-                context={"source": SOURCE_IMPORT},
-                data=config[DOMAIN],
-            )
-        )
-
-    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/nextcloud/__init__.py
+++ b/homeassistant/components/nextcloud/__init__.py
@@ -17,11 +17,14 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.helpers import config_validation as cv
 
 from .const import DOMAIN
 from .coordinator import NextcloudDataUpdateCoordinator
 
 PLATFORMS = (Platform.SENSOR, Platform.BINARY_SENSOR)
+
+CONFIG_SCHEMA = cv.removed(DOMAIN, raise_if_present=False)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/nextcloud/config_flow.py
+++ b/homeassistant/components/nextcloud/config_flow.py
@@ -2,14 +2,12 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-import logging
 from typing import Any
 
 from nextcloudmonitor import (
     NextcloudMonitor,
     NextcloudMonitorAuthorizationError,
     NextcloudMonitorConnectionError,
-    NextcloudMonitorError,
     NextcloudMonitorRequestError,
 )
 import voluptuous as vol
@@ -35,8 +33,6 @@ DATA_SCHEMA_REAUTH = vol.Schema(
     }
 )
 
-_LOGGER = logging.getLogger(__name__)
-
 
 class NextcloudConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a Nextcloud config flow."""
@@ -52,25 +48,6 @@ class NextcloudConfigFlow(ConfigFlow, domain=DOMAIN):
             user_input[CONF_USERNAME],
             user_input[CONF_PASSWORD],
             user_input.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL),
-        )
-
-    async def async_step_import(self, user_input: dict[str, Any]) -> FlowResult:
-        """Handle a flow initiated by configuration file."""
-        self._async_abort_entries_match({CONF_URL: user_input.get(CONF_URL)})
-        try:
-            await self.hass.async_add_executor_job(self._try_connect_nc, user_input)
-        except NextcloudMonitorError:
-            _LOGGER.error(
-                "Connection error during import of yaml configuration, import aborted"
-            )
-            return self.async_abort(reason="connection_error_during_import")
-        return await self.async_step_user(
-            {
-                CONF_URL: user_input[CONF_URL],
-                CONF_PASSWORD: user_input[CONF_PASSWORD],
-                CONF_USERNAME: user_input[CONF_USERNAME],
-                CONF_VERIFY_SSL: DEFAULT_VERIFY_SSL,
-            }
         )
 
     async def async_step_user(

--- a/homeassistant/components/nextcloud/strings.json
+++ b/homeassistant/components/nextcloud/strings.json
@@ -28,11 +28,5 @@
       "connection_error": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]"
     }
-  },
-  "issues": {
-    "deprecated_yaml": {
-      "title": "The Nextcloud YAML configuration has been deprecated",
-      "description": "Configuring Nextcloud using YAML has been deprecated.\n\nYour existing YAML configuration has been imported into the UI automatically.\n\nRemove the `nextcloud` YAML configuration from your configuration.yaml file and restart Home Assistant to fix this issue."
-    }
   }
 }

--- a/tests/components/nextcloud/test_config_flow.py
+++ b/tests/components/nextcloud/test_config_flow.py
@@ -4,14 +4,13 @@ from unittest.mock import Mock, patch
 from nextcloudmonitor import (
     NextcloudMonitorAuthorizationError,
     NextcloudMonitorConnectionError,
-    NextcloudMonitorError,
     NextcloudMonitorRequestError,
 )
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.nextcloud import DOMAIN
-from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_REAUTH, SOURCE_USER
+from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER
 from homeassistant.const import CONF_PASSWORD, CONF_URL, CONF_USERNAME, CONF_VERIFY_SSL
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -129,67 +128,6 @@ async def test_user_already_configured(
 
     assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "already_configured"
-
-
-async def test_import(
-    hass: HomeAssistant, mock_nextcloud_monitor: Mock, snapshot: SnapshotAssertion
-) -> None:
-    """Test that the import step works."""
-    with patch(
-        "homeassistant.components.nextcloud.config_flow.NextcloudMonitor",
-        return_value=mock_nextcloud_monitor,
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_IMPORT},
-            data=VALID_CONFIG,
-        )
-    assert result["type"] == FlowResultType.CREATE_ENTRY
-    assert result["title"] == "nc_url"
-    assert result["data"] == snapshot
-
-
-async def test_import_already_configured(
-    hass: HomeAssistant, mock_nextcloud_monitor: Mock
-) -> None:
-    """Test that import step is aborted when duplicates are added."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        title="nc_url",
-        unique_id="nc_url",
-        data=VALID_CONFIG,
-    )
-    entry.add_to_hass(hass)
-
-    with patch(
-        "homeassistant.components.nextcloud.config_flow.NextcloudMonitor",
-        return_value=mock_nextcloud_monitor,
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_IMPORT},
-            data=VALID_CONFIG,
-        )
-        await hass.async_block_till_done()
-
-    assert result["type"] == FlowResultType.ABORT
-    assert result["reason"] == "already_configured"
-
-
-async def test_import_connection_error(hass: HomeAssistant) -> None:
-    """Test that import step is aborted on connection error."""
-    with patch(
-        "homeassistant.components.nextcloud.config_flow.NextcloudMonitor",
-        side_effect=NextcloudMonitorError,
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_IMPORT},
-            data=VALID_CONFIG,
-        )
-        await hass.async_block_till_done()
-    assert result["type"] == FlowResultType.ABORT
-    assert result["reason"] == "connection_error_during_import"
 
 
 async def test_reauth(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Configuring Nextcloud via YAML was deprecated in Home Assistant Core 2023.4 and support has now been removed.
The YAML configuration was automatically imported to a config entry by release Home Assistant Core 2023.4 ~ 5. Please remove Nextcloud YAML configuration from your `configuration.yaml` file.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove platform yaml nextcloud, deprecation started in 2023.4 and is now ended after 2 releases.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
