### PR TITLE
Add charging switch to BMW Connected Drive

### DIFF
--- a/homeassistant/components/bmw_connected_drive/switch.py
+++ b/homeassistant/components/bmw_connected_drive/switch.py
@@ -120,17 +120,9 @@ class BMWSwitch(BMWBaseEntity, SwitchEntity):
         except MyBMWAPIError as ex:
             raise HomeAssistantError(ex) from ex
 
-        # BMW remote services that change the vehicle's state update the local object
-        # when executing the service, so only the HA state machine needs further updates.
-        self.coordinator.async_update_listeners()
-
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
         try:
             await self.entity_description.remote_service_off(self.vehicle)
         except MyBMWAPIError as ex:
             raise HomeAssistantError(ex) from ex
-
-        # BMW remote services that change the vehicle's state update the local object
-        # when executing the service, so only the HA state machine needs further updates.
-        self.coordinator.async_update_listeners()

--- a/homeassistant/components/bmw_connected_drive/switch.py
+++ b/homeassistant/components/bmw_connected_drive/switch.py
@@ -120,9 +120,17 @@ class BMWSwitch(BMWBaseEntity, SwitchEntity):
         except MyBMWAPIError as ex:
             raise HomeAssistantError(ex) from ex
 
+        # BMW remote services that change the vehicle's state update the local object
+        # when executing the service, so only the HA state machine needs further updates.
+        self.coordinator.async_update_listeners()
+
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
         try:
             await self.entity_description.remote_service_off(self.vehicle)
         except MyBMWAPIError as ex:
             raise HomeAssistantError(ex) from ex
+
+        # BMW remote services that change the vehicle's state update the local object
+        # when executing the service, so only the HA state machine needs further updates.
+        self.coordinator.async_update_listeners()

--- a/homeassistant/components/bmw_connected_drive/switch.py
+++ b/homeassistant/components/bmw_connected_drive/switch.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from bimmer_connected.models import MyBMWAPIError
 from bimmer_connected.vehicle import MyBMWVehicle
+from bimmer_connected.vehicle.fuel_and_battery import ChargingState
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.config_entries import ConfigEntry
@@ -38,6 +39,15 @@ class BMWSwitchEntityDescription(SwitchEntityDescription, BMWRequiredKeysMixin):
     dynamic_options: Callable[[MyBMWVehicle], list[str]] | None = None
 
 
+CHARGING_STATE_ON = {
+    ChargingState.CHARGING,
+    ChargingState.COMPLETE,
+    ChargingState.FULLY_CHARGED,
+    ChargingState.FINISHED_FULLY_CHARGED,
+    ChargingState.FINISHED_NOT_FULL,
+    ChargingState.TARGET_REACHED,
+}
+
 NUMBER_TYPES: list[BMWSwitchEntityDescription] = [
     BMWSwitchEntityDescription(
         key="climate",
@@ -47,6 +57,15 @@ NUMBER_TYPES: list[BMWSwitchEntityDescription] = [
         remote_service_on=lambda v: v.remote_services.trigger_remote_air_conditioning(),
         remote_service_off=lambda v: v.remote_services.trigger_remote_air_conditioning_stop(),
         icon="mdi:fan",
+    ),
+    BMWSwitchEntityDescription(
+        key="charging",
+        name="Charging",
+        is_available=lambda v: v.is_remote_charge_stop_enabled,
+        value_fn=lambda v: v.fuel_and_battery.charging_status in CHARGING_STATE_ON,
+        remote_service_on=lambda v: v.remote_services.trigger_charge_start(),
+        remote_service_off=lambda v: v.remote_services.trigger_charge_stop(),
+        icon="mdi:ev-station",
     ),
 ]
 

--- a/tests/components/bmw_connected_drive/conftest.py
+++ b/tests/components/bmw_connected_drive/conftest.py
@@ -1,10 +1,14 @@
 """Fixtures for BMW tests."""
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 from bimmer_connected.api.authentication import MyBMWAuthentication
 from bimmer_connected.vehicle.remote_services import RemoteServices, RemoteServiceStatus
 import pytest
+
+from homeassistant.components.bmw_connected_drive.coordinator import (
+    BMWDataUpdateCoordinator,
+)
 
 from . import mock_login, mock_vehicles
 
@@ -18,6 +22,12 @@ async def bmw_fixture(monkeypatch):
         RemoteServices,
         "trigger_remote_service",
         AsyncMock(return_value=RemoteServiceStatus({"eventStatus": "EXECUTED"})),
+    )
+
+    monkeypatch.setattr(
+        BMWDataUpdateCoordinator,
+        "async_update_listeners",
+        Mock(),
     )
 
     with mock_vehicles():

