### PR TITLE
Add persistent_notifications function to access notifications in templates

### DIFF
--- a/homeassistant/components/persistent_notification/__init__.py
+++ b/homeassistant/components/persistent_notification/__init__.py
@@ -11,7 +11,7 @@ import voluptuous as vol
 from homeassistant.backports.enum import StrEnum
 from homeassistant.components import websocket_api
 from homeassistant.core import HomeAssistant, ServiceCall, callback
-from homeassistant.helpers import config_validation as cv, singleton
+from homeassistant.helpers import config_validation as cv, singleton, template
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
     async_dispatcher_send,
@@ -198,6 +198,14 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     websocket_api.async_register_command(hass, websocket_get_notifications)
     websocket_api.async_register_command(hass, websocket_subscribe_notifications)
+
+    def _get_persistent_notifications(hass: HomeAssistant) -> list[Notification]:
+        """Return a list of persistent notifications."""
+        return list(_async_get_or_create_notifications(hass).values())
+
+    template.async_register_hass_environment_function(
+        hass, "persistent_notifications", _get_persistent_notifications
+    )
 
     return True
 

--- a/homeassistant/components/persistent_notification/__init__.py
+++ b/homeassistant/components/persistent_notification/__init__.py
@@ -133,6 +133,12 @@ def async_dismiss(hass: HomeAssistant, notification_id: str) -> None:
     )
 
 
