### PR TITLE
Make RestoreStateData.async_get_instance backwards compatible

### DIFF
--- a/homeassistant/helpers/restore_state.py
+++ b/homeassistant/helpers/restore_state.py
@@ -125,7 +125,9 @@ class RestoreStateData:
         # In fact they should not be accessing this at all.
         report(
             "restore_state.RestoreStateData.async_get_instance is deprecated, "
-            "modify your code to use restore_state.async_get(hass)"
+            "and not intended to be called by custom components; Please"
+            "refactor your code to use RestoreEntity instead;"
+            " restore_state.async_get(hass) can be used in the meantime",
         )
         return async_get(hass)
 

--- a/homeassistant/helpers/restore_state.py
+++ b/homeassistant/helpers/restore_state.py
@@ -96,7 +96,7 @@ class StoredState:
 
 async def async_load(hass: HomeAssistant) -> None:
     """Load the restore state task."""
-    hass.data[DATA_RESTORE_STATE] = await RestoreStateData.async_get_instance(hass)
+    hass.data[DATA_RESTORE_STATE] = await RestoreStateData.async_create(hass)
 
 
 @callback
@@ -109,7 +109,7 @@ class RestoreStateData:
     """Helper class for managing the helper saved data."""
 
     @staticmethod
-    async def async_get_instance(hass: HomeAssistant) -> RestoreStateData:
+    async def async_create(hass: HomeAssistant) -> RestoreStateData:
         """Get the instance of this data helper."""
         data = RestoreStateData(hass)
         await data.async_load()

--- a/homeassistant/helpers/restore_state.py
+++ b/homeassistant/helpers/restore_state.py
@@ -16,6 +16,7 @@ import homeassistant.util.dt as dt_util
 from . import start
 from .entity import Entity
 from .event import async_track_time_interval
+from .frame import report
 from .json import JSONEncoder
 from .storage import Store
 
@@ -119,6 +120,11 @@ class RestoreStateData:
     @callback
     def async_get_instance(cls, hass: HomeAssistant) -> RestoreStateData:
         """Return the instance of this class."""
+        # Nothing should actually be calling this anymore, but we'll keep it
+        # around for a while to avoid breaking custom components.
+        report(
+            "async_get_instance is deprecated, modify your code to use async_get(hass)"
+        )
         return async_get(hass)
 
     def __init__(self, hass: HomeAssistant) -> None:

--- a/homeassistant/helpers/restore_state.py
+++ b/homeassistant/helpers/restore_state.py
@@ -214,12 +214,12 @@ class RestoreStateData:
         """Save the current state machine to storage."""
         _LOGGER.debug("Dumping states")
         try:
-            states_to_save = [
-                stored_state.as_dict()
-                for stored_state in self.async_get_stored_states()
-            ]
-            _LOGGER.debug("States to save: %s", len(states_to_save))
-            await self.store.async_save(states_to_save)
+            await self.store.async_save(
+                [
+                    stored_state.as_dict()
+                    for stored_state in self.async_get_stored_states()
+                ]
+            )
         except HomeAssistantError as exc:
             _LOGGER.error("Error saving current states", exc_info=exc)
 

--- a/homeassistant/helpers/restore_state.py
+++ b/homeassistant/helpers/restore_state.py
@@ -124,7 +124,8 @@ class RestoreStateData:
         #
         # In fact they should not be accessing this at all.
         report(
-            "restore_state.RestoreStateData.async_get_instance is deprecated, modify your code to use restore_state.async_get(hass)"
+            "restore_state.RestoreStateData.async_get_instance is deprecated, "
+            "modify your code to use restore_state.async_get(hass)"
         )
         return async_get(hass)
 

--- a/homeassistant/helpers/restore_state.py
+++ b/homeassistant/helpers/restore_state.py
@@ -191,7 +191,7 @@ class RestoreStateData:
             for state in all_states
             if state.entity_id in self.entities and
             # Ignore all states that are entity registry placeholders
-            state.entity_id in current_entity_ids
+            not state.attributes.get(ATTR_RESTORED)
         ]
         expiration_time = now - STATE_EXPIRATION
 
@@ -309,15 +309,15 @@ class RestoreEntity(Entity):
 
     async def async_internal_added_to_hass(self) -> None:
         """Register this entity as a restorable entity."""
-        async_get(self.hass).async_restore_entity_added(self)
         await super().async_internal_added_to_hass()
+        async_get(self.hass).async_restore_entity_added(self)
 
     async def async_internal_will_remove_from_hass(self) -> None:
         """Run when entity will be removed from hass."""
