### PR TITLE
Switch some frequently called call_laters to call_at

### DIFF
--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -770,8 +770,8 @@ class Entity(ABC):
             await self.parallel_updates.acquire()
 
         if warning:
-            update_warn = hass.loop.call_later(
-                SLOW_UPDATE_WARNING, self._async_slow_update_warning
+            update_warn = hass.loop.call_at(
+                hass.loop.time() + SLOW_UPDATE_WARNING, self._async_slow_update_warning
             )
 
         try:

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -288,8 +288,8 @@ class EntityPlatform:
             )
 
         logger.info("Setting up %s", full_name)
-        warn_task = hass.loop.call_later(
-            SLOW_SETUP_WARNING,
+        warn_task = hass.loop.call_at(
+            hass.loop.time() + SLOW_SETUP_WARNING,
             logger.warning,
             "Setup of %s platform %s is taking over %s seconds.",
             self.domain,

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -223,16 +223,18 @@ async def test_platform_warn_slow_setup(hass: HomeAssistant) -> None:
 
     component = EntityComponent(_LOGGER, DOMAIN, hass)
 
-    with patch.object(hass.loop, "call_later") as mock_call:
+    with patch.object(hass.loop, "call_at") as mock_call:
         await component.async_setup({DOMAIN: {"platform": "platform"}})
         await hass.async_block_till_done()
         assert mock_call.called
 
         # mock_calls[0] is the warning message for component setup
         # mock_calls[4] is the warning message for platform setup
-        timeout, logger_method = mock_call.mock_calls[4][1][:2]
+        timeout, logger_method = mock_call.mock_calls[10][1][:2]
 
-        assert timeout == entity_platform.SLOW_SETUP_WARNING
+        assert timeout - hass.loop.time() == pytest.approx(
+            entity_platform.SLOW_SETUP_WARNING, 0.5
+        )
         assert logger_method == _LOGGER.warning
 
         assert mock_call().cancel.called

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -228,8 +228,8 @@ async def test_platform_warn_slow_setup(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
         assert mock_call.called
 
-        # mock_calls[0] is the warning message for component setup
-        # mock_calls[4] is the warning message for platform setup
+        # mock_calls[3] is the warning message for component setup
+        # mock_calls[10] is the warning message for platform setup
         timeout, logger_method = mock_call.mock_calls[10][1][:2]
 
         assert timeout - hass.loop.time() == pytest.approx(


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
`call_at` is a bit faster than `call_later` since `call_later` is a wrapper around `call_at`.

We call at lot of these at startup so it helps a bit when we are resource constrained

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
