### PR TITLE
Make unit converter use a factory to avoid looking up the ratios each conversion

### DIFF
--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -229,7 +229,10 @@ def _get_display_to_statistic_unit_converter(
     statistic_unit: str | None,
 ) -> Callable[[float], float] | None:
     """Prepare a converter from the display unit to the statistics unit."""
-    if (converter := STATISTIC_UNIT_TO_UNIT_CONVERTER.get(statistic_unit)) is None:
+    if (
+        display_unit == statistic_unit
+        or (converter := STATISTIC_UNIT_TO_UNIT_CONVERTER.get(statistic_unit)) is None
+    ):
         return None
     return converter.converter_factory(from_unit=display_unit, to_unit=statistic_unit)
 

--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -219,15 +219,9 @@ def _get_statistic_to_display_unit_converter(
     if display_unit == statistic_unit:
         return None
 
-    convert = converter.convert
-
-    def _from_normalized_unit(val: float | None) -> float | None:
-        """Return val."""
-        if val is None:
-            return val
-        return convert(val, statistic_unit, display_unit)
-
-    return _from_normalized_unit
+    return converter.converter_factory_allow_none(
+        from_unit=statistic_unit, to_unit=display_unit
+    )
 
 
 def _get_display_to_statistic_unit_converter(
@@ -243,7 +237,7 @@ def _get_display_to_statistic_unit_converter(
     if (converter := STATISTIC_UNIT_TO_UNIT_CONVERTER.get(statistic_unit)) is None:
         return no_conversion
 
-    return partial(converter.convert, from_unit=display_unit, to_unit=statistic_unit)
+    return converter.converter_factory(from_unit=display_unit, to_unit=statistic_unit)
 
 
 def _get_unit_converter(

--- a/homeassistant/util/unit_conversion.py
+++ b/homeassistant/util/unit_conversion.py
@@ -84,6 +84,19 @@ class BaseUnitConverter:
         return lambda val: (val / from_ratio) * to_ratio
 
     @classmethod
+    def _get_from_to_ratio(
+        cls, from_unit: str | None, to_unit: str | None
+    ) -> tuple[float, float]:
+        """Get unit ratio between units of measurement."""
+        unit_conversion = cls._UNIT_CONVERSION
+        try:
+            return unit_conversion[from_unit], unit_conversion[to_unit]
+        except KeyError as err:
+            raise HomeAssistantError(
+                UNIT_NOT_RECOGNIZED_TEMPLATE.format(err.args[0], cls.UNIT_CLASS)
+            ) from err
+
+    @classmethod
     @lru_cache
     def converter_factory_allow_none(
         cls, from_unit: str | None, to_unit: str | None
@@ -100,19 +113,6 @@ class BaseUnitConverter:
         """Get unit ratio between units of measurement."""
         from_ratio, to_ratio = cls._get_from_to_ratio(from_unit, to_unit)
         return from_ratio / to_ratio
-
-    @classmethod
-    def _get_from_to_ratio(
-        cls, from_unit: str | None, to_unit: str | None
-    ) -> tuple[float, float]:
-        """Get unit ratio between units of measurement."""
-        unit_conversion = cls._UNIT_CONVERSION
-        try:
-            return unit_conversion[from_unit], unit_conversion[to_unit]
-        except KeyError as err:
-            raise HomeAssistantError(
-                UNIT_NOT_RECOGNIZED_TEMPLATE.format(err.args[0], cls.UNIT_CLASS)
-            ) from err
 
 
 class DataRateConverter(BaseUnitConverter):

--- a/homeassistant/util/unit_conversion.py
+++ b/homeassistant/util/unit_conversion.py
@@ -85,10 +85,10 @@ class BaseUnitConverter:
         try:
             from_ratio = unit_conversion[from_unit]
             to_ratio = unit_conversion[to_unit]
-        except KeyError as ex:
+        except KeyError as err:
             raise HomeAssistantError(
-                UNIT_NOT_RECOGNIZED_TEMPLATE.format(ex.args[0], cls.UNIT_CLASS)
-            ) from ex
+                UNIT_NOT_RECOGNIZED_TEMPLATE.format(err.args[0], cls.UNIT_CLASS)
+            ) from err
 
         return lambda val: (val / from_ratio) * to_ratio
 
@@ -105,10 +105,10 @@ class BaseUnitConverter:
         try:
             from_ratio = unit_conversion[from_unit]
             to_ratio = unit_conversion[to_unit]
-        except KeyError as ex:
+        except KeyError as err:
             raise HomeAssistantError(
-                UNIT_NOT_RECOGNIZED_TEMPLATE.format(ex.args[0], cls.UNIT_CLASS)
-            ) from ex
+                UNIT_NOT_RECOGNIZED_TEMPLATE.format(err.args[0], cls.UNIT_CLASS)
+            ) from err
 
         return lambda val: None if val is None else (val / from_ratio) * to_ratio
 
@@ -120,10 +120,10 @@ class BaseUnitConverter:
 
         try:
             return unit_conversion[from_unit] / unit_conversion[to_unit]
-        except KeyError as ex:
+        except KeyError as err:
             raise HomeAssistantError(
-                UNIT_NOT_RECOGNIZED_TEMPLATE.format(ex.args[0], cls.UNIT_CLASS)
-            ) from ex
+                UNIT_NOT_RECOGNIZED_TEMPLATE.format(err.args[0], cls.UNIT_CLASS)
+            ) from err
 
 
 class DataRateConverter(BaseUnitConverter):

--- a/homeassistant/util/unit_conversion.py
+++ b/homeassistant/util/unit_conversion.py
@@ -80,16 +80,7 @@ class BaseUnitConverter:
         """Return a function to convert one unit of measurement to another."""
         if from_unit == to_unit:
             return lambda value: value
-
-        unit_conversion = cls._UNIT_CONVERSION
-        try:
-            from_ratio = unit_conversion[from_unit]
-            to_ratio = unit_conversion[to_unit]
-        except KeyError as err:
-            raise HomeAssistantError(
-                UNIT_NOT_RECOGNIZED_TEMPLATE.format(err.args[0], cls.UNIT_CLASS)
-            ) from err
-
+        from_ratio, to_ratio = cls._get_from_to_ratio(from_unit, to_unit)
         return lambda val: (val / from_ratio) * to_ratio
 
     @classmethod
@@ -100,26 +91,24 @@ class BaseUnitConverter:
         """Return a function to convert one unit of measurement to another which allows None."""
         if from_unit == to_unit:
             return lambda value: value
-
-        unit_conversion = cls._UNIT_CONVERSION
-        try:
-            from_ratio = unit_conversion[from_unit]
-            to_ratio = unit_conversion[to_unit]
-        except KeyError as err:
-            raise HomeAssistantError(
-                UNIT_NOT_RECOGNIZED_TEMPLATE.format(err.args[0], cls.UNIT_CLASS)
-            ) from err
-
+        from_ratio, to_ratio = cls._get_from_to_ratio(from_unit, to_unit)
         return lambda val: None if val is None else (val / from_ratio) * to_ratio
 
     @classmethod
     @lru_cache
     def get_unit_ratio(cls, from_unit: str | None, to_unit: str | None) -> float:
         """Get unit ratio between units of measurement."""
-        unit_conversion = cls._UNIT_CONVERSION
+        from_ratio, to_ratio = cls._get_from_to_ratio(from_unit, to_unit)
+        return from_ratio / to_ratio
 
+    @classmethod
+    def _get_from_to_ratio(
+        cls, from_unit: str | None, to_unit: str | None
+    ) -> tuple[float, float]:
+        """Get unit ratio between units of measurement."""
+        unit_conversion = cls._UNIT_CONVERSION
         try:
-            return unit_conversion[from_unit] / unit_conversion[to_unit]
+            return unit_conversion[from_unit], unit_conversion[to_unit]
         except KeyError as err:
             raise HomeAssistantError(
                 UNIT_NOT_RECOGNIZED_TEMPLATE.format(err.args[0], cls.UNIT_CLASS)

--- a/homeassistant/util/unit_conversion.py
+++ b/homeassistant/util/unit_conversion.py
@@ -78,6 +78,9 @@ class BaseUnitConverter:
         cls, from_unit: str | None, to_unit: str | None
     ) -> Callable[[float], float]:
         """Return a function to convert one unit of measurement to another."""
+        if from_unit == to_unit:
+            return lambda value: value
+
         ratio = cls.get_unit_ratio(from_unit, to_unit)
 
         def _converter(value: float) -> float:
@@ -91,6 +94,9 @@ class BaseUnitConverter:
         cls, from_unit: str | None, to_unit: str | None
     ) -> Callable[[float | None], float | None]:
         """Return a function to convert one unit of measurement to another which allows None."""
+        if from_unit == to_unit:
+            return lambda value: value
+
         ratio = cls.get_unit_ratio(from_unit, to_unit)
 
         def _converter_allow_none(value: float | None) -> float | None:
@@ -102,9 +108,6 @@ class BaseUnitConverter:
     @lru_cache
     def get_unit_ratio(cls, from_unit: str | None, to_unit: str | None) -> float:
         """Get unit ratio between units of measurement."""
-        if from_unit == to_unit:
-            return 1
-
         try:
             from_ratio = cls._UNIT_CONVERSION[from_unit]
         except KeyError as err:

--- a/homeassistant/util/unit_conversion.py
+++ b/homeassistant/util/unit_conversion.py
@@ -385,13 +385,8 @@ class TemperatureConverter(BaseUnitConverter):
             # in _converter_factory because we do not want to wrap
             # it with the None check in this case.
             return lambda value: value
-
         convert = cls._converter_factory(from_unit, to_unit)
-
-        def _converter_allow_none(value: float | None) -> float | None:
-            return None if value is None else convert(value)
-
-        return _converter_allow_none
+        return lambda value: None if value is None else convert(value)
 
     @classmethod
     def _converter_factory(

--- a/homeassistant/util/unit_conversion.py
+++ b/homeassistant/util/unit_conversion.py
@@ -78,10 +78,7 @@ class BaseUnitConverter:
         cls, from_unit: str | None, to_unit: str | None, allow_same_unit: bool = False
     ) -> Callable[[float], float]:
         """Return a function to convert one unit of measurement to another."""
-        if not allow_same_unit and from_unit == to_unit:
-            raise HomeAssistantError("from_unit and to_unit cannot be the same")
-
-        ratio = cls._get_unit_ratio_or_raise(from_unit, to_unit)
+        ratio = cls._get_unit_ratio_or_raise(from_unit, to_unit, allow_same_unit)
 
         def _converter(value: float) -> float:
             return value / ratio
@@ -94,10 +91,7 @@ class BaseUnitConverter:
         cls, from_unit: str | None, to_unit: str | None
     ) -> Callable[[float | None], float | None]:
         """Return a function to convert one unit of measurement to another which allows None."""
