### PR TITLE
Pass device ID to conversation input

### DIFF
--- a/homeassistant/components/assist_pipeline/__init__.py
+++ b/homeassistant/components/assist_pipeline/__init__.py
@@ -57,6 +57,7 @@ async def async_pipeline_from_audio_stream(
     pipeline_id: str | None = None,
     conversation_id: str | None = None,
     tts_audio_output: str | None = None,
+    device_id: str | None = None,
 ) -> None:
     """Create an audio pipeline from an audio stream.
 
@@ -64,6 +65,7 @@ async def async_pipeline_from_audio_stream(
     """
     pipeline_input = PipelineInput(
         conversation_id=conversation_id,
+        device_id=device_id,
         stt_metadata=stt_metadata,
         stt_stream=stt_stream,
         run=PipelineRun(

--- a/homeassistant/components/assist_pipeline/pipeline.py
+++ b/homeassistant/components/assist_pipeline/pipeline.py
@@ -499,7 +499,7 @@ class PipelineRun:
         self.intent_agent = agent_info.id
 
     async def recognize_intent(
-        self, intent_input: str, conversation_id: str | None
+        self, intent_input: str, conversation_id: str | None, device_id: str | None
     ) -> str:
         """Run intent recognition portion of pipeline. Returns text to speak."""
         if self.intent_agent is None:
@@ -521,6 +521,7 @@ class PipelineRun:
                 hass=self.hass,
                 text=intent_input,
                 conversation_id=conversation_id,
+                device_id=device_id,
                 context=self.context,
                 language=self.pipeline.conversation_language,
                 agent_id=self.intent_agent,
@@ -655,6 +656,8 @@ class PipelineInput:
 
     conversation_id: str | None = None
 
+    device_id: str | None = None
+
     async def execute(self) -> None:
         """Run pipeline."""
         self.run.start()
@@ -678,7 +681,9 @@ class PipelineInput:
                 if current_stage == PipelineStage.INTENT:
                     assert intent_input is not None
                     tts_input = await self.run.recognize_intent(
-                        intent_input, self.conversation_id
+                        intent_input,
+                        self.conversation_id,
+                        self.device_id,
                     )
                     current_stage = PipelineStage.TTS
 

--- a/homeassistant/components/conversation/__init__.py
+++ b/homeassistant/components/conversation/__init__.py
@@ -362,6 +362,7 @@ async def async_converse(
     context: core.Context,
     language: str | None = None,
     agent_id: str | None = None,
+    device_id: str | None = None,
 ) -> ConversationResult:
     """Process text and get intent."""
     agent = await _get_agent_manager(hass).async_get_agent(agent_id)
@@ -375,6 +376,7 @@ async def async_converse(
             text=text,
             context=context,
             conversation_id=conversation_id,
+            device_id=device_id,
             language=language,
         )
     )

--- a/homeassistant/components/conversation/agent.py
+++ b/homeassistant/components/conversation/agent.py
@@ -16,6 +16,7 @@ class ConversationInput:
     text: str
     context: Context
     conversation_id: str | None
+    device_id: str | None
     language: str
 
 

--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -143,7 +143,7 @@ async def async_setup_entry(  # noqa: C901
     port = entry.data[CONF_PORT]
     password = entry.data[CONF_PASSWORD]
     noise_psk = entry.data.get(CONF_NOISE_PSK)
-    device_id: str | None = None
+    device_id: str = None  # type: ignore[assignment]
 
     zeroconf_instance = await zeroconf.async_get_instance(hass)
 
@@ -316,6 +316,7 @@ async def async_setup_entry(  # noqa: C901
 
         hass.async_create_background_task(
             voice_assistant_udp_server.run_pipeline(
+                device_id=device_id,
                 conversation_id=conversation_id or None,
                 use_vad=use_vad,
             ),

--- a/homeassistant/components/esphome/voice_assistant.py
+++ b/homeassistant/components/esphome/voice_assistant.py
@@ -293,6 +293,7 @@ class VoiceAssistantUDPServer(asyncio.DatagramProtocol):
 
     async def run_pipeline(
         self,
+        device_id: str,
         conversation_id: str | None,
         use_vad: bool = False,
         pipeline_timeout: float = 30.0,
@@ -331,6 +332,7 @@ class VoiceAssistantUDPServer(asyncio.DatagramProtocol):
                         self.hass, DOMAIN, self.device_info.mac_address
                     ),
                     conversation_id=conversation_id,
+                    device_id=device_id,
                     tts_audio_output=tts_audio_output,
                 )
 

--- a/homeassistant/components/voip/voip.py
+++ b/homeassistant/components/voip/voip.py
@@ -251,6 +251,7 @@ class PipelineRtpDatagramProtocol(RtpDatagramProtocol):
                         self.hass, DOMAIN, self.voip_device.voip_id
                     ),
                     conversation_id=self._conversation_id,
+                    device_id=self.voip_device.device_id,
                     tts_audio_output="raw",
                 )
 

--- a/tests/components/conversation/test_init.py
+++ b/tests/components/conversation/test_init.py
@@ -1371,6 +1371,7 @@ async def test_non_default_response(hass: HomeAssistant, init_components) -> Non
             text="open the front door",
             context=Context(),
             conversation_id=None,
+            device_id=None,
             language=hass.config.language,
         )
     )

