### PR TITLE
Add proxy support for HTTP clients

### DIFF
--- a/homeassistant/components/auth/indieauth.py
+++ b/homeassistant/components/auth/indieauth.py
@@ -92,7 +92,7 @@ async def fetch_redirect_uris(hass: HomeAssistant, url: str) -> list[str]:
     parser = LinkTagParser("redirect_uri")
     chunks = 0
     try:
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(trust_env=True) as session:
             async with session.get(url, timeout=5) as resp:
                 async for data in resp.content.iter_chunked(1024):
                     parser.feed(data.decode())

--- a/homeassistant/helpers/aiohttp_client.py
+++ b/homeassistant/helpers/aiohttp_client.py
@@ -138,6 +138,7 @@ def _async_create_clientsession(
         connector=_async_get_connector(hass, verify_ssl),
         json_serialize=json_dumps,
         response_class=HassClientResponse,
+        trust_env=True,
         **kwargs,
     )
     # Prevent packages accidentally overriding our default headers

--- a/homeassistant/helpers/httpx_client.py
+++ b/homeassistant/helpers/httpx_client.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 import sys
+import os
 from typing import Any
 
 import httpx
@@ -75,9 +76,22 @@ def create_async_httpx_client(
         if verify_ssl
         else create_no_verify_ssl_context(ssl_cipher_list)
     )
+
+    # Check proxies in environment variables
+    http_proxy = os.environ.get("http_proxy") or os.environ.get("HTTP_PROXY")
+    https_proxy = os.environ.get("https_proxy") or os.environ.get("HTTPS_PROXY")
+    proxies = None
+    if http_proxy or https_proxy:
+        proxies = {}
+        if http_proxy:
+            proxies["http://"] = http_proxy
+        if https_proxy:
+            proxies["https://"] = https_proxy
+
     client = HassHttpXAsyncClient(
         verify=ssl_context,
         headers={USER_AGENT: SERVER_SOFTWARE},
+        proxies=proxies,
         **kwargs,
     )
 

--- a/tests/helpers/test_aiohttp_compat.py
+++ b/tests/helpers/test_aiohttp_compat.py
@@ -44,6 +44,7 @@ async def test_handler_cancellation(socket_enabled, unused_tcp_port_factory) -> 
     try:
         async with client.ClientSession(
             timeout=client.ClientTimeout(total=0.1)
+            trust_env=True
         ) as sess:
             with pytest.raises(asyncio.TimeoutError):
                 await sess.get(f"http://127.0.0.1:{port}/")

--- a/tests/test_util/aiohttp.py
+++ b/tests/test_util/aiohttp.py
@@ -112,7 +112,11 @@ class AiohttpClientMocker:
 
     def create_session(self, loop):
         """Create a ClientSession that is bound to this mocker."""
-        session = ClientSession(loop=loop, json_serialize=json_dumps)
+        session = ClientSession(
+            loop=loop,
+            json_serialize=json_dumps,
+            trust_env=True,
+        )
         # Setting directly on `session` will raise deprecation warning
         object.__setattr__(session, "_request", self.match_request)
         return session


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

No breaking change.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

HACS uses `aiohttp` to make HTTP requests, it does not use `http_proxy`, `https_proxy` and `no_proxy` in environment variables by default. Some third-party integrations (such as HACS) also use the `aiohttp.ClientSession` in HACS Core for HTTP requests.

In some countries and regions it is difficult to access some websites (e.g. GitHub, which is used a lot). In some network environments, direct access to the Internet is not possible and a proxy is required. HomeAssistant and third-party integrations should respect the user's proxy settings, so I added `trust_env=True` wherever aiohttp is used.

This PR adds a parameter `trust_env=True` to the creation of `ClientSession`, and then everything is s using proxy from environment variables.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to aiohttp documentation: [Client Reference](https://docs.aiohttp.org/en/stable/client_reference.html)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

~If user exposed functionality or configuration variables are added/changed:~

~If the code communicates with devices, web services, or third-party tools:~

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