-        if from_unit == to_unit:
-            raise HomeAssistantError("from_unit and to_unit cannot be the same")
-
-        ratio = cls._get_unit_ratio_or_raise(from_unit, to_unit)
+        ratio = cls._get_unit_ratio_or_raise(from_unit, to_unit, False)
 
         def _converter_allow_none(value: float | None) -> float | None:
             return None if value is None else value / ratio
@@ -106,9 +100,12 @@ class BaseUnitConverter:
 
     @classmethod
     def _get_unit_ratio_or_raise(
-        cls, from_unit: str | None, to_unit: str | None
+        cls, from_unit: str | None, to_unit: str | None, allow_same_unit: bool = False
     ) -> float:
         """Return the from_ratio and to_ratio for a unit conversion."""
+        if not allow_same_unit and from_unit == to_unit:
+            raise HomeAssistantError("from_unit and to_unit cannot be the same")
+
         try:
             from_ratio = cls._UNIT_CONVERSION[from_unit]
         except KeyError as err:

--- a/homeassistant/util/unit_conversion.py
+++ b/homeassistant/util/unit_conversion.py
@@ -81,9 +81,10 @@ class BaseUnitConverter:
         if from_unit == to_unit:
             return lambda value: value
 
+        unit_conversion = cls._UNIT_CONVERSION
         try:
