### PR TITLE
Fix not retrying on connection reset during nexia config entry setup

### DIFF
--- a/homeassistant/components/nexia/__init__.py
+++ b/homeassistant/components/nexia/__init__.py
@@ -56,6 +56,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             )
             return False
         raise ConfigEntryNotReady(f"Error from Nexia service: {http_ex}") from http_ex
+    except aiohttp.ClientOSError as os_error:
+        raise ConfigEntryNotReady(
+            f"Error connecting to Nexia service: {os_error}"
+        ) from os_error
 
     coordinator = NexiaDataUpdateCoordinator(hass, nexia_home)
     await coordinator.async_config_entry_first_refresh()

--- a/tests/components/nexia/test_init.py
+++ b/tests/components/nexia/test_init.py
@@ -1,5 +1,8 @@
 """The init tests for the nexia platform."""
+import aiohttp
+
 from homeassistant.components.nexia.const import DOMAIN
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import EntityRegistry
@@ -8,6 +11,12 @@ from homeassistant.setup import async_setup_component
 from .util import async_init_integration
 
 from tests.typing import WebSocketGenerator
+
+
+async def test_setup_retry_client_os_error(hass: HomeAssistant) -> None:
+    """Verify we retry setup on aiohttp.ClientOSError."""
+    config_entry = await async_init_integration(hass, exception=aiohttp.ClientOSError)
+    assert config_entry.state == ConfigEntryState.SETUP_RETRY
 
 
 async def remove_device(ws_client, device_id, config_entry_id):

--- a/tests/components/nexia/util.py
+++ b/tests/components/nexia/util.py
@@ -15,6 +15,7 @@ from tests.test_util.aiohttp import mock_aiohttp_client
 async def async_init_integration(
     hass: HomeAssistant,
     skip_setup: bool = False,
+    exception: Exception | None = None,
 ) -> MockConfigEntry:
     """Set up the nexia integration in Home Assistant."""
 
@@ -25,9 +26,18 @@ async def async_init_integration(
         "nexia.home.load_or_create_uuid", return_value=uuid.uuid4()
     ):
         nexia = NexiaHome(mock_session)
-        mock_session.post(
-            nexia.API_MOBILE_SESSION_URL, text=load_fixture(session_fixture)
-        )
+        if exception:
+
+            async def _raise_exception(*args, **kwargs):
+                raise exception
+
+            mock_session.post(
+                nexia.API_MOBILE_SESSION_URL, side_effect=_raise_exception
+            )
+        else:
+            mock_session.post(
+                nexia.API_MOBILE_SESSION_URL, text=load_fixture(session_fixture)
+            )
         mock_session.get(
             nexia.API_MOBILE_HOUSES_URL.format(house_id=123456),
             text=load_fixture(house_fixture),


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
fixes
```
2023-05-26 00:15:39.129 ERROR (MainThread) [homeassistant.config_entries] Error setting up entry Alexander for nexia
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/aiohttp/client.py", line 558, in _request
    resp = await req.send(conn)
           ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/aiohttp/client_reqrep.py", line 670, in send
    await writer.write_headers(status_line, self.headers)
  File "/usr/local/lib/python3.11/site-packages/aiohttp/http_writer.py", line 130, in write_headers
    self._write(buf)
  File "/usr/local/lib/python3.11/site-packages/aiohttp/http_writer.py", line 75, in _write
    raise ConnectionResetError("Cannot write to closing transport")
ConnectionResetError: Cannot write to closing transport

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 387, in async_setup
    result = await component.async_setup_entry(hass, self)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/nexia/__init__.py", line 47, in async_setup_entry
    await nexia_home.login()
  File "/usr/local/lib/python3.11/site-packages/nexia/home.py", line 385, in login
    request = await self.post_url(self.API_MOBILE_ACCOUNTS_SIGN_IN_URL, payload)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/nexia/home.py", line 157, in post_url
    response: aiohttp.ClientResponse = await self.session.post(
                                       ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/aiohttp/client.py", line 572, in _request
    raise ClientOSError(*exc.args) from exc
aiohttp.client_exceptions.ClientOSError: Cannot write to closing transport
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