+@callback
+def _async_get_notifications_list(hass: HomeAssistant) -> list[Notification]:
+    """Return a list of persistent notifications."""
+    return list(_async_get_or_create_notifications(hass).values())
+
+
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the persistent notification component."""
     notifications = _async_get_or_create_notifications(hass)
@@ -199,12 +205,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     websocket_api.async_register_command(hass, websocket_get_notifications)
     websocket_api.async_register_command(hass, websocket_subscribe_notifications)
 
-    def _get_persistent_notifications(hass: HomeAssistant) -> list[Notification]:
-        """Return a list of persistent notifications."""
-        return list(_async_get_or_create_notifications(hass).values())
-
     template.async_register_hass_environment_function(
-        hass, "persistent_notifications", _get_persistent_notifications
+        hass, "persistent_notifications", _async_get_notifications_list
     )
 
     return True
@@ -219,9 +221,7 @@ def websocket_get_notifications(
 ) -> None:
     """Return a list of persistent_notifications."""
     connection.send_message(
-        websocket_api.result_message(
-            msg["id"], list(_async_get_or_create_notifications(hass).values())
-        )
+        websocket_api.result_message(msg["id"], _async_get_notifications_list(hass))
     )
 
 

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -22,7 +22,6 @@ from struct import error as StructError, pack, unpack_from
 import sys
 from types import CodeType
 from typing import (
-    TYPE_CHECKING,
     Any,
     Concatenate,
     Literal,
@@ -83,9 +82,6 @@ from homeassistant.util.thread import ThreadWithException
 from . import area_registry, device_registry, entity_registry, location as loc_helper
 from .singleton import singleton
 from .typing import TemplateVarsType
-
-if TYPE_CHECKING:
-    pass
 
 # mypy: allow-untyped-defs, no-check-untyped-defs
 

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -463,7 +463,7 @@ def async_register_hass_environment_function(
     """Register the environment function."""
     for env in _ENVIRONMENTS:
         template_env = cast(TemplateEnvironment, hass.data[env])
-        template_env.async_register_function(name, func)
+        template_env.async_register_hass_function(name, func)
 
 
 class Template:
@@ -2530,8 +2530,8 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
 
         return pass_context(wrapper)
 
-    def async_register_function(self, name: str, func: Callable[..., Any]) -> None:
-        """Register a function."""
+    def async_register_hass_function(self, name: str, func: Callable[..., Any]) -> None:
+        """Register a function that needs to be wrapped with hass."""
         hass_func = self.hassfunction(func)
         self.globals[name] = hass_func
         self.filters[name] = hass_func

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -96,7 +96,10 @@ DATE_STR_FORMAT = "%Y-%m-%d %H:%M:%S"
 _ENVIRONMENT = "template.environment"
 _ENVIRONMENT_LIMITED = "template.environment_limited"
 _ENVIRONMENT_STRICT = "template.environment_strict"
-_ENVIRONMENTS = (_ENVIRONMENT, _ENVIRONMENT_LIMITED, _ENVIRONMENT_STRICT)
+
+# We don't register functions into the limited environment
+# since its only for device_entities
+_REGISTER_ENVIRONMENTS = (_ENVIRONMENT, _ENVIRONMENT_STRICT)
 
 _HASS_LOADER = "template.hass_loader"
 
@@ -461,7 +464,7 @@ def async_register_hass_environment_function(
     hass: HomeAssistant, name: str, func: Callable[Concatenate[HomeAssistant, _P], _R]
 ) -> None:
     """Register the environment function."""
-    for env in _ENVIRONMENTS:
+    for env in _REGISTER_ENVIRONMENTS:
         template_env = cast(TemplateEnvironment, hass.data[env])
         template_env.async_register_hass_function(name, func)
 

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -461,8 +461,10 @@ def _async_get_registered_hass_functions(
     hass: HomeAssistant,
 ) -> dict[str, Callable[Concatenate[HomeAssistant, _P], _R]]:
     """Return the registered hass functions."""
-    functions = hass.data.setdefault(_REGISTERED_HASS_FUNCTIONS, {})
-    return cast(dict[str, Callable[Concatenate[HomeAssistant, _P], _R]], functions)
+    functions: dict[
+        str, Callable[Concatenate[HomeAssistant, _P], _R]
+    ] = hass.data.setdefault(_REGISTERED_HASS_FUNCTIONS, {})
+    return functions
 
 
 @callback

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -458,7 +458,7 @@ class RenderInfo:
 
 @callback
 def async_register_hass_environment_function(
-    hass: HomeAssistant, name: str, func: Callable[..., Any]
+    hass: HomeAssistant, name: str, func: Callable[Concatenate[HomeAssistant, _P], _R]
 ) -> None:
     """Register the environment function."""
     for env in _ENVIRONMENTS:
@@ -2530,7 +2530,9 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
 
         return pass_context(wrapper)
 
-    def async_register_hass_function(self, name: str, func: Callable[..., Any]) -> None:
+    def async_register_hass_function(
+        self, name: str, func: Callable[Concatenate[HomeAssistant, _P], _R]
+    ) -> None:
         """Register a function that needs to be wrapped with hass."""
         hass_func = self.hassfunction(func)
         self.globals[name] = hass_func

--- a/tests/common.py
+++ b/tests/common.py
@@ -63,6 +63,7 @@ from homeassistant.helpers import (
     restore_state,
     restore_state as rs,
     storage,
+    template,
 )
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.json import JSONEncoder
@@ -267,6 +268,7 @@ async def async_test_home_assistant(event_loop, load_registries=True):
                 ir.async_load(hass),
                 rs.async_load(hass),
             )
+            template.async_setup(hass)
         hass.data[bootstrap.DATA_REGISTRIES_LOADED] = None
 
     hass.state = CoreState.running

--- a/tests/common.py
+++ b/tests/common.py
@@ -63,7 +63,6 @@ from homeassistant.helpers import (
     restore_state,
     restore_state as rs,
     storage,
-    template,
 )
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.json import JSONEncoder
@@ -268,7 +267,6 @@ async def async_test_home_assistant(event_loop, load_registries=True):
                 ir.async_load(hass),
                 rs.async_load(hass),
             )
-            template.async_setup(hass)
         hass.data[bootstrap.DATA_REGISTRIES_LOADED] = None
 
     hass.state = CoreState.running

--- a/tests/components/persistent_notification/test_init.py
+++ b/tests/components/persistent_notification/test_init.py
@@ -4,6 +4,7 @@ import pytest
 import homeassistant.components.persistent_notification as pn
 from homeassistant.components.websocket_api.const import TYPE_RESULT
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.template import Template
 from homeassistant.setup import async_setup_component
 
 from tests.typing import WebSocketGenerator
@@ -13,6 +14,29 @@ from tests.typing import WebSocketGenerator
 async def setup_integration(hass):
     """Set up persistent notification integration."""
     assert await async_setup_component(hass, pn.DOMAIN, {})
+
+
+async def test_template_usage(hass: HomeAssistant) -> None:
+    """Test enumerating persistent notifications in a template."""
+    await hass.services.async_call(
+        pn.DOMAIN,
+        "create",
+        {"notification_id": "Beer 2", "message": "test"},
+        blocking=True,
+    )
+
+    result = Template("{{ persistent_notifications() | count }}", hass).async_render()
+    assert result == 1
+
+    await hass.services.async_call(
+        pn.DOMAIN,
+        "dismiss",
+        {"notification_id": "Beer 2"},
+        blocking=True,
+    )
+
+    result = Template("{{ persistent_notifications() | count }}", hass).async_render()
+    assert result == 0
 
 
 async def test_create(hass: HomeAssistant) -> None:

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -4560,3 +4560,27 @@ async def test_lru_increases_with_many_entities(hass: HomeAssistant) -> None:
     assert template.CACHED_TEMPLATE_NO_COLLECT_LRU.get_size() == int(
         round(mock_entity_count * template.ENTITY_COUNT_GROWTH_FACTOR)
     )
+
+
+async def test_async_register_hass_environment_function(hass: HomeAssistant) -> None:
+    """Test adding a new function to templates."""
+
+    template.async_setup(hass)
+
+    template.async_register_hass_environment_function(
+        hass, "before_render", lambda hass: "before_render"
+    )
+
+    assert (
+        template.Template("{{ before_render() }}", hass).async_render()
+        == "before_render"
+    )
+
+    with pytest.raises(TemplateError, match="'zombies' is undefined"):
+        template.Template("{{ zombies() }}", hass).async_render()
+
+    template.async_register_hass_environment_function(
+        hass, "zombies", lambda hass: "zombies"
+    )
+
+    assert template.Template("{{ zombies() }}", hass).async_render() == "zombies"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

<img width="926" alt="Screenshot 2023-06-06 at 8 10 55 AM" src="https://github.com/home-assistant/core/assets/663432/88af32db-b848-4b77-bb93-ef7cced999a7">


It has the following limitations:

- It does not force the template to re-render when notifications change
- If we were to expand it to force it to re-render when notifications change we would need to teach templates about persistent notifications updates which would likely be a bit messy and have a negative performance impact on all templates since it would have to be checked (maybe we can overcome).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/27674

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
