### PR TITLE
Fix august aiohttp session being closed out from under it

### DIFF
--- a/homeassistant/components/august/__init__.py
+++ b/homeassistant/components/august/__init__.py
@@ -23,7 +23,7 @@ from homeassistant.exceptions import (
     ConfigEntryNotReady,
     HomeAssistantError,
 )
-from homeassistant.helpers import device_registry as dr, discovery_flow
+from homeassistant.helpers import aiohttp_client, device_registry as dr, discovery_flow
 
 from .activity import ActivityStream
 from .const import CONF_BRAND, DOMAIN, MIN_TIME_BETWEEN_DETAIL_UPDATES, PLATFORMS
@@ -44,8 +44,11 @@ YALEXS_BLE_DOMAIN = "yalexs_ble"
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up August from a config entry."""
-
-    august_gateway = AugustGateway(hass)
+    # Create an aiohttp session instead of using the default one since the
+    # default one is likely to trigger august's WAF if another integration
+    # is also using Cloudflare
+    session = aiohttp_client.async_create_clientsession(hass)
+    august_gateway = AugustGateway(hass, session)
 
     try:
         await august_gateway.async_setup(entry.data)

--- a/homeassistant/components/august/config_flow.py
+++ b/homeassistant/components/august/config_flow.py
@@ -171,6 +171,7 @@ class AugustConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Shutdown the gateway."""
         if self._aiohttp_session is not None:
             self._aiohttp_session.detach()
+        self._august_gateway = None
 
     async def async_step_reauth(self, entry_data: Mapping[str, Any]) -> FlowResult:
         """Handle configuration by re-auth."""

--- a/homeassistant/components/august/config_flow.py
+++ b/homeassistant/components/august/config_flow.py
@@ -4,13 +4,16 @@ from dataclasses import dataclass
 import logging
 from typing import Any
 
+import aiohttp
 import voluptuous as vol
 from yalexs.authenticator import ValidationResult
 from yalexs.const import BRANDS, DEFAULT_BRAND
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers import aiohttp_client
 
 from .const import (
     CONF_ACCESS_TOKEN_CACHE_FILE,
@@ -80,6 +83,7 @@ class AugustConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     def __init__(self):
         """Store an AugustGateway()."""
         self._august_gateway: AugustGateway | None = None
+        self._aiohttp_session: aiohttp.ClientSession | None = None
         self._user_auth_details: dict[str, Any] = {}
         self._needs_reset = True
         self._mode = None
@@ -87,7 +91,6 @@ class AugustConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(self, user_input=None):
         """Handle the initial step."""
-        self._august_gateway = AugustGateway(self.hass)
         return await self.async_step_user_validate()
 
     async def async_step_user_validate(self, user_input=None):
@@ -151,12 +154,29 @@ class AugustConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             },
         )
 
+    @callback
+    def _async_get_gateway(self) -> AugustGateway:
+        """Set up the gateway."""
+        if self._august_gateway is not None:
+            return self._august_gateway
+        # Create an aiohttp session instead of using the default one since the
+        # default one is likely to trigger august's WAF if another integration
+        # is also using Cloudflare
+        self._aiohttp_session = aiohttp_client.async_create_clientsession(self.hass)
+        self._august_gateway = AugustGateway(self.hass, self._aiohttp_session)
+        return self._august_gateway
+
+    @callback
+    def _async_shutdown_gateway(self) -> None:
+        """Shutdown the gateway."""
+        if self._aiohttp_session is not None:
+            self._aiohttp_session.detach()
+
     async def async_step_reauth(self, entry_data: Mapping[str, Any]) -> FlowResult:
         """Handle configuration by re-auth."""
         self._user_auth_details = dict(entry_data)
         self._mode = "reauth"
         self._needs_reset = True
-        self._august_gateway = AugustGateway(self.hass)
         return await self.async_step_reauth_validate()
 
     async def async_step_reauth_validate(self, user_input=None):
@@ -206,7 +226,7 @@ class AugustConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def _async_auth_or_validate(self) -> ValidateResult:
         """Authenticate or validate."""
         user_auth_details = self._user_auth_details
-        gateway = self._august_gateway
+        gateway = self._async_get_gateway()
         assert gateway is not None
         await self._async_reset_access_token_cache_if_needed(
             gateway,
@@ -239,6 +259,8 @@ class AugustConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def _async_update_or_create_entry(self, info: dict[str, Any]) -> FlowResult:
         """Update existing entry or create a new one."""
+        self._async_shutdown_gateway()
+
         existing_entry = await self.async_set_unique_id(
             self._user_auth_details[CONF_USERNAME]
         )

--- a/homeassistant/components/august/gateway.py
+++ b/homeassistant/components/august/gateway.py
@@ -7,7 +7,7 @@ import logging
 import os
 from typing import Any
 
-from aiohttp import ClientError, ClientResponseError
+from aiohttp import ClientError, ClientResponseError, ClientSession
 from yalexs.api_async import ApiAsync
 from yalexs.authenticator_async import AuthenticationState, AuthenticatorAsync
 from yalexs.authenticator_common import Authentication
@@ -16,7 +16,6 @@ from yalexs.exceptions import AugustApiAIOHTTPError
 
 from homeassistant.const import CONF_PASSWORD, CONF_TIMEOUT, CONF_USERNAME
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import aiohttp_client
 
 from .const import (
     CONF_ACCESS_TOKEN_CACHE_FILE,
@@ -35,12 +34,9 @@ _LOGGER = logging.getLogger(__name__)
 class AugustGateway:
     """Handle the connection to August."""
 
-    def __init__(self, hass: HomeAssistant) -> None:
+    def __init__(self, hass: HomeAssistant, aiohttp_session: ClientSession) -> None:
         """Init the connection."""
-        # Create an aiohttp session instead of using the default one since the
-        # default one is likely to trigger august's WAF if another integration
-        # is also using Cloudflare
-        self._aiohttp_session = aiohttp_client.async_create_clientsession(hass)
+        self._aiohttp_session = aiohttp_session
         self._token_refresh_lock = asyncio.Lock()
         self._access_token_cache_file: str | None = None
         self._hass: HomeAssistant = hass

--- a/tests/components/august/test_gateway.py
+++ b/tests/components/august/test_gateway.py
@@ -35,7 +35,7 @@ async def _patched_refresh_access_token(
             "original_token", 1234, AuthenticationState.AUTHENTICATED
         )
     )
-    august_gateway = AugustGateway(hass)
+    august_gateway = AugustGateway(hass, MagicMock())
     mocked_config = _mock_get_config()
     await august_gateway.async_setup(mocked_config[DOMAIN])
     await august_gateway.async_authenticate()


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

fixes #93941

I wish we could get rid of the separate session but its clearly been effective at solving the issue with users being blockd by the WAF since all the issues stopped as soon as it was changed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