-            from_ratio = cls._UNIT_CONVERSION[from_unit]
-            to_ratio = cls._UNIT_CONVERSION[to_unit]
+            from_ratio = unit_conversion[from_unit]
+            to_ratio = unit_conversion[to_unit]
         except KeyError as ex:
             raise HomeAssistantError(
                 UNIT_NOT_RECOGNIZED_TEMPLATE.format(ex.args[0], cls.UNIT_CLASS)
@@ -100,9 +101,10 @@ class BaseUnitConverter:
         if from_unit == to_unit:
             return lambda value: value
 
+        unit_conversion = cls._UNIT_CONVERSION
         try:
-            from_ratio = cls._UNIT_CONVERSION[from_unit]
-            to_ratio = cls._UNIT_CONVERSION[to_unit]
+            from_ratio = unit_conversion[from_unit]
+            to_ratio = unit_conversion[to_unit]
         except KeyError as ex:
             raise HomeAssistantError(
                 UNIT_NOT_RECOGNIZED_TEMPLATE.format(ex.args[0], cls.UNIT_CLASS)
@@ -114,8 +116,10 @@ class BaseUnitConverter:
     @lru_cache
     def get_unit_ratio(cls, from_unit: str | None, to_unit: str | None) -> float:
         """Get unit ratio between units of measurement."""
+        unit_conversion = cls._UNIT_CONVERSION
+
         try:
-            return cls._UNIT_CONVERSION[from_unit] / cls._UNIT_CONVERSION[to_unit]
+            return unit_conversion[from_unit] / unit_conversion[to_unit]
         except KeyError as ex:
             raise HomeAssistantError(
                 UNIT_NOT_RECOGNIZED_TEMPLATE.format(ex.args[0], cls.UNIT_CLASS)

--- a/homeassistant/util/unit_conversion.py
+++ b/homeassistant/util/unit_conversion.py
@@ -122,7 +122,7 @@ class BaseUnitConverter:
     ) -> float:
         """Return the from_ratio and to_ratio for a unit conversion."""
         if from_unit == to_unit:
-            raise ValueError("from_unit and to_unit cannot be the same")
+            raise HomeAssistantError("from_unit and to_unit cannot be the same")
 
         try:
             from_ratio = cls._UNIT_CONVERSION[from_unit]

--- a/homeassistant/util/unit_conversion.py
+++ b/homeassistant/util/unit_conversion.py
@@ -78,7 +78,7 @@ class BaseUnitConverter:
         cls, from_unit: str | None, to_unit: str | None
     ) -> Callable[[float], float]:
         """Return a function to convert one unit of measurement to another."""
-        ratio = cls._get_unit_ratio_or_raise(from_unit, to_unit)
+        ratio = cls.get_unit_ratio(from_unit, to_unit)
 
         def _converter(value: float) -> float:
             return value / ratio
@@ -91,7 +91,7 @@ class BaseUnitConverter:
         cls, from_unit: str | None, to_unit: str | None
     ) -> Callable[[float | None], float | None]:
         """Return a function to convert one unit of measurement to another which allows None."""
-        ratio = cls._get_unit_ratio_or_raise(from_unit, to_unit)
+        ratio = cls.get_unit_ratio(from_unit, to_unit)
 
         def _converter_allow_none(value: float | None) -> float | None:
             return None if value is None else value / ratio
@@ -99,10 +99,9 @@ class BaseUnitConverter:
         return _converter_allow_none
 
     @classmethod
-    def _get_unit_ratio_or_raise(
-        cls, from_unit: str | None, to_unit: str | None
-    ) -> float:
-        """Return the from_ratio and to_ratio for a unit conversion."""
+    @lru_cache(maxsize=128)
+    def get_unit_ratio(cls, from_unit: str | None, to_unit: str | None) -> float:
+        """Get unit ratio between units of measurement."""
         if from_unit == to_unit:
             return 1
 
