### PR TITLE
Remove async_setup from ring

### DIFF
--- a/homeassistant/components/ring/__init__.py
+++ b/homeassistant/components/ring/__init__.py
@@ -6,7 +6,6 @@ from collections.abc import Callable
 from datetime import timedelta
 from functools import partial
 import logging
-from pathlib import Path
 from typing import Any
 
 from oauthlib.oauth2 import AccessDeniedError
@@ -18,7 +17,6 @@ from homeassistant.const import Platform, __version__
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.event import async_track_time_interval
-from homeassistant.helpers.typing import ConfigType
 from homeassistant.util.async_ import run_callback_threadsafe
 
 _LOGGER = logging.getLogger(__name__)
@@ -39,22 +37,6 @@ PLATFORMS = [
     Platform.CAMERA,
     Platform.SIREN,
 ]
-
-
-async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up the Ring component."""
-    if DOMAIN not in config:
-        return True
-
-    def legacy_cleanup():
-        """Clean up old tokens."""
-        old_cache = Path(hass.config.path(".ring_cache.pickle"))
-        if old_cache.is_file():
-            old_cache.unlink()
-
-    await hass.async_add_executor_job(legacy_cleanup)
-
-    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/tests/components/ring/test_config_flow.py
+++ b/tests/components/ring/test_config_flow.py
@@ -22,8 +22,6 @@ async def test_form(hass: HomeAssistant) -> None:
             fetch_token=Mock(return_value={"access_token": "mock-token"})
         ),
     ), patch(
-        "homeassistant.components.ring.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.ring.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -39,7 +37,6 @@ async def test_form(hass: HomeAssistant) -> None:
         "username": "hello@home-assistant.io",
         "token": {"access_token": "mock-token"},
     }
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 

--- a/tests/components/ring/test_init.py
+++ b/tests/components/ring/test_init.py
@@ -1,5 +1,4 @@
 """The tests for the Ring component."""
-from datetime import timedelta
 
 import requests_mock
 
@@ -8,12 +7,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import load_fixture
-
-ATTRIBUTION = "Data provided by Ring.com"
-
-VALID_CONFIG = {
-    "ring": {"username": "foo", "password": "bar", "scan_interval": timedelta(10)}
-}
 
 
 async def test_setup(hass: HomeAssistant, requests_mock: requests_mock.Mocker) -> None:
@@ -39,5 +32,3 @@ async def test_setup(hass: HomeAssistant, requests_mock: requests_mock.Mocker) -
         "https://api.ring.com/clients_api/doorbots/987652/health",
         text=load_fixture("doorboot_health_attrs.json", "ring"),
     )
-
-    assert await ring.async_setup(hass, VALID_CONFIG)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove `async_setup` from `ring`

The `async_setup` function implemented a once-off cleanup which was introduced 3.5 years ago and can now be safely removed: https://github.com/home-assistant/core/pull/30666

Background in https://github.com/home-assistant/core/pull/93587

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
