### PR TITLE
Add romy vacuum integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1094,6 +1094,9 @@ omit =
     homeassistant/components/ripple/sensor.py
     homeassistant/components/roborock/coordinator.py
     homeassistant/components/rocketchat/notify.py
+    homeassistant/components/romy/__init__.py
+    homeassistant/components/romy/coordinator.py
+    homeassistant/components/romy/vacuum.py
     homeassistant/components/roomba/__init__.py
     homeassistant/components/roomba/binary_sensor.py
     homeassistant/components/roomba/braava.py

--- a/.strict-typing
+++ b/.strict-typing
@@ -361,6 +361,7 @@ homeassistant.components.rhasspy.*
 homeassistant.components.ridwell.*
 homeassistant.components.rituals_perfume_genie.*
 homeassistant.components.roku.*
+homeassistant.components.romy.*
 homeassistant.components.rpi_power.*
 homeassistant.components.rss_feed_template.*
 homeassistant.components.rtsp_to_webrtc.*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1120,6 +1120,8 @@ build.json @home-assistant/supervisor
 /tests/components/roborock/ @humbertogontijo @Lash-L
 /homeassistant/components/roku/ @ctalkington
 /tests/components/roku/ @ctalkington
+/homeassistant/components/romy/ @xeniter
+/tests/components/romy/ @xeniter
 /homeassistant/components/roomba/ @pschmitt @cyr-ius @shenxn @Xitee1
 /tests/components/roomba/ @pschmitt @cyr-ius @shenxn @Xitee1
 /homeassistant/components/roon/ @pavoni

--- a/homeassistant/components/osoenergy/config_flow.py
+++ b/homeassistant/components/osoenergy/config_flow.py
@@ -22,7 +22,6 @@ class OSOEnergyFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a OSO Energy config flow."""
 
     VERSION = 1
-    CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
 
     def __init__(self) -> None:
         """Initialize."""

--- a/homeassistant/components/osoenergy/config_flow.py
+++ b/homeassistant/components/osoenergy/config_flow.py
@@ -22,6 +22,7 @@ class OSOEnergyFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a OSO Energy config flow."""
 
     VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
 
     def __init__(self) -> None:
         """Initialize."""

--- a/homeassistant/components/romy/__init__.py
+++ b/homeassistant/components/romy/__init__.py
@@ -13,9 +13,10 @@ from .coordinator import RomyVacuumCoordinator
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Initialize the ROMY platform via config entry."""
 
-    password = config_entry.data.get(CONF_PASSWORD, "")
-
-    new_romy = await romy.create_romy(config_entry.data[CONF_HOST], password)
+    new_romy = await romy.create_romy(
+        config_entry.data[CONF_HOST],
+        config_entry.data.get(CONF_PASSWORD, "")
+    )
 
     coordinator = RomyVacuumCoordinator(hass, new_romy)
     await coordinator.async_config_entry_first_refresh()

--- a/homeassistant/components/romy/__init__.py
+++ b/homeassistant/components/romy/__init__.py
@@ -1,0 +1,44 @@
+"""ROMY Integration."""
+
+import romy
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PASSWORD
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN, LOGGER, PLATFORMS
+from .coordinator import RomyVacuumCoordinator
+
+
+async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    """TODO."""
+
+    password = ""
+    if CONF_PASSWORD in config_entry.data:
+        password = config_entry.data[CONF_PASSWORD]
+
+    new_romy = await romy.create_romy(config_entry.data[CONF_HOST], password)
+
+    name = config_entry.data[CONF_NAME]
+    if name != new_romy.name:
+        await new_romy.set_name(name)
+        LOGGER.info("Settings ROMY's name to: %s", new_romy.name)
+
+    coordinator = RomyVacuumCoordinator(hass, new_romy)
+    await coordinator.async_config_entry_first_refresh()
+
+    # hass.data.setdefault(DOMAIN, {})
+    # hass.data[DOMAIN][config_entry.entry_id] = coordinator
+    hass.data.setdefault(DOMAIN, {})[config_entry.entry_id] = coordinator
+
+    await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    """Handle removal of an entry."""
+    unload_ok = await hass.config_entries.async_unload_platforms(
+        config_entry, PLATFORMS
+    )
+    return unload_ok

--- a/homeassistant/components/romy/__init__.py
+++ b/homeassistant/components/romy/__init__.py
@@ -3,7 +3,7 @@
 import romy
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PASSWORD
+from homeassistant.const import CONF_HOST, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN, PLATFORMS
@@ -16,10 +16,6 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     password = config_entry.data.get(CONF_PASSWORD, "")
 
     new_romy = await romy.create_romy(config_entry.data[CONF_HOST], password)
-
-    name = config_entry.data[CONF_NAME]
-    if name != new_romy.name:
-        await new_romy.set_name(name)
 
     coordinator = RomyVacuumCoordinator(hass, new_romy)
     await coordinator.async_config_entry_first_refresh()

--- a/homeassistant/components/romy/__init__.py
+++ b/homeassistant/components/romy/__init__.py
@@ -13,9 +13,7 @@ from .coordinator import RomyVacuumCoordinator
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Initialize the ROMY platform via config entry."""
 
-    password = ""
-    if CONF_PASSWORD in config_entry.data:
-        password = config_entry.data[CONF_PASSWORD]
+    password = config_entry.data.get(CONF_PASSWORD, "")
 
     new_romy = await romy.create_romy(config_entry.data[CONF_HOST], password)
 

--- a/homeassistant/components/romy/__init__.py
+++ b/homeassistant/components/romy/__init__.py
@@ -31,10 +31,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Handle removal of an entry."""
-    if unload_ok := await hass.config_entries.async_unload_platforms(
-        config_entry, PLATFORMS
-    ):
+    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         hass.data[DOMAIN].pop(entry.entry_id)
     return unload_ok

--- a/homeassistant/components/romy/__init__.py
+++ b/homeassistant/components/romy/__init__.py
@@ -6,12 +6,12 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN, LOGGER, PLATFORMS
+from .const import DOMAIN, PLATFORMS
 from .coordinator import RomyVacuumCoordinator
 
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
-    """TODO."""
+    """Initialize the ROMY platform via config entry."""
 
     password = ""
     if CONF_PASSWORD in config_entry.data:
@@ -22,13 +22,10 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     name = config_entry.data[CONF_NAME]
     if name != new_romy.name:
         await new_romy.set_name(name)
-        LOGGER.info("Settings ROMY's name to: %s", new_romy.name)
 
     coordinator = RomyVacuumCoordinator(hass, new_romy)
     await coordinator.async_config_entry_first_refresh()
 
-    # hass.data.setdefault(DOMAIN, {})
-    # hass.data[DOMAIN][config_entry.entry_id] = coordinator
     hass.data.setdefault(DOMAIN, {})[config_entry.entry_id] = coordinator
 
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)

--- a/homeassistant/components/romy/__init__.py
+++ b/homeassistant/components/romy/__init__.py
@@ -6,7 +6,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN, PLATFORMS
+from .const import DOMAIN, LOGGER, PLATFORMS
 from .coordinator import RomyVacuumCoordinator
 
 
@@ -24,6 +24,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
 
+    config_entry.async_on_unload(config_entry.add_update_listener(update_listener))
+
     return True
 
 
@@ -32,3 +34,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         hass.data[DOMAIN].pop(entry.entry_id)
     return unload_ok
+
+
+async def update_listener(hass: HomeAssistant, config_entry: ConfigEntry) -> None:
+    """Handle options update."""
+    LOGGER.debug("update_listener")
+    await hass.config_entries.async_reload(config_entry.entry_id)

--- a/homeassistant/components/romy/__init__.py
+++ b/homeassistant/components/romy/__init__.py
@@ -33,7 +33,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
 async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Handle removal of an entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(
+    if unload_ok := await hass.config_entries.async_unload_platforms(
         config_entry, PLATFORMS
-    )
+    ):
+        hass.data[DOMAIN].pop(entry.entry_id)
     return unload_ok

--- a/homeassistant/components/romy/__init__.py
+++ b/homeassistant/components/romy/__init__.py
@@ -14,8 +14,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     """Initialize the ROMY platform via config entry."""
 
     new_romy = await romy.create_romy(
-        config_entry.data[CONF_HOST],
-        config_entry.data.get(CONF_PASSWORD, "")
+        config_entry.data[CONF_HOST], config_entry.data.get(CONF_PASSWORD, "")
     )
 
     coordinator = RomyVacuumCoordinator(hass, new_romy)

--- a/homeassistant/components/romy/config_flow.py
+++ b/homeassistant/components/romy/config_flow.py
@@ -98,15 +98,9 @@ class RomyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             }
         )
 
-        if new_discovered_romy.is_unlocked:
-            self.discovery_schema = _schema_with_defaults(
-                host=discovery_info.host,
-                name=discovery_info.name,
-            )
-        else:
-            self.discovery_schema = _schema_with_defaults_and_password(
-                host=discovery_info.host,
-                name=discovery_info.name,
-                password="",
-            )
+        self.discovery_schema = _schema_with_defaults(
+            host=discovery_info.host,
+            name=discovery_info.name,
+            requires_password=not new_discovered_romy.is_unlocked,
+        )
         return await self.async_step_user()

--- a/homeassistant/components/romy/config_flow.py
+++ b/homeassistant/components/romy/config_flow.py
@@ -72,9 +72,10 @@ class RomyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 if not new_romy.is_unlocked:
                     errors[CONF_PASSWORD] = "invalid_auth"
 
-                return self.async_create_entry(
-                    title=user_input["name"], data=user_input
-                )
+                if not errors:
+	            return self.async_create_entry(
+	                title=user_input["name"], data=user_input
+	            )
 
         return self.async_show_form(step_id="user", data_schema=data, errors=errors)
 

--- a/homeassistant/components/romy/config_flow.py
+++ b/homeassistant/components/romy/config_flow.py
@@ -49,8 +49,7 @@ class RomyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             new_romy = await romy.create_romy(user_input[CONF_HOST], user_input.get(CONF_PASSWORD, ""))
 
             # get robots name in case none was provided
-            if name == "":
-                name = new_romy.name
+            if not user_input[CONF_NAME]:
                 user_input["name"] = new_romy.name
 
             if not new_romy.is_initialized:

--- a/homeassistant/components/romy/config_flow.py
+++ b/homeassistant/components/romy/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for ROMY integration."""
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 
 import romy
 import voluptuous as vol
@@ -54,6 +54,8 @@ class RomyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             new_romy = await romy.create_romy(
                 user_input[CONF_HOST], user_input.get(CONF_PASSWORD, "")
             )
+
+            await self.async_set_unique_id(new_romy.unique_id)
 
             # get robots name in case none was provided
             if not user_input[CONF_NAME]:

--- a/homeassistant/components/romy/config_flow.py
+++ b/homeassistant/components/romy/config_flow.py
@@ -14,11 +14,11 @@ from .const import DOMAIN, LOGGER
 
 
 def _schema_with_defaults(
-    host: str = "", name: str = "", requires_password: bool = False
+    default_values: dict[str, Any] = {}, requires_password: bool = False
 ) -> vol.Schema:
     schema = {
-        vol.Required(CONF_HOST, default=host): cv.string,
-        vol.Optional(CONF_NAME, default=name): cv.string,
+        vol.Required(CONF_HOST, default=default_values.get(CONF_HOST, "")): cv.string,
+        vol.Optional(CONF_NAME, default=default_values.get(CONF_NAME,"")): cv.string,
     }
 
     if requires_password:

--- a/homeassistant/components/romy/config_flow.py
+++ b/homeassistant/components/romy/config_flow.py
@@ -67,13 +67,13 @@ class RomyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 new_romy = await romy.create_romy(self.host, self.password)
 
                 if not new_romy.is_initialized:
-                    errors[CONF_HOST] = "wrong host"
+                    errors[CONF_HOST] = "cannot_connect"
                     return self.async_show_form(
                         step_id="user", data_schema=data, errors=errors
                     )
 
                 if not new_romy.is_unlocked:
-                    errors[CONF_PASSWORD] = "wrong password"
+                    errors[CONF_PASSWORD] = "invalid_auth"
                     return self.async_show_form(
                         step_id="user", data_schema=data, errors=errors
                     )

--- a/homeassistant/components/romy/config_flow.py
+++ b/homeassistant/components/romy/config_flow.py
@@ -58,7 +58,7 @@ class RomyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             if not new_romy.is_unlocked:
                 data = _schema_with_defaults(
-                    host=host, name=name, requires_password=True
+                    user_input, requires_password=True
                 )
                 errors[CONF_PASSWORD] = "invalid_auth"
 

--- a/homeassistant/components/romy/config_flow.py
+++ b/homeassistant/components/romy/config_flow.py
@@ -62,8 +62,6 @@ class RomyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
                 if not new_romy.is_unlocked:
                     return await self.async_step_password()
