### PR TITLE
Replace Float 'nan' with None for modbus floats

### DIFF
--- a/homeassistant/components/modbus/base_platform.py
+++ b/homeassistant/components/modbus/base_platform.py
@@ -218,13 +218,11 @@ class BaseStructPlatform(BasePlatform, RestoreEntity):
                 # the conversion only when it's absolutely necessary.
                 if isinstance(v_temp, int) and self._precision == 0:
                     v_result.append(str(v_temp))
-                else:
+                elif v_temp != v_temp:  # noqa: PLR0124
                     # NaN float detection replace with None
-                    # Issue: https://github.com/home-assistant/core/issues/93297
-                    if v_temp != v_temp:
-                        v_result.append(None)
-                    else:
-                        v_result.append(f"{float(v_temp):.{self._precision}f}")
+                    v_result.append("nan")
+                else:
+                    v_result.append(f"{float(v_temp):.{self._precision}f}")
             return ",".join(map(str, v_result))
 
         # Apply scale, precision, limits to floats and ints
@@ -233,16 +231,16 @@ class BaseStructPlatform(BasePlatform, RestoreEntity):
         # We could convert int to float, and the code would still work; however
         # we lose some precision, and unit tests will fail. Therefore, we do
         # the conversion only when it's absolutely necessary.
+
+        # NaN float detection replace with None
+        if val_result != val_result:  # noqa: PLR0124
+            return None  # pragma: no cover
         if isinstance(val_result, int) and self._precision == 0:
             return str(val_result)
         if isinstance(val_result, str):
             if val_result == "nan":
                 val_result = STATE_UNAVAILABLE  # pragma: no cover
             return val_result
-        # NaN float detection replace with None
-        # Issue: https://github.com/home-assistant/core/issues/93297
-        if val_result != val_result:
-            return None  # pragma: no cover
         return f"{float(val_result):.{self._precision}f}"
 
 

--- a/homeassistant/components/modbus/base_platform.py
+++ b/homeassistant/components/modbus/base_platform.py
@@ -219,7 +219,12 @@ class BaseStructPlatform(BasePlatform, RestoreEntity):
                 if isinstance(v_temp, int) and self._precision == 0:
                     v_result.append(str(v_temp))
                 else:
-                    v_result.append(f"{float(v_temp):.{self._precision}f}")
+                    # NaN float detection replace with None
+                    # Issue: https://github.com/home-assistant/core/issues/93297
+                    if v_temp != v_temp:
+                        v_result.append(None)
+                    else:
+                        v_result.append(f"{float(v_temp):.{self._precision}f}")
             return ",".join(map(str, v_result))
 
         # Apply scale, precision, limits to floats and ints
@@ -234,6 +239,10 @@ class BaseStructPlatform(BasePlatform, RestoreEntity):
             if val_result == "nan":
                 val_result = STATE_UNAVAILABLE  # pragma: no cover
             return val_result
+        # NaN float detection replace with None
+        # Issue: https://github.com/home-assistant/core/issues/93297
+        if val_result != val_result:
+            return None  # pragma: no cover
         return f"{float(val_result):.{self._precision}f}"
 
 

--- a/homeassistant/components/modbus/base_platform.py
+++ b/homeassistant/components/modbus/base_platform.py
@@ -220,7 +220,7 @@ class BaseStructPlatform(BasePlatform, RestoreEntity):
                     v_result.append(str(v_temp))
                 elif v_temp != v_temp:  # noqa: PLR0124
                     # NaN float detection replace with None
-                    v_result.append("nan")
+                    v_result.append("nan")  # pragma: no cover
                 else:
                     v_result.append(f"{float(v_temp):.{self._precision}f}")
             return ",".join(map(str, v_result))


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Detect NaN from modbus registers. Float 16/32/64 can return NaN 0x7FC0 which currently gets converted to a string, resulting in the core throwing an error as it's expecting a number. The PR detects 'nan' in unpack_structure_result, replacing with None

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
fixes #93297
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
