### PR TITLE
Fix history start time state returning None with some postgresql versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,9 +46,10 @@ env:
   MARIADB_VERSIONS: "['mariadb:10.3.32','mariadb:10.6.10','mariadb:10.10.3','mysql:8.0.32']"
   # 12 is the oldest supported version
   # - 12.14 is the latest (as of 9 Feb 2023)
+  # 14.8 reported issues in https://github.com/home-assistant/core/issues/93258
   # 15 is the latest version
   # - 15.2 is the latest (as of 9 Feb 2023)
-  POSTGRESQL_VERSIONS: "['postgres:12.14','postgres:15.2']"
+  POSTGRESQL_VERSIONS: "['postgres:12.14','postgres:14.8','postgres:15.2']"
   PRE_COMMIT_CACHE: ~/.cache/pre-commit
   PIP_CACHE: /tmp/pip-cache
   SQLALCHEMY_WARN_20: 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,10 +46,9 @@ env:
   MARIADB_VERSIONS: "['mariadb:10.3.32','mariadb:10.6.10','mariadb:10.10.3','mysql:8.0.32']"
   # 12 is the oldest supported version
   # - 12.14 is the latest (as of 9 Feb 2023)
-  # 14.8 reported issues in https://github.com/home-assistant/core/issues/93258
   # 15 is the latest version
   # - 15.2 is the latest (as of 9 Feb 2023)
-  POSTGRESQL_VERSIONS: "['postgres:12.14','postgres:14.8','postgres:15.2']"
+  POSTGRESQL_VERSIONS: "['postgres:12.14','postgres:15.2']"
   PRE_COMMIT_CACHE: ~/.cache/pre-commit
   PIP_CACHE: /tmp/pip-cache
   SQLALCHEMY_WARN_20: 1

--- a/homeassistant/components/recorder/history/modern.py
+++ b/homeassistant/components/recorder/history/modern.py
@@ -264,6 +264,7 @@ def get_significant_states_with_session(
         entity_id_to_metadata_id,
         minimal_response,
         compressed_state_format,
+        no_attributes=no_attributes,
     )
 
 
@@ -418,6 +419,7 @@ def state_changes_during_period(
                 entity_ids,
                 entity_id_to_metadata_id,
                 descending=descending,
+                no_attributes=no_attributes,
             ),
         )
 
@@ -513,6 +515,7 @@ def get_last_state_changes(
                 None,
                 entity_ids,
                 entity_id_to_metadata_id,
+                no_attributes=False,
             ),
         )
 
@@ -636,6 +639,7 @@ def _sorted_states_to_dict(
     minimal_response: bool = False,
     compressed_state_format: bool = False,
     descending: bool = False,
+    no_attributes: bool = False,
 ) -> MutableMapping[str, list[State | dict[str, Any]]]:
     """Convert SQL results into JSON friendly data structure.
 
@@ -650,7 +654,7 @@ def _sorted_states_to_dict(
     """
     field_map = _FIELD_MAP
     state_class: Callable[
-        [Row, dict[str, dict[str, Any]], float | None, str, str, float | None],
+        [Row, dict[str, dict[str, Any]], float | None, str, str, float | None, bool],
         State | dict[str, Any],
     ]
     if compressed_state_format:
@@ -701,6 +705,7 @@ def _sorted_states_to_dict(
                     entity_id,
                     db_state[state_idx],
                     db_state[last_updated_ts_idx],
+                    False,
                 )
                 for db_state in group
             )
@@ -723,6 +728,7 @@ def _sorted_states_to_dict(
                     entity_id,
                     prev_state,  # type: ignore[arg-type]
                     first_state[last_updated_ts_idx],
+                    no_attributes,
                 )
             )
 

--- a/homeassistant/components/recorder/models/state.py
+++ b/homeassistant/components/recorder/models/state.py
@@ -53,6 +53,7 @@ class LazyState(State):
         entity_id: str,
         state: str,
         last_updated_ts: float | None,
+        no_attributes: bool,
     ) -> None:
         """Init the lazy state."""
         self._row = row
@@ -143,14 +144,14 @@ def row_to_compressed_state(
     entity_id: str,
     state: str,
     last_updated_ts: float | None,
+    no_attributes: bool,
 ) -> dict[str, Any]:
     """Convert a database row to a compressed state schema 41 and later."""
