### PR TITLE
Conversation API to include if there is an options flow

### DIFF
--- a/homeassistant/components/config/config_entries.py
+++ b/homeassistant/components/config/config_entries.py
@@ -545,19 +545,13 @@ async def async_matching_config_entries(
 @callback
 def entry_json(entry: config_entries.ConfigEntry) -> dict:
     """Return JSON value of a config entry."""
-    handler = config_entries.HANDLERS.get(entry.domain)
-    # work out if handler has support for options flow
-    supports_options = handler is not None and handler.async_supports_options_flow(
-        entry
-    )
-
     return {
         "entry_id": entry.entry_id,
         "domain": entry.domain,
         "title": entry.title,
         "source": entry.source,
         "state": entry.state.value,
-        "supports_options": supports_options,
+        "supports_options": entry.supports_options_flow(),
         "supports_remove_device": entry.supports_remove_device or False,
         "supports_unload": entry.supports_unload or False,
         "pref_disable_new_entities": entry.pref_disable_new_entities,

--- a/homeassistant/components/conversation/__init__.py
+++ b/homeassistant/components/conversation/__init__.py
@@ -335,6 +335,7 @@ class AgentInfo:
 
     id: str
     name: str
+    has_options_flow: bool
 
 
 @core.callback
@@ -433,6 +434,7 @@ class AgentManager:
             AgentInfo(
                 id=HOME_ASSISTANT_AGENT,
                 name="Home Assistant",
+                has_options_flow=False,
             )
         ]
         for agent_id, agent in self._agents.items():
@@ -451,6 +453,7 @@ class AgentManager:
                 AgentInfo(
                     id=agent_id,
                     name=config_entry.title or config_entry.domain,
+                    has_options_flow=config_entry.supports_options_flow(),
                 )
             )
         return agents

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -661,6 +661,12 @@ class ConfigEntry:
 
         return lambda: self.update_listeners.remove(weak_listener)
 
+    def supports_options_flow(self) -> bool:
+        """Return if config entry supports options flow."""
+        return (
+            handler := HANDLERS.get(self.domain)
+        ) is not None and handler.async_supports_options_flow(self)
+
     def as_dict(self) -> dict[str, Any]:
         """Return dictionary version of this entry."""
         return {

--- a/tests/components/conversation/snapshots/test_init.ambr
+++ b/tests/components/conversation/snapshots/test_init.ambr
@@ -1,24 +1,28 @@
 # serializer version: 1
 # name: test_get_agent_info
   dict({
+    'has_options_flow': False,
     'id': 'mock-entry',
     'name': 'Mock Title',
   })
 # ---
 # name: test_get_agent_info.1
   dict({
+    'has_options_flow': False,
     'id': 'homeassistant',
     'name': 'Home Assistant',
   })
 # ---
 # name: test_get_agent_info.2
   dict({
+    'has_options_flow': False,
     'id': 'mock-entry',
     'name': 'Mock Title',
   })
 # ---
 # name: test_get_agent_info.3
   dict({
+    'has_options_flow': False,
     'id': 'mock-entry',
     'name': 'test',
   })

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -1110,7 +1110,9 @@ async def test_entry_options(
     entry = MockConfigEntry(domain="test", data={"first": True}, options=None)
     entry.add_to_manager(manager)
 
-    class TestFlow:
+    assert entry.supports_options_flow() is False
+
+    class TestFlow(config_entries.ConfigFlow):
         """Test flow."""
 
         @staticmethod
@@ -1123,7 +1125,10 @@ async def test_entry_options(
 
             return OptionsFlowHandler()
 
-    config_entries.HANDLERS["test"] = TestFlow()
+    config_entries.HANDLERS["test"] = TestFlow
+
+    assert entry.supports_options_flow() is True
+
     flow = await manager.options.async_create_flow(
         entry.entry_id, context={"source": "test"}, data=None
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update the conversation websocket API to list agents to include if a conversation agent supports an options flow.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
