### PR TITLE
Import `util.dt` as `dt_util` in `components/[k-o]*`

### DIFF
--- a/homeassistant/components/moehlenhoff_alpha2/button.py
+++ b/homeassistant/components/moehlenhoff_alpha2/button.py
@@ -6,7 +6,7 @@ from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from . import Alpha2BaseCoordinator
 from .const import DOMAIN
@@ -38,4 +38,4 @@ class Alpha2TimeSyncButton(CoordinatorEntity[Alpha2BaseCoordinator], ButtonEntit
 
     async def async_press(self) -> None:
         """Synchronize current local time from HA instance to base station."""
-        await self.coordinator.base.set_datetime(dt.now())
+        await self.coordinator.base.set_datetime(dt_util.now())

--- a/homeassistant/components/mqtt_room/sensor.py
+++ b/homeassistant/components/mqtt_room/sensor.py
@@ -23,7 +23,7 @@ from homeassistant.core import HomeAssistant, callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
-from homeassistant.util import dt, slugify
+from homeassistant.util import dt as dt_util, slugify
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -122,7 +122,7 @@ class MQTTRoomSensor(SensorEntity):
             """Update the sensor state."""
             self._state = room
             self._distance = distance
-            self._updated = dt.utcnow()
+            self._updated = dt_util.utcnow()
 
             self.async_write_ha_state()
 
@@ -144,7 +144,7 @@ class MQTTRoomSensor(SensorEntity):
                     # device is in the same room OR
                     # device is closer to another room OR
                     # last update from other room was too long ago
-                    timediff = dt.utcnow() - self._updated
+                    timediff = dt_util.utcnow() - self._updated
                     if (
                         device.get(ATTR_ROOM) == self._state
                         or device.get(ATTR_DISTANCE) < self._distance
@@ -174,7 +174,7 @@ class MQTTRoomSensor(SensorEntity):
         if (
             self._updated
             and self._consider_home
-            and dt.utcnow() - self._updated > self._consider_home
+            and dt_util.utcnow() - self._updated > self._consider_home
         ):
             self._state = STATE_NOT_HOME
 

--- a/homeassistant/components/nobo_hub/climate.py
+++ b/homeassistant/components/nobo_hub/climate.py
@@ -28,7 +28,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from .const import (
     ATTR_SERIAL,
@@ -158,7 +158,7 @@ class NoboZone(ClimateEntity):
     @callback
     def _read_state(self) -> None:
         """Read the current state from the hub. These are only local calls."""
-        state = self._nobo.get_current_zone_mode(self._id, dt.now())
+        state = self._nobo.get_current_zone_mode(self._id, dt_util.now())
         self._attr_hvac_mode = HVACMode.AUTO
         self._attr_preset_mode = PRESET_NONE
 

--- a/homeassistant/components/openweathermap/weather_update_coordinator.py
+++ b/homeassistant/components/openweathermap/weather_update_coordinator.py
@@ -12,7 +12,7 @@ from homeassistant.components.weather import (
 from homeassistant.const import UnitOfTemperature
 from homeassistant.helpers import sun
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 from homeassistant.util.unit_conversion import TemperatureConverter
 
 from .const import (
@@ -159,7 +159,7 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator):
     def _convert_forecast(self, entry):
         """Convert the forecast data."""
         forecast = {
-            ATTR_API_FORECAST_TIME: dt.utc_from_timestamp(
+            ATTR_API_FORECAST_TIME: dt_util.utc_from_timestamp(
                 entry.reference_time("unix")
             ).isoformat(),
             ATTR_API_FORECAST_PRECIPITATION: self._calc_precipitation(
@@ -252,7 +252,7 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator):
         """Get weather condition from weather data."""
         if weather_code == WEATHER_CODE_SUNNY_OR_CLEAR_NIGHT:
             if timestamp:
-                timestamp = dt.utc_from_timestamp(timestamp)
+                timestamp = dt_util.utc_from_timestamp(timestamp)
 
             if sun.is_up(self.hass, timestamp):
                 return ATTR_CONDITION_SUNNY

--- a/tests/components/knx/test_binary_sensor.py
+++ b/tests/components/knx/test_binary_sensor.py
@@ -12,7 +12,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers import entity_registry as er
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from .conftest import KNXTestKit
 
@@ -147,7 +147,7 @@ async def test_binary_sensor_ignore_internal_state(
 
 async def test_binary_sensor_counter(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test KNX binary_sensor with context timeout."""
-    async_fire_time_changed(hass, dt.utcnow())
+    async_fire_time_changed(hass, dt_util.utcnow())
     context_timeout = 1
 
     await knx.setup_integration(
@@ -172,7 +172,7 @@ async def test_binary_sensor_counter(hass: HomeAssistant, knx: KNXTestKit) -> No
     state = hass.states.get("binary_sensor.test")
     assert state.state is STATE_OFF
     assert state.attributes.get("counter") == 0
-    async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=context_timeout))
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=context_timeout))
     await hass.async_block_till_done()
     await knx.xknx.task_registry.block_till_done()
     # state changed twice after context timeout - once to ON with counter 1 and once to counter 0
@@ -196,7 +196,7 @@ async def test_binary_sensor_counter(hass: HomeAssistant, knx: KNXTestKit) -> No
     state = hass.states.get("binary_sensor.test")
     assert state.state is STATE_ON
     assert state.attributes.get("counter") == 0
-    async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=context_timeout))
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=context_timeout))
     await knx.xknx.task_registry.block_till_done()
     await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.test")
@@ -213,7 +213,7 @@ async def test_binary_sensor_counter(hass: HomeAssistant, knx: KNXTestKit) -> No
 
 async def test_binary_sensor_reset(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test KNX binary_sensor with reset_after function."""
-    async_fire_time_changed(hass, dt.utcnow())
+    async_fire_time_changed(hass, dt_util.utcnow())
 
     await knx.setup_integration(
         {
@@ -233,7 +233,7 @@ async def test_binary_sensor_reset(hass: HomeAssistant, knx: KNXTestKit) -> None
     await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.test")
     assert state.state is STATE_ON
-    async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=1))
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=1))
     await hass.async_block_till_done()
     await hass.async_block_till_done()
     # state reset after after timeout

--- a/tests/components/knx/test_button.py
+++ b/tests/components/knx/test_button.py
@@ -13,7 +13,7 @@ from homeassistant.components.knx.const import (
 from homeassistant.components.knx.schema import ButtonSchema
 from homeassistant.const import CONF_NAME, CONF_TYPE
 from homeassistant.core import HomeAssistant
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from .conftest import KNXTestKit
 
@@ -42,7 +42,7 @@ async def test_button_simple(hass: HomeAssistant, knx: KNXTestKit) -> None:
 
     # received telegrams on button GA are ignored by the entity
     old_state = hass.states.get("button.test")
-    async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=3))
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=3))
     await knx.receive_write("1/2/3", False)
     await knx.receive_write("1/2/3", True)
     new_state = hass.states.get("button.test")

--- a/tests/components/knx/test_expose.py
+++ b/tests/components/knx/test_expose.py
@@ -9,7 +9,7 @@ from homeassistant.components.knx import CONF_KNX_EXPOSE, DOMAIN, KNX_ADDRESS
 from homeassistant.components.knx.schema import ExposeSchema
 from homeassistant.const import CONF_ATTRIBUTE, CONF_ENTITY_ID, CONF_TYPE
 from homeassistant.core import HomeAssistant
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from .conftest import KNXTestKit
 
@@ -192,7 +192,9 @@ async def test_expose_cooldown(hass: HomeAssistant, knx: KNXTestKit) -> None:
     hass.states.async_set(entity_id, "3", {})
     await knx.assert_no_telegram()
     # Wait for cooldown to pass
-    async_fire_time_changed_exact(hass, dt.utcnow() + timedelta(seconds=cooldown_time))
+    async_fire_time_changed_exact(
+        hass, dt_util.utcnow() + timedelta(seconds=cooldown_time)
+    )
     await hass.async_block_till_done()
     await knx.assert_write("1/1/8", (3,))
 

--- a/tests/components/knx/test_interface_device.py
+++ b/tests/components/knx/test_interface_device.py
@@ -8,7 +8,7 @@ from homeassistant.components.knx.sensor import SCAN_INTERVAL
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from .conftest import KNXTestKit
 
@@ -47,7 +47,7 @@ async def test_diagnostic_entities(
     knx.xknx.connection_manager.cemi_count_outgoing_error = 2
 
     events = async_capture_events(hass, "state_changed")
-    async_fire_time_changed(hass, dt.utcnow() + SCAN_INTERVAL)
+    async_fire_time_changed(hass, dt_util.utcnow() + SCAN_INTERVAL)
     await hass.async_block_till_done()
 
     assert len(events) == 3  # 5 polled sensors - 2 disabled

--- a/tests/components/knx/test_light.py
+++ b/tests/components/knx/test_light.py
@@ -18,7 +18,7 @@ from homeassistant.components.light import (
 )
 from homeassistant.const import CONF_NAME, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from .conftest import KNXTestKit
 
@@ -764,7 +764,7 @@ async def test_light_rgbw_individual(hass: HomeAssistant, knx: KNXTestKit) -> No
     # # individual color debounce takes 0.2 seconds if not all 4 addresses received
     knx.assert_state("light.test", STATE_ON)
     async_fire_time_changed(
-        hass, dt.utcnow() + timedelta(seconds=XknxLight.DEBOUNCE_TIMEOUT)
+        hass, dt_util.utcnow() + timedelta(seconds=XknxLight.DEBOUNCE_TIMEOUT)
     )
     await knx.xknx.task_registry.block_till_done()
     knx.assert_state("light.test", STATE_OFF)

--- a/tests/components/kostal_plenticore/test_number.py
+++ b/tests/components/kostal_plenticore/test_number.py
@@ -16,7 +16,7 @@ from homeassistant.components.number import (
 from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_registry import async_get
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
@@ -168,7 +168,7 @@ async def test_number_has_value(
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=3))
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=3))
     await hass.async_block_till_done()
 
     state = hass.states.get("number.scb_battery_min_soc")
@@ -191,7 +191,7 @@ async def test_number_is_unavailable(
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=3))
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=3))
     await hass.async_block_till_done()
 
     state = hass.states.get("number.scb_battery_min_soc")
