### PR TITLE
Import `util.dt` as `dt_util` in `components/[p-s]*`

### DIFF
--- a/tests/components/picnic/test_sensor.py
+++ b/tests/components/picnic/test_sensor.py
@@ -19,7 +19,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
 )
 from homeassistant.helpers import device_registry as dr, entity_registry as er
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from tests.common import (
     MockConfigEntry,
@@ -177,7 +177,7 @@ class TestPicnicSensor(unittest.IsolatedAsyncioTestCase):
         # Trigger a reload of the data
         async_fire_time_changed(
             self.hass,
-            dt.utcnow()
+            dt_util.utcnow()
             + timedelta(seconds=config_entries.RELOAD_AFTER_UPDATE_DELAY + 1),
         )
         await self.hass.async_block_till_done()

--- a/tests/components/pjlink/test_media_player.py
+++ b/tests/components/pjlink/test_media_player.py
@@ -12,7 +12,7 @@ import homeassistant.components.media_player as media_player
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from tests.common import assert_setup_component, async_fire_time_changed
 
@@ -206,7 +206,7 @@ async def test_update_unavailable(projector_from_address, hass: HomeAssistant) -
         assert state.state == "off"
 
         projector_from_address.side_effect = socket.timeout
-        async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=10))
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=10))
         await hass.async_block_till_done()
 
         state = hass.states.get("media_player.test")
@@ -235,7 +235,7 @@ async def test_unavailable_time(mocked_projector, hass: HomeAssistant) -> None:
     assert state.attributes["is_volume_muted"] is not False
 
     mocked_projector.get_power.side_effect = ProjectorError("unavailable time")
-    async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=10))
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=10))
     await hass.async_block_till_done()
 
     state = hass.states.get("media_player.test")

--- a/tests/components/plex/test_button.py
+++ b/tests/components/plex/test_button.py
@@ -6,7 +6,7 @@ from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRE
 from homeassistant.components.plex.const import DEBOUNCE_TIMEOUT
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from tests.common import async_fire_time_changed
 