-
-            if not errors:
                 return await self._async_step_finish_config()
 
         return self.async_show_form(

--- a/homeassistant/components/romy/config_flow.py
+++ b/homeassistant/components/romy/config_flow.py
@@ -53,15 +53,15 @@ class RomyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             if not new_romy.is_initialized:
                 errors[CONF_HOST] = "cannot_connect"
+            else:
+                # check if already setuped
+                await self.async_set_unique_id(new_romy.unique_id)
+                self._abort_if_unique_id_configured()
 
-            # check if already setuped
-            await self.async_set_unique_id(new_romy.unique_id)
-            self._abort_if_unique_id_configured()
+                self.romy_info[CONF_NAME] = new_romy.name
 
-            self.romy_info[CONF_NAME] = new_romy.name
-
-            if not new_romy.is_unlocked:
-                return await self.async_step_unlock_http_interface()
+                if not new_romy.is_unlocked:
+                    return await self.async_step_unlock_http_interface()
 
             if not errors:
                 return await self._async_step_finish_config()

--- a/homeassistant/components/romy/config_flow.py
+++ b/homeassistant/components/romy/config_flow.py
@@ -71,9 +71,6 @@ class RomyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
                 if not new_romy.is_unlocked:
                     errors[CONF_PASSWORD] = "invalid_auth"
-                    return self.async_show_form(
-                        step_id="user", data_schema=data, errors=errors
-                    )
 
                 return self.async_create_entry(
                     title=user_input["name"], data=user_input

--- a/homeassistant/components/romy/config_flow.py
+++ b/homeassistant/components/romy/config_flow.py
@@ -129,7 +129,6 @@ class RomyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     "name": self.discovery_info[CONF_NAME],
                     "host": self.discovery_info[CONF_HOST],
                 },
-                errors={},
             )
 
         return self.async_create_entry(

--- a/homeassistant/components/romy/config_flow.py
+++ b/homeassistant/components/romy/config_flow.py
@@ -16,7 +16,7 @@ from .const import DOMAIN, LOGGER
 
 
 def _schema_with_defaults(
-    default_values: Optional[dict[str, Any]] = None,
+    default_values: dict[str, Any] | None = None,
     requires_password: bool = False,
 ) -> vol.Schema:
     if default_values is None:

--- a/homeassistant/components/romy/config_flow.py
+++ b/homeassistant/components/romy/config_flow.py
@@ -50,7 +50,6 @@ class RomyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         data = self.discovery_schema or _schema_with_defaults()
 
         if user_input is not None:
-            if not errors:
                 ## Save the user input and finish the setup
                 self.host = user_input["host"]
                 self.name = user_input["name"]

--- a/homeassistant/components/romy/config_flow.py
+++ b/homeassistant/components/romy/config_flow.py
@@ -8,7 +8,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.components import zeroconf
-from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PASSWORD, CONF_UUID
+from homeassistant.const import CONF_HOST, CONF_PASSWORD
 from homeassistant.data_entry_flow import FlowResult
 import homeassistant.helpers.config_validation as cv
 
@@ -37,58 +37,63 @@ class RomyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     def __init__(self) -> None:
         """Handle a config flow for ROMY."""
-        self.romy_info: dict[str, Any] = {}
+        self.host: str = ""
+        self.password: str = ""
+        self.robot_name_given_by_user: str = ""
 
     async def async_step_user(
         self, user_input: dict[str, str] | None = None
     ) -> FlowResult:
         """Handle the user step."""
         errors: dict[str, str] = {}
-        data = _schema_with_host()
 
         if user_input:
-            self.romy_info[CONF_HOST] = user_input[CONF_HOST]
+            self.host = user_input[CONF_HOST]
 
-            new_romy = await romy.create_romy(self.romy_info[CONF_HOST], "")
+            new_romy = await romy.create_romy(self.host, "")
 
             if not new_romy.is_initialized:
                 errors[CONF_HOST] = "cannot_connect"
             else:
-                # check if already setuped
                 await self.async_set_unique_id(new_romy.unique_id)
                 self._abort_if_unique_id_configured()
 
-                self.romy_info[CONF_NAME] = new_romy.name
+                self.robot_name_given_by_user = new_romy.user_name
 
                 if not new_romy.is_unlocked:
-                    return await self.async_step_unlock_http_interface()
+                    return await self.async_step_password()
 
             if not errors:
                 return await self._async_step_finish_config()
 
-        return self.async_show_form(step_id="user", data_schema=data, errors=errors)
+        return self.async_show_form(
+            step_id="user", data_schema=_schema_with_host(), errors=errors
+        )
 
-    async def async_step_unlock_http_interface(
+    async def async_step_password(
         self, user_input: dict[str, str] | None = None
     ) -> FlowResult:
-        """Unlock the http interface with password if robot is locked."""
+        """Unlock the robots local http interface with password."""
         errors: dict[str, str] = {}
-        data = _schema_with_password()
 
         if user_input:
-            self.romy_info[CONF_PASSWORD] = user_input[CONF_PASSWORD]
-            new_romy = await romy.create_romy(
-                self.romy_info[CONF_HOST], self.romy_info[CONF_PASSWORD]
-            )
+            self.password = user_input[CONF_PASSWORD]
+            new_romy = await romy.create_romy(self.host, self.password)
 
-            if not new_romy.is_initialized or not new_romy.is_unlocked:
+            if not new_romy.is_initialized:
+                errors[CONF_HOST] = "cannot_connect"
+                return self.async_show_form(
+                    step_id="user", data_schema=_schema_with_host(), errors=errors
+                )
+
+            if not new_romy.is_unlocked:
                 errors[CONF_PASSWORD] = "invalid_auth"
 
             if not errors:
                 return await self._async_step_finish_config()
 
         return self.async_show_form(
-            step_id="unlock_http_interface", data_schema=data, errors=errors
+            step_id="password", data_schema=_schema_with_password(), errors=errors
         )
 
     async def async_step_zeroconf(
@@ -99,13 +104,13 @@ class RomyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         LOGGER.debug("Zeroconf discovery_info: %s", discovery_info)
 
         # connect and gather information from your ROMY
-        host = discovery_info.host
-        LOGGER.debug("ZeroConf Host: %s", host)
+        self.host = discovery_info.host
+        LOGGER.debug("ZeroConf Host: %s", self.host)
 
-        new_discovered_romy = await romy.create_romy(host, "")
+        new_discovered_romy = await romy.create_romy(self.host, "")
 
-        name = new_discovered_romy.name
-        LOGGER.debug("ZeroConf Name: %s", name)
+        self.robot_name_given_by_user = new_discovered_romy.user_name
+        LOGGER.debug("ZeroConf Name: %s", self.robot_name_given_by_user)
 
         # get unique id and stop discovery if robot is already added
         unique_id = new_discovered_romy.unique_id
@@ -115,20 +120,21 @@ class RomyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         self.context.update(
             {
-                "title_placeholders": {"name": f"{name} ({host} / {unique_id})"},
-                "configuration_url": f"http://{host}:{new_discovered_romy.port}",
+                "title_placeholders": {
+                    "name": f"{self.robot_name_given_by_user} ({self.host} / {unique_id})"
+                },
+                "configuration_url": f"http://{self.host}:{new_discovered_romy.port}",
             }
         )
 
-        self.romy_info[CONF_HOST] = host
-        self.romy_info[CONF_NAME] = name
-        self.romy_info[CONF_UUID] = unique_id
+        # if robot got already unlocked with password add it directly
+        if not new_discovered_romy.is_initialized:
+            return self.async_abort(reason="cannot_connect")
 
-        # if robot is already unlocked add it directly
-        if new_discovered_romy.is_initialized and new_discovered_romy.is_unlocked:
+        if new_discovered_romy.is_unlocked:
             return await self.async_step_zeroconf_confirm()
 
-        return await self.async_step_unlock_http_interface()
+        return await self.async_step_password()
 
     async def async_step_zeroconf_confirm(
         self, user_input: dict[str, str] | None = None
@@ -138,14 +144,17 @@ class RomyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_show_form(
                 step_id="zeroconf_confirm",
                 description_placeholders={
-                    "name": self.romy_info[CONF_NAME],
-                    "host": self.romy_info[CONF_HOST],
+                    "name": self.robot_name_given_by_user,
+                    "host": self.host,
                 },
             )
         return await self._async_step_finish_config()
 
     async def _async_step_finish_config(self) -> FlowResult:
         """Finish the configuration setup."""
+        romy_info: dict[str, Any] = {}
+        romy_info[CONF_HOST] = self.host
+        romy_info[CONF_PASSWORD] = self.password
         return self.async_create_entry(
-            title=self.romy_info[CONF_NAME], data=self.romy_info
+            title=self.robot_name_given_by_user, data=romy_info
         )

--- a/homeassistant/components/romy/config_flow.py
+++ b/homeassistant/components/romy/config_flow.py
@@ -53,14 +53,10 @@ class RomyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, str] | None = None
     ) -> FlowResult:
         """Handle the user step."""
-        errors = {}
+        errors: dict[str, str] = {}
         data = self.discovery_schema or _schema_with_defaults()
 
         if user_input is not None:
-            # Validate the user input
-            if "host" not in user_input:
-                errors["host"] = "Please enter a host."
-
             if not errors:
                 ## Save the user input and finish the setup
                 self.host = user_input["host"]

--- a/homeassistant/components/romy/config_flow.py
+++ b/homeassistant/components/romy/config_flow.py
@@ -73,9 +73,9 @@ class RomyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     errors[CONF_PASSWORD] = "invalid_auth"
 
                 if not errors:
-	            return self.async_create_entry(
-	                title=user_input["name"], data=user_input
-	            )
+                    return self.async_create_entry(
+                        title=user_input["name"], data=user_input
+                    )
 
         return self.async_show_form(step_id="user", data_schema=data, errors=errors)
 

--- a/homeassistant/components/romy/config_flow.py
+++ b/homeassistant/components/romy/config_flow.py
@@ -1,0 +1,128 @@
+"""Config flow for ROMY integration."""
+from __future__ import annotations
+
+import romy
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.components import zeroconf
+from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PASSWORD
+from homeassistant.data_entry_flow import FlowResult
+import homeassistant.helpers.config_validation as cv
+
+from .const import DOMAIN, LOGGER
+
+
+def _schema_with_defaults(
+    host: str = "", port: int = 8080, name: str = ""
+) -> vol.Schema:
+    return vol.Schema(
+        {
+            vol.Required(CONF_HOST, default=host): cv.string,
+            vol.Optional(CONF_NAME, default=name): cv.string,
+        },
+    )
+
+
+def _schema_with_defaults_and_password(
+    host: str = "", port: int = 8080, name: str = "", password: str = ""
+) -> vol.Schema:
+    return vol.Schema(
+        {
+            vol.Required(CONF_HOST, default=host): cv.string,
+            vol.Optional(CONF_NAME, default=name): cv.string,
+            vol.Required(CONF_PASSWORD, default=password): vol.All(str, vol.Length(8)),
+        },
+    )
+
+
+class RomyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle config flow for ROMY."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
+
+    def __init__(self) -> None:
+        """Handle a config flow for ROMY."""
+        self.discovery_schema = None
+        self.host: str = ""
+        self.name: str = ""
+        self.password: str = ""
+
+    async def async_step_user(
+        self, user_input: dict[str, str] | None = None
+    ) -> FlowResult:
+        """Handle the user step."""
+        errors = {}
+        data = self.discovery_schema or _schema_with_defaults()
+
+        if user_input is not None:
+            # Validate the user input
+            if "host" not in user_input:
+                errors["host"] = "Please enter a host."
+
+            if not errors:
+                ## Save the user input and finish the setup
+                self.host = user_input["host"]
+                self.name = user_input["name"]
+                if "password" in user_input:
+                    self.password = user_input["password"]
+
+                new_romy = await romy.create_romy(self.host, self.password)
+
+                if not new_romy.is_initialized:
+                    errors[CONF_HOST] = "wrong host"
+                    return self.async_show_form(
+                        step_id="user", data_schema=data, errors=errors
+                    )
+
+                if not new_romy.is_unlocked:
+                    errors[CONF_PASSWORD] = "wrong password"
+                    return self.async_show_form(
+                        step_id="user", data_schema=data, errors=errors
+                    )
+
+                return self.async_create_entry(
+                    title=user_input["name"], data=user_input
+                )
+
+        return self.async_show_form(step_id="user", data_schema=data, errors=errors)
+
+    async def async_step_zeroconf(
+        self, discovery_info: zeroconf.ZeroconfServiceInfo
+    ) -> FlowResult:
+        """Handle zeroconf discovery."""
+
+        LOGGER.debug("Zeroconf discovery_info: %s", discovery_info)
+
+        # extract unique id and stop discovery if robot is already added
+        unique_id = discovery_info.hostname.split(".")[0]
+        LOGGER.debug("Unique_id: %s", unique_id)
+        await self.async_set_unique_id(unique_id)
+        self._abort_if_unique_id_configured()
+
+        # get ROMY's name and check if local http interface is locked
+        new_discovered_romy = await romy.create_romy(discovery_info.host, "")
+        discovery_info.name = new_discovered_romy.name
+
+        self.context.update(
+            {
+                "title_placeholders": {
+                    "name": f"{unique_id.split('-')[1]} ({discovery_info.host})"
+                },
+                "configuration_url": f"http://{discovery_info.host}:{new_discovered_romy.port}",
+            }
+        )
+
+        if new_discovered_romy.is_unlocked:
+            self.discovery_schema = _schema_with_defaults(
+                host=discovery_info.host,
+                name=discovery_info.name,
+            )
+        else:
+            self.discovery_schema = _schema_with_defaults_and_password(
+                host=discovery_info.host,
+                name=discovery_info.name,
+                password="",
+            )
+        return await self.async_step_user()

--- a/homeassistant/components/romy/config_flow.py
+++ b/homeassistant/components/romy/config_flow.py
@@ -14,26 +14,19 @@ from .const import DOMAIN, LOGGER
 
 
 def _schema_with_defaults(
-    host: str = "", port: int = 8080, name: str = ""
+    host: str = "", name: str = "", requires_password: bool = False
 ) -> vol.Schema:
-    return vol.Schema(
-        {
-            vol.Required(CONF_HOST, default=host): cv.string,
-            vol.Optional(CONF_NAME, default=name): cv.string,
-        },
-    )
+    schema = {
+        vol.Required(CONF_HOST, default=host): cv.string,
+        vol.Optional(CONF_NAME, default=name): cv.string,
+    }
 
+    if requires_password:
+        schema.update(
+            {vol.Required(CONF_PASSWORD, default=""): vol.All(str, vol.Length(8))}
+        )
 
-def _schema_with_defaults_and_password(
-    host: str = "", port: int = 8080, name: str = "", password: str = ""
-) -> vol.Schema:
-    return vol.Schema(
-        {
-            vol.Required(CONF_HOST, default=host): cv.string,
-            vol.Optional(CONF_NAME, default=name): cv.string,
-            vol.Required(CONF_PASSWORD, default=password): vol.All(str, vol.Length(8)),
-        },
-    )
+    return vol.Schema(schema)
 
 
 class RomyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):

--- a/homeassistant/components/romy/config_flow.py
+++ b/homeassistant/components/romy/config_flow.py
@@ -38,9 +38,6 @@ class RomyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     def __init__(self) -> None:
         """Handle a config flow for ROMY."""
         self.discovery_schema = None
-        self.host: str = ""
-        self.name: str = ""
-        self.password: str = ""
 
     async def async_step_user(
         self, user_input: dict[str, str] | None = None
@@ -51,16 +48,17 @@ class RomyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             # Save the user input and finish the setup
-            self.host = user_input["host"]
-            self.name = user_input["name"]
+            host = user_input["host"]
+            name = user_input["name"]
+            password = ""
             if "password" in user_input:
-                self.password = user_input["password"]
+                password = user_input["password"]
 
-            new_romy = await romy.create_romy(self.host, self.password)
+            new_romy = await romy.create_romy(host, password)
 
             # get robots name in case none was provided
-            if self.name == "":
-                self.name = new_romy.name
+            if name == "":
+                name = new_romy.name
                 user_input["name"] = new_romy.name
 
             if not new_romy.is_initialized:
@@ -68,7 +66,7 @@ class RomyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             if not new_romy.is_unlocked:
                 data = _schema_with_defaults(
-                    host=self.host, name=self.name, requires_password=True
+                    host=host, name=name, requires_password=True
                 )
                 errors[CONF_PASSWORD] = "invalid_auth"
 

--- a/homeassistant/components/romy/config_flow.py
+++ b/homeassistant/components/romy/config_flow.py
@@ -116,7 +116,7 @@ class RomyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         unique_id = new_discovered_romy.unique_id
         LOGGER.debug("ZeroConf Unique_id: %s", unique_id)
         await self.async_set_unique_id(unique_id)
-        self._abort_if_unique_id_configured()
+        self._abort_if_unique_id_configured(updates={CONF_HOST: discovery_info.host})
 
         self.context.update(
             {

--- a/homeassistant/components/romy/config_flow.py
+++ b/homeassistant/components/romy/config_flow.py
@@ -152,9 +152,10 @@ class RomyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def _async_step_finish_config(self) -> FlowResult:
         """Finish the configuration setup."""
-        romy_info: dict[str, Any] = {}
-        romy_info[CONF_HOST] = self.host
-        romy_info[CONF_PASSWORD] = self.password
         return self.async_create_entry(
-            title=self.robot_name_given_by_user, data=romy_info
+            title=self.robot_name_given_by_user,
+            data={
+                CONF_HOST: self.host,
+                CONF_PASSWORD: self.password,
+            }
         )

--- a/homeassistant/components/romy/config_flow.py
+++ b/homeassistant/components/romy/config_flow.py
@@ -22,9 +22,7 @@ def _schema_with_defaults(
     }
 
     if requires_password:
-        schema.update(
-            {vol.Required(CONF_PASSWORD, default=""): vol.All(str, vol.Length(8))}
-        )
+        schema[vol.Required(CONF_PASSWORD)]= vol.All(str, vol.Length(8))
 
     return vol.Schema(schema)
 

--- a/homeassistant/components/romy/config_flow.py
+++ b/homeassistant/components/romy/config_flow.py
@@ -84,7 +84,7 @@ class RomyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         unique_id = discovery_info.hostname.split(".")[0]
         LOGGER.debug("Unique_id: %s", unique_id)
         await self.async_set_unique_id(unique_id)
-        self._abort_if_unique_id_configured()
+        self._abort_if_unique_id_configured(updates={CONF_HOST: discovery_info.host})
 
         # get ROMY's name and check if local http interface is locked
         new_discovered_romy = await romy.create_romy(discovery_info.host, "")

--- a/homeassistant/components/romy/config_flow.py
+++ b/homeassistant/components/romy/config_flow.py
@@ -68,9 +68,6 @@ class RomyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
                 if not new_romy.is_initialized:
                     errors[CONF_HOST] = "cannot_connect"
-                    return self.async_show_form(
-                        step_id="user", data_schema=data, errors=errors
-                    )
 
                 if not new_romy.is_unlocked:
                     errors[CONF_PASSWORD] = "invalid_auth"

--- a/homeassistant/components/romy/config_flow.py
+++ b/homeassistant/components/romy/config_flow.py
@@ -15,20 +15,18 @@ import homeassistant.helpers.config_validation as cv
 from .const import DOMAIN, LOGGER
 
 
-def _schema_with_defaults(
-    default_values: dict[str, Any] | None = None,
-    requires_password: bool = False,
-) -> vol.Schema:
-    if default_values is None:
-        default_values = {}
-    schema = {
-        vol.Required(CONF_HOST, default=default_values.get(CONF_HOST, "")): cv.string,
-    }
+def _schema_with_host() -> vol.Schema:
+    return vol.Schema(
+        {
+            vol.Required(CONF_HOST): cv.string,
+        },
+    )
 
-    if requires_password:
-        schema[vol.Required(CONF_PASSWORD)] = vol.All(str, vol.Length(8))
 
-    return vol.Schema(schema)
+def _schema_with_password() -> vol.Schema:
+    return vol.Schema(
+        {vol.Required(CONF_PASSWORD): vol.All(cv.string, vol.Length(8))},
+    )
 
 
 class RomyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -39,35 +37,59 @@ class RomyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     def __init__(self) -> None:
         """Handle a config flow for ROMY."""
-        self.discovery_schema = None
-        self.discovery_info: dict[str, Any] = {}
+        self.romy_info: dict[str, Any] = {}
 
     async def async_step_user(
         self, user_input: dict[str, str] | None = None
     ) -> FlowResult:
         """Handle the user step."""
         errors: dict[str, str] = {}
-        data = self.discovery_schema or _schema_with_defaults()
+        data = _schema_with_host()
 
         if user_input:
-            # Save the user input and finish the setup
-            new_romy = await romy.create_romy(
-                user_input[CONF_HOST], user_input.get(CONF_PASSWORD, "")
-            )
+            self.romy_info[CONF_HOST] = user_input[CONF_HOST]
 
-            await self.async_set_unique_id(new_romy.unique_id)
+            new_romy = await romy.create_romy(self.romy_info[CONF_HOST], "")
 
             if not new_romy.is_initialized:
                 errors[CONF_HOST] = "cannot_connect"
 
+            # check if already setuped
+            await self.async_set_unique_id(new_romy.unique_id)
+            self._abort_if_unique_id_configured()
+
+            self.romy_info[CONF_NAME] = new_romy.name
+
             if not new_romy.is_unlocked:
-                data = _schema_with_defaults(user_input, requires_password=True)
+                return await self.async_step_unlock_http_interface()
+
+            if not errors:
+                return await self._async_step_finish_config()
+
+        return self.async_show_form(step_id="user", data_schema=data, errors=errors)
+
+    async def async_step_unlock_http_interface(
+        self, user_input: dict[str, str] | None = None
+    ) -> FlowResult:
+        """Unlock the http interface with password if robot is locked."""
+        errors: dict[str, str] = {}
+        data = _schema_with_password()
+
+        if user_input:
+            self.romy_info[CONF_PASSWORD] = user_input[CONF_PASSWORD]
+            new_romy = await romy.create_romy(
+                self.romy_info[CONF_HOST], self.romy_info[CONF_PASSWORD]
+            )
+
+            if not new_romy.is_initialized or not new_romy.is_unlocked:
                 errors[CONF_PASSWORD] = "invalid_auth"
 
             if not errors:
-                return self.async_create_entry(title=new_romy.name, data=user_input)
+                return await self._async_step_finish_config()
 
-        return self.async_show_form(step_id="user", data_schema=data, errors=errors)
+        return self.async_show_form(
+            step_id="unlock_http_interface", data_schema=data, errors=errors
+        )
 
     async def async_step_zeroconf(
         self, discovery_info: zeroconf.ZeroconfServiceInfo
@@ -76,28 +98,19 @@ class RomyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         LOGGER.debug("Zeroconf discovery_info: %s", discovery_info)
 
-        # get ROMY's name and check if local http interface is locked
+        # connect and gather information from your ROMY
         host = discovery_info.host
         LOGGER.debug("ZeroConf Host: %s", host)
 
         new_discovered_romy = await romy.create_romy(host, "")
 
+        name = new_discovered_romy.name
+        LOGGER.debug("ZeroConf Name: %s", name)
+
         # get unique id and stop discovery if robot is already added
         unique_id = new_discovered_romy.unique_id
         LOGGER.debug("ZeroConf Unique_id: %s", unique_id)
         await self.async_set_unique_id(unique_id)
-
-        name = new_discovered_romy.name
-        LOGGER.debug("ZeroConf Name: %s", name)
-
-        self.discovery_info.update(
-            {
-                CONF_HOST: host,
-                CONF_NAME: name,
-                CONF_UUID: unique_id,
-            }
-        )
-
         self._abort_if_unique_id_configured()
 
         self.context.update(
@@ -107,31 +120,32 @@ class RomyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             }
         )
 
-        self.discovery_schema = _schema_with_defaults(
-            {CONF_HOST: discovery_info.host},
-            requires_password=not new_discovered_romy.is_unlocked,
-        )
+        self.romy_info[CONF_HOST] = host
+        self.romy_info[CONF_NAME] = name
+        self.romy_info[CONF_UUID] = unique_id
 
         # if robot is already unlocked add it directly
         if new_discovered_romy.is_initialized and new_discovered_romy.is_unlocked:
             return await self.async_step_zeroconf_confirm()
 
-        return await self.async_step_user()
+        return await self.async_step_unlock_http_interface()
 
     async def async_step_zeroconf_confirm(
-        self, user_input: dict[str, Any] | None = None
+        self, user_input: dict[str, str] | None = None
     ) -> FlowResult:
         """Handle a confirmation flow initiated by zeroconf."""
         if user_input is None:
             return self.async_show_form(
                 step_id="zeroconf_confirm",
                 description_placeholders={
-                    "name": self.discovery_info[CONF_NAME],
-                    "host": self.discovery_info[CONF_HOST],
+                    "name": self.romy_info[CONF_NAME],
+                    "host": self.romy_info[CONF_HOST],
                 },
             )
+        return await self._async_step_finish_config()
 
+    async def _async_step_finish_config(self) -> FlowResult:
+        """Finish the configuration setup."""
         return self.async_create_entry(
-            title=self.discovery_info[CONF_NAME],
-            data=self.discovery_info,
+            title=self.romy_info[CONF_NAME], data=self.romy_info
         )

--- a/homeassistant/components/romy/config_flow.py
+++ b/homeassistant/components/romy/config_flow.py
@@ -49,7 +49,7 @@ class RomyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
         data = self.discovery_schema or _schema_with_defaults()
 
-        if user_input is not None:
+        if user_input:
             # Save the user input and finish the setup
             new_romy = await romy.create_romy(
                 user_input[CONF_HOST], user_input.get(CONF_PASSWORD, "")

--- a/homeassistant/components/romy/config_flow.py
+++ b/homeassistant/components/romy/config_flow.py
@@ -17,7 +17,6 @@ class RomyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle config flow for ROMY."""
 
     VERSION = 1
-    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
 
     def __init__(self) -> None:
         """Handle a config flow for ROMY."""

--- a/homeassistant/components/romy/config_flow.py
+++ b/homeassistant/components/romy/config_flow.py
@@ -46,13 +46,7 @@ class RomyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             # Save the user input and finish the setup
-            host = user_input["host"]
-            name = user_input["name"]
-            password = ""
-            if "password" in user_input:
-                password = user_input["password"]
-
-            new_romy = await romy.create_romy(host, password)
+            new_romy = await romy.create_romy(user_input[CONF_HOST], user_input.get(CONF_PASSWORD, ""))
 
             # get robots name in case none was provided
             if name == "":

--- a/homeassistant/components/romy/config_flow.py
+++ b/homeassistant/components/romy/config_flow.py
@@ -82,15 +82,15 @@ class RomyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         LOGGER.debug("Zeroconf discovery_info: %s", discovery_info)
 
-        # extract unique id and stop discovery if robot is already added
-        unique_id = discovery_info.hostname.split(".")[0]
-        LOGGER.debug("Unique_id: %s", unique_id)
-        await self.async_set_unique_id(unique_id)
-        self._abort_if_unique_id_configured(updates={CONF_HOST: discovery_info.host})
-
         # get ROMY's name and check if local http interface is locked
         new_discovered_romy = await romy.create_romy(discovery_info.host, "")
         discovery_info.name = new_discovered_romy.name
+
+        # get unique id and stop discovery if robot is already added
+        unique_id = new_discovered_romy.unique_id
+        LOGGER.debug("Unique_id: %s", unique_id)
+        await self.async_set_unique_id(unique_id)
+        self._abort_if_unique_id_configured(updates={CONF_HOST: discovery_info.host})
 
         self.context.update(
             {

--- a/homeassistant/components/romy/const.py
+++ b/homeassistant/components/romy/const.py
@@ -5,8 +5,6 @@ import logging
 
 from homeassistant.const import Platform
 
-# This is the internal name of the integration, it should also match the directory
-# name for the integration.
 DOMAIN = "romy"
 ICON = "mdi:robot-vacuum"
 PLATFORMS = [Platform.VACUUM]

--- a/homeassistant/components/romy/const.py
+++ b/homeassistant/components/romy/const.py
@@ -6,7 +6,6 @@ import logging
 from homeassistant.const import Platform
 
 DOMAIN = "romy"
-ICON = "mdi:robot-vacuum"
 PLATFORMS = [Platform.VACUUM]
 UPDATE_INTERVAL = timedelta(seconds=5)
 LOGGER = logging.getLogger(__package__)

--- a/homeassistant/components/romy/const.py
+++ b/homeassistant/components/romy/const.py
@@ -1,0 +1,14 @@
+"""Constants for the ROMY integration."""
+
+from datetime import timedelta
+import logging
+
+from homeassistant.const import Platform
+
+# This is the internal name of the integration, it should also match the directory
+# name for the integration.
+DOMAIN = "romy"
+ICON = "mdi:robot-vacuum"
+PLATFORMS = [Platform.VACUUM]
+UPDATE_INTERVAL = timedelta(seconds=5)
+LOGGER = logging.getLogger(__package__)

--- a/homeassistant/components/romy/coordinator.py
+++ b/homeassistant/components/romy/coordinator.py
@@ -1,0 +1,22 @@
+"""ROMY coordinator."""
+
+from romy import RomyRobot
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from .const import DOMAIN, LOGGER, UPDATE_INTERVAL
+
+
+class RomyVacuumCoordinator(DataUpdateCoordinator):
+    """ROMY Vacuum Coordinator."""
+
+    def __init__(self, hass: HomeAssistant, romy: RomyRobot) -> None:
+        """Setuping ROMY Vacuum Coordinator class."""
+        super().__init__(hass, LOGGER, name=DOMAIN, update_interval=UPDATE_INTERVAL)
+        self.hass = hass
+        self.romy = romy
+
+    async def _async_update_data(self) -> None:
+        """Update ROMY Vacuum Cleaner data."""
+        await self.romy.async_update()

--- a/homeassistant/components/romy/coordinator.py
+++ b/homeassistant/components/romy/coordinator.py
@@ -8,7 +8,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from .const import DOMAIN, LOGGER, UPDATE_INTERVAL
 
 
-class RomyVacuumCoordinator(DataUpdateCoordinator):
+class RomyVacuumCoordinator(DataUpdateCoordinator[None]):
     """ROMY Vacuum Coordinator."""
 
     def __init__(self, hass: HomeAssistant, romy: RomyRobot) -> None:

--- a/homeassistant/components/romy/coordinator.py
+++ b/homeassistant/components/romy/coordinator.py
@@ -12,7 +12,7 @@ class RomyVacuumCoordinator(DataUpdateCoordinator):
     """ROMY Vacuum Coordinator."""
 
     def __init__(self, hass: HomeAssistant, romy: RomyRobot) -> None:
-        """Setuping ROMY Vacuum Coordinator class."""
+        """Initialize."""
         super().__init__(hass, LOGGER, name=DOMAIN, update_interval=UPDATE_INTERVAL)
         self.hass = hass
         self.romy = romy

--- a/homeassistant/components/romy/manifest.json
+++ b/homeassistant/components/romy/manifest.json
@@ -1,0 +1,11 @@
+{
+  "domain": "romy",
+  "name": "ROMY Vacuum Cleaner",
+  "codeowners": ["@xeniter"],
+  "config_flow": true,
+  "dependencies": [],
+  "documentation": "https://www.home-assistant.io/integrations/romy",
+  "iot_class": "local_polling",
+  "requirements": ["romy==0.0.2"],
+  "zeroconf": ["_aicu-http._tcp.local."]
+}

--- a/homeassistant/components/romy/manifest.json
+++ b/homeassistant/components/romy/manifest.json
@@ -3,7 +3,6 @@
   "name": "ROMY Vacuum Cleaner",
   "codeowners": ["@xeniter"],
   "config_flow": true,
-  "dependencies": [],
   "documentation": "https://www.home-assistant.io/integrations/romy",
   "iot_class": "local_polling",
   "requirements": ["romy==0.0.2"],

--- a/homeassistant/components/romy/manifest.json
+++ b/homeassistant/components/romy/manifest.json
@@ -5,6 +5,6 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/romy",
   "iot_class": "local_polling",
-  "requirements": ["romy==0.0.2"],
+  "requirements": ["romy==0.0.5"],
   "zeroconf": ["_aicu-http._tcp.local."]
 }

--- a/homeassistant/components/romy/manifest.json
+++ b/homeassistant/components/romy/manifest.json
@@ -5,6 +5,6 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/romy",
   "iot_class": "local_polling",
-  "requirements": ["romy==0.0.5"],
+  "requirements": ["romy==0.0.7"],
   "zeroconf": ["_aicu-http._tcp.local."]
 }

--- a/homeassistant/components/romy/strings.json
+++ b/homeassistant/components/romy/strings.json
@@ -6,7 +6,8 @@
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]"
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
     },
     "step": {
       "user": {
@@ -14,18 +15,17 @@
           "host": "[%key:common::config_flow::data::host%]"
         }
       },
-      "unlock_http_interface": {
-        "title": "Local Http Interface is locked",
+      "password": {
+        "title": "Password required",
         "data": {
           "password": "[%key:common::config_flow::data::password%]"
         },
         "data_description": {
-          "password": "Please provide password (8 characters, see QR Code under the dustbin)."
+          "password": "(8 characters, see QR Code under the dustbin)."
         }
       },
       "zeroconf_confirm": {
-        "description": "Do you want to set up {name} at {host}?",
-        "title": "Discovered romy"
+        "description": "Do you want to add ROMY Vacuum Cleaner {name} to Home Asssistant?"
       }
     }
   },

--- a/homeassistant/components/romy/strings.json
+++ b/homeassistant/components/romy/strings.json
@@ -2,7 +2,8 @@
   "config": {
     "flow_title": "{name}",
     "error": {
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]"
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
@@ -12,9 +13,10 @@
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
           "port": "[%key:common::config_flow::data::port%]",
-          "name": "[%key:common::config_flow::data::name%]"
+          "name": "[%key:common::config_flow::data::name%]",
+          "password": "[%key:common::config_flow::data::name%]"
         },
-        "title": "Please provide ROMYs IP Address"
+        "title": "[%key:common::config_flow::title%]"
       }
     }
   }

--- a/homeassistant/components/romy/strings.json
+++ b/homeassistant/components/romy/strings.json
@@ -25,7 +25,7 @@
         }
       },
       "zeroconf_confirm": {
-        "description": "Do you want to add ROMY Vacuum Cleaner {name} to Home Asssistant?"
+        "description": "Do you want to add ROMY Vacuum Cleaner {name} to Home Assistant?"
       }
     }
   },

--- a/homeassistant/components/romy/strings.json
+++ b/homeassistant/components/romy/strings.json
@@ -3,7 +3,7 @@
     "flow_title": "{name}",
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]"
+      "invalid_auth": "Local Http Interface is locked! Please provide password (see QR Code under the dustbin)."
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"

--- a/homeassistant/components/romy/strings.json
+++ b/homeassistant/components/romy/strings.json
@@ -18,5 +18,25 @@
         }
       }
     }
+  },
+  "entity": {
+    "vacuum": {
+      "romy": {
+        "name": "romy",
+        "state_attributes": {
+          "fan_speed": {
+            "state": {
+              "default": "Default",
+              "normal": "Normal",
+              "silent": "Silent",
+              "intensive": "Intensive",
+              "super_silent": "Super silent",
+              "high": "High",
+              "auto": "Auto"
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/homeassistant/components/romy/strings.json
+++ b/homeassistant/components/romy/strings.json
@@ -14,9 +14,8 @@
           "host": "[%key:common::config_flow::data::host%]",
           "port": "[%key:common::config_flow::data::port%]",
           "name": "[%key:common::config_flow::data::name%]",
-          "password": "[%key:common::config_flow::data::name%]"
-        },
-        "title": "[%key:common::config_flow::title%]"
+          "password": "[%key:common::config_flow::data::password%]"
+        }
       }
     }
   }

--- a/homeassistant/components/romy/strings.json
+++ b/homeassistant/components/romy/strings.json
@@ -3,7 +3,7 @@
     "flow_title": "{name}",
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "invalid_auth": "Local Http Interface is locked! Please provide password (see QR Code under the dustbin)."
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]"
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
@@ -11,9 +11,16 @@
     "step": {
       "user": {
         "data": {
-          "host": "[%key:common::config_flow::data::host%]",
-          "name": "[%key:common::config_flow::data::name%]",
+          "host": "[%key:common::config_flow::data::host%]"
+        }
+      },
+      "unlock_http_interface": {
+        "title": "Local Http Interface is locked",
+        "data": {
           "password": "[%key:common::config_flow::data::password%]"
+        },
+        "data_description": {
+          "password": "Please provide password (8 characters, see QR Code under the dustbin)."
         }
       },
       "zeroconf_confirm": {

--- a/homeassistant/components/romy/strings.json
+++ b/homeassistant/components/romy/strings.json
@@ -1,0 +1,21 @@
+{
+  "config": {
+    "flow_title": "{name}",
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "port": "[%key:common::config_flow::data::port%]",
+          "name": "[%key:common::config_flow::data::name%]"
+        },
+        "title": "Please provide ROMYs IP Address"
+      }
+    }
+  }
+}

--- a/homeassistant/components/romy/strings.json
+++ b/homeassistant/components/romy/strings.json
@@ -32,7 +32,6 @@
   "entity": {
     "vacuum": {
       "romy": {
-        "name": "romy",
         "state_attributes": {
           "fan_speed": {
             "state": {

--- a/homeassistant/components/romy/strings.json
+++ b/homeassistant/components/romy/strings.json
@@ -12,7 +12,6 @@
       "user": {
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
-          "port": "[%key:common::config_flow::data::port%]",
           "name": "[%key:common::config_flow::data::name%]",
           "password": "[%key:common::config_flow::data::password%]"
         }

--- a/homeassistant/components/romy/strings.json
+++ b/homeassistant/components/romy/strings.json
@@ -15,6 +15,10 @@
           "name": "[%key:common::config_flow::data::name%]",
           "password": "[%key:common::config_flow::data::password%]"
         }
+      },
+      "zeroconf_confirm": {
+        "description": "Do you want to set up {name} at {host}?",
+        "title": "Discovered romy"
       }
     }
   },

--- a/homeassistant/components/romy/vacuum.py
+++ b/homeassistant/components/romy/vacuum.py
@@ -89,9 +89,6 @@ class RomyVacuumEntity(CoordinatorEntity[RomyVacuumCoordinator], StateVacuumEnti
         self.romy = romy
         self._device_info = device_info
         self._attr_unique_id = self.romy.unique_id
-        self._attr_supported_features = SUPPORT_ROMY_ROBOT
-        self._attr_fan_speed_list = FAN_SPEEDS
-        self._attr_icon = ICON
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/homeassistant/components/romy/vacuum.py
+++ b/homeassistant/components/romy/vacuum.py
@@ -75,6 +75,7 @@ class RomyVacuumEntity(CoordinatorEntity[RomyVacuumCoordinator], StateVacuumEnti
     _attr_supported_features = SUPPORT_ROMY_ROBOT
     _attr_fan_speed_list = FAN_SPEEDS
     _attr_icon = ICON
+    _attr_name = None
 
     def __init__(
         self,

--- a/homeassistant/components/romy/vacuum.py
+++ b/homeassistant/components/romy/vacuum.py
@@ -15,8 +15,10 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, ICON, LOGGER
+from .const import DOMAIN, LOGGER
 from .coordinator import RomyVacuumCoordinator
+
+ICON = "mdi:robot-vacuum"
 
 FAN_SPEED_NONE = "default"
 FAN_SPEED_NORMAL = "normal"
@@ -75,7 +77,6 @@ async def async_setup_entry(
 class RomyVacuumEntity(CoordinatorEntity[RomyVacuumCoordinator], StateVacuumEntity):
     """Representation of a ROMY vacuum cleaner robot."""
 
-    _attr_name = None
     _attr_has_entity_name = True
     _attr_supported_features = SUPPORT_ROMY_ROBOT
     _attr_fan_speed_list = FAN_SPEEDS

--- a/homeassistant/components/romy/vacuum.py
+++ b/homeassistant/components/romy/vacuum.py
@@ -87,7 +87,6 @@ class RomyVacuumEntity(CoordinatorEntity[RomyVacuumCoordinator], StateVacuumEnti
         self.romy = romy
         self._device_info = device_info
         self._attr_unique_id = self.romy.unique_id
-        self._state_attrs: dict[str, Any] = {}
 
         self._is_on = False
         self._fan_speed = FAN_SPEEDS.index(FAN_SPEED_NONE)

--- a/homeassistant/components/romy/vacuum.py
+++ b/homeassistant/components/romy/vacuum.py
@@ -119,9 +119,7 @@ class RomyVacuumEntity(CoordinatorEntity[RomyVacuumCoordinator], StateVacuumEnti
     async def async_return_to_base(self, **kwargs: Any) -> None:
         """Return vacuum back to base."""
         LOGGER.debug("async_return_to_base")
-        ret = await self.romy.async_return_to_base()
-        if ret:
-            self._is_on = False
+        await self.romy.async_return_to_base()
 
     async def async_pause(self, **kwargs: Any) -> None:
         """Pause the cleaning cycle (api call stop means stop robot where is is and not sending back to docking station)."""

--- a/homeassistant/components/romy/vacuum.py
+++ b/homeassistant/components/romy/vacuum.py
@@ -62,10 +62,7 @@ async def async_setup_entry(
     coordinator: RomyVacuumCoordinator = hass.data[DOMAIN][config_entry.entry_id]
     romy: RomyRobot = coordinator.romy
 
-    romy_vacuum_entity = RomyVacuumEntity(coordinator, romy)
-
-    entities = [romy_vacuum_entity]
-    async_add_entities(entities, True)
+    async_add_entities([RomyVacuumEntity(coordinator, romy)], True)
 
 
 class RomyVacuumEntity(CoordinatorEntity[RomyVacuumCoordinator], StateVacuumEntity):

--- a/homeassistant/components/romy/vacuum.py
+++ b/homeassistant/components/romy/vacuum.py
@@ -5,7 +5,7 @@ https://home-assistant.io/components/vacuum.romy/.
 """
 
 
-from typing import Any, Optional
+from typing import Any
 
 from romy import RomyRobot
 
@@ -72,10 +72,10 @@ class RomyVacuumEntity(CoordinatorEntity[RomyVacuumCoordinator], StateVacuumEnti
     """Representation of a ROMY vacuum cleaner robot."""
 
     _attr_has_entity_name = True
+    _attr_name = None
     _attr_supported_features = SUPPORT_ROMY_ROBOT
     _attr_fan_speed_list = FAN_SPEEDS
     _attr_icon = ICON
-    _attr_name: Optional[str] = None
 
     def __init__(
         self,
@@ -100,7 +100,6 @@ class RomyVacuumEntity(CoordinatorEntity[RomyVacuumCoordinator], StateVacuumEnti
         self._attr_fan_speed = FAN_SPEEDS[self.romy.fan_speed]
         self._attr_battery_level = self.romy.battery_level
         self._attr_state = self.romy.status
-        self._attr_name = self.romy.name
 
         self._device_info[ATTR_NAME] = self.romy.name
         self._device_info[ATTR_SW_VERSION] = self.romy.firmware

--- a/homeassistant/components/romy/vacuum.py
+++ b/homeassistant/components/romy/vacuum.py
@@ -5,7 +5,6 @@ https://home-assistant.io/components/vacuum.romy/.
 """
 
 
-from collections.abc import Mapping
 from typing import Any
 
 from romy import RomyRobot
@@ -87,22 +86,18 @@ class RomyVacuumEntity(CoordinatorEntity[RomyVacuumCoordinator], StateVacuumEnti
         self.romy = romy
         self._device_info = device_info
         self._attr_unique_id = self.romy.unique_id
+        self._attr_supported_features = SUPPORT_ROMY_ROBOT
+        self._attr_fan_speed_list = FAN_SPEEDS
+        self._attr_icon = ICON
 
         self._is_on = False
         self._fan_speed = FAN_SPEEDS.index(FAN_SPEED_NONE)
         self._fan_speed_update = False
 
-    self._attr_supported_features = SUPPORT_ROMY_ROBOT
-
     @property
     def fan_speed(self) -> str:
         """Return the current fan speed of the vacuum cleaner."""
         return FAN_SPEEDS[self.romy.fan_speed]
-
-    @property
-    def fan_speed_list(self) -> list[str]:
-        """Get the list of available fan speed steps of the vacuum cleaner."""
-        return FAN_SPEEDS
 
     @property
     def battery_level(self) -> None | int:
@@ -123,11 +118,6 @@ class RomyVacuumEntity(CoordinatorEntity[RomyVacuumCoordinator], StateVacuumEnti
     def name(self) -> str:
         """Return the name of the device."""
         return self.romy.name
-
-    @property
-    def icon(self) -> str:
-        """Return the icon to use for device."""
-        return ICON
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the vacuum on."""

--- a/homeassistant/components/romy/vacuum.py
+++ b/homeassistant/components/romy/vacuum.py
@@ -11,7 +11,7 @@ from romy import RomyRobot
 
 from homeassistant.components.vacuum import StateVacuumEntity, VacuumEntityFeature
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -92,30 +92,39 @@ class RomyVacuumEntity(CoordinatorEntity[RomyVacuumCoordinator], StateVacuumEnti
         self._fan_speed = FAN_SPEEDS.index(FAN_SPEED_NONE)
         self._fan_speed_update = False
 
-    @property
-    def fan_speed(self) -> str:
-        """Return the current fan speed of the vacuum cleaner."""
-        return FAN_SPEEDS[self.romy.fan_speed]
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._attr_fan_speed = FAN_SPEEDS[self.romy.fan_speed]
+        self._attr_battery_level = self.romy.battery_level
+        self._attr_state = self.romy.status
+        self._attr_name = self.romy.name
+        self.async_write_ha_state()
 
-    @property
-    def battery_level(self) -> None | int:
-        """Return the battery level of the vacuum cleaner."""
-        return self.romy.battery_level
-
-    @property
-    def state(self) -> None | str:
-        """Return the state/status of the vacuum cleaner."""
-        return self.romy.status
+    #    @property
+    #    def fan_speed(self) -> str:
+    #        """Return the current fan speed of the vacuum cleaner."""
+    #        return FAN_SPEEDS[self.romy.fan_speed]
+    #
+    #    @property
+    #    def battery_level(self) -> None | int:
+    #        """Return the battery level of the vacuum cleaner."""
+    #        return self.romy.battery_level
+    #
+    #    @property
+    #    def state(self) -> None | str:
+    #        """Return the state/status of the vacuum cleaner."""
+    #        return self.romy.status
+    #
+    #    @property
+    #    def name(self) -> str:
+    #        """Return the name of the device."""
+    #        return self.romy.name
 
     @property
     def is_on(self) -> bool:
         """Return True if entity is on."""
         return self._is_on
-
-    @property
-    def name(self) -> str:
-        """Return the name of the device."""
-        return self.romy.name
 
     async def async_start(self, **kwargs: Any) -> None:
         """Turn the vacuum on."""

--- a/homeassistant/components/romy/vacuum.py
+++ b/homeassistant/components/romy/vacuum.py
@@ -90,7 +90,6 @@ class RomyVacuumEntity(CoordinatorEntity[RomyVacuumCoordinator], StateVacuumEnti
         self._attr_supported_features = SUPPORT_ROMY_ROBOT
         self._attr_fan_speed_list = FAN_SPEEDS
         self._attr_icon = ICON
-        self._is_on = False
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -100,11 +99,6 @@ class RomyVacuumEntity(CoordinatorEntity[RomyVacuumCoordinator], StateVacuumEnti
         self._attr_state = self.romy.status
         self._attr_name = self.romy.name
         self.async_write_ha_state()
-
-    @property
-    def is_on(self) -> bool:
-        """Return True if entity is on."""
-        return self._is_on
 
     async def async_start(self, **kwargs: Any) -> None:
         """Turn the vacuum on."""
@@ -125,7 +119,6 @@ class RomyVacuumEntity(CoordinatorEntity[RomyVacuumCoordinator], StateVacuumEnti
         """Pause the cleaning cycle (api call stop means stop robot where is is and not sending back to docking station)."""
         LOGGER.debug("async_pause")
         await self.romy.async_stop()
-
 
     async def async_set_fan_speed(self, fan_speed: str, **kwargs: Any) -> None:
         """Set fan speed."""

--- a/homeassistant/components/romy/vacuum.py
+++ b/homeassistant/components/romy/vacuum.py
@@ -41,7 +41,6 @@ SUPPORT_ROMY_ROBOT = (
     VacuumEntityFeature.BATTERY
     | VacuumEntityFeature.PAUSE
     | VacuumEntityFeature.RETURN_HOME
-    | VacuumEntityFeature.SEND_COMMAND
     | VacuumEntityFeature.STATE
     | VacuumEntityFeature.START
     | VacuumEntityFeature.STOP

--- a/homeassistant/components/romy/vacuum.py
+++ b/homeassistant/components/romy/vacuum.py
@@ -92,10 +92,7 @@ class RomyVacuumEntity(CoordinatorEntity[RomyVacuumCoordinator], StateVacuumEnti
         self._fan_speed = FAN_SPEEDS.index(FAN_SPEED_NONE)
         self._fan_speed_update = False
 
-    @property
-    def supported_features(self) -> VacuumEntityFeature:
-        """Flag vacuum cleaner robot features that are supported."""
-        return SUPPORT_ROMY_ROBOT
+    self._attr_supported_features = SUPPORT_ROMY_ROBOT
 
     @property
     def fan_speed(self) -> str:

--- a/homeassistant/components/romy/vacuum.py
+++ b/homeassistant/components/romy/vacuum.py
@@ -132,11 +132,6 @@ class RomyVacuumEntity(CoordinatorEntity[RomyVacuumCoordinator], StateVacuumEnti
         """Return the icon to use for device."""
         return ICON
 
-    @property
-    def device_state_attributes(self) -> Mapping[str, Any] | None:
-        """Return the state attributes of the device."""
-        return self._state_attrs
-
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the vacuum on."""
         LOGGER.debug("async_turn_on")

--- a/homeassistant/components/romy/vacuum.py
+++ b/homeassistant/components/romy/vacuum.py
@@ -11,7 +11,6 @@ from romy import RomyRobot
 
 from homeassistant.components.vacuum import StateVacuumEntity, VacuumEntityFeature
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_NAME, ATTR_SW_VERSION
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -97,9 +96,6 @@ class RomyVacuumEntity(CoordinatorEntity[RomyVacuumCoordinator], StateVacuumEnti
         self._attr_fan_speed = FAN_SPEEDS[self.romy.fan_speed]
         self._attr_battery_level = self.romy.battery_level
         self._attr_state = self.romy.status
-
-        self._device_info[ATTR_NAME] = self.romy.name
-        self._device_info[ATTR_SW_VERSION] = self.romy.firmware
 
         self.async_write_ha_state()
 

--- a/homeassistant/components/romy/vacuum.py
+++ b/homeassistant/components/romy/vacuum.py
@@ -75,7 +75,7 @@ async def async_setup_entry(
 class RomyVacuumEntity(CoordinatorEntity[RomyVacuumCoordinator], StateVacuumEntity):
     """Representation of a ROMY vacuum cleaner robot."""
 
-    _attr_translation_key = DOMAIN
+    _attr_name = None
     _attr_has_entity_name = True
 
     def __init__(

--- a/homeassistant/components/romy/vacuum.py
+++ b/homeassistant/components/romy/vacuum.py
@@ -132,13 +132,6 @@ class RomyVacuumEntity(CoordinatorEntity[RomyVacuumCoordinator], StateVacuumEnti
         if ret:
             self._is_on = False
 
-    async def async_start_pause(self, **kwargs: Any) -> None:
-        """Pause the cleaning task or resume it."""
-        LOGGER.debug("async_start_pause")
-        if self.is_on:
-            await self.async_pause()
-        else:
-            await self.async_start()
 
     async def async_set_fan_speed(self, fan_speed: str, **kwargs: Any) -> None:
         """Set fan speed."""

--- a/homeassistant/components/romy/vacuum.py
+++ b/homeassistant/components/romy/vacuum.py
@@ -60,9 +60,11 @@ async def async_setup_entry(
 
     device_info = {
         "manufacturer": "ROMY",
+        "name": "romy",
         "model": romy.model,
         "sw_version": romy.firmware,
         "identifiers": {"serial": romy.unique_id},
+        "name_by_user": romy.name,
     }
 
     romy_vacuum_entity = RomyVacuumEntity(coordinator, romy, device_info)
@@ -98,6 +100,7 @@ class RomyVacuumEntity(CoordinatorEntity[RomyVacuumCoordinator], StateVacuumEnti
         self._attr_battery_level = self.romy.battery_level
         self._attr_state = self.romy.status
         self._attr_name = self.romy.name
+        self._device_info["name_by_user"] = self.romy.name
         self.async_write_ha_state()
 
     async def async_start(self, **kwargs: Any) -> None:

--- a/homeassistant/components/romy/vacuum.py
+++ b/homeassistant/components/romy/vacuum.py
@@ -101,26 +101,6 @@ class RomyVacuumEntity(CoordinatorEntity[RomyVacuumCoordinator], StateVacuumEnti
         self._attr_name = self.romy.name
         self.async_write_ha_state()
 
-    #    @property
-    #    def fan_speed(self) -> str:
-    #        """Return the current fan speed of the vacuum cleaner."""
-    #        return FAN_SPEEDS[self.romy.fan_speed]
-    #
-    #    @property
-    #    def battery_level(self) -> None | int:
-    #        """Return the battery level of the vacuum cleaner."""
-    #        return self.romy.battery_level
-    #
-    #    @property
-    #    def state(self) -> None | str:
-    #        """Return the state/status of the vacuum cleaner."""
-    #        return self.romy.status
-    #
-    #    @property
-    #    def name(self) -> str:
-    #        """Return the name of the device."""
-    #        return self.romy.name
-
     @property
     def is_on(self) -> bool:
         """Return True if entity is on."""

--- a/homeassistant/components/romy/vacuum.py
+++ b/homeassistant/components/romy/vacuum.py
@@ -77,6 +77,9 @@ class RomyVacuumEntity(CoordinatorEntity[RomyVacuumCoordinator], StateVacuumEnti
 
     _attr_name = None
     _attr_has_entity_name = True
+    _attr_supported_features = SUPPORT_ROMY_ROBOT
+    _attr_fan_speed_list = FAN_SPEEDS
+    _attr_icon = ICON
 
     def __init__(
         self,

--- a/homeassistant/components/romy/vacuum.py
+++ b/homeassistant/components/romy/vacuum.py
@@ -82,6 +82,7 @@ class RomyVacuumEntity(CoordinatorEntity[RomyVacuumCoordinator], StateVacuumEnti
         self._device_info = DeviceInfo(
             identifiers={(DOMAIN, romy.unique_id)},
             manufacturer="ROMY",
+            name=romy.name,
             model=romy.model,
         )
 

--- a/homeassistant/components/romy/vacuum.py
+++ b/homeassistant/components/romy/vacuum.py
@@ -59,9 +59,7 @@ async def async_setup_entry(
     """Set up ROMY vacuum cleaner."""
 
     coordinator: RomyVacuumCoordinator = hass.data[DOMAIN][config_entry.entry_id]
-    romy: RomyRobot = coordinator.romy
-
-    async_add_entities([RomyVacuumEntity(coordinator, romy)], True)
+    async_add_entities([RomyVacuumEntity(coordinator, coordinator.romy)], True)
 
 
 class RomyVacuumEntity(CoordinatorEntity[RomyVacuumCoordinator], StateVacuumEntity):

--- a/homeassistant/components/romy/vacuum.py
+++ b/homeassistant/components/romy/vacuum.py
@@ -152,21 +152,18 @@ class RomyVacuumEntity(CoordinatorEntity[RomyVacuumCoordinator], StateVacuumEnti
         if ret:
             self._is_on = False
 
-    # turn off robot (-> sending back to docking station)
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the vacuum off (-> send it back to docking station)."""
         LOGGER.debug("async_turn_off")
         await self.async_return_to_base()
 
-    # stop robot (-> sending back to docking station)
     async def async_stop(self, **kwargs: Any) -> None:
         """Stop the vacuum cleaner. (-> send it back to docking station)."""
         LOGGER.debug("async_stop")
         await self.async_return_to_base()
 
-    # pause robot (api call stop means stop robot where is is and not sending back to docking station)
     async def async_pause(self, **kwargs: Any) -> None:
-        """Pause the cleaning cycle."""
+        """Pause the cleaning cycle (api call stop means stop robot where is is and not sending back to docking station)."""
         LOGGER.debug("async_pause")
         ret = await self.romy.async_stop()
         if ret:

--- a/homeassistant/components/romy/vacuum.py
+++ b/homeassistant/components/romy/vacuum.py
@@ -82,9 +82,7 @@ class RomyVacuumEntity(CoordinatorEntity[RomyVacuumCoordinator], StateVacuumEnti
         self._device_info = DeviceInfo(
             identifiers={(DOMAIN, romy.unique_id)},
             manufacturer="ROMY",
-            name=romy.name,
             model=romy.model,
-            sw_version=romy.firmware,
         )
 
     @callback

--- a/homeassistant/components/romy/vacuum.py
+++ b/homeassistant/components/romy/vacuum.py
@@ -109,9 +109,9 @@ class RomyVacuumEntity(CoordinatorEntity[RomyVacuumCoordinator], StateVacuumEnti
         await self.romy.async_clean_start_or_continue()
 
     async def async_stop(self, **kwargs: Any) -> None:
-        """Stop the vacuum cleaner. (-> send it back to docking station)."""
+        """Stop the vacuum cleaner."""
         LOGGER.debug("async_stop")
-        await self.async_return_to_base()
+        await self.romy.async_stop()
 
     async def async_return_to_base(self, **kwargs: Any) -> None:
         """Return vacuum back to base."""

--- a/homeassistant/components/romy/vacuum.py
+++ b/homeassistant/components/romy/vacuum.py
@@ -184,29 +184,3 @@ class RomyVacuumEntity(CoordinatorEntity[RomyVacuumCoordinator], StateVacuumEnti
         """Set fan speed."""
         LOGGER.debug("async_set_fan_speed to %s", fan_speed)
         await self.romy.async_set_fan_speed(FAN_SPEEDS.index(fan_speed))
-
-
-#    async def async_update(self) -> None:
-#        """Fetch state from the device."""
-#        LOGGER.error("async_update")
-
-# ret, response = await self.romy_async_query("get/status")
-# if ret:
-#    status = json.loads(response)
-#    self._status = status["mode"]
-#    self._battery_level = status["battery_level"]
-# else:
-#    LOGGER.error(
-#        "ROMY function async_update -> async_query response: %s", response
-#    )
-
-# ret, response = await self.romy_async_query("get/cleaning_parameter_set")
-# if ret:
-#    status = json.loads(response)
-#    # dont update if we set fan speed currently:
-#    if not self._fan_speed_update:
-#        self._fan_speed = status["cleaning_parameter_set"]
-# else:
-#    LOGGER.error(
-#        "FOMY function async_update -> async_query response: %s", response
-#   )

--- a/homeassistant/components/romy/vacuum.py
+++ b/homeassistant/components/romy/vacuum.py
@@ -11,6 +11,7 @@ from romy import RomyRobot
 
 from homeassistant.components.vacuum import StateVacuumEntity, VacuumEntityFeature
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ATTR_NAME, ATTR_SW_VERSION
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -100,8 +101,8 @@ class RomyVacuumEntity(CoordinatorEntity[RomyVacuumCoordinator], StateVacuumEnti
         self._attr_state = self.romy.status
         self._attr_name = self.romy.name
 
-        self._device_info["name"] = self.romy.name
-        self._device_info["sw_version"] = self.romy.firmware
+        self._device_info[ATTR_NAME] = self.romy.name
+        self._device_info[ATTR_SW_VERSION] = self.romy.firmware
 
         self.async_write_ha_state()
 

--- a/homeassistant/components/romy/vacuum.py
+++ b/homeassistant/components/romy/vacuum.py
@@ -128,9 +128,7 @@ class RomyVacuumEntity(CoordinatorEntity[RomyVacuumCoordinator], StateVacuumEnti
     async def async_pause(self, **kwargs: Any) -> None:
         """Pause the cleaning cycle (api call stop means stop robot where is is and not sending back to docking station)."""
         LOGGER.debug("async_pause")
-        ret = await self.romy.async_stop()
-        if ret:
-            self._is_on = False
+        await self.romy.async_stop()
 
 
     async def async_set_fan_speed(self, fan_speed: str, **kwargs: Any) -> None:

--- a/homeassistant/components/romy/vacuum.py
+++ b/homeassistant/components/romy/vacuum.py
@@ -109,9 +109,7 @@ class RomyVacuumEntity(CoordinatorEntity[RomyVacuumCoordinator], StateVacuumEnti
     async def async_start(self, **kwargs: Any) -> None:
         """Turn the vacuum on."""
         LOGGER.debug("async_start")
-        ret = await self.romy.async_clean_start_or_continue()
-        if ret:
-            self._is_on = True
+        await self.romy.async_clean_start_or_continue()
 
     async def async_stop(self, **kwargs: Any) -> None:
         """Stop the vacuum cleaner. (-> send it back to docking station)."""

--- a/homeassistant/components/romy/vacuum.py
+++ b/homeassistant/components/romy/vacuum.py
@@ -42,7 +42,6 @@ FAN_SPEEDS: list[str] = [
 # Commonly supported features
 SUPPORT_ROMY_ROBOT = (
     VacuumEntityFeature.BATTERY
-    | VacuumEntityFeature.PAUSE
     | VacuumEntityFeature.RETURN_HOME
     | VacuumEntityFeature.STATE
     | VacuumEntityFeature.START
@@ -111,11 +110,6 @@ class RomyVacuumEntity(CoordinatorEntity[RomyVacuumCoordinator], StateVacuumEnti
         """Return vacuum back to base."""
         LOGGER.debug("async_return_to_base")
         await self.romy.async_return_to_base()
-
-    async def async_pause(self, **kwargs: Any) -> None:
-        """Pause the cleaning cycle (api call stop means stop robot where is is and not sending back to docking station)."""
-        LOGGER.debug("async_pause")
-        await self.romy.async_stop()
 
     async def async_set_fan_speed(self, fan_speed: str, **kwargs: Any) -> None:
         """Set fan speed."""

--- a/homeassistant/components/romy/vacuum.py
+++ b/homeassistant/components/romy/vacuum.py
@@ -1,0 +1,212 @@
+"""Support for Wi-Fi enabled ROMY vacuum cleaner robots.
+
+For more details about this platform, please refer to the documentation
+https://home-assistant.io/components/vacuum.romy/.
+"""
+
+
+from collections.abc import Mapping
+from typing import Any
+
+from romy import RomyRobot
+
+from homeassistant.components.vacuum import StateVacuumEntity, VacuumEntityFeature
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN, ICON, LOGGER
+from .coordinator import RomyVacuumCoordinator
+
+FAN_SPEED_NONE = "Default"
+FAN_SPEED_NORMAL = "Normal"
+FAN_SPEED_SILENT = "Silent"
+FAN_SPEED_INTENSIVE = "Intensive"
+FAN_SPEED_SUPER_SILENT = "Super_Silent"
+FAN_SPEED_HIGH = "High"
+FAN_SPEED_AUTO = "Auto"
+
+FAN_SPEEDS: list[str] = [
+    FAN_SPEED_NONE,
+    FAN_SPEED_NORMAL,
+    FAN_SPEED_SILENT,
+    FAN_SPEED_INTENSIVE,
+    FAN_SPEED_SUPER_SILENT,
+    FAN_SPEED_HIGH,
+    FAN_SPEED_AUTO,
+]
+
+# Commonly supported features
+SUPPORT_ROMY_ROBOT = (
+    VacuumEntityFeature.BATTERY
+    | VacuumEntityFeature.PAUSE
+    | VacuumEntityFeature.RETURN_HOME
+    | VacuumEntityFeature.SEND_COMMAND
+    | VacuumEntityFeature.STATUS
+    | VacuumEntityFeature.STOP
+    | VacuumEntityFeature.TURN_OFF
+    | VacuumEntityFeature.TURN_ON
+    | VacuumEntityFeature.FAN_SPEED
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up ROMY vacuum cleaner."""
+
+    coordinator: RomyVacuumCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    romy: RomyRobot = coordinator.romy
+
+    device_info = {
+        "manufacturer": "ROMY",
+        "model": romy.model,
+        "sw_version": romy.firmware,
+        "identifiers": {"serial": romy.unique_id},
+    }
+
+    romy_vacuum_entity = RomyVacuumEntity(coordinator, romy, device_info)
+    entities = [romy_vacuum_entity]
+    async_add_entities(entities, True)
+
+
+class RomyVacuumEntity(CoordinatorEntity[RomyVacuumCoordinator], StateVacuumEntity):
+    """Representation of a ROMY vacuum cleaner robot."""
+
+    def __init__(
+        self,
+        coordinator: RomyVacuumCoordinator,
+        romy: RomyRobot,
+        device_info: dict[str, Any],
+    ) -> None:
+        """Initialize the ROMY Robot."""
+        super().__init__(coordinator)
+        self.romy = romy
+        self._device_info = device_info
+        self._attr_unique_id = self.romy.unique_id
+        self._state_attrs: dict[str, Any] = {}
+
+        self._is_on = False
+        self._fan_speed = FAN_SPEEDS.index(FAN_SPEED_NONE)
+        self._fan_speed_update = False
+
+    @property
+    def supported_features(self) -> VacuumEntityFeature:
+        """Flag vacuum cleaner robot features that are supported."""
+        return SUPPORT_ROMY_ROBOT
+
+    @property
+    def fan_speed(self) -> str:
+        """Return the current fan speed of the vacuum cleaner."""
+        return FAN_SPEEDS[self.romy.fan_speed]
+
+    @property
+    def fan_speed_list(self) -> list[str]:
+        """Get the list of available fan speed steps of the vacuum cleaner."""
+        return FAN_SPEEDS
+
+    @property
+    def battery_level(self) -> None | int:
+        """Return the battery level of the vacuum cleaner."""
+        return self.romy.battery_level
+
+    @property
+    def state(self) -> None | str:
+        """Return the state/status of the vacuum cleaner."""
+        return self.romy.status
+
+    @property
+    def is_on(self) -> bool:
+        """Return True if entity is on."""
+        return self._is_on
+
+    @property
+    def name(self) -> str:
+        """Return the name of the device."""
+        return self.romy.name
+
+    @property
+    def icon(self) -> str:
+        """Return the icon to use for device."""
+        return ICON
+
+    @property
+    def device_state_attributes(self) -> Mapping[str, Any] | None:
+        """Return the state attributes of the device."""
+        return self._state_attrs
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the vacuum on."""
+        LOGGER.debug("async_turn_on")
+        ret = await self.romy.async_clean_start_or_continue()
+        if ret:
+            self._is_on = True
+
+    async def async_return_to_base(self, **kwargs: Any) -> None:
+        """Return vacuum back to base."""
+        LOGGER.debug("async_return_to_base")
+        ret = await self.romy.async_return_to_base()
+        if ret:
+            self._is_on = False
+
+    # turn off robot (-> sending back to docking station)
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the vacuum off (-> send it back to docking station)."""
+        LOGGER.debug("async_turn_off")
+        await self.async_return_to_base()
+
+    # stop robot (-> sending back to docking station)
+    async def async_stop(self, **kwargs: Any) -> None:
+        """Stop the vacuum cleaner. (-> send it back to docking station)."""
+        LOGGER.debug("async_stop")
+        await self.async_return_to_base()
+
+    # pause robot (api call stop means stop robot where is is and not sending back to docking station)
+    async def async_pause(self, **kwargs: Any) -> None:
+        """Pause the cleaning cycle."""
+        LOGGER.debug("async_pause")
+        ret = await self.romy.async_stop()
+        if ret:
+            self._is_on = False
+
+    async def async_start_pause(self, **kwargs: Any) -> None:
+        """Pause the cleaning task or resume it."""
+        LOGGER.debug("async_start_pause")
+        if self.is_on:
+            await self.async_pause()
+        else:
+            await self.async_turn_on()
+
+    async def async_set_fan_speed(self, fan_speed: str, **kwargs: Any) -> None:
+        """Set fan speed."""
+        LOGGER.debug("async_set_fan_speed to %s", fan_speed)
+        await self.romy.async_set_fan_speed(FAN_SPEEDS.index(fan_speed))
+
+
+#    async def async_update(self) -> None:
+#        """Fetch state from the device."""
+#        LOGGER.error("async_update")
+
+# ret, response = await self.romy_async_query("get/status")
+# if ret:
+#    status = json.loads(response)
+#    self._status = status["mode"]
+#    self._battery_level = status["battery_level"]
+# else:
+#    LOGGER.error(
+#        "ROMY function async_update -> async_query response: %s", response
+#    )
+
+# ret, response = await self.romy_async_query("get/cleaning_parameter_set")
+# if ret:
+#    status = json.loads(response)
+#    # dont update if we set fan speed currently:
+#    if not self._fan_speed_update:
+#        self._fan_speed = status["cleaning_parameter_set"]
+# else:
+#    LOGGER.error(
+#        "FOMY function async_update -> async_query response: %s", response
+#   )

--- a/homeassistant/components/romy/vacuum.py
+++ b/homeassistant/components/romy/vacuum.py
@@ -5,7 +5,7 @@ https://home-assistant.io/components/vacuum.romy/.
 """
 
 
-from typing import Any
+from typing import Any, Optional
 
 from romy import RomyRobot
 
@@ -75,7 +75,7 @@ class RomyVacuumEntity(CoordinatorEntity[RomyVacuumCoordinator], StateVacuumEnti
     _attr_supported_features = SUPPORT_ROMY_ROBOT
     _attr_fan_speed_list = FAN_SPEEDS
     _attr_icon = ICON
-    _attr_name = None
+    _attr_name: Optional[str] = None
 
     def __init__(
         self,

--- a/homeassistant/components/romy/vacuum.py
+++ b/homeassistant/components/romy/vacuum.py
@@ -18,13 +18,13 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import DOMAIN, ICON, LOGGER
 from .coordinator import RomyVacuumCoordinator
 
-FAN_SPEED_NONE = "Default"
-FAN_SPEED_NORMAL = "Normal"
-FAN_SPEED_SILENT = "Silent"
-FAN_SPEED_INTENSIVE = "Intensive"
-FAN_SPEED_SUPER_SILENT = "Super_Silent"
-FAN_SPEED_HIGH = "High"
-FAN_SPEED_AUTO = "Auto"
+FAN_SPEED_NONE = "default"
+FAN_SPEED_NORMAL = "normal"
+FAN_SPEED_SILENT = "silent"
+FAN_SPEED_INTENSIVE = "intensive"
+FAN_SPEED_SUPER_SILENT = "super_silent"
+FAN_SPEED_HIGH = "high"
+FAN_SPEED_AUTO = "auto"
 
 FAN_SPEEDS: list[str] = [
     FAN_SPEED_NONE,
@@ -73,6 +73,9 @@ async def async_setup_entry(
 class RomyVacuumEntity(CoordinatorEntity[RomyVacuumCoordinator], StateVacuumEntity):
     """Representation of a ROMY vacuum cleaner robot."""
 
+    _attr_translation_key = DOMAIN
+    _attr_has_entity_name = True
+
     def __init__(
         self,
         coordinator: RomyVacuumCoordinator,
@@ -87,10 +90,7 @@ class RomyVacuumEntity(CoordinatorEntity[RomyVacuumCoordinator], StateVacuumEnti
         self._attr_supported_features = SUPPORT_ROMY_ROBOT
         self._attr_fan_speed_list = FAN_SPEEDS
         self._attr_icon = ICON
-
         self._is_on = False
-        self._fan_speed = FAN_SPEEDS.index(FAN_SPEED_NONE)
-        self._fan_speed_update = False
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -428,6 +428,7 @@ FLOWS = {
         "rituals_perfume_genie",
         "roborock",
         "roku",
+        "romy",
         "roomba",
         "roon",
         "rpi_power",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -4963,6 +4963,12 @@
       "config_flow": true,
       "iot_class": "local_polling"
     },
+    "romy": {
+      "name": "ROMY Vacuum Cleaner",
+      "integration_type": "hub",
+      "config_flow": true,
+      "iot_class": "local_polling"
+    },
     "roomba": {
       "name": "iRobot Roomba and Braava",
       "integration_type": "hub",

--- a/homeassistant/generated/zeroconf.py
+++ b/homeassistant/generated/zeroconf.py
@@ -248,6 +248,11 @@ ZEROCONF = {
             "domain": "volumio",
         },
     ],
+    "_aicu-http._tcp.local.": [
+        {
+            "domain": "romy",
+        },
+    ],
     "_airplay._tcp.local.": [
         {
             "domain": "apple_tv",

--- a/mypy.ini
+++ b/mypy.ini
@@ -3371,6 +3371,16 @@ disallow_untyped_defs = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.romy.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.rpi_power.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2437,7 +2437,7 @@ rocketchat-API==0.6.1
 rokuecp==0.18.1
 
 # homeassistant.components.romy
-romy==0.0.2
+romy==0.0.5
 
 # homeassistant.components.roomba
 roombapy==1.6.10

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2436,6 +2436,9 @@ rocketchat-API==0.6.1
 # homeassistant.components.roku
 rokuecp==0.18.1
 
+# homeassistant.components.romy
+romy==0.0.2
+
 # homeassistant.components.roomba
 roombapy==1.6.10
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2437,7 +2437,7 @@ rocketchat-API==0.6.1
 rokuecp==0.18.1
 
 # homeassistant.components.romy
-romy==0.0.5
+romy==0.0.7
 
 # homeassistant.components.roomba
 roombapy==1.6.10

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1856,7 +1856,7 @@ ring-doorbell[listen]==0.8.5
 rokuecp==0.18.1
 
 # homeassistant.components.romy
-romy==0.0.2
+romy==0.0.5
 
 # homeassistant.components.roomba
 roombapy==1.6.10

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1855,6 +1855,9 @@ ring-doorbell[listen]==0.8.5
 # homeassistant.components.roku
 rokuecp==0.18.1
 
+# homeassistant.components.romy
+romy==0.0.2
+
 # homeassistant.components.roomba
 roombapy==1.6.10
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1856,7 +1856,7 @@ ring-doorbell[listen]==0.8.5
 rokuecp==0.18.1
 
 # homeassistant.components.romy
-romy==0.0.5
+romy==0.0.7
 
 # homeassistant.components.roomba
 roombapy==1.6.10

--- a/tests/components/romy/__init__.py
+++ b/tests/components/romy/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the ROMY integration."""

--- a/tests/components/romy/test_config_flow.py
+++ b/tests/components/romy/test_config_flow.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components import zeroconf
 from homeassistant.components.romy.const import DOMAIN
-from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PASSWORD
+from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PASSWORD, CONF_UUID
 from homeassistant.core import HomeAssistant
 
 
@@ -247,5 +247,19 @@ async def test_zero_conf_unlocked_interface_robot(hass: HomeAssistant) -> None:
             context={"source": config_entries.SOURCE_ZEROCONF},
         )
 
-    assert result["step_id"] == "user"
+    assert result["step_id"] == "zeroconf_confirm"
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_HOST: "1.2.3.4"},
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+
+    assert result["data"]
+    assert result["data"][CONF_HOST] == "1.2.3.4"
+    assert result["data"][CONF_UUID] == "aicu-aicgsbksisfapcjqmqjq"
+
+    assert result["result"]
+    assert result["result"].unique_id == "aicu-aicgsbksisfapcjqmqjq"

--- a/tests/components/romy/test_config_flow.py
+++ b/tests/components/romy/test_config_flow.py
@@ -210,7 +210,7 @@ async def test_show_user_with_locked_interface_robot_with_connection_loss(
         )
 
         assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-        assert result["step_id"] == "user"
+        assert result["step_id"] == "password"
 
 
 # zero conf tests

--- a/tests/components/romy/test_config_flow.py
+++ b/tests/components/romy/test_config_flow.py
@@ -140,11 +140,11 @@ async def test_show_user_form_with_config_which_contains_wrong_password(
 ###################
 
 DISCOVERY_INFO = zeroconf.ZeroconfServiceInfo(
-    host="1.2.3.4",
-    hostname="aicu-aicgsbksisfapcjqmqjq.local",
+    ip_address=ip_address("1.2.3.4"),
+    ip_addresses=[ip_address("1.2.3.4")],
     port=8080,
+    hostname="aicu-aicgsbksisfapcjqmqjq.local",
     type="mock_type",
-    addresses="addresses",
     name="myROMY",
     properties={zeroconf.ATTR_PROPERTIES_ID: "aicu-aicgsbksisfapcjqmqjq"},
 )

--- a/tests/components/romy/test_config_flow.py
+++ b/tests/components/romy/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the ROMY config flow."""
+from ipaddress import ip_address
 from unittest.mock import MagicMock, PropertyMock, patch
 
 from homeassistant import config_entries, data_entry_flow

--- a/tests/components/romy/test_config_flow.py
+++ b/tests/components/romy/test_config_flow.py
@@ -1,6 +1,8 @@
 """Test the ROMY config flow."""
 from ipaddress import ip_address
-from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+from unittest.mock import Mock, PropertyMock, patch
+
+from romy import RomyRobot
 
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components import zeroconf
@@ -18,7 +20,7 @@ def _create_mocked_romy(
     model="005:000:000:000:005",
     port=8080,
 ):
-    mocked_romy = AsyncMock(MagicMock)
+    mocked_romy = Mock(spec_set=RomyRobot)
     type(mocked_romy).is_initialized = PropertyMock(return_value=is_initialized)
     type(mocked_romy).is_unlocked = PropertyMock(return_value=is_unlocked)
     type(mocked_romy).name = PropertyMock(return_value=name)
@@ -26,17 +28,6 @@ def _create_mocked_romy(
     type(mocked_romy).unique_id = PropertyMock(return_value=unique_id)
     type(mocked_romy).port = PropertyMock(return_value=port)
     type(mocked_romy).model = PropertyMock(return_value=model)
-
-    # Mock async methods
-    async def mock_set_name(new_name):
-        mocked_romy.name = PropertyMock(return_value=new_name)
-        return True, '{"success": true}'
-
-    async def async_update():
-        return
-
-    type(mocked_romy).set_name = AsyncMock(side_effect=mock_set_name)
-    type(mocked_romy).async_update = AsyncMock(side_effect=async_update)
 
     return mocked_romy
 

--- a/tests/components/romy/test_config_flow.py
+++ b/tests/components/romy/test_config_flow.py
@@ -187,7 +187,7 @@ async def test_show_user_with_locked_interface_robot_with_connection_loss(
         )
 
     assert result["step_id"] == "password"
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     mocked_disconnected_romy = _create_mocked_romy(
         is_initialized=False,

--- a/tests/components/romy/test_config_flow.py
+++ b/tests/components/romy/test_config_flow.py
@@ -163,7 +163,7 @@ async def test_show_user_with_locked_interface_robot_with_correct_password(
             result["flow_id"], user_input=INPUT_CONFIG_PASS
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
 
 async def test_show_user_with_locked_interface_robot_with_connection_loss(

--- a/tests/components/romy/test_config_flow.py
+++ b/tests/components/romy/test_config_flow.py
@@ -206,8 +206,6 @@ async def test_show_user_with_locked_interface_robot_with_connection_loss(
         assert result["step_id"] == "password"
 
 
-# zero conf tests
-###################
 
 DISCOVERY_INFO = zeroconf.ZeroconfServiceInfo(
     ip_address=ip_address("1.2.3.4"),

--- a/tests/components/romy/test_config_flow.py
+++ b/tests/components/romy/test_config_flow.py
@@ -124,7 +124,7 @@ async def test_show_user_with_locked_interface_robot_with_wrong_password(
         )
 
         assert result["step_id"] == "password"
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
 
 
 async def test_show_user_with_locked_interface_robot_with_correct_password(

--- a/tests/components/romy/test_config_flow.py
+++ b/tests/components/romy/test_config_flow.py
@@ -39,7 +39,7 @@ INPUT_CONFIG_HOST = {
 }
 
 
-async def test_show_user_form1(hass: HomeAssistant) -> None:
+async def test_show_user_form_robot_is_offline_and_locked(hass: HomeAssistant) -> None:
     """Test that the user set up form with config."""
 
     # Robot not reachable
@@ -82,7 +82,7 @@ async def test_show_user_form1(hass: HomeAssistant) -> None:
         assert result3["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
 
-async def test_show_user_form2(hass: HomeAssistant) -> None:
+async def test_show_user_form_robot_unlock_with_password(hass: HomeAssistant) -> None:
     """Test that the user set up form with config."""
 
     with patch(
@@ -131,7 +131,7 @@ async def test_show_user_form2(hass: HomeAssistant) -> None:
         assert result4["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
 
-async def test_show_user_form3(hass: HomeAssistant) -> None:
+async def test_show_user_form_robot_reachable_again(hass: HomeAssistant) -> None:
     """Test that the user set up form with config."""
 
     # Robot not reachable

--- a/tests/components/romy/test_config_flow.py
+++ b/tests/components/romy/test_config_flow.py
@@ -89,7 +89,7 @@ async def test_show_user_form_with_wrong_host(
         )
 
     assert result["errors"].get("host") == "cannot_connect"
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
 
 async def test_show_user_with_locked_interface_robot_with_wrong_password(

--- a/tests/components/romy/test_config_flow.py
+++ b/tests/components/romy/test_config_flow.py
@@ -32,11 +32,6 @@ def _create_mocked_romy(
 
     type(mocked_romy).set_name = AsyncMock(side_effect=mock_set_name)
 
-    async def mock_async_update():
-        return
-
-    type(mocked_romy).async_update = AsyncMock(side_effect=mock_async_update)
-
     return mocked_romy
 
 

--- a/tests/components/romy/test_config_flow.py
+++ b/tests/components/romy/test_config_flow.py
@@ -1,6 +1,6 @@
 """Test the ROMY config flow."""
 from ipaddress import ip_address
-from unittest.mock import MagicMock, PropertyMock, patch
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components import zeroconf
@@ -9,11 +9,36 @@ from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 
 
-def _create_mocked_romy(is_initialized, is_unlocked, name="Nadine"):
-    mocked_romy = MagicMock()
+def _create_mocked_romy(
+    is_initialized,
+    is_unlocked,
+    name="Nadine",
+    unique_id="aicu-aicgsbksisfapcjqmqjq",
+    port=8080,
+    model="005:000:000:000:005",
+    firmware="CHRON-0.0.1-new-wifi-release-3.15.3175",
+):
+    mocked_romy = AsyncMock(MagicMock)
     type(mocked_romy).is_initialized = PropertyMock(return_value=is_initialized)
     type(mocked_romy).is_unlocked = PropertyMock(return_value=is_unlocked)
     type(mocked_romy).name = PropertyMock(return_value=name)
+    type(mocked_romy).unique_id = PropertyMock(return_value=unique_id)
+    type(mocked_romy).port = PropertyMock(return_value=port)
+    type(mocked_romy).model = PropertyMock(return_value=model)
+    type(mocked_romy).firmware = PropertyMock(return_value=firmware)
+
+    # Mock async methods
+    async def mock_set_name(new_name):
+        mocked_romy.name = PropertyMock(return_value=new_name)
+        return True, '{"success": true}'
+
+    type(mocked_romy).set_name = AsyncMock(side_effect=mock_set_name)
+
+    async def mock_async_update():
+        return
+
+    type(mocked_romy).async_update = AsyncMock(side_effect=mock_async_update)
+
     return mocked_romy
 
 
@@ -117,6 +142,7 @@ async def test_show_user_form_with_config_which_contains_password(
 
     assert "errors" not in result
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["context"]["unique_id"] == "aicu-aicgsbksisfapcjqmqjq"
 
 
 async def test_show_user_form_with_config_which_contains_wrong_host(
@@ -177,7 +203,7 @@ DISCOVERY_INFO = zeroconf.ZeroconfServiceInfo(
     hostname="aicu-aicgsbksisfapcjqmqjq.local",
     type="mock_type",
     name="myROMY",
-    properties={zeroconf.ATTR_PROPERTIES_ID: "aicu-aicgsbksisfapcjqmqjq"},
+    properties={zeroconf.ATTR_PROPERTIES_ID: "aicu-aicgsbksisfapcjqmqjqZERO"},
 )
 
 

--- a/tests/components/romy/test_config_flow.py
+++ b/tests/components/romy/test_config_flow.py
@@ -65,7 +65,7 @@ async def test_show_user_form(hass: HomeAssistant) -> None:
         )
 
     assert "errors" not in result
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
 
 async def test_show_user_form_with_wrong_host(

--- a/tests/components/romy/test_config_flow.py
+++ b/tests/components/romy/test_config_flow.py
@@ -1,0 +1,214 @@
+"""Test the ROMY config flow."""
+from unittest.mock import MagicMock, PropertyMock, patch
+
+from homeassistant import config_entries, data_entry_flow
+from homeassistant.components import zeroconf
+from homeassistant.components.romy.const import DOMAIN
+from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PASSWORD
+from homeassistant.core import HomeAssistant
+
+
+def _create_mocked_romy(is_initialized, is_unlocked):
+    mocked_romy = MagicMock()
+    type(mocked_romy).is_initialized = PropertyMock(return_value=is_initialized)
+    type(mocked_romy).is_unlocked = PropertyMock(return_value=is_unlocked)
+    return mocked_romy
+
+
+async def test_show_user_form(hass: HomeAssistant) -> None:
+    """Test that the user set up form is served."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_USER},
+    )
+
+    assert result["errors"] is not None
+    assert result["step_id"] == "user"
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+
+
+CONFIG = {CONF_HOST: "1.2.3.4", CONF_NAME: "myROMY", CONF_PASSWORD: "12345678"}
+
+INPUT_CONFIG = {
+    CONF_HOST: CONFIG[CONF_HOST],
+    CONF_NAME: CONFIG[CONF_NAME],
+}
+
+
+async def test_show_user_form_with_config(hass: HomeAssistant) -> None:
+    """Test that the user set up form with config."""
+
+    mocked_romy = _create_mocked_romy(
+        is_initialized=True,
+        is_unlocked=True,
+    )
+
+    with patch(
+        "homeassistant.components.romy.config_flow.romy.create_romy",
+        return_value=mocked_romy,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+            data=INPUT_CONFIG,
+        )
+
+    assert "errors" not in result
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+
+
+INPUT_CONFIG_HOST_MISSING = {
+    CONF_NAME: CONFIG[CONF_NAME],
+}
+
+
+async def test_show_user_form_with_config_with_missing_host(
+    hass: HomeAssistant,
+) -> None:
+    """Test that the user set up form with config where host is missing."""
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_USER},
+        data=INPUT_CONFIG_HOST_MISSING,
+    )
+
+    assert "errors" in result
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+
+
+INPUT_CONFIG_WITH_PASS = {
+    CONF_HOST: CONFIG[CONF_HOST],
+    CONF_NAME: CONFIG[CONF_NAME],
+    CONF_PASSWORD: CONFIG[CONF_PASSWORD],
+}
+
+
+async def test_show_user_form_with_config_which_contains_password(
+    hass: HomeAssistant,
+) -> None:
+    """Test that the user set up form with config which contains password."""
+
+    mocked_romy = _create_mocked_romy(
+        is_initialized=True,
+        is_unlocked=True,
+    )
+
+    with patch(
+        "homeassistant.components.romy.config_flow.romy.create_romy",
+        return_value=mocked_romy,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+            data=INPUT_CONFIG_WITH_PASS,
+        )
+
+    assert "errors" not in result
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+
+
+async def test_show_user_form_with_config_which_contains_wrong_host(
+    hass: HomeAssistant,
+) -> None:
+    """Test that the user set up form with config which contains password."""
+
+    mocked_romy = _create_mocked_romy(
+        is_initialized=False,
+        is_unlocked=False,
+    )
+
+    with patch(
+        "homeassistant.components.romy.config_flow.romy.create_romy",
+        return_value=mocked_romy,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+            data=INPUT_CONFIG_WITH_PASS,
+        )
+
+    assert "errors" in result
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+
+
+async def test_show_user_form_with_config_which_contains_wrong_password(
+    hass: HomeAssistant,
+) -> None:
+    """Test that the user set up form with config which contains password."""
+
+    mocked_romy = _create_mocked_romy(
+        is_initialized=True,
+        is_unlocked=False,
+    )
+
+    with patch(
+        "homeassistant.components.romy.config_flow.romy.create_romy",
+        return_value=mocked_romy,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+            data=INPUT_CONFIG_WITH_PASS,
+        )
+
+    assert "errors" in result
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+
+
+# zero conf tests
+###################
+
+DISCOVERY_INFO = zeroconf.ZeroconfServiceInfo(
+    host="1.2.3.4",
+    hostname="aicu-aicgsbksisfapcjqmqjq.local",
+    port=8080,
+    type="mock_type",
+    addresses="addresses",
+    name="myROMY",
+    properties={zeroconf.ATTR_PROPERTIES_ID: "aicu-aicgsbksisfapcjqmqjq"},
+)
+
+
+async def test_zero_conf_locked_interface_robot(hass: HomeAssistant) -> None:
+    """Test zerconf which discovered locked robot."""
+
+    mocked_romy = _create_mocked_romy(
+        is_initialized=True,
+        is_unlocked=False,
+    )
+
+    with patch(
+        "homeassistant.components.romy.config_flow.romy.create_romy",
+        return_value=mocked_romy,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            data=DISCOVERY_INFO,
+            context={"source": config_entries.SOURCE_ZEROCONF},
+        )
+
+    assert result["step_id"] == "user"
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+
+
+async def test_zero_conf_unlocked_interface_robot(hass: HomeAssistant) -> None:
+    """Test zerconf which discovered already unlocked robot."""
+
+    mocked_romy = _create_mocked_romy(
+        is_initialized=True,
+        is_unlocked=True,
+    )
+
+    with patch(
+        "homeassistant.components.romy.config_flow.romy.create_romy",
+        return_value=mocked_romy,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            data=DISCOVERY_INFO,
+            context={"source": config_entries.SOURCE_ZEROCONF},
+        )
+
+    assert result["step_id"] == "user"
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM

--- a/tests/components/romy/test_config_flow.py
+++ b/tests/components/romy/test_config_flow.py
@@ -288,7 +288,7 @@ async def test_zero_conf_unlocked_interface_robot(hass: HomeAssistant) -> None:
         user_input={CONF_HOST: "1.2.3.4"},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
 
     assert result["data"]
     assert result["data"][CONF_HOST] == "1.2.3.4"

--- a/tests/components/romy/test_config_flow.py
+++ b/tests/components/romy/test_config_flow.py
@@ -57,26 +57,6 @@ async def test_show_user_form_with_config(hass: HomeAssistant) -> None:
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
 
 
-INPUT_CONFIG_HOST_MISSING = {
-    CONF_NAME: CONFIG[CONF_NAME],
-}
-
-
-async def test_show_user_form_with_config_with_missing_host(
-    hass: HomeAssistant,
-) -> None:
-    """Test that the user set up form with config where host is missing."""
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": config_entries.SOURCE_USER},
-        data=INPUT_CONFIG_HOST_MISSING,
-    )
-
-    assert "errors" in result
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-
-
 INPUT_CONFIG_WITH_PASS = {
     CONF_HOST: CONFIG[CONF_HOST],
     CONF_NAME: CONFIG[CONF_NAME],
@@ -128,7 +108,7 @@ async def test_show_user_form_with_config_which_contains_wrong_host(
             data=INPUT_CONFIG_WITH_PASS,
         )
 
-    assert "errors" in result
+    assert result["errors"].get("host") == "wrong host"
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
 
 
@@ -152,7 +132,7 @@ async def test_show_user_form_with_config_which_contains_wrong_password(
             data=INPUT_CONFIG_WITH_PASS,
         )
 
-    assert "errors" in result
+    assert result["errors"].get("password") == "wrong password"
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
 
 

--- a/tests/components/romy/test_config_flow.py
+++ b/tests/components/romy/test_config_flow.py
@@ -281,7 +281,7 @@ async def test_zero_conf_unlocked_interface_robot(hass: HomeAssistant) -> None:
         )
 
     assert result["step_id"] == "zeroconf_confirm"
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],

--- a/tests/components/romy/test_config_flow.py
+++ b/tests/components/romy/test_config_flow.py
@@ -202,7 +202,7 @@ async def test_show_user_with_locked_interface_robot_with_connection_loss(
             result["flow_id"], user_input=INPUT_CONFIG_PASS
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "password"
 
 

--- a/tests/components/romy/test_config_flow.py
+++ b/tests/components/romy/test_config_flow.py
@@ -237,7 +237,7 @@ async def test_zero_conf_locked_interface_robot(hass: HomeAssistant) -> None:
         )
 
     assert result["step_id"] == "password"
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
 
 async def test_zero_conf_uninitialized_robot(hass: HomeAssistant) -> None:

--- a/tests/components/romy/test_config_flow.py
+++ b/tests/components/romy/test_config_flow.py
@@ -108,7 +108,7 @@ async def test_show_user_form_with_config_which_contains_wrong_host(
             data=INPUT_CONFIG_WITH_PASS,
         )
 
-    assert result["errors"].get("host") == "wrong host"
+    assert result["errors"].get("host") == "cannot_connect"
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
 
 
@@ -132,7 +132,7 @@ async def test_show_user_form_with_config_which_contains_wrong_password(
             data=INPUT_CONFIG_WITH_PASS,
         )
 
-    assert result["errors"].get("password") == "wrong password"
+    assert result["errors"].get("password") == "invalid_auth"
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
 
 

--- a/tests/components/romy/test_config_flow.py
+++ b/tests/components/romy/test_config_flow.py
@@ -113,7 +113,7 @@ async def test_show_user_with_locked_interface_robot_with_wrong_password(
         )
 
     assert result["step_id"] == "password"
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     with patch(
         "homeassistant.components.romy.config_flow.romy.create_romy",

--- a/tests/components/romy/test_config_flow.py
+++ b/tests/components/romy/test_config_flow.py
@@ -9,10 +9,11 @@ from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 
 
-def _create_mocked_romy(is_initialized, is_unlocked):
+def _create_mocked_romy(is_initialized, is_unlocked, name="Nadine"):
     mocked_romy = MagicMock()
     type(mocked_romy).is_initialized = PropertyMock(return_value=is_initialized)
     type(mocked_romy).is_unlocked = PropertyMock(return_value=is_unlocked)
+    type(mocked_romy).name = PropertyMock(return_value=name)
     return mocked_romy
 
 
@@ -29,6 +30,7 @@ async def test_show_user_form(hass: HomeAssistant) -> None:
 
 
 CONFIG = {CONF_HOST: "1.2.3.4", CONF_NAME: "myROMY", CONF_PASSWORD: "12345678"}
+
 
 INPUT_CONFIG = {
     CONF_HOST: CONFIG[CONF_HOST],
@@ -52,6 +54,34 @@ async def test_show_user_form_with_config(hass: HomeAssistant) -> None:
             DOMAIN,
             context={"source": config_entries.SOURCE_USER},
             data=INPUT_CONFIG,
+        )
+
+    assert "errors" not in result
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+
+
+INPUT_CONFIG_WITHOUT_NAME = {
+    CONF_HOST: CONFIG[CONF_HOST],
+    CONF_NAME: None,
+}
+
+
+async def test_show_user_form_with_config_without_name(hass: HomeAssistant) -> None:
+    """Test that the user set up form with config."""
+
+    mocked_romy = _create_mocked_romy(
+        is_initialized=True,
+        is_unlocked=True,
+    )
+
+    with patch(
+        "homeassistant.components.romy.config_flow.romy.create_romy",
+        return_value=mocked_romy,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+            data=INPUT_CONFIG_WITHOUT_NAME,
         )
 
     assert "errors" not in result

--- a/tests/components/romy/test_config_flow.py
+++ b/tests/components/romy/test_config_flow.py
@@ -46,8 +46,6 @@ INPUT_CONFIG_PASS = {
 }
 
 
-# user conf tests
-###################
 async def test_show_user_form(hass: HomeAssistant) -> None:
     """Test that the user set up form with config."""
 

--- a/tests/components/romy/test_config_flow.py
+++ b/tests/components/romy/test_config_flow.py
@@ -148,7 +148,7 @@ async def test_show_user_with_locked_interface_robot_with_correct_password(
         )
 
     assert result["step_id"] == "password"
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
 
     mocked_unlocked_romy = _create_mocked_romy(
         is_initialized=True,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->Add romy vacuum core integration
ROMY vacuum cleaner homepage: https://www.romyrobot.com

PYPI package: https://pypi.org/project/romy/
PYPI package Source: https://github.com/xeniter/romy/releases/tag/0.0.5
Version 0.0.5 containing fix that robot returns initialized true even it can't read sensor value(this is the case when the http interface is still locked): https://github.com/xeniter/romy/compare/0.0.4..0.0.5
0.0.6 contains code review changes from [this merge request](https://github.com/home-assistant/core/pull/93750/files/c6bf9875d44b70ab11b289016aeb9ae4dd63a6ea#diff-5bb90f607761436fad9d5e46b567cdde28216c4420a892d2210d2ac1eb2fd828)
Latest Version 0.0.7 contains github workflow to release pypi romy package


- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/27578
- Link to brand pull request: https://github.com/home-assistant/brands/pull/4413

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
