### PR TITLE
Directly check string representation of sensor states in APCUPSD tests

### DIFF
--- a/tests/components/apcupsd/test_sensor.py
+++ b/tests/components/apcupsd/test_sensor.py
@@ -1,5 +1,4 @@
 """Test sensors of APCUPSd integration."""
-import pytest
 
 from homeassistant.components.sensor import (
     ATTR_STATE_CLASS,
@@ -35,7 +34,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
     # Test two representative voltage sensors.
     state = hass.states.get("sensor.ups_input_voltage")
     assert state
-    assert pytest.approx(float(state.state)) == 124.0
+    assert state.state == "124.0"
     assert (
         state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfElectricPotential.VOLT
     )
@@ -47,7 +46,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
 
     state = hass.states.get("sensor.ups_battery_voltage")
     assert state
-    assert pytest.approx(float(state.state)) == 13.7
+    assert state.state == "13.7"
     assert (
         state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfElectricPotential.VOLT
     )
@@ -60,7 +59,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
     # Test a representative percentage sensor.
     state = hass.states.get("sensor.ups_load")
     assert state
-    assert pytest.approx(float(state.state)) == 14.0
+    assert state.state == "14.0"
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == PERCENTAGE
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
     entry = registry.async_get("sensor.ups_load")
@@ -70,7 +69,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
     # Test a representative wattage sensor.
     state = hass.states.get("sensor.ups_nominal_output_power")
     assert state
-    assert pytest.approx(float(state.state)) == 330.0
+    assert state.state == "330.0"
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfPower.WATT
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.POWER
     entry = registry.async_get("sensor.ups_nominal_output_power")

--- a/tests/components/apcupsd/test_sensor.py
+++ b/tests/components/apcupsd/test_sensor.py
@@ -69,7 +69,7 @@ async def test_sensor(hass: HomeAssistant) -> None:
     # Test a representative wattage sensor.
     state = hass.states.get("sensor.ups_nominal_output_power")
     assert state
-    assert state.state == "330.0"
+    assert state.state == "330"
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfPower.WATT
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.POWER
     entry = registry.async_get("sensor.ups_nominal_output_power")


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

In the APCUPSD tests, we currently convert the numeric sensor states to floats and use `pytest.approx` to verify if the states match the expected values. This conversion had to be done due to a previous issue in the APCUPSD integration's unit split logic for the raw strings. The bug caused the sensors to inaccurately report numeric values with an additional trailing space (e.g., `12.0 ` instead of `12.0`). Refer to issue #81476 for more details.

PR #93724 rewrote the unit inference logic and coincidentally fixed the issue. This PR removes the "hacks" (conversions  to floats) in the test code and strictly checks the string representations of the sensor states to prevent future regressions.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #81476
- This PR is related to issue: #81476
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