@@ -23,7 +23,7 @@ async def test_scan_clients_button_schedule(
 
         async_fire_time_changed(
             hass,
-            dt.utcnow() + timedelta(seconds=DEBOUNCE_TIMEOUT),
+            dt_util.utcnow() + timedelta(seconds=DEBOUNCE_TIMEOUT),
         )
 
         assert await hass.services.async_call(

--- a/tests/components/plex/test_sensor.py
+++ b/tests/components/plex/test_sensor.py
@@ -13,7 +13,7 @@ from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_send
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from .helpers import trigger_plex_update, wait_for_debouncer
 
@@ -125,7 +125,7 @@ async def test_library_sensor_values(
 
     async_fire_time_changed(
         hass,
-        dt.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
+        dt_util.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
     )
 
     media = [MockPlexTVEpisode()]
@@ -196,7 +196,7 @@ async def test_library_sensor_values(
 
     async_fire_time_changed(
         hass,
-        dt.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
+        dt_util.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
     )
 
     media = [MockPlexMovie()]
@@ -214,7 +214,7 @@ async def test_library_sensor_values(
         async_dispatcher_send(
             hass, PLEX_UPDATE_LIBRARY_SIGNAL.format(mock_plex_server.machine_identifier)
         )
-        async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=3))
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=3))
         await hass.async_block_till_done()
 
     library_movies_sensor = hass.states.get("sensor.plex_server_1_library_movies")
@@ -232,7 +232,7 @@ async def test_library_sensor_values(
 
     async_fire_time_changed(
         hass,
-        dt.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
+        dt_util.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
     )
 
     media = [MockPlexMusic()]

--- a/tests/components/recorder/test_models.py
+++ b/tests/components/recorder/test_models.py
@@ -24,7 +24,7 @@ from homeassistant.const import EVENT_STATE_CHANGED
 import homeassistant.core as ha
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import InvalidEntityFormatError
-from homeassistant.util import dt, dt as dt_util
+from homeassistant.util import dt as dt_util
 
 
 def test_from_event_to_db_event() -> None:
@@ -85,7 +85,7 @@ def test_from_event_to_db_state_attributes() -> None:
 def test_repr() -> None:
     """Test converting event to db state repr."""
     attrs = {"this_attr": True}
-    fixed_time = datetime(2016, 7, 9, 11, 0, 0, tzinfo=dt.UTC, microsecond=432432)
+    fixed_time = datetime(2016, 7, 9, 11, 0, 0, tzinfo=dt_util.UTC, microsecond=432432)
     state = ha.State(
         "sensor.temperature",
         "18",
@@ -105,7 +105,7 @@ def test_repr() -> None:
 
 def test_states_repr_without_timestamp() -> None:
     """Test repr for a state without last_updated_ts."""
-    fixed_time = datetime(2016, 7, 9, 11, 0, 0, tzinfo=dt.UTC, microsecond=432432)
+    fixed_time = datetime(2016, 7, 9, 11, 0, 0, tzinfo=dt_util.UTC, microsecond=432432)
     states = States(
         entity_id="sensor.temp",
         attributes=None,
@@ -123,7 +123,7 @@ def test_states_repr_without_timestamp() -> None:
 
 def test_events_repr_without_timestamp() -> None:
     """Test repr for an event without time_fired_ts."""
-    fixed_time = datetime(2016, 7, 9, 11, 0, 0, tzinfo=dt.UTC, microsecond=432432)
+    fixed_time = datetime(2016, 7, 9, 11, 0, 0, tzinfo=dt_util.UTC, microsecond=432432)
     events = Events(
         event_type="any",
         event_data=None,
@@ -180,7 +180,7 @@ def test_states_from_native_invalid_entity_id() -> None:
 
 async def test_process_timestamp() -> None:
     """Test processing time stamp to UTC."""
-    datetime_with_tzinfo = datetime(2016, 7, 9, 11, 0, 0, tzinfo=dt.UTC)
+    datetime_with_tzinfo = datetime(2016, 7, 9, 11, 0, 0, tzinfo=dt_util.UTC)
     datetime_without_tzinfo = datetime(2016, 7, 9, 11, 0, 0)
     est = dt_util.get_time_zone("US/Eastern")
     datetime_est_timezone = datetime(2016, 7, 9, 11, 0, 0, tzinfo=est)
@@ -190,26 +190,26 @@ async def test_process_timestamp() -> None:
     datetime_hst_timezone = datetime(2016, 7, 9, 11, 0, 0, tzinfo=hst)
 
     assert process_timestamp(datetime_with_tzinfo) == datetime(
-        2016, 7, 9, 11, 0, 0, tzinfo=dt.UTC
+        2016, 7, 9, 11, 0, 0, tzinfo=dt_util.UTC
     )
     assert process_timestamp(datetime_without_tzinfo) == datetime(
-        2016, 7, 9, 11, 0, 0, tzinfo=dt.UTC
+        2016, 7, 9, 11, 0, 0, tzinfo=dt_util.UTC
     )
     assert process_timestamp(datetime_est_timezone) == datetime(
-        2016, 7, 9, 15, 0, tzinfo=dt.UTC
+        2016, 7, 9, 15, 0, tzinfo=dt_util.UTC
     )
     assert process_timestamp(datetime_nst_timezone) == datetime(
-        2016, 7, 9, 13, 30, tzinfo=dt.UTC
+        2016, 7, 9, 13, 30, tzinfo=dt_util.UTC
     )
     assert process_timestamp(datetime_hst_timezone) == datetime(
-        2016, 7, 9, 21, 0, tzinfo=dt.UTC
+        2016, 7, 9, 21, 0, tzinfo=dt_util.UTC
     )
     assert process_timestamp(None) is None
 
 
 async def test_process_timestamp_to_utc_isoformat() -> None:
     """Test processing time stamp to UTC isoformat."""
-    datetime_with_tzinfo = datetime(2016, 7, 9, 11, 0, 0, tzinfo=dt.UTC)
+    datetime_with_tzinfo = datetime(2016, 7, 9, 11, 0, 0, tzinfo=dt_util.UTC)
     datetime_without_tzinfo = datetime(2016, 7, 9, 11, 0, 0)
     est = dt_util.get_time_zone("US/Eastern")
     datetime_est_timezone = datetime(2016, 7, 9, 11, 0, 0, tzinfo=est)
@@ -409,7 +409,7 @@ async def test_process_datetime_to_timestamp_mirrors_utc_isoformat_behavior(
 ) -> None:
     """Test process_datetime_to_timestamp mirrors process_timestamp_to_utc_isoformat."""
     hass.config.set_time_zone(time_zone)
-    datetime_with_tzinfo = datetime(2016, 7, 9, 11, 0, 0, tzinfo=dt.UTC)
+    datetime_with_tzinfo = datetime(2016, 7, 9, 11, 0, 0, tzinfo=dt_util.UTC)
     datetime_without_tzinfo = datetime(2016, 7, 9, 11, 0, 0)
     est = dt_util.get_time_zone("US/Eastern")
     datetime_est_timezone = datetime(2016, 7, 9, 11, 0, 0, tzinfo=est)

--- a/tests/components/risco/test_sensor.py
+++ b/tests/components/risco/test_sensor.py
@@ -11,7 +11,7 @@ from homeassistant.components.risco import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from tests.common import async_fire_time_changed
 
@@ -137,7 +137,7 @@ def _check_state(hass, category, entity_id):
     event_index = CATEGORIES_TO_EVENTS[category]
     event = TEST_EVENTS[event_index]
     state = hass.states.get(entity_id)
-    assert state.state == dt.parse_datetime(event.time).isoformat()
+    assert state.state == dt_util.parse_datetime(event.time).isoformat()
     assert state.attributes["category_id"] == event.category_id
     assert state.attributes["category_name"] == event.category_name
     assert state.attributes["type_id"] == event.type_id
@@ -192,7 +192,7 @@ async def test_cloud_setup(
         "homeassistant.components.risco.Store.async_load",
         return_value={LAST_EVENT_TIMESTAMP_KEY: TEST_EVENTS[0].time},
     ):
-        async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=65))
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=65))
         await hass.async_block_till_done()
         events_mock.assert_awaited_once_with(TEST_EVENTS[0].time, 10)
 

--- a/tests/components/sensibo/test_binary_sensor.py
+++ b/tests/components/sensibo/test_binary_sensor.py
@@ -9,7 +9,7 @@ import pytest
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from tests.common import async_fire_time_changed
 
@@ -53,7 +53,7 @@ async def test_binary_sensor(
     ):
         async_fire_time_changed(
             hass,
-            dt.utcnow() + timedelta(minutes=5),
+            dt_util.utcnow() + timedelta(minutes=5),
         )
         await hass.async_block_till_done()
 

--- a/tests/components/sensibo/test_button.py
+++ b/tests/components/sensibo/test_button.py
@@ -13,7 +13,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from tests.common import async_fire_time_changed
 
@@ -35,7 +35,9 @@ async def test_button(
     assert state_filter_clean.state is STATE_ON
     assert state_filter_last_reset.state == "2022-03-12T15:24:26+00:00"
 
-    today = datetime(datetime.now().year + 1, 6, 19, 20, 0, 0).replace(tzinfo=dt.UTC)
+    today = datetime(datetime.now().year + 1, 6, 19, 20, 0, 0).replace(
+        tzinfo=dt_util.UTC
+    )
     today_str = today.isoformat()
     freezer.move_to(today)
 
@@ -69,7 +71,7 @@ async def test_button(
     ):
         async_fire_time_changed(
             hass,
-            dt.utcnow() + timedelta(minutes=5),
+            dt_util.utcnow() + timedelta(minutes=5),
         )
         await hass.async_block_till_done()
 

--- a/tests/components/sensibo/test_climate.py
+++ b/tests/components/sensibo/test_climate.py
@@ -55,7 +55,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from tests.common import async_fire_time_changed
 
@@ -162,7 +162,7 @@ async def test_climate_fan(
     ):
         async_fire_time_changed(
             hass,
-            dt.utcnow() + timedelta(minutes=5),
+            dt_util.utcnow() + timedelta(minutes=5),
         )
         await hass.async_block_till_done()
 
@@ -228,7 +228,7 @@ async def test_climate_swing(
     ):
         async_fire_time_changed(
             hass,
-            dt.utcnow() + timedelta(minutes=5),
+            dt_util.utcnow() + timedelta(minutes=5),
         )
         await hass.async_block_till_done()
 
@@ -381,7 +381,7 @@ async def test_climate_temperatures(
     ):
         async_fire_time_changed(
             hass,
-            dt.utcnow() + timedelta(minutes=5),
+            dt_util.utcnow() + timedelta(minutes=5),
         )
         await hass.async_block_till_done()
 
@@ -434,7 +434,7 @@ async def test_climate_temperature_is_none(
     ):
         async_fire_time_changed(
             hass,
-            dt.utcnow() + timedelta(minutes=5),
+            dt_util.utcnow() + timedelta(minutes=5),
         )
         await hass.async_block_till_done()
 
@@ -488,7 +488,7 @@ async def test_climate_hvac_mode(
     ):
         async_fire_time_changed(
             hass,
-            dt.utcnow() + timedelta(minutes=5),
+            dt_util.utcnow() + timedelta(minutes=5),
         )
         await hass.async_block_till_done()
 
@@ -520,7 +520,7 @@ async def test_climate_hvac_mode(
     ):
         async_fire_time_changed(
             hass,
-            dt.utcnow() + timedelta(minutes=5),
+            dt_util.utcnow() + timedelta(minutes=5),
         )
         await hass.async_block_till_done()
 
@@ -559,7 +559,7 @@ async def test_climate_on_off(
     ):
         async_fire_time_changed(
             hass,
-            dt.utcnow() + timedelta(minutes=5),
+            dt_util.utcnow() + timedelta(minutes=5),
         )
         await hass.async_block_till_done()
 
@@ -619,7 +619,7 @@ async def test_climate_service_failed(
     ):
         async_fire_time_changed(
             hass,
-            dt.utcnow() + timedelta(minutes=5),
+            dt_util.utcnow() + timedelta(minutes=5),
         )
         await hass.async_block_till_done()
 
@@ -658,7 +658,7 @@ async def test_climate_assumed_state(
     ):
         async_fire_time_changed(
             hass,
-            dt.utcnow() + timedelta(minutes=5),
+            dt_util.utcnow() + timedelta(minutes=5),
         )
         await hass.async_block_till_done()
 
@@ -707,7 +707,7 @@ async def test_climate_no_fan_no_swing(
     ):
         async_fire_time_changed(
             hass,
-            dt.utcnow() + timedelta(minutes=5),
+            dt_util.utcnow() + timedelta(minutes=5),
         )
         await hass.async_block_till_done()
 
@@ -733,7 +733,7 @@ async def test_climate_set_timer(
     ):
         async_fire_time_changed(
             hass,
-            dt.utcnow() + timedelta(minutes=5),
+            dt_util.utcnow() + timedelta(minutes=5),
         )
         await hass.async_block_till_done()
 
@@ -803,7 +803,7 @@ async def test_climate_set_timer(
     monkeypatch.setattr(
         get_data.parsed["ABC999111"],
         "timer_time",
-        datetime(2022, 6, 6, 12, 00, 00, tzinfo=dt.UTC),
+        datetime(2022, 6, 6, 12, 00, 00, tzinfo=dt_util.UTC),
     )
 
     with patch(
@@ -812,7 +812,7 @@ async def test_climate_set_timer(
     ):
         async_fire_time_changed(
             hass,
-            dt.utcnow() + timedelta(minutes=5),
+            dt_util.utcnow() + timedelta(minutes=5),
         )
         await hass.async_block_till_done()
 
@@ -837,7 +837,7 @@ async def test_climate_pure_boost(
     ):
         async_fire_time_changed(
             hass,
-            dt.utcnow() + timedelta(minutes=5),
+            dt_util.utcnow() + timedelta(minutes=5),
         )
         await hass.async_block_till_done()
 
@@ -908,7 +908,7 @@ async def test_climate_pure_boost(
     ):
         async_fire_time_changed(
             hass,
-            dt.utcnow() + timedelta(minutes=5),
+            dt_util.utcnow() + timedelta(minutes=5),
         )
         await hass.async_block_till_done()
 
@@ -941,7 +941,7 @@ async def test_climate_climate_react(
     ):
         async_fire_time_changed(
             hass,
-            dt.utcnow() + timedelta(minutes=5),
+            dt_util.utcnow() + timedelta(minutes=5),
         )
         await hass.async_block_till_done()
 
@@ -1075,7 +1075,7 @@ async def test_climate_climate_react(
     ):
         async_fire_time_changed(
             hass,
-            dt.utcnow() + timedelta(minutes=5),
+            dt_util.utcnow() + timedelta(minutes=5),
         )
         await hass.async_block_till_done()
 
@@ -1104,7 +1104,7 @@ async def test_climate_climate_react_fahrenheit(
     ):
         async_fire_time_changed(
             hass,
-            dt.utcnow() + timedelta(minutes=5),
+            dt_util.utcnow() + timedelta(minutes=5),
         )
         await hass.async_block_till_done()
 
@@ -1218,7 +1218,7 @@ async def test_climate_climate_react_fahrenheit(
     ):
         async_fire_time_changed(
             hass,
-            dt.utcnow() + timedelta(minutes=5),
+            dt_util.utcnow() + timedelta(minutes=5),
         )
         await hass.async_block_till_done()
 
@@ -1247,7 +1247,7 @@ async def test_climate_full_ac_state(
     ):
         async_fire_time_changed(
             hass,
-            dt.utcnow() + timedelta(minutes=5),
+            dt_util.utcnow() + timedelta(minutes=5),
         )
         await hass.async_block_till_done()
 
@@ -1311,7 +1311,7 @@ async def test_climate_full_ac_state(
     ):
         async_fire_time_changed(
             hass,
-            dt.utcnow() + timedelta(minutes=5),
+            dt_util.utcnow() + timedelta(minutes=5),
         )
         await hass.async_block_till_done()
 

--- a/tests/components/sensibo/test_coordinator.py
+++ b/tests/components/sensibo/test_coordinator.py
@@ -12,7 +12,7 @@ from homeassistant.components.sensibo.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from . import ENTRY_CONFIG
 
@@ -54,7 +54,7 @@ async def test_coordinator(
         mock_data.reset_mock()
 
         mock_data.side_effect = SensiboError("info")
-        async_fire_time_changed(hass, dt.utcnow() + timedelta(minutes=1))
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=1))
         await hass.async_block_till_done()
         mock_data.assert_called_once()
         state = hass.states.get("climate.hallway")
@@ -63,7 +63,7 @@ async def test_coordinator(
 
         mock_data.return_value = SensiboData(raw={}, parsed={})
         mock_data.side_effect = None
-        async_fire_time_changed(hass, dt.utcnow() + timedelta(minutes=3))
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=3))
         await hass.async_block_till_done()
         mock_data.assert_called_once()
         state = hass.states.get("climate.hallway")
@@ -75,7 +75,7 @@ async def test_coordinator(
 
         mock_data.return_value = get_data
         mock_data.side_effect = None
-        async_fire_time_changed(hass, dt.utcnow() + timedelta(minutes=5))
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5))
         await hass.async_block_till_done()
         mock_data.assert_called_once()
         state = hass.states.get("climate.hallway")
@@ -83,7 +83,7 @@ async def test_coordinator(
         mock_data.reset_mock()
 
         mock_data.side_effect = AuthenticationError("info")
-        async_fire_time_changed(hass, dt.utcnow() + timedelta(minutes=7))
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=7))
         await hass.async_block_till_done()
         mock_data.assert_called_once()
         state = hass.states.get("climate.hallway")

