### PR TITLE
Add Button lights switch to roborock

### DIFF
--- a/homeassistant/components/roborock/strings.json
+++ b/homeassistant/components/roborock/strings.json
@@ -100,6 +100,9 @@
     "switch": {
       "child_lock": {
         "name": "Child lock"
+      },
+      "button_lights": {
+        "name": "Button lights"
       }
     },
     "vacuum": {

--- a/homeassistant/components/roborock/switch.py
+++ b/homeassistant/components/roborock/switch.py
@@ -50,7 +50,7 @@ SWITCH_DESCRIPTIONS: list[RoborockSwitchDescription] = [
         translation_key="child_lock",
         icon="mdi:account-lock",
         entity_category=EntityCategory.CONFIG,
-    )
+    ),
 ]
 
 
@@ -96,15 +96,16 @@ class RoborockSwitchEntity(RoborockCoordinatedEntity, SwitchEntity):
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the switch."""
         await self.entity_description.set_command(self, False)
-        return self.async_schedule_update_ha_state(True)
+        self.async_schedule_update_ha_state(True)
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the switch."""
         await self.entity_description.set_command(self, True)
-        return self.async_schedule_update_ha_state(True)
+        self.async_schedule_update_ha_state(True)
 
     async def async_update(self) -> None:
         """Update switch."""
+        await super().async_update()
         self._attr_is_on = self.entity_description.evaluate_value(
             await self.entity_description.get_value(self)
         )

--- a/homeassistant/components/roborock/switch.py
+++ b/homeassistant/components/roborock/switch.py
@@ -27,7 +27,7 @@ class RoborockSwitchDescriptionMixin:
     # Gets the status of the switch
     get_value: Callable[[RoborockCoordinatedEntity], Coroutine[Any, Any, dict]]
     # Evaluate the result of get_value to determine a bool
-    evaluate_value: Callable[[dict], bool]
+    evaluate_value: Callable[[dict | int], bool]
     # Sets the status of the switch
     set_command: Callable[[RoborockCoordinatedEntity, bool], Coroutine[Any, Any, dict]]
 
@@ -45,10 +45,21 @@ SWITCH_DESCRIPTIONS: list[RoborockSwitchDescription] = [
             RoborockCommand.SET_CHILD_LOCK_STATUS, {"lock_status": 1 if value else 0}
         ),
         get_value=lambda data: data.send(RoborockCommand.GET_CHILD_LOCK_STATUS),
-        evaluate_value=lambda data: data["lock_status"] == 1,
+        evaluate_value=lambda data: isinstance(data, dict) and data["lock_status"] == 1,
         key="child_lock",
         translation_key="child_lock",
         icon="mdi:account-lock",
+        entity_category=EntityCategory.CONFIG,
+    ),
+    RoborockSwitchDescription(
+        set_command=lambda entity, value: entity.send(
+            RoborockCommand.SET_LED_STATUS, [1] if value else [0]
+        ),
+        get_value=lambda data: data.send(RoborockCommand.GET_LED_STATUS),
+        evaluate_value=lambda data: isinstance(data, int) and data == 1,
+        key="button_lights",
+        translation_key="button_lights",
+        icon="mdi:alarm-light-outline",
         entity_category=EntityCategory.CONFIG,
     ),
 ]

--- a/tests/components/roborock/test_switch.py
+++ b/tests/components/roborock/test_switch.py
@@ -13,9 +13,7 @@ from tests.common import MockConfigEntry
 
 @pytest.mark.parametrize(
     ("entity_id"),
-    [
-        ("switch.roborock_s7_maxv_child_lock"),
-    ],
+    [("switch.roborock_s7_maxv_child_lock"), ("switch.roborock_s7_maxv_button_lights")],
 )
 async def test_update_success(
     hass: HomeAssistant,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds a switch to control button lights for Roborock vacuums. Also addresses feedback here #93833

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
