### PR TITLE
Improve performance when serializing small bits of JSON

### DIFF
--- a/homeassistant/helpers/json.py
+++ b/homeassistant/helpers/json.py
@@ -6,7 +6,7 @@ from functools import partial
 import json
 import logging
 from pathlib import Path
-from typing import Any, Final
+from typing import TYPE_CHECKING, Any, Final
 
 import orjson
 
@@ -56,6 +56,18 @@ def json_encoder_default(obj: Any) -> Any:
     raise TypeError
 
 
+if TYPE_CHECKING:
+
+    def json_bytes(obj: Any) -> bytes:
+        """Dump json bytes."""
+
+else:
+    json_bytes = partial(
+        orjson.dumps, option=orjson.OPT_NON_STR_KEYS, default=json_encoder_default
+    )
+    """Dump json bytes."""
+
+
 class ExtendedJSONEncoder(JSONEncoder):
     """JSONEncoder that supports Home Assistant objects and falls back to repr(o)."""
 
@@ -98,12 +110,6 @@ def json_bytes_strip_null(data: Any) -> bytes:
     # We work on the processed result so we don't need to worry about
     # Home Assistant extensions which allows encoding sets, tuples, etc.
     return json_bytes(_strip_null(orjson.loads(result)))
-
-
-json_bytes = partial(
-    orjson.dumps, option=orjson.OPT_NON_STR_KEYS, default=json_encoder_default
-)
-"""Dump json bytes."""
 
 
 def json_dumps(data: Any) -> str:

--- a/homeassistant/helpers/json.py
+++ b/homeassistant/helpers/json.py
@@ -2,6 +2,7 @@
 from collections import deque
 from collections.abc import Callable
 import datetime
+from functools import partial
 import json
 import logging
 from pathlib import Path
@@ -75,13 +76,6 @@ class ExtendedJSONEncoder(JSONEncoder):
             return {"__type": str(type(o)), "repr": repr(o)}
 
 
-def json_bytes(data: Any) -> bytes:
-    """Dump json bytes."""
-    return orjson.dumps(
-        data, option=orjson.OPT_NON_STR_KEYS, default=json_encoder_default
-    )
-
-
 def _strip_null(obj: Any) -> Any:
     """Strip NUL from an object."""
     if isinstance(obj, str):
@@ -106,6 +100,12 @@ def json_bytes_strip_null(data: Any) -> bytes:
     return json_bytes(_strip_null(orjson.loads(result)))
 
 
+json_bytes = partial(
+    orjson.dumps, option=orjson.OPT_NON_STR_KEYS, default=json_encoder_default
+)
+"""Dump json bytes."""
+
+
 def json_dumps(data: Any) -> str:
     """Dump json string.
 
@@ -119,9 +119,7 @@ def json_dumps(data: Any) -> str:
     with option |= orjson.OPT_PASSTHROUGH_DATACLASS and it
     will fallback to as_dict
     """
-    return orjson.dumps(
-        data, option=orjson.OPT_NON_STR_KEYS, default=json_encoder_default
-    ).decode("utf-8")
+    return json_bytes(data).decode("utf-8")
 
 
 def json_dumps_sorted(data: Any) -> str:


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Making json_bytes a `partial` reduced the run time to build the small JSON messages by ~18.75% since it doesn't have to build the arguments every time.

We serialize a lot of small messages over the websocket and this makes a difference because orjson is so fast that the python overhead is a large chunk of the run time for small messages.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
