### PR TITLE
Remove `mark_read` service from persistent_notification

### DIFF
--- a/homeassistant/components/persistent_notification/__init__.py
+++ b/homeassistant/components/persistent_notification/__init__.py
@@ -29,8 +29,6 @@ ATTR_NOTIFICATION_ID: Final = "notification_id"
 ATTR_TITLE: Final = "title"
 ATTR_STATUS: Final = "status"
 
-STATUS_UNREAD = "unread"
-STATUS_READ = "read"
 
 # Remove EVENT_PERSISTENT_NOTIFICATIONS_UPDATED in Home Assistant 2023.9
 EVENT_PERSISTENT_NOTIFICATIONS_UPDATED = "persistent_notifications_updated"
@@ -43,7 +41,6 @@ class Notification(TypedDict):
     message: str
     notification_id: str
     title: str | None
-    status: str
 
 
 class UpdateType(StrEnum):
@@ -98,7 +95,6 @@ def async_create(
     notifications[notification_id] = {
         ATTR_MESSAGE: message,
         ATTR_NOTIFICATION_ID: notification_id,
-        ATTR_STATUS: STATUS_UNREAD,
         ATTR_TITLE: title,
         ATTR_CREATED_AT: dt_util.utcnow(),
     }
@@ -135,7 +131,6 @@ def async_dismiss(hass: HomeAssistant, notification_id: str) -> None:
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the persistent notification component."""
-    notifications = _async_get_or_create_notifications(hass)
 
     @callback
     def create_service(call: ServiceCall) -> None:
@@ -152,29 +147,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         """Handle the dismiss notification service call."""
         async_dismiss(hass, call.data[ATTR_NOTIFICATION_ID])
 
-    @callback
-    def mark_read_service(call: ServiceCall) -> None:
-        """Handle the mark_read notification service call."""
-        notification_id = call.data.get(ATTR_NOTIFICATION_ID)
-        if notification_id not in notifications:
-            _LOGGER.error(
-                (
-                    "Marking persistent_notification read failed: "
-                    "Notification ID %s not found"
-                ),
-                notification_id,
-            )
-            return
-
-        notification = notifications[notification_id]
-        notification[ATTR_STATUS] = STATUS_READ
-        async_dispatcher_send(
-            hass,
-            SIGNAL_PERSISTENT_NOTIFICATIONS_UPDATED,
-            UpdateType.UPDATED,
-            {notification_id: notification},
-        )
-
     hass.services.async_register(
         DOMAIN,
         "create",
@@ -190,10 +162,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     hass.services.async_register(
         DOMAIN, "dismiss", dismiss_service, SCHEMA_SERVICE_NOTIFICATION
-    )
-
-    hass.services.async_register(
-        DOMAIN, "mark_read", mark_read_service, SCHEMA_SERVICE_NOTIFICATION
     )
 
     websocket_api.async_register_command(hass, websocket_get_notifications)

--- a/homeassistant/components/persistent_notification/services.yaml
+++ b/homeassistant/components/persistent_notification/services.yaml
@@ -22,18 +22,6 @@ create:
       selector:
         text:
 
-dismiss:
-  name: Dismiss
-  description: Remove a notification from the frontend.
-  fields:
-    notification_id:
-      name: Notification ID
-      description: Target ID of the notification, which should be removed.
-      required: true
-      example: 1234
-      selector:
-        text:
-
 mark_read:
   name: Mark read
   description: Mark a notification read.

--- a/homeassistant/components/persistent_notification/services.yaml
+++ b/homeassistant/components/persistent_notification/services.yaml
@@ -22,13 +22,13 @@ create:
       selector:
         text:
 
-mark_read:
-  name: Mark read
-  description: Mark a notification read.
+dismiss:
+  name: Dismiss
+  description: Remove a notification from the frontend.
   fields:
     notification_id:
       name: Notification ID
-      description: Target ID of the notification, which should be mark read.
+      description: Target ID of the notification, which should be removed.
       required: true
       example: 1234
       selector:

--- a/tests/components/persistent_notification/test_init.py
+++ b/tests/components/persistent_notification/test_init.py
@@ -25,7 +25,6 @@ async def test_create(hass: HomeAssistant) -> None:
     assert len(notifications) == 1
 
     notification = notifications[list(notifications)[0]]
-    assert notification["status"] == pn.STATUS_UNREAD
     assert notification["message"] == "Hello World 2"
     assert notification["title"] == "2 beers"
     assert notification["created_at"] is not None
@@ -66,39 +65,6 @@ async def test_dismiss_notification(hass: HomeAssistant) -> None:
     assert len(notifications) == 0
 
 
-async def test_mark_read(hass: HomeAssistant) -> None:
-    """Ensure notification is marked as Read."""
-    notifications = pn._async_get_or_create_notifications(hass)
-    assert len(notifications) == 0
-
-    await hass.services.async_call(
-        pn.DOMAIN,
-        "create",
-        {"notification_id": "Beer 2", "message": "test"},
-        blocking=True,
-    )
-
-    assert len(notifications) == 1
-    notification = notifications[list(notifications)[0]]
-    assert notification["status"] == pn.STATUS_UNREAD
-
-    await hass.services.async_call(
-        pn.DOMAIN, "mark_read", {"notification_id": "Beer 2"}, blocking=True
-    )
-
-    assert len(notifications) == 1
-    notification = notifications[list(notifications)[0]]
-    assert notification["status"] == pn.STATUS_READ
-
-    await hass.services.async_call(
-        pn.DOMAIN,
-        "dismiss",
-        {"notification_id": "Beer 2"},
-        blocking=True,
-    )
-    assert len(notifications) == 0
-
-
 async def test_ws_get_notifications(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
@@ -128,18 +94,7 @@ async def test_ws_get_notifications(
     assert notification["notification_id"] == "Beer 2"
     assert notification["message"] == "test"
     assert notification["title"] is None
-    assert notification["status"] == pn.STATUS_UNREAD
     assert notification["created_at"] is not None
-
-    # Mark Read
-    await hass.services.async_call(
-        pn.DOMAIN, "mark_read", {"notification_id": "Beer 2"}
-    )
-    await client.send_json({"id": 7, "type": "persistent_notification/get"})
-    msg = await client.receive_json()
-    notifications = msg["result"]
-    assert len(notifications) == 1
-    assert notifications[0]["status"] == pn.STATUS_READ
 
     # Dismiss
     pn.async_dismiss(hass, "Beer 2")
@@ -186,23 +141,7 @@ async def test_ws_get_subscribe(
     assert notification["notification_id"] == "Beer 2"
     assert notification["message"] == "test"
     assert notification["title"] is None
-    assert notification["status"] == pn.STATUS_UNREAD
     assert notification["created_at"] is not None
-
-    # Mark Read
-    await hass.services.async_call(
-        pn.DOMAIN, "mark_read", {"notification_id": "Beer 2"}
-    )
-    msg = await client.receive_json()
-    assert msg["id"] == 5
-    assert msg["type"] == "event"
-    assert msg["event"]
-    event = msg["event"]
-    assert event["type"] == "updated"
-    notifications = event["notifications"]
-    assert len(notifications) == 1
-    notification = notifications[list(notifications)[0]]
-    assert notification["status"] == pn.STATUS_READ
 
     # Dismiss
     pn.async_dismiss(hass, "Beer 2")


### PR DESCRIPTION
## Breaking change

The `mark_read` service has been removed from `persistent_notification`.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Followup to #92828

Nothing on the frontend uses this, and there is not much point in keeping this as the notifications are no longer stored in the state machine.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