-        await super().async_internal_will_remove_from_hass()
         async_get(self.hass).async_restore_entity_removed(
             self.entity_id, self.extra_restore_state_data
         )
+        await super().async_internal_will_remove_from_hass()
 
     @callback
     def _async_get_restored_data(self) -> StoredState | None:

--- a/homeassistant/helpers/restore_state.py
+++ b/homeassistant/helpers/restore_state.py
@@ -122,6 +122,8 @@ class RestoreStateData:
         """Return the instance of this class."""
         # Nothing should actually be calling this anymore, but we'll keep it
         # around for a while to avoid breaking custom components.
+        #
+        # In fact they should not be accessing this at all.
         report(
             "async_get_instance is deprecated, modify your code to use async_get(hass)"
         )

--- a/homeassistant/helpers/restore_state.py
+++ b/homeassistant/helpers/restore_state.py
@@ -115,6 +115,12 @@ class RestoreStateData:
         """Dump states now."""
         await async_get(hass).async_dump_states()
 
+    @classmethod
+    @callback
+    def async_get_instance(cls, hass: HomeAssistant) -> RestoreStateData:
+        """Return the instance of this class."""
+        return async_get(hass)
+
     def __init__(self, hass: HomeAssistant) -> None:
         """Initialize the restore state data class."""
         self.hass: HomeAssistant = hass

--- a/homeassistant/helpers/restore_state.py
+++ b/homeassistant/helpers/restore_state.py
@@ -124,7 +124,7 @@ class RestoreStateData:
         #
         # In fact they should not be accessing this at all.
         report(
-            "async_get_instance is deprecated, modify your code to use async_get(hass)"
+            "restore_state.RestoreStateData.async_get_instance is deprecated, modify your code to use restore_state.async_get(hass)"
         )
         return async_get(hass)
 

--- a/homeassistant/helpers/restore_state.py
+++ b/homeassistant/helpers/restore_state.py
@@ -117,8 +117,7 @@ class RestoreStateData:
         await async_get(hass).async_dump_states()
 
     @classmethod
-    @callback
-    def async_get_instance(cls, hass: HomeAssistant) -> RestoreStateData:
+    async def async_get_instance(cls, hass: HomeAssistant) -> RestoreStateData:
         """Return the instance of this class."""
         # Nothing should actually be calling this anymore, but we'll keep it
         # around for a while to avoid breaking custom components.

--- a/tests/helpers/test_restore_state.py
+++ b/tests/helpers/test_restore_state.py
@@ -90,8 +90,12 @@ async def test_async_get_instance_backwards_compatibility(hass: HomeAssistant) -
     """Test async_get_instance backwards compatibility."""
     await async_load(hass)
     data = async_get(hass)
+    # When called from core it should raise
     with pytest.raises(RuntimeError):
         await RestoreStateData.async_get_instance(hass)
+
+    # When called from a component it should not raise
+    # but it should report
     with patch("homeassistant.helpers.restore_state.report"):
         assert data is await RestoreStateData.async_get_instance(hass)
 