--- a/tests/components/bmw_connected_drive/conftest.py
+++ b/tests/components/bmw_connected_drive/conftest.py
@@ -1,14 +1,10 @@
 """Fixtures for BMW tests."""
 
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock
 
 from bimmer_connected.api.authentication import MyBMWAuthentication
 from bimmer_connected.vehicle.remote_services import RemoteServices, RemoteServiceStatus
 import pytest
-
-from homeassistant.components.bmw_connected_drive.coordinator import (
-    BMWDataUpdateCoordinator,
-)
 
 from . import mock_login, mock_vehicles
 
@@ -22,12 +18,6 @@ async def bmw_fixture(monkeypatch):
         RemoteServices,
         "trigger_remote_service",
         AsyncMock(return_value=RemoteServiceStatus({"eventStatus": "EXECUTED"})),
-    )
-
-    monkeypatch.setattr(
-        BMWDataUpdateCoordinator,
-        "async_update_listeners",
-        Mock(),
     )
 
     with mock_vehicles():

--- a/tests/components/bmw_connected_drive/fixtures/vehicles/G26/bmw-eadrax-vcs_v4_vehicles_state_WBA00000000DEMO02.json
+++ b/tests/components/bmw_connected_drive/fixtures/vehicles/G26/bmw-eadrax-vcs_v4_vehicles_state_WBA00000000DEMO02.json
@@ -43,7 +43,11 @@
     "lights": true,
     "lock": true,
     "remote360": true,
-    "remoteChargingCommands": {},
+    "remoteChargingCommands": {
+      "chargingControl": ["START", "STOP"],
+      "flapControl": ["NOT_SUPPORTED"],
+      "plugControl": ["NOT_SUPPORTED"]
+    },
     "remoteSoftwareUpgrade": true,
     "sendPoi": true,
     "specialThemeSupport": [],
@@ -159,9 +163,9 @@
     "electricChargingState": {
       "chargingConnectionType": "UNKNOWN",
       "chargingLevelPercent": 80,
-      "chargingStatus": "INVALID",
+      "chargingStatus": "CHARGING",
       "chargingTarget": 80,
-      "isChargerConnected": false,
+      "isChargerConnected": true,
       "range": 472,
       "remainingChargingMinutes": 10
     },

--- a/tests/components/bmw_connected_drive/snapshots/test_diagnostics.ambr
+++ b/tests/components/bmw_connected_drive/snapshots/test_diagnostics.ambr
@@ -289,6 +289,16 @@
             'lock': True,
             'remote360': True,
             'remoteChargingCommands': dict({
+              'chargingControl': list([
+                'START',
+                'STOP',
+              ]),
+              'flapControl': list([
+                'NOT_SUPPORTED',
+              ]),
+              'plugControl': list([
+                'NOT_SUPPORTED',
+              ]),
             }),
             'remoteSoftwareUpgrade': True,
             'sendPoi': True,
@@ -524,9 +534,9 @@
             'electricChargingState': dict({
               'chargingConnectionType': 'UNKNOWN',
               'chargingLevelPercent': 80,
-              'chargingStatus': 'INVALID',
+              'chargingStatus': 'CHARGING',
               'chargingTarget': 80,
-              'isChargerConnected': False,
+              'isChargerConnected': True,
               'range': 472,
               'remainingChargingMinutes': 10,
             }),
@@ -778,9 +788,9 @@
           'charging_end_time': '2022-07-10T11:10:00+00:00',
           'charging_start_time': None,
           'charging_start_time_no_tz': None,
-          'charging_status': 'NOT_CHARGING',
+          'charging_status': 'CHARGING',
           'charging_target': 80,
