### PR TITLE
Make SMTP notify send images as attachments if html is disabled

### DIFF
--- a/tests/components/smtp/test_notify.py
+++ b/tests/components/smtp/test_notify.py
@@ -101,7 +101,7 @@ EMAIL_DATA = [
     (
         "Test msg",
         {"images": ["tests/testing_config/notify/test.jpg"]},
-        "Content-Type: multipart/related",
+        "Content-Type: multipart/mixed",
     ),
     (
         "Test msg",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
SMTP integration will send images as attachments to a plain text email instead of html in-line when the `html` field is not set. Previous behavior was to send all images as html in-line even when the `html` field was not set. To continue sending images as in-line, please set the optional `html` field and include the images as `<img src="cid:image_name.ext">` within the html block as described in the docs: https://www.home-assistant.io/integrations/smtp/#usage

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Current behavior:
1. Plain text message (no `html` or `images` defined), is sent as plain text
2. Plain text message with `images` defined (no `html` defined) is sent as html with images in-line
3. Messages with `html` defined are sent as html with images in-line (if any)

Proposed behavior:
1. Plain text message (no `html` or `images` defined), is sent as plain text (No change)
2. **_Plain text message with `images` defined (no `html` defined) is sent as plain text with images as separate attachments_**
3. Messages with `html` defined are sent as html with images in-line (if any) (No change)

Only proposed change is to the second type listed above. Currently, if the user drafts a plain text message, but adds an image, it is force converted to html and sent that way. That is not the user's intention as they could have drafted an html message if that were the intention. This change respects the user's choice with regards to plain text vs html.

I personally consider this a bugfix, because currently a plain text email is force converted to html. Most notable issue it causes is when we try to use an email-sms gateway to send a text message to a cell phone (ie. email to `5555555555@msg.fi.google.com`). Without an image, email is sent plain text and is successfully delivered to the mobile device as a text/sms message. With an image, the mobile device displays the message body as raw html, and the inline images are entirely missing.

With the proposed changes, a plain text email with images get delivered to the mobile device as a proper plain text mms, along with the pictures as mms attachments.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/27524

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