--- a/tests/components/sensibo/test_number.py
+++ b/tests/components/sensibo/test_number.py
@@ -16,7 +16,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from tests.common import async_fire_time_changed
 
@@ -43,7 +43,7 @@ async def test_number(
     ):
         async_fire_time_changed(
             hass,
-            dt.utcnow() + timedelta(minutes=5),
+            dt_util.utcnow() + timedelta(minutes=5),
         )
         await hass.async_block_till_done()
 

--- a/tests/components/sensibo/test_select.py
+++ b/tests/components/sensibo/test_select.py
@@ -16,7 +16,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from tests.common import async_fire_time_changed
 
@@ -42,7 +42,7 @@ async def test_select(
     ):
         async_fire_time_changed(
             hass,
-            dt.utcnow() + timedelta(minutes=5),
+            dt_util.utcnow() + timedelta(minutes=5),
         )
         await hass.async_block_till_done()
 
@@ -76,7 +76,7 @@ async def test_select_set_option(
     ):
         async_fire_time_changed(
             hass,
-            dt.utcnow() + timedelta(minutes=5),
+            dt_util.utcnow() + timedelta(minutes=5),
         )
         await hass.async_block_till_done()
 
@@ -122,7 +122,7 @@ async def test_select_set_option(
     ):
         async_fire_time_changed(
             hass,
-            dt.utcnow() + timedelta(minutes=5),
+            dt_util.utcnow() + timedelta(minutes=5),
         )
         await hass.async_block_till_done()
 

