### PR TITLE
Add a debounce to ld2410 to prevent it from overwhelming the state machine with many devices

### DIFF
--- a/homeassistant/components/ld2410_ble/__init__.py
+++ b/homeassistant/components/ld2410_ble/__init__.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from bleak_retry_connector import BleakError, get_device
+from bleak_retry_connector import BleakError, close_stale_connections, get_device
 from ld2410_ble import LD2410BLE
 
 from homeassistant.components import bluetooth
@@ -31,6 +31,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         raise ConfigEntryNotReady(
             f"Could not find LD2410B device with address {address}"
         )
+
+    await close_stale_connections(ble_device)
+
     ld2410_ble = LD2410BLE(ble_device)
 
     coordinator = LD2410BLECoordinator(hass, ld2410_ble)

--- a/homeassistant/components/ld2410_ble/coordinator.py
+++ b/homeassistant/components/ld2410_ble/coordinator.py
@@ -43,6 +43,7 @@ class LD2410BLECoordinator(DataUpdateCoordinator[None]):
     def _async_handle_debounced_update(self, _now: datetime) -> None:
         """Handle debounced update."""
         self._debounce_cancel = None
+        self._last_update_time = time.monotonic()
         self.async_set_updated_data(None)
 
     @callback

--- a/homeassistant/components/ld2410_ble/coordinator.py
+++ b/homeassistant/components/ld2410_ble/coordinator.py
@@ -1,15 +1,21 @@
 """Data coordinator for receiving LD2410B updates."""
 
+from datetime import datetime
 import logging
+import time
 
 from ld2410_ble import LD2410BLE, LD2410BLEState
 
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import CALLBACK_TYPE, HassJob, HomeAssistant, callback
+from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
+
+NEVER_TIME = -86400.0
+DEBOUNCE_SECONDS = 1.0
 
 
 class LD2410BLECoordinator(DataUpdateCoordinator[None]):
@@ -26,15 +32,42 @@ class LD2410BLECoordinator(DataUpdateCoordinator[None]):
         ld2410_ble.register_callback(self._async_handle_update)
         ld2410_ble.register_disconnected_callback(self._async_handle_disconnect)
         self.connected = False
+        self._last_update_time = NEVER_TIME
+        self._debounce_cancel: CALLBACK_TYPE | None = None
+        self._debounced_update_job = HassJob(
+            self._async_handle_debounced_update,
+            f"LD2410 {ld2410_ble.address} BLE debounced update",
+        )
+
+    @callback
+    def _async_handle_debounced_update(self, _now: datetime) -> None:
+        """Handle debounced update."""
+        self._debounce_cancel = None
+        self.async_set_updated_data(None)
 
     @callback
     def _async_handle_update(self, state: LD2410BLEState) -> None:
         """Just trigger the callbacks."""
         self.connected = True
-        self.async_set_updated_data(None)
+        previous_last_updated_time = self._last_update_time
+        self._last_update_time = time.monotonic()
+        if self._last_update_time - previous_last_updated_time >= DEBOUNCE_SECONDS:
+            self.async_set_updated_data(None)
+            return
+        if self._debounce_cancel is None:
+            self._debounce_cancel = async_call_later(
+                self.hass, DEBOUNCE_SECONDS, self._debounced_update_job
+            )
 
     @callback
     def _async_handle_disconnect(self) -> None:
         """Trigger the callbacks for disconnected."""
         self.connected = False
         self.async_update_listeners()
+
+    async def async_shutdown(self) -> None:
+        """Shutdown the coordinator."""
+        if self._debounce_cancel is not None:
+            self._debounce_cancel()
+            self._debounce_cancel = None
+        await super().async_shutdown()


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


fixes #86665


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
