### PR TITLE
Remove Workday YAML configuration

### DIFF
--- a/homeassistant/components/workday/binary_sensor.py
+++ b/homeassistant/components/workday/binary_sensor.py
@@ -2,25 +2,17 @@
 from __future__ import annotations
 
 from datetime import date, timedelta
-from typing import Any
 
 import holidays
 from holidays import DateLike, HolidayBase
-import voluptuous as vol
 
-from homeassistant.components.binary_sensor import (
-    PLATFORM_SCHEMA as PARENT_PLATFORM_SCHEMA,
-    BinarySensorEntity,
-)
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util import dt as dt_util
 
 from .const import (
@@ -32,79 +24,9 @@ from .const import (
     CONF_PROVINCE,
     CONF_REMOVE_HOLIDAYS,
     CONF_WORKDAYS,
-    DEFAULT_EXCLUDES,
-    DEFAULT_NAME,
-    DEFAULT_OFFSET,
-    DEFAULT_WORKDAYS,
     DOMAIN,
     LOGGER,
 )
-
-
-def valid_country(value: Any) -> str:
-    """Validate that the given country is supported."""
-    value = cv.string(value)
-    all_supported_countries = holidays.list_supported_countries()
-
-    try:
-        raw_value = value.encode("utf-8")
-    except UnicodeError as err:
-        raise vol.Invalid(
-            "The country name or the abbreviation must be a valid UTF-8 string."
-        ) from err
-    if not raw_value:
-        raise vol.Invalid("Country name or the abbreviation must not be empty.")
-    if value not in all_supported_countries:
-        raise vol.Invalid("Country is not supported.")
-    return value
-
-
-PLATFORM_SCHEMA = PARENT_PLATFORM_SCHEMA.extend(
-    {
-        vol.Required(CONF_COUNTRY): valid_country,
-        vol.Optional(CONF_EXCLUDES, default=DEFAULT_EXCLUDES): vol.All(
-            cv.ensure_list, [vol.In(ALLOWED_DAYS)]
-        ),
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Optional(CONF_OFFSET, default=DEFAULT_OFFSET): vol.Coerce(int),
-        vol.Optional(CONF_PROVINCE): cv.string,
-        vol.Optional(CONF_WORKDAYS, default=DEFAULT_WORKDAYS): vol.All(
-            cv.ensure_list, [vol.In(ALLOWED_DAYS)]
-        ),
-        vol.Optional(CONF_ADD_HOLIDAYS, default=[]): vol.All(
-            cv.ensure_list, [cv.string]
-        ),
-        vol.Optional(CONF_REMOVE_HOLIDAYS, default=[]): vol.All(
-            cv.ensure_list, [cv.string]
-        ),
-    }
-)
-
-
-async def async_setup_platform(
-    hass: HomeAssistant,
-    config: ConfigType,
-    async_add_entities: AddEntitiesCallback,
-    discovery_info: DiscoveryInfoType | None = None,
-) -> None:
-    """Set up the Workday sensor."""
-    async_create_issue(
-        hass,
-        DOMAIN,
-        "deprecated_yaml",
-        breaks_in_ha_version="2023.7.0",
-        is_fixable=False,
-        severity=IssueSeverity.WARNING,
-        translation_key="deprecated_yaml",
-    )
-
-    hass.async_create_task(
-        hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_IMPORT},
-            data=config,
-        )
-    )
 
 
 async def async_setup_entry(

--- a/homeassistant/components/workday/config_flow.py
+++ b/homeassistant/components/workday/config_flow.py
@@ -155,33 +155,6 @@ class WorkdayConfigFlow(ConfigFlow, domain=DOMAIN):
         """Get the options flow for this handler."""
         return WorkdayOptionsFlowHandler(config_entry)
 
-    async def async_step_import(self, config: dict[str, Any]) -> FlowResult:
-        """Import a configuration from config.yaml."""
-
-        abort_match = {
-            CONF_COUNTRY: config[CONF_COUNTRY],
-            CONF_EXCLUDES: config[CONF_EXCLUDES],
-            CONF_OFFSET: config[CONF_OFFSET],
-            CONF_WORKDAYS: config[CONF_WORKDAYS],
-            CONF_ADD_HOLIDAYS: config[CONF_ADD_HOLIDAYS],
-            CONF_REMOVE_HOLIDAYS: config[CONF_REMOVE_HOLIDAYS],
-            CONF_PROVINCE: config.get(CONF_PROVINCE),
-        }
-        new_config = config.copy()
-        new_config[CONF_PROVINCE] = config.get(CONF_PROVINCE)
-        LOGGER.debug("Importing with %s", new_config)
-
-        self._async_abort_entries_match(abort_match)
-
-        self.data[CONF_NAME] = config.get(CONF_NAME, DEFAULT_NAME)
-        self.data[CONF_COUNTRY] = config[CONF_COUNTRY]
-        LOGGER.debug(
-            "No duplicate, next step with name %s for country %s",
-            self.data[CONF_NAME],
-            self.data[CONF_COUNTRY],
-        )
-        return await self.async_step_options(user_input=new_config)
-
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:

--- a/homeassistant/components/workday/strings.json
+++ b/homeassistant/components/workday/strings.json
@@ -63,12 +63,6 @@
       "already_configured": "Service with this configuration already exist"
     }
   },
