### PR TITLE
Add support for extra people attributes

### DIFF
--- a/homeassistant/components/person/__init__.py
+++ b/homeassistant/components/person/__init__.py
@@ -60,10 +60,12 @@ _LOGGER = logging.getLogger(__name__)
 ATTR_SOURCE = "source"
 ATTR_USER_ID = "user_id"
 ATTR_DEVICE_TRACKERS = "device_trackers"
+ATTR_EXTRA_ATTRIBUTES = "extra_attributes"
 
 CONF_DEVICE_TRACKERS = "device_trackers"
 CONF_USER_ID = "user_id"
 CONF_PICTURE = "picture"
+CONF_EXTRA_ATTRIBUTES = "extra_attributes"
 
 DOMAIN = "person"
 
@@ -81,6 +83,7 @@ PERSON_SCHEMA = vol.Schema(
             cv.ensure_list, cv.entities_domain(DEVICE_TRACKER_DOMAIN)
         ),
         vol.Optional(CONF_PICTURE): cv.string,
+        vol.Optional(CONF_EXTRA_ATTRIBUTES): dict,
     }
 )
 
@@ -168,6 +171,7 @@ CREATE_FIELDS = {
         cv.ensure_list, cv.entities_domain(DEVICE_TRACKER_DOMAIN)
     ),
     vol.Optional(CONF_PICTURE): vol.Any(str, None),
+    vol.Optional(CONF_EXTRA_ATTRIBUTES): vol.Any(dict, None),
 }
 
 
@@ -178,6 +182,7 @@ UPDATE_FIELDS = {
         cv.ensure_list, cv.entities_domain(DEVICE_TRACKER_DOMAIN)
     ),
     vol.Optional(CONF_PICTURE): vol.Any(str, None),
+    vol.Optional(CONF_EXTRA_ATTRIBUTES): vol.Any(dict, None),
 }
 
 
@@ -442,7 +447,8 @@ class Person(collection.CollectionEntity, RestoreEntity):
     @property
     def extra_state_attributes(self):
         """Return the state attributes of the person."""
-        data = {ATTR_EDITABLE: self.editable, ATTR_ID: self.unique_id}
+        data = self._config.get(ATTR_EXTRA_ATTRIBUTES, {})
+        data.update({ATTR_EDITABLE: self.editable, ATTR_ID: self.unique_id})
         if self._latitude is not None:
             data[ATTR_LATITUDE] = self._latitude
         if self._longitude is not None:

--- a/tests/components/person/test_init.py
+++ b/tests/components/person/test_init.py
@@ -847,3 +847,25 @@ async def test_entities_in_person(hass: HomeAssistant) -> None:
         "device_tracker.paulus_iphone",
         "device_tracker.paulus_ipad",
     ]
+
+
+async def test_extra_attributes(hass: HomeAssistant) -> None:
+    """Test extra attributes."""
+    config = {
+        DOMAIN: {
+            "id": "1234",
+            "name": "test person",
+            "extra_attributes": {"address": "123, fake st", "mobile": "489032984"},
+        }
+    }
+    assert await async_setup_component(hass, DOMAIN, config)
+
+    state = hass.states.get("person.test_person")
+    assert state.state == STATE_UNKNOWN
+    assert state.attributes.get(ATTR_LATITUDE) is None
+    assert state.attributes.get(ATTR_LONGITUDE) is None
+    assert state.attributes.get(ATTR_SOURCE) is None
+    assert state.attributes.get(ATTR_USER_ID) is None
+    assert state.attributes.get(ATTR_ENTITY_PICTURE) is None
+    assert state.attributes.get("address") == "123, fake st"
+    assert state.attributes.get("mobile") == "489032984"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds the ability to add adhoc attributes to a person entity. This is useful for automations where you want to send a text message, or email to a person entity.

This only adds support for yaml based config. The Websocket creation would support the extra field, but I didn't want to update the frontend before getting the all OK on this PR.

Example yaml config would be

```
person:
- name: Michael
  id: michael
  device_trackers:
    - device_tracker.michaels_s20
  extra_attributes:
    address: "123 Fake St"
    email: "myEmail@fake.com"
    phone: "316020387"
```

This makes for cleaner automations and templates.
If you wish to reject this PR, please provide an alternative way of storing bespoke data on home assistant entities.

Thanks!

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
