### PR TITLE
Don't add Roborock switches if it is not supported

### DIFF
--- a/homeassistant/components/roborock/switch.py
+++ b/homeassistant/components/roborock/switch.py
@@ -100,7 +100,11 @@ async def async_setup_entry(
         ),
         return_exceptions=True,
     )
-
+    for result in results:
+        if isinstance(result, Exception):
+            if not isinstance(result, RoborockException):
+                raise result
+            _LOGGER.info("Not setting a entity because of %s", result)
     async_add_entities(
         (
             RoborockSwitchEntity(

--- a/homeassistant/components/roborock/switch.py
+++ b/homeassistant/components/roborock/switch.py
@@ -100,22 +100,23 @@ async def async_setup_entry(
         ),
         return_exceptions=True,
     )
-    for result in results:
+    valid_entities: list[RoborockSwitchEntity] = []
+    for posible_entity, result in zip(possible_entities, results):
         if isinstance(result, Exception):
             if not isinstance(result, RoborockException):
                 raise result
-            _LOGGER.info("Not setting a entity because of %s", result)
-    async_add_entities(
-        (
-            RoborockSwitchEntity(
-                f"{posible_entity[2].key}_{slugify(posible_entity[0])}",
-                posible_entity[1],
-                posible_entity[2],
-                result,
+            _LOGGER.debug("Not adding entity because of %s", result)
+        else:
+            valid_entities.append(
+                RoborockSwitchEntity(
+                    f"{posible_entity[2].key}_{slugify(posible_entity[0])}",
+                    posible_entity[1],
+                    posible_entity[2],
+                    result,
+                )
             )
-            for posible_entity, result in zip(possible_entities, results)
-            if not isinstance(result, RoborockException) and result is not None
-        ),
+    async_add_entities(
+        valid_entities,
         True,
     )
 

--- a/homeassistant/components/roborock/switch.py
+++ b/homeassistant/components/roborock/switch.py
@@ -5,13 +5,13 @@ from dataclasses import dataclass
 import logging
 from typing import Any
 
+from roborock.exceptions import RoborockException
 from roborock.roborock_typing import RoborockCommand
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util import slugify
 
@@ -32,6 +32,8 @@ class RoborockSwitchDescriptionMixin:
     evaluate_value: Callable[[dict], bool]
     # Sets the status of the switch
     set_command: Callable[[RoborockEntity, bool], Coroutine[Any, Any, dict]]
+    # Check support of this feature
+    check_support: Callable[[RoborockDataUpdateCoordinator], Coroutine[Any, Any, dict]]
 
 
 @dataclass
@@ -47,6 +49,9 @@ SWITCH_DESCRIPTIONS: list[RoborockSwitchDescription] = [
             RoborockCommand.SET_CHILD_LOCK_STATUS, {"lock_status": 1 if value else 0}
         ),
         get_value=lambda data: data.send(RoborockCommand.GET_CHILD_LOCK_STATUS),
+        check_support=lambda data: data.api.send_command(
+            RoborockCommand.GET_CHILD_LOCK_STATUS
+        ),
         evaluate_value=lambda data: data["lock_status"] == 1,
         key="child_lock",
         translation_key="child_lock",
@@ -58,6 +63,9 @@ SWITCH_DESCRIPTIONS: list[RoborockSwitchDescription] = [
             RoborockCommand.SET_FLOW_LED_STATUS, {"status": 1 if value else 0}
         ),
         get_value=lambda data: data.send(RoborockCommand.GET_FLOW_LED_STATUS),
+        check_support=lambda data: data.api.send_command(
+            RoborockCommand.GET_FLOW_LED_STATUS
+        ),
         evaluate_value=lambda data: data["status"] == 1,
         key="status_indicator",
         translation_key="status_indicator",
@@ -77,26 +85,32 @@ async def async_setup_entry(
     coordinators: dict[str, RoborockDataUpdateCoordinator] = hass.data[DOMAIN][
         config_entry.entry_id
     ]
-    possible_entities = [
-        RoborockSwitchEntity(
-            f"{description.key}_{slugify(device_id)}",
-            coordinator,
-            description,
-        )
+    possible_entities: list[
+        tuple[str, RoborockDataUpdateCoordinator, RoborockSwitchDescription]
+    ] = [
+        (device_id, coordinator, description)
         for device_id, coordinator in coordinators.items()
         for description in SWITCH_DESCRIPTIONS
     ]
     # We need to check if this function is supported by the device.
     results = await asyncio.gather(
-        *(entity.entity_description.get_value(entity) for entity in possible_entities),
+        *(
+            description.check_support(coordinator)
+            for _, coordinator, description in possible_entities
+        ),
         return_exceptions=True,
     )
 
     async_add_entities(
         (
-            entity
-            for entity, result in zip(possible_entities, results)
-            if not isinstance(result, HomeAssistantError)
+            RoborockSwitchEntity(
+                f"{posible_entity[2].key}_{slugify(posible_entity[0])}",
+                posible_entity[1],
+                posible_entity[2],
+                result,
+            )
+            for posible_entity, result in zip(possible_entities, results)
+            if not isinstance(result, RoborockException) and result is not None
         ),
         True,
     )
@@ -112,10 +126,12 @@ class RoborockSwitchEntity(RoborockEntity, SwitchEntity):
         unique_id: str,
         coordinator: RoborockDataUpdateCoordinator,
         entity_description: RoborockSwitchDescription,
+        initial_value: bool,
     ) -> None:
         """Create a switch entity."""
         self.entity_description = entity_description
         super().__init__(unique_id, coordinator.device_info, coordinator.api)
+        self._attr_is_on = initial_value
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the switch."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Roborock devices return 'unknown_method' if the command is not supported. in the most recent bump, that is now an exception that is thrown(and caught by the send method in device.py and raises HomeAssistantError)

So if a HomeAssistantError is raised, we should avoid adding this entity.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #94044 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