--- a/tests/components/sensibo/test_sensor.py
+++ b/tests/components/sensibo/test_sensor.py
@@ -9,7 +9,7 @@ import pytest
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from tests.common import async_fire_time_changed
 
@@ -61,7 +61,7 @@ async def test_sensor(
     ):
         async_fire_time_changed(
             hass,
-            dt.utcnow() + timedelta(minutes=5),
+            dt_util.utcnow() + timedelta(minutes=5),
         )
         await hass.async_block_till_done()
 

--- a/tests/components/sensibo/test_switch.py
+++ b/tests/components/sensibo/test_switch.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from tests.common import async_fire_time_changed
 
@@ -62,7 +62,7 @@ async def test_switch_timer(
     ):
         async_fire_time_changed(
             hass,
-            dt.utcnow() + timedelta(minutes=5),
+            dt_util.utcnow() + timedelta(minutes=5),
         )
         await hass.async_block_till_done()
     state1 = hass.states.get("switch.hallway_timer")
@@ -95,7 +95,7 @@ async def test_switch_timer(
     ):
         async_fire_time_changed(
             hass,
-            dt.utcnow() + timedelta(minutes=5),
+            dt_util.utcnow() + timedelta(minutes=5),
         )
         await hass.async_block_till_done()
 
@@ -140,7 +140,7 @@ async def test_switch_pure_boost(
     ):
         async_fire_time_changed(
             hass,
-            dt.utcnow() + timedelta(minutes=5),
+            dt_util.utcnow() + timedelta(minutes=5),
         )
         await hass.async_block_till_done()
     state1 = hass.states.get("switch.kitchen_pure_boost")
