### PR TITLE
Fix async_track_point_in_utc_time firing too early

### DIFF
--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -1327,6 +1327,17 @@ def async_track_point_in_utc_time(
     )
     loop = hass.loop
     delta = expected_fire_timestamp - time.time()
+    #
+    # Depending on the available clock support (including timer hardware
+    # and the OS kernel) it can happen that we fire a little bit too early
+    # as measured by utcnow() because asyncio will fire any timer that ready
+    # inside the clock resolution window.
+    #
+    # That is bad when callbacks have assumptions about the current time.
+    #
+    # To avoid this problem we add the worst _CLOCK_RESOLUTION to the call_at
+    # which is usually less than a microsecond.
+    #
     cancel_callback = loop.call_at(
         loop.time() + _CLOCK_RESOLUTION + delta,
         hass.async_run_hass_job,

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -1333,6 +1333,8 @@ def async_track_point_in_utc_time(
     # as measured by utcnow() because asyncio will fire any timer that ready
     # inside the clock resolution window.
     #
+    # https://github.com/python/cpython/blob/3fdb55c48291a459fb1e33edb5140ec0383222df/Lib/asyncio/base_events.py#L1919
+    #
     # That is bad when callbacks have assumptions about the current time.
     #
     # To avoid this problem we add the worst _CLOCK_RESOLUTION to the call_at

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -1337,7 +1337,6 @@ def async_track_point_in_utc_time(
     @callback
     def unsub_point_in_time_listener() -> None:
         """Cancel the call_at."""
-        assert cancel_callback is not None
         cancel_callback.cancel()
 
     return unsub_point_in_time_listener

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -1303,7 +1303,9 @@ def async_track_point_in_time(
 
 
 track_point_in_time = threaded_listener_factory(async_track_point_in_time)
-_CLOCK_RESOLUTION = time.get_clock_info("monotonic").resolution
+_CLOCK_RESOLUTION = max(
+    time.get_clock_info("monotonic").resolution, time.get_clock_info("time").resolution
+)
 
 
 @callback

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -113,7 +113,6 @@ async def test_track_point_in_time_drift_rearm(hass: HomeAssistant) -> None:
     async_fire_time_changed(
         hass,
         datetime(now.year + 1, 5, 24, 21, 59, 00, tzinfo=dt_util.UTC),
-        fire_all=True,
     )
     await hass.async_block_till_done()
     assert len(specific_runs) == 0
@@ -3886,7 +3885,6 @@ async def test_periodic_task_clock_rollback(hass: HomeAssistant) -> None:
     async_fire_time_changed(
         hass,
         datetime(now.year + 1, 5, 24, 22, 0, 0, 999999, tzinfo=dt_util.UTC),
-        fire_all=True,
     )
     await hass.async_block_till_done()
     assert len(specific_runs) == 1
@@ -3894,7 +3892,6 @@ async def test_periodic_task_clock_rollback(hass: HomeAssistant) -> None:
     async_fire_time_changed(
         hass,
         datetime(now.year + 1, 5, 24, 0, 0, 0, 999999, tzinfo=dt_util.UTC),
-        fire_all=True,
     )
     await hass.async_block_till_done()
     assert len(specific_runs) == 1


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
asyncio adds the clock resolution to figure out if it should run a callback or not. We can calculate this in advance to avoid the need to re-arm and fire again if we fire the event too early

https://github.com/python/cpython/blob/3fdb55c48291a459fb1e33edb5140ec0383222df/Lib/asyncio/base_events.py#L1919

There have been multiple PRs (#93431 #73295 #42176) to solve this but I didn't realize the root cause until I was digging through the cpython source for another issue.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
