### PR TITLE
Make Riemann sum sensors restore last valid state

### DIFF
--- a/homeassistant/components/integration/sensor.py
+++ b/homeassistant/components/integration/sensor.py
@@ -230,7 +230,7 @@ class IntegrationSensor(RestoreSensor):
 
         if (last_sensor_data := await self.async_get_last_sensor_data()) is not None:
             self._state = (
-                None
+                Decimal(str(last_sensor_data.native_value))
                 if last_sensor_data.native_value
                 else last_sensor_data.last_valid_state
             )

--- a/homeassistant/components/integration/sensor.py
+++ b/homeassistant/components/integration/sensor.py
@@ -234,7 +234,11 @@ class IntegrationSensor(RestoreSensor):
             self._attr_native_value = last_sensor_data.native_value
             self._unit_of_measurement = last_sensor_data.native_unit_of_measurement
             self._last_valid_state = last_sensor_data.last_valid_state
-
+            _LOGGER.debug(
+                "Restored state %s and last_valid_state %s",
+                self._state,
+                self._last_valid_state,
+            )
         elif (state := await self.async_get_last_state()) is not None:
             # legacy to be removed on 2023.10 (we are keeping this to avoid losing data during the transition)
             if state.state in [STATE_UNAVAILABLE, STATE_UNKNOWN]:

--- a/homeassistant/components/integration/sensor.py
+++ b/homeassistant/components/integration/sensor.py
@@ -107,15 +107,16 @@ class IntegrationSensorExtraStoredData(SensorExtraStoredData):
 
         source_entity = restored.get(ATTR_SOURCE_ID)
 
