### PR TITLE
Fix thread leak in onvif discovery

### DIFF
--- a/homeassistant/components/onvif/config_flow.py
+++ b/homeassistant/components/onvif/config_flow.py
@@ -51,12 +51,15 @@ CONF_MANUAL_INPUT = "Manually configure ONVIF device"
 def wsdiscovery() -> list[Service]:
     """Get ONVIF Profile S devices from network."""
     discovery = WSDiscovery(ttl=4)
-    discovery.start()
-    services = discovery.searchServices(
-        scopes=[Scope("onvif://www.onvif.org/Profile/Streaming")]
-    )
-    discovery.stop()
-    return services
+    try:
+        discovery.start()
+        return discovery.searchServices(
+            scopes=[Scope("onvif://www.onvif.org/Profile/Streaming")]
+        )
+    finally:
+        discovery.stop()
+        # Stop the threads started by WSDiscovery since otherwise there is a leak.
+        discovery._stopThreads()  # pylint: disable=protected-access
 
 
 async def async_discovery(hass: HomeAssistant) -> list[dict[str, Any]]:

--- a/tests/components/onvif/test_config_flow.py
+++ b/tests/components/onvif/test_config_flow.py
@@ -60,10 +60,13 @@ def setup_mock_discovery(
     with_mac=False,
     two_devices=False,
     with_hardware=True,
+    no_devices=False,
 ):
     """Prepare mock discovery result."""
     services = []
     for item in DISCOVERY:
+        if no_devices:
+            continue
         service = MagicMock()
         service.getXAddrs = MagicMock(
             return_value=[
@@ -92,7 +95,10 @@ def setup_mock_discovery(
             scopes.append(scope)
         service.getScopes = MagicMock(return_value=scopes)
         services.append(service)
-    mock_discovery.return_value = services
+
+    mock_ws_discovery = MagicMock()
+    mock_ws_discovery.searchServices = MagicMock(return_value=services)
+    mock_discovery.return_value = mock_ws_discovery
 
 
 async def test_flow_discovered_devices(hass: HomeAssistant) -> None:
@@ -108,7 +114,7 @@ async def test_flow_discovered_devices(hass: HomeAssistant) -> None:
     with patch(
         "homeassistant.components.onvif.config_flow.get_device"
     ) as mock_onvif_camera, patch(
-        "homeassistant.components.onvif.config_flow.wsdiscovery"
+        "homeassistant.components.onvif.config_flow.WSDiscovery"
     ) as mock_discovery, patch(
         "homeassistant.components.onvif.ONVIFDevice"
     ) as mock_device:
@@ -178,7 +184,7 @@ async def test_flow_discovered_devices_ignore_configured_manual_input(
     with patch(
         "homeassistant.components.onvif.config_flow.get_device"
     ) as mock_onvif_camera, patch(
-        "homeassistant.components.onvif.config_flow.wsdiscovery"
+        "homeassistant.components.onvif.config_flow.WSDiscovery"
     ) as mock_discovery, patch(
         "homeassistant.components.onvif.ONVIFDevice"
     ) as mock_device:
@@ -217,12 +223,12 @@ async def test_flow_discovered_no_device(hass: HomeAssistant) -> None:
     with patch(
         "homeassistant.components.onvif.config_flow.get_device"
     ) as mock_onvif_camera, patch(
-        "homeassistant.components.onvif.config_flow.wsdiscovery"
+        "homeassistant.components.onvif.config_flow.WSDiscovery"
     ) as mock_discovery, patch(
         "homeassistant.components.onvif.ONVIFDevice"
     ) as mock_device:
         setup_mock_onvif_camera(mock_onvif_camera)
-        mock_discovery.return_value = []
+        setup_mock_discovery(mock_discovery, no_devices=True)
         setup_mock_device(mock_device)
 
         result = await hass.config_entries.flow.async_configure(
@@ -259,7 +265,7 @@ async def test_flow_discovery_ignore_existing_and_abort(hass: HomeAssistant) -> 
     with patch(
         "homeassistant.components.onvif.config_flow.get_device"
     ) as mock_onvif_camera, patch(
-        "homeassistant.components.onvif.config_flow.wsdiscovery"
+        "homeassistant.components.onvif.config_flow.WSDiscovery"
     ) as mock_discovery, patch(
         "homeassistant.components.onvif.ONVIFDevice"
     ) as mock_device:
@@ -302,7 +308,7 @@ async def test_flow_manual_entry(hass: HomeAssistant) -> None:
     with patch(
         "homeassistant.components.onvif.config_flow.get_device"
     ) as mock_onvif_camera, patch(
-        "homeassistant.components.onvif.config_flow.wsdiscovery"
+        "homeassistant.components.onvif.config_flow.WSDiscovery"
     ) as mock_discovery, patch(
         "homeassistant.components.onvif.ONVIFDevice"
     ) as mock_device:
@@ -359,7 +365,7 @@ async def test_flow_manual_entry_no_profiles(hass: HomeAssistant) -> None:
     with patch(
         "homeassistant.components.onvif.config_flow.get_device"
     ) as mock_onvif_camera, patch(
-        "homeassistant.components.onvif.config_flow.wsdiscovery"
+        "homeassistant.components.onvif.config_flow.WSDiscovery"
     ) as mock_discovery, patch(
         "homeassistant.components.onvif.ONVIFDevice"
     ) as mock_device:
@@ -399,7 +405,7 @@ async def test_flow_manual_entry_no_mac(hass: HomeAssistant) -> None:
     with patch(
         "homeassistant.components.onvif.config_flow.get_device"
     ) as mock_onvif_camera, patch(
-        "homeassistant.components.onvif.config_flow.wsdiscovery"
+        "homeassistant.components.onvif.config_flow.WSDiscovery"
     ) as mock_discovery, patch(
         "homeassistant.components.onvif.ONVIFDevice"
     ) as mock_device:
@@ -441,7 +447,7 @@ async def test_flow_manual_entry_fails(hass: HomeAssistant) -> None:
     with patch(
         "homeassistant.components.onvif.config_flow.get_device"
     ) as mock_onvif_camera, patch(
-        "homeassistant.components.onvif.config_flow.wsdiscovery"
+        "homeassistant.components.onvif.config_flow.WSDiscovery"
     ) as mock_discovery, patch(
         "homeassistant.components.onvif.ONVIFDevice"
     ) as mock_device:
@@ -549,7 +555,7 @@ async def test_flow_manual_entry_wrong_password(hass: HomeAssistant) -> None:
     with patch(
         "homeassistant.components.onvif.config_flow.get_device"
     ) as mock_onvif_camera, patch(
-        "homeassistant.components.onvif.config_flow.wsdiscovery"
+        "homeassistant.components.onvif.config_flow.WSDiscovery"
     ) as mock_discovery, patch(
         "homeassistant.components.onvif.ONVIFDevice"
     ) as mock_device:
@@ -826,7 +832,7 @@ async def test_flow_manual_entry_updates_existing_user_password(
     with patch(
         "homeassistant.components.onvif.config_flow.get_device"
     ) as mock_onvif_camera, patch(
-        "homeassistant.components.onvif.config_flow.wsdiscovery"
+        "homeassistant.components.onvif.config_flow.WSDiscovery"
     ) as mock_discovery, patch(
         "homeassistant.components.onvif.ONVIFDevice"
     ) as mock_device:
@@ -877,7 +883,7 @@ async def test_flow_manual_entry_wrong_port(hass: HomeAssistant) -> None:
     with patch(
         "homeassistant.components.onvif.config_flow.get_device"
     ) as mock_onvif_camera, patch(
-        "homeassistant.components.onvif.config_flow.wsdiscovery"
+        "homeassistant.components.onvif.config_flow.WSDiscovery"
     ) as mock_discovery, patch(
         "homeassistant.components.onvif.ONVIFDevice"
     ) as mock_device:


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Every onvif discovery would leak a thread because WSDiscovery was not stopping the threads


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