@@ -171,7 +171,7 @@ async def test_switch_pure_boost(
     ):
         async_fire_time_changed(
             hass,
-            dt.utcnow() + timedelta(minutes=5),
+            dt_util.utcnow() + timedelta(minutes=5),
         )
         await hass.async_block_till_done()
 
@@ -262,7 +262,7 @@ async def test_switch_climate_react(
     ):
         async_fire_time_changed(
             hass,
-            dt.utcnow() + timedelta(minutes=5),
+            dt_util.utcnow() + timedelta(minutes=5),
         )
         await hass.async_block_till_done()
     state1 = hass.states.get("switch.hallway_climate_react")
@@ -293,7 +293,7 @@ async def test_switch_climate_react(
     ):
         async_fire_time_changed(
             hass,
-            dt.utcnow() + timedelta(minutes=5),
+            dt_util.utcnow() + timedelta(minutes=5),
         )
         await hass.async_block_till_done()
 
@@ -317,7 +317,7 @@ async def test_switch_climate_react_no_data(
     ):
         async_fire_time_changed(
             hass,
-            dt.utcnow() + timedelta(minutes=5),
+            dt_util.utcnow() + timedelta(minutes=5),
         )
         await hass.async_block_till_done()
 

--- a/tests/components/sensibo/test_update.py
+++ b/tests/components/sensibo/test_update.py
@@ -10,7 +10,7 @@ import pytest
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from tests.common import async_fire_time_changed
 
