### PR TITLE
Fix onvif setup failing when unable to parse camera time

### DIFF
--- a/homeassistant/components/onvif/device.py
+++ b/homeassistant/components/onvif/device.py
@@ -23,7 +23,7 @@ from homeassistant.const import (
     CONF_USERNAME,
     Platform,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 import homeassistant.util.dt as dt_util
 
 from .const import (
@@ -189,14 +189,19 @@ class ONVIFDevice:
         dt_param.DateTimeType = "Manual"
         # Retrieve DST setting from system
         dt_param.DaylightSavings = bool(time.localtime().tm_isdst)
-        dt_param.UTCDateTime = device_time.UTCDateTime
+        dt_param.UTCDateTime = {
+            "Date": {
+                "Year": system_date.year,
+                "Month": system_date.month,
+                "Day": system_date.day,
+            },
+            "Time": {
+                "Hour": system_date.hour,
+                "Minute": system_date.minute,
+                "Second": system_date.second,
+            },
+        }
         # Retrieve timezone from system
-        dt_param.UTCDateTime.Date.Year = system_date.year
-        dt_param.UTCDateTime.Date.Month = system_date.month
-        dt_param.UTCDateTime.Date.Day = system_date.day
-        dt_param.UTCDateTime.Time.Hour = system_date.hour
-        dt_param.UTCDateTime.Time.Minute = system_date.minute
-        dt_param.UTCDateTime.Time.Second = system_date.second
         system_timezone = str(system_date.astimezone().tzinfo)
         timezone_names: list[str | None] = [system_timezone]
         if (time_zone := device_time.TimeZone) and system_timezone != time_zone.TZ:
@@ -283,6 +288,22 @@ class ONVIFDevice:
         if abs(self._dt_diff_seconds) < 5:
             return
 
+        if device_time.DateTimeType != "Manual":
+            self._async_log_time_out_of_sync(cam_date_utc, system_date)
+            return
+
+        # Set Date and Time ourselves if Date and Time is set manually in the camera.
+        try:
+            await self.async_manually_set_date_and_time()
+        except (RequestError, TransportError, IndexError, Fault):
+            LOGGER.warning("%s: Could not sync date/time on this camera", self.name)
+            self._async_log_time_out_of_sync(cam_date_utc, system_date)
+
+    @callback
+    def _async_log_time_out_of_sync(
+        self, cam_date_utc: dt.datetime, system_date: dt.datetime
+    ) -> None:
+        """Log a warning if the camera and system date/time are not synced."""
         LOGGER.warning(
             (
                 "The date/time on %s (UTC) is '%s', "
@@ -293,15 +314,6 @@ class ONVIFDevice:
             cam_date_utc,
             system_date,
         )
-
-        if device_time.DateTimeType != "Manual":
-            return
-
-        # Set Date and Time ourselves if Date and Time is set manually in the camera.
-        try:
-            await self.async_manually_set_date_and_time()
-        except (RequestError, TransportError, IndexError, Fault):
-            LOGGER.warning("%s: Could not sync date/time on this camera", self.name)
 
     async def async_get_device_info(self) -> DeviceInfo:
         """Obtain information about this device."""


### PR DESCRIPTION
Not tagged for a patch since I found this on an old refurb dlink camera I bought and its not been reported. I figure its not worth the change risk for an issue that has not been reported, and can wait to go through beta.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
fixes
```
2023-05-27 19:21:14.280 ERROR (MainThread) [homeassistant.config_entries] Error setting up entry dlink - B0:C5:54:5E:04:29 for onvif
Traceback (most recent call last):
  File "/Users/bdraco/home-assistant/homeassistant/config_entries.py", line 387, in async_setup
    result = await component.async_setup_entry(hass, self)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/bdraco/home-assistant/homeassistant/components/onvif/__init__.py", line 46, in async_setup_entry
    await device.async_setup()
  File "/Users/bdraco/home-assistant/homeassistant/components/onvif/device.py", line 118, in async_setup
    await self.async_check_date_and_time()
  File "/Users/bdraco/home-assistant/homeassistant/components/onvif/device.py", line 303, in async_check_date_and_time
    await self.async_manually_set_date_and_time()
  File "/Users/bdraco/home-assistant/homeassistant/components/onvif/device.py", line 195, in async_manually_set_date_and_time
    dt_param.UTCDateTime.Date.Year = system_date.year
    ^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: NoneType object has no attribute Date
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