@@ -121,11 +120,6 @@ class BaseUnitConverter:
             ) from err
 
         return from_ratio / to_ratio
-
-    @classmethod
-    def get_unit_ratio(cls, from_unit: str | None, to_unit: str | None) -> float:
-        """Get unit ratio between units of measurement."""
-        return cls._UNIT_CONVERSION[from_unit] / cls._UNIT_CONVERSION[to_unit]
 
 
 class DataRateConverter(BaseUnitConverter):

--- a/homeassistant/util/unit_conversion.py
+++ b/homeassistant/util/unit_conversion.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from functools import lru_cache
-from operator import truediv
-from typing import cast
 
 from homeassistant.const import (
     CONCENTRATION_PARTS_PER_BILLION,
@@ -83,12 +81,15 @@ class BaseUnitConverter:
         if from_unit == to_unit:
             return lambda value: value
 
-        from_ratio, to_ratio = cls._get_from_to_ratio(from_unit, to_unit)
+        try:
+            from_ratio = cls._UNIT_CONVERSION[from_unit]
+            to_ratio = cls._UNIT_CONVERSION[to_unit]
+        except KeyError as ex:
+            raise HomeAssistantError(
+                UNIT_NOT_RECOGNIZED_TEMPLATE.format(ex.args[0], cls.UNIT_CLASS)
+            ) from ex
 
-        def _converter(value: float) -> float:
-            return (value / from_ratio) * to_ratio
-
-        return _converter
+        return lambda value: (value / from_ratio) * to_ratio
 
     @classmethod
     @lru_cache
@@ -99,7 +100,13 @@ class BaseUnitConverter:
         if from_unit == to_unit:
             return lambda value: value
 
-        from_ratio, to_ratio = cls._get_from_to_ratio(from_unit, to_unit)
+        try:
+            from_ratio = cls._UNIT_CONVERSION[from_unit]
+            to_ratio = cls._UNIT_CONVERSION[to_unit]
+        except KeyError as ex:
+            raise HomeAssistantError(
+                UNIT_NOT_RECOGNIZED_TEMPLATE.format(ex.args[0], cls.UNIT_CLASS)
+            ) from ex
 
         def _converter_allow_none(value: float | None) -> float | None:
             return None if value is None else (value / from_ratio) * to_ratio
@@ -108,22 +115,14 @@ class BaseUnitConverter:
 
     @classmethod
     @lru_cache
-    def _get_from_to_ratio(
-        cls, from_unit: str | None, to_unit: str | None
-    ) -> tuple[float, float]:
-        """Get the from_ratio and to_ratio  for units."""
+    def get_unit_ratio(cls, from_unit: str | None, to_unit: str | None) -> float:
+        """Get unit ratio between units of measurement."""
         try:
-            return cls._UNIT_CONVERSION[from_unit], cls._UNIT_CONVERSION[to_unit]
+            return cls._UNIT_CONVERSION[from_unit] / cls._UNIT_CONVERSION[to_unit]
         except KeyError as ex:
             raise HomeAssistantError(
                 UNIT_NOT_RECOGNIZED_TEMPLATE.format(ex.args[0], cls.UNIT_CLASS)
             ) from ex
-
-    @classmethod
-    @lru_cache
-    def get_unit_ratio(cls, from_unit: str | None, to_unit: str | None) -> float:
-        """Get unit ratio between units of measurement."""
-        return cast(float, truediv(*cls._get_from_to_ratio(from_unit, to_unit)))
 
 
 class DataRateConverter(BaseUnitConverter):

--- a/homeassistant/util/unit_conversion.py
+++ b/homeassistant/util/unit_conversion.py
@@ -461,12 +461,12 @@ class TemperatureConverter(BaseUnitConverter):
     @classmethod
     def _kelvin_to_fahrenheit(cls, kelvin: float) -> float:
         """Convert a temperature in Kelvin to Fahrenheit."""
-        return cls._celsius_to_fahrenheit(cls._kelvin_to_celsius(kelvin))
+        return (kelvin - 273.15) * 1.8 + 32.0
 
     @classmethod
     def _fahrenheit_to_kelvin(cls, fahrenheit: float) -> float:
         """Convert a temperature in Fahrenheit to Kelvin."""
-        return cls._celsius_to_kelvin(cls._fahrenheit_to_celsius(fahrenheit))
+        return 273.15 + ((fahrenheit - 32.0) / 1.8)
 
     @classmethod
     def _fahrenheit_to_celsius(cls, fahrenheit: float) -> float:

--- a/homeassistant/util/unit_conversion.py
+++ b/homeassistant/util/unit_conversion.py
@@ -89,7 +89,7 @@ class BaseUnitConverter:
                 UNIT_NOT_RECOGNIZED_TEMPLATE.format(ex.args[0], cls.UNIT_CLASS)
             ) from ex
 
-        return lambda value: (value / from_ratio) * to_ratio
+        return lambda val: (val / from_ratio) * to_ratio
 
     @classmethod
     @lru_cache
@@ -108,10 +108,7 @@ class BaseUnitConverter:
                 UNIT_NOT_RECOGNIZED_TEMPLATE.format(ex.args[0], cls.UNIT_CLASS)
             ) from ex
 
