### PR TITLE
Ensure state update after BMW remote service execution

### DIFF
--- a/homeassistant/components/bmw_connected_drive/button.py
+++ b/homeassistant/components/bmw_connected_drive/button.py
@@ -122,7 +122,4 @@ class BMWButton(BMWBaseEntity, ButtonEntity):
             )
             await self.entity_description.account_function(self.coordinator)
 
-        # Always update HA states after a button was executed.
-        # BMW remote services that change the vehicle's state update the local object
-        # when executing the service, so only the HA state machine needs further updates.
-        self.coordinator.async_update_listeners()
+        self.coordinator.refresh_state_after_remote_service()

--- a/homeassistant/components/bmw_connected_drive/button.py
+++ b/homeassistant/components/bmw_connected_drive/button.py
@@ -122,4 +122,4 @@ class BMWButton(BMWBaseEntity, ButtonEntity):
             )
             await self.entity_description.account_function(self.coordinator)
 
-        self.coordinator.refresh_state_after_remote_service()
+        self.coordinator.async_update_listeners()

--- a/homeassistant/components/bmw_connected_drive/coordinator.py
+++ b/homeassistant/components/bmw_connected_drive/coordinator.py
@@ -83,11 +83,3 @@ class BMWDataUpdateCoordinator(DataUpdateCoordinator[None]):
         if not refresh_token:
             data.pop(CONF_REFRESH_TOKEN)
         self.hass.config_entries.async_update_entry(self._entry, data=data)
-
-    def refresh_state_after_remote_service(self) -> None:
-        """Refresh the state of all entities after a remote service call.
-
-        If a remote service changes the state of the vehicle, `BMWDataUpdateCoordinator.account.vehicles` will be refreshed automatically.
-        We therefore only need to update the HA state machine without further API calls.
-        """
-        self.async_update_listeners()

--- a/homeassistant/components/bmw_connected_drive/coordinator.py
+++ b/homeassistant/components/bmw_connected_drive/coordinator.py
@@ -83,3 +83,11 @@ class BMWDataUpdateCoordinator(DataUpdateCoordinator[None]):
         if not refresh_token:
             data.pop(CONF_REFRESH_TOKEN)
         self.hass.config_entries.async_update_entry(self._entry, data=data)
+
+    def refresh_state_after_remote_service(self) -> None:
+        """Refresh the state of all entities after a remote service call.
+
+        If a remote service changes the state of the vehicle, `BMWDataUpdateCoordinator.account.vehicles` will be refreshed automatically.
+        We therefore only need to update the HA state machine without further API calls.
+        """
+        self.async_update_listeners()

--- a/homeassistant/components/bmw_connected_drive/lock.py
+++ b/homeassistant/components/bmw_connected_drive/lock.py
@@ -68,7 +68,7 @@ class BMWLock(BMWBaseEntity, LockEntity):
             self.async_write_ha_state()
         await self.vehicle.remote_services.trigger_remote_door_lock()
 
-        self.coordinator.refresh_state_after_remote_service()
+        self.coordinator.async_update_listeners()
 
     async def async_unlock(self, **kwargs: Any) -> None:
         """Unlock the car."""
@@ -81,7 +81,7 @@ class BMWLock(BMWBaseEntity, LockEntity):
             self.async_write_ha_state()
         await self.vehicle.remote_services.trigger_remote_door_unlock()
 
-        self.coordinator.refresh_state_after_remote_service()
+        self.coordinator.async_update_listeners()
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/homeassistant/components/bmw_connected_drive/lock.py
+++ b/homeassistant/components/bmw_connected_drive/lock.py
@@ -68,6 +68,8 @@ class BMWLock(BMWBaseEntity, LockEntity):
             self.async_write_ha_state()
         await self.vehicle.remote_services.trigger_remote_door_lock()
 
+        self.coordinator.refresh_state_after_remote_service()
+
     async def async_unlock(self, **kwargs: Any) -> None:
         """Unlock the car."""
         _LOGGER.debug("%s: unlocking doors", self.vehicle.name)
@@ -78,6 +80,8 @@ class BMWLock(BMWBaseEntity, LockEntity):
             self._attr_is_locked = False
             self.async_write_ha_state()
         await self.vehicle.remote_services.trigger_remote_door_unlock()
+
+        self.coordinator.refresh_state_after_remote_service()
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/homeassistant/components/bmw_connected_drive/number.py
+++ b/homeassistant/components/bmw_connected_drive/number.py
@@ -117,4 +117,4 @@ class BMWNumber(BMWBaseEntity, NumberEntity):
         except MyBMWAPIError as ex:
             raise HomeAssistantError(ex) from ex
 
