### PR TITLE
Add Water Heater to Google Assistant integration

### DIFF
--- a/homeassistant/components/google_assistant/const.py
+++ b/homeassistant/components/google_assistant/const.py
@@ -22,6 +22,7 @@ from homeassistant.components import (
     sensor,
     switch,
     vacuum,
+    water_heater,
 )
 
 DOMAIN = "google_assistant"
@@ -93,6 +94,7 @@ TYPE_THERMOSTAT = f"{PREFIX_TYPES}THERMOSTAT"
 TYPE_TV = f"{PREFIX_TYPES}TV"
 TYPE_WINDOW = f"{PREFIX_TYPES}WINDOW"
 TYPE_VACUUM = f"{PREFIX_TYPES}VACUUM"
+TYPE_WATERHEATER = f"{PREFIX_TYPES}WATERHEATER"
 
 SERVICE_REQUEST_SYNC = "request_sync"
 HOMEGRAPH_URL = "https://homegraph.googleapis.com/"
@@ -147,6 +149,7 @@ DOMAIN_TO_GOOGLE_TYPES = {
     sensor.DOMAIN: TYPE_SENSOR,
     switch.DOMAIN: TYPE_SWITCH,
     vacuum.DOMAIN: TYPE_VACUUM,
+    water_heater.DOMAIN: TYPE_WATERHEATER,
 }
 
 DEVICE_CLASS_TO_GOOGLE_TYPES = {

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -29,6 +29,7 @@ from homeassistant.components import (
     sensor,
     switch,
     vacuum,
+    water_heater,
 )
 from homeassistant.components.alarm_control_panel import AlarmControlPanelEntityFeature
 from homeassistant.components.camera import CameraEntityFeature
@@ -146,6 +147,7 @@ COMMAND_THERMOSTAT_TEMPERATURE_SET_RANGE = (
     f"{PREFIX_COMMANDS}ThermostatTemperatureSetRange"
 )
 COMMAND_THERMOSTAT_SET_MODE = f"{PREFIX_COMMANDS}ThermostatSetMode"
+COMMAND_WATERHEATER_SET_TEMPERATURE = f"{PREFIX_COMMANDS}SetTemperature"
 COMMAND_LOCKUNLOCK = f"{PREFIX_COMMANDS}LockUnlock"
 COMMAND_FANSPEED = f"{PREFIX_COMMANDS}SetFanSpeed"
 COMMAND_FANSPEEDRELATIVE = f"{PREFIX_COMMANDS}SetFanSpeedRelative"
@@ -421,6 +423,7 @@ class OnOffTrait(_Trait):
             light.DOMAIN,
             media_player.DOMAIN,
             humidifier.DOMAIN,
+            water_heater.DOMAIN,
         )
 
     def sync_attributes(self):
@@ -897,16 +900,34 @@ class TemperatureControlTrait(_Trait):
 
     name = TRAIT_TEMPERATURE_CONTROL
 
+    commands = [
+        COMMAND_WATERHEATER_SET_TEMPERATURE,
+    ]
+
     @staticmethod
     def supported(domain, features, device_class, _):
         """Test if state is supported."""
         return (
             domain == sensor.DOMAIN
             and device_class == sensor.SensorDeviceClass.TEMPERATURE
-        )
+        ) or (domain == water_heater.DOMAIN)
 
     def sync_attributes(self):
         """Return temperature attributes for a sync request."""
