### PR TITLE
Restore original websocket commands for config entries

### DIFF
--- a/homeassistant/components/config/config_entries.py
+++ b/homeassistant/components/config/config_entries.py
@@ -41,9 +41,9 @@ async def async_setup(hass):
     hass.http.register_view(OptionManagerFlowIndexView(hass.config_entries.options))
     hass.http.register_view(OptionManagerFlowResourceView(hass.config_entries.options))
 
-    websocket_api.async_register_command(hass, config_entries_get_matching)
+    websocket_api.async_register_command(hass, config_entries_get)
     websocket_api.async_register_command(hass, config_entry_disable)
-    websocket_api.async_register_command(hass, config_entry_get)
+    websocket_api.async_register_command(hass, config_entry_get_single)
     websocket_api.async_register_command(hass, config_entry_update)
     websocket_api.async_register_command(hass, config_entries_subscribe)
     websocket_api.async_register_command(hass, config_entries_progress)
@@ -288,12 +288,12 @@ def get_entry(
 @websocket_api.require_admin
 @websocket_api.websocket_command(
     {
-        "type": "config_entries/get",
+        "type": "config_entries/get_single",
         "entry_id": str,
     }
 )
 @websocket_api.async_response
-async def config_entry_get(
+async def config_entry_get_single(
     hass: HomeAssistant,
     connection: websocket_api.ActiveConnection,
     msg: dict[str, Any],
@@ -432,13 +432,13 @@ async def ignore_config_flow(
 
 @websocket_api.websocket_command(
     {
-        vol.Required("type"): "config_entries/get_matching",
+        vol.Required("type"): "config_entries/get",
         vol.Optional("type_filter"): vol.All(cv.ensure_list, [str]),
         vol.Optional("domain"): str,
     }
 )
 @websocket_api.async_response
-async def config_entries_get_matching(
+async def config_entries_get(
     hass: HomeAssistant,
     connection: websocket_api.ActiveConnection,
     msg: dict[str, Any],

--- a/tests/components/bluetooth/test_config_flow.py
+++ b/tests/components/bluetooth/test_config_flow.py
@@ -36,7 +36,7 @@ async def test_options_flow_disabled_not_setup(
     await ws_client.send_json(
         {
             "id": 5,
-            "type": "config_entries/get_matching",
+            "type": "config_entries/get",
             "domain": "bluetooth",
         }
     )
@@ -370,7 +370,7 @@ async def test_options_flow_disabled_macos(
     await ws_client.send_json(
         {
             "id": 5,
-            "type": "config_entries/get_matching",
+            "type": "config_entries/get",
             "domain": "bluetooth",
         }
     )
@@ -403,7 +403,7 @@ async def test_options_flow_enabled_linux(
     await ws_client.send_json(
         {
             "id": 5,
-            "type": "config_entries/get_matching",
+            "type": "config_entries/get",
             "domain": "bluetooth",
         }
     )

--- a/tests/components/config/test_config_entries.py
+++ b/tests/components/config/test_config_entries.py
@@ -969,7 +969,9 @@ async def test_options_flow_with_invalid_data(hass: HomeAssistant, client) -> No
         }
 
 
-async def test_get(hass: HomeAssistant, hass_ws_client: WebSocketGenerator) -> None:
+async def test_get_single(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
     """Test that we can get a config entry."""
     assert await async_setup_component(hass, "config", {})
     ws_client = await hass_ws_client(hass)
@@ -982,7 +984,7 @@ async def test_get(hass: HomeAssistant, hass_ws_client: WebSocketGenerator) -> N
 
     await ws_client.send_json_auto_id(
         {
-            "type": "config_entries/get",
+            "type": "config_entries/get_single",
             "entry_id": entry.entry_id,
         }
     )
@@ -1006,7 +1008,7 @@ async def test_get(hass: HomeAssistant, hass_ws_client: WebSocketGenerator) -> N
 
     await ws_client.send_json_auto_id(
         {
-            "type": "config_entries/get",
+            "type": "config_entries/get_single",
             "entry_id": "blah",
         }
     )
@@ -1317,7 +1319,7 @@ async def test_get_matching_entries_ws(
 
     ws_client = await hass_ws_client(hass)
 
-    await ws_client.send_json_auto_id({"type": "config_entries/get_matching"})
+    await ws_client.send_json_auto_id({"type": "config_entries/get"})
     response = await ws_client.receive_json()
     assert response["result"] == [
         {
@@ -1394,7 +1396,7 @@ async def test_get_matching_entries_ws(
 
     await ws_client.send_json_auto_id(
         {
-            "type": "config_entries/get_matching",
+            "type": "config_entries/get",
             "domain": "comp1",
             "type_filter": "hub",
         }
@@ -1419,7 +1421,7 @@ async def test_get_matching_entries_ws(
 
     await ws_client.send_json_auto_id(
         {
-            "type": "config_entries/get_matching",
+            "type": "config_entries/get",
             "type_filter": ["service", "device"],
         }
     )
@@ -1457,7 +1459,7 @@ async def test_get_matching_entries_ws(
 
     await ws_client.send_json_auto_id(
         {
-            "type": "config_entries/get_matching",
+            "type": "config_entries/get",
             "type_filter": "hub",
         }
     )
@@ -1500,7 +1502,7 @@ async def test_get_matching_entries_ws(
     ):
         await ws_client.send_json_auto_id(
             {
-                "type": "config_entries/get_matching",
+                "type": "config_entries/get",
                 "type_filter": "hub",
             }
         )
@@ -1586,7 +1588,7 @@ async def test_get_matching_entries_ws(
     ):
         await ws_client.send_json_auto_id(
             {
-                "type": "config_entries/get_matching",
+                "type": "config_entries/get",
                 "type_filter": ["helper"],
             }
         )
@@ -1602,7 +1604,7 @@ async def test_get_matching_entries_ws(
     ):
         await ws_client.send_json_auto_id(
             {
-                "type": "config_entries/get_matching",
+                "type": "config_entries/get",
                 "type_filter": ["device", "hub", "service"],
             }
         )

--- a/tests/components/shelly/test_config_flow.py
+++ b/tests/components/shelly/test_config_flow.py
@@ -858,7 +858,7 @@ async def test_options_flow_disabled_gen_1(
     await ws_client.send_json(
         {
             "id": 5,
-            "type": "config_entries/get_matching",
+            "type": "config_entries/get",
             "domain": "shelly",
         }
     )
@@ -879,7 +879,7 @@ async def test_options_flow_enabled_gen_2(
     await ws_client.send_json(
         {
             "id": 5,
-            "type": "config_entries/get_matching",
+            "type": "config_entries/get",
             "domain": "shelly",
         }
     )
@@ -900,7 +900,7 @@ async def test_options_flow_disabled_sleepy_gen_2(
     await ws_client.send_json(
         {
             "id": 5,
-            "type": "config_entries/get_matching",
+            "type": "config_entries/get",
             "domain": "shelly",
         }
     )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Partially rewrite https://github.com/home-assistant/core/pull/93387#discussion_r1207169344 to not have a breaking change in the WS API that currently breaks all custom panels using this and potentially also other custom frontend integrations.

Restore original websocket commands and add "config_entries/get_single"

See https://github.com/home-assistant/frontend/pull/16647


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
