### PR TITLE
Import `util.dt` as `dt_util` in `components/[g-i]*`

### DIFF
--- a/homeassistant/components/gdacs/sensor.py
+++ b/homeassistant/components/gdacs/sensor.py
@@ -8,7 +8,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from .const import DEFAULT_ICON, DOMAIN, FEED
 
@@ -93,10 +93,12 @@ class GdacsSensor(SensorEntity):
         """Update the internal state from the provided information."""
         self._status = status_info.status
         self._last_update = (
-            dt.as_utc(status_info.last_update) if status_info.last_update else None
+            dt_util.as_utc(status_info.last_update) if status_info.last_update else None
         )
         if status_info.last_update_successful:
-            self._last_update_successful = dt.as_utc(status_info.last_update_successful)
+            self._last_update_successful = dt_util.as_utc(
+                status_info.last_update_successful
+            )
         else:
             self._last_update_successful = None
         self._last_timestamp = status_info.last_timestamp

--- a/homeassistant/components/geonetnz_quakes/sensor.py
+++ b/homeassistant/components/geonetnz_quakes/sensor.py
@@ -8,7 +8,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN, FEED
 
@@ -94,10 +94,12 @@ class GeonetnzQuakesSensor(SensorEntity):
         """Update the internal state from the provided information."""
         self._status = status_info.status
         self._last_update = (
-            dt.as_utc(status_info.last_update) if status_info.last_update else None
+            dt_util.as_utc(status_info.last_update) if status_info.last_update else None
         )
         if status_info.last_update_successful:
-            self._last_update_successful = dt.as_utc(status_info.last_update_successful)
+            self._last_update_successful = dt_util.as_utc(
+                status_info.last_update_successful
+            )
         else:
             self._last_update_successful = None
         self._last_timestamp = status_info.last_timestamp

