### PR TITLE
Reduce overhead to match homekit zeroconf discoveries

### DIFF
--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -55,6 +55,7 @@ HOMEKIT_TYPES = [
     # Thread based devices
     "_hap._udp.local.",
 ]
+_HOMEKIT_MODEL_SPLITS = (None, " ", "-")
 
 # Top level keys we support matching against in properties that are always matched in
 # lower case. ex: ZeroconfServiceInfo.name
@@ -66,7 +67,8 @@ DEFAULT_DEFAULT_INTERFACE = True
 DEFAULT_IPV6 = True
 
 HOMEKIT_PAIRED_STATUS_FLAG = "sf"
-HOMEKIT_MODEL = "md"
+HOMEKIT_MODEL_LOWER = "md"
+HOMEKIT_MODEL_UPPER = "MD"
 
 # Property key=value has a max length of 255
 # so we use 230 to leave space for key=
@@ -192,7 +194,17 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     zeroconf_types, homekit_models = await asyncio.gather(
         async_get_zeroconf(hass), async_get_homekit(hass)
     )
-    discovery = ZeroconfDiscovery(hass, zeroconf, zeroconf_types, homekit_models, ipv6)
+    homekit_model_lookup, homekit_model_matchers = _build_homekit_model_lookups(
+        homekit_models
+    )
+    discovery = ZeroconfDiscovery(
+        hass,
+        zeroconf,
+        zeroconf_types,
+        homekit_model_lookup,
+        homekit_model_matchers,
+        ipv6,
+    )
     await discovery.async_setup()
 
     async def _async_zeroconf_hass_start(hass: HomeAssistant, comp: str) -> None:
@@ -210,6 +222,25 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     async_when_setup_or_start(hass, "frontend", _async_zeroconf_hass_start)
 
     return True
+
+
+def _build_homekit_model_lookups(
+    homekit_models: dict[str, HomeKitDiscoveredIntegration]
+) -> tuple[
+    dict[str, HomeKitDiscoveredIntegration],
+    dict[re.Pattern, HomeKitDiscoveredIntegration],
+]:
+    """Build lookups for homekit models."""
+    homekit_model_lookup: dict[str, HomeKitDiscoveredIntegration] = {}
+    homekit_model_matchers: dict[re.Pattern, HomeKitDiscoveredIntegration] = {}
+
+    for model, discovery in homekit_models.items():
+        if "*" in model or "?" in model or "[" in model:
+            homekit_model_matchers[_compile_fnmatch(model)] = discovery
+        else:
+            homekit_model_lookup[model] = discovery
+
+    return homekit_model_lookup, homekit_model_matchers
 
 
 def _get_announced_addresses(
@@ -347,14 +378,17 @@ class ZeroconfDiscovery:
         hass: HomeAssistant,
         zeroconf: HaZeroconf,
         zeroconf_types: dict[str, list[dict[str, str | dict[str, str]]]],
-        homekit_models: dict[str, HomeKitDiscoveredIntegration],
+        homekit_model_lookups: dict[str, HomeKitDiscoveredIntegration],
+        homekit_model_matchers: dict[re.Pattern, HomeKitDiscoveredIntegration],
         ipv6: bool,
     ) -> None:
         """Init discovery."""
         self.hass = hass
         self.zeroconf = zeroconf
         self.zeroconf_types = zeroconf_types
-        self.homekit_models = homekit_models
+        self.homekit_model_lookups = homekit_model_lookups
+        self.homekit_model_matchers = homekit_model_matchers
+
         self.ipv6 = ipv6
 
         self.async_service_browser: HaAsyncServiceBrowser | None = None
@@ -450,14 +484,14 @@ class ZeroconfDiscovery:
 
         # If we can handle it as a HomeKit discovery, we do that here.
         if service_type in HOMEKIT_TYPES and (
-            homekit_model := async_get_homekit_discovery_domain(
-                self.homekit_models, props
+            homekit_discovery := async_get_homekit_discovery(
+                self.homekit_model_lookups, self.homekit_model_matchers, props
             )
         ):
-            domain = homekit_model.domain
+            domain = homekit_discovery.domain
             discovery_flow.async_create_flow(
                 self.hass,
-                homekit_model.domain,
+                homekit_discovery.domain,
                 {"source": config_entries.SOURCE_HOMEKIT},
                 info,
             )
@@ -468,7 +502,7 @@ class ZeroconfDiscovery:
             # We only send updates to homekit_controller
             # if the device is already paired in order to avoid
             # offering a second discovery for the same device
-            if not is_homekit_paired(props) and not homekit_model.always_discover:
+            if not is_homekit_paired(props) and not homekit_discovery.always_discover:
                 # If the device is paired with HomeKit we must send on
                 # the update to homekit_controller so it can see when
                 # the 'c#' field is updated. This is used to detect
@@ -513,31 +547,28 @@ class ZeroconfDiscovery:
             )
 
 
-def async_get_homekit_discovery_domain(
-    homekit_models: dict[str, HomeKitDiscoveredIntegration], props: dict[str, Any]
+def async_get_homekit_discovery(
+    homekit_model_lookups: dict[str, HomeKitDiscoveredIntegration],
+    homekit_model_matchers: dict[re.Pattern, HomeKitDiscoveredIntegration],
+    props: dict[str, Any],
 ) -> HomeKitDiscoveredIntegration | None:
     """Handle a HomeKit discovery.
 
     Return the domain to forward the discovery data to
     """
-    model = None
-    for key in props:
-        if key.lower() == HOMEKIT_MODEL:
-            model = props[key]
-            break
-
-    if model is None:
+    if not (model := props.get(HOMEKIT_MODEL_LOWER) or props.get(HOMEKIT_MODEL_UPPER)):
         return None
 
-    for test_model in homekit_models:
-        if (
-            model != test_model
-            and not model.startswith((f"{test_model} ", f"{test_model}-"))
-            and not _memorized_fnmatch(model, test_model)
-        ):
-            continue
+    assert isinstance(model, str)
 
-        return homekit_models[test_model]
+    for split_str in _HOMEKIT_MODEL_SPLITS:
+        key = (model.split(split_str))[0] if split_str else model
+        if discovery := homekit_model_lookups.get(key):
+            return discovery
+
+    for pattern, discovery in homekit_model_matchers.items():
+        if pattern.match(model):
+            return discovery
 
     return None
 


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Reduce overhead to match homekit zeroconf discoveries

Instead of thousands of matches via linear searching, most of these can be 3 dict lookups except for the ones with fnmatch patterns. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
