### PR TITLE
Add check for integration config schema to hassfest

### DIFF
--- a/script/hassfest/__main__.py
+++ b/script/hassfest/__main__.py
@@ -11,6 +11,7 @@ from . import (
     bluetooth,
     codeowners,
     config_flow,
+    config_schema,
     coverage,
     dependencies,
     dhcp,
@@ -32,6 +33,7 @@ INTEGRATION_PLUGINS = [
     application_credentials,
     bluetooth,
     codeowners,
+    config_schema,
     dependencies,
     dhcp,
     json,
@@ -43,7 +45,7 @@ INTEGRATION_PLUGINS = [
     translations,
     usb,
     zeroconf,
-    config_flow,
+    config_flow,  # This needs to run last, after translations are processed
 ]
 HASS_PLUGINS = [
     coverage,

--- a/script/hassfest/config_schema.py
+++ b/script/hassfest/config_schema.py
@@ -1,0 +1,95 @@
+"""Generate config flow file."""
+from __future__ import annotations
+
+import ast
+
+from .model import Config, Integration
+
+UNIQUE_ID_IGNORE = {"huawei_lte", "mqtt", "adguard"}
+
+
+def _has_assignment(module: ast.Module, name: str) -> bool:
+    """Test if the module assigns to a name."""
+    for item in module.body:
+        if type(item) not in (ast.Assign, ast.AnnAssign, ast.AugAssign):
+            continue
+        if type(item) == ast.Assign:
+            for target in item.targets:
+                if target.id == name:
+                    return True
+            continue
+        if item.target.id == name:
+            return True
+    return False
+
+
+def _has_function(
+    module: ast.Module, _type: ast.AsyncFunctionDef | ast.FunctionDef, name: str
+) -> bool:
+    """Test if the module defines a function."""
+    for item in module.body:
+        if type(item) == _type and item.name == name:
+            return True
+    return False
+
+
+def _has_import(module: ast.Module, name: str) -> bool:
+    """Test if the module imports to a name."""
+    for item in module.body:
+        if type(item) not in (ast.Import, ast.ImportFrom):
+            continue
+        for alias in item.names:
+            if alias.asname == name or (alias.asname is None and alias.name == name):
+                return True
+    return False
+
+
+def _validate_integration(config: Config, integration: Integration) -> None:
+    """Validate integration has has a configuration schema."""
+    init_file = integration.path / "__init__.py"
+
+    if not init_file.is_file():
+        # Virtual integrations don't have any implementation
+        return
+
+    init = ast.parse(init_file.read_text())
+
+    no_yaml_support = not _has_function(
+        init, ast.AsyncFunctionDef, "async_setup"
+    ) and not _has_function(init, ast.FunctionDef, "setup")
+
+    if no_yaml_support:
+        return
+
+    has_schema = (
+        _has_assignment(init, "CONFIG_SCHEMA")
+        or _has_assignment(init, "PLATFORM_SCHEMA")
+        or _has_assignment(init, "PLATFORM_SCHEMA_BASE")
+        or _has_import(init, "CONFIG_SCHEMA")
+        or _has_import(init, "PLATFORM_SCHEMA")
+        or _has_import(init, "PLATFORM_SCHEMA_BASE")
+    )
+
+    if has_schema:
+        return
+
+    if config.specific_integrations:
+        notice_method = integration.add_warning
+    else:
+        notice_method = integration.add_error
+
+    notice_method(
+        "config_schema",
+        "Integrations which implement 'async_setup' or 'setup' must "
+        "define either 'CONFIG_SCHEMA', 'PLATFORM_SCHEMA' or 'PLATFORM_SCHEMA_BASE'. "
+        "If the integration has no configuration parameters or can not be setup from "
+        "YAML, import one of CONFIG_SCHEMA_... from "
+        "homeassistant.helpers.config_validation as CONFIG_SCHEMA",
+    )
+
+
+def validate(integrations: dict[str, Integration], config: Config) -> None:
+    """Validate integrations have configuration schemas."""
+    for domain in sorted(integrations):
+        integration = integrations[domain]
+        _validate_integration(config, integration)

--- a/script/hassfest/config_schema.py
+++ b/script/hassfest/config_schema.py
@@ -1,4 +1,4 @@
-"""Generate config flow file."""
+"""Validate integrations which can be setup from YAML have config schemas."""
 from __future__ import annotations
 
 import ast

--- a/script/hassfest/config_schema.py
+++ b/script/hassfest/config_schema.py
@@ -59,7 +59,7 @@ def _validate_integration(config: Config, integration: Integration) -> None:
         return
 
     # No schema
-    if not (
+    if (
         _has_assignment(init, "CONFIG_SCHEMA")
         or _has_assignment(init, "PLATFORM_SCHEMA")
         or _has_assignment(init, "PLATFORM_SCHEMA_BASE")

--- a/script/hassfest/config_schema.py
+++ b/script/hassfest/config_schema.py
@@ -52,23 +52,21 @@ def _validate_integration(config: Config, integration: Integration) -> None:
 
     init = ast.parse(init_file.read_text())
 
-    no_yaml_support = not _has_function(
+    # No YAML Support
+    if not _has_function(
         init, ast.AsyncFunctionDef, "async_setup"
-    ) and not _has_function(init, ast.FunctionDef, "setup")
-
-    if no_yaml_support:
+    ) and not _has_function(init, ast.FunctionDef, "setup"):
         return
 
-    has_schema = (
+    # No schema
+    if not (
         _has_assignment(init, "CONFIG_SCHEMA")
         or _has_assignment(init, "PLATFORM_SCHEMA")
         or _has_assignment(init, "PLATFORM_SCHEMA_BASE")
         or _has_import(init, "CONFIG_SCHEMA")
         or _has_import(init, "PLATFORM_SCHEMA")
         or _has_import(init, "PLATFORM_SCHEMA_BASE")
-    )
-
-    if has_schema:
+    ):
         return
 
     if config.specific_integrations:

--- a/script/hassfest/config_schema.py
+++ b/script/hassfest/config_schema.py
@@ -5,6 +5,13 @@ import ast
 
 from .model import Config, Integration
 
+CONFIG_SCHEMA_IGNORE = {
+    # Configuration under the homeassistant key is a special case, it's handled by
+    # conf_util.async_process_ha_core_config already during bootstrapping, not by
+    # a schema in the homeassistant integration.
+    "homeassistant",
+}
+
 
 def _has_assignment(module: ast.Module, name: str) -> bool:
     """Test if the module assigns to a name."""
@@ -44,6 +51,9 @@ def _has_import(module: ast.Module, name: str) -> bool:
 
 def _validate_integration(config: Config, integration: Integration) -> None:
     """Validate integration has has a configuration schema."""
+    if integration.domain in CONFIG_SCHEMA_IGNORE:
+        return
+
     init_file = integration.path / "__init__.py"
 
     if not init_file.is_file():

--- a/script/hassfest/config_schema.py
+++ b/script/hassfest/config_schema.py
@@ -92,11 +92,12 @@ def _validate_integration(config: Config, integration: Integration) -> None:
 
     notice_method(
         "config_schema",
-        "Integrations which implement 'async_setup' or 'setup' must "
-        "define either 'CONFIG_SCHEMA', 'PLATFORM_SCHEMA' or 'PLATFORM_SCHEMA_BASE'. "
-        "If the integration has no configuration parameters or can not be setup from "
-        "YAML, import one of CONFIG_SCHEMA_... from "
-        "homeassistant.helpers.config_validation as CONFIG_SCHEMA",
+        "Integrations which implement 'async_setup' or 'setup' must define either "
+        "'CONFIG_SCHEMA', 'PLATFORM_SCHEMA' or 'PLATFORM_SCHEMA_BASE'. If the "
+        "integration has no configuration parameters, can only be set up from platforms"
+        " or can only be set up from config entries, one of the helpers "
+        "cv.empty_config_schema, cv.platform_only_config_schema or "
+        "cv.config_entry_only_config_schema can be used.",
     )
 
 

--- a/script/hassfest/config_schema.py
+++ b/script/hassfest/config_schema.py
@@ -69,6 +69,12 @@ def _validate_integration(config: Config, integration: Integration) -> None:
     ):
         return
 
+    config_file = integration.path / "config.py"
+    if config_file.is_file():
+        config_module = ast.parse(config_file.read_text())
+        if _has_function(config_module, ast.AsyncFunctionDef, "async_validate_config"):
+            return
+
     if config.specific_integrations:
         notice_method = integration.add_warning
     else:

--- a/script/hassfest/config_schema.py
+++ b/script/hassfest/config_schema.py
@@ -5,8 +5,6 @@ import ast
 
 from .model import Config, Integration
 
-UNIQUE_ID_IGNORE = {"huawei_lte", "mqtt", "adguard"}
-
 
 def _has_assignment(module: ast.Module, name: str) -> bool:
     """Test if the module assigns to a name."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add check for integration config schema to hassfest

### Background:
Integrations which can be setup via YAML but don't support any configuration parameters commonly don't declare any CONFIG_SCHEMA. This means useless configurations such as this won't be warned against:
```
api:
   blah # Not supported by the `api` integration
```

Also, there is no warning if integrations which can not be setup via YAML are referenced in the configuration.
There are two cases, integrations which define an `async_setup` or `setup` but can't be setup via YAML and integrations which don't declare `async_setup` or `setup`.

### Suggestion:
- Enforce that integrations with `async_setup` or `setup` has either of `CONFIG_SCHEMA`, `PLATFORM_SCHEMA`, `PLATFORM_SCHEMA_BASE` or a `config` platform
  - Implemented in this PR
  - Existing integrations which fail the new check should either declare an empty schema if setup via yaml is possible (for example `api`), or a schema which logs a warning / repair saying yaml configuration is not supported (for example `discord`)
  Updating integrations will be handled in separate PRs
- For integrations which do not have `async_setup` or `setup` but are referenced in the config we log a warning / repair
  - https://github.com/home-assistant/core/pull/93589

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