--- a/homeassistant/components/geonetnz_volcano/sensor.py
+++ b/homeassistant/components/geonetnz_volcano/sensor.py
@@ -9,7 +9,7 @@ from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE, UnitOfLength
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 from homeassistant.util.unit_conversion import DistanceConverter
 
 from .const import (
@@ -124,9 +124,9 @@ class GeonetnzVolcanoSensor(SensorEntity):
         self._alert_level = feed_entry.alert_level
         self._activity = feed_entry.activity
         self._hazards = feed_entry.hazards
-        self._feed_last_update = dt.as_utc(last_update) if last_update else None
+        self._feed_last_update = dt_util.as_utc(last_update) if last_update else None
         self._feed_last_update_successful = (
-            dt.as_utc(last_update_successful) if last_update_successful else None
+            dt_util.as_utc(last_update_successful) if last_update_successful else None
         )
 
     @property

--- a/homeassistant/components/google/api.py
+++ b/homeassistant/components/google/api.py
@@ -24,7 +24,7 @@ from homeassistant.helpers.event import (
     async_track_point_in_utc_time,
     async_track_time_interval,
 )
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from .const import (
     CONF_CALENDAR_ACCESS,
@@ -51,7 +51,9 @@ class DeviceAuth(AuthImplementation):
     async def async_resolve_external_data(self, external_data: Any) -> dict:
         """Resolve a Google API Credentials object to Home Assistant token."""
         creds: Credentials = external_data[DEVICE_AUTH_CREDS]
-        delta = creds.token_expiry.replace(tzinfo=datetime.timezone.utc) - dt.utcnow()
+        delta = (
+            creds.token_expiry.replace(tzinfo=datetime.timezone.utc) - dt_util.utcnow()
+        )
         _LOGGER.debug(
             "Token expires at %s (in %s)", creds.token_expiry, delta.total_seconds()
         )
@@ -108,7 +110,9 @@ class DeviceFlow:
     def async_start_exchange(self) -> None:
         """Start the device auth exchange flow polling."""
         _LOGGER.debug("Starting exchange flow")
-        max_timeout = dt.utcnow() + datetime.timedelta(seconds=EXCHANGE_TIMEOUT_SECONDS)
+        max_timeout = dt_util.utcnow() + datetime.timedelta(
+            seconds=EXCHANGE_TIMEOUT_SECONDS
+        )
         # For some reason, oauth.step1_get_device_and_user_codes() returns a datetime
         # object without tzinfo. For the comparison below to work, it needs one.
         user_code_expiry = self._device_flow_info.user_code_expiry.replace(

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -68,7 +68,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import DOMAIN as HA_DOMAIN
 from homeassistant.helpers.network import get_url
-from homeassistant.util import color as color_util, dt
+from homeassistant.util import color as color_util, dt as dt_util
 from homeassistant.util.percentage import (
     ordered_list_item_to_percentage,
     percentage_to_ordered_list_item,
@@ -2218,7 +2218,7 @@ class TransportControlTrait(_Trait):
             rel_position = params["relativePositionMs"] / 1000
             seconds_since = 0  # Default to 0 seconds
             if self.state.state == STATE_PLAYING:
-                now = dt.utcnow()
+                now = dt_util.utcnow()
                 upd_at = self.state.attributes.get(
                     media_player.ATTR_MEDIA_POSITION_UPDATED_AT, now
                 )

--- a/homeassistant/components/google_wifi/sensor.py
+++ b/homeassistant/components/google_wifi/sensor.py
@@ -23,7 +23,7 @@ from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
-from homeassistant.util import Throttle, dt
+from homeassistant.util import Throttle, dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -212,7 +212,7 @@ class GoogleWifiAPI:
                     elif attr_key == ATTR_UPTIME:
                         sensor_value = round(sensor_value / (3600 * 24), 2)
                     elif attr_key == ATTR_LAST_RESTART:
-                        last_restart = dt.now() - timedelta(seconds=sensor_value)
+                        last_restart = dt_util.now() - timedelta(seconds=sensor_value)
                         sensor_value = last_restart.strftime("%Y-%m-%d %H:%M:%S")
                     elif attr_key == ATTR_STATUS:
                         if sensor_value:

--- a/homeassistant/components/growatt_server/sensor.py
+++ b/homeassistant/components/growatt_server/sensor.py
@@ -13,7 +13,7 @@ from homeassistant.const import CONF_NAME, CONF_PASSWORD, CONF_URL, CONF_USERNAM
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.util import Throttle, dt
+from homeassistant.util import Throttle, dt as dt_util
 
 from .const import (
     CONF_PLANT_ID,
@@ -234,10 +234,10 @@ class GrowattData:
                 sorted_keys = sorted(mix_chart_entries)
 
                 # Create datetime from the latest entry
-                date_now = dt.now().date()
-                last_updated_time = dt.parse_time(str(sorted_keys[-1]))
+                date_now = dt_util.now().date()
+                last_updated_time = dt_util.parse_time(str(sorted_keys[-1]))
                 mix_detail["lastdataupdate"] = datetime.datetime.combine(
-                    date_now, last_updated_time, dt.DEFAULT_TIME_ZONE
+                    date_now, last_updated_time, dt_util.DEFAULT_TIME_ZONE
                 )
 
                 # Dashboard data is largely inaccurate for mix system but it is the only

--- a/homeassistant/components/here_travel_time/__init__.py
+++ b/homeassistant/components/here_travel_time/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_API_KEY, CONF_MODE, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from .const import (
     CONF_ARRIVAL_TIME,
@@ -32,8 +32,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     """Set up HERE Travel Time from a config entry."""
     api_key = config_entry.data[CONF_API_KEY]
 
-    arrival = dt.parse_time(config_entry.options.get(CONF_ARRIVAL_TIME, ""))
-    departure = dt.parse_time(config_entry.options.get(CONF_DEPARTURE_TIME, ""))
+    arrival = dt_util.parse_time(config_entry.options.get(CONF_ARRIVAL_TIME, ""))
+    departure = dt_util.parse_time(config_entry.options.get(CONF_DEPARTURE_TIME, ""))
 
     here_travel_time_config = HERETravelTimeConfig(
         destination_latitude=config_entry.data.get(CONF_DESTINATION_LATITUDE),

--- a/homeassistant/components/here_travel_time/coordinator.py
+++ b/homeassistant/components/here_travel_time/coordinator.py
@@ -29,7 +29,7 @@ from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.location import find_coordinates
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 from homeassistant.util.unit_conversion import DistanceConverter
 
 from .const import DEFAULT_SCAN_INTERVAL, DOMAIN, ROUTE_MODE_FASTEST
@@ -336,7 +336,7 @@ def build_hass_attribution(sections: list[dict[str, Any]]) -> str | None:
 
 def next_datetime(simple_time: time) -> datetime:
     """Take a time like 08:00:00 and combine it with the current date."""
-    combined = datetime.combine(dt.start_of_local_day(), simple_time)
+    combined = datetime.combine(dt_util.start_of_local_day(), simple_time)
     if combined < datetime.now():
         combined = combined + timedelta(days=1)
     return combined

--- a/homeassistant/components/hydrawise/sensor.py
+++ b/homeassistant/components/hydrawise/sensor.py
@@ -15,7 +15,7 @@ from homeassistant.core import HomeAssistant, callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN, LOGGER
 from .coordinator import HydrawiseDataUpdateCoordinator
@@ -86,7 +86,7 @@ class HydrawiseSensor(HydrawiseEntity, SensorEntity):
         else:  # _sensor_type == 'next_cycle'
             next_cycle = min(relay_data["time"], TWO_YEAR_SECONDS)
             LOGGER.debug("New cycle time: %s", next_cycle)
-            self._attr_native_value = dt.utc_from_timestamp(
-                dt.as_timestamp(dt.now()) + next_cycle
+            self._attr_native_value = dt_util.utc_from_timestamp(
+                dt_util.as_timestamp(dt_util.now()) + next_cycle
             )
         super()._handle_coordinator_update()

--- a/homeassistant/components/iotawatt/sensor.py
+++ b/homeassistant/components/iotawatt/sensor.py
@@ -28,7 +28,7 @@ from homeassistant.helpers import device_registry as dr, entity, entity_registry
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN, VOLT_AMPERE_REACTIVE, VOLT_AMPERE_REACTIVE_HOURS
 from .coordinator import IotawattUpdater
@@ -203,7 +203,7 @@ class IotaWattSensor(CoordinatorEntity[IotawattUpdater], SensorEntity):
             return
 
         if (begin := self._sensor_data.getBegin()) and (
-            last_reset := dt.parse_datetime(begin)
+            last_reset := dt_util.parse_datetime(begin)
         ):
             self._attr_last_reset = last_reset
 

--- a/tests/components/github/test_sensor.py
+++ b/tests/components/github/test_sensor.py
@@ -5,7 +5,7 @@ import pytest
 
 from homeassistant.components.github.const import DOMAIN, FALLBACK_UPDATE_INTERVAL
 from homeassistant.core import HomeAssistant
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from .common import TEST_REPOSITORY
 
@@ -42,7 +42,7 @@ async def test_sensor_updates_with_empty_release_array(
         headers=headers,
     )
 
-    async_fire_time_changed(hass, dt.utcnow() + FALLBACK_UPDATE_INTERVAL)
+    async_fire_time_changed(hass, dt_util.utcnow() + FALLBACK_UPDATE_INTERVAL)
     await hass.async_block_till_done()
 
     new_state = hass.states.get(TEST_SENSOR_ENTITY)

--- a/tests/components/google_assistant/test_helpers.py
+++ b/tests/components/google_assistant/test_helpers.py
@@ -17,7 +17,7 @@ from homeassistant.components.google_assistant.const import (
 from homeassistant.config import async_process_ha_core_config
 from homeassistant.core import HomeAssistant, State
 from homeassistant.setup import async_setup_component
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from . import MockConfig
 
@@ -128,7 +128,7 @@ async def test_config_local_sdk(
     assert config.is_local_connected is True
     with patch(
         "homeassistant.components.google_assistant.helpers.utcnow",
-        return_value=dt.utcnow() + timedelta(seconds=90),
+        return_value=dt_util.utcnow() + timedelta(seconds=90),
     ):
         assert config.is_local_connected is False
 
@@ -255,7 +255,7 @@ async def test_agent_user_id_storage(
     }
 
     async def _check_after_delay(data):
-        async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=2))
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=2))
         await hass.async_block_till_done()
 
         assert (

--- a/tests/components/hyperion/test_light.py
+++ b/tests/components/hyperion/test_light.py
@@ -44,7 +44,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 import homeassistant.util.color as color_util
 
 from . import (
@@ -1370,7 +1370,7 @@ async def test_lights_can_be_enabled(hass: HomeAssistant) -> None:
 
         async_fire_time_changed(
             hass,
-            dt.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
+            dt_util.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
         )
         await hass.async_block_till_done()
 

--- a/tests/components/hyperion/test_switch.py
+++ b/tests/components/hyperion/test_switch.py
@@ -22,7 +22,7 @@ from homeassistant.config_entries import RELOAD_AFTER_UPDATE_DELAY
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
-from homeassistant.util import dt, slugify
+from homeassistant.util import dt as dt_util, slugify
 
 from . import (
     TEST_CONFIG_ENTRY_ID,
@@ -215,7 +215,7 @@ async def test_switches_can_be_enabled(hass: HomeAssistant) -> None:
 
             async_fire_time_changed(
                 hass,
-                dt.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
+                dt_util.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
             )
             await hass.async_block_till_done()
 

--- a/tests/components/image_upload/test_init.py
+++ b/tests/components/image_upload/test_init.py
@@ -8,7 +8,7 @@ from aiohttp import ClientSession, ClientWebSocketResponse
 from homeassistant.components.websocket_api import const as ws_const
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
-from homeassistant.util import dt as util_dt
+from homeassistant.util import dt as dt_util
 
 from . import TEST_IMAGE
 
@@ -21,7 +21,7 @@ async def test_upload_image(
     hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test we can upload an image."""
-    now = util_dt.utcnow()
+    now = dt_util.utcnow()
 
     with tempfile.TemporaryDirectory() as tempdir, patch.object(
         hass.config, "path", return_value=tempdir


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Datetime related module names are unfortunate, but being consistent with how they're imported helps. About 70% of the cases throughout the tree already imports `homeassistant.util.dt` as `dt_util`, this PR is one in a series that brings the rest in line (to be followed by a ruff config change that will start to enforce this).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