-        self.coordinator.refresh_state_after_remote_service()
+        self.coordinator.async_update_listeners()

--- a/homeassistant/components/bmw_connected_drive/number.py
+++ b/homeassistant/components/bmw_connected_drive/number.py
@@ -116,3 +116,5 @@ class BMWNumber(BMWBaseEntity, NumberEntity):
             await self.entity_description.remote_service(self.vehicle, value)
         except MyBMWAPIError as ex:
             raise HomeAssistantError(ex) from ex
+
+        self.coordinator.refresh_state_after_remote_service()

--- a/homeassistant/components/bmw_connected_drive/select.py
+++ b/homeassistant/components/bmw_connected_drive/select.py
@@ -125,4 +125,4 @@ class BMWSelect(BMWBaseEntity, SelectEntity):
         )
         await self.entity_description.remote_service(self.vehicle, option)
 
-        self.coordinator.refresh_state_after_remote_service()
+        self.coordinator.async_update_listeners()

--- a/homeassistant/components/bmw_connected_drive/select.py
+++ b/homeassistant/components/bmw_connected_drive/select.py
@@ -124,3 +124,5 @@ class BMWSelect(BMWBaseEntity, SelectEntity):
             option,
         )
         await self.entity_description.remote_service(self.vehicle, option)
+
+        self.coordinator.refresh_state_after_remote_service()

--- a/homeassistant/components/bmw_connected_drive/switch.py
+++ b/homeassistant/components/bmw_connected_drive/switch.py
@@ -101,7 +101,7 @@ class BMWSwitch(BMWBaseEntity, SwitchEntity):
         except MyBMWAPIError as ex:
             raise HomeAssistantError(ex) from ex
 
-        self.coordinator.refresh_state_after_remote_service()
+        self.coordinator.async_update_listeners()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
@@ -110,4 +110,4 @@ class BMWSwitch(BMWBaseEntity, SwitchEntity):
         except MyBMWAPIError as ex:
             raise HomeAssistantError(ex) from ex
 
-        self.coordinator.refresh_state_after_remote_service()
+        self.coordinator.async_update_listeners()

--- a/homeassistant/components/bmw_connected_drive/switch.py
+++ b/homeassistant/components/bmw_connected_drive/switch.py
@@ -101,9 +101,13 @@ class BMWSwitch(BMWBaseEntity, SwitchEntity):
         except MyBMWAPIError as ex:
             raise HomeAssistantError(ex) from ex
 
+        self.coordinator.refresh_state_after_remote_service()
+
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
         try:
             await self.entity_description.remote_service_off(self.vehicle)
         except MyBMWAPIError as ex:
             raise HomeAssistantError(ex) from ex
+
+        self.coordinator.refresh_state_after_remote_service()

--- a/tests/components/bmw_connected_drive/conftest.py
+++ b/tests/components/bmw_connected_drive/conftest.py
@@ -1,10 +1,14 @@
 """Fixtures for BMW tests."""
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 from bimmer_connected.api.authentication import MyBMWAuthentication
 from bimmer_connected.vehicle.remote_services import RemoteServices, RemoteServiceStatus
 import pytest
+
+from homeassistant.components.bmw_connected_drive.coordinator import (
+    BMWDataUpdateCoordinator,
+)
 
 from . import mock_login, mock_vehicles
 
@@ -18,6 +22,12 @@ async def bmw_fixture(monkeypatch):
         RemoteServices,
         "trigger_remote_service",
         AsyncMock(return_value=RemoteServiceStatus({"eventStatus": "EXECUTED"})),
+    )
+
+    monkeypatch.setattr(
+        BMWDataUpdateCoordinator,
+        "async_update_listeners",
+        Mock(),
     )
 
     with mock_vehicles():

