### PR TITLE
Import `util.dt` as `dt_util` in `components/[a-d]*`

### DIFF
--- a/homeassistant/components/alexa/auth.py
+++ b/homeassistant/components/alexa/auth.py
@@ -12,7 +12,7 @@ from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET
 from homeassistant.core import callback
 from homeassistant.helpers import aiohttp_client
 from homeassistant.helpers.storage import Store
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -95,12 +95,12 @@ class Auth:
         if not self._prefs[STORAGE_ACCESS_TOKEN]:
             return False
 
-        expire_time = dt.parse_datetime(self._prefs[STORAGE_EXPIRE_TIME])
+        expire_time = dt_util.parse_datetime(self._prefs[STORAGE_EXPIRE_TIME])
         preemptive_expire_time = expire_time - timedelta(
             seconds=PREEMPTIVE_REFRESH_TTL_IN_SECONDS
         )
 
-        return dt.utcnow() < preemptive_expire_time
+        return dt_util.utcnow() < preemptive_expire_time
 
     async def _async_request_new_token(self, lwa_params):
         try:
@@ -130,7 +130,7 @@ class Auth:
         access_token = response_json["access_token"]
         refresh_token = response_json["refresh_token"]
         expires_in = response_json["expires_in"]
-        expire_time = dt.utcnow() + timedelta(seconds=expires_in)
+        expire_time = dt_util.utcnow() + timedelta(seconds=expires_in)
 
         await self._async_update_preferences(
             access_token, refresh_token, expire_time.isoformat()

--- a/homeassistant/components/backup/manager.py
+++ b/homeassistant/components/backup/manager.py
@@ -18,7 +18,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import integration_platform
 from homeassistant.helpers.json import save_json
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 from homeassistant.util.json import json_loads_object
 
 from .const import DOMAIN, EXCLUDE_FROM_BACKUP, LOGGER
@@ -176,7 +176,7 @@ class BackupManager:
                     raise result
 
             backup_name = f"Core {HAVERSION}"
-            date_str = dt.now().isoformat()
+            date_str = dt_util.now().isoformat()
             slug = _generate_slug(date_str, backup_name)
 
             backup_data = {

--- a/homeassistant/components/broadlink/remote.py
+++ b/homeassistant/components/broadlink/remote.py
@@ -39,7 +39,7 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.storage import Store
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN
 from .entity import BroadlinkEntity
@@ -330,8 +330,8 @@ class BroadlinkRemote(BroadlinkEntity, RemoteEntity, RestoreEntity):
         )
 
         try:
-            start_time = dt.utcnow()
-            while (dt.utcnow() - start_time) < LEARNING_TIMEOUT:
+            start_time = dt_util.utcnow()
+            while (dt_util.utcnow() - start_time) < LEARNING_TIMEOUT:
                 await asyncio.sleep(1)
                 try:
                     code = await device.async_request(device.api.check_data)
@@ -368,8 +368,8 @@ class BroadlinkRemote(BroadlinkEntity, RemoteEntity, RestoreEntity):
         )
 
         try:
-            start_time = dt.utcnow()
-            while (dt.utcnow() - start_time) < LEARNING_TIMEOUT:
+            start_time = dt_util.utcnow()
+            while (dt_util.utcnow() - start_time) < LEARNING_TIMEOUT:
                 await asyncio.sleep(1)
                 found = await device.async_request(device.api.check_frequency)
                 if found:
@@ -403,8 +403,8 @@ class BroadlinkRemote(BroadlinkEntity, RemoteEntity, RestoreEntity):
         )
 
         try:
-            start_time = dt.utcnow()
-            while (dt.utcnow() - start_time) < LEARNING_TIMEOUT:
+            start_time = dt_util.utcnow()
+            while (dt_util.utcnow() - start_time) < LEARNING_TIMEOUT:
                 await asyncio.sleep(1)
                 try:
                     code = await device.async_request(device.api.check_data)

