### PR TITLE
Remove outdated HAOS check from bluetooth

### DIFF
--- a/homeassistant/components/bluetooth/__init__.py
+++ b/homeassistant/components/bluetooth/__init__.py
@@ -6,7 +6,6 @@ import logging
 import platform
 from typing import TYPE_CHECKING
 
-from awesomeversion import AwesomeVersion
 from bleak_retry_connector import BleakSlotManager
 from bluetooth_adapters import (
     ADAPTER_ADDRESS,
@@ -25,12 +24,8 @@ from bluetooth_adapters import (
 from home_assistant_bluetooth import BluetoothServiceInfo, BluetoothServiceInfoBleak
 
 from homeassistant.components import usb
-from homeassistant.config_entries import (
-    SOURCE_IGNORE,
-    SOURCE_INTEGRATION_DISCOVERY,
-    ConfigEntry,
-)
-from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, EVENT_HOMEASSISTANT_STOP
+from homeassistant.config_entries import SOURCE_INTEGRATION_DISCOVERY, ConfigEntry
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import Event, HassJob, HomeAssistant, callback as hass_callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import (
@@ -40,11 +35,7 @@ from homeassistant.helpers import (
 )
 from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.event import async_call_later
-from homeassistant.helpers.issue_registry import (
-    IssueSeverity,
-    async_create_issue,
-    async_delete_issue,
-)
+from homeassistant.helpers.issue_registry import async_delete_issue
 from homeassistant.loader import async_get_bluetooth
 
 from . import models
@@ -121,8 +112,6 @@ __all__ = [
 
 _LOGGER = logging.getLogger(__name__)
 
-RECOMMENDED_MIN_HAOS_VERSION = AwesomeVersion("9.0.dev0")
-
 CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
 
 
@@ -131,43 +120,6 @@ async def _async_get_adapter_from_address(
 ) -> str | None:
     """Get an adapter by the address."""
     return await _get_manager(hass).async_get_adapter_from_address(address)
-
-
-@hass_callback
-def _async_haos_is_new_enough(hass: HomeAssistant) -> bool:
-    """Check if the version of Home Assistant Operating System is new enough."""
-    # Only warn if a USB adapter is plugged in
-    if not any(
-        entry
-        for entry in hass.config_entries.async_entries(DOMAIN)
-        if entry.source != SOURCE_IGNORE
-    ):
-        return True
-    if (
-        not hass.components.hassio.is_hassio()
-        or not (os_info := hass.components.hassio.get_os_info())
-        or not (haos_version := os_info.get("version"))
-        or AwesomeVersion(haos_version) >= RECOMMENDED_MIN_HAOS_VERSION
-    ):
-        return True
-    return False
-
-
-@hass_callback
-def _async_check_haos(hass: HomeAssistant) -> None:
-    """Create or delete an the haos_outdated issue."""
-    if _async_haos_is_new_enough(hass):
-        async_delete_issue(hass, DOMAIN, "haos_outdated")
-        return
-    async_create_issue(
-        hass,
-        DOMAIN,
-        "haos_outdated",
-        is_fixable=False,
-        severity=IssueSeverity.WARNING,
-        learn_more_url="/config/updates",
-        translation_key="haos_outdated",
-    )
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
@@ -242,12 +194,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         EVENT_HOMEASSISTANT_STOP, hass_callback(lambda event: cancel())
     )
 
-    # Wait to check until after start to make sure
-    # that the system info is available.
-    hass.bus.async_listen_once(
-        EVENT_HOMEASSISTANT_STARTED,
-        hass_callback(lambda event: _async_check_haos(hass)),
-    )
+    async_delete_issue(hass, DOMAIN, "haos_outdated")
     return True
 
 

--- a/homeassistant/components/bluetooth/manifest.json
+++ b/homeassistant/components/bluetooth/manifest.json
@@ -1,7 +1,6 @@
 {
   "domain": "bluetooth",
   "name": "Bluetooth",
-  "after_dependencies": ["hassio"],
   "codeowners": ["@bdraco"],
   "config_flow": true,
   "dependencies": ["logger", "usb"],

--- a/homeassistant/components/bluetooth/strings.json
+++ b/homeassistant/components/bluetooth/strings.json
@@ -1,10 +1,4 @@
 {
-  "issues": {
-    "haos_outdated": {
-      "title": "Update to Home Assistant Operating System 9.0 or later",
-      "description": "To improve Bluetooth reliability and performance, we highly recommend you update to version 9.0 or later of the Home Assistant Operating System."
-    }
-  },
   "config": {
     "flow_title": "{name}",
     "step": {

--- a/tests/components/bluetooth/test_init.py
+++ b/tests/components/bluetooth/test_init.py
@@ -8,7 +8,6 @@ from bleak import BleakError
 from bleak.backends.scanner import AdvertisementData, BLEDevice
 from bluetooth_adapters import DEFAULT_ADDRESS
 import pytest
-from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components import bluetooth
 from homeassistant.components.bluetooth import (
@@ -2922,35 +2921,13 @@ async def test_discover_new_usb_adapters_with_firmware_fallback_delay(
     assert len(hass.config_entries.flow.async_progress(DOMAIN)) == 1
 
 
-async def test_issue_outdated_haos(
-    hass: HomeAssistant,
-    mock_bleak_scanner_start: MagicMock,
-    one_adapter: None,
-    operating_system_85: None,
-    snapshot: SnapshotAssertion,
-) -> None:
-    """Test we create an issue on outdated haos."""
-    entry = MockConfigEntry(
-        domain=bluetooth.DOMAIN, data={}, unique_id="00:00:00:00:00:01"
-    )
-    entry.add_to_hass(hass)
-    assert await async_setup_component(hass, bluetooth.DOMAIN, {})
-    await hass.async_block_till_done()
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
-    await hass.async_block_till_done()
-    registry = async_get_issue_registry(hass)
-    issue = registry.async_get_issue(DOMAIN, "haos_outdated")
-    assert issue is not None
-    assert issue == snapshot
-
-
-async def test_issue_outdated_haos_no_adapters(
+async def test_issue_outdated_haos_removed(
     hass: HomeAssistant,
     mock_bleak_scanner_start: MagicMock,
     no_adapters: None,
     operating_system_85: None,
 ) -> None:
-    """Test we do not create an issue on outdated haos if there are no adapters."""
+    """Test we do not create an issue on outdated haos anymore."""
     assert await async_setup_component(hass, bluetooth.DOMAIN, {})
     await hass.async_block_till_done()
     hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When bluetooth was released we had a lot of problems with outdated HAOS. This check was added to reduce the influx of issues and get users in a good place. Analytics shows that almost every reporting install is at 9.x+ or later


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
