### PR TITLE
Reduce overhead to convert units when calling statistics_during_period

### DIFF
--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -200,7 +200,7 @@ def _get_statistic_to_display_unit_converter(
     statistic_unit: str | None,
     state_unit: str | None,
     requested_units: dict[str, str] | None,
-) -> Callable[[float | None], float | None] | None:
+) -> Callable[[float], float] | None:
     """Prepare a converter from the statistics unit to display unit."""
     if (converter := STATISTIC_UNIT_TO_UNIT_CONVERTER.get(statistic_unit)) is None:
         return None
@@ -219,13 +219,7 @@ def _get_statistic_to_display_unit_converter(
     if display_unit == statistic_unit:
         return None
 
-    convert = partial(converter.convert, from_unit=statistic_unit, to_unit=display_unit)
-
-    def _from_normalized_unit(val: float | None) -> float | None:
-        """Return val."""
-        return None if val is None else convert(val)
-
-    return _from_normalized_unit
+    return partial(converter.convert, from_unit=statistic_unit, to_unit=display_unit)
 
 
 def _get_display_to_statistic_unit_converter(
@@ -1491,7 +1485,10 @@ def statistic_during_period(
     if state := hass.states.get(statistic_id):
         state_unit = state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
     if convert := _get_statistic_to_display_unit_converter(unit, state_unit, units):
-        return {key: convert(value) for key, value in result.items()}
+        return {
+            key: None if value is None else convert(value)
+            for key, value in result.items()
+        }
     return result
 
 
@@ -1575,7 +1572,8 @@ def _augment_result_with_change(
             convert = _get_statistic_to_display_unit_converter(unit, state_unit, units)
 
             if convert is not None:
-                prev_sums[statistic_id] = convert(row.sum)
+                _sum = row.sum
+                prev_sums[statistic_id] = None if _sum is None else convert(_sum)
             else:
                 prev_sums[statistic_id] = row.sum
 
@@ -1952,7 +1950,7 @@ def _fast_build_sum_list(
             {
                 "start": (start_ts := db_state[start_ts_idx]),
                 "end": start_ts + table_duration_seconds,
-                "sum": convert(db_state[sum_idx]),
+                "sum": None if (_sum := db_state[sum_idx]) is None else convert(_sum),
             }
             for db_state in stats_list
         ]

--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -219,13 +219,11 @@ def _get_statistic_to_display_unit_converter(
     if display_unit == statistic_unit:
         return None
 
-    convert = converter.convert
+    convert = partial(converter.convert, from_unit=statistic_unit, to_unit=display_unit)
 
     def _from_normalized_unit(val: float | None) -> float | None:
         """Return val."""
-        if val is None:
-            return val
-        return convert(val, statistic_unit, display_unit)
+        return None if val is None else convert(val)
 
     return _from_normalized_unit
 
@@ -1492,9 +1490,9 @@ def statistic_during_period(
     state_unit = unit = metadata[1]["unit_of_measurement"]
     if state := hass.states.get(statistic_id):
         state_unit = state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
-    convert = _get_statistic_to_display_unit_converter(unit, state_unit, units)
-
-    return {key: convert(value) if convert else value for key, value in result.items()}
+    if convert := _get_statistic_to_display_unit_converter(unit, state_unit, units):
+        return {key: convert(value) for key, value in result.items()}
+    return result
 
 
 _type_column_mapping = {

--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -200,7 +200,7 @@ def _get_statistic_to_display_unit_converter(
     statistic_unit: str | None,
     state_unit: str | None,
     requested_units: dict[str, str] | None,
-) -> Callable[[float], float] | None:
+) -> Callable[[float | None], float | None] | None:
     """Prepare a converter from the statistics unit to display unit."""
     if (converter := STATISTIC_UNIT_TO_UNIT_CONVERTER.get(statistic_unit)) is None:
         return None
@@ -219,7 +219,13 @@ def _get_statistic_to_display_unit_converter(
     if display_unit == statistic_unit:
         return None
 
-    return partial(converter.convert, from_unit=statistic_unit, to_unit=display_unit)
+    convert = partial(converter.convert, from_unit=statistic_unit, to_unit=display_unit)
+
+    def _from_normalized_unit(val: float | None) -> float | None:
+        """Return val."""
+        return None if val is None else convert(val)
+
+    return _from_normalized_unit
 
 
 def _get_display_to_statistic_unit_converter(
@@ -1485,10 +1491,7 @@ def statistic_during_period(
     if state := hass.states.get(statistic_id):
         state_unit = state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
     if convert := _get_statistic_to_display_unit_converter(unit, state_unit, units):
-        return {
-            key: None if value is None else convert(value)
-            for key, value in result.items()
-        }
+        return {key: convert(value) for key, value in result.items()}
     return result
 
 
@@ -1572,8 +1575,7 @@ def _augment_result_with_change(
             convert = _get_statistic_to_display_unit_converter(unit, state_unit, units)
 
             if convert is not None:
-                _sum = row.sum
-                prev_sums[statistic_id] = None if _sum is None else convert(_sum)
+                prev_sums[statistic_id] = convert(row.sum)
             else:
                 prev_sums[statistic_id] = row.sum
 
@@ -1950,7 +1952,7 @@ def _fast_build_sum_list(
             {
                 "start": (start_ts := db_state[start_ts_idx]),
                 "end": start_ts + table_duration_seconds,
-                "sum": None if (_sum := db_state[sum_idx]) is None else convert(_sum),
+                "sum": convert(db_state[sum_idx]),
             }
             for db_state in stats_list
         ]


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Reduce overhead to convert units when calling statistics_during_period

Also makes the case were no conversion is needed much faster as it avoids a dict comp on all the data.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