-    comp_state: dict[str, Any] = {
-        COMPRESSED_STATE_STATE: state,
-        COMPRESSED_STATE_ATTRIBUTES: decode_attributes_from_source(
+    comp_state: dict[str, Any] = {COMPRESSED_STATE_STATE: state}
+    if not no_attributes:
+        comp_state[COMPRESSED_STATE_ATTRIBUTES] = decode_attributes_from_source(
             getattr(row, "attributes", None), attr_cache
-        ),
-    }
+        )
     row_last_updated_ts: float = last_updated_ts or start_time_ts  # type: ignore[assignment]
     comp_state[COMPRESSED_STATE_LAST_UPDATED] = row_last_updated_ts
     if (

--- a/tests/components/history/test_websocket_api.py
+++ b/tests/components/history/test_websocket_api.py
@@ -98,7 +98,7 @@ async def test_history_during_period(
     assert len(sensor_test_history) == 3
 
     assert sensor_test_history[0]["s"] == "on"
-    assert sensor_test_history[0]["a"] == {}
+    assert "a" not in sensor_test_history[0]  # no_attributes = True
     assert isinstance(sensor_test_history[0]["lu"], float)
     assert "lc" not in sensor_test_history[0]  # skipped if the same a last_updated (lu)
 
@@ -511,17 +511,13 @@ async def test_history_stream_historical_only(
             "start_time": now.timestamp(),
             "states": {
                 "sensor.four": [
-                    {"a": {}, "lu": sensor_four_last_updated.timestamp(), "s": "off"}
+                    {"lu": sensor_four_last_updated.timestamp(), "s": "off"}
                 ],
-                "sensor.one": [
-                    {"a": {}, "lu": sensor_one_last_updated.timestamp(), "s": "on"}
-                ],
+                "sensor.one": [{"lu": sensor_one_last_updated.timestamp(), "s": "on"}],
                 "sensor.three": [
-                    {"a": {}, "lu": sensor_three_last_updated.timestamp(), "s": "off"}
+                    {"lu": sensor_three_last_updated.timestamp(), "s": "off"}
                 ],
-                "sensor.two": [
-                    {"a": {}, "lu": sensor_two_last_updated.timestamp(), "s": "off"}
-                ],
+                "sensor.two": [{"lu": sensor_two_last_updated.timestamp(), "s": "off"}],
             },
         },
         "id": 1,
@@ -858,12 +854,8 @@ async def test_history_stream_live_no_attributes_minimal_response(
             "end_time": first_end_time,
             "start_time": now.timestamp(),
             "states": {
-                "sensor.one": [
-                    {"a": {}, "lu": sensor_one_last_updated.timestamp(), "s": "on"}
-                ],
-                "sensor.two": [
-                    {"a": {}, "lu": sensor_two_last_updated.timestamp(), "s": "off"}
-                ],
+                "sensor.one": [{"lu": sensor_one_last_updated.timestamp(), "s": "on"}],
+                "sensor.two": [{"lu": sensor_two_last_updated.timestamp(), "s": "off"}],
             },
         },
         "id": 1,
@@ -1221,12 +1213,8 @@ async def test_history_stream_live_no_attributes_minimal_response_specific_entit
             "end_time": first_end_time,
             "start_time": now.timestamp(),
             "states": {
-                "sensor.one": [
-                    {"a": {}, "lu": sensor_one_last_updated.timestamp(), "s": "on"}
-                ],
-                "sensor.two": [
-                    {"a": {}, "lu": sensor_two_last_updated.timestamp(), "s": "off"}
-                ],
+                "sensor.one": [{"lu": sensor_one_last_updated.timestamp(), "s": "on"}],
+                "sensor.two": [{"lu": sensor_two_last_updated.timestamp(), "s": "off"}],
             },
         },
         "id": 1,
@@ -1307,12 +1295,8 @@ async def test_history_stream_live_with_future_end_time(
             "end_time": first_end_time,
             "start_time": now.timestamp(),
             "states": {
-                "sensor.one": [
-                    {"a": {}, "lu": sensor_one_last_updated.timestamp(), "s": "on"}
-                ],
-                "sensor.two": [
-                    {"a": {}, "lu": sensor_two_last_updated.timestamp(), "s": "off"}
-                ],
+                "sensor.one": [{"lu": sensor_one_last_updated.timestamp(), "s": "on"}],
+                "sensor.two": [{"lu": sensor_two_last_updated.timestamp(), "s": "off"}],
             },
         },
         "id": 1,
@@ -1506,10 +1490,10 @@ async def test_overflow_queue(
                 "start_time": now.timestamp(),
                 "states": {
                     "sensor.one": [
-                        {"a": {}, "lu": sensor_one_last_updated.timestamp(), "s": "on"}
+                        {"lu": sensor_one_last_updated.timestamp(), "s": "on"}
                     ],
                     "sensor.two": [
-                        {"a": {}, "lu": sensor_two_last_updated.timestamp(), "s": "off"}
+                        {"lu": sensor_two_last_updated.timestamp(), "s": "off"}
                     ],
                 },
             },
@@ -1723,9 +1707,7 @@ async def test_history_stream_for_invalid_entity_ids(
             "end_time": sensor_one_last_updated.timestamp(),
             "start_time": now.timestamp(),
             "states": {
-                "sensor.one": [
-                    {"a": {}, "lu": sensor_one_last_updated.timestamp(), "s": "on"}
-                ],
+                "sensor.one": [{"lu": sensor_one_last_updated.timestamp(), "s": "on"}],
             },
         },
         "id": 1,
@@ -1755,12 +1737,8 @@ async def test_history_stream_for_invalid_entity_ids(
             "end_time": sensor_two_last_updated.timestamp(),
             "start_time": now.timestamp(),
             "states": {
-                "sensor.one": [
-                    {"a": {}, "lu": sensor_one_last_updated.timestamp(), "s": "on"}
-                ],
-                "sensor.two": [
-                    {"a": {}, "lu": sensor_two_last_updated.timestamp(), "s": "off"}
-                ],
+                "sensor.one": [{"lu": sensor_one_last_updated.timestamp(), "s": "on"}],
+                "sensor.two": [{"lu": sensor_two_last_updated.timestamp(), "s": "off"}],
             },
         },
         "id": 2,
@@ -1913,11 +1891,10 @@ async def test_history_stream_historical_only_with_start_time_state_past(
             "start_time": now.timestamp(),
             "states": {
                 "sensor.four": [
-                    {"a": {}, "lu": sensor_four_last_updated.timestamp(), "s": "off"}
+                    {"lu": sensor_four_last_updated.timestamp(), "s": "off"}
                 ],
                 "sensor.one": [
                     {
-                        "a": {},
                         "lu": now.timestamp(),
                         "s": "first",
                     },  # should use start time state
@@ -1925,11 +1902,9 @@ async def test_history_stream_historical_only_with_start_time_state_past(
                     {"lu": sensor_one_last_updated_third.timestamp(), "s": "third"},
                 ],
                 "sensor.three": [
-                    {"a": {}, "lu": sensor_three_last_updated.timestamp(), "s": "off"}
+                    {"lu": sensor_three_last_updated.timestamp(), "s": "off"}
                 ],
-                "sensor.two": [
-                    {"a": {}, "lu": sensor_two_last_updated.timestamp(), "s": "off"}
-                ],
+                "sensor.two": [{"lu": sensor_two_last_updated.timestamp(), "s": "off"}],
             },
         },
         "id": 1,

--- a/tests/components/recorder/test_models.py
+++ b/tests/components/recorder/test_models.py
@@ -271,7 +271,7 @@ async def test_lazy_state_handles_include_json(
         entity_id="sensor.invalid",
         shared_attrs="{INVALID_JSON}",
     )
-    assert LazyState(row, {}, None, row.entity_id, "", 1).attributes == {}
+    assert LazyState(row, {}, None, row.entity_id, "", 1, False).attributes == {}
     assert "Error converting row to state attributes" in caplog.text
 
 
@@ -283,7 +283,9 @@ async def test_lazy_state_can_decode_attributes(
         entity_id="sensor.invalid",
         attributes='{"shared":true}',
     )
-    assert LazyState(row, {}, None, row.entity_id, "", 1).attributes == {"shared": True}
+    assert LazyState(row, {}, None, row.entity_id, "", 1, False).attributes == {
+        "shared": True
+    }
 
 
 async def test_lazy_state_handles_different_last_updated_and_last_changed(
@@ -298,7 +300,9 @@ async def test_lazy_state_handles_different_last_updated_and_last_changed(
         last_updated_ts=now.timestamp(),
         last_changed_ts=(now - timedelta(seconds=60)).timestamp(),
     )
-    lstate = LazyState(row, {}, None, row.entity_id, row.state, row.last_updated_ts)
+    lstate = LazyState(
+        row, {}, None, row.entity_id, row.state, row.last_updated_ts, False
+    )
     assert lstate.as_dict() == {
         "attributes": {"shared": True},
         "entity_id": "sensor.valid",
@@ -329,7 +333,9 @@ async def test_lazy_state_handles_same_last_updated_and_last_changed(
         last_updated_ts=now.timestamp(),
         last_changed_ts=now.timestamp(),
     )
-    lstate = LazyState(row, {}, None, row.entity_id, row.state, row.last_updated_ts)
+    lstate = LazyState(
+        row, {}, None, row.entity_id, row.state, row.last_updated_ts, False
+    )
     assert lstate.as_dict() == {
         "attributes": {"shared": True},
         "entity_id": "sensor.valid",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
postgresql does not guarantee the unioned query will be returned in the order it was constructed because of https://www.postgresql.org/docs/14/parallel-plans.html#PARALLEL-APPEND. It may return the start time state query after the primary data query instead of before as the query was made.

We now re-sort the whole unioned query after its built.  This comes with a performance hit (still faster than 2023.4.x was) but I don't see a way to avoid it since the database cannot make a guarantee on the order without it.

This also fixes an internal exception happening in sqlalchemy ( that wasn't being raised ) which was now obvious because we failed to pass `no_attributes` for the first state in the result set.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #93258
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
