### PR TITLE
Fix missed case for device tuple fallback in rfxtrx

### DIFF
--- a/homeassistant/components/rfxtrx/helpers.py
+++ b/homeassistant/components/rfxtrx/helpers.py
@@ -18,8 +18,8 @@ def async_get_device_object(hass: HomeAssistant, device_id: str) -> RFXtrxDevice
         raise ValueError(f"Device {device_id} not found")
 
     device_tuple = get_device_tuple_from_identifiers(registry_device.identifiers)
-    if device_tuple is None:
-        raise ValueError(f"Can't find tuple for {device_id}")
+    assert device_tuple
+
     return get_device(
         int(device_tuple[0], 16), int(device_tuple[1], 16), device_tuple[2]
     )

--- a/homeassistant/components/rfxtrx/helpers.py
+++ b/homeassistant/components/rfxtrx/helpers.py
@@ -6,6 +6,8 @@ from RFXtrx import RFXtrxDevice, get_device
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
 
+from . import get_device_tuple_from_identifiers
+
 
 @callback
 def async_get_device_object(hass: HomeAssistant, device_id: str) -> RFXtrxDevice:
@@ -15,7 +17,9 @@ def async_get_device_object(hass: HomeAssistant, device_id: str) -> RFXtrxDevice
     if registry_device is None:
         raise ValueError(f"Device {device_id} not found")
 
-    device_tuple = list(list(registry_device.identifiers)[0])
+    device_tuple = get_device_tuple_from_identifiers(registry_device.identifiers)
+    if device_tuple is None:
+        raise ValueError(f"Can't find tuple for {device_id}")
     return get_device(
-        int(device_tuple[1], 16), int(device_tuple[2], 16), device_tuple[3]
+        int(device_tuple[0], 16), int(device_tuple[1], 16), device_tuple[2]
     )

--- a/tests/components/rfxtrx/test_device_action.py
+++ b/tests/components/rfxtrx/test_device_action.py
@@ -89,6 +89,14 @@ async def test_get_actions(
     device_entry = device_registry.async_get_device(device.device_identifiers, set())
     assert device_entry
 
+    # Add alternate identifiers, to make sure we can handle future formats
+    identifiers: list[str] = list(*device_entry.identifiers)
+    device_registry.async_update_device(
+        device_entry.id, merge_identifiers={(identifiers[0], "_".join(identifiers[1:]))}
+    )
+    device_entry = device_registry.async_get_device(device.device_identifiers, set())
+    assert device_entry
+
     actions = await async_get_device_automations(
         hass, DeviceAutomationType.ACTION, device_entry.id
     )

--- a/tests/components/rfxtrx/test_device_trigger.py
+++ b/tests/components/rfxtrx/test_device_trigger.py
@@ -88,6 +88,15 @@ async def test_get_triggers(
     await setup_entry(hass, {event.code: {}})
 
     device_entry = device_registry.async_get_device(event.device_identifiers, set())
+    assert device_entry
+
+    # Add alternate identifiers, to make sure we can handle future formats
+    identifiers: list[str] = list(*event.device_identifiers)
+    device_registry.async_update_device(
+        device_entry.id, merge_identifiers={(identifiers[0], "_".join(identifiers[1:]))}
+    )
+    device_entry = device_registry.async_get_device(event.device_identifiers, set())
+    assert device_entry
 
     expected_triggers = [
         {


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Previously the code was prepared for a backward compatible migration of tuples, where both styles of identifiers might exist in device registry at the same time.

This place was sadly missed. So if we add new style of identifiers to registry, downgrades would fail. So until this has propagated out into mainstream for one or two releases, identifier migration need to wait.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