--- a/tests/components/bmw_connected_drive/test_number.py
+++ b/tests/components/bmw_connected_drive/test_number.py
@@ -7,6 +7,9 @@ import pytest
 import respx
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.bmw_connected_drive.coordinator import (
+    BMWDataUpdateCoordinator,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 
@@ -43,6 +46,7 @@ async def test_update_triggers_success(
 
     # Setup component
     assert await setup_mocked_integration(hass)
+    BMWDataUpdateCoordinator.async_update_listeners.reset_mock()
 
     # Test
     await hass.services.async_call(
@@ -53,6 +57,7 @@ async def test_update_triggers_success(
         target={"entity_id": entity_id},
     )
     assert RemoteServices.trigger_remote_service.call_count == 1
+    assert BMWDataUpdateCoordinator.async_update_listeners.call_count == 1
 
 
 @pytest.mark.parametrize(
@@ -71,6 +76,7 @@ async def test_update_triggers_fail(
 
     # Setup component
     assert await setup_mocked_integration(hass)
+    BMWDataUpdateCoordinator.async_update_listeners.reset_mock()
 
     # Test
     with pytest.raises(ValueError):
@@ -82,6 +88,7 @@ async def test_update_triggers_fail(
             target={"entity_id": entity_id},
         )
     assert RemoteServices.trigger_remote_service.call_count == 0
+    assert BMWDataUpdateCoordinator.async_update_listeners.call_count == 0
 
 
 @pytest.mark.parametrize(
@@ -103,6 +110,7 @@ async def test_update_triggers_exceptions(
 
     # Setup component
     assert await setup_mocked_integration(hass)
+    BMWDataUpdateCoordinator.async_update_listeners.reset_mock()
 
     # Setup exception
     monkeypatch.setattr(
@@ -121,3 +129,4 @@ async def test_update_triggers_exceptions(
             target={"entity_id": "number.i4_edrive40_target_soc"},
         )
     assert RemoteServices.trigger_remote_service.call_count == 1
+    assert BMWDataUpdateCoordinator.async_update_listeners.call_count == 0

--- a/tests/components/bmw_connected_drive/test_select.py
+++ b/tests/components/bmw_connected_drive/test_select.py
@@ -4,6 +4,9 @@ import pytest
 import respx
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.bmw_connected_drive.coordinator import (
+    BMWDataUpdateCoordinator,
+)
 from homeassistant.core import HomeAssistant
 
 from . import setup_mocked_integration
@@ -41,6 +44,7 @@ async def test_update_triggers_success(
 
     # Setup component
     assert await setup_mocked_integration(hass)
+    BMWDataUpdateCoordinator.async_update_listeners.reset_mock()
 
     # Test
     await hass.services.async_call(
@@ -51,6 +55,7 @@ async def test_update_triggers_success(
         target={"entity_id": entity_id},
     )
     assert RemoteServices.trigger_remote_service.call_count == 1
+    assert BMWDataUpdateCoordinator.async_update_listeners.call_count == 1
 
 
 @pytest.mark.parametrize(
@@ -69,6 +74,7 @@ async def test_update_triggers_fail(
 
     # Setup component
     assert await setup_mocked_integration(hass)
+    BMWDataUpdateCoordinator.async_update_listeners.reset_mock()
 
     # Test
     with pytest.raises(ValueError):
@@ -80,3 +86,4 @@ async def test_update_triggers_fail(
             target={"entity_id": entity_id},
         )
     assert RemoteServices.trigger_remote_service.call_count == 0
+    assert BMWDataUpdateCoordinator.async_update_listeners.call_count == 0

--- a/tests/components/bmw_connected_drive/test_switch.py
+++ b/tests/components/bmw_connected_drive/test_switch.py
@@ -7,6 +7,9 @@ import pytest
 import respx
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.bmw_connected_drive.coordinator import (
+    BMWDataUpdateCoordinator,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 
@@ -22,6 +25,7 @@ async def test_entity_state_attrs(
 
     # Setup component
     assert await setup_mocked_integration(hass)
+    BMWDataUpdateCoordinator.async_update_listeners.reset_mock()
 
     # Get all switch entities
     assert hass.states.async_all("switch") == snapshot
@@ -44,6 +48,7 @@ async def test_update_triggers_success(
 
     # Setup component
     assert await setup_mocked_integration(hass)
+    BMWDataUpdateCoordinator.async_update_listeners.reset_mock()
 
     # Test
     await hass.services.async_call(
@@ -53,6 +58,7 @@ async def test_update_triggers_success(
         target={"entity_id": entity_id},
     )
     assert RemoteServices.trigger_remote_service.call_count == 1
+    assert BMWDataUpdateCoordinator.async_update_listeners.call_count == 1
 
 
 @pytest.mark.parametrize(
@@ -74,6 +80,7 @@ async def test_update_triggers_exceptions(
 
     # Setup component
     assert await setup_mocked_integration(hass)
+    BMWDataUpdateCoordinator.async_update_listeners.reset_mock()
 
     # Setup exception
     monkeypatch.setattr(
@@ -98,3 +105,4 @@ async def test_update_triggers_exceptions(
             target={"entity_id": "switch.i4_edrive40_climate"},
         )
     assert RemoteServices.trigger_remote_service.call_count == 2
+    assert BMWDataUpdateCoordinator.async_update_listeners.call_count == 0


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When implementing #93737, I realised that the HA update listeners are not called after a state refresh for the new entities.
With this PR, the update listeners are called once the remote service on a vehicle is executed, therefore "refreshing" the state in HA.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
