### PR TITLE
Update aioairzone to v0.6.1

### DIFF
--- a/homeassistant/components/airzone/entity.py
+++ b/homeassistant/components/airzone/entity.py
@@ -7,6 +7,7 @@ from typing import Any
 from aioairzone.const import (
     API_SYSTEM_ID,
     API_ZONE_ID,
+    AZD_AVAILABLE,
     AZD_FIRMWARE,
     AZD_FULL_NAME,
     AZD_ID,
@@ -65,6 +66,11 @@ class AirzoneSystemEntity(AirzoneEntity):
             via_device=(DOMAIN, f"{entry.entry_id}_ws"),
         )
         self._attr_unique_id = entry.unique_id or entry.entry_id
+
+    @property
+    def available(self) -> bool:
+        """Return system availability."""
+        return super().available and self.get_airzone_value(AZD_AVAILABLE)
 
     def get_airzone_value(self, key: str) -> Any:
         """Return system value by key."""
@@ -129,6 +135,11 @@ class AirzoneZoneEntity(AirzoneEntity):
             via_device=(DOMAIN, f"{entry.entry_id}_{self.system_id}"),
         )
         self._attr_unique_id = entry.unique_id or entry.entry_id
+
+    @property
+    def available(self) -> bool:
+        """Return zone availability."""
+        return super().available and self.get_airzone_value(AZD_AVAILABLE)
 
     def get_airzone_value(self, key: str) -> Any:
         """Return zone value by key."""

--- a/homeassistant/components/airzone/manifest.json
+++ b/homeassistant/components/airzone/manifest.json
@@ -11,5 +11,5 @@
   "documentation": "https://www.home-assistant.io/integrations/airzone",
   "iot_class": "local_polling",
   "loggers": ["aioairzone"],
-  "requirements": ["aioairzone==0.5.6"]
+  "requirements": ["aioairzone==0.6.1"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -119,7 +119,7 @@ aioairq==0.2.4
 aioairzone-cloud==0.1.6
 
 # homeassistant.components.airzone
-aioairzone==0.5.6
+aioairzone==0.6.1
 
 # homeassistant.components.ambient_station
 aioambient==2023.04.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -109,7 +109,7 @@ aioairq==0.2.4
 aioairzone-cloud==0.1.6
 
 # homeassistant.components.airzone
-aioairzone==0.5.6
+aioairzone==0.6.1
 
 # homeassistant.components.ambient_station
 aioambient==2023.04.0

--- a/tests/components/airzone/test_diagnostics.py
+++ b/tests/components/airzone/test_diagnostics.py
@@ -14,7 +14,6 @@ from aioairzone.const import (
     AZD_SYSTEM,
     AZD_SYSTEMS,
     AZD_ZONES,
-    AZD_ZONES_NUM,
     RAW_HVAC,
     RAW_VERSION,
     RAW_WEBSERVER,
@@ -93,7 +92,6 @@ async def test_config_entry_diagnostics(
         diag["coord_data"][AZD_SYSTEMS]["1"].items()
         >= {
             AZD_ID: 1,
-            AZD_ZONES_NUM: 5,
         }.items()
     )
 

--- a/tests/components/airzone/test_sensor.py
+++ b/tests/components/airzone/test_sensor.py
@@ -1,8 +1,23 @@
 """The sensor tests for the Airzone platform."""
 
-from homeassistant.core import HomeAssistant
+from unittest.mock import patch
 
-from .util import async_init_integration
+from aioairzone.const import API_DATA, API_SYSTEMS
+
+from homeassistant.components.airzone.coordinator import SCAN_INTERVAL
+from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
+from homeassistant.util.dt import utcnow
+
+from .util import (
+    HVAC_MOCK,
+    HVAC_SYSTEMS_MOCK,
+    HVAC_VERSION_MOCK,
+    HVAC_WEBSERVER_MOCK,
+    async_init_integration,
+)
+
+from tests.common import async_fire_time_changed
 
 
 async def test_airzone_create_sensors(
@@ -58,3 +73,36 @@ async def test_airzone_create_sensors(
 
     state = hass.states.get("sensor.dkn_plus_humidity")
     assert state is None
+
+
+async def test_airzone_sensors_availability(
+    hass: HomeAssistant, entity_registry_enabled_by_default: None
+) -> None:
+    """Test sensors availability."""
+
+    await async_init_integration(hass)
+
+    HVAC_MOCK_UNAVAILABLE_ZONE = {**HVAC_MOCK}
+    del HVAC_MOCK_UNAVAILABLE_ZONE[API_SYSTEMS][0][API_DATA][1]
+
+    with patch(
+        "homeassistant.components.airzone.AirzoneLocalApi.get_hvac",
+        return_value=HVAC_MOCK_UNAVAILABLE_ZONE,
+    ), patch(
+        "homeassistant.components.airzone.AirzoneLocalApi.get_hvac_systems",
+        return_value=HVAC_SYSTEMS_MOCK,
+    ), patch(
+        "homeassistant.components.airzone.AirzoneLocalApi.get_version",
+        return_value=HVAC_VERSION_MOCK,
+    ), patch(
+        "homeassistant.components.airzone.AirzoneLocalApi.get_webserver",
+        return_value=HVAC_WEBSERVER_MOCK,
+    ):
+        async_fire_time_changed(hass, utcnow() + SCAN_INTERVAL)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.dorm_ppal_temperature")
+    assert state.state == STATE_UNAVAILABLE
+
+    state = hass.states.get("sensor.dorm_ppal_humidity")
+    assert state.state == STATE_UNAVAILABLE


### PR DESCRIPTION
## Proposed change
Update aioairzone to [v0.6.1](https://github.com/Noltari/aioairzone/compare/0.5.6...0.6.1).
The code has been refactored and improved and now the library will detect when a zone disappears from the API and will set AZD_AVAILABLE to False in that case. This happened to me when one of my thermostats ran out of battery and the API stopped providing its data.

Releases:
- https://github.com/Noltari/aioairzone/releases/tag/0.6.1
- https://github.com/Noltari/aioairzone/releases/tag/0.6.0

Git compare: https://github.com/Noltari/aioairzone/compare/0.5.6...0.6.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
