### PR TITLE
Give zwave_js platinum quality score

### DIFF
--- a/homeassistant/components/zwave_js/manifest.json
+++ b/homeassistant/components/zwave_js/manifest.json
@@ -8,6 +8,7 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "loggers": ["zwave_js_server"],
+  "quality_scale": "platinum",
   "requirements": ["pyserial==3.5", "zwave-js-server-python==0.49.0"],
   "usb": [
     {


### PR DESCRIPTION
## Proposed change
I believe we finally qualify now that the test coverage has improved 🎉 . Test results below:

```
---------- coverage: platform darwin, python 3.11.3-final-0 ----------
Name                                                             Stmts   Miss  Cover   Missing
----------------------------------------------------------------------------------------------
homeassistant/components/zwave_js/__init__.py                      370      1    99%   944
homeassistant/components/zwave_js/addon.py                          10      0   100%
homeassistant/components/zwave_js/api.py                           835      0   100%
homeassistant/components/zwave_js/binary_sensor.py                 114      0   100%
homeassistant/components/zwave_js/button.py                         64      0   100%
homeassistant/components/zwave_js/climate.py                       241      0   100%
homeassistant/components/zwave_js/config_flow.py                   433      0   100%
homeassistant/components/zwave_js/config_validation.py              15      0   100%
homeassistant/components/zwave_js/const.py                         108      0   100%
homeassistant/components/zwave_js/cover.py                         197      4    98%   348-349, 380-381
homeassistant/components/zwave_js/device_action.py                  92      1    99%   194
homeassistant/components/zwave_js/device_automation_helpers.py      40      0   100%
homeassistant/components/zwave_js/device_condition.py               90      0   100%
homeassistant/components/zwave_js/device_trigger.py                143      2    99%   511, 518
homeassistant/components/zwave_js/diagnostics.py                    69      0   100%
homeassistant/components/zwave_js/discovery.py                     176      4    98%   104, 1016, 1039, 1186
homeassistant/components/zwave_js/discovery_data_template.py       150      3    98%   381, 534-535
homeassistant/components/zwave_js/entity.py                        120      1    99%   157
homeassistant/components/zwave_js/fan.py                           206      2    99%   118, 307
homeassistant/components/zwave_js/helpers.py                       191      1    99%   433
homeassistant/components/zwave_js/humidifier.py                     99      1    99%   183
homeassistant/components/zwave_js/light.py                         216      5    98%   289, 449-453
homeassistant/components/zwave_js/lock.py                           52      0   100%
homeassistant/components/zwave_js/logbook.py                        44      0   100%
homeassistant/components/zwave_js/migrate.py                        97      0   100%
homeassistant/components/zwave_js/number.py                         88      0   100%
homeassistant/components/zwave_js/select.py                         86      0   100%
homeassistant/components/zwave_js/sensor.py                        220      5    98%   471, 665, 709, 721, 825
homeassistant/components/zwave_js/services.py                      225      3    99%   98, 161, 576
homeassistant/components/zwave_js/siren.py                          49      0   100%
homeassistant/components/zwave_js/switch.py                         87      0   100%
homeassistant/components/zwave_js/trigger.py                        18      0   100%
homeassistant/components/zwave_js/triggers/__init__.py               0      0   100%
homeassistant/components/zwave_js/triggers/event.py                113      2    98%   83, 163
homeassistant/components/zwave_js/triggers/trigger_helpers.py       20      0   100%
homeassistant/components/zwave_js/triggers/value_updated.py         68      0   100%
homeassistant/components/zwave_js/update.py                        173      1    99%   150
----------------------------------------------------------------------------------------------
TOTAL                                                             5319     36    99%
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/27599

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
