### PR TITLE
Remove Brottsplatskartan YAML configuration

### DIFF
--- a/homeassistant/components/brottsplatskartan/config_flow.py
+++ b/homeassistant/components/brottsplatskartan/config_flow.py
@@ -34,21 +34,6 @@ class BPKConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
-    async def async_step_import(self, config: dict[str, Any]) -> FlowResult:
-        """Import a configuration from config.yaml."""
-
-        if config.get(CONF_LATITUDE):
-            config[CONF_LOCATION] = {
-                CONF_LATITUDE: config[CONF_LATITUDE],
-                CONF_LONGITUDE: config[CONF_LONGITUDE],
-            }
-        if not config.get(CONF_AREA):
-            config[CONF_AREA] = "none"
-        else:
-            config[CONF_AREA] = config[CONF_AREA][0]
-
-        return await self.async_step_user(user_input=config)
-
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:

--- a/homeassistant/components/brottsplatskartan/sensor.py
+++ b/homeassistant/components/brottsplatskartan/sensor.py
@@ -5,61 +5,18 @@ from collections import defaultdict
 from datetime import timedelta
 
 from brottsplatskartan import ATTRIBUTION, BrottsplatsKartan
-import voluptuous as vol
 
-from homeassistant.components.sensor import (
-    PLATFORM_SCHEMA as PARENT_PLATFORM_SCHEMA,
-    SensorEntity,
-)
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
-from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE
 from homeassistant.core import HomeAssistant
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from .const import AREAS, CONF_APP_ID, CONF_AREA, DEFAULT_NAME, DOMAIN, LOGGER
+from .const import CONF_APP_ID, CONF_AREA, DOMAIN, LOGGER
 
 SCAN_INTERVAL = timedelta(minutes=30)
-
-PLATFORM_SCHEMA = PARENT_PLATFORM_SCHEMA.extend(
-    {
-        vol.Inclusive(CONF_LATITUDE, "coordinates"): cv.latitude,
-        vol.Inclusive(CONF_LONGITUDE, "coordinates"): cv.longitude,
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Optional(CONF_AREA, default=[]): vol.All(cv.ensure_list, [vol.In(AREAS)]),
-    }
-)
-
-
-async def async_setup_platform(
-    hass: HomeAssistant,
-    config: ConfigType,
-    async_add_entities: AddEntitiesCallback,
-    discovery_info: DiscoveryInfoType | None = None,
-) -> None:
-    """Set up the Brottsplatskartan platform."""
-
-    async_create_issue(
-        hass,
-        DOMAIN,
-        "deprecated_yaml",
-        breaks_in_ha_version="2023.7.0",
-        is_fixable=False,
-        severity=IssueSeverity.WARNING,
-        translation_key="deprecated_yaml",
-    )
-
-    hass.async_create_task(
-        hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_IMPORT},
-            data=config,
-        )
-    )
 
 
 async def async_setup_entry(

--- a/homeassistant/components/brottsplatskartan/strings.json
+++ b/homeassistant/components/brottsplatskartan/strings.json
@@ -16,12 +16,6 @@
       }
     }
   },
