### PR TITLE
Import `util.dt` as `dt_util` in `components/[e-f]*`

### DIFF
--- a/homeassistant/components/easyenergy/coordinator.py
+++ b/homeassistant/components/easyenergy/coordinator.py
@@ -16,7 +16,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN, LOGGER, SCAN_INTERVAL, THRESHOLD_HOUR
 
@@ -47,7 +47,7 @@ class EasyEnergyDataUpdateCoordinator(DataUpdateCoordinator[EasyEnergyData]):
 
     async def _async_update_data(self) -> EasyEnergyData:
         """Fetch data from easyEnergy."""
-        today = dt.now().date()
+        today = dt_util.now().date()
         gas_today = None
         energy_tomorrow = None
 
@@ -62,7 +62,7 @@ class EasyEnergyDataUpdateCoordinator(DataUpdateCoordinator[EasyEnergyData]):
             except EasyEnergyNoDataError:
                 LOGGER.debug("No data for gas prices for easyEnergy integration")
             # Energy for tomorrow only after 14:00 UTC
-            if dt.utcnow().hour >= THRESHOLD_HOUR:
+            if dt_util.utcnow().hour >= THRESHOLD_HOUR:
                 tomorrow = today + timedelta(days=1)
                 try:
                     energy_tomorrow = await self.easyenergy.energy_prices(

--- a/homeassistant/components/energyzero/coordinator.py
+++ b/homeassistant/components/energyzero/coordinator.py
@@ -16,7 +16,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN, LOGGER, SCAN_INTERVAL, THRESHOLD_HOUR
 
@@ -47,7 +47,7 @@ class EnergyZeroDataUpdateCoordinator(DataUpdateCoordinator[EnergyZeroData]):
 
     async def _async_update_data(self) -> EnergyZeroData:
         """Fetch data from EnergyZero."""
-        today = dt.now().date()
+        today = dt_util.now().date()
         gas_today = None
         energy_tomorrow = None
 
@@ -62,7 +62,7 @@ class EnergyZeroDataUpdateCoordinator(DataUpdateCoordinator[EnergyZeroData]):
             except EnergyZeroNoDataError:
                 LOGGER.debug("No data for gas prices for EnergyZero integration")
             # Energy for tomorrow only after 14:00 UTC
-            if dt.utcnow().hour >= THRESHOLD_HOUR:
+            if dt_util.utcnow().hour >= THRESHOLD_HOUR:
                 tomorrow = today + timedelta(days=1)
                 try:
                     energy_tomorrow = await self.energyzero.energy_prices(

--- a/homeassistant/components/environment_canada/weather.py
+++ b/homeassistant/components/environment_canada/weather.py
@@ -33,7 +33,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from . import device_info
 from .const import DOMAIN
@@ -169,7 +169,7 @@ def get_forecast(ec_data, hourly):
             return None
 
         today = {
-            ATTR_FORECAST_TIME: dt.now().isoformat(),
+            ATTR_FORECAST_TIME: dt_util.now().isoformat(),
             ATTR_FORECAST_CONDITION: icon_code_to_condition(
                 int(half_days[0]["icon_code"])
             ),
@@ -201,7 +201,7 @@ def get_forecast(ec_data, hourly):
             forecast_array.append(
                 {
                     ATTR_FORECAST_TIME: (
-                        dt.now() + datetime.timedelta(days=day)
+                        dt_util.now() + datetime.timedelta(days=day)
                     ).isoformat(),
                     ATTR_FORECAST_NATIVE_TEMP: int(half_days[high]["temperature"]),
                     ATTR_FORECAST_NATIVE_TEMP_LOW: int(half_days[low]["temperature"]),

--- a/homeassistant/components/esphome/sensor.py
+++ b/homeassistant/components/esphome/sensor.py
@@ -21,7 +21,7 @@ from homeassistant.components.sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 from homeassistant.util.enum import try_parse_enum
 
 from . import EsphomeEntity, esphome_state_property, platform_async_setup_entry
@@ -81,7 +81,7 @@ class EsphomeSensor(EsphomeEntity[SensorInfo, SensorState], SensorEntity):
         if self._state.missing_state:
             return None
         if self.device_class == SensorDeviceClass.TIMESTAMP:
-            return dt.utc_from_timestamp(self._state.state)
+            return dt_util.utc_from_timestamp(self._state.state)
         return f"{self._state.state:.{self._static_info.accuracy_decimals}f}"
 
     @property

--- a/tests/components/flo/test_device.py
+++ b/tests/components/flo/test_device.py
@@ -11,7 +11,7 @@ from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import UpdateFailed
 from homeassistant.setup import async_setup_component
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from .common import TEST_PASSWORD, TEST_USER_ID
 
@@ -83,7 +83,7 @@ async def test_device(
 
     call_count = aioclient_mock.call_count
 
-    async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=90))
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=90))
     await hass.async_block_till_done()
 
     assert aioclient_mock.call_count == call_count + 6

--- a/tests/components/fronius/__init__.py
+++ b/tests/components/fronius/__init__.py
@@ -6,7 +6,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from tests.common import MockConfigEntry, async_fire_time_changed, load_fixture
 from tests.test_util.aiohttp import AiohttpClientMocker
@@ -96,5 +96,5 @@ async def enable_all_entities(hass, config_entry_id, time_till_next_update):
     ]:
         registry.async_update_entity(entry.entity_id, **{"disabled_by": None})
     await hass.async_block_till_done()
-    async_fire_time_changed(hass, dt.utcnow() + time_till_next_update)
+    async_fire_time_changed(hass, dt_util.utcnow() + time_till_next_update)
     await hass.async_block_till_done()

--- a/tests/components/fronius/test_coordinator.py
+++ b/tests/components/fronius/test_coordinator.py
@@ -7,7 +7,7 @@ from homeassistant.components.fronius.coordinator import (
     FroniusInverterUpdateCoordinator,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from . import mock_responses, setup_fronius_integration
 
@@ -26,7 +26,7 @@ async def test_adaptive_update_interval(
         mock_inverter_data.reset_mock()
 
         async_fire_time_changed(
-            hass, dt.utcnow() + FroniusInverterUpdateCoordinator.default_interval
+            hass, dt_util.utcnow() + FroniusInverterUpdateCoordinator.default_interval
         )
         await hass.async_block_till_done()
         mock_inverter_data.assert_called_once()
@@ -36,14 +36,15 @@ async def test_adaptive_update_interval(
         # first 3 bad requests at default interval - 4th has different interval
         for _ in range(3):
             async_fire_time_changed(
-                hass, dt.utcnow() + FroniusInverterUpdateCoordinator.default_interval
+                hass,
+                dt_util.utcnow() + FroniusInverterUpdateCoordinator.default_interval,
             )
             await hass.async_block_till_done()
         assert mock_inverter_data.call_count == 3
         mock_inverter_data.reset_mock()
 
         async_fire_time_changed(
-            hass, dt.utcnow() + FroniusInverterUpdateCoordinator.error_interval
+            hass, dt_util.utcnow() + FroniusInverterUpdateCoordinator.error_interval
         )
         await hass.async_block_till_done()
         assert mock_inverter_data.call_count == 1
@@ -52,14 +53,14 @@ async def test_adaptive_update_interval(
         mock_inverter_data.side_effect = None
         # next successful request resets to default interval
         async_fire_time_changed(
-            hass, dt.utcnow() + FroniusInverterUpdateCoordinator.error_interval
+            hass, dt_util.utcnow() + FroniusInverterUpdateCoordinator.error_interval
         )
         await hass.async_block_till_done()
         mock_inverter_data.assert_called_once()
         mock_inverter_data.reset_mock()
 
         async_fire_time_changed(
-            hass, dt.utcnow() + FroniusInverterUpdateCoordinator.default_interval
+            hass, dt_util.utcnow() + FroniusInverterUpdateCoordinator.default_interval
         )
         await hass.async_block_till_done()
         mock_inverter_data.assert_called_once()
@@ -70,7 +71,8 @@ async def test_adaptive_update_interval(
         # first 3 requests at default interval - 4th has different interval
         for _ in range(3):
             async_fire_time_changed(
-                hass, dt.utcnow() + FroniusInverterUpdateCoordinator.default_interval
+                hass,
+                dt_util.utcnow() + FroniusInverterUpdateCoordinator.default_interval,
             )
             await hass.async_block_till_done()
         # BadStatusError does 3 silent retries for inverter endpoint * 3 request intervals = 9

--- a/tests/components/fronius/test_sensor.py
+++ b/tests/components/fronius/test_sensor.py
@@ -8,7 +8,7 @@ from homeassistant.components.fronius.coordinator import (
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from . import enable_all_entities, mock_responses, setup_fronius_integration
 
@@ -43,7 +43,7 @@ async def test_symo_inverter(
     # Second test at daytime when inverter is producing
     mock_responses(aioclient_mock, night=False)
     async_fire_time_changed(
-        hass, dt.utcnow() + FroniusInverterUpdateCoordinator.default_interval
+        hass, dt_util.utcnow() + FroniusInverterUpdateCoordinator.default_interval
     )
     await hass.async_block_till_done()
     assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 56
@@ -65,7 +65,7 @@ async def test_symo_inverter(
     # Third test at nighttime - additional AC entities default to 0
     mock_responses(aioclient_mock, night=True)
     async_fire_time_changed(
-        hass, dt.utcnow() + FroniusInverterUpdateCoordinator.default_interval
+        hass, dt_util.utcnow() + FroniusInverterUpdateCoordinator.default_interval
     )
     await hass.async_block_till_done()
     assert_state("sensor.symo_20_ac_current", 0)
@@ -150,7 +150,7 @@ async def test_symo_power_flow(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test Fronius Symo power flow entities."""
-    async_fire_time_changed(hass, dt.utcnow())
+    async_fire_time_changed(hass, dt_util.utcnow())
 
     def assert_state(entity_id, expected_state):
         state = hass.states.get(entity_id)
@@ -176,7 +176,7 @@ async def test_symo_power_flow(
     # Second test at daytime when inverter is producing
     mock_responses(aioclient_mock, night=False)
     async_fire_time_changed(
-        hass, dt.utcnow() + FroniusPowerFlowUpdateCoordinator.default_interval
+        hass, dt_util.utcnow() + FroniusPowerFlowUpdateCoordinator.default_interval
     )
     await hass.async_block_till_done()
     # 54 because power_flow `rel_SelfConsumption` and `P_PV` is not `null` anymore
@@ -193,7 +193,7 @@ async def test_symo_power_flow(
     # Third test at nighttime - default values are used
     mock_responses(aioclient_mock, night=True)
     async_fire_time_changed(
-        hass, dt.utcnow() + FroniusPowerFlowUpdateCoordinator.default_interval
+        hass, dt_util.utcnow() + FroniusPowerFlowUpdateCoordinator.default_interval
     )
     await hass.async_block_till_done()
     assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 54

--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -21,7 +21,7 @@ from homeassistant.components.websocket_api.const import TYPE_RESULT
 from homeassistant.core import HomeAssistant
 from homeassistant.loader import async_get_integration
 from homeassistant.setup import async_setup_component
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from tests.common import MockUser, async_capture_events, async_fire_time_changed
 from tests.typing import WebSocketGenerator
@@ -228,7 +228,7 @@ async def test_themes_save_storage(
     )
 
     # To trigger the call_later
-    async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=60))
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=60))
     # To execute the save
     await hass.async_block_till_done()
 

--- a/tests/components/fully_kiosk/test_binary_sensor.py
+++ b/tests/components/fully_kiosk/test_binary_sensor.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
@@ -76,7 +76,7 @@ async def test_binary_sensors(
 
     # Test unknown/missing data
     mock_fully_kiosk.getDeviceInfo.return_value = {}
-    async_fire_time_changed(hass, dt.utcnow() + UPDATE_INTERVAL)
+    async_fire_time_changed(hass, dt_util.utcnow() + UPDATE_INTERVAL)
     await hass.async_block_till_done()
 
     state = hass.states.get("binary_sensor.amazon_fire_plugged_in")
@@ -85,7 +85,7 @@ async def test_binary_sensors(
 
     # Test failed update
     mock_fully_kiosk.getDeviceInfo.side_effect = FullyKioskError("error", "status")
-    async_fire_time_changed(hass, dt.utcnow() + UPDATE_INTERVAL)
+    async_fire_time_changed(hass, dt_util.utcnow() + UPDATE_INTERVAL)
     await hass.async_block_till_done()
 
     state = hass.states.get("binary_sensor.amazon_fire_plugged_in")

--- a/tests/components/fully_kiosk/test_number.py
+++ b/tests/components/fully_kiosk/test_number.py
@@ -6,7 +6,7 @@ import homeassistant.components.number as number
 from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
@@ -52,7 +52,7 @@ async def test_numbers(
 
     # Test invalid numeric data
     mock_fully_kiosk.getSettings.return_value = {"screenBrightness": "invalid"}
-    async_fire_time_changed(hass, dt.utcnow() + UPDATE_INTERVAL)
+    async_fire_time_changed(hass, dt_util.utcnow() + UPDATE_INTERVAL)
     await hass.async_block_till_done()
 
     state = hass.states.get("number.amazon_fire_screen_brightness")
@@ -61,7 +61,7 @@ async def test_numbers(
 
     # Test unknown/missing data
     mock_fully_kiosk.getSettings.return_value = {}
-    async_fire_time_changed(hass, dt.utcnow() + UPDATE_INTERVAL)
+    async_fire_time_changed(hass, dt_util.utcnow() + UPDATE_INTERVAL)
     await hass.async_block_till_done()
 
     state = hass.states.get("number.amazon_fire_screensaver_timer")

--- a/tests/components/fully_kiosk/test_sensor.py
+++ b/tests/components/fully_kiosk/test_sensor.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
@@ -141,7 +141,7 @@ async def test_sensors_sensors(
 
     # Test unknown/missing data
     mock_fully_kiosk.getDeviceInfo.return_value = {}
-    async_fire_time_changed(hass, dt.utcnow() + UPDATE_INTERVAL)
+    async_fire_time_changed(hass, dt_util.utcnow() + UPDATE_INTERVAL)
     await hass.async_block_till_done()
 
     state = hass.states.get("sensor.amazon_fire_internal_storage_free_space")
@@ -150,7 +150,7 @@ async def test_sensors_sensors(
 
     # Test failed update
     mock_fully_kiosk.getDeviceInfo.side_effect = FullyKioskError("error", "status")
-    async_fire_time_changed(hass, dt.utcnow() + UPDATE_INTERVAL)
+    async_fire_time_changed(hass, dt_util.utcnow() + UPDATE_INTERVAL)
     await hass.async_block_till_done()
 
     state = hass.states.get("sensor.amazon_fire_internal_storage_free_space")
@@ -176,7 +176,7 @@ async def test_url_sensor_truncating(
     mock_fully_kiosk.getDeviceInfo.return_value = {
         "currentPage": long_url,
     }
-    async_fire_time_changed(hass, dt.utcnow() + UPDATE_INTERVAL)
+    async_fire_time_changed(hass, dt_util.utcnow() + UPDATE_INTERVAL)
     await hass.async_block_till_done()
 
     state = hass.states.get("sensor.amazon_fire_current_page")


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Datetime related module names are unfortunate, but being consistent with how they're imported helps. About 70% of the cases throughout the tree already imports `homeassistant.util.dt` as `dt_util`, this PR is one in a series that brings the rest in line (to be followed by a ruff config change that will start to enforce this).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