@@ -39,7 +39,7 @@ async def test_select(
     ):
         async_fire_time_changed(
             hass,
-            dt.utcnow() + timedelta(minutes=5),
+            dt_util.utcnow() + timedelta(minutes=5),
         )
         await hass.async_block_till_done()
 

--- a/tests/components/shelly/__init__.py
+++ b/tests/components/shelly/__init__.py
@@ -20,7 +20,7 @@ from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, format_mac
 from homeassistant.helpers.entity_registry import async_get
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
@@ -80,14 +80,14 @@ def inject_rpc_device_event(
 
 async def mock_rest_update(hass: HomeAssistant, seconds=REST_SENSORS_UPDATE_INTERVAL):
     """Move time to create REST sensors update event."""
-    async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=seconds))
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=seconds))
     await hass.async_block_till_done()
 
 
 async def mock_polling_rpc_update(hass: HomeAssistant):
     """Move time to create polling RPC sensors update event."""
     async_fire_time_changed(
-        hass, dt.utcnow() + timedelta(seconds=RPC_SENSORS_POLLING_INTERVAL)
+        hass, dt_util.utcnow() + timedelta(seconds=RPC_SENSORS_POLLING_INTERVAL)
     )
     await hass.async_block_till_done()
 

--- a/tests/components/shelly/test_coordinator.py
+++ b/tests/components/shelly/test_coordinator.py
@@ -24,7 +24,7 @@ from homeassistant.helpers.device_registry import (
     async_entries_for_config_entry,
     async_get as async_get_dev_reg,
 )
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from . import (
     init_integration,
@@ -64,7 +64,7 @@ async def test_block_reload_on_cfg_change(
 
     # Wait for debouncer
     async_fire_time_changed(
-        hass, dt.utcnow() + timedelta(seconds=ENTRY_RELOAD_COOLDOWN)
+        hass, dt_util.utcnow() + timedelta(seconds=ENTRY_RELOAD_COOLDOWN)
     )
     await hass.async_block_till_done()
 
@@ -94,7 +94,7 @@ async def test_block_no_reload_on_bulb_changes(
 
     # Wait for debouncer
     async_fire_time_changed(
-        hass, dt.utcnow() + timedelta(seconds=ENTRY_RELOAD_COOLDOWN)
+        hass, dt_util.utcnow() + timedelta(seconds=ENTRY_RELOAD_COOLDOWN)
     )
     await hass.async_block_till_done()
 
@@ -110,7 +110,7 @@ async def test_block_no_reload_on_bulb_changes(
 
     # Wait for debouncer
     async_fire_time_changed(
-        hass, dt.utcnow() + timedelta(seconds=ENTRY_RELOAD_COOLDOWN)
+        hass, dt_util.utcnow() + timedelta(seconds=ENTRY_RELOAD_COOLDOWN)
     )
     await hass.async_block_till_done()
 
@@ -132,7 +132,7 @@ async def test_block_polling_auth_error(
 
     # Move time to generate polling
     async_fire_time_changed(
-        hass, dt.utcnow() + timedelta(seconds=UPDATE_PERIOD_MULTIPLIER * 15)
+        hass, dt_util.utcnow() + timedelta(seconds=UPDATE_PERIOD_MULTIPLIER * 15)
     )
     await hass.async_block_till_done()
 
@@ -198,7 +198,7 @@ async def test_block_polling_connection_error(
 
     # Move time to generate polling
     async_fire_time_changed(
-        hass, dt.utcnow() + timedelta(seconds=UPDATE_PERIOD_MULTIPLIER * 15)
+        hass, dt_util.utcnow() + timedelta(seconds=UPDATE_PERIOD_MULTIPLIER * 15)
     )
     await hass.async_block_till_done()
 
@@ -242,7 +242,7 @@ async def test_block_sleeping_device_no_periodic_updates(
 
     # Move time to generate polling
     async_fire_time_changed(
-        hass, dt.utcnow() + timedelta(seconds=SLEEP_PERIOD_MULTIPLIER * 1000)
+        hass, dt_util.utcnow() + timedelta(seconds=SLEEP_PERIOD_MULTIPLIER * 1000)
     )
     await hass.async_block_till_done()
 
@@ -328,7 +328,7 @@ async def test_rpc_reload_on_cfg_change(
 
     # Wait for debouncer
     async_fire_time_changed(
-        hass, dt.utcnow() + timedelta(seconds=ENTRY_RELOAD_COOLDOWN)
+        hass, dt_util.utcnow() + timedelta(seconds=ENTRY_RELOAD_COOLDOWN)
     )
     await hass.async_block_till_done()
 
@@ -394,7 +394,7 @@ async def test_rpc_update_entry_sleep_period(
     # Move time to generate sleep period update
     monkeypatch.setitem(mock_rpc_device.status["sys"], "wakeup_period", 3600)
     async_fire_time_changed(
-        hass, dt.utcnow() + timedelta(seconds=600 * SLEEP_PERIOD_MULTIPLIER)
+        hass, dt_util.utcnow() + timedelta(seconds=600 * SLEEP_PERIOD_MULTIPLIER)
     )
     await hass.async_block_till_done()
 
@@ -423,7 +423,7 @@ async def test_rpc_sleeping_device_no_periodic_updates(
 
     # Move time to generate polling
     async_fire_time_changed(
-        hass, dt.utcnow() + timedelta(seconds=SLEEP_PERIOD_MULTIPLIER * 1000)
+        hass, dt_util.utcnow() + timedelta(seconds=SLEEP_PERIOD_MULTIPLIER * 1000)
     )
     await hass.async_block_till_done()
 
@@ -449,7 +449,7 @@ async def test_rpc_reconnect_auth_error(
 
     # Move time to generate reconnect
     async_fire_time_changed(
-        hass, dt.utcnow() + timedelta(seconds=RPC_RECONNECT_INTERVAL)
+        hass, dt_util.utcnow() + timedelta(seconds=RPC_RECONNECT_INTERVAL)
     )
     await hass.async_block_till_done()
 
@@ -519,7 +519,7 @@ async def test_rpc_reconnect_error(
 
     # Move time to generate reconnect
     async_fire_time_changed(
-        hass, dt.utcnow() + timedelta(seconds=RPC_RECONNECT_INTERVAL)
+        hass, dt_util.utcnow() + timedelta(seconds=RPC_RECONNECT_INTERVAL)
     )
     await hass.async_block_till_done()
 

--- a/tests/components/shelly/test_utils.py
+++ b/tests/components/shelly/test_utils.py
@@ -11,7 +11,7 @@ from homeassistant.components.shelly.utils import (
     get_rpc_input_triggers,
     is_block_momentary_input,
 )
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 DEVICE_BLOCK_ID = 4
 
@@ -153,12 +153,12 @@ async def test_get_block_device_sleep_period(settings, sleep_period) -> None:
 async def test_get_device_uptime() -> None:
     """Test block test get device uptime."""
     assert get_device_uptime(
-        55, dt.as_utc(dt.parse_datetime("2019-01-10 18:42:00+00:00"))
-    ) == dt.as_utc(dt.parse_datetime("2019-01-10 18:42:00+00:00"))
+        55, dt_util.as_utc(dt_util.parse_datetime("2019-01-10 18:42:00+00:00"))
+    ) == dt_util.as_utc(dt_util.parse_datetime("2019-01-10 18:42:00+00:00"))
 
     assert get_device_uptime(
-        50, dt.as_utc(dt.parse_datetime("2019-01-10 18:42:00+00:00"))
-    ) == dt.as_utc(dt.parse_datetime("2019-01-10 18:42:10+00:00"))
+        50, dt_util.as_utc(dt_util.parse_datetime("2019-01-10 18:42:00+00:00"))
+    ) == dt_util.as_utc(dt_util.parse_datetime("2019-01-10 18:42:10+00:00"))
 
 
 async def test_get_block_input_triggers(mock_block_device, monkeypatch) -> None:

--- a/tests/components/smarttub/__init__.py
+++ b/tests/components/smarttub/__init__.py
@@ -3,13 +3,13 @@
 from datetime import timedelta
 
 from homeassistant.components.smarttub.const import SCAN_INTERVAL
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from tests.common import async_fire_time_changed
 
 
 async def trigger_update(hass):
     """Trigger a polling update by moving time forward."""
-    new_time = dt.utcnow() + timedelta(seconds=SCAN_INTERVAL + 1)
+    new_time = dt_util.utcnow() + timedelta(seconds=SCAN_INTERVAL + 1)
     async_fire_time_changed(hass, new_time)
     await hass.async_block_till_done()

--- a/tests/components/sonos/test_switch.py
+++ b/tests/components/sonos/test_switch.py
@@ -16,7 +16,7 @@ from homeassistant.config_entries import RELOAD_AFTER_UPDATE_DELAY
 from homeassistant.const import ATTR_TIME, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from .conftest import SonosMockEvent
 
@@ -114,7 +114,7 @@ async def test_switch_attributes(
     with patch.object(hass.data[DATA_SONOS_DISCOVERY_MANAGER], "async_shutdown") as m:
         async_fire_time_changed(
             hass,
-            dt.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
+            dt_util.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
         )
         await hass.async_block_till_done()
         assert m.called

--- a/tests/components/soundtouch/test_media_player.py
+++ b/tests/components/soundtouch/test_media_player.py
@@ -31,7 +31,7 @@ from homeassistant.config_entries import RELOAD_AFTER_UPDATE_DELAY
 from homeassistant.const import STATE_OFF, STATE_PAUSED, STATE_PLAYING
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from .conftest import DEVICE_1_ENTITY_ID, DEVICE_2_ENTITY_ID
 
@@ -662,7 +662,7 @@ async def test_zone_attributes(
     # Fast-forward time to allow all entities to be set up and updated again
     async_fire_time_changed(
         hass,
-        dt.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
+        dt_util.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
     )
     await hass.async_block_till_done()
 

--- a/tests/components/sql/test_sensor.py
+++ b/tests/components/sql/test_sensor.py
@@ -17,7 +17,7 @@ from homeassistant.const import CONF_UNIQUE_ID, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.setup import async_setup_component
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from . import (
     YAML_CONFIG,
@@ -218,7 +218,7 @@ async def test_invalid_url_on_update(
         await init_integration(hass, config)
         async_fire_time_changed(
             hass,
-            dt.utcnow() + timedelta(minutes=1),
+            dt_util.utcnow() + timedelta(minutes=1),
         )
         await hass.async_block_till_done()
 
@@ -399,7 +399,7 @@ async def test_no_issue_when_view_has_the_text_entity_id_in_it(
         )
         async_fire_time_changed(
             hass,
-            dt.utcnow() + timedelta(minutes=1),
+            dt_util.utcnow() + timedelta(minutes=1),
         )
         await hass.async_block_till_done()
 

--- a/tests/components/switcher_kis/test_init.py
+++ b/tests/components/switcher_kis/test_init.py
@@ -14,7 +14,7 @@ from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
-from homeassistant.util import dt, slugify
+from homeassistant.util import dt as dt_util, slugify
 
 from . import init_integration
 from .consts import DUMMY_SWITCHER_DEVICES, YAML_CONFIG
@@ -63,7 +63,7 @@ async def test_update_fail(
     assert len(hass.data[DOMAIN][DATA_DEVICE]) == 2
 
     async_fire_time_changed(
-        hass, dt.utcnow() + timedelta(seconds=MAX_UPDATE_INTERVAL_SEC + 1)
+        hass, dt_util.utcnow() + timedelta(seconds=MAX_UPDATE_INTERVAL_SEC + 1)
     )
     await hass.async_block_till_done()
 
@@ -84,7 +84,7 @@ async def test_update_fail(
     mock_bridge.mock_callbacks(DUMMY_SWITCHER_DEVICES)
     await hass.async_block_till_done()
     async_fire_time_changed(
-        hass, dt.utcnow() + timedelta(seconds=MAX_UPDATE_INTERVAL_SEC - 1)
+        hass, dt_util.utcnow() + timedelta(seconds=MAX_UPDATE_INTERVAL_SEC - 1)
     )
 
     for device in DUMMY_SWITCHER_DEVICES:


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Datetime related module names are unfortunate, but being consistent with how they're imported helps. About 70% of the cases throughout the tree already imports `homeassistant.util.dt` as `dt_util`, this PR is one in a series that brings the rest in line (to be followed by a ruff config change that will start to enforce this).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