@@ -214,7 +214,7 @@ async def test_set_value(
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=3))
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=3))
     await hass.async_block_till_done()
 
     await hass.services.async_call(

--- a/tests/components/mqtt_room/test_sensor.py
+++ b/tests/components/mqtt_room/test_sensor.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from tests.common import async_fire_mqtt_message
 from tests.typing import MqttMockHAClient
@@ -110,7 +110,7 @@ async def test_room_update(hass: HomeAssistant, mqtt_mock: MqttMockHAClient) -> 
     await assert_state(hass, LIVING_ROOM)
     await assert_distance(hass, 1)
 
-    time = dt.utcnow() + datetime.timedelta(seconds=7)
+    time = dt_util.utcnow() + datetime.timedelta(seconds=7)
     with patch("homeassistant.helpers.condition.dt_util.utcnow", return_value=time):
         await send_message(hass, BEDROOM_TOPIC, FAR_MESSAGE)
         await assert_state(hass, BEDROOM)

--- a/tests/components/nest/test_api.py
+++ b/tests/components/nest/test_api.py
@@ -14,7 +14,7 @@ import pytest
 
 from homeassistant.components.nest.const import API_URL, OAUTH2_TOKEN, SDM_SCOPES
 from homeassistant.core import HomeAssistant
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from .common import CLIENT_ID, CLIENT_SECRET, PROJECT_ID, PlatformSetup
 from .conftest import FAKE_REFRESH_TOKEN, FAKE_TOKEN
@@ -80,7 +80,7 @@ async def test_auth(
     creds = captured_creds
     assert creds.token == FAKE_TOKEN
     assert creds.refresh_token == FAKE_REFRESH_TOKEN
-    assert int(dt.as_timestamp(creds.expiry)) == int(token_expiration_time)
+    assert int(dt_util.as_timestamp(creds.expiry)) == int(token_expiration_time)
     assert creds.valid
     assert not creds.expired
     assert creds.token_uri == OAUTH2_TOKEN
@@ -157,7 +157,7 @@ async def test_auth_expired_token(
     creds = captured_creds
     assert creds.token == FAKE_TOKEN
     assert creds.refresh_token == FAKE_REFRESH_TOKEN
-    assert int(dt.as_timestamp(creds.expiry)) == int(token_expiration_time)
+    assert int(dt_util.as_timestamp(creds.expiry)) == int(token_expiration_time)
     assert not creds.valid
     assert creds.expired
     assert creds.token_uri == OAUTH2_TOKEN

--- a/tests/components/netatmo/test_camera.py
+++ b/tests/components/netatmo/test_camera.py
@@ -17,7 +17,7 @@ from homeassistant.components.netatmo.const import (
 from homeassistant.const import CONF_WEBHOOK_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from .common import fake_post_request, selected_platforms, simulate_webhook
 
@@ -420,7 +420,7 @@ async def test_camera_reconnect_webhook(hass: HomeAssistant, config_entry) -> No
 
         async_fire_time_changed(
             hass,
-            dt.utcnow() + timedelta(seconds=60),
+            dt_util.utcnow() + timedelta(seconds=60),
         )
         await hass.async_block_till_done()
         assert fake_post_hits >= calls

--- a/tests/components/netatmo/test_init.py
+++ b/tests/components/netatmo/test_init.py
@@ -12,7 +12,7 @@ from homeassistant.components.netatmo import DOMAIN
 from homeassistant.const import CONF_WEBHOOK_ID
 from homeassistant.core import CoreState, HomeAssistant
 from homeassistant.setup import async_setup_component
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from .common import (
     FAKE_WEBHOOK_ACTIVATION,
@@ -339,7 +339,7 @@ async def test_setup_component_with_delay(hass: HomeAssistant, config_entry) -> 
 
         async_fire_time_changed(
             hass,
-            dt.utcnow() + timedelta(seconds=60),
+            dt_util.utcnow() + timedelta(seconds=60),
         )
         await hass.async_block_till_done()
 


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Datetime related module names are unfortunate, but being consistent with how they're imported helps. About 70% of the cases throughout the tree already imports `homeassistant.util.dt` as `dt_util`, this PR is one in a series that brings the rest in line (to be followed by a ruff config change that will start to enforce this).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