-        def _converter_allow_none(value: float | None) -> float | None:
-            return None if value is None else (value / from_ratio) * to_ratio
-
-        return _converter_allow_none
+        return lambda val: None if val is None else (val / from_ratio) * to_ratio
 
     @classmethod
     @lru_cache

--- a/homeassistant/util/unit_conversion.py
+++ b/homeassistant/util/unit_conversion.py
@@ -127,6 +127,11 @@ class BaseUnitConverter:
     ) -> tuple[float, float]:
         """Get the from_ratio and to_ratio  for units."""
         try:
+            return cls._UNIT_CONVERSION[from_unit], cls._UNIT_CONVERSION[to_unit]
+        except KeyError:
+            pass
+
+        try:
             from_ratio = cls._UNIT_CONVERSION[from_unit]
         except KeyError as err:
             raise HomeAssistantError(

--- a/homeassistant/util/unit_conversion.py
+++ b/homeassistant/util/unit_conversion.py
@@ -83,20 +83,6 @@ class BaseUnitConverter:
         if from_unit == to_unit:
             return lambda value: value
 
-        try:
-            from_ratio = cls._UNIT_CONVERSION[from_unit]
-        except KeyError as err:
-            raise HomeAssistantError(
-                UNIT_NOT_RECOGNIZED_TEMPLATE.format(from_unit, cls.UNIT_CLASS)
-            ) from err
-
-        try:
-            to_ratio = cls._UNIT_CONVERSION[to_unit]
-        except KeyError as err:
-            raise HomeAssistantError(
-                UNIT_NOT_RECOGNIZED_TEMPLATE.format(to_unit, cls.UNIT_CLASS)
-            ) from err
-
         from_ratio, to_ratio = cls._get_from_to_ratio(from_unit, to_unit)
 
         def _converter(value: float) -> float:

--- a/homeassistant/util/unit_conversion.py
+++ b/homeassistant/util/unit_conversion.py
@@ -73,7 +73,7 @@ class BaseUnitConverter:
         return cls.converter_factory(from_unit, to_unit)(value)
 
     @classmethod
-    @lru_cache(maxsize=128)
+    @lru_cache
     def converter_factory(
         cls, from_unit: str | None, to_unit: str | None
     ) -> Callable[[float], float]:
@@ -86,7 +86,7 @@ class BaseUnitConverter:
         return _converter
 
     @classmethod
-    @lru_cache(maxsize=128)
+    @lru_cache
     def converter_factory_allow_none(
         cls, from_unit: str | None, to_unit: str | None
     ) -> Callable[[float | None], float | None]:
@@ -99,7 +99,7 @@ class BaseUnitConverter:
         return _converter_allow_none
 
     @classmethod
-    @lru_cache(maxsize=128)
+    @lru_cache
     def get_unit_ratio(cls, from_unit: str | None, to_unit: str | None) -> float:
         """Get unit ratio between units of measurement."""
         if from_unit == to_unit:
@@ -368,7 +368,7 @@ class TemperatureConverter(BaseUnitConverter):
     }
 
     @classmethod
-    @lru_cache(maxsize=16)
+    @lru_cache(maxsize=8)
     def converter_factory(
         cls, from_unit: str | None, to_unit: str | None
     ) -> Callable[[float], float]:
@@ -382,7 +382,7 @@ class TemperatureConverter(BaseUnitConverter):
         return cls._converter_factory(from_unit, to_unit)
 
     @classmethod
-    @lru_cache(maxsize=16)
+    @lru_cache(maxsize=8)
     def converter_factory_allow_none(
         cls, from_unit: str | None, to_unit: str | None
     ) -> Callable[[float | None], float | None]:

--- a/homeassistant/util/unit_conversion.py
+++ b/homeassistant/util/unit_conversion.py
@@ -377,7 +377,30 @@ class TemperatureConverter(BaseUnitConverter):
     }
 
     @classmethod
