### PR TITLE
Fix mqtt climate initial temperature conversion and precision

### DIFF
--- a/homeassistant/components/mqtt/climate.py
+++ b/homeassistant/components/mqtt/climate.py
@@ -693,7 +693,7 @@ class MqttClimate(MqttTemperatureControlEntity, ClimateEntity):
 
         self._optimistic = config[CONF_OPTIMISTIC]
 
-        # convert init temp to target unit if this is not Celsius
+        # Set init temp, if it is missing convert the default to the temperature units
         init_temp: float = config.get(
             CONF_TEMP_INITIAL,
             TemperatureConverter.convert(

--- a/homeassistant/components/mqtt/climate.py
+++ b/homeassistant/components/mqtt/climate.py
@@ -15,9 +15,7 @@ from homeassistant.components.climate import (
     ATTR_TARGET_TEMP_HIGH,
     ATTR_TARGET_TEMP_LOW,
     DEFAULT_MAX_HUMIDITY,
-    DEFAULT_MAX_TEMP,
     DEFAULT_MIN_HUMIDITY,
-    DEFAULT_MIN_TEMP,
     FAN_AUTO,
     FAN_HIGH,
     FAN_LOW,
@@ -42,12 +40,14 @@ from homeassistant.const import (
     PRECISION_HALVES,
     PRECISION_TENTHS,
     PRECISION_WHOLE,
+    UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant, callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.template import Template
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.util.unit_conversion import TemperatureConverter
 
 from . import subscription
 from .config import DEFAULT_RETAIN, MQTT_BASE_SCHEMA
@@ -149,6 +149,8 @@ CONF_TEMP_INITIAL = "initial"
 CONF_TEMP_MAX = "max_temp"
 CONF_TEMP_MIN = "min_temp"
 CONF_TEMP_STEP = "temp_step"
+
+DEFAULT_INITIAL_TEMPERATURE = 21.0
 
 MQTT_CLIMATE_ATTRIBUTES_BLOCKED = frozenset(
     {
@@ -338,9 +340,9 @@ _PLATFORM_SCHEMA_BASE = MQTT_BASE_SCHEMA.extend(
         ): cv.ensure_list,
         vol.Optional(CONF_SWING_MODE_STATE_TEMPLATE): cv.template,
         vol.Optional(CONF_SWING_MODE_STATE_TOPIC): valid_subscribe_topic,
-        vol.Optional(CONF_TEMP_INITIAL, default=21): cv.positive_int,
-        vol.Optional(CONF_TEMP_MIN, default=DEFAULT_MIN_TEMP): vol.Coerce(float),
-        vol.Optional(CONF_TEMP_MAX, default=DEFAULT_MAX_TEMP): vol.Coerce(float),
+        vol.Optional(CONF_TEMP_INITIAL): cv.positive_int,
+        vol.Optional(CONF_TEMP_MIN): vol.Coerce(float),
+        vol.Optional(CONF_TEMP_MAX): vol.Coerce(float),
         vol.Optional(CONF_TEMP_STEP, default=1.0): vol.Coerce(float),
         vol.Optional(CONF_TEMP_COMMAND_TEMPLATE): cv.template,
         vol.Optional(CONF_TEMP_COMMAND_TOPIC): valid_publish_topic,
@@ -442,6 +444,9 @@ class MqttTemperatureControlEntity(MqttEntity, ABC):
     MqttTemperatureControlEntity supports shared methods for
     climate and water_heater platforms.
     """
+
+    _attr_target_temperature_low: float | None
+    _attr_target_temperature_high: float | None
 
     _optimistic: bool
     _topic: dict[str, Any]
@@ -637,7 +642,7 @@ class MqttTemperatureControlEntity(MqttEntity, ABC):
         self.async_write_ha_state()
 
 
-class MqttClimate(MqttTemperatureControlEntity, ClimateEntity):  # type: ignore[misc]
+class MqttClimate(MqttTemperatureControlEntity, ClimateEntity):
     """Representation of an MQTT climate device."""
 
     _entity_id_format = climate.ENTITY_ID_FORMAT
@@ -668,28 +673,41 @@ class MqttClimate(MqttTemperatureControlEntity, ClimateEntity):  # type: ignore[
     def _setup_from_config(self, config: ConfigType) -> None:
         """(Re)Setup the entity."""
         self._attr_hvac_modes = config[CONF_MODE_LIST]
-        self._attr_min_temp = config[CONF_TEMP_MIN]
-        self._attr_max_temp = config[CONF_TEMP_MAX]
-        self._attr_min_humidity = config[CONF_HUMIDITY_MIN]
-        self._attr_max_humidity = config[CONF_HUMIDITY_MAX]
-        self._attr_precision = config.get(CONF_PRECISION, super().precision)
-        self._attr_fan_modes = config[CONF_FAN_MODE_LIST]
-        self._attr_swing_modes = config[CONF_SWING_MODE_LIST]
-        self._attr_target_temperature_step = config[CONF_TEMP_STEP]
+        # Make sure the min an max temp is converted to the correct when not set
         self._attr_temperature_unit = config.get(
             CONF_TEMPERATURE_UNIT, self.hass.config.units.temperature_unit
         )
+        if (min_temp := config.get(CONF_TEMP_MIN)) is not None:
+            self._attr_min_temp = min_temp
+        if (max_temp := config.get(CONF_TEMP_MAX)) is not None:
+            self._attr_max_temp = max_temp
+        self._attr_min_humidity = config[CONF_HUMIDITY_MIN]
+        self._attr_max_humidity = config[CONF_HUMIDITY_MAX]
+        if (precision := config.get(CONF_PRECISION)) is not None:
+            self._attr_precision = precision
+        self._attr_fan_modes = config[CONF_FAN_MODE_LIST]
+        self._attr_swing_modes = config[CONF_SWING_MODE_LIST]
+        self._attr_target_temperature_step = config[CONF_TEMP_STEP]
 
         self._topic = {key: config.get(key) for key in TOPIC_KEYS}
 
         self._optimistic = config[CONF_OPTIMISTIC]
 
+        # convert init temp to target unit if this is not Celsius
+        init_temp: float = config.get(
+            CONF_TEMP_INITIAL,
+            TemperatureConverter.convert(
+                DEFAULT_INITIAL_TEMPERATURE,
+                UnitOfTemperature.CELSIUS,
+                self.temperature_unit,
+            ),
+        )
         if self._topic[CONF_TEMP_STATE_TOPIC] is None or self._optimistic:
-            self._attr_target_temperature = config[CONF_TEMP_INITIAL]
+            self._attr_target_temperature = init_temp
         if self._topic[CONF_TEMP_LOW_STATE_TOPIC] is None or self._optimistic:
-            self._attr_target_temperature_low = config[CONF_TEMP_INITIAL]
+            self._attr_target_temperature_low = init_temp
         if self._topic[CONF_TEMP_HIGH_STATE_TOPIC] is None or self._optimistic:
-            self._attr_target_temperature_high = config[CONF_TEMP_INITIAL]
+            self._attr_target_temperature_high = init_temp
 
         if self._topic[CONF_FAN_MODE_STATE_TOPIC] is None or self._optimistic:
             self._attr_fan_mode = FAN_LOW

--- a/tests/components/mqtt/test_climate.py
+++ b/tests/components/mqtt/test_climate.py
@@ -1770,19 +1770,18 @@ async def test_alt_temperature_unit(
     current: float,
 ) -> None:
     """Test deriving the systems temperature unit."""
-    hass.config.units.temperature_unit = temperature_unit
+    with patch.object(hass.config.units, "temperature_unit", temperature_unit):
+        await mqtt_mock_entry()
 
-    await mqtt_mock_entry()
+        state = hass.states.get(ENTITY_CLIMATE)
+        assert state.attributes.get("temperature") == initial
+        assert state.attributes.get("min_temp") == min
+        assert state.attributes.get("max_temp") == max
 
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("temperature") == initial
-    assert state.attributes.get("min_temp") == min
-    assert state.attributes.get("max_temp") == max
+        async_fire_mqtt_message(hass, "current_temperature", "77")
 
-    async_fire_mqtt_message(hass, "current_temperature", "77")
-
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("current_temperature") == current
+        state = hass.states.get(ENTITY_CLIMATE)
+        assert state.attributes.get("current_temperature") == current
 
 
 async def test_setting_attribute_via_mqtt_json_message(

--- a/tests/components/mqtt/test_climate.py
+++ b/tests/components/mqtt/test_climate.py
@@ -27,8 +27,11 @@ from homeassistant.components.climate import (
     HVACAction,
     HVACMode,
 )
-from homeassistant.components.mqtt.climate import MQTT_CLIMATE_ATTRIBUTES_BLOCKED
-from homeassistant.const import ATTR_TEMPERATURE, Platform
+from homeassistant.components.mqtt.climate import (
+    DEFAULT_INITIAL_TEMPERATURE,
+    MQTT_CLIMATE_ATTRIBUTES_BLOCKED,
+)
+from homeassistant.const import ATTR_TEMPERATURE, Platform, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 
 from .test_common import (
@@ -1690,10 +1693,96 @@ async def test_temperature_unit(
     """Test that setting temperature unit converts temperature values."""
     await mqtt_mock_entry()
 
+    state = hass.states.get(ENTITY_CLIMATE)
+    assert state.attributes.get("temperature") == DEFAULT_INITIAL_TEMPERATURE
+    assert state.attributes.get("min_temp") == DEFAULT_MIN_TEMP
+    assert state.attributes.get("max_temp") == DEFAULT_MAX_TEMP
+
     async_fire_mqtt_message(hass, "current_temperature", "77")
 
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get("current_temperature") == 25
+
+
+@pytest.mark.parametrize(
+    ("hass_config", "temperature_unit", "initial", "min", "max", "current"),
+    [
+        (
+            help_custom_config(
+                climate.DOMAIN,
+                DEFAULT_CONFIG,
+                (
+                    {
+                        "temperature_unit": "F",
+                        "current_temperature_topic": "current_temperature",
+                    },
+                ),
+            ),
+            UnitOfTemperature.CELSIUS,
+            DEFAULT_INITIAL_TEMPERATURE,
+            DEFAULT_MIN_TEMP,
+            DEFAULT_MAX_TEMP,
+            25,
+        ),
+        (
+            help_custom_config(
+                climate.DOMAIN,
+                DEFAULT_CONFIG,
+                (
+                    {
+                        "temperature_unit": "F",
+                        "current_temperature_topic": "current_temperature",
+                    },
+                ),
+            ),
+            UnitOfTemperature.KELVIN,
+            294,
+            280,
+            308,
+            298,
+        ),
+        (
+            help_custom_config(
+                climate.DOMAIN,
+                DEFAULT_CONFIG,
+                (
+                    {
+                        "temperature_unit": "F",
+                        "current_temperature_topic": "current_temperature",
+                    },
+                ),
+            ),
+            UnitOfTemperature.FAHRENHEIT,
+            70,
+            45,
+            95,
+            77,
+        ),
+    ],
+)
+async def test_alt_temperature_unit(
+    hass: HomeAssistant,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+    temperature_unit: UnitOfTemperature,
+    initial: float,
+    min: float,
+    max: float,
+    current: float,
+) -> None:
+    """Test deriving the systems temperature unit."""
+    hass.config.units.temperature_unit = temperature_unit
+
+    await mqtt_mock_entry()
+
+    state = hass.states.get(ENTITY_CLIMATE)
+    assert state.attributes.get("temperature") == initial
+    assert state.attributes.get("min_temp") == min
+    assert state.attributes.get("max_temp") == max
+
+    async_fire_mqtt_message(hass, "current_temperature", "77")
+
+    state = hass.states.get(ENTITY_CLIMATE)
+    assert state.attributes.get("current_temperature") == current
 
 
 async def test_setting_attribute_via_mqtt_json_message(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
If the `initial` temperature, `min_temp` or `max_temp` is not set, the default temperature will be converted to the set `temperature_unit` or system default temperature unit if this is not degrees Celsius.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Ensure correct conversion of initial, min and max target temperature if the defaults are derived for MQTT climates when the temperature unit is not Celsius.
The climate code should set `_attr_precision` if default behavior is expected.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/27628

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