-  "issues": {
-    "deprecated_yaml": {
-      "title": "The Brottsplatskartan YAML configuration is being removed",
-      "description": "Configuring Brottsplatskartan using YAML is being removed.\n\nYour existing YAML configuration has been imported into the UI automatically.\n\nRemove the Brottsplatskartan YAML configuration from your configuration.yaml file and restart Home Assistant to fix this issue."
-    }
-  },
   "selector": {
     "areas": {
       "options": {

--- a/tests/components/brottsplatskartan/test_config_flow.py
+++ b/tests/components/brottsplatskartan/test_config_flow.py
@@ -1,8 +1,6 @@
 """Test the Brottsplatskartan config flow."""
 from __future__ import annotations
 
-from unittest.mock import patch
-
 import pytest
 
 from homeassistant import config_entries
@@ -10,8 +8,6 @@ from homeassistant.components.brottsplatskartan.const import CONF_AREA, DOMAIN
 from homeassistant.const import CONF_LATITUDE, CONF_LOCATION, CONF_LONGITUDE
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
-
-from tests.common import MockConfigEntry
 
 pytestmark = pytest.mark.usefixtures("mock_setup_entry")
 
@@ -103,107 +99,3 @@ async def test_form_area(hass: HomeAssistant) -> None:
         "area": "Stockholms län",
         "app_id": "ha-1234567890",
     }
-
-
-async def test_import_flow_success(hass: HomeAssistant) -> None:
-    """Test a successful import of yaml."""
-
-    with patch(
-        "homeassistant.components.brottsplatskartan.sensor.BrottsplatsKartan",
-    ):
-        result2 = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_IMPORT},
-            data={},
-        )
-        await hass.async_block_till_done()
-
-    assert result2["type"] == FlowResultType.CREATE_ENTRY
-    assert result2["title"] == "Brottsplatskartan HOME"
-    assert result2["data"] == {
-        "latitude": hass.config.latitude,
-        "longitude": hass.config.longitude,
-        "area": None,
-        "app_id": "ha-1234567890",
-    }
-
-
-async def test_import_flow_location_success(hass: HomeAssistant) -> None:
-    """Test a successful import of yaml with location."""
-
-    with patch(
-        "homeassistant.components.brottsplatskartan.sensor.BrottsplatsKartan",
-    ):
-        result2 = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_IMPORT},
-            data={
-                CONF_LATITUDE: 59.32,
-                CONF_LONGITUDE: 18.06,
-            },
-        )
-        await hass.async_block_till_done()
-
-    assert result2["type"] == FlowResultType.CREATE_ENTRY
-    assert result2["title"] == "Brottsplatskartan 59.32, 18.06"
-    assert result2["data"] == {
-        "latitude": 59.32,
-        "longitude": 18.06,
-        "area": None,
-        "app_id": "ha-1234567890",
-    }
-
-
-async def test_import_flow_location_area_success(hass: HomeAssistant) -> None:
-    """Test a successful import of yaml with location and area."""
-
-    with patch(
-        "homeassistant.components.brottsplatskartan.sensor.BrottsplatsKartan",
-    ):
-        result2 = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_IMPORT},
-            data={
-                CONF_LATITUDE: 59.32,
-                CONF_LONGITUDE: 18.06,
-                CONF_AREA: ["Blekinge län"],
-            },
-        )
-        await hass.async_block_till_done()
-
-    assert result2["type"] == FlowResultType.CREATE_ENTRY
-    assert result2["title"] == "Brottsplatskartan Blekinge län"
-    assert result2["data"] == {
-        "latitude": None,
-        "longitude": None,
-        "area": "Blekinge län",
-        "app_id": "ha-1234567890",
-    }
-
-
-async def test_import_flow_already_exist(hass: HomeAssistant) -> None:
-    """Test import of yaml already exist."""
-
-    MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            "latitude": hass.config.latitude,
-            "longitude": hass.config.longitude,
-            "area": None,
-            "app_id": "ha-1234567890",
-        },
-        unique_id="bpk-home",
-    ).add_to_hass(hass)
-
-    with patch(
-        "homeassistant.components.brottsplatskartan.sensor.BrottsplatsKartan",
-    ):
-        result3 = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_IMPORT},
-            data={},
-        )
-        await hass.async_block_till_done()
-
-    assert result3["type"] == FlowResultType.ABORT
-    assert result3["reason"] == "already_configured"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Configuring Brottsplatskartan via YAML was deprecated in Home Assistant Core 2023.5 and support has now been removed.
The YAML configuration was automatically imported to a config entry by release Home Assistant Core 2023.5. Please remove Brottsplatskartan YAML configuration from your `configuration.yaml` file.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove platform yaml brottsplatskartan, deprecation started in 2023.5 and is now ended after 2 releases.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
