### PR TITLE
Use shorthand attributes in NextBus

### DIFF
--- a/homeassistant/components/nextbus/sensor.py
+++ b/homeassistant/components/nextbus/sensor.py
@@ -115,8 +115,6 @@ class NextBusDepartureSensor(SensorEntity):
         if name:
             self._attr_name = name
 
-        self._attr_unique_id = "_".join((agency, route, stop))
-
         self._client = client
 
     def _log_debug(self, message, *args):

--- a/homeassistant/components/nextbus/sensor.py
+++ b/homeassistant/components/nextbus/sensor.py
@@ -108,40 +108,22 @@ class NextBusDepartureSensor(SensorEntity):
         self.agency = agency
         self.route = route
         self.stop = stop
-        self._custom_name = name
-        # Maybe pull a more user friendly name from the API here
-        self._name = f"{agency} {route}"
-        self._client = client
+        self._attr_extra_state_attributes = {}
 
-        # set up default state attributes
-        self._state = None
-        self._attributes = {}
+        # Maybe pull a more user friendly name from the API here
+        if name:
+            self._attr_name = name
+        else:
+            self._attr_name = f"{agency} {route}"
+
+        # Set unique id using agency, route, and stop
+        self._attr_unique_id = "_".join((agency, route, stop))
+
+        self._client = client
 
     def _log_debug(self, message, *args):
         """Log debug message with prefix."""
         _LOGGER.debug(":".join((self.agency, self.route, self.stop, message)), *args)
-
-    @property
-    def name(self):
-        """Return sensor name.
-
-        Uses an auto generated name based on the data from the API unless a
-        custom name is provided in the configuration.
-        """
-        if self._custom_name:
-            return self._custom_name
-
-        return self._name
-
-    @property
-    def native_value(self):
-        """Return current state of the sensor."""
-        return self._state
-
-    @property
-    def extra_state_attributes(self):
-        """Return additional state attributes."""
-        return self._attributes
 
     def update(self) -> None:
         """Update sensor with new departures times."""
@@ -151,21 +133,22 @@ class NextBusDepartureSensor(SensorEntity):
         )
 
         self._log_debug("Predictions results: %s", results)
+        self._attr_attribution = results.get("copyright")
 
         if "Error" in results:
             self._log_debug("Could not get predictions: %s", results)
 
         if not results.get("predictions"):
             self._log_debug("No predictions available")
-            self._state = None
+            self._attr_native_value = None
             # Remove attributes that may now be outdated
-            self._attributes.pop("upcoming", None)
+            self._attr_extra_state_attributes.pop("upcoming", None)
             return
 
         results = results["predictions"]
 
         # Set detailed attributes
-        self._attributes.update(
+        self._attr_extra_state_attributes.update(
             {
                 "agency": results.get("agencyTitle"),
                 "route": results.get("routeTitle"),
@@ -176,13 +159,13 @@ class NextBusDepartureSensor(SensorEntity):
         # List all messages in the attributes
         messages = listify(results.get("message", []))
         self._log_debug("Messages: %s", messages)
-        self._attributes["message"] = " -- ".join(
+        self._attr_extra_state_attributes["message"] = " -- ".join(
             message.get("text", "") for message in messages
         )
 
         # List out all directions in the attributes
         directions = listify(results.get("direction", []))
-        self._attributes["direction"] = ", ".join(
+        self._attr_extra_state_attributes["direction"] = ", ".join(
             direction.get("title", "") for direction in directions
         )
 
@@ -196,14 +179,16 @@ class NextBusDepartureSensor(SensorEntity):
         # Short circuit if we don't have any actual bus predictions
         if not predictions:
             self._log_debug("No upcoming predictions available")
-            self._state = None
-            self._attributes["upcoming"] = "No upcoming predictions"
+            self._attr_native_value = None
+            self._attr_extra_state_attributes["upcoming"] = "No upcoming predictions"
             return
 
         # Generate list of upcoming times
-        self._attributes["upcoming"] = ", ".join(
+        self._attr_extra_state_attributes["upcoming"] = ", ".join(
             sorted((p["minutes"] for p in predictions), key=int)
         )
 
         latest_prediction = maybe_first(predictions)
-        self._state = utc_from_timestamp(int(latest_prediction["epochTime"]) / 1000)
+        self._attr_native_value = utc_from_timestamp(
+            int(latest_prediction["epochTime"]) / 1000
+        )

--- a/homeassistant/components/nextbus/sensor.py
+++ b/homeassistant/components/nextbus/sensor.py
@@ -111,12 +111,10 @@ class NextBusDepartureSensor(SensorEntity):
         self._attr_extra_state_attributes = {}
 
         # Maybe pull a more user friendly name from the API here
+        self._attr_name = f"{agency} {route}"
         if name:
             self._attr_name = name
-        else:
-            self._attr_name = f"{agency} {route}"
 
-        # Set unique id using agency, route, and stop
         self._attr_unique_id = "_".join((agency, route, stop))
 
         self._client = client


### PR DESCRIPTION
## Proposed change
Use `self._attr_*` rather than properties to set values in NextBus sensor.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: Supporting #92149 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
