### PR TITLE
Add time component to Melnor Bluetooth integration

### DIFF
--- a/homeassistant/components/melnor/__init__.py
+++ b/homeassistant/components/melnor/__init__.py
@@ -18,6 +18,7 @@ PLATFORMS: list[Platform] = [
     Platform.NUMBER,
     Platform.SENSOR,
     Platform.SWITCH,
+    Platform.TIME,
 ]
 
 

--- a/homeassistant/components/melnor/manifest.json
+++ b/homeassistant/components/melnor/manifest.json
@@ -12,5 +12,5 @@
   "dependencies": ["bluetooth_adapters"],
   "documentation": "https://www.home-assistant.io/integrations/melnor",
   "iot_class": "local_polling",
-  "requirements": ["melnor-bluetooth==0.0.21"]
+  "requirements": ["melnor-bluetooth==0.0.22"]
 }

--- a/homeassistant/components/melnor/time.py
+++ b/homeassistant/components/melnor/time.py
@@ -41,7 +41,6 @@ class MelnorZoneTimeEntityDescription(
 ZONE_ENTITY_DESCRIPTIONS: list[MelnorZoneTimeEntityDescription] = [
     MelnorZoneTimeEntityDescription(
         entity_category=EntityCategory.CONFIG,
-        icon="mdi:calendar-clock-outline",
         key="frequency_start_time",
         name="Schedule Start Time",
         set_time_fn=lambda valve, value: valve.set_frequency_start_time(value),
@@ -69,7 +68,7 @@ async def async_setup_entry(
 
 
 class MelnorZoneTime(MelnorZoneEntity, TimeEntity):
-    """A number implementation for a melnor device."""
+    """A time implementation for a melnor device."""
 
     entity_description: MelnorZoneTimeEntityDescription
 

--- a/homeassistant/components/melnor/time.py
+++ b/homeassistant/components/melnor/time.py
@@ -1,0 +1,92 @@
+"""Number support for Melnor Bluetooth water timer."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Coroutine
+from dataclasses import dataclass
+from datetime import time
+from typing import Any
+
+from melnor_bluetooth.device import Valve
+
+from homeassistant.components.time import TimeEntity, TimeEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .models import (
+    MelnorDataUpdateCoordinator,
+    MelnorZoneEntity,
+    get_entities_for_valves,
+)
+
+
+@dataclass
+class MelnorZoneTimeEntityDescriptionMixin:
+    """Mixin for required keys."""
+
+    set_time_fn: Callable[[Valve, time], Coroutine[Any, Any, None]]
+    state_fn: Callable[[Valve], Any]
+
+
+@dataclass
+class MelnorZoneTimeEntityDescription(
+    TimeEntityDescription, MelnorZoneTimeEntityDescriptionMixin
+):
+    """Describes Melnor number entity."""
+
+
+ZONE_ENTITY_DESCRIPTIONS: list[MelnorZoneTimeEntityDescription] = [
+    MelnorZoneTimeEntityDescription(
+        entity_category=EntityCategory.CONFIG,
+        icon="mdi:calendar-clock-outline",
+        key="frequency_start_time",
+        name="Schedule Start Time",
+        set_time_fn=lambda valve, value: valve.set_frequency_start_time(value),
+        state_fn=lambda valve: valve.frequency.start_time,
+    ),
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the number platform."""
+
+    coordinator: MelnorDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+
+    async_add_entities(
+        get_entities_for_valves(
+            coordinator,
+            ZONE_ENTITY_DESCRIPTIONS,
+            lambda valve, description: MelnorZoneTime(coordinator, description, valve),
+        )
+    )
+
+
+class MelnorZoneTime(MelnorZoneEntity, TimeEntity):
+    """A number implementation for a melnor device."""
+
+    entity_description: MelnorZoneTimeEntityDescription
+
+    def __init__(
+        self,
+        coordinator: MelnorDataUpdateCoordinator,
+        entity_description: MelnorZoneTimeEntityDescription,
+        valve: Valve,
+    ) -> None:
+        """Initialize a number for a melnor device."""
+        super().__init__(coordinator, entity_description, valve)
+
+    @property
+    def native_value(self) -> time | None:
+        """Return the current value."""
+        return self.entity_description.state_fn(self._valve)
+
+    async def async_set_value(self, value: time) -> None:
+        """Update the current value."""
+        await self.entity_description.set_time_fn(self._valve, value)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1122,7 +1122,7 @@ mcstatus==6.0.0
 meater-python==0.0.8
 
 # homeassistant.components.melnor
-melnor-bluetooth==0.0.21
+melnor-bluetooth==0.0.22
 
 # homeassistant.components.message_bird
 messagebird==1.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -848,7 +848,7 @@ mcstatus==6.0.0
 meater-python==0.0.8
 
 # homeassistant.components.melnor
-melnor-bluetooth==0.0.21
+melnor-bluetooth==0.0.22
 
 # homeassistant.components.meteo_france
 meteofrance-api==1.2.0

--- a/tests/components/melnor/test_time.py
+++ b/tests/components/melnor/test_time.py
@@ -1,4 +1,4 @@
-"""Test the Melnor sensors."""
+"""Test the Melnor time platform."""
 from __future__ import annotations
 
 from datetime import time

--- a/tests/components/melnor/test_time.py
+++ b/tests/components/melnor/test_time.py
@@ -1,0 +1,50 @@
+"""Test the Melnor sensors."""
+from __future__ import annotations
+
+from datetime import time
+
+from homeassistant.core import HomeAssistant
+import homeassistant.util.dt as dt_util
+
+from .conftest import (
+    mock_config_entry,
+    patch_async_ble_device_from_address,
+    patch_async_register_callback,
+    patch_melnor_device,
+)
+
+from tests.common import async_fire_time_changed
+
+
+async def test_schedule_start_time(hass: HomeAssistant) -> None:
+    """Test the frequency schedule start time."""
+
+    now = dt_util.now()
+
+    entry = mock_config_entry(hass)
+
+    with patch_async_ble_device_from_address(), patch_melnor_device() as device_patch, patch_async_register_callback():
+        device = device_patch.return_value
+
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        time_entity = hass.states.get("time.zone_1_schedule_start_time")
+
+        assert time_entity is not None
+        assert time_entity.state == device.zone1.frequency.start_time.isoformat()
+
+        await hass.services.async_call(
+            "time",
+            "set_value",
+            {"entity_id": "time.zone_1_schedule_start_time", "time": time(1, 0)},
+            blocking=True,
+        )
+
+        async_fire_time_changed(hass, now + dt_util.dt.timedelta(seconds=10))
+        await hass.async_block_till_done()
+
+        time_entity = hass.states.get("time.zone_1_schedule_start_time")
+
+        assert time_entity is not None
+        assert time_entity.state == time(1, 0).isoformat()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Following up on the scheduler support in #93333 this PR adds the final missing piece: `time` support for setting the start time of the frequency schedule.

This change includes a bugfix bump to the `melnor-bluetooth` library to fix some date handling around schedules https://github.com/vanstinator/melnor-bluetooth/compare/v0.0.21...v0.0.22


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/27553

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