-    def convert(cls, value: float, from_unit: str | None, to_unit: str | None) -> float:
+    @lru_cache(maxsize=16)
+    def converter_factory(
+        cls, from_unit: str | None, to_unit: str | None, allow_same_unit: bool = False
+    ) -> Callable[[float], float]:
+        """Return a function to convert a temperature from one unit to another."""
+        return cls._converter_factory(from_unit, to_unit, allow_same_unit)
+
+    @classmethod
+    @lru_cache(maxsize=16)
+    def converter_factory_allow_none(
+        cls, from_unit: str | None, to_unit: str | None
+    ) -> Callable[[float | None], float | None]:
+        """Return a function to convert a temperature from one unit to another which allows None."""
+        convert = cls._converter_factory(from_unit, to_unit, True)
+
+        def _converter_allow_none(value: float | None) -> float | None:
+            return None if value is None else convert(value)
+
+        return _converter_allow_none
+
+    @classmethod
+    def _converter_factory(
+        cls, from_unit: str | None, to_unit: str | None, allow_same_unit: bool = False
+    ) -> Callable[[float], float]:
         """Convert a temperature from one unit to another.
 
         eg. 10°C will return 50°F
@@ -388,31 +411,33 @@ class TemperatureConverter(BaseUnitConverter):
         # We cannot use the implementation from BaseUnitConverter here because the
         # temperature units do not use the same floor: 0°C, 0°F and 0K do not align
         if from_unit == to_unit:
-            return value
+            if not allow_same_unit:
+                raise HomeAssistantError("from_unit and to_unit cannot be the same")
+            return lambda value: value
 
         if from_unit == UnitOfTemperature.CELSIUS:
             if to_unit == UnitOfTemperature.FAHRENHEIT:
-                return cls._celsius_to_fahrenheit(value)
+                return cls._celsius_to_fahrenheit
             if to_unit == UnitOfTemperature.KELVIN:
-                return cls._celsius_to_kelvin(value)
+                return cls._celsius_to_kelvin
             raise HomeAssistantError(
                 UNIT_NOT_RECOGNIZED_TEMPLATE.format(to_unit, cls.UNIT_CLASS)
             )
 
         if from_unit == UnitOfTemperature.FAHRENHEIT:
             if to_unit == UnitOfTemperature.CELSIUS:
-                return cls._fahrenheit_to_celsius(value)
+                return cls._fahrenheit_to_celsius
             if to_unit == UnitOfTemperature.KELVIN:
-                return cls._celsius_to_kelvin(cls._fahrenheit_to_celsius(value))
+                return cls._fahrenheit_to_kelvin
             raise HomeAssistantError(
                 UNIT_NOT_RECOGNIZED_TEMPLATE.format(to_unit, cls.UNIT_CLASS)
             )
 
         if from_unit == UnitOfTemperature.KELVIN:
             if to_unit == UnitOfTemperature.CELSIUS:
-                return cls._kelvin_to_celsius(value)
+                return cls._kelvin_to_celsius
             if to_unit == UnitOfTemperature.FAHRENHEIT:
-                return cls._celsius_to_fahrenheit(cls._kelvin_to_celsius(value))
+                return cls._kelvin_to_fahrenheit
             raise HomeAssistantError(
                 UNIT_NOT_RECOGNIZED_TEMPLATE.format(to_unit, cls.UNIT_CLASS)
             )
@@ -431,7 +456,17 @@ class TemperatureConverter(BaseUnitConverter):
         """
         # We use BaseUnitConverter implementation here because we are only interested
         # in the ratio between the units.
-        return super().convert(interval, from_unit, to_unit)
+        return super().converter_factory(from_unit, to_unit, True)(interval)
+
+    @classmethod
+    def _kelvin_to_fahrenheit(cls, kelvin: float) -> float:
+        """Convert a temperature in Kelvin to Fahrenheit."""
+        return cls._celsius_to_fahrenheit(cls._kelvin_to_celsius(kelvin))
+
+    @classmethod
+    def _fahrenheit_to_kelvin(cls, fahrenheit: float) -> float:
+        """Convert a temperature in Fahrenheit to Kelvin."""
+        return cls._celsius_to_kelvin(cls._fahrenheit_to_celsius(fahrenheit))
 
     @classmethod
     def _fahrenheit_to_celsius(cls, fahrenheit: float) -> float:

--- a/homeassistant/util/unit_conversion.py
+++ b/homeassistant/util/unit_conversion.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from functools import lru_cache
 from operator import truediv
+from typing import cast
 
 from homeassistant.const import (
     CONCENTRATION_PARTS_PER_BILLION,
@@ -145,7 +146,7 @@ class BaseUnitConverter:
     @lru_cache
     def get_unit_ratio(cls, from_unit: str | None, to_unit: str | None) -> float:
         """Get unit ratio between units of measurement."""
-        return truediv(*cls._get_from_to_ratio(from_unit, to_unit))  # type: ignore[no-any-return]
+        return cast(float, truediv(*cls._get_from_to_ratio(from_unit, to_unit)))
 
 
 class DataRateConverter(BaseUnitConverter):

--- a/homeassistant/util/unit_conversion.py
+++ b/homeassistant/util/unit_conversion.py
@@ -128,24 +128,10 @@ class BaseUnitConverter:
         """Get the from_ratio and to_ratio  for units."""
         try:
             return cls._UNIT_CONVERSION[from_unit], cls._UNIT_CONVERSION[to_unit]
-        except KeyError:
-            pass
-
-        try:
-            from_ratio = cls._UNIT_CONVERSION[from_unit]
-        except KeyError as err:
+        except KeyError as ex:
             raise HomeAssistantError(
-                UNIT_NOT_RECOGNIZED_TEMPLATE.format(from_unit, cls.UNIT_CLASS)
-            ) from err
-
-        try:
-            to_ratio = cls._UNIT_CONVERSION[to_unit]
-        except KeyError as err:
-            raise HomeAssistantError(
-                UNIT_NOT_RECOGNIZED_TEMPLATE.format(to_unit, cls.UNIT_CLASS)
-            ) from err
-
-        return from_ratio, to_ratio
+                UNIT_NOT_RECOGNIZED_TEMPLATE.format(ex.args[0], cls.UNIT_CLASS)
+            ) from ex
 
     @classmethod
     @lru_cache

--- a/tests/components/recorder/test_websocket_api.py
+++ b/tests/components/recorder/test_websocket_api.py
@@ -1973,6 +1973,36 @@ async def test_change_statistics_unit(
         ],
     }
 