-        try:
-            last_valid_state: Decimal | None = (
-                Decimal(restored[ATTR_LAST_VALID_STATE])
-                if restored.get(ATTR_LAST_VALID_STATE)
-                else None
-            )
-        except InvalidOperation:
-            # last_period is corrupted
-            _LOGGER.error("Could not use last_valid_state")
+        if restored.get(ATTR_LAST_VALID_STATE):
+            try:
+                last_valid_state: Decimal | None = Decimal(
+                    restored[ATTR_LAST_VALID_STATE]
+                )
+            except InvalidOperation:
+                # last_period is corrupted
+                _LOGGER.error("Could not use last_valid_state")
+                return None
+        else:
             return None
 
         return cls(

--- a/homeassistant/components/integration/sensor.py
+++ b/homeassistant/components/integration/sensor.py
@@ -107,16 +107,18 @@ class IntegrationSensorExtraStoredData(SensorExtraStoredData):
 
         source_entity = restored.get(ATTR_SOURCE_ID)
 
-        if restored.get(ATTR_LAST_VALID_STATE):
-            try:
-                last_valid_state: Decimal | None = Decimal(
-                    restored[ATTR_LAST_VALID_STATE]
-                )
-            except InvalidOperation:
-                # last_period is corrupted
-                _LOGGER.error("Could not use last_valid_state")
-                return None
-        else:
+        try:
+            last_valid_state = (
+                Decimal(str(restored.get(ATTR_LAST_VALID_STATE)))
+                if restored.get(ATTR_LAST_VALID_STATE)
+                else None
+            )
+        except InvalidOperation:
+            # last_period is corrupted
+            _LOGGER.error("Could not use last_valid_state")
+            return None
+
+        if last_valid_state is None:
             return None
 
         return cls(
@@ -234,6 +236,7 @@ class IntegrationSensor(RestoreSensor):
             self._attr_native_value = last_sensor_data.native_value
             self._unit_of_measurement = last_sensor_data.native_unit_of_measurement
             self._last_valid_state = last_sensor_data.last_valid_state
+
             _LOGGER.debug(
                 "Restored state %s and last_valid_state %s",
                 self._state,

--- a/homeassistant/components/integration/sensor.py
+++ b/homeassistant/components/integration/sensor.py
@@ -113,10 +113,6 @@ class IntegrationSensorExtraStoredData(SensorExtraStoredData):
                 if restored.get(ATTR_LAST_VALID_STATE)
                 else None
             )
-        except KeyError:
-            # restored is a dict, but does not have all values
-            _LOGGER.error("Could not restore last_valid_state")
-            return None
         except InvalidOperation:
             # last_period is corrupted
             _LOGGER.error("Could not use last_valid_state")

--- a/homeassistant/components/integration/sensor.py
+++ b/homeassistant/components/integration/sensor.py
@@ -411,7 +411,6 @@ class IntegrationSensor(RestoreSensor):
         """Restore Utility Meter Sensor Extra Stored Data."""
         if (restored_last_extra_data := await self.async_get_last_extra_data()) is None:
             return None
-        _LOGGER.error(restored_last_extra_data.as_dict())
 
         return IntegrationSensorExtraStoredData.from_dict(
             restored_last_extra_data.as_dict()

--- a/homeassistant/components/integration/sensor.py
+++ b/homeassistant/components/integration/sensor.py
@@ -239,7 +239,7 @@ class IntegrationSensor(RestoreSensor):
             self._last_valid_state = last_sensor_data.last_valid_state
 
         elif (state := await self.async_get_last_state()) is not None:
-            # legacy to be removed on 2023.10 (we are keeping this to avoid utility_meter counter losses)
+            # legacy to be removed on 2023.10 (we are keeping this to avoid losing data during the transition)
             if state.state in [STATE_UNAVAILABLE, STATE_UNKNOWN]:
                 if state.state == STATE_UNAVAILABLE:
                     self._attr_available = False

--- a/homeassistant/components/integration/sensor.py
+++ b/homeassistant/components/integration/sensor.py
@@ -48,7 +48,6 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 ATTR_SOURCE_ID: Final = "source"
-ATTR_LAST_VALID_STATE: Final = "last_valid_state"
 
 # SI Metric prefixes
 UNIT_PREFIXES = {None: 1, "k": 10**3, "M": 10**6, "G": 10**9, "T": 10**12}
@@ -109,8 +108,8 @@ class IntegrationSensorExtraStoredData(SensorExtraStoredData):
 
         try:
             last_valid_state = (
-                Decimal(str(restored.get(ATTR_LAST_VALID_STATE)))
-                if restored.get(ATTR_LAST_VALID_STATE)
+                Decimal(str(restored.get("last_valid_state")))
+                if restored.get("last_valid_state")
                 else None
             )
         except InvalidOperation:
@@ -390,7 +389,6 @@ class IntegrationSensor(RestoreSensor):
         """Return the state attributes of the sensor."""
         state_attr = {
             ATTR_SOURCE_ID: self._source_entity,
-            ATTR_LAST_VALID_STATE: str(self._last_valid_state),
         }
 
         return state_attr

--- a/homeassistant/components/integration/sensor.py
+++ b/homeassistant/components/integration/sensor.py
@@ -1,16 +1,19 @@
 """Numeric integration of data coming from a source sensor over time."""
 from __future__ import annotations
 
-from decimal import Decimal, DecimalException
+from dataclasses import dataclass
+from decimal import Decimal, DecimalException, InvalidOperation
 import logging
-from typing import Final
+from typing import Any, Final
 
+from typing_extensions import Self
 import voluptuous as vol
 
 from homeassistant.components.sensor import (
     PLATFORM_SCHEMA,
+    RestoreSensor,
     SensorDeviceClass,
-    SensorEntity,
+    SensorExtraStoredData,
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
@@ -28,7 +31,6 @@ from homeassistant.core import Event, HomeAssistant, State, callback
 from homeassistant.helpers import config_validation as cv, entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_state_change_event
-from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from .const import (
@@ -46,6 +48,7 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 ATTR_SOURCE_ID: Final = "source"
+ATTR_LAST_VALID_STATE: Final = "last_valid_state"
 
 # SI Metric prefixes
 UNIT_PREFIXES = {None: 1, "k": 10**3, "M": 10**6, "G": 10**9, "T": 10**12}
@@ -77,6 +80,54 @@ PLATFORM_SCHEMA = vol.All(
         }
     ),
 )
+
+
+@dataclass
+class IntegrationSensorExtraStoredData(SensorExtraStoredData):
+    """Object to hold extra stored data."""
+
+    source_entity: str | None
+    last_valid_state: Decimal | None
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a dict representation of the utility sensor data."""
+        data = super().as_dict()
+        data["source_entity"] = self.source_entity
+        data["last_valid_state"] = (
+            str(self.last_valid_state) if self.last_valid_state else None
+        )
+        return data
+
+    @classmethod
+    def from_dict(cls, restored: dict[str, Any]) -> Self | None:
+        """Initialize a stored sensor state from a dict."""
+        extra = SensorExtraStoredData.from_dict(restored)
+        if extra is None:
+            return None
+
+        source_entity = restored.get(ATTR_SOURCE_ID)
+
+        try:
+            last_valid_state: Decimal | None = (
+                Decimal(restored[ATTR_LAST_VALID_STATE])
+                if restored.get(ATTR_LAST_VALID_STATE)
+                else None
+            )
+        except KeyError:
+            # restored is a dict, but does not have all values
+            _LOGGER.error("Could not restore last_valid_state")
+            return None
+        except InvalidOperation:
+            # last_period is corrupted
+            _LOGGER.error("Could not use last_valid_state")
+            return None
+
+        return cls(
+            extra.native_value,
+            extra.native_unit_of_measurement,
+            source_entity,
+            last_valid_state,
+        )
 
 
 async def async_setup_entry(
@@ -129,7 +180,7 @@ async def async_setup_platform(
 
 
 # pylint: disable-next=hass-invalid-inheritance # needs fixing
-class IntegrationSensor(RestoreEntity, SensorEntity):
+class IntegrationSensor(RestoreSensor):
     """Representation of an integration sensor."""
 
     _attr_state_class = SensorStateClass.TOTAL
@@ -160,7 +211,8 @@ class IntegrationSensor(RestoreEntity, SensorEntity):
         self._unit_time = UNIT_TIME[unit_time]
         self._unit_time_str = unit_time
         self._attr_icon = "mdi:chart-histogram"
-        self._attr_extra_state_attributes = {ATTR_SOURCE_ID: source_entity}
+        self._source_entity: str = source_entity
+        self._last_valid_state: Decimal | None = None
 
     def _unit(self, source_unit: str) -> str:
         """Derive unit from the source sensor, SI prefix and time unit."""
@@ -175,10 +227,23 @@ class IntegrationSensor(RestoreEntity, SensorEntity):
     async def async_added_to_hass(self) -> None:
         """Handle entity which will be added."""
         await super().async_added_to_hass()
-        if (state := await self.async_get_last_state()) is not None:
-            if state.state == STATE_UNAVAILABLE:
-                self._attr_available = False
-            elif state.state != STATE_UNKNOWN:
+
+        if (last_sensor_data := await self.async_get_last_sensor_data()) is not None:
+            self._state = (
+                None
+                if last_sensor_data.native_value
+                else last_sensor_data.last_valid_state
+            )
+            self._attr_native_value = last_sensor_data.native_value
+            self._unit_of_measurement = last_sensor_data.native_unit_of_measurement
+            self._last_valid_state = last_sensor_data.last_valid_state
+
+        elif (state := await self.async_get_last_state()) is not None:
+            # legacy to be removed on 2023.10 (we are keeping this to avoid utility_meter counter losses)
+            if state.state in [STATE_UNAVAILABLE, STATE_UNKNOWN]:
+                if state.state == STATE_UNAVAILABLE:
+                    self._attr_available = False
+            else:
                 try:
                     self._state = Decimal(state.state)
                 except (DecimalException, ValueError) as err:
@@ -295,6 +360,7 @@ class IntegrationSensor(RestoreEntity, SensorEntity):
                     self._state += integral
                 else:
                     self._state = integral
+                self._last_valid_state = self._state
                 self.async_write_ha_state()
 
         self.async_on_remove(
@@ -314,3 +380,35 @@ class IntegrationSensor(RestoreEntity, SensorEntity):
     def native_unit_of_measurement(self) -> str | None:
         """Return the unit the value is expressed in."""
         return self._unit_of_measurement
+
+    @property
+    def extra_state_attributes(self) -> dict[str, str] | None:
+        """Return the state attributes of the sensor."""
+        state_attr = {
+            ATTR_SOURCE_ID: self._source_entity,
+            ATTR_LAST_VALID_STATE: str(self._last_valid_state),
+        }
+
+        return state_attr
+
+    @property
+    def extra_restore_state_data(self) -> IntegrationSensorExtraStoredData:
+        """Return sensor specific state data to be restored."""
+        return IntegrationSensorExtraStoredData(
+            self.native_value,
+            self.native_unit_of_measurement,
+            self._source_entity,
+            self._last_valid_state,
+        )
+
+    async def async_get_last_sensor_data(
+        self,
+    ) -> IntegrationSensorExtraStoredData | None:
+        """Restore Utility Meter Sensor Extra Stored Data."""
+        if (restored_last_extra_data := await self.async_get_last_extra_data()) is None:
+            return None
+        _LOGGER.error(restored_last_extra_data.as_dict())
+
+        return IntegrationSensorExtraStoredData.from_dict(
+            restored_last_extra_data.as_dict()
+        )

--- a/tests/components/integration/test_sensor.py
+++ b/tests/components/integration/test_sensor.py
@@ -204,7 +204,6 @@ async def test_restore_unavailable_state(hass: HomeAssistant) -> None:
     state = hass.states.get("sensor.integration")
     assert state
     assert state.state == "100.00"
-    assert state.attributes.get("last_valid_state") == "100.00"
 
 
 @pytest.mark.parametrize(

--- a/tests/components/integration/test_sensor.py
+++ b/tests/components/integration/test_sensor.py
@@ -19,7 +19,7 @@ from homeassistant.core import HomeAssistant, State
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
-from tests.common import mock_restore_cache
+from tests.common import mock_restore_cache, mock_restore_cache_with_extra_data
 
 
 @pytest.mark.parametrize("method", ["trapezoidal", "left", "right"])
@@ -163,6 +163,48 @@ async def test_restore_state(hass: HomeAssistant) -> None:
     assert state.state == "100.00"
     assert state.attributes.get("unit_of_measurement") == UnitOfEnergy.KILO_WATT_HOUR
     assert state.attributes.get("device_class") == SensorDeviceClass.ENERGY
+    assert state.attributes.get("last_good_state") is None
+
+
+async def test_restore_unavailable_state(hass: HomeAssistant) -> None:
+    """Test integration sensor state is restored correctly."""
+    mock_restore_cache_with_extra_data(
+        hass,
+        [
+            (
+                State(
+                    "sensor.integration",
+                    STATE_UNAVAILABLE,
+                    {
+                        "device_class": SensorDeviceClass.ENERGY,
+                        "unit_of_measurement": UnitOfEnergy.KILO_WATT_HOUR,
+                    },
+                ),
+                {
+                    "native_value": None,
+                    "native_unit_of_measurement": "kWh",
+                    "source_entity": "sensor.power",
+                    "last_valid_state": "100.00",
+                },
+            ),
+        ],
+    )
+    config = {
+        "sensor": {
+            "platform": "integration",
+            "name": "integration",
+            "source": "sensor.power",
+            "round": 2,
+        }
+    }
+
+    assert await async_setup_component(hass, "sensor", config)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.integration")
+    assert state
+    assert state.state == "100.00"
+    assert state.attributes.get("last_valid_state") == "100.00"
 
 
 async def test_restore_state_failed(hass: HomeAssistant) -> None:

--- a/tests/components/integration/test_sensor.py
+++ b/tests/components/integration/test_sensor.py
@@ -219,7 +219,7 @@ async def test_restore_unavailable_state(hass: HomeAssistant) -> None:
             "native_value": None,
             "native_unit_of_measurement": "kWh",
             "source_entity": "sensor.power",
-            "last_valid_state": None,
+            "last_valid_state": "None",
         },
     ],
 )

--- a/tests/components/integration/test_sensor.py
+++ b/tests/components/integration/test_sensor.py
@@ -219,7 +219,7 @@ async def test_restore_unavailable_state(hass: HomeAssistant) -> None:
             "native_value": None,
             "native_unit_of_measurement": "kWh",
             "source_entity": "sensor.power",
-            "last_valid_state": STATE_UNAVAILABLE,
+            "last_valid_state": None,
         },
     ],
 )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Riemann integration would reset its value if the source sensor was unavailable (or unknown) when HA is restarted. 
This PR follows the same pattern already used in utility_meter to keep an extra attribute with last_valid_state from which to restore back.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #92912
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