+        domain = self.state.domain
+        attrs = self.state.attributes
+
+        if domain == water_heater.DOMAIN:
+            return {
+                "temperatureUnitForUX": _google_temp_unit(
+                    self.hass.config.units.temperature_unit
+                ),
+                "temperatureRange": {
+                    "minThresholdCelsius": attrs[water_heater.ATTR_MIN_TEMP],
+                    "maxThresholdCelsius": attrs[water_heater.ATTR_MAX_TEMP],
+                },
+            }
+
         return {
             "temperatureUnitForUX": _google_temp_unit(
                 self.hass.config.units.temperature_unit
@@ -922,6 +943,29 @@ class TemperatureControlTrait(_Trait):
         """Return temperature states."""
         response = {}
         unit = self.hass.config.units.temperature_unit
+        domain = self.state.domain
+        attrs = self.state.attributes
+
+        if domain == water_heater.DOMAIN:
+            target_temp = round(
+                TemperatureConverter.convert(
+                    float(attrs["temperature"] or 0), unit, UnitOfTemperature.CELSIUS
+                ),
+                1,
+            )
+            current_temp = round(
+                TemperatureConverter.convert(
+                    float(attrs["current_temperature"] or 0),
+                    unit,
+                    UnitOfTemperature.CELSIUS,
+                ),
+                1,
+            )
+            return {
+                "temperatureSetpointCelsius": target_temp,
+                "temperatureAmbientCelsius": current_temp,
+            }
+
         current_temp = self.state.state
         if current_temp not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
             temp = round(
@@ -936,8 +980,35 @@ class TemperatureControlTrait(_Trait):
         return response
 
     async def execute(self, command, data, params, challenge):
-        """Unsupported."""
-        raise SmartHomeError(ERR_NOT_SUPPORTED, "Execute is not supported by sensor")
+        """Execute a temperature point or mode command."""
+        # All sent in temperatures are always in Celsius
+        domain = self.state.domain
+
+        if domain == water_heater.DOMAIN:
+            unit = self.hass.config.units.temperature_unit
+            min_temp = self.state.attributes[water_heater.ATTR_MIN_TEMP]
+            max_temp = self.state.attributes[water_heater.ATTR_MAX_TEMP]
+
+            if command == COMMAND_WATERHEATER_SET_TEMPERATURE:
+                temp = TemperatureConverter.convert(
+                    params["temperature"], UnitOfTemperature.CELSIUS, unit
+                )
+                if unit == UnitOfTemperature.FAHRENHEIT:
+                    temp = round(temp)
+
+                if temp < min_temp or temp > max_temp:
+                    raise SmartHomeError(
+                        ERR_VALUE_OUT_OF_RANGE,
+                        f"Temperature should be between {min_temp} and {max_temp}",
+                    )
+
+                await self.hass.services.async_call(
+                    water_heater.DOMAIN,
+                    water_heater.SERVICE_SET_TEMPERATURE,
+                    {ATTR_ENTITY_ID: self.state.entity_id, ATTR_TEMPERATURE: temp},
+                    blocking=not self.config.should_report_state,
+                    context=data.context,
+                )
 
 
 @register_trait

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -963,7 +963,7 @@ class TemperatureControlTrait(_Trait):
                     ),
                     1,
                 )
-            if current_temp not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
+            if current_temp is not None:
                 response["temperatureAmbientCelsius"] = round(
                     TemperatureConverter.convert(
                         float(current_temp),

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -140,6 +140,7 @@ COMMAND_PAUSEUNPAUSE = f"{PREFIX_COMMANDS}PauseUnpause"
 COMMAND_BRIGHTNESS_ABSOLUTE = f"{PREFIX_COMMANDS}BrightnessAbsolute"
 COMMAND_COLOR_ABSOLUTE = f"{PREFIX_COMMANDS}ColorAbsolute"
 COMMAND_ACTIVATE_SCENE = f"{PREFIX_COMMANDS}ActivateScene"
+COMMAND_SET_TEMPERATURE = f"{PREFIX_COMMANDS}SetTemperature"
 COMMAND_THERMOSTAT_TEMPERATURE_SETPOINT = (
     f"{PREFIX_COMMANDS}ThermostatTemperatureSetpoint"
 )
@@ -147,7 +148,6 @@ COMMAND_THERMOSTAT_TEMPERATURE_SET_RANGE = (
     f"{PREFIX_COMMANDS}ThermostatTemperatureSetRange"
 )
 COMMAND_THERMOSTAT_SET_MODE = f"{PREFIX_COMMANDS}ThermostatSetMode"
-COMMAND_WATERHEATER_SET_TEMPERATURE = f"{PREFIX_COMMANDS}SetTemperature"
 COMMAND_LOCKUNLOCK = f"{PREFIX_COMMANDS}LockUnlock"
 COMMAND_FANSPEED = f"{PREFIX_COMMANDS}SetFanSpeed"
 COMMAND_FANSPEEDRELATIVE = f"{PREFIX_COMMANDS}SetFanSpeedRelative"
@@ -901,7 +901,7 @@ class TemperatureControlTrait(_Trait):
     name = TRAIT_TEMPERATURE_CONTROL
 
     commands = [
-        COMMAND_WATERHEATER_SET_TEMPERATURE,
+        COMMAND_SET_TEMPERATURE,
     ]
 
     @staticmethod
@@ -989,7 +989,7 @@ class TemperatureControlTrait(_Trait):
             min_temp = self.state.attributes[water_heater.ATTR_MIN_TEMP]
             max_temp = self.state.attributes[water_heater.ATTR_MAX_TEMP]
 
-            if command == COMMAND_WATERHEATER_SET_TEMPERATURE:
+            if command == COMMAND_SET_TEMPERATURE:
                 temp = TemperatureConverter.convert(
                     params["temperature"], UnitOfTemperature.CELSIUS, unit
                 )

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -915,9 +915,8 @@ class TemperatureControlTrait(_Trait):
     def sync_attributes(self):
         """Return temperature attributes for a sync request."""
         domain = self.state.domain
-        attrs = self.state.attributes
-
         if domain == water_heater.DOMAIN:
+            attrs = self.state.attributes
             return {
                 "temperatureUnitForUX": _google_temp_unit(
                     self.hass.config.units.temperature_unit
@@ -927,7 +926,6 @@ class TemperatureControlTrait(_Trait):
                     "maxThresholdCelsius": attrs[water_heater.ATTR_MAX_TEMP],
                 },
             }
-
         return {
             "temperatureUnitForUX": _google_temp_unit(
                 self.hass.config.units.temperature_unit
@@ -942,29 +940,30 @@ class TemperatureControlTrait(_Trait):
     def query_attributes(self):
         """Return temperature states."""
         response = {}
-        unit = self.hass.config.units.temperature_unit
         domain = self.state.domain
-        attrs = self.state.attributes
-
+        unit = self.hass.config.units.temperature_unit
         if domain == water_heater.DOMAIN:
-            target_temp = round(
-                TemperatureConverter.convert(
-                    float(attrs["temperature"] or 0), unit, UnitOfTemperature.CELSIUS
-                ),
-                1,
-            )
-            current_temp = round(
-                TemperatureConverter.convert(
-                    float(attrs["current_temperature"] or 0),
-                    unit,
-                    UnitOfTemperature.CELSIUS,
-                ),
-                1,
-            )
-            return {
-                "temperatureSetpointCelsius": target_temp,
-                "temperatureAmbientCelsius": current_temp,
-            }
+            target_temp = self.state.attributes[water_heater.ATTR_TEMPERATURE]
+            current_temp = self.state.attributes[water_heater.ATTR_CURRENT_TEMPERATURE]
+            if target_temp not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
+                response["temperatureSetpointCelsius"] = round(
+                    TemperatureConverter.convert(
+                        float(target_temp),
+                        unit,
+                        UnitOfTemperature.CELSIUS,
+                    ),
+                    1,
+                )
+            if current_temp not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
+                response["temperatureAmbientCelsius"] = round(
+                    TemperatureConverter.convert(
+                        float(current_temp),
+                        unit,
+                        UnitOfTemperature.CELSIUS,
+                    ),
+                    1,
+                )
+            return response
 
         current_temp = self.state.state
         if current_temp not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
@@ -983,13 +982,13 @@ class TemperatureControlTrait(_Trait):
         """Execute a temperature point or mode command."""
         # All sent in temperatures are always in Celsius
         domain = self.state.domain
+        unit = self.hass.config.units.temperature_unit
 
-        if domain == water_heater.DOMAIN:
-            unit = self.hass.config.units.temperature_unit
-            min_temp = self.state.attributes[water_heater.ATTR_MIN_TEMP]
-            max_temp = self.state.attributes[water_heater.ATTR_MAX_TEMP]
+        if command == COMMAND_SET_TEMPERATURE:
+            if domain == water_heater.DOMAIN:
+                min_temp = self.state.attributes[water_heater.ATTR_MIN_TEMP]
+                max_temp = self.state.attributes[water_heater.ATTR_MAX_TEMP]
 
-            if command == COMMAND_SET_TEMPERATURE:
                 temp = TemperatureConverter.convert(
                     params["temperature"], UnitOfTemperature.CELSIUS, unit
                 )
@@ -1009,6 +1008,9 @@ class TemperatureControlTrait(_Trait):
                     blocking=not self.config.should_report_state,
                     context=data.context,
                 )
+                return
+
+        raise SmartHomeError(ERR_NOT_SUPPORTED, f"Execute is not supported by {domain}")
 
 
 @register_trait

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -942,7 +942,7 @@ class TemperatureControlTrait(_Trait):
         else:
             response["queryOnlyTemperatureControl"] = True
             response["temperatureRange"] = {
-                "minThresholdCelsius": -100,
+                "minThresholdCelsius": 0,
                 "maxThresholdCelsius": 100,
             }
 

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -914,37 +914,39 @@ class TemperatureControlTrait(_Trait):
 
     def sync_attributes(self):
         """Return temperature attributes for a sync request."""
+        response = {}
         domain = self.state.domain
+        attrs = self.state.attributes
         unit = self.hass.config.units.temperature_unit
+        response["temperatureUnitForUX"] = _google_temp_unit(unit)
+
         if domain == water_heater.DOMAIN:
-            min_temp = TemperatureConverter.convert(
-                self.state.attributes[water_heater.ATTR_MIN_TEMP],
-                unit,
-                UnitOfTemperature.CELSIUS,
+            min_temp = round(
+                TemperatureConverter.convert(
+                    float(attrs[water_heater.ATTR_MIN_TEMP]),
+                    unit,
+                    UnitOfTemperature.CELSIUS,
+                )
             )
-            max_temp = TemperatureConverter.convert(
-                self.state.attributes[water_heater.ATTR_MAX_TEMP],
-                unit,
-                UnitOfTemperature.CELSIUS,
+            max_temp = round(
+                TemperatureConverter.convert(
+                    float(attrs[water_heater.ATTR_MAX_TEMP]),
+                    unit,
+                    UnitOfTemperature.CELSIUS,
+                )
             )
-            if unit == UnitOfTemperature.FAHRENHEIT:
-                min_temp = round(min_temp)
-                max_temp = round(max_temp)
-            return {
-                "temperatureUnitForUX": _google_temp_unit(unit),
-                "temperatureRange": {
-                    "minThresholdCelsius": min_temp,
-                    "maxThresholdCelsius": max_temp,
-                },
+            response["temperatureRange"] = {
+                "minThresholdCelsius": min_temp,
+                "maxThresholdCelsius": max_temp,
             }
-        return {
-            "temperatureUnitForUX": _google_temp_unit(unit),
-            "queryOnlyTemperatureControl": True,
-            "temperatureRange": {
+        else:
+            response["queryOnlyTemperatureControl"] = True
+            response["temperatureRange"] = {
                 "minThresholdCelsius": -100,
                 "maxThresholdCelsius": 100,
-            },
-        }
+            }
+
+        return response
 
     def query_attributes(self):
         """Return temperature states."""

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -1237,7 +1237,7 @@ async def test_temperature_control(hass: HomeAssistant) -> None:
     assert trt.sync_attributes() == {
         "queryOnlyTemperatureControl": True,
         "temperatureUnitForUX": "C",
-        "temperatureRange": {"maxThresholdCelsius": 100, "minThresholdCelsius": -100},
+        "temperatureRange": {"maxThresholdCelsius": 100, "minThresholdCelsius": 0},
     }
     assert trt.query_attributes() == {
         "temperatureSetpointCelsius": 18,
@@ -3228,7 +3228,7 @@ async def test_temperature_control_sensor_data(
     assert trt.sync_attributes() == {
         "queryOnlyTemperatureControl": True,
         "temperatureUnitForUX": unit_out,
-        "temperatureRange": {"maxThresholdCelsius": 100, "minThresholdCelsius": -100},
+        "temperatureRange": {"maxThresholdCelsius": 100, "minThresholdCelsius": 0},
     }
 
     if ambient:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
An addition to the Google Assistant component to enable the water heater platform to set temperature. Currently the only way to set temperature is with the Climate entity, which does not allow for temperatures above `100` degrees Celsius.

I am currently working on integrating a desktop vaporizer I own into Home Assistant, and the water heater platform seemed to be the best fit for my requirements. The vaporizer has a temperature range of `40` - `230` degrees Celsius, and so the very sane limits of `-100` to `100` placed on the `TemperatureControlTrait` for the sensor platform are a bit restrictive.
This instead allows the temperature control trait to rely on the `min_temp` and `max_temp` of the `water_heater` platform, and allow for higher temperatures.

This PR is paired with [this one](https://github.com/home-assistant/core/pull/93644), which provide a way to register water heater devices via the MQTT integration.

Replaced by https://github.com/home-assistant/core/pull/105915

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
-->
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/27551

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
