### PR TITLE
Add jsonlog component for dedicated JSON-formatted log file

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -194,6 +194,7 @@ homeassistant.components.islamic_prayer_times.*
 homeassistant.components.isy994.*
 homeassistant.components.jellyfin.*
 homeassistant.components.jewish_calendar.*
+homeassistant.components.jsonlog.*
 homeassistant.components.jvc_projector.*
 homeassistant.components.kaleidescape.*
 homeassistant.components.knx.*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -636,6 +636,8 @@ build.json @home-assistant/supervisor
 /tests/components/jellyfin/ @j-stienstra @ctalkington
 /homeassistant/components/jewish_calendar/ @tsvi
 /tests/components/jewish_calendar/ @tsvi
+/homeassistant/components/jsonlog/ @janw
+/tests/components/jsonlog/ @janw
 /homeassistant/components/juicenet/ @jesserockz
 /tests/components/juicenet/ @jesserockz
 /homeassistant/components/justnimbus/ @kvanzuijlen

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -77,6 +77,8 @@ LOGGING_INTEGRATIONS = {
     # Error logging
     "system_log",
     "sentry",
+    # JSON logging
+    "jsonlog",
 }
 FRONTEND_INTEGRATIONS = {
     # Get the frontend up and running as soon as possible so problem

--- a/homeassistant/components/jsonlog/__init__.py
+++ b/homeassistant/components/jsonlog/__init__.py
@@ -1,0 +1,82 @@
+"""Support for setting the level of logging for components."""
+from __future__ import annotations
+
+import logging
+import os
+from queue import SimpleQueue
+
+import voluptuous as vol
+
+from homeassistant.const import CONF_FILENAME, EVENT_HOMEASSISTANT_CLOSE
+from homeassistant.core import HomeAssistant, ServiceCall, callback
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.typing import ConfigType
+
+from .const import (
+    CONF_ATTRIBUTES,
+    DEFAULT_FILENAME,
+    DOMAIN,
+    LOGATTRS,
+    LOGGER,
+    SERVICE_ROTATE,
+    LogAttribute,
+)
+from .helpers import setup_listener_handler, setup_queue_handler
+
+CONFIG_SCHEMA = vol.Schema(
+    {
+        DOMAIN: vol.Schema(
+            {
+                vol.Optional(CONF_ATTRIBUTES, default=LOGATTRS): vol.All(
+                    cv.ensure_list, [vol.In(LOGATTRS)]
+                ),
+                vol.Optional(CONF_FILENAME, default=DEFAULT_FILENAME): cv.path,
+            }
+        )
+    },
+    extra=vol.ALLOW_EXTRA,
+)
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the logfile component."""
+
+    logpath: str = config[DOMAIN][CONF_FILENAME]
+    if not os.path.isabs(logpath):
+        logpath = hass.config.path(logpath)
+    logattrs = [LogAttribute(attr) for attr in config[DOMAIN][CONF_ATTRIBUTES]]
+
+    LOGGER.info("Setting up JSON log at %s", logpath)
+    if not (listener_handler := setup_listener_handler(logpath=logpath)):
+        return False
+
+    queue: SimpleQueue[logging.Handler] = SimpleQueue()
+    queue_handler = setup_queue_handler(queue=queue, logattrs=logattrs)
+    hass.data[DOMAIN] = queue_handler
+
+    @callback
+    def _async_stop_handler(_) -> None:
+        """Cleanup handler."""
+        queue_handler.close()
+        logging.root.removeHandler(queue_handler)
+        del hass.data[DOMAIN]
+
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_CLOSE, _async_stop_handler)
+
+    logging.root.addHandler(queue_handler)
+    listener = logging.handlers.QueueListener(queue, listener_handler)
+    queue_handler.listener = listener
+    listener.start()
+
+    async def async_service_handler_rotate(service: ServiceCall) -> None:
+        """Handle log file rotation service call."""
+        try:
+            assert listener_handler
+            listener_handler.doRollover()
+            LOGGER.info("Rotated log file")
+        except OSError as err:
+            LOGGER.error("Error rotating log file: %s", err)
+
+    hass.services.async_register(DOMAIN, SERVICE_ROTATE, async_service_handler_rotate)
+
+    return True

--- a/homeassistant/components/jsonlog/__init__.py
+++ b/homeassistant/components/jsonlog/__init__.py
@@ -8,7 +8,7 @@ from queue import SimpleQueue
 import voluptuous as vol
 
 from homeassistant.const import CONF_FILENAME, EVENT_HOMEASSISTANT_CLOSE
-from homeassistant.core import HomeAssistant, ServiceCall, callback
+from homeassistant.core import Event, HomeAssistant, ServiceCall, callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
@@ -55,7 +55,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     hass.data[DOMAIN] = queue_handler
 
     @callback
-    def _async_stop_handler(_) -> None:
+    def _async_stop_handler(event: Event) -> None:
         """Cleanup handler."""
         queue_handler.close()
         logging.root.removeHandler(queue_handler)

--- a/homeassistant/components/jsonlog/__init__.py
+++ b/homeassistant/components/jsonlog/__init__.py
@@ -39,7 +39,7 @@ CONFIG_SCHEMA = vol.Schema(
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up the logfile component."""
+    """Set up the jsonlog component."""
 
     logpath: str = config[DOMAIN][CONF_FILENAME]
     if not os.path.isabs(logpath):

--- a/homeassistant/components/jsonlog/const.py
+++ b/homeassistant/components/jsonlog/const.py
@@ -1,8 +1,7 @@
 """Constants for the jsonlog integration."""
+from enum import StrEnum
 import logging
 from typing import Final
-
-from homeassistant.backports.enum import StrEnum
 
 DOMAIN: Final = "jsonlog"
 LOGGER = logging.getLogger(__package__)

--- a/homeassistant/components/jsonlog/const.py
+++ b/homeassistant/components/jsonlog/const.py
@@ -1,4 +1,4 @@
-"""Constants for the logfile integration."""
+"""Constants for the jsonlog integration."""
 import logging
 from typing import Final
 

--- a/homeassistant/components/jsonlog/const.py
+++ b/homeassistant/components/jsonlog/const.py
@@ -1,0 +1,39 @@
+"""Constants for the logfile integration."""
+import logging
+from typing import Final
+
+from homeassistant.backports.enum import StrEnum
+
+DOMAIN: Final = "jsonlog"
+LOGGER = logging.getLogger(__package__)
+
+
+class LogAttribute(StrEnum):
+    """Supported log record attributes."""
+
+    ASCTIME = "asctime"
+    CREATED = "created"
+    FILENAME = "filename"
+    FUNCNAME = "funcName"
+    LEVELNAME = "levelname"
+    LEVELNO = "levelno"
+    LINENO = "lineno"
+    MESSAGE = "message"
+    MODULE = "module"
+    MSECS = "msecs"
+    NAME = "name"
+    PATHNAME = "pathname"
+    PROCESSNAME = "processName"
+    PROCESS = "process"
+    RELATIVECREATED = "relativeCreated"
+    THREADNAME = "threadName"
+    THREAD = "thread"
+
+
+LOGATTRS = [f.value for f in LogAttribute]
+
+DEFAULT_FILENAME = DOMAIN + ".log"
+
+CONF_ATTRIBUTES = "attributes"
+
+SERVICE_ROTATE = "rotate"

--- a/homeassistant/components/jsonlog/helpers.py
+++ b/homeassistant/components/jsonlog/helpers.py
@@ -1,0 +1,61 @@
+"""Helpers for the logger integration."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import logging
+import os
+from queue import SimpleQueue
+
+from pythonjsonlogger import jsonlogger
+
+from homeassistant.util.logging import HomeAssistantQueueHandler
+
+from .const import LOGGER, LogAttribute
+
+
+class JsonFormatter(jsonlogger.JsonFormatter):
+    """Formats log messages as JSON objects."""
+
+    def formatTime(self, record: logging.LogRecord, datefmt: str | None = None) -> str:
+        """Format log record created timestamp as ISO8601 string."""
+        created = datetime.fromtimestamp(record.created, tz=timezone.utc)
+        return created.isoformat(sep="T", timespec="milliseconds")
+
+
+def setup_listener_handler(
+    *,
+    logpath: str,
+    log_backup_count: int = 2,
+    log_max_bytes: int = 5 * 1024**2,
+) -> logging.handlers.RotatingFileHandler | None:
+    """Set up a file-based log handler to attach to the queue listener."""
+
+    path_exists = os.path.isfile(logpath)
+    log_dir = os.path.dirname(logpath)
+
+    # Check if we can write to the error log if it exists or that
+    # we can create files in the containing directory if not.
+    if (path_exists and not os.access(logpath, os.W_OK)) or (
+        not path_exists and not os.access(log_dir, os.W_OK)
+    ):
+        LOGGER.error("Unable to set up log file %s (access denied)", logpath)
+
+    handler = logging.handlers.RotatingFileHandler(
+        logpath,
+        backupCount=log_backup_count,
+        maxBytes=log_max_bytes,
+    )
+
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    return handler
+
+
+def setup_queue_handler(
+    *, queue: SimpleQueue[logging.Handler], logattrs: list[LogAttribute]
+) -> HomeAssistantQueueHandler:
+    """Set up a queue log handler with JSON formatter."""
+
+    formatter = JsonFormatter(" ".join([f"%({attr})" for attr in logattrs]))
+    handler = HomeAssistantQueueHandler(queue)
+    handler.setFormatter(formatter)
+    return handler

--- a/homeassistant/components/jsonlog/helpers.py
+++ b/homeassistant/components/jsonlog/helpers.py
@@ -1,7 +1,7 @@
 """Helpers for the logger integration."""
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 import logging
 import os
 from queue import SimpleQueue
@@ -18,7 +18,7 @@ class JsonFormatter(jsonlogger.JsonFormatter):
 
     def formatTime(self, record: logging.LogRecord, datefmt: str | None = None) -> str:
         """Format log record created timestamp as ISO8601 string."""
-        created = datetime.fromtimestamp(record.created, tz=timezone.utc)
+        created = datetime.fromtimestamp(record.created, tz=UTC)
         return created.isoformat(sep="T", timespec="milliseconds")
 
 
@@ -55,7 +55,7 @@ def setup_queue_handler(
 ) -> HomeAssistantQueueHandler:
     """Set up a queue log handler with JSON formatter."""
 
-    formatter = JsonFormatter(" ".join([f"%({attr})" for attr in logattrs]))
+    formatter = JsonFormatter(" ".join([f"%({attr})" for attr in logattrs]))  # type: ignore[no-untyped-call]
     handler = HomeAssistantQueueHandler(queue)
     handler.setFormatter(formatter)
     return handler

--- a/homeassistant/components/jsonlog/manifest.json
+++ b/homeassistant/components/jsonlog/manifest.json
@@ -1,0 +1,9 @@
+{
+  "domain": "jsonlog",
+  "name": "JSON Log",
+  "codeowners": ["@janw"],
+  "documentation": "https://www.home-assistant.io/integrations/jsonlog",
+  "integration_type": "system",
+  "quality_scale": "internal",
+  "requirements": ["python-json-logger==2.0.7"]
+}

--- a/homeassistant/components/jsonlog/services.yaml
+++ b/homeassistant/components/jsonlog/services.yaml
@@ -1,3 +1,1 @@
 rotate:
-  name: Rotate
-  description: Rotate the log file.

--- a/homeassistant/components/jsonlog/services.yaml
+++ b/homeassistant/components/jsonlog/services.yaml
@@ -1,0 +1,3 @@
+rotate:
+  name: Rotate
+  description: Rotate the log file.

--- a/mypy.ini
+++ b/mypy.ini
@@ -1702,6 +1702,16 @@ disallow_untyped_defs = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.jsonlog.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.jvc_projector.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2127,6 +2127,9 @@ python-izone==1.2.9
 # homeassistant.components.joaoapps_join
 python-join-api==0.0.9
 
+# homeassistant.components.jsonlog
+python-json-logger==2.0.7
+
 # homeassistant.components.juicenet
 python-juicenet==1.1.0
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1580,6 +1580,9 @@ python-homewizard-energy==2.1.0
 # homeassistant.components.izone
 python-izone==1.2.9
 
+# homeassistant.components.jsonlog
+python-json-logger==2.0.7
+
 # homeassistant.components.juicenet
 python-juicenet==1.1.0
 

--- a/script/hassfest/manifest.py
+++ b/script/hassfest/manifest.py
@@ -84,6 +84,7 @@ NO_IOT_CLASS = [
     "input_text",
     "intent_script",
     "intent",
+    "jsonlog",
     "logbook",
     "logger",
     "lovelace",

--- a/tests/components/jsonlog/__init__.py
+++ b/tests/components/jsonlog/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the jsonlog component."""

--- a/tests/components/jsonlog/test_init.py
+++ b/tests/components/jsonlog/test_init.py
@@ -1,0 +1,172 @@
+"""Test jsonlog component."""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+import random
+
+import pytest
+
+from homeassistant.components import jsonlog
+from homeassistant.const import EVENT_HOMEASSISTANT_CLOSE
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+_LOGGER = logging.getLogger("test_logger")
+
+
+@pytest.fixture
+def logfile(tmp_path: Path) -> Path:
+    """Generate a random logfile path."""
+    subdir = tmp_path / str(random.randint(0, 1000))
+    subdir.mkdir()
+    return subdir / "test.log"
+
+
+@pytest.fixture
+def basic_config(logfile: Path) -> dict:
+    """Generate a basic config for jsonlog."""
+    return {
+        jsonlog.DOMAIN: {
+            jsonlog.CONF_FILENAME: str(logfile),
+        }
+    }
+
+
+def _generate_and_log_exception(exception, log):
+    try:
+        raise Exception(exception)
+    except Exception:  # pylint: disable=broad-except
+        _LOGGER.exception(log)
+
+
+def find_log_record(logfile: Path, level: str) -> dict:
+    """Return log with specific level."""
+    with logfile.open() as logobj:
+        logs = logobj.readlines()
+    logs.reverse()
+    for line in logs:
+        try:
+            log_record = json.loads(line)
+        except Exception as exc:
+            raise AssertionError("Could not parse JSON\n%s", logs) from exc
+        if "levelname" in log_record and log_record["levelname"] == level:
+            return log_record
+    raise AssertionError("No matching log record found %s", logs)
+
+
+def assert_log(log, exception, message, level, logger="test_logger"):
+    """Assert that specified values are in a specific log entry."""
+    assert log["name"] == logger
+    assert exception in log.get("exc_info", "")
+    assert message == log["message"]
+    assert level == log["levelname"]
+
+
+async def test_exception(
+    hass: HomeAssistant, basic_config: dict, logfile: Path
+) -> None:
+    """Test that exceptions are logged and retrieved correctly."""
+    await async_setup_component(hass, jsonlog.DOMAIN, basic_config)
+
+    _generate_and_log_exception("exception message", "log message")
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_CLOSE)
+    await hass.async_block_till_done()
+
+    log = find_log_record(logfile, "ERROR")
+    assert_log(log, "exception message", "log message", "ERROR")
+
+
+async def test_warning(hass: HomeAssistant, basic_config: dict, logfile: Path) -> None:
+    """Test that warning are logged and retrieved correctly."""
+    await async_setup_component(hass, jsonlog.DOMAIN, basic_config)
+
+    _LOGGER.warning("warning message")
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_CLOSE)
+    await hass.async_block_till_done()
+
+    log = find_log_record(logfile, "WARNING")
+    assert_log(log, "", "warning message", "WARNING")
+
+
+async def test_warning_good_format(
+    hass: HomeAssistant, basic_config: dict, logfile: Path
+) -> None:
+    """Test that warning with good format arguments are logged and retrieved correctly."""
+    await async_setup_component(hass, jsonlog.DOMAIN, basic_config)
+
+    _LOGGER.warning("warning message: %s", "test")
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_CLOSE)
+    await hass.async_block_till_done()
+
+    log = find_log_record(logfile, "WARNING")
+    assert_log(log, "", "warning message: test", "WARNING")
+
+
+async def test_warning_missing_format_args(
+    hass: HomeAssistant, basic_config: dict, logfile: Path
+) -> None:
+    """Test that warning with missing format arguments are logged and retrieved correctly."""
+    await async_setup_component(hass, jsonlog.DOMAIN, basic_config)
+
+    _LOGGER.warning("warning message missing a format arg %s")
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_CLOSE)
+    await hass.async_block_till_done()
+
+    log = find_log_record(logfile, "WARNING")
+    assert_log(log, "", "warning message missing a format arg %s", "WARNING")
+
+
+async def test_error(hass: HomeAssistant, basic_config: dict, logfile: Path) -> None:
+    """Test that errors are logged and retrieved correctly."""
+    await async_setup_component(hass, jsonlog.DOMAIN, basic_config)
+
+    _LOGGER.error("error message")
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_CLOSE)
+    await hass.async_block_till_done()
+
+    log = find_log_record(logfile, "ERROR")
+    assert_log(log, "", "error message", "ERROR")
+
+
+async def test_critical(hass: HomeAssistant, basic_config: dict, logfile: Path) -> None:
+    """Test that critical are logged and retrieved correctly."""
+    await async_setup_component(hass, jsonlog.DOMAIN, basic_config)
+
+    _LOGGER.critical("critical message")
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_CLOSE)
+    await hass.async_block_till_done()
+
+    log = find_log_record(logfile, "CRITICAL")
+    assert_log(log, "", "critical message", "CRITICAL")
+
+
+async def test_service_rotate_logfile(
+    hass: HomeAssistant, basic_config: dict, logfile: Path
+) -> None:
+    """Test that the log can be rotated via a service call."""
+
+    await async_setup_component(hass, jsonlog.DOMAIN, basic_config)
+    assert logfile.exists()
+    assert not logfile.with_suffix(".log.1").exists()
+
+    _LOGGER.error("error message")
+
+    await hass.services.async_call(jsonlog.DOMAIN, jsonlog.SERVICE_ROTATE)
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_CLOSE)
+    await hass.async_block_till_done()
+
+    with pytest.raises(AssertionError):
+        find_log_record(logfile, "ERROR")
+    log = find_log_record(logfile, "INFO")
+    assert_log(log, "", "Rotated log file", "INFO", logger=jsonlog.__package__)
+    assert logfile.exists()
+    assert logfile.with_suffix(".log.1").exists()