--- a/homeassistant/components/broadlink/updater.py
+++ b/homeassistant/components/broadlink/updater.py
@@ -6,7 +6,7 @@ import logging
 from broadlink.exceptions import AuthorizationError, BroadlinkException
 
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -64,7 +64,7 @@ class BroadlinkUpdateManager(ABC):
 
         except (BroadlinkException, OSError) as err:
             if self.available and (
-                dt.utcnow() - self.last_update > self.SCAN_INTERVAL * 3
+                dt_util.utcnow() - self.last_update > self.SCAN_INTERVAL * 3
                 or isinstance(err, (AuthorizationError, OSError))
             ):
                 self.available = False
@@ -84,7 +84,7 @@ class BroadlinkUpdateManager(ABC):
                 self.device.api.host[0],
             )
         self.available = True
-        self.last_update = dt.utcnow()
+        self.last_update = dt_util.utcnow()
         return data
 
     @abstractmethod

--- a/homeassistant/components/caldav/calendar.py
+++ b/homeassistant/components/caldav/calendar.py
@@ -29,7 +29,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import generate_entity_id
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
-from homeassistant.util import Throttle, dt
+from homeassistant.util import Throttle, dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -204,8 +204,8 @@ class WebDavCalendarData:
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
         """Get the latest data."""
-        start_of_today = dt.start_of_local_day()
-        start_of_tomorrow = dt.start_of_local_day() + timedelta(days=self.days)
+        start_of_today = dt_util.start_of_local_day()
+        start_of_tomorrow = dt_util.start_of_local_day() + timedelta(days=self.days)
 
         # We have to retrieve the results for the whole day as the server
         # won't return events that have already started
@@ -312,7 +312,7 @@ class WebDavCalendarData:
     @staticmethod
     def is_over(vevent):
         """Return if the event is over."""
