### PR TITLE
Use ReadOnlyDict for entity registry options

### DIFF
--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 from collections import UserDict
 from collections.abc import Callable, Iterable, Mapping, ValuesView
 import logging
-from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 import attr
@@ -44,6 +43,7 @@ from homeassistant.core import (
 from homeassistant.exceptions import MaxLengthExceeded
 from homeassistant.util import slugify, uuid as uuid_util
 from homeassistant.util.json import format_unserializable_data
+from homeassistant.util.read_only_dict import ReadOnlyDict
 
 from . import device_registry as dr, storage
 from .device_registry import EVENT_DEVICE_REGISTRY_UPDATED
@@ -102,6 +102,7 @@ class RegistryEntryHider(StrEnum):
 
 
 EntityOptionsType = Mapping[str, Mapping[str, Any]]
+ReadOnlyEntityOptionsType = ReadOnlyDict[str, Mapping[str, Any]]
 
 DISLAY_DICT_OPTIONAL = (
     ("ai", "area_id"),
@@ -110,27 +111,13 @@ DISLAY_DICT_OPTIONAL = (
 )
 
 
-class _EntityOptions(UserDict[str, MappingProxyType]):
-    """Container for entity options."""
-
-    def __init__(self, data: Mapping[str, Mapping] | None) -> None:
-        """Initialize."""
-        super().__init__()
-        if data is None:
-            return
-        self.data = {key: MappingProxyType(val) for key, val in data.items()}
-
-    def __setitem__(self, key: str, entry: Mapping) -> None:
-        """Add an item."""
-        raise NotImplementedError
-
-    def __delitem__(self, key: str) -> None:
-        """Remove an item."""
-        raise NotImplementedError
-
-    def as_dict(self) -> dict[str, dict]:
-        """Return dictionary version."""
-        return {key: dict(val) for key, val in self.data.items()}
+def _protect_entity_options(
+    data: EntityOptionsType | None,
+) -> ReadOnlyEntityOptionsType:
+    """Protect entity options from being modified."""
+    if data is None:
+        return ReadOnlyDict({})
+    return ReadOnlyDict({key: ReadOnlyDict(val) for key, val in data.items()})
 
 
 @attr.s(slots=True, frozen=True)
@@ -154,7 +141,9 @@ class RegistryEntry:
     id: str = attr.ib(factory=uuid_util.random_uuid_hex)
     has_entity_name: bool = attr.ib(default=False)
     name: str | None = attr.ib(default=None)
-    options: _EntityOptions = attr.ib(default=None, converter=_EntityOptions)
+    options: ReadOnlyEntityOptionsType = attr.ib(
+        default=None, converter=_protect_entity_options
+    )
     # As set by integration
     original_device_class: str | None = attr.ib(default=None)
     original_icon: str | None = attr.ib(default=None)
@@ -1029,7 +1018,7 @@ class EntityRegistry:
                 "id": entry.id,
                 "has_entity_name": entry.has_entity_name,
                 "name": entry.name,
-                "options": entry.options.as_dict(),
+                "options": entry.options,
                 "original_device_class": entry.original_device_class,
                 "original_icon": entry.original_icon,
                 "original_name": entry.original_name,

--- a/tests/components/homeassistant/snapshots/test_exposed_entities.ambr
+++ b/tests/components/homeassistant/snapshots/test_exposed_entities.ambr
@@ -1,7 +1,7 @@
 # serializer version: 1
 # name: test_get_assistant_settings
   dict({
-    'climate.test_unique1': mappingproxy({
+    'climate.test_unique1': ReadOnlyDict({
       'should_expose': True,
     }),
     'light.not_in_registry': dict({

--- a/tests/helpers/test_entity_registry.py
+++ b/tests/helpers/test_entity_registry.py
@@ -748,13 +748,13 @@ async def test_update_entity_options(entity_registry: er.EntityRegistry) -> None
     assert new_entry_1.options == {"light": {"minimum_brightness": 20}}
 
     # Test it's not possible to modify the options
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(RuntimeError):
         new_entry_1.options["blah"] = {}
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(RuntimeError):
         new_entry_1.options["light"] = {}
-    with pytest.raises(TypeError):
+    with pytest.raises(RuntimeError):
         new_entry_1.options["light"]["blah"] = 123
-    with pytest.raises(TypeError):
+    with pytest.raises(RuntimeError):
         new_entry_1.options["light"]["minimum_brightness"] = 123
 
     entity_registry.async_update_entity_options(

--- a/tests/syrupy.py
+++ b/tests/syrupy.py
@@ -170,7 +170,7 @@ class HomeAssistantSnapshotSerializer(AmberDataSerializer):
                 "config_entry_id": ANY,
                 "device_id": ANY,
                 "id": ANY,
-                "options": data.options.as_dict(),
+                "options": {k: dict(v) for k, v in data.options.items()},
             }
         )
         serialized.pop("_partial_repr")


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
While reviewing #93601 it was noticed this was slow at startup https://github.com/home-assistant/core/pull/93601#issuecomment-1568958280. Its the most expensive call besides the inspect module (for loading new modules)

This is a first pass attempt to improve the performance


<img width="885" alt="Screenshot 2023-05-30 at 2 21 16 PM" src="https://github.com/home-assistant/core/assets/663432/c5775254-abe9-4ce2-8bad-87142c04fce8">


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