--- a/tests/components/jsonlog/test_init.py
+++ b/tests/components/jsonlog/test_init.py
@@ -164,8 +164,6 @@ async def test_service_rotate_logfile(
     hass.bus.async_fire(EVENT_HOMEASSISTANT_CLOSE)
     await hass.async_block_till_done()
 
-    with pytest.raises(AssertionError):
-        find_log_record(logfile, "ERROR")
     log = find_log_record(logfile, "INFO")
     assert_log(log, "", "Rotated log file", "INFO", logger=jsonlog.__package__)
     assert logfile.exists()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This adds the `jsonlog` component for emitting JSON-formatted log messages to a dedicated log file.

With the current approach of emitting primarily human-readable log output it is difficult for users to make use of centralised logging tools such as Grafana Loki or an ELK-Stack because querying for specific properties of the log records might require elaborate message parsing, that can be brittle long-term. With this PR, adding the `jsonlog` component to the configuration causes Home Assistant to emit JSON logs into a file, providing consistent and easily parseable logs to be consumed by external systems. Emitted messages will look something like this:

```json
{
    "asctime": "2023-05-26T19:10:22.936+00:00",
    "created": 1685128222.936547,
    "exc_info": "Traceback (most recent call last):\n (…) \nOSError: [Errno 48] Address already in use",
    "filename": "runner.py",
    "funcName": "_async_loop_exception_handler",
    "levelname": "ERROR",
    "lineno": 138,
    "message": "Error doing job: Task exception was never retrieved",
    "module": "runner",
    "name": "homeassistant",
    "pathname": "/Users/jan/repos/homeassistant-core/homeassistant/runner.py",
    "processName": "MainProcess",
    "relativeCreated": 1980.6129932403564,
    "threadName": "MainThread"
}
```

(indendation/line-breaks above only added for readability)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: n/a
- This PR is related to issue: n/a
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/27541

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