-  "issues": {
-    "deprecated_yaml": {
-      "title": "The Workday YAML configuration is being removed",
-      "description": "Configuring Workday using YAML is being removed.\n\nYour existing YAML configuration has been imported into the UI automatically.\n\nRemove the Workday YAML configuration from your configuration.yaml file and restart Home Assistant to fix this issue."
-    }
-  },
   "selector": {
     "province": {
       "options": {

--- a/tests/components/workday/test_binary_sensor.py
+++ b/tests/components/workday/test_binary_sensor.py
@@ -4,9 +4,7 @@ from typing import Any
 
 from freezegun.api import FrozenDateTimeFactory
 import pytest
-import voluptuous as vol
 
-from homeassistant.components.workday import binary_sensor
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import UTC
@@ -28,21 +26,6 @@ from . import (
     TEST_CONFIG_YESTERDAY,
     init_integration,
 )
-
-
-async def test_valid_country_yaml() -> None:
-    """Test valid country from yaml."""
-    # Invalid UTF-8, must not contain U+D800 to U+DFFF
-    with pytest.raises(vol.Invalid):
-        binary_sensor.valid_country("\ud800")
-    with pytest.raises(vol.Invalid):
-        binary_sensor.valid_country("\udfff")
-    # Country MUST NOT be empty
-    with pytest.raises(vol.Invalid):
-        binary_sensor.valid_country("")
-    # Country must be supported by holidays
-    with pytest.raises(vol.Invalid):
-        binary_sensor.valid_country("HomeAssistantLand")
 
 
 @pytest.mark.parametrize(
@@ -76,34 +59,6 @@ async def test_setup(
         "workdays": config["workdays"],
         "excludes": config["excludes"],
         "days_offset": config["days_offset"],
-    }
-
-
-async def test_setup_from_import(
-    hass: HomeAssistant,
-    freezer: FrozenDateTimeFactory,
-) -> None:
-    """Test setup from various configs."""
-    freezer.move_to(datetime(2022, 4, 15, 12, tzinfo=UTC))  # Monday
-    await async_setup_component(
-        hass,
-        "binary_sensor",
-        {
-            "binary_sensor": {
-                "platform": "workday",
-                "country": "DE",
-            }
-        },
-    )
-    await hass.async_block_till_done()
-
-    state = hass.states.get("binary_sensor.workday_sensor")
-    assert state.state == "off"
-    assert state.attributes == {
-        "friendly_name": "Workday Sensor",
-        "workdays": ["mon", "tue", "wed", "thu", "fri"],
-        "excludes": ["sat", "sun", "holiday"],
-        "days_offset": 0,
     }
 
 

--- a/tests/components/workday/test_config_flow.py
+++ b/tests/components/workday/test_config_flow.py
@@ -13,7 +13,6 @@ from homeassistant.components.workday.const import (
     CONF_REMOVE_HOLIDAYS,
     CONF_WORKDAYS,
     DEFAULT_EXCLUDES,
-    DEFAULT_NAME,
     DEFAULT_OFFSET,
     DEFAULT_WORKDAYS,
     DOMAIN,
@@ -23,8 +22,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from . import init_integration
-
-from tests.common import MockConfigEntry
 
 pytestmark = pytest.mark.usefixtures("mock_setup_entry")
 
@@ -112,142 +109,6 @@ async def test_form_no_subdivision(hass: HomeAssistant) -> None:
         "remove_holidays": [],
         "province": None,
     }
-
-
-async def test_import_flow_success(hass: HomeAssistant) -> None:
-    """Test a successful import of yaml."""
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": config_entries.SOURCE_IMPORT},
-        data={
-            CONF_NAME: DEFAULT_NAME,
-            CONF_COUNTRY: "DE",
-            CONF_EXCLUDES: DEFAULT_EXCLUDES,
-            CONF_OFFSET: DEFAULT_OFFSET,
-            CONF_WORKDAYS: DEFAULT_WORKDAYS,
-            CONF_ADD_HOLIDAYS: [],
-            CONF_REMOVE_HOLIDAYS: [],
-        },
-    )
-    await hass.async_block_till_done()
-
-    assert result["type"] == FlowResultType.CREATE_ENTRY
-    assert result["title"] == "Workday Sensor"
-    assert result["options"] == {
-        "name": "Workday Sensor",
-        "country": "DE",
-        "excludes": ["sat", "sun", "holiday"],
-        "days_offset": 0,
-        "workdays": ["mon", "tue", "wed", "thu", "fri"],
-        "add_holidays": [],
-        "remove_holidays": [],
-        "province": None,
-    }
-
-    result2 = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": config_entries.SOURCE_IMPORT},
-        data={
-            CONF_NAME: "Workday Sensor 2",
-            CONF_COUNTRY: "DE",
-            CONF_PROVINCE: "BW",
-            CONF_EXCLUDES: DEFAULT_EXCLUDES,
-            CONF_OFFSET: DEFAULT_OFFSET,
-            CONF_WORKDAYS: DEFAULT_WORKDAYS,
-            CONF_ADD_HOLIDAYS: [],
-            CONF_REMOVE_HOLIDAYS: [],
-        },
-    )
-    await hass.async_block_till_done()
-
-    assert result2["type"] == FlowResultType.CREATE_ENTRY
-    assert result2["title"] == "Workday Sensor 2"
-    assert result2["options"] == {
-        "name": "Workday Sensor 2",
-        "country": "DE",
-        "province": "BW",
-        "excludes": ["sat", "sun", "holiday"],
-        "days_offset": 0,
-        "workdays": ["mon", "tue", "wed", "thu", "fri"],
-        "add_holidays": [],
-        "remove_holidays": [],
-    }
-
-
-async def test_import_flow_already_exist(hass: HomeAssistant) -> None:
-    """Test import of yaml already exist."""
-
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={},
-        options={
-            "name": "Workday Sensor",
-            "country": "DE",
-            "excludes": ["sat", "sun", "holiday"],
-            "days_offset": 0,
-            "workdays": ["mon", "tue", "wed", "thu", "fri"],
-            "add_holidays": [],
-            "remove_holidays": [],
-            "province": None,
-        },
-    )
-    entry.add_to_hass(hass)
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": config_entries.SOURCE_IMPORT},
-        data={
-            CONF_NAME: "Workday sensor 2",
-            CONF_COUNTRY: "DE",
-            CONF_EXCLUDES: ["sat", "sun", "holiday"],
-            CONF_OFFSET: 0,
-            CONF_WORKDAYS: ["mon", "tue", "wed", "thu", "fri"],
-            CONF_ADD_HOLIDAYS: [],
-            CONF_REMOVE_HOLIDAYS: [],
-        },
-    )
-    await hass.async_block_till_done()
-
-    assert result["type"] == FlowResultType.ABORT
-    assert result["reason"] == "already_configured"
-
-
-async def test_import_flow_province_no_conflict(hass: HomeAssistant) -> None:
-    """Test import of yaml with province."""
-
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={},
-        options={
-            "name": "Workday Sensor",
-            "country": "DE",
-            "excludes": ["sat", "sun", "holiday"],
-            "days_offset": 0,
-            "workdays": ["mon", "tue", "wed", "thu", "fri"],
-            "add_holidays": [],
-            "remove_holidays": [],
-        },
-    )
-    entry.add_to_hass(hass)
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": config_entries.SOURCE_IMPORT},
-        data={
-            CONF_NAME: "Workday sensor 2",
-            CONF_COUNTRY: "DE",
-            CONF_PROVINCE: "BW",
-            CONF_EXCLUDES: ["sat", "sun", "holiday"],
-            CONF_OFFSET: 0,
-            CONF_WORKDAYS: ["mon", "tue", "wed", "thu", "fri"],
-            CONF_ADD_HOLIDAYS: [],
-            CONF_REMOVE_HOLIDAYS: [],
-        },
-    )
-    await hass.async_block_till_done()
-
-    assert result["type"] == FlowResultType.CREATE_ENTRY
 
 
 async def test_options_form(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Configuring Workday via YAML was deprecated in Home Assistant Core 2023.5 and support has now been removed.
The YAML configuration was automatically imported to a config entry by release Home Assistant Core 2023.5. Please remove Workday YAML configuration from your `configuration.yaml` file.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove platform yaml workday, deprecation started in 2023.5 and is now ended after 2 releases.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
