### PR TITLE
Import `util.dt` as `dt_util` in `components/[t-z]*`

### DIFF
--- a/homeassistant/components/todoist/calendar.py
+++ b/homeassistant/components/todoist/calendar.py
@@ -24,7 +24,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from .const import (
     ALL_DAY,
@@ -214,14 +214,14 @@ async def async_setup_platform(
             data["due_lang"] = call.data[DUE_DATE_LANG]
 
         if DUE_DATE in call.data:
-            due_date = dt.parse_datetime(call.data[DUE_DATE])
+            due_date = dt_util.parse_datetime(call.data[DUE_DATE])
             if due_date is None:
-                due = dt.parse_date(call.data[DUE_DATE])
+                due = dt_util.parse_date(call.data[DUE_DATE])
                 if due is None:
                     raise ValueError(f"Invalid due_date: {call.data[DUE_DATE]}")
                 due_date = datetime(due.year, due.month, due.day)
             # Format it in the manner Todoist expects
-            due_date = dt.as_utc(due_date)
+            due_date = dt_util.as_utc(due_date)
             date_format = "%Y-%m-%dT%H:%M:%S"
             data["due_datetime"] = datetime.strftime(due_date, date_format)
 
@@ -239,16 +239,16 @@ async def async_setup_platform(
             _reminder_due["lang"] = call.data[REMINDER_DATE_LANG]
 
         if REMINDER_DATE in call.data:
-            due_date = dt.parse_datetime(call.data[REMINDER_DATE])
+            due_date = dt_util.parse_datetime(call.data[REMINDER_DATE])
             if due_date is None:
-                due = dt.parse_date(call.data[REMINDER_DATE])
+                due = dt_util.parse_date(call.data[REMINDER_DATE])
                 if due is None:
                     raise ValueError(
                         f"Invalid reminder_date: {call.data[REMINDER_DATE]}"
                     )
                 due_date = datetime(due.year, due.month, due.day)
             # Format it in the manner Todoist expects
-            due_date = dt.as_utc(due_date)
+            due_date = dt_util.as_utc(due_date)
             date_format = "%Y-%m-%dT%H:%M:%S"
             _reminder_due["date"] = datetime.strftime(due_date, date_format)
 
@@ -453,7 +453,7 @@ class TodoistProjectData:
             LABELS: [],
             OVERDUE: False,
             PRIORITY: data.priority,
-            START: dt.now(),
+            START: dt_util.now(),
             SUMMARY: data.content,
         }
 
@@ -474,19 +474,19 @@ class TodoistProjectData:
         # complete the task.
         # Generally speaking, that means right now.
         if data.due is not None:
-            end = dt.parse_datetime(
+            end = dt_util.parse_datetime(
                 data.due.datetime if data.due.datetime else data.due.date
             )
-            task[END] = dt.as_local(end) if end is not None else end
+            task[END] = dt_util.as_local(end) if end is not None else end
             if task[END] is not None:
                 if self._due_date_days is not None and (
-                    task[END] > dt.now() + self._due_date_days
+                    task[END] > dt_util.now() + self._due_date_days
                 ):
                     # This task is out of range of our due date;
                     # it shouldn't be counted.
                     return None
 
-                task[DUE_TODAY] = task[END].date() == dt.now().date()
+                task[DUE_TODAY] = task[END].date() == dt_util.now().date()
 
                 # Special case: Task is overdue.
                 if task[END] <= task[START]:
@@ -669,10 +669,10 @@ class TodoistProjectData:
 def get_start(due: Due) -> datetime | date | None:
     """Return the task due date as a start date or date time."""
     if due.datetime:
-        start = dt.parse_datetime(due.datetime)
+        start = dt_util.parse_datetime(due.datetime)
         if not start:
             return None
-        return dt.as_local(start)
+        return dt_util.as_local(start)
     if due.date:
-        return dt.parse_date(due.date)
+        return dt_util.parse_date(due.date)
     return None

--- a/homeassistant/components/trafikverket_ferry/coordinator.py
+++ b/homeassistant/components/trafikverket_ferry/coordinator.py
@@ -15,7 +15,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from .const import CONF_FROM, CONF_TIME, CONF_TO, DOMAIN
 
@@ -60,20 +60,22 @@ class TVDataUpdateCoordinator(DataUpdateCoordinator):
         )
         self._from: str = entry.data[CONF_FROM]
         self._to: str = entry.data[CONF_TO]
-        self._time: time | None = dt.parse_time(entry.data[CONF_TIME])
+        self._time: time | None = dt_util.parse_time(entry.data[CONF_TIME])
         self._weekdays: list[str] = entry.data[CONF_WEEKDAY]
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data from Trafikverket."""
 
         departure_day = next_departuredate(self._weekdays)
-        current_time = dt.now()
+        current_time = dt_util.now()
         when = (
             datetime.combine(
-                departure_day, self._time, dt.get_time_zone(self.hass.config.time_zone)
+                departure_day,
+                self._time,
+                dt_util.get_time_zone(self.hass.config.time_zone),
             )
             if self._time
-            else dt.now()
+            else dt_util.now()
         )
         if current_time > when:
             when = current_time

--- a/homeassistant/components/trafikverket_train/sensor.py
+++ b/homeassistant/components/trafikverket_train/sensor.py
@@ -19,7 +19,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from .const import CONF_FROM, CONF_TIME, CONF_TO, DOMAIN
 from .util import create_unique_id
@@ -48,7 +48,7 @@ async def async_setup_entry(
     to_station = hass.data[DOMAIN][entry.entry_id][CONF_TO]
     from_station = hass.data[DOMAIN][entry.entry_id][CONF_FROM]
     get_time: str | None = entry.data.get(CONF_TIME)
-    train_time = dt.parse_time(get_time) if get_time else None
+    train_time = dt_util.parse_time(get_time) if get_time else None
 
     async_add_entities(
         [
@@ -89,7 +89,7 @@ def next_departuredate(departure: list[str]) -> date:
 
 def _to_iso_format(traintime: datetime) -> str:
     """Return isoformatted utc time."""
-    return dt.as_utc(traintime).isoformat()
+    return dt_util.as_utc(traintime).isoformat()
 
 
 class TrainSensor(SensorEntity):
@@ -131,12 +131,14 @@ class TrainSensor(SensorEntity):
 
     async def async_update(self) -> None:
         """Retrieve latest state."""
-        when = dt.now()
+        when = dt_util.now()
         _state: TrainStop | None = None
         if self._time:
             departure_day = next_departuredate(self._weekday)
             when = datetime.combine(
-                departure_day, self._time, dt.get_time_zone(self.hass.config.time_zone)
+                departure_day,
+                self._time,
+                dt_util.get_time_zone(self.hass.config.time_zone),
             )
         try:
             if self._time:
@@ -162,11 +164,11 @@ class TrainSensor(SensorEntity):
         # The original datetime doesn't provide a timezone so therefore attaching it here.
         if TYPE_CHECKING:
             assert _state.advertised_time_at_location
-        self._attr_native_value = dt.as_utc(_state.advertised_time_at_location)
+        self._attr_native_value = dt_util.as_utc(_state.advertised_time_at_location)
         if _state.time_at_location:
-            self._attr_native_value = dt.as_utc(_state.time_at_location)
+            self._attr_native_value = dt_util.as_utc(_state.time_at_location)
         if _state.estimated_time_at_location:
-            self._attr_native_value = dt.as_utc(_state.estimated_time_at_location)
+            self._attr_native_value = dt_util.as_utc(_state.estimated_time_at_location)
 
         self._update_attributes(_state)
 

--- a/homeassistant/components/vallox/sensor.py
+++ b/homeassistant/components/vallox/sensor.py
@@ -21,7 +21,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from . import ValloxDataUpdateCoordinator, ValloxEntity
 from .const import (
@@ -108,7 +108,7 @@ class ValloxFilterRemainingSensor(ValloxSensorEntity):
 
         return datetime.combine(
             next_filter_change_date,
-            time(hour=13, minute=0, second=0, tzinfo=dt.DEFAULT_TIME_ZONE),
+            time(hour=13, minute=0, second=0, tzinfo=dt_util.DEFAULT_TIME_ZONE),
         )
 
 

--- a/homeassistant/components/withings/common.py
+++ b/homeassistant/components/withings/common.py
@@ -41,7 +41,7 @@ from homeassistant.helpers.config_entry_oauth2_flow import (
 )
 from homeassistant.helpers.entity import Entity, EntityDescription
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from . import const
 from .const import Measurement
@@ -411,7 +411,7 @@ class DataManager:
     async def async_get_measures(self) -> dict[Measurement, Any]:
         """Get the measures data."""
         _LOGGER.debug("Updating withings measures")
-        now = dt.utcnow()
+        now = dt_util.utcnow()
         startdate = now - datetime.timedelta(days=7)
 
         response = await self._hass.async_add_executor_job(
@@ -439,7 +439,7 @@ class DataManager:
     async def async_get_sleep_summary(self) -> dict[Measurement, Any]:
         """Get the sleep summary data."""
         _LOGGER.debug("Updating withing sleep summary")
-        now = dt.utcnow()
+        now = dt_util.utcnow()
         yesterday = now - datetime.timedelta(days=1)
         yesterday_noon = datetime.datetime(
             yesterday.year,

--- a/homeassistant/components/workday/binary_sensor.py
+++ b/homeassistant/components/workday/binary_sensor.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from .const import (
     ALLOWED_DAYS,
@@ -120,7 +120,7 @@ async def async_setup_entry(
     sensor_name: str = entry.options[CONF_NAME]
     workdays: list[str] = entry.options[CONF_WORKDAYS]
 
-    year: int = (dt.now() + timedelta(days=days_offset)).year
+    year: int = (dt_util.now() + timedelta(days=days_offset)).year
     obj_holidays: HolidayBase = getattr(holidays, country)(years=year)
 
     if province:
@@ -140,7 +140,7 @@ async def async_setup_entry(
     for remove_holiday in remove_holidays:
         try:
             # is this formatted as a date?
-            if dt.parse_date(remove_holiday):
+            if dt_util.parse_date(remove_holiday):
                 # remove holiday by date
                 removed = obj_holidays.pop(remove_holiday)
                 LOGGER.debug("Removed %s", remove_holiday)
@@ -231,7 +231,7 @@ class IsWorkdaySensor(BinarySensorEntity):
         self._attr_is_on = False
 
         # Get ISO day of the week (1 = Monday, 7 = Sunday)
-        adjusted_date = dt.now() + timedelta(days=self._days_offset)
+        adjusted_date = dt_util.now() + timedelta(days=self._days_offset)
         day = adjusted_date.isoweekday() - 1
         day_of_week = ALLOWED_DAYS[day]
 

--- a/homeassistant/components/workday/config_flow.py
+++ b/homeassistant/components/workday/config_flow.py
@@ -24,7 +24,7 @@ from homeassistant.helpers.selector import (
     SelectSelectorMode,
     TextSelector,
 )
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from .const import (
     ALLOWED_DAYS,
@@ -73,16 +73,16 @@ def validate_custom_dates(user_input: dict[str, Any]) -> None:
     """Validate custom dates for add/remove holidays."""
 
     for add_date in user_input[CONF_ADD_HOLIDAYS]:
-        if dt.parse_date(add_date) is None:
+        if dt_util.parse_date(add_date) is None:
             raise AddDatesError("Incorrect date")
 
-    year: int = dt.now().year
+    year: int = dt_util.now().year
     obj_holidays = country_holidays(
         user_input[CONF_COUNTRY], user_input.get(CONF_PROVINCE), year
     )
 
     for remove_date in user_input[CONF_REMOVE_HOLIDAYS]:
-        if dt.parse_date(remove_date) is None:
+        if dt_util.parse_date(remove_date) is None:
             if obj_holidays.get_named(remove_date) == []:
                 raise RemoveDatesError("Incorrect date or name")
 

--- a/homeassistant/components/xiaomi_miio/light.py
+++ b/homeassistant/components/xiaomi_miio/light.py
@@ -38,7 +38,7 @@ from homeassistant.core import HomeAssistant, ServiceCall
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.util import color, dt
+from homeassistant.util import color, dt as dt_util
 
 from .const import (
     CONF_DEVICE,
@@ -362,7 +362,7 @@ class XiaomiPhilipsGenericLight(XiaomiPhilipsAbstractLight):
 
         delayed_turn_off = self.delayed_turn_off_timestamp(
             state.delay_off_countdown,
-            dt.utcnow(),
+            dt_util.utcnow(),
             self._state_attrs[ATTR_DELAYED_TURN_OFF],
         )
 
@@ -523,7 +523,7 @@ class XiaomiPhilipsBulb(XiaomiPhilipsGenericLight):
 
         delayed_turn_off = self.delayed_turn_off_timestamp(
             state.delay_off_countdown,
-            dt.utcnow(),
+            dt_util.utcnow(),
             self._state_attrs[ATTR_DELAYED_TURN_OFF],
         )
 
@@ -582,7 +582,7 @@ class XiaomiPhilipsCeilingLamp(XiaomiPhilipsBulb):
 
         delayed_turn_off = self.delayed_turn_off_timestamp(
             state.delay_off_countdown,
-            dt.utcnow(),
+            dt_util.utcnow(),
             self._state_attrs[ATTR_DELAYED_TURN_OFF],
         )
 
@@ -625,7 +625,7 @@ class XiaomiPhilipsEyecareLamp(XiaomiPhilipsGenericLight):
 
         delayed_turn_off = self.delayed_turn_off_timestamp(
             state.delay_off_countdown,
-            dt.utcnow(),
+            dt_util.utcnow(),
             self._state_attrs[ATTR_DELAYED_TURN_OFF],
         )
 

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -23,7 +23,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowHandler, FlowResult
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.selector import FileSelector, FileSelectorConfig
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from .core.const import (
     CONF_BAUDRATE,
@@ -69,7 +69,7 @@ def _format_backup_choice(
 ) -> str:
     """Format network backup info into a short piece of text."""
     if not pan_ids:
-        return dt.as_local(backup.backup_time).strftime("%c")
+        return dt_util.as_local(backup.backup_time).strftime("%c")
 
     identifier = (
         # PAN ID
@@ -78,7 +78,7 @@ def _format_backup_choice(
         f":{str(backup.network_info.extended_pan_id).replace(':', '')}"
     ).lower()
 
-    return f"{dt.as_local(backup.backup_time).strftime('%c')} ({identifier})"
+    return f"{dt_util.as_local(backup.backup_time).strftime('%c')} ({identifier})"
 
 
 async def list_serial_ports(hass: HomeAssistant) -> list[ListPortInfo]:

--- a/tests/components/tasmota/test_sensor.py
+++ b/tests/components/tasmota/test_sensor.py
@@ -19,7 +19,7 @@ from homeassistant.components.tasmota.const import DEFAULT_PREFIX
 from homeassistant.const import ATTR_ASSUMED_STATE, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from .test_common import (
     DEFAULT_CONFIG,
@@ -727,7 +727,7 @@ async def test_restart_time_status_sensor_state_via_mqtt(
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
 
     # Test polled state update
-    utc_now = datetime.datetime(2020, 11, 11, 8, 0, 0, tzinfo=dt.UTC)
+    utc_now = datetime.datetime(2020, 11, 11, 8, 0, 0, tzinfo=dt_util.UTC)
     hatasmota.status_sensor.datetime.now.return_value = utc_now
     async_fire_mqtt_message(
         hass,
@@ -931,7 +931,8 @@ async def test_enable_status_sensor(
 
     async_fire_time_changed(
         hass,
-        dt.utcnow() + timedelta(seconds=config_entries.RELOAD_AFTER_UPDATE_DELAY + 1),
+        dt_util.utcnow()
+        + timedelta(seconds=config_entries.RELOAD_AFTER_UPDATE_DELAY + 1),
     )
     await hass.async_block_till_done()
 

--- a/tests/components/todoist/test_calendar.py
+++ b/tests/components/todoist/test_calendar.py
@@ -21,7 +21,7 @@ from homeassistant.const import CONF_TOKEN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_component import async_update_entity
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from tests.typing import ClientSessionGenerator
 
@@ -39,7 +39,9 @@ def set_time_zone(hass: HomeAssistant):
 @pytest.fixture(name="due")
 def mock_due() -> Due:
     """Mock a todoist Task Due date/time."""
-    return Due(is_recurring=False, date=dt.now().strftime("%Y-%m-%d"), string="today")
+    return Due(
+        is_recurring=False, date=dt_util.now().strftime("%Y-%m-%d"), string="today"
+    )
 
 
 @pytest.fixture(name="task")
@@ -187,7 +189,7 @@ async def test_update_entity_for_custom_project_no_due_date_on(
     "due",
     [
         Due(
-            date=(dt.now() + timedelta(days=3)).strftime("%Y-%m-%d"),
+            date=(dt_util.now() + timedelta(days=3)).strftime("%Y-%m-%d"),
             is_recurring=False,
             string="3 days from today",
         )
@@ -203,7 +205,9 @@ async def test_update_entity_for_calendar_with_due_date_in_the_future(
     assert state.state == "on"
 
     # The end time should be in the user's timezone
-    expected_end_time = (dt.now() + timedelta(days=3)).strftime("%Y-%m-%d 00:00:00")
+    expected_end_time = (dt_util.now() + timedelta(days=3)).strftime(
+        "%Y-%m-%d 00:00:00"
+    )
     assert state.attributes["end_time"] == expected_end_time
 
 

--- a/tests/components/totalconnect/test_alarm_control_panel.py
+++ b/tests/components/totalconnect/test_alarm_control_panel.py
@@ -32,7 +32,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_component import async_update_entity
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from .common import (
     LOCATION_ID,
@@ -107,7 +107,7 @@ async def test_arm_home_success(hass: HomeAssistant) -> None:
         )
         assert mock_request.call_count == 2
 
-        async_fire_time_changed(hass, dt.utcnow() + DELAY)
+        async_fire_time_changed(hass, dt_util.utcnow() + DELAY)
         await hass.async_block_till_done()
         assert mock_request.call_count == 3
         assert hass.states.get(ENTITY_ID).state == STATE_ALARM_ARMED_HOME
@@ -163,7 +163,7 @@ async def test_arm_home_instant_success(hass: HomeAssistant) -> None:
         )
         assert mock_request.call_count == 2
 
-        async_fire_time_changed(hass, dt.utcnow() + DELAY)
+        async_fire_time_changed(hass, dt_util.utcnow() + DELAY)
         await hass.async_block_till_done()
         assert mock_request.call_count == 3
         assert hass.states.get(ENTITY_ID).state == STATE_ALARM_ARMED_HOME
@@ -220,7 +220,7 @@ async def test_arm_away_instant_success(hass: HomeAssistant) -> None:
         )
         assert mock_request.call_count == 2
 
-        async_fire_time_changed(hass, dt.utcnow() + DELAY)
+        async_fire_time_changed(hass, dt_util.utcnow() + DELAY)
         await hass.async_block_till_done()
         assert mock_request.call_count == 3
         assert hass.states.get(ENTITY_ID).state == STATE_ALARM_ARMED_AWAY
@@ -276,7 +276,7 @@ async def test_arm_away_success(hass: HomeAssistant) -> None:
         )
         assert mock_request.call_count == 2
 
-        async_fire_time_changed(hass, dt.utcnow() + DELAY)
+        async_fire_time_changed(hass, dt_util.utcnow() + DELAY)
         await hass.async_block_till_done()
         assert mock_request.call_count == 3
         assert hass.states.get(ENTITY_ID).state == STATE_ALARM_ARMED_AWAY
@@ -329,7 +329,7 @@ async def test_disarm_success(hass: HomeAssistant) -> None:
         )
         assert mock_request.call_count == 2
 
-        async_fire_time_changed(hass, dt.utcnow() + DELAY)
+        async_fire_time_changed(hass, dt_util.utcnow() + DELAY)
         await hass.async_block_till_done()
         assert mock_request.call_count == 3
         assert hass.states.get(ENTITY_ID).state == STATE_ALARM_DISARMED
@@ -386,7 +386,7 @@ async def test_arm_night_success(hass: HomeAssistant) -> None:
         )
         assert mock_request.call_count == 2
 
-        async_fire_time_changed(hass, dt.utcnow() + DELAY)
+        async_fire_time_changed(hass, dt_util.utcnow() + DELAY)
         await hass.async_block_till_done()
         assert mock_request.call_count == 3
         assert hass.states.get(ENTITY_ID).state == STATE_ALARM_ARMED_NIGHT
@@ -439,7 +439,7 @@ async def test_arming(hass: HomeAssistant) -> None:
         )
         assert mock_request.call_count == 2
 
-        async_fire_time_changed(hass, dt.utcnow() + DELAY)
+        async_fire_time_changed(hass, dt_util.utcnow() + DELAY)
         await hass.async_block_till_done()
         assert mock_request.call_count == 3
         assert hass.states.get(ENTITY_ID).state == STATE_ALARM_ARMING
@@ -460,7 +460,7 @@ async def test_disarming(hass: HomeAssistant) -> None:
         )
         assert mock_request.call_count == 2
 
-        async_fire_time_changed(hass, dt.utcnow() + DELAY)
+        async_fire_time_changed(hass, dt_util.utcnow() + DELAY)
         await hass.async_block_till_done()
         assert mock_request.call_count == 3
         assert hass.states.get(ENTITY_ID).state == STATE_ALARM_DISARMING
@@ -546,31 +546,31 @@ async def test_other_update_failures(hass: HomeAssistant) -> None:
         assert mock_request.call_count == 1
 
         # then an error: ServiceUnavailable --> UpdateFailed
-        async_fire_time_changed(hass, dt.utcnow() + SCAN_INTERVAL)
+        async_fire_time_changed(hass, dt_util.utcnow() + SCAN_INTERVAL)
         await hass.async_block_till_done()
         assert hass.states.get(ENTITY_ID).state == STATE_UNAVAILABLE
         assert mock_request.call_count == 2
 
         # works again
-        async_fire_time_changed(hass, dt.utcnow() + SCAN_INTERVAL * 2)
+        async_fire_time_changed(hass, dt_util.utcnow() + SCAN_INTERVAL * 2)
         await hass.async_block_till_done()
         assert hass.states.get(ENTITY_ID).state == STATE_ALARM_DISARMED
         assert mock_request.call_count == 3
 
         # then an error: TotalConnectError --> UpdateFailed
-        async_fire_time_changed(hass, dt.utcnow() + SCAN_INTERVAL * 3)
+        async_fire_time_changed(hass, dt_util.utcnow() + SCAN_INTERVAL * 3)
         await hass.async_block_till_done()
         assert hass.states.get(ENTITY_ID).state == STATE_UNAVAILABLE
         assert mock_request.call_count == 4
 
         # works again
-        async_fire_time_changed(hass, dt.utcnow() + SCAN_INTERVAL * 4)
+        async_fire_time_changed(hass, dt_util.utcnow() + SCAN_INTERVAL * 4)
         await hass.async_block_till_done()
         assert hass.states.get(ENTITY_ID).state == STATE_ALARM_DISARMED
         assert mock_request.call_count == 5
 
         # unknown TotalConnect status via ValueError
-        async_fire_time_changed(hass, dt.utcnow() + SCAN_INTERVAL * 5)
+        async_fire_time_changed(hass, dt_util.utcnow() + SCAN_INTERVAL * 5)
         await hass.async_block_till_done()
         assert hass.states.get(ENTITY_ID).state == STATE_UNAVAILABLE
         assert mock_request.call_count == 6

--- a/tests/components/trafikverket_ferry/conftest.py
+++ b/tests/components/trafikverket_ferry/conftest.py
@@ -10,7 +10,7 @@ from pytrafikverket.trafikverket_ferry import FerryStop
 from homeassistant.components.trafikverket_ferry.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER
 from homeassistant.core import HomeAssistant
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from . import ENTRY_CONFIG
 
@@ -49,30 +49,32 @@ def fixture_get_ferries() -> list[FerryStop]:
     depart1 = FerryStop(
         "13",
         False,
-        datetime(dt.now().year + 1, 5, 1, 12, 0, tzinfo=dt.UTC),
+        datetime(dt_util.now().year + 1, 5, 1, 12, 0, tzinfo=dt_util.UTC),
         [""],
         "0",
-        datetime(dt.now().year, 5, 1, 12, 0, tzinfo=dt.UTC),
+        datetime(dt_util.now().year, 5, 1, 12, 0, tzinfo=dt_util.UTC),
         "Harbor 1",
         "Harbor 2",
     )
     depart2 = FerryStop(
         "14",
         False,
-        datetime(dt.now().year + 1, 5, 1, 12, 0, tzinfo=dt.UTC) + timedelta(minutes=15),
+        datetime(dt_util.now().year + 1, 5, 1, 12, 0, tzinfo=dt_util.UTC)
+        + timedelta(minutes=15),
         [""],
         "0",
-        datetime(dt.now().year, 5, 1, 12, 0, tzinfo=dt.UTC),
+        datetime(dt_util.now().year, 5, 1, 12, 0, tzinfo=dt_util.UTC),
         "Harbor 1",
         "Harbor 2",
     )
     depart3 = FerryStop(
         "15",
         False,
-        datetime(dt.now().year + 1, 5, 1, 12, 0, tzinfo=dt.UTC) + timedelta(minutes=30),
+        datetime(dt_util.now().year + 1, 5, 1, 12, 0, tzinfo=dt_util.UTC)
+        + timedelta(minutes=30),
         [""],
         "0",
-        datetime(dt.now().year, 5, 1, 12, 0, tzinfo=dt.UTC),
+        datetime(dt_util.now().year, 5, 1, 12, 0, tzinfo=dt_util.UTC),
         "Harbor 1",
         "Harbor 2",
     )

--- a/tests/components/trafikverket_ferry/test_coordinator.py
+++ b/tests/components/trafikverket_ferry/test_coordinator.py
@@ -14,7 +14,7 @@ from homeassistant.components.trafikverket_ferry.coordinator import next_departu
 from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import STATE_UNAVAILABLE, WEEKDAYS
 from homeassistant.core import HomeAssistant
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from . import ENTRY_CONFIG
 
@@ -50,16 +50,16 @@ async def test_coordinator(
         state3 = hass.states.get("sensor.harbor1_departure_time")
         assert state1.state == "Harbor 1"
         assert state2.state == "Harbor 2"
-        assert state3.state == str(dt.now().year + 1) + "-05-01T12:00:00+00:00"
+        assert state3.state == str(dt_util.now().year + 1) + "-05-01T12:00:00+00:00"
         mock_data.reset_mock()
 
         monkeypatch.setattr(
             get_ferries[0],
             "departure_time",
-            datetime(dt.now().year + 2, 5, 1, 12, 0, tzinfo=dt.UTC),
+            datetime(dt_util.now().year + 2, 5, 1, 12, 0, tzinfo=dt_util.UTC),
         )
 
-        async_fire_time_changed(hass, dt.utcnow() + timedelta(minutes=6))
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=6))
         await hass.async_block_till_done()
         mock_data.assert_called_once()
         state1 = hass.states.get("sensor.harbor1_departure_from")
@@ -67,11 +67,11 @@ async def test_coordinator(
         state3 = hass.states.get("sensor.harbor1_departure_time")
         assert state1.state == "Harbor 1"
         assert state2.state == "Harbor 2"
-        assert state3.state == str(dt.now().year + 2) + "-05-01T12:00:00+00:00"
+        assert state3.state == str(dt_util.now().year + 2) + "-05-01T12:00:00+00:00"
         mock_data.reset_mock()
 
         mock_data.side_effect = NoFerryFound()
-        async_fire_time_changed(hass, dt.utcnow() + timedelta(minutes=6))
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=6))
         await hass.async_block_till_done()
         mock_data.assert_called_once()
         state1 = hass.states.get("sensor.harbor1_departure_from")
@@ -80,7 +80,7 @@ async def test_coordinator(
 
         mock_data.return_value = get_ferries
         mock_data.side_effect = None
-        async_fire_time_changed(hass, dt.utcnow() + timedelta(minutes=6))
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=6))
         await hass.async_block_till_done()
         # mock_data.assert_called_once()
         state1 = hass.states.get("sensor.harbor1_departure_from")
@@ -88,7 +88,7 @@ async def test_coordinator(
         mock_data.reset_mock()
 
         mock_data.side_effect = InvalidAuthentication()
-        async_fire_time_changed(hass, dt.utcnow() + timedelta(minutes=6))
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=6))
         await hass.async_block_till_done()
         mock_data.assert_called_once()
         state1 = hass.states.get("sensor.harbor1_departure_from")

--- a/tests/components/trafikverket_ferry/test_sensor.py
+++ b/tests/components/trafikverket_ferry/test_sensor.py
@@ -9,7 +9,7 @@ from pytrafikverket.trafikverket_ferry import FerryStop
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from tests.common import async_fire_time_changed
 
@@ -26,7 +26,7 @@ async def test_sensor(
     state3 = hass.states.get("sensor.harbor1_departure_time")
     assert state1.state == "Harbor 1"
     assert state2.state == "Harbor 2"
-    assert state3.state == str(dt.now().year + 1) + "-05-01T12:00:00+00:00"
+    assert state3.state == str(dt_util.now().year + 1) + "-05-01T12:00:00+00:00"
     assert state1.attributes["icon"] == "mdi:ferry"
     assert state1.attributes["other_information"] == [""]
     assert state2.attributes["icon"] == "mdi:ferry"
@@ -39,7 +39,7 @@ async def test_sensor(
     ):
         async_fire_time_changed(
             hass,
-            dt.utcnow() + timedelta(minutes=6),
+            dt_util.utcnow() + timedelta(minutes=6),
         )
         await hass.async_block_till_done()
 

--- a/tests/components/unifi/test_switch.py
+++ b/tests/components/unifi/test_switch.py
@@ -31,7 +31,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryDisabler
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from .test_controller import (
     CONTROLLER_HOST,
@@ -1129,7 +1129,7 @@ async def test_poe_port_switches(
 
     async_fire_time_changed(
         hass,
-        dt.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
+        dt_util.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
     )
     await hass.async_block_till_done()
 

--- a/tests/components/uptimerobot/test_binary_sensor.py
+++ b/tests/components/uptimerobot/test_binary_sensor.py
@@ -11,7 +11,7 @@ from homeassistant.components.uptimerobot.const import (
 )
 from homeassistant.const import STATE_ON, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from .common import (
     MOCK_UPTIMEROBOT_MONITOR,
@@ -45,7 +45,7 @@ async def test_unaviable_on_update_failure(hass: HomeAssistant) -> None:
         "pyuptimerobot.UptimeRobot.async_get_monitors",
         side_effect=UptimeRobotAuthenticationException,
     ):
-        async_fire_time_changed(hass, dt.utcnow() + COORDINATOR_UPDATE_INTERVAL)
+        async_fire_time_changed(hass, dt_util.utcnow() + COORDINATOR_UPDATE_INTERVAL)
         await hass.async_block_till_done()
 
     entity = hass.states.get(UPTIMEROBOT_BINARY_SENSOR_TEST_ENTITY)

--- a/tests/components/uptimerobot/test_init.py
+++ b/tests/components/uptimerobot/test_init.py
@@ -12,7 +12,7 @@ from homeassistant.components.uptimerobot.const import (
 from homeassistant.const import STATE_ON, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from .common import (
     MOCK_UPTIMEROBOT_CONFIG_ENTRY_DATA,
@@ -106,7 +106,7 @@ async def test_reauthentication_trigger_after_setup(
         "pyuptimerobot.UptimeRobot.async_get_monitors",
         side_effect=UptimeRobotAuthenticationException,
     ):
-        async_fire_time_changed(hass, dt.utcnow() + COORDINATOR_UPDATE_INTERVAL)
+        async_fire_time_changed(hass, dt_util.utcnow() + COORDINATOR_UPDATE_INTERVAL)
         await hass.async_block_till_done()
 
     flows = hass.config_entries.flow.async_progress()
@@ -134,7 +134,7 @@ async def test_integration_reload(hass: HomeAssistant) -> None:
         return_value=mock_uptimerobot_api_response(),
     ):
         assert await hass.config_entries.async_reload(mock_entry.entry_id)
-        async_fire_time_changed(hass, dt.utcnow() + COORDINATOR_UPDATE_INTERVAL)
+        async_fire_time_changed(hass, dt_util.utcnow() + COORDINATOR_UPDATE_INTERVAL)
         await hass.async_block_till_done()
 
     entry = hass.config_entries.async_get_entry(mock_entry.entry_id)
@@ -152,7 +152,7 @@ async def test_update_errors(
         "pyuptimerobot.UptimeRobot.async_get_monitors",
         side_effect=UptimeRobotException,
     ):
-        async_fire_time_changed(hass, dt.utcnow() + COORDINATOR_UPDATE_INTERVAL)
+        async_fire_time_changed(hass, dt_util.utcnow() + COORDINATOR_UPDATE_INTERVAL)
         await hass.async_block_till_done()
         assert (
             hass.states.get(UPTIMEROBOT_BINARY_SENSOR_TEST_ENTITY).state
@@ -163,7 +163,7 @@ async def test_update_errors(
         "pyuptimerobot.UptimeRobot.async_get_monitors",
         return_value=mock_uptimerobot_api_response(),
     ):
-        async_fire_time_changed(hass, dt.utcnow() + COORDINATOR_UPDATE_INTERVAL)
+        async_fire_time_changed(hass, dt_util.utcnow() + COORDINATOR_UPDATE_INTERVAL)
         await hass.async_block_till_done()
         assert hass.states.get(UPTIMEROBOT_BINARY_SENSOR_TEST_ENTITY).state == STATE_ON
 
@@ -171,7 +171,7 @@ async def test_update_errors(
         "pyuptimerobot.UptimeRobot.async_get_monitors",
         return_value=mock_uptimerobot_api_response(key=MockApiResponseKey.ERROR),
     ):
-        async_fire_time_changed(hass, dt.utcnow() + COORDINATOR_UPDATE_INTERVAL)
+        async_fire_time_changed(hass, dt_util.utcnow() + COORDINATOR_UPDATE_INTERVAL)
         await hass.async_block_till_done()
         assert (
             hass.states.get(UPTIMEROBOT_BINARY_SENSOR_TEST_ENTITY).state
@@ -201,7 +201,7 @@ async def test_device_management(hass: HomeAssistant) -> None:
             data=[MOCK_UPTIMEROBOT_MONITOR, {**MOCK_UPTIMEROBOT_MONITOR, "id": 12345}]
         ),
     ):
-        async_fire_time_changed(hass, dt.utcnow() + COORDINATOR_UPDATE_INTERVAL)
+        async_fire_time_changed(hass, dt_util.utcnow() + COORDINATOR_UPDATE_INTERVAL)
         await hass.async_block_till_done()
 
     devices = dr.async_entries_for_config_entry(dev_reg, mock_entry.entry_id)
@@ -218,7 +218,7 @@ async def test_device_management(hass: HomeAssistant) -> None:
         "pyuptimerobot.UptimeRobot.async_get_monitors",
         return_value=mock_uptimerobot_api_response(),
     ):
-        async_fire_time_changed(hass, dt.utcnow() + COORDINATOR_UPDATE_INTERVAL)
+        async_fire_time_changed(hass, dt_util.utcnow() + COORDINATOR_UPDATE_INTERVAL)
         await hass.async_block_till_done()
         await hass.async_block_till_done()
 

--- a/tests/components/uptimerobot/test_sensor.py
+++ b/tests/components/uptimerobot/test_sensor.py
@@ -8,7 +8,7 @@ from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.components.uptimerobot.const import COORDINATOR_UPDATE_INTERVAL
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from .common import (
     MOCK_UPTIMEROBOT_MONITOR,
@@ -52,7 +52,7 @@ async def test_unaviable_on_update_failure(hass: HomeAssistant) -> None:
         "pyuptimerobot.UptimeRobot.async_get_monitors",
         side_effect=UptimeRobotAuthenticationException,
     ):
-        async_fire_time_changed(hass, dt.utcnow() + COORDINATOR_UPDATE_INTERVAL)
+        async_fire_time_changed(hass, dt_util.utcnow() + COORDINATOR_UPDATE_INTERVAL)
         await hass.async_block_till_done()
 
     entity = hass.states.get(UPTIMEROBOT_SENSOR_TEST_ENTITY)

--- a/tests/components/vallox/test_sensor.py
+++ b/tests/components/vallox/test_sensor.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant.core import HomeAssistant
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from .conftest import patch_metrics
 
@@ -42,7 +42,7 @@ def _sensor_to_datetime(sensor):
 
 
 def _now_at_13():
-    return dt.now().timetz().replace(hour=13, minute=0, second=0, microsecond=0)
+    return dt_util.now().timetz().replace(hour=13, minute=0, second=0, microsecond=0)
 
 
 async def test_remaining_filter_returns_timestamp(
@@ -52,7 +52,7 @@ async def test_remaining_filter_returns_timestamp(
     # Act
     with patch(
         "homeassistant.components.vallox._api_get_next_filter_change_date",
-        return_value=dt.now().date(),
+        return_value=dt_util.now().date(),
     ), patch_metrics(metrics={}):
         await hass.config_entries.async_setup(mock_entry.entry_id)
         await hass.async_block_till_done()
@@ -94,7 +94,7 @@ async def test_remaining_time_for_filter_in_the_future(
     """Test remaining time for filter when Vallox returns a date in the future."""
     # Arrange
     remaining_days = 112
-    mocked_filter_end_date = dt.now().date() + timedelta(days=remaining_days)
+    mocked_filter_end_date = dt_util.now().date() + timedelta(days=remaining_days)
 
     # Act
     with patch(
@@ -118,7 +118,7 @@ async def test_remaining_time_for_filter_today(
     """Test remaining time for filter when Vallox returns today."""
     # Arrange
     remaining_days = 0
-    mocked_filter_end_date = dt.now().date() + timedelta(days=remaining_days)
+    mocked_filter_end_date = dt_util.now().date() + timedelta(days=remaining_days)
 
     # Act
     with patch(
@@ -142,7 +142,7 @@ async def test_remaining_time_for_filter_in_the_past(
     """Test remaining time for filter when Vallox returns a date in the past."""
     # Arrange
     remaining_days = -3
-    mocked_filter_end_date = dt.now().date() + timedelta(days=remaining_days)
+    mocked_filter_end_date = dt_util.now().date() + timedelta(days=remaining_days)
 
     # Act
     with patch(

--- a/tests/components/version/common.py
+++ b/tests/components/version/common.py
@@ -14,7 +14,7 @@ from homeassistant.components.version.const import (
 )
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
@@ -47,7 +47,9 @@ async def mock_get_version_update(
         return_value=(version, data),
         side_effect=side_effect,
     ):
-        async_fire_time_changed(hass, dt.utcnow() + UPDATE_COORDINATOR_UPDATE_INTERVAL)
+        async_fire_time_changed(
+            hass, dt_util.utcnow() + UPDATE_COORDINATOR_UPDATE_INTERVAL
+        )
         await hass.async_block_till_done()
 
 

--- a/tests/components/version/test_config_flow.py
+++ b/tests/components/version/test_config_flow.py
@@ -20,7 +20,7 @@ from homeassistant.components.version.const import (
 from homeassistant.const import CONF_SOURCE
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from .common import MOCK_VERSION, MOCK_VERSION_DATA, setup_version_integration
 
@@ -37,7 +37,9 @@ async def test_reload_config_entry(hass: HomeAssistant) -> None:
         return_value=(MOCK_VERSION, MOCK_VERSION_DATA),
     ):
         assert await hass.config_entries.async_reload(config_entry.entry_id)
-        async_fire_time_changed(hass, dt.utcnow() + UPDATE_COORDINATOR_UPDATE_INTERVAL)
+        async_fire_time_changed(
+            hass, dt_util.utcnow() + UPDATE_COORDINATOR_UPDATE_INTERVAL
+        )
         await hass.async_block_till_done()
 
     entry = hass.config_entries.async_get_entry(config_entry.entry_id)

--- a/tests/components/webostv/test_media_player.py
+++ b/tests/components/webostv/test_media_player.py
@@ -63,7 +63,7 @@ from homeassistant.core import HomeAssistant, State
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from . import setup_webostv
 from .const import CHANNEL_2, ENTITY_ID, TV_NAME
@@ -479,7 +479,7 @@ async def test_client_disconnected(hass: HomeAssistant, client, monkeypatch) -> 
     monkeypatch.setattr(client, "is_connected", Mock(return_value=False))
     monkeypatch.setattr(client, "connect", Mock(side_effect=asyncio.TimeoutError))
 
-    async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=20))
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=20))
     await hass.async_block_till_done()
 
 
@@ -804,7 +804,7 @@ async def test_reauth_reconnect(hass: HomeAssistant, client, monkeypatch) -> Non
 
     assert entry.state == ConfigEntryState.LOADED
 
-    async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=20))
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=20))
     await hass.async_block_till_done()
 
     assert entry.state == ConfigEntryState.LOADED

--- a/tests/components/wemo/test_init.py
+++ b/tests/components/wemo/test_init.py
@@ -9,7 +9,7 @@ from homeassistant.components.wemo.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from .conftest import (
     MOCK_FIRMWARE_VERSION,
@@ -164,7 +164,7 @@ async def test_discovery(hass: HomeAssistant, pywemo_registry) -> None:
         # Test that discovery runs periodically and the async_dispatcher_send code works.
         async_fire_time_changed(
             hass,
-            dt.utcnow()
+            dt_util.utcnow()
             + timedelta(seconds=WemoDiscovery.ADDITIONAL_SECONDS_BETWEEN_SCANS + 1),
         )
         await hass.async_block_till_done()

--- a/tests/components/youtube/test_sensor.py
+++ b/tests/components/youtube/test_sensor.py
@@ -7,7 +7,7 @@ from google.auth.exceptions import RefreshError
 from homeassistant import config_entries
 from homeassistant.components.youtube import DOMAIN
 from homeassistant.core import HomeAssistant
-from homeassistant.util import dt
+from homeassistant.util import dt as dt_util
 
 from ...common import async_fire_time_changed
 from .conftest import TOKEN, ComponentSetup
@@ -43,7 +43,7 @@ async def test_sensor_reauth_trigger(
     await setup_integration()
 
     with patch(TOKEN, side_effect=RefreshError):
-        future = dt.utcnow() + timedelta(minutes=15)
+        future = dt_util.utcnow() + timedelta(minutes=15)
         async_fire_time_changed(hass, future)
         await hass.async_block_till_done()
 


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Datetime related module names are unfortunate, but being consistent with how they're imported helps. About 70% of the cases throughout the tree already imports `homeassistant.util.dt` as `dt_util`, this PR is one in a series that brings the rest in line (to be followed by a ruff config change that will start to enforce this).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