-          'is_charger_connected': False,
+          'is_charger_connected': True,
           'remaining_battery_percent': 80,
           'remaining_fuel': list([
             None,
@@ -804,8 +814,8 @@
         'has_electric_drivetrain': True,
         'is_charging_plan_supported': True,
         'is_lsc_enabled': True,
-        'is_remote_charge_start_enabled': False,
-        'is_remote_charge_stop_enabled': False,
+        'is_remote_charge_start_enabled': True,
+        'is_remote_charge_stop_enabled': True,
         'is_remote_climate_start_enabled': True,
         'is_remote_climate_stop_enabled': True,
         'is_remote_horn_enabled': True,
@@ -1687,6 +1697,16 @@
             'lock': True,
             'remote360': True,
             'remoteChargingCommands': dict({
+              'chargingControl': list([
+                'START',
+                'STOP',
+              ]),
+              'flapControl': list([
+                'NOT_SUPPORTED',
+              ]),
+              'plugControl': list([
+                'NOT_SUPPORTED',
+              ]),
             }),
             'remoteSoftwareUpgrade': True,
             'sendPoi': True,
@@ -1812,9 +1832,9 @@
             'electricChargingState': dict({
               'chargingConnectionType': 'UNKNOWN',
               'chargingLevelPercent': 80,
-              'chargingStatus': 'INVALID',
+              'chargingStatus': 'CHARGING',
               'chargingTarget': 80,
-              'isChargerConnected': False,
+              'isChargerConnected': True,
               'range': 472,
               'remainingChargingMinutes': 10,
             }),
@@ -3191,6 +3211,16 @@
             'lock': True,
             'remote360': True,
             'remoteChargingCommands': dict({
+              'chargingControl': list([
+                'START',
+                'STOP',
+              ]),
+              'flapControl': list([
+                'NOT_SUPPORTED',
+              ]),
+              'plugControl': list([
+                'NOT_SUPPORTED',
+              ]),
             }),
             'remoteSoftwareUpgrade': True,
             'sendPoi': True,
@@ -3316,9 +3346,9 @@
             'electricChargingState': dict({
               'chargingConnectionType': 'UNKNOWN',
               'chargingLevelPercent': 80,
-              'chargingStatus': 'INVALID',
+              'chargingStatus': 'CHARGING',
               'chargingTarget': 80,
-              'isChargerConnected': False,
+              'isChargerConnected': True,
               'range': 472,
               'remainingChargingMinutes': 10,
             }),
@@ -4024,6 +4054,16 @@
             'lock': True,
             'remote360': True,
             'remoteChargingCommands': dict({
+              'chargingControl': list([
+                'START',
+                'STOP',
+              ]),
+              'flapControl': list([
+                'NOT_SUPPORTED',
+              ]),
+              'plugControl': list([
+                'NOT_SUPPORTED',
+              ]),
             }),
             'remoteSoftwareUpgrade': True,
             'sendPoi': True,
@@ -4149,9 +4189,9 @@
             'electricChargingState': dict({
               'chargingConnectionType': 'UNKNOWN',
               'chargingLevelPercent': 80,
-              'chargingStatus': 'INVALID',
+              'chargingStatus': 'CHARGING',
               'chargingTarget': 80,
-              'isChargerConnected': False,
+              'isChargerConnected': True,
               'range': 472,
               'remainingChargingMinutes': 10,
             }),

--- a/tests/components/bmw_connected_drive/snapshots/test_switch.ambr
+++ b/tests/components/bmw_connected_drive/snapshots/test_switch.ambr
@@ -16,11 +16,11 @@
     StateSnapshot({
       'attributes': ReadOnlyDict({
         'attribution': 'Data provided by MyBMW',
-        'friendly_name': 'i4 eDrive40 Charge',
+        'friendly_name': 'i4 eDrive40 Charging',
         'icon': 'mdi:ev-station',
       }),
       'context': <ANY>,
-      'entity_id': 'switch.i4_edrive40_charge',
+      'entity_id': 'switch.i4_edrive40_charging',
       'last_changed': <ANY>,
       'last_updated': <ANY>,
       'state': 'on',

--- a/tests/components/bmw_connected_drive/snapshots/test_switch.ambr
+++ b/tests/components/bmw_connected_drive/snapshots/test_switch.ambr
@@ -16,11 +16,11 @@
     StateSnapshot({
       'attributes': ReadOnlyDict({
         'attribution': 'Data provided by MyBMW',
-        'friendly_name': 'i4 eDrive40 Charging',
+        'friendly_name': 'i4 eDrive40 Charge',
         'icon': 'mdi:ev-station',
       }),
       'context': <ANY>,
-      'entity_id': 'switch.i4_edrive40_charging',
+      'entity_id': 'switch.i4_edrive40_charge',
       'last_changed': <ANY>,
       'last_updated': <ANY>,
       'state': 'on',

--- a/tests/components/bmw_connected_drive/snapshots/test_switch.ambr
+++ b/tests/components/bmw_connected_drive/snapshots/test_switch.ambr
@@ -13,5 +13,17 @@
       'last_updated': <ANY>,
       'state': 'off',
     }),
+    StateSnapshot({
+      'attributes': ReadOnlyDict({
+        'attribution': 'Data provided by MyBMW',
+        'friendly_name': 'i4 eDrive40 Charge',
+        'icon': 'mdi:ev-station',
+      }),
+      'context': <ANY>,
+      'entity_id': 'switch.i4_edrive40_charge',
+      'last_changed': <ANY>,
+      'last_updated': <ANY>,
+      'state': 'on',
+    }),
   ])
 # ---

--- a/tests/components/bmw_connected_drive/test_switch.py
+++ b/tests/components/bmw_connected_drive/test_switch.py
@@ -7,6 +7,9 @@ import pytest
 import respx
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.bmw_connected_drive.coordinator import (
+    BMWDataUpdateCoordinator,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 
@@ -32,8 +35,8 @@ async def test_entity_state_attrs(
     [
         ("switch.i4_edrive40_climate", "ON"),
         ("switch.i4_edrive40_climate", "OFF"),
-        ("switch.i4_edrive40_charge", "ON"),
-        ("switch.i4_edrive40_charge", "OFF"),
+        ("switch.i4_edrive40_charging", "ON"),
+        ("switch.i4_edrive40_charging", "OFF"),
     ],
 )
 async def test_update_triggers_success(
@@ -46,6 +49,7 @@ async def test_update_triggers_success(
 
     # Setup component
     assert await setup_mocked_integration(hass)
+    BMWDataUpdateCoordinator.async_update_listeners.reset_mock()
 
     # Test
     await hass.services.async_call(
@@ -55,6 +59,7 @@ async def test_update_triggers_success(
         target={"entity_id": entity_id},
     )
     assert RemoteServices.trigger_remote_service.call_count == 1
+    assert BMWDataUpdateCoordinator.async_update_listeners.call_count == 1
 
 
 @pytest.mark.parametrize(

--- a/tests/components/bmw_connected_drive/test_switch.py
+++ b/tests/components/bmw_connected_drive/test_switch.py
@@ -7,9 +7,6 @@ import pytest
 import respx
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.bmw_connected_drive.coordinator import (
-    BMWDataUpdateCoordinator,
-)
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 
@@ -35,8 +32,8 @@ async def test_entity_state_attrs(
     [
         ("switch.i4_edrive40_climate", "ON"),
         ("switch.i4_edrive40_climate", "OFF"),
-        ("switch.i4_edrive40_charging", "ON"),
-        ("switch.i4_edrive40_charging", "OFF"),
+        ("switch.i4_edrive40_charge", "ON"),
+        ("switch.i4_edrive40_charge", "OFF"),
     ],
 )
 async def test_update_triggers_success(
@@ -49,7 +46,6 @@ async def test_update_triggers_success(
 
     # Setup component
     assert await setup_mocked_integration(hass)
-    BMWDataUpdateCoordinator.async_update_listeners.reset_mock()
 
     # Test
     await hass.services.async_call(
@@ -59,7 +55,6 @@ async def test_update_triggers_success(
         target={"entity_id": entity_id},
     )
     assert RemoteServices.trigger_remote_service.call_count == 1
-    assert BMWDataUpdateCoordinator.async_update_listeners.call_count == 1
 
 
 @pytest.mark.parametrize(

--- a/tests/components/bmw_connected_drive/test_switch.py
+++ b/tests/components/bmw_connected_drive/test_switch.py
@@ -32,6 +32,8 @@ async def test_entity_state_attrs(
     [
         ("switch.i4_edrive40_climate", "ON"),
         ("switch.i4_edrive40_climate", "OFF"),
+        ("switch.i4_edrive40_charge", "ON"),
+        ("switch.i4_edrive40_charge", "OFF"),
     ],
 )
 async def test_update_triggers_success(

--- a/tests/components/bmw_connected_drive/test_switch.py
+++ b/tests/components/bmw_connected_drive/test_switch.py
@@ -32,8 +32,8 @@ async def test_entity_state_attrs(
     [
         ("switch.i4_edrive40_climate", "ON"),
         ("switch.i4_edrive40_climate", "OFF"),
-        ("switch.i4_edrive40_charge", "ON"),
-        ("switch.i4_edrive40_charge", "OFF"),
+        ("switch.i4_edrive40_charging", "ON"),
+        ("switch.i4_edrive40_charging", "OFF"),
     ],
 )
 async def test_update_triggers_success(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds the ability to start/stop charging via the `switch` platform. 

This switch is not available on many cars (apparently only on iX right now).
To not add another vehicle fixture, the fixtures were slightly adjusted for tests.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/bimmerconnected/bimmer_connected/pull/520#issuecomment-1547872507
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/27575

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
