### PR TITLE
Add demo entities with color temperature / brightness mode only

### DIFF
--- a/homeassistant/components/demo/light.py
+++ b/homeassistant/components/demo/light.py
@@ -90,7 +90,7 @@ async def async_setup_entry(
             ),
             DemoLight(
                 available=True,
-                name="Bathroom CT Lights",
+                device_name="Bathroom CT Lights",
                 ct=LIGHT_TEMPS[1],
                 state=True,
                 supported_color_modes={ColorMode.COLOR_TEMP},
@@ -98,7 +98,7 @@ async def async_setup_entry(
             ),
             DemoLight(
                 available=True,
-                name="Garage Brightness Lights",
+                device_name="Garage Brightness Lights",
                 state=True,
                 supported_color_modes={ColorMode.BRIGHTNESS},
                 unique_id="light_8",

--- a/homeassistant/components/demo/light.py
+++ b/homeassistant/components/demo/light.py
@@ -153,8 +153,6 @@ class DemoLight(LightEntity):
             self._color_mode = ColorMode.COLOR_TEMP
         elif supported_color_modes and ColorMode.BRIGHTNESS in supported_color_modes:
             self._color_mode = ColorMode.BRIGHTNESS
-        elif supported_color_modes and ColorMode.ONOFF in supported_color_modes:
-            self._color_mode = ColorMode.ONOFF
         else:
             self._color_mode = ColorMode.COLOR_TEMP
         if self._effect_list is not None:

--- a/homeassistant/components/demo/light.py
+++ b/homeassistant/components/demo/light.py
@@ -88,6 +88,14 @@ async def async_setup_entry(
                 supported_color_modes=SUPPORT_DEMO_HS_WHITE,
                 unique_id="light_6",
             ),
+            DemoLight(
+                available=True,
+                name="Bathroom CT Lights",
+                ct=LIGHT_TEMPS[1],
+                state=True,
+                supported_color_modes={ColorMode.COLOR_TEMP},
+                unique_id="light_7",
+            ),
         ]
     )
 

--- a/homeassistant/components/demo/light.py
+++ b/homeassistant/components/demo/light.py
@@ -96,6 +96,13 @@ async def async_setup_entry(
                 supported_color_modes={ColorMode.COLOR_TEMP},
                 unique_id="light_7",
             ),
+            DemoLight(
+                available=True,
+                name="Garage Brightness Lights",
+                state=True,
+                supported_color_modes={ColorMode.BRIGHTNESS},
+                unique_id="light_8",
+            ),
         ]
     )
 

--- a/homeassistant/components/demo/light.py
+++ b/homeassistant/components/demo/light.py
@@ -146,8 +146,12 @@ class DemoLight(LightEntity):
             self._color_mode = ColorMode.RGBW
         elif rgbww_color:
             self._color_mode = ColorMode.RGBWW
-        else:
+        elif ct:
             self._color_mode = ColorMode.COLOR_TEMP
+        elif supported_color_modes and ColorMode.BRIGHTNESS in supported_color_modes:
+            self._color_mode = ColorMode.BRIGHTNESS
+        else:
+            self._color_mode = ColorMode.ONOFF
         if not supported_color_modes:
             supported_color_modes = SUPPORT_DEMO
         self._color_modes = supported_color_modes

--- a/homeassistant/components/demo/light.py
+++ b/homeassistant/components/demo/light.py
@@ -140,6 +140,9 @@ class DemoLight(LightEntity):
         self._rgbww_color = rgbww_color
         self._state = state
         self._unique_id = unique_id
+        if not supported_color_modes:
+            supported_color_modes = SUPPORT_DEMO
+        self._color_modes = supported_color_modes
         if hs_color:
             self._color_mode = ColorMode.HS
         elif rgbw_color:
@@ -150,11 +153,10 @@ class DemoLight(LightEntity):
             self._color_mode = ColorMode.COLOR_TEMP
         elif supported_color_modes and ColorMode.BRIGHTNESS in supported_color_modes:
             self._color_mode = ColorMode.BRIGHTNESS
-        else:
+        elif supported_color_modes and ColorMode.ONOFF in supported_color_modes:
             self._color_mode = ColorMode.ONOFF
-        if not supported_color_modes:
-            supported_color_modes = SUPPORT_DEMO
-        self._color_modes = supported_color_modes
+        else:
+            self._color_mode = ColorMode.COLOR_TEMP
         if self._effect_list is not None:
             self._attr_supported_features |= LightEntityFeature.EFFECT
         self._attr_device_info = DeviceInfo(

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -93,6 +93,8 @@ ENTITY_IDS_BY_NUMBER = {
     "24": "media_player.kitchen",
     "25": "light.office_rgbw_lights",
     "26": "light.living_room_rgbww_lights",
+    "27": "light.bathroom_ct_lights",
+    "28": "light.garage_brightness_lights",
 }
 
 ENTITY_NUMBERS_BY_ID = {v: k for k, v in ENTITY_IDS_BY_NUMBER.items()}

--- a/tests/components/google_assistant/__init__.py
+++ b/tests/components/google_assistant/__init__.py
@@ -422,4 +422,25 @@ DEMO_DEVICES = [
         "type": "action.devices.types.LIGHT",
         "willReportState": False,
     },
+    {
+        "id": "light.bathroom_ct_lights",
+        "name": {"name": "Bathroom CT Lights"},
+        "traits": [
+            "action.devices.traits.OnOff",
+            "action.devices.traits.Brightness",
+            "action.devices.traits.ColorSetting",
+        ],
+        "type": "action.devices.types.LIGHT",
+        "willReportState": False,
+    },
+    {
+        "id": "light.garage_brightness_lights",
+        "name": {"name": "Garage Brightness Lights"},
+        "traits": [
+            "action.devices.traits.OnOff",
+            "action.devices.traits.Brightness",
+        ],
+        "type": "action.devices.types.LIGHT",
+        "willReportState": False,
+    },
 ]


### PR DESCRIPTION
## Proposed change

Add lights demo with temperature color mode only and brightness mode only for easier front-end development.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