--- a/tests/components/esphome/test_voice_assistant.py
+++ b/tests/components/esphome/test_voice_assistant.py
@@ -68,7 +68,9 @@ async def test_pipeline_events(
 ) -> None:
     """Test that the pipeline function is called."""
 
-    async def async_pipeline_from_audio_stream(*args, **kwargs):
+    async def async_pipeline_from_audio_stream(*args, device_id, **kwargs):
+        assert device_id == "mock-device-id"
+
         event_callback = kwargs["event_callback"]
 
         # Fake events
@@ -121,7 +123,9 @@ async def test_pipeline_events(
     ):
         voice_assistant_udp_server_v1.transport = Mock()
 
-        await voice_assistant_udp_server_v1.run_pipeline(conversation_id=None)
+        await voice_assistant_udp_server_v1.run_pipeline(
+            device_id="mock-device-id", conversation_id=None
+        )
 
 
 async def test_udp_server(
@@ -380,7 +384,7 @@ async def test_speech_detection(
         voice_assistant_udp_server_v2.queue.put_nowait(bytes(_ONE_SECOND))
 
         await voice_assistant_udp_server_v2.run_pipeline(
-            conversation_id=None, use_vad=True, pipeline_timeout=1.0
+            device_id="", conversation_id=None, use_vad=True, pipeline_timeout=1.0
         )
 
 
@@ -412,7 +416,7 @@ async def test_no_speech(
         voice_assistant_udp_server_v2.queue.put_nowait(bytes(_ONE_SECOND))
 
         await voice_assistant_udp_server_v2.run_pipeline(
-            conversation_id=None, use_vad=True, pipeline_timeout=1.0
+            device_id="", conversation_id=None, use_vad=True, pipeline_timeout=1.0
         )
 
 
@@ -452,7 +456,7 @@ async def test_speech_timeout(
         voice_assistant_udp_server_v2.queue.put_nowait(bytes([255] * (_ONE_SECOND * 2)))
 
         await voice_assistant_udp_server_v2.run_pipeline(
-            conversation_id=None, use_vad=True, pipeline_timeout=1.0
+            device_id="", conversation_id=None, use_vad=True, pipeline_timeout=1.0
         )
 
 
@@ -467,7 +471,7 @@ async def test_cancelled(
     voice_assistant_udp_server_v2.queue.put_nowait(b"")
 
     await voice_assistant_udp_server_v2.run_pipeline(
-        conversation_id=None, use_vad=True, pipeline_timeout=1.0
+        device_id="", conversation_id=None, use_vad=True, pipeline_timeout=1.0
     )
 
     # No events should be sent if cancelled while waiting for speech

--- a/tests/components/voip/test_voip.py
+++ b/tests/components/voip/test_voip.py
@@ -31,7 +31,9 @@ async def test_pipeline(
     # Used to test that audio queue is cleared before pipeline starts
     bad_chunk = bytes([1, 2, 3, 4])
 
-    async def async_pipeline_from_audio_stream(*args, **kwargs):
+    async def async_pipeline_from_audio_stream(*args, device_id, **kwargs):
+        assert device_id == voip_device.device_id
+
         stt_stream = kwargs["stt_stream"]
         event_callback = kwargs["event_callback"]
         async for _chunk in stt_stream:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
ESPHome and VoIP will now pass their device ID to assist pipeline, which will forward it to the conversation integration.

This PR does not update conversation integrations to leverage this information.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