+    # Changing to the same unit is allowed but does nothing
+    await client.send_json(
+        {
+            "id": 6,
+            "type": "recorder/change_statistics_unit",
+            "statistic_id": "sensor.test",
+            "new_unit_of_measurement": "W",
+            "old_unit_of_measurement": "W",
+        }
+    )
+    response = await client.receive_json()
+    assert response["success"]
+    await async_recorder_block_till_done(hass)
+
+    await client.send_json({"id": 7, "type": "recorder/list_statistic_ids"})
+    response = await client.receive_json()
+    assert response["success"]
+    assert response["result"] == [
+        {
+            "statistic_id": "sensor.test",
+            "display_unit_of_measurement": "kW",
+            "has_mean": True,
+            "has_sum": False,
+            "name": None,
+            "source": "recorder",
+            "statistics_unit_of_measurement": "W",
+            "unit_class": "power",
+        }
+    ]
+
 
 async def test_change_statistics_unit_errors(
     recorder_mock: Recorder,

--- a/tests/util/test_unit_conversion.py
+++ b/tests/util/test_unit_conversion.py
@@ -558,10 +558,30 @@ def test_unit_conversion_factory(
     )
 
 
-def test_unit_conversion_factory_raises_same_unit() -> None:
+@pytest.mark.parametrize(
+    ("converter", "value", "from_unit", "expected", "to_unit"),
+    [
+        # Process all items in _CONVERTED_VALUE
+        (converter, value, from_unit, expected, to_unit)
+        for converter, item in _CONVERTED_VALUE.items()
+        for value, from_unit, expected, to_unit in item
+        if from_unit == to_unit
+    ],
+)
+def test_unit_conversion_factory_same_unit(
+    converter: type[BaseUnitConverter],
+    value: float,
+    from_unit: str,
+    expected: float,
+    to_unit: str,
+) -> None:
     """Test conversion to other units."""
     with pytest.raises(HomeAssistantError):
-        SpeedConverter.converter_factory("km/h", "km/h")
+        converter.converter_factory(from_unit, to_unit, allow_same_unit=False)
+
+    assert converter.converter_factory(from_unit, to_unit, allow_same_unit=True)(
+        value
+    ) == pytest.approx(expected)
 
 
 @pytest.mark.parametrize(

--- a/tests/util/test_unit_conversion.py
+++ b/tests/util/test_unit_conversion.py
@@ -575,13 +575,10 @@ def test_unit_conversion_factory_same_unit(
     expected: float,
     to_unit: str,
 ) -> None:
-    """Test conversion to other units."""
-    with pytest.raises(HomeAssistantError):
-        converter.converter_factory(from_unit, to_unit, allow_same_unit=False)
-
-    assert converter.converter_factory(from_unit, to_unit, allow_same_unit=True)(
-        value
-    ) == pytest.approx(expected)
+    """Test conversion to same units."""
+    assert converter.converter_factory(from_unit, to_unit)(value) == pytest.approx(
+        expected
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/util/test_unit_conversion.py
+++ b/tests/util/test_unit_conversion.py
@@ -557,6 +557,34 @@ def test_unit_conversion_factory(
     )
 
 
+def test_unit_conversion_factory_allow_none_with_none() -> None:
+    """Test test_unit_conversion_factory_allow_none with None."""
+    assert (
+        SpeedConverter.converter_factory_allow_none(
+            UnitOfSpeed.FEET_PER_SECOND, UnitOfSpeed.FEET_PER_SECOND
+        )(1)
+        == 1
+    )
+    assert (
+        SpeedConverter.converter_factory_allow_none(
+            UnitOfSpeed.FEET_PER_SECOND, UnitOfSpeed.FEET_PER_SECOND
+        )(None)
+        is None
+    )
+    assert (
+        TemperatureConverter.converter_factory_allow_none(
+            UnitOfTemperature.CELSIUS, UnitOfTemperature.CELSIUS
+        )(1)
+        == 1
+    )
+    assert (
+        TemperatureConverter.converter_factory_allow_none(
+            UnitOfTemperature.CELSIUS, UnitOfTemperature.CELSIUS
+        )(None)
+        is None
+    )
+
+
 @pytest.mark.parametrize(
     ("converter", "value", "from_unit", "expected", "to_unit"),
     chain(

--- a/tests/util/test_unit_conversion.py
+++ b/tests/util/test_unit_conversion.py
@@ -558,6 +558,12 @@ def test_unit_conversion_factory(
     )
 
 
+def test_unit_conversion_factory_raises_same_unit() -> None:
+    """Test conversion to other units."""
+    with pytest.raises(HomeAssistantError):
+        SpeedConverter.converter_factory("km/h", "km/h")
+
+
 @pytest.mark.parametrize(
     ("converter", "value", "from_unit", "expected", "to_unit"),
     chain(

--- a/tests/util/test_unit_conversion.py
+++ b/tests/util/test_unit_conversion.py
@@ -542,7 +542,6 @@ def test_unit_conversion(
         (converter, value, from_unit, expected, to_unit)
         for converter, item in _CONVERTED_VALUE.items()
         for value, from_unit, expected, to_unit in item
-        if from_unit != to_unit
     ],
 )
 def test_unit_conversion_factory(
@@ -560,43 +559,18 @@ def test_unit_conversion_factory(
 
 @pytest.mark.parametrize(
     ("converter", "value", "from_unit", "expected", "to_unit"),
-    [
-        # Process all items in _CONVERTED_VALUE
-        (converter, value, from_unit, expected, to_unit)
-        for converter, item in _CONVERTED_VALUE.items()
-        for value, from_unit, expected, to_unit in item
-        if from_unit == to_unit
-    ],
-)
-def test_unit_conversion_factory_same_unit(
-    converter: type[BaseUnitConverter],
-    value: float,
-    from_unit: str,
-    expected: float,
-    to_unit: str,
-) -> None:
-    """Test conversion to same units."""
-    assert converter.converter_factory(from_unit, to_unit)(value) == pytest.approx(
-        expected
-    )
-
-
-@pytest.mark.parametrize(
-    ("converter", "value", "from_unit", "expected", "to_unit"),
     chain(
         [
             # Process all items in _CONVERTED_VALUE
             (converter, value, from_unit, expected, to_unit)
             for converter, item in _CONVERTED_VALUE.items()
             for value, from_unit, expected, to_unit in item
-            if from_unit != to_unit
         ],
         [
             # Process all items in _CONVERTED_VALUE and replace the value with None
             (converter, None, from_unit, None, to_unit)
             for converter, item in _CONVERTED_VALUE.items()
             for value, from_unit, expected, to_unit in item
-            if from_unit != to_unit
         ],
     ),
 )

--- a/tests/util/test_unit_conversion.py
+++ b/tests/util/test_unit_conversion.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import inspect
+from itertools import chain
 
 import pytest
 
@@ -532,6 +533,61 @@ def test_unit_conversion(
 ) -> None:
     """Test conversion to other units."""
     assert converter.convert(value, from_unit, to_unit) == pytest.approx(expected)
+
+
+@pytest.mark.parametrize(
+    ("converter", "value", "from_unit", "expected", "to_unit"),
+    [
+        # Process all items in _CONVERTED_VALUE
+        (converter, value, from_unit, expected, to_unit)
+        for converter, item in _CONVERTED_VALUE.items()
+        for value, from_unit, expected, to_unit in item
+        if from_unit != to_unit
+    ],
+)
+def test_unit_conversion_factory(
+    converter: type[BaseUnitConverter],
+    value: float,
+    from_unit: str,
+    expected: float,
+    to_unit: str,
+) -> None:
+    """Test conversion to other units."""
+    assert converter.converter_factory(from_unit, to_unit)(value) == pytest.approx(
+        expected
+    )
+
+
+@pytest.mark.parametrize(
+    ("converter", "value", "from_unit", "expected", "to_unit"),
+    chain(
+        [
+            # Process all items in _CONVERTED_VALUE
+            (converter, value, from_unit, expected, to_unit)
+            for converter, item in _CONVERTED_VALUE.items()
+            for value, from_unit, expected, to_unit in item
+            if from_unit != to_unit
+        ],
+        [
+            # Process all items in _CONVERTED_VALUE and replace the value with None
+            (converter, None, from_unit, None, to_unit)
+            for converter, item in _CONVERTED_VALUE.items()
+            for value, from_unit, expected, to_unit in item
+            if from_unit != to_unit
+        ],
+    ),
+)
+def test_unit_conversion_factory_allow_none(
+    converter: type[BaseUnitConverter],
+    value: float,
+    from_unit: str,
+    expected: float,
+    to_unit: str,
+) -> None:
+    """Test conversion to other units."""
+    assert converter.converter_factory_allow_none(from_unit, to_unit)(
+        value
+    ) == pytest.approx(expected)
 
 
 @pytest.mark.parametrize(

--- a/tests/util/test_volume.py
+++ b/tests/util/test_volume.py
@@ -27,7 +27,7 @@ def test_raise_deprecation_warning(caplog: pytest.LogCaptureFixture) -> None:
     ("function_name", "value", "expected"),
     [
         ("liter_to_gallon", 2, pytest.approx(0.528344)),
-        ("gallon_to_liter", 2, 7.570823568),
+        ("gallon_to_liter", 2, pytest.approx(7.570823568)),
         ("cubic_meter_to_cubic_feet", 2, pytest.approx(70.629333)),
         ("cubic_feet_to_cubic_meter", 2, pytest.approx(0.0566337)),
     ],

--- a/tests/util/test_volume.py
+++ b/tests/util/test_volume.py
@@ -27,7 +27,7 @@ def test_raise_deprecation_warning(caplog: pytest.LogCaptureFixture) -> None:
     ("function_name", "value", "expected"),
     [
         ("liter_to_gallon", 2, pytest.approx(0.528344)),
-        ("gallon_to_liter", 2, pytest.approx(7.570823568)),
+        ("gallon_to_liter", 2, 7.570823568),
         ("cubic_meter_to_cubic_feet", 2, pytest.approx(70.629333)),
         ("cubic_feet_to_cubic_meter", 2, pytest.approx(0.0566337)),
     ],


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
With statistics we are doing the same conversion  for each data point, and we currently have to do lookups every time to do the convert. Since its the same to/from unit over and over we can use a factory pattern to avoid all but the first set of lookups (unless its already in the LRU).

I added LRUs to avoid building the converters over and over since we also use this in sensor to convert units. It most cases we end up with ~20-30 tiny cached converter functions which uses less memory than most of our python modules.

After this change, all the unit conversion no longer show in all the statistics profiling because they are too small to be included.  The flame on 1939 no longer has a sub-flame for the conversion:

<img width="1651" alt="Screenshot 2023-05-28 at 11 03 07 AM" src="https://github.com/home-assistant/core/assets/663432/8a3c286e-de30-4490-a4dd-e357826932b0">


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