-        return dt.now() >= WebDavCalendarData.to_datetime(
+        return dt_util.now() >= WebDavCalendarData.to_datetime(
             WebDavCalendarData.get_end_date(vevent)
         )
 
@@ -321,7 +321,7 @@ class WebDavCalendarData:
         """Return a datetime."""
         if isinstance(obj, datetime):
             return WebDavCalendarData.to_local(obj)
-        return datetime.combine(obj, time.min).replace(tzinfo=dt.DEFAULT_TIME_ZONE)
+        return datetime.combine(obj, time.min).replace(tzinfo=dt_util.DEFAULT_TIME_ZONE)
 
     @staticmethod
     def to_local(obj: datetime | date) -> datetime | date:
@@ -332,7 +332,7 @@ class WebDavCalendarData:
         used by the caldav client and dateutil so the datetime can be copied.
         """
         if isinstance(obj, datetime):
-            return dt.as_local(obj)
+            return dt_util.as_local(obj)
         return obj
 
     @staticmethod

--- a/homeassistant/components/cert_expiry/helper.py
+++ b/homeassistant/components/cert_expiry/helper.py
@@ -3,7 +3,7 @@ import socket
 import ssl
 
 from homeassistant.core import HomeAssistant
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from .const import TIMEOUT
 from .errors import (
@@ -52,4 +52,4 @@ async def get_cert_expiry_timestamp(
         raise ValidationFailure(err.args[0]) from err
 
     ts_seconds = ssl.cert_time_to_seconds(cert["notAfter"])
-    return dt.utc_from_timestamp(ts_seconds)
+    return dt_util.utc_from_timestamp(ts_seconds)

--- a/homeassistant/components/demo/mailbox.py
+++ b/homeassistant/components/demo/mailbox.py
@@ -9,7 +9,7 @@ from typing import Any
 from homeassistant.components.mailbox import CONTENT_TYPE_MPEG, Mailbox, StreamError
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -34,7 +34,9 @@ class DemoMailbox(Mailbox):
         self._messages: dict[str, dict[str, Any]] = {}
         txt = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
         for idx in range(0, 10):
-            msgtime = int(dt.as_timestamp(dt.utcnow()) - 3600 * 24 * (10 - idx))
+            msgtime = int(
+                dt_util.as_timestamp(dt_util.utcnow()) - 3600 * 24 * (10 - idx)
+            )
             msgtxt = f"Message {idx + 1}. {txt * (1 + idx * (idx % 2))}"
             msgsha = sha1(msgtxt.encode("utf-8")).hexdigest()
             msg = {

--- a/tests/components/advantage_air/test_binary_sensor.py
+++ b/tests/components/advantage_air/test_binary_sensor.py
@@ -5,7 +5,7 @@ from homeassistant.config_entries import RELOAD_AFTER_UPDATE_DELAY
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from . import (
     TEST_SET_RESPONSE,
@@ -88,7 +88,7 @@ async def test_binary_sensor_async_setup_entry(
 
     async_fire_time_changed(
         hass,
-        dt.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
+        dt_util.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
     )
     await hass.async_block_till_done()
 
@@ -110,7 +110,7 @@ async def test_binary_sensor_async_setup_entry(
 
     async_fire_time_changed(
         hass,
-        dt.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
+        dt_util.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
     )
     await hass.async_block_till_done()
 

--- a/tests/components/advantage_air/test_sensor.py
+++ b/tests/components/advantage_air/test_sensor.py
@@ -11,7 +11,7 @@ from homeassistant.config_entries import RELOAD_AFTER_UPDATE_DELAY
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from . import (
     TEST_SET_RESPONSE,
@@ -144,7 +144,7 @@ async def test_sensor_platform(
 
     async_fire_time_changed(
         hass,
-        dt.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
+        dt_util.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
     )
     await hass.async_block_till_done()
 

--- a/tests/components/anova/test_sensor.py
+++ b/tests/components/anova/test_sensor.py
@@ -8,7 +8,7 @@ from anova_wifi import AnovaApi, AnovaOffline
 
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from . import async_init_integration
 
@@ -54,7 +54,7 @@ async def test_update_failed(hass: HomeAssistant, anova_api: AnovaApi) -> None:
         "homeassistant.components.anova.AnovaPrecisionCooker.update",
         side_effect=AnovaOffline(),
     ):
-        async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=61))
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=61))
         await hass.async_block_till_done()
 
         state = hass.states.get("sensor.anova_precision_cooker_water_temperature")

--- a/tests/components/broadlink/test_heartbeat.py
+++ b/tests/components/broadlink/test_heartbeat.py
@@ -5,7 +5,7 @@ import pytest
 
 from homeassistant.components.broadlink.heartbeat import BroadlinkHeartbeat
 from homeassistant.core import HomeAssistant
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from . import get_device
 
@@ -48,7 +48,7 @@ async def test_heartbeat_trigger_right_time(hass: HomeAssistant) -> None:
 
     with patch(DEVICE_PING) as mock_ping:
         async_fire_time_changed(
-            hass, dt.utcnow() + BroadlinkHeartbeat.HEARTBEAT_INTERVAL
+            hass, dt_util.utcnow() + BroadlinkHeartbeat.HEARTBEAT_INTERVAL
         )
         await hass.async_block_till_done()
 
@@ -66,7 +66,7 @@ async def test_heartbeat_do_not_trigger_before_time(hass: HomeAssistant) -> None
     with patch(DEVICE_PING) as mock_ping:
         async_fire_time_changed(
             hass,
-            dt.utcnow() + BroadlinkHeartbeat.HEARTBEAT_INTERVAL // 2,
+            dt_util.utcnow() + BroadlinkHeartbeat.HEARTBEAT_INTERVAL // 2,
         )
         await hass.async_block_till_done()
 
@@ -85,7 +85,7 @@ async def test_heartbeat_unload(hass: HomeAssistant) -> None:
 
     with patch(DEVICE_PING) as mock_ping:
         async_fire_time_changed(
-            hass, dt.utcnow() + BroadlinkHeartbeat.HEARTBEAT_INTERVAL
+            hass, dt_util.utcnow() + BroadlinkHeartbeat.HEARTBEAT_INTERVAL
         )
 
     assert mock_ping.call_count == 0
@@ -105,7 +105,7 @@ async def test_heartbeat_do_not_unload(hass: HomeAssistant) -> None:
 
     with patch(DEVICE_PING) as mock_ping:
         async_fire_time_changed(
-            hass, dt.utcnow() + BroadlinkHeartbeat.HEARTBEAT_INTERVAL
+            hass, dt_util.utcnow() + BroadlinkHeartbeat.HEARTBEAT_INTERVAL
         )
         await hass.async_block_till_done()
 

--- a/tests/components/broadlink/test_sensors.py
+++ b/tests/components/broadlink/test_sensors.py
@@ -7,7 +7,7 @@ from homeassistant.const import ATTR_FRIENDLY_NAME, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_component import async_update_entity
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from . import get_device
 
@@ -384,7 +384,9 @@ async def test_scb1e_sensor_update(
     }
 
     target_time = (
-        dt.utcnow() + BroadlinkSP4UpdateManager.SCAN_INTERVAL * 3 + timedelta(seconds=1)
+        dt_util.utcnow()
+        + BroadlinkSP4UpdateManager.SCAN_INTERVAL * 3
+        + timedelta(seconds=1)
     )
 
     mock_setup = await device.setup_entry(hass, mock_api=mock_api)

--- a/tests/components/caldav/test_calendar.py
+++ b/tests/components/caldav/test_calendar.py
@@ -9,7 +9,7 @@ import pytest
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 DEVICE_DATA = {"name": "Private Calendar", "device_id": "Private Calendar"}
 
@@ -360,7 +360,7 @@ def get_api_events(hass_client):
 
 def _local_datetime(hours, minutes):
     """Build a datetime object for testing in the correct timezone."""
-    return dt.as_local(datetime.datetime(2017, 11, 27, hours, minutes, 0))
+    return dt_util.as_local(datetime.datetime(2017, 11, 27, hours, minutes, 0))
 
 
 def _mocked_dav_client(*names, calendars=None):
@@ -693,7 +693,9 @@ async def test_all_day_event_returned_early(
         hass,
         calendar,
         config,
-        datetime.datetime(2017, 11, 27, 0, 30).replace(tzinfo=dt.DEFAULT_TIME_ZONE),
+        datetime.datetime(2017, 11, 27, 0, 30).replace(
+            tzinfo=dt_util.DEFAULT_TIME_ZONE
+        ),
     )
 
 
@@ -711,7 +713,9 @@ async def test_all_day_event_returned_mid(
         hass,
         calendar,
         config,
-        datetime.datetime(2017, 11, 27, 12, 30).replace(tzinfo=dt.DEFAULT_TIME_ZONE),
+        datetime.datetime(2017, 11, 27, 12, 30).replace(
+            tzinfo=dt_util.DEFAULT_TIME_ZONE
+        ),
     )
 
 
@@ -729,7 +733,9 @@ async def test_all_day_event_returned_late(
         hass,
         calendar,
         config,
-        datetime.datetime(2017, 11, 27, 23, 30).replace(tzinfo=dt.DEFAULT_TIME_ZONE),
+        datetime.datetime(2017, 11, 27, 23, 30).replace(
+            tzinfo=dt_util.DEFAULT_TIME_ZONE
+        ),
     )
 
 
@@ -883,7 +889,7 @@ async def test_event_rrule_all_day_early(hass: HomeAssistant, calendar, set_tz) 
         hass,
         calendar,
         config,
-        datetime.datetime(2016, 12, 1, 0, 30).replace(tzinfo=dt.DEFAULT_TIME_ZONE),
+        datetime.datetime(2016, 12, 1, 0, 30).replace(tzinfo=dt_util.DEFAULT_TIME_ZONE),
     )
 
 
@@ -899,7 +905,9 @@ async def test_event_rrule_all_day_mid(hass: HomeAssistant, calendar, set_tz) ->
         hass,
         calendar,
         config,
-        datetime.datetime(2016, 12, 1, 17, 30).replace(tzinfo=dt.DEFAULT_TIME_ZONE),
+        datetime.datetime(2016, 12, 1, 17, 30).replace(
+            tzinfo=dt_util.DEFAULT_TIME_ZONE
+        ),
     )
 
 
@@ -915,14 +923,16 @@ async def test_event_rrule_all_day_late(hass: HomeAssistant, calendar, set_tz) -
         hass,
         calendar,
         config,
-        datetime.datetime(2016, 12, 1, 23, 30).replace(tzinfo=dt.DEFAULT_TIME_ZONE),
+        datetime.datetime(2016, 12, 1, 23, 30).replace(
+            tzinfo=dt_util.DEFAULT_TIME_ZONE
+        ),
     )
 
 
 @pytest.mark.parametrize("set_tz", ["utc"], indirect=True)
 @patch(
     "homeassistant.util.dt.now",
-    return_value=dt.as_local(datetime.datetime(2015, 11, 27, 0, 15)),
+    return_value=dt_util.as_local(datetime.datetime(2015, 11, 27, 0, 15)),
 )
 async def test_event_rrule_hourly_on_first(
     mock_now, hass: HomeAssistant, calendar, set_tz
@@ -949,7 +959,7 @@ async def test_event_rrule_hourly_on_first(
 @pytest.mark.parametrize("set_tz", ["utc"], indirect=True)
 @patch(
     "homeassistant.util.dt.now",
-    return_value=dt.as_local(datetime.datetime(2015, 11, 27, 11, 15)),
+    return_value=dt_util.as_local(datetime.datetime(2015, 11, 27, 11, 15)),
 )
 async def test_event_rrule_hourly_on_last(
     mock_now, hass: HomeAssistant, calendar, set_tz
@@ -975,7 +985,7 @@ async def test_event_rrule_hourly_on_last(
 
 @patch(
     "homeassistant.util.dt.now",
-    return_value=dt.as_local(datetime.datetime(2015, 11, 27, 0, 45)),
+    return_value=dt_util.as_local(datetime.datetime(2015, 11, 27, 0, 45)),
 )
 async def test_event_rrule_hourly_off_first(
     mock_now, hass: HomeAssistant, calendar
@@ -991,7 +1001,7 @@ async def test_event_rrule_hourly_off_first(
 
 @patch(
     "homeassistant.util.dt.now",
-    return_value=dt.as_local(datetime.datetime(2015, 11, 27, 11, 45)),
+    return_value=dt_util.as_local(datetime.datetime(2015, 11, 27, 11, 45)),
 )
 async def test_event_rrule_hourly_off_last(
     mock_now, hass: HomeAssistant, calendar
@@ -1007,7 +1017,7 @@ async def test_event_rrule_hourly_off_last(
 
 @patch(
     "homeassistant.util.dt.now",
-    return_value=dt.as_local(datetime.datetime(2015, 11, 27, 12, 15)),
+    return_value=dt_util.as_local(datetime.datetime(2015, 11, 27, 12, 15)),
 )
 async def test_event_rrule_hourly_ended(
     mock_now, hass: HomeAssistant, calendar

--- a/tests/components/cert_expiry/helpers.py
+++ b/tests/components/cert_expiry/helpers.py
@@ -1,12 +1,12 @@
 """Helpers for Cert Expiry tests."""
 from datetime import datetime, timedelta
 
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 
 def static_datetime():
     """Build a datetime object for testing in the correct timezone."""
-    return dt.as_utc(datetime(2020, 6, 12, 8, 0, 0))
+    return dt_util.as_utc(datetime(2020, 6, 12, 8, 0, 0))
 
 
 def future_timestamp(days):

--- a/tests/components/cloud/test_repairs.py
+++ b/tests/components/cloud/test_repairs.py
@@ -10,7 +10,7 @@ from homeassistant.components.repairs import DOMAIN as REPAIRS_DOMAIN
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.issue_registry as ir
 from homeassistant.setup import async_setup_component
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from . import mock_cloud
 
@@ -28,7 +28,7 @@ async def test_do_not_create_repair_issues_at_startup_if_not_logged_in(
     with patch("homeassistant.components.cloud.Cloud.is_logged_in", False):
         await mock_cloud(hass)
 
-        async_fire_time_changed(hass, dt.utcnow() + timedelta(hours=1))
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(hours=1))
         await hass.async_block_till_done()
 
     assert not issue_registry.async_get_issue(
@@ -51,7 +51,7 @@ async def test_create_repair_issues_at_startup_if_logged_in(
     with patch("homeassistant.components.cloud.Cloud.is_logged_in", True):
         await mock_cloud(hass)
 
-        async_fire_time_changed(hass, dt.utcnow() + timedelta(hours=1))
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(hours=1))
         await hass.async_block_till_done()
 
     assert issue_registry.async_get_issue(

--- a/tests/components/command_line/test_sensor.py
+++ b/tests/components/command_line/test_sensor.py
@@ -13,7 +13,7 @@ from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 import homeassistant.helpers.issue_registry as ir
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from tests.common import async_fire_time_changed
 
@@ -123,7 +123,7 @@ async def test_template_render(
     # Give time for template to load
     async_fire_time_changed(
         hass,
-        dt.utcnow() + timedelta(minutes=1),
+        dt_util.utcnow() + timedelta(minutes=1),
     )
     await hass.async_block_till_done()
 
@@ -158,7 +158,7 @@ async def test_template_render_with_quote(hass: HomeAssistant) -> None:
         # Give time for template to load
         async_fire_time_changed(
             hass,
-            dt.utcnow() + timedelta(minutes=1),
+            dt_util.utcnow() + timedelta(minutes=1),
         )
         await hass.async_block_till_done()
 

--- a/tests/components/deconz/test_sensor.py
+++ b/tests/components/deconz/test_sensor.py
@@ -24,7 +24,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from .test_gateway import DECONZ_WEB_REQUEST, setup_deconz_integration
 
@@ -785,7 +785,7 @@ async def test_sensors(
 
         async_fire_time_changed(
             hass,
-            dt.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
+            dt_util.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
         )
         await hass.async_block_till_done()
 

--- a/tests/components/demo/test_vacuum.py
+++ b/tests/components/demo/test_vacuum.py
@@ -38,7 +38,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from tests.common import async_fire_time_changed, async_mock_service
 from tests.components.vacuum import common
@@ -179,7 +179,7 @@ async def test_methods(hass: HomeAssistant) -> None:
     state = hass.states.get(ENTITY_VACUUM_STATE)
     assert state.state == STATE_RETURNING
 
-    async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=31))
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=31))
     await hass.async_block_till_done()
     state = hass.states.get(ENTITY_VACUUM_STATE)
     assert state.state == STATE_DOCKED

--- a/tests/components/devolo_home_network/test_binary_sensor.py
+++ b/tests/components/devolo_home_network/test_binary_sensor.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from . import configure_integration
 from .const import PLCNET_ATTACHED
@@ -66,7 +66,7 @@ async def test_update_attached_to_router(
     mock_device.plcnet.async_get_network_overview = AsyncMock(
         side_effect=DeviceUnavailable
     )
-    async_fire_time_changed(hass, dt.utcnow() + LONG_UPDATE_INTERVAL)
+    async_fire_time_changed(hass, dt_util.utcnow() + LONG_UPDATE_INTERVAL)
     await hass.async_block_till_done()
 
     state = hass.states.get(state_key)
@@ -77,7 +77,7 @@ async def test_update_attached_to_router(
     mock_device.plcnet.async_get_network_overview = AsyncMock(
         return_value=PLCNET_ATTACHED
     )
-    async_fire_time_changed(hass, dt.utcnow() + LONG_UPDATE_INTERVAL)
+    async_fire_time_changed(hass, dt_util.utcnow() + LONG_UPDATE_INTERVAL)
     await hass.async_block_till_done()
 
     state = hass.states.get(state_key)

--- a/tests/components/devolo_home_network/test_device_tracker.py
+++ b/tests/components/devolo_home_network/test_device_tracker.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from . import configure_integration
 from .const import CONNECTED_STATIONS, DISCOVERY_INFO, NO_CONNECTED_STATIONS
@@ -40,13 +40,13 @@ async def test_device_tracker(
     entry = configure_integration(hass)
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
-    async_fire_time_changed(hass, dt.utcnow() + LONG_UPDATE_INTERVAL)
+    async_fire_time_changed(hass, dt_util.utcnow() + LONG_UPDATE_INTERVAL)
     await hass.async_block_till_done()
 
     # Enable entity
     entity_registry.async_update_entity(state_key, disabled_by=None)
     await hass.async_block_till_done()
-    async_fire_time_changed(hass, dt.utcnow() + LONG_UPDATE_INTERVAL)
+    async_fire_time_changed(hass, dt_util.utcnow() + LONG_UPDATE_INTERVAL)
     await hass.async_block_till_done()
 
     state = hass.states.get(state_key)
@@ -62,7 +62,7 @@ async def test_device_tracker(
     mock_device.device.async_get_wifi_connected_station = AsyncMock(
         return_value=NO_CONNECTED_STATIONS
     )
-    async_fire_time_changed(hass, dt.utcnow() + LONG_UPDATE_INTERVAL)
+    async_fire_time_changed(hass, dt_util.utcnow() + LONG_UPDATE_INTERVAL)
     await hass.async_block_till_done()
 
     state = hass.states.get(state_key)
@@ -73,7 +73,7 @@ async def test_device_tracker(
     mock_device.device.async_get_wifi_connected_station = AsyncMock(
         side_effect=DeviceUnavailable
     )
-    async_fire_time_changed(hass, dt.utcnow() + LONG_UPDATE_INTERVAL)
+    async_fire_time_changed(hass, dt_util.utcnow() + LONG_UPDATE_INTERVAL)
     await hass.async_block_till_done()
 
     state = hass.states.get(state_key)

--- a/tests/components/devolo_home_network/test_sensor.py
+++ b/tests/components/devolo_home_network/test_sensor.py
@@ -12,7 +12,7 @@ from homeassistant.components.sensor import DOMAIN, SensorStateClass
 from homeassistant.const import ATTR_FRIENDLY_NAME, STATE_UNAVAILABLE, EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from . import configure_integration
 from .mock import MockDevice
@@ -57,7 +57,7 @@ async def test_update_connected_wifi_clients(
     mock_device.device.async_get_wifi_connected_station = AsyncMock(
         side_effect=DeviceUnavailable
     )
-    async_fire_time_changed(hass, dt.utcnow() + SHORT_UPDATE_INTERVAL)
+    async_fire_time_changed(hass, dt_util.utcnow() + SHORT_UPDATE_INTERVAL)
     await hass.async_block_till_done()
 
     state = hass.states.get(state_key)
@@ -66,7 +66,7 @@ async def test_update_connected_wifi_clients(
 
     # Emulate state change
     mock_device.reset()
-    async_fire_time_changed(hass, dt.utcnow() + SHORT_UPDATE_INTERVAL)
+    async_fire_time_changed(hass, dt_util.utcnow() + SHORT_UPDATE_INTERVAL)
     await hass.async_block_till_done()
 
     state = hass.states.get(state_key)
@@ -103,7 +103,7 @@ async def test_update_neighboring_wifi_networks(
     mock_device.device.async_get_wifi_neighbor_access_points = AsyncMock(
         side_effect=DeviceUnavailable
     )
-    async_fire_time_changed(hass, dt.utcnow() + LONG_UPDATE_INTERVAL)
+    async_fire_time_changed(hass, dt_util.utcnow() + LONG_UPDATE_INTERVAL)
     await hass.async_block_till_done()
 
     state = hass.states.get(state_key)
@@ -112,7 +112,7 @@ async def test_update_neighboring_wifi_networks(
 
     # Emulate state change
     mock_device.reset()
-    async_fire_time_changed(hass, dt.utcnow() + LONG_UPDATE_INTERVAL)
+    async_fire_time_changed(hass, dt_util.utcnow() + LONG_UPDATE_INTERVAL)
     await hass.async_block_till_done()
 
     state = hass.states.get(state_key)
@@ -148,7 +148,7 @@ async def test_update_connected_plc_devices(
     mock_device.plcnet.async_get_network_overview = AsyncMock(
         side_effect=DeviceUnavailable
     )
-    async_fire_time_changed(hass, dt.utcnow() + LONG_UPDATE_INTERVAL)
+    async_fire_time_changed(hass, dt_util.utcnow() + LONG_UPDATE_INTERVAL)
     await hass.async_block_till_done()
 
     state = hass.states.get(state_key)
@@ -157,7 +157,7 @@ async def test_update_connected_plc_devices(
 
     # Emulate state change
     mock_device.reset()
-    async_fire_time_changed(hass, dt.utcnow() + LONG_UPDATE_INTERVAL)
+    async_fire_time_changed(hass, dt_util.utcnow() + LONG_UPDATE_INTERVAL)
     await hass.async_block_till_done()
 
     state = hass.states.get(state_key)

--- a/tests/components/devolo_home_network/test_switch.py
+++ b/tests/components/devolo_home_network/test_switch.py
@@ -24,7 +24,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.update_coordinator import REQUEST_REFRESH_DEFAULT_COOLDOWN
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from . import configure_integration
 from .mock import MockDevice
@@ -90,7 +90,7 @@ async def test_update_enable_guest_wifi(
     mock_device.device.async_get_wifi_guest_access.return_value = WifiGuestAccessGet(
         enabled=True
     )
-    async_fire_time_changed(hass, dt.utcnow() + SHORT_UPDATE_INTERVAL)
+    async_fire_time_changed(hass, dt_util.utcnow() + SHORT_UPDATE_INTERVAL)
     await hass.async_block_till_done()
 
     state = hass.states.get(state_key)
@@ -115,7 +115,7 @@ async def test_update_enable_guest_wifi(
         turn_off.assert_called_once_with(False)
 
     async_fire_time_changed(
-        hass, dt.utcnow() + timedelta(seconds=REQUEST_REFRESH_DEFAULT_COOLDOWN)
+        hass, dt_util.utcnow() + timedelta(seconds=REQUEST_REFRESH_DEFAULT_COOLDOWN)
     )
     await hass.async_block_till_done()
 
@@ -137,7 +137,7 @@ async def test_update_enable_guest_wifi(
         turn_on.assert_called_once_with(True)
 
     async_fire_time_changed(
-        hass, dt.utcnow() + timedelta(seconds=REQUEST_REFRESH_DEFAULT_COOLDOWN)
+        hass, dt_util.utcnow() + timedelta(seconds=REQUEST_REFRESH_DEFAULT_COOLDOWN)
     )
     await hass.async_block_till_done()
 
@@ -177,7 +177,7 @@ async def test_update_enable_leds(
 
     # Emulate state change
     mock_device.device.async_get_led_setting.return_value = True
-    async_fire_time_changed(hass, dt.utcnow() + SHORT_UPDATE_INTERVAL)
+    async_fire_time_changed(hass, dt_util.utcnow() + SHORT_UPDATE_INTERVAL)
     await hass.async_block_till_done()
 
     state = hass.states.get(state_key)
@@ -200,7 +200,7 @@ async def test_update_enable_leds(
         turn_off.assert_called_once_with(False)
 
     async_fire_time_changed(
-        hass, dt.utcnow() + timedelta(seconds=REQUEST_REFRESH_DEFAULT_COOLDOWN)
+        hass, dt_util.utcnow() + timedelta(seconds=REQUEST_REFRESH_DEFAULT_COOLDOWN)
     )
     await hass.async_block_till_done()
 
@@ -220,7 +220,7 @@ async def test_update_enable_leds(
         turn_on.assert_called_once_with(True)
 
     async_fire_time_changed(
-        hass, dt.utcnow() + timedelta(seconds=REQUEST_REFRESH_DEFAULT_COOLDOWN)
+        hass, dt_util.utcnow() + timedelta(seconds=REQUEST_REFRESH_DEFAULT_COOLDOWN)
     )
     await hass.async_block_till_done()
 
@@ -268,7 +268,7 @@ async def test_device_failure(
 
     api = getattr(mock_device.device, get_method)
     api.side_effect = DeviceUnavailable
-    async_fire_time_changed(hass, dt.utcnow() + update_interval)
+    async_fire_time_changed(hass, dt_util.utcnow() + update_interval)
     await hass.async_block_till_done()
 
     state = hass.states.get(state_key)

--- a/tests/components/dnsip/test_sensor.py
+++ b/tests/components/dnsip/test_sensor.py
@@ -17,7 +17,7 @@ from homeassistant.components.dnsip.const import (
 from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import CONF_NAME, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from . import RetrieveDNS
 
@@ -97,7 +97,7 @@ async def test_sensor_no_response(hass: HomeAssistant) -> None:
     ):
         async_fire_time_changed(
             hass,
-            dt.utcnow() + timedelta(minutes=10),
+            dt_util.utcnow() + timedelta(minutes=10),
         )
         await hass.async_block_till_done()
 


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Datetime related module names are unfortunate, but being consistent with how they're imported helps. About 70% of the cases throughout the tree already imports `homeassistant.util.dt` as `dt_util`, this PR is one in a series that brings the rest in line (to be followed by a ruff config change that will start to enforce this).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