--- a/tests/helpers/test_restore_state.py
+++ b/tests/helpers/test_restore_state.py
@@ -488,3 +488,18 @@ async def test_restore_entity_end_to_end(
     assert len(storage_data) == 1
     assert storage_data[0]["state"]["entity_id"] == entity_id
     assert storage_data[0]["state"]["state"] == "stored"
+
+    await platform.async_reset()
+
+    assert hass.states.get(entity_id) is None
+
+    # Make sure the entity still gets saved to restore state
+    # even though the platform has been reset since it should
+    # not be expired yet.
+    await data.async_dump_states()
+    await hass.async_block_till_done()
+
+    storage_data = hass_storage[STORAGE_KEY]["data"]
+    assert len(storage_data) == 1
+    assert storage_data[0]["state"]["entity_id"] == entity_id
+    assert storage_data[0]["state"]["state"] == "stored"

--- a/tests/helpers/test_restore_state.py
+++ b/tests/helpers/test_restore_state.py
@@ -1,12 +1,17 @@
 """The tests for the Restore component."""
+from collections.abc import Coroutine
 from datetime import datetime, timedelta
+import logging
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import CoreState, HomeAssistant, State
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.reload import async_get_platform_without_config_entry
 from homeassistant.helpers.restore_state import (
     DATA_RESTORE_STATE,
     STORAGE_KEY,
@@ -16,9 +21,20 @@ from homeassistant.helpers.restore_state import (
     async_get,
     async_load,
 )
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util import dt as dt_util
 
-from tests.common import async_fire_time_changed
+from tests.common import (
+    MockModule,
+    MockPlatform,
+    async_fire_time_changed,
+    mock_entity_platform,
+    mock_integration,
+)
+
+_LOGGER = logging.getLogger(__name__)
+DOMAIN = "test_domain"
+PLATFORM = "test_platform"
 
 
 async def test_caching_data(hass: HomeAssistant) -> None:
@@ -401,3 +417,74 @@ async def test_restoring_invalid_entity_id(
 
     state = await entity.async_get_last_state()
     assert state is None
+
+
+async def test_restore_entity_end_to_end(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
+    """Test restoring an entity end-to-end."""
+    component_setup = Mock(return_value=True)
+
+    setup_called = []
+
+    entity_id = "test_domain.unnamed_device"
+    data = async_get(hass)
+    now = dt_util.utcnow()
+    data.last_states = {
+        entity_id: StoredState(State(entity_id, "stored"), None, now),
+    }
+
+    class MockRestoreEntity(RestoreEntity):
+        """Mock restore entity."""
+
+        def __init__(self):
+            """Initialize the mock entity."""
+            self._state: str | None = None
+
+        @property
+        def state(self):
+            """Return the state."""
+            return self._state
+
+        async def async_added_to_hass(self) -> Coroutine[Any, Any, None]:
+            """Run when entity about to be added to hass."""
+            await super().async_added_to_hass()
+            self._state = (await self.async_get_last_state()).state
+
+    async def async_setup_platform(
+        hass: HomeAssistant,
+        config: ConfigType,
+        async_add_entities: AddEntitiesCallback,
+        discovery_info: DiscoveryInfoType | None = None,
+    ) -> None:
+        """Set up the test platform."""
+        async_add_entities([MockRestoreEntity()])
+        setup_called.append(True)
+
+    mock_integration(hass, MockModule(DOMAIN, setup=component_setup))
+    mock_integration(hass, MockModule(PLATFORM, dependencies=[DOMAIN]))
+
+    mock_platform = MockPlatform(async_setup_platform=async_setup_platform)
+    mock_entity_platform(hass, f"{DOMAIN}.{PLATFORM}", mock_platform)
+
+    component = EntityComponent(_LOGGER, DOMAIN, hass)
+
+    await component.async_setup({DOMAIN: {"platform": PLATFORM, "sensors": None}})
+    await hass.async_block_till_done()
+    assert component_setup.called
+
+    assert f"{DOMAIN}.{PLATFORM}" in hass.config.components
+    assert len(setup_called) == 1
+
+    platform = async_get_platform_without_config_entry(hass, PLATFORM, DOMAIN)
+    assert platform.platform_name == PLATFORM
+    assert platform.domain == DOMAIN
+    assert hass.states.get(entity_id).state == "stored"
+
+    await data.async_dump_states()
+    await hass.async_block_till_done()
+
+    storage_data = hass_storage[STORAGE_KEY]["data"]
+    assert len(storage_data) == 1
+    assert storage_data[0]["state"]["entity_id"] == entity_id
+    assert storage_data[0]["state"]["state"] == "stored"

--- a/tests/helpers/test_restore_state.py
+++ b/tests/helpers/test_restore_state.py
@@ -5,6 +5,8 @@ import logging
 from typing import Any
 from unittest.mock import Mock, patch
 
+import pytest
+
 from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import CoreState, HomeAssistant, State
 from homeassistant.exceptions import HomeAssistantError
@@ -82,6 +84,16 @@ async def test_caching_data(hass: HomeAssistant) -> None:
     assert state.state == "on"
 
     assert mock_write_data.called
+
+
+async def test_async_get_instance_backwards_compatibility(hass: HomeAssistant) -> None:
+    """Test async_get_instance backwards compatibility."""
+    await async_load(hass)
+    data = async_get(hass)
+    with pytest.raises(RuntimeError):
+        await RestoreStateData.async_get_instance(hass)
+    with patch("homeassistant.helpers.restore_state.report"):
+        assert data is await RestoreStateData.async_get_instance(hass)
 
 
 async def test_periodic_write(hass: HomeAssistant) -> None:


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In #beta it was reported the sometimes `core.restore_state` is empty on restart. I reworked `RestoreStateData.async_get_instance` to be safe to call again since custom components were calling into it and causing it to load again. It will now `report` as well.  

Custom components shouldn't be calling into this directly. They should be using it only via `RestoreEntity`, but considering the impact is high (all restore state data is erased), I made this backwards compatible. 

https://github.com/custom-components/pyscript/blob/d140770acce95dbd5311c43ca65ff57d44a0a54d/custom_components/pyscript/state.py#L220

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
