### PR TITLE
Revert "Increase Zigbee command retries (#93877)"

### DIFF
--- a/homeassistant/components/zha/core/cluster_handlers/__init__.py
+++ b/homeassistant/components/zha/core/cluster_handlers/__init__.py
@@ -45,8 +45,6 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
-DEFAULT_REQUEST_RETRIES = 3
-
 
 class AttrReportConfig(TypedDict, total=True):
     """Configuration to report for the attributes."""
@@ -80,8 +78,6 @@ def decorate_command(cluster_handler, command):
 
     @wraps(command)
     async def wrapper(*args, **kwds):
-        kwds.setdefault("tries", DEFAULT_REQUEST_RETRIES)
-
         try:
             result = await command(*args, **kwds)
             cluster_handler.debug(

--- a/tests/components/zha/test_alarm_control_panel.py
+++ b/tests/components/zha/test_alarm_control_panel.py
@@ -96,7 +96,6 @@ async def test_alarm_control_panel(
         0,
         security.IasAce.AudibleNotification.Default_Sound,
         security.IasAce.AlarmStatus.No_Alarm,
-        tries=3,
     )
 
     # disarm from HA
@@ -135,7 +134,6 @@ async def test_alarm_control_panel(
         0,
         security.IasAce.AudibleNotification.Default_Sound,
         security.IasAce.AlarmStatus.Emergency,
-        tries=3,
     )
 
     # reset the panel
@@ -159,7 +157,6 @@ async def test_alarm_control_panel(
         0,
         security.IasAce.AudibleNotification.Default_Sound,
         security.IasAce.AlarmStatus.No_Alarm,
-        tries=3,
     )
 
     # arm_night from HA
@@ -180,7 +177,6 @@ async def test_alarm_control_panel(
         0,
         security.IasAce.AudibleNotification.Default_Sound,
         security.IasAce.AlarmStatus.No_Alarm,
-        tries=3,
     )
 
     # reset the panel
@@ -278,6 +274,5 @@ async def reset_alarm_panel(hass, cluster, entity_id):
         0,
         security.IasAce.AudibleNotification.Default_Sound,
         security.IasAce.AlarmStatus.No_Alarm,
-        tries=3,
     )
     cluster.client_command.reset_mock()

--- a/tests/components/zha/test_device_action.py
+++ b/tests/components/zha/test_device_action.py
@@ -328,7 +328,7 @@ async def test_action(hass: HomeAssistant, device_ias, device_inovelli) -> None:
                 5,
                 expect_reply=False,
                 manufacturer=4151,
-                tries=3,
+                tries=1,
                 tsn=None,
             )
             in cluster.request.call_args_list
@@ -345,7 +345,7 @@ async def test_action(hass: HomeAssistant, device_ias, device_inovelli) -> None:
                 5,
                 expect_reply=False,
                 manufacturer=4151,
-                tries=3,
+                tries=1,
                 tsn=None,
             )
             in cluster.request.call_args_list

--- a/tests/components/zha/test_discover.py
+++ b/tests/components/zha/test_discover.py
@@ -131,7 +131,7 @@ async def test_devices(
                     ),
                     expect_reply=True,
                     manufacturer=None,
-                    tries=3,
+                    tries=1,
                     tsn=None,
                 )
             ]

--- a/tests/components/zha/test_light.py
+++ b/tests/components/zha/test_light.py
@@ -553,7 +553,7 @@ async def test_transitions(
         transition_time=0,
         expect_reply=True,
         manufacturer=None,
-        tries=3,
+        tries=1,
         tsn=None,
     )
 
@@ -589,7 +589,7 @@ async def test_transitions(
         transition_time=35,
         expect_reply=True,
         manufacturer=None,
-        tries=3,
+        tries=1,
         tsn=None,
     )
     assert dev1_cluster_color.request.call_args == call(
@@ -600,7 +600,7 @@ async def test_transitions(
         transition_time=35,
         expect_reply=True,
         manufacturer=None,
-        tries=3,
+        tries=1,
         tsn=None,
     )
 
@@ -637,7 +637,7 @@ async def test_transitions(
         transition_time=0,
         expect_reply=True,
         manufacturer=None,
-        tries=3,
+        tries=1,
         tsn=None,
     )
 
@@ -674,7 +674,7 @@ async def test_transitions(
         transition_time=0,
         expect_reply=True,
         manufacturer=None,
-        tries=3,
+        tries=1,
         tsn=None,
     )
     assert dev1_cluster_color.request.call_args == call(
@@ -685,7 +685,7 @@ async def test_transitions(
         transition_time=0,  # no transition when new_color_provided_while_off
         expect_reply=True,
         manufacturer=None,
-        tries=3,
+        tries=1,
         tsn=None,
     )
     assert dev1_cluster_level.request.call_args_list[1] == call(
@@ -696,7 +696,7 @@ async def test_transitions(
         transition_time=10,
         expect_reply=True,
         manufacturer=None,
-        tries=3,
+        tries=1,
         tsn=None,
     )
 
@@ -758,7 +758,7 @@ async def test_transitions(
         transition_time=0,
         expect_reply=True,
         manufacturer=None,
-        tries=3,
+        tries=1,
         tsn=None,
     )
     assert dev1_cluster_color.request.call_args == call(
@@ -769,7 +769,7 @@ async def test_transitions(
         transition_time=0,  # no transition when new_color_provided_while_off
         expect_reply=True,
         manufacturer=None,
-        tries=3,
+        tries=1,
         tsn=None,
     )
     assert dev1_cluster_level.request.call_args_list[1] == call(
@@ -780,7 +780,7 @@ async def test_transitions(
         transition_time=0,
         expect_reply=True,
         manufacturer=None,
-        tries=3,
+        tries=1,
         tsn=None,
     )
 
@@ -838,7 +838,7 @@ async def test_transitions(
         dev1_cluster_on_off.commands_by_name["on"].schema,
         expect_reply=True,
         manufacturer=None,
-        tries=3,
+        tries=1,
         tsn=None,
     )
 
@@ -850,7 +850,7 @@ async def test_transitions(
         transition_time=0,  # no transition when new_color_provided_while_off
         expect_reply=True,
         manufacturer=None,
-        tries=3,
+        tries=1,
         tsn=None,
     )
 
@@ -910,7 +910,7 @@ async def test_transitions(
         transition_time=1,  # transition time - sengled light uses default minimum
         expect_reply=True,
         manufacturer=None,
-        tries=3,
+        tries=1,
         tsn=None,
     )
 
@@ -968,7 +968,7 @@ async def test_transitions(
         transition_time=1,
         expect_reply=True,
         manufacturer=None,
-        tries=3,
+        tries=1,
         tsn=None,
     )
     assert dev2_cluster_color.request.call_args == call(
@@ -979,7 +979,7 @@ async def test_transitions(
         transition_time=1,  # sengled transition == 1 when new_color_provided_while_off
         expect_reply=True,
         manufacturer=None,
-        tries=3,
+        tries=1,
         tsn=None,
     )
     assert dev2_cluster_level.request.call_args_list[1] == call(
@@ -990,7 +990,7 @@ async def test_transitions(
         transition_time=10,
         expect_reply=True,
         manufacturer=None,
-        tries=3,
+        tries=1,
         tsn=None,
     )
 
@@ -1121,7 +1121,7 @@ async def test_transitions(
         transition_time=20,  # transition time
         expect_reply=True,
         manufacturer=None,
-        tries=3,
+        tries=1,
         tsn=None,
     )
 
@@ -1151,7 +1151,7 @@ async def test_transitions(
         transition_time=1,  # transition time - sengled light uses default minimum
         expect_reply=True,
         manufacturer=None,
-        tries=3,
+        tries=1,
         tsn=None,
     )
 
@@ -1184,7 +1184,7 @@ async def test_transitions(
         eWeLink_cluster_on_off.commands_by_name["on"].schema,
         expect_reply=True,
         manufacturer=None,
-        tries=3,
+        tries=1,
         tsn=None,
     )
     assert dev1_cluster_color.request.call_args == call(
@@ -1195,7 +1195,7 @@ async def test_transitions(
         transition_time=0,
         expect_reply=True,
         manufacturer=None,
-        tries=3,
+        tries=1,
         tsn=None,
     )
 
@@ -1261,7 +1261,7 @@ async def test_on_with_off_color(hass: HomeAssistant, device_light_1) -> None:
         dev1_cluster_on_off.commands_by_name["on"].schema,
         expect_reply=True,
         manufacturer=None,
-        tries=3,
+        tries=1,
         tsn=None,
     )
     assert dev1_cluster_color.request.call_args == call(
@@ -1272,7 +1272,7 @@ async def test_on_with_off_color(hass: HomeAssistant, device_light_1) -> None:
         transition_time=0,
         expect_reply=True,
         manufacturer=None,
-        tries=3,
+        tries=1,
         tsn=None,
     )
 
@@ -1319,7 +1319,7 @@ async def test_on_with_off_color(hass: HomeAssistant, device_light_1) -> None:
         transition_time=0,
         expect_reply=True,
         manufacturer=None,
-        tries=3,
+        tries=1,
         tsn=None,
     )
     assert dev1_cluster_color.request.call_args == call(
@@ -1330,7 +1330,7 @@ async def test_on_with_off_color(hass: HomeAssistant, device_light_1) -> None:
         transition_time=0,
         expect_reply=True,
         manufacturer=None,
-        tries=3,
+        tries=1,
         tsn=None,
     )
     assert dev1_cluster_level.request.call_args_list[1] == call(
@@ -1341,7 +1341,7 @@ async def test_on_with_off_color(hass: HomeAssistant, device_light_1) -> None:
         transition_time=0,
         expect_reply=True,
         manufacturer=None,
-        tries=3,
+        tries=1,
         tsn=None,
     )
 
@@ -1373,9 +1373,7 @@ async def async_test_on_from_light(hass, cluster, entity_id):
     assert hass.states.get(entity_id).state == STATE_ON
 
 
-async def async_test_on_off_from_hass(
-    hass, cluster, entity_id, expected_tries: int = 3
-):
+async def async_test_on_off_from_hass(hass, cluster, entity_id):
     """Test on off functionality from hass."""
     # turn on via UI
     cluster.request.reset_mock()
@@ -1390,16 +1388,14 @@ async def async_test_on_off_from_hass(
         cluster.commands_by_name["on"].schema,
         expect_reply=True,
         manufacturer=None,
-        tries=expected_tries,
+        tries=1,
         tsn=None,
     )
 
-    await async_test_off_from_hass(
-        hass, cluster, entity_id, expected_tries=expected_tries
-    )
+    await async_test_off_from_hass(hass, cluster, entity_id)
 
 
-async def async_test_off_from_hass(hass, cluster, entity_id, expected_tries: int = 3):
+async def async_test_off_from_hass(hass, cluster, entity_id):
     """Test turning off the light from Home Assistant."""
 
     # turn off via UI
@@ -1415,18 +1411,13 @@ async def async_test_off_from_hass(hass, cluster, entity_id, expected_tries: int
         cluster.commands_by_name["off"].schema,
         expect_reply=True,
         manufacturer=None,
-        tries=expected_tries,
+        tries=1,
         tsn=None,
     )
 
 
 async def async_test_level_on_off_from_hass(
-    hass,
-    on_off_cluster,
-    level_cluster,
-    entity_id,
-    expected_default_transition: int = 0,
-    expected_tries: int = 3,
+    hass, on_off_cluster, level_cluster, entity_id, expected_default_transition: int = 0
 ):
     """Test on off functionality from hass."""
 
@@ -1448,7 +1439,7 @@ async def async_test_level_on_off_from_hass(
         on_off_cluster.commands_by_name["on"].schema,
         expect_reply=True,
         manufacturer=None,
-        tries=expected_tries,
+        tries=1,
         tsn=None,
     )
     on_off_cluster.request.reset_mock()
@@ -1472,7 +1463,7 @@ async def async_test_level_on_off_from_hass(
         on_off_cluster.commands_by_name["on"].schema,
         expect_reply=True,
         manufacturer=None,
-        tries=expected_tries,
+        tries=1,
         tsn=None,
     )
     assert level_cluster.request.call_args == call(
@@ -1483,7 +1474,7 @@ async def async_test_level_on_off_from_hass(
         transition_time=100,
         expect_reply=True,
         manufacturer=None,
-        tries=expected_tries,
+        tries=1,
         tsn=None,
     )
     on_off_cluster.request.reset_mock()
@@ -1508,15 +1499,13 @@ async def async_test_level_on_off_from_hass(
         transition_time=int(expected_default_transition),
         expect_reply=True,
         manufacturer=None,
-        tries=expected_tries,
+        tries=1,
         tsn=None,
     )
     on_off_cluster.request.reset_mock()
     level_cluster.request.reset_mock()
 
-    await async_test_off_from_hass(
-        hass, on_off_cluster, entity_id, expected_tries=expected_tries
-    )
+    await async_test_off_from_hass(hass, on_off_cluster, entity_id)
 
 
 async def async_test_dimmer_from_light(hass, cluster, entity_id, level, expected_state):
@@ -1533,9 +1522,7 @@ async def async_test_dimmer_from_light(hass, cluster, entity_id, level, expected
     assert hass.states.get(entity_id).attributes.get("brightness") == level
 
 
-async def async_test_flash_from_hass(
-    hass, cluster, entity_id, flash, expected_tries: int = 3
-):
+async def async_test_flash_from_hass(hass, cluster, entity_id, flash):
     """Test flash functionality from hass."""
     # turn on via UI
     cluster.request.reset_mock()
@@ -1555,7 +1542,7 @@ async def async_test_flash_from_hass(
         effect_variant=general.Identify.EffectVariant.Default,
         expect_reply=True,
         manufacturer=None,
-        tries=expected_tries,
+        tries=1,
         tsn=None,
     )
 
@@ -1655,15 +1642,13 @@ async def test_zha_group_light_entity(
     assert "color_mode" not in group_state.attributes
 
     # test turning the lights on and off from the HA
-    await async_test_on_off_from_hass(
-        hass, group_cluster_on_off, group_entity_id, expected_tries=1
-    )
+    await async_test_on_off_from_hass(hass, group_cluster_on_off, group_entity_id)
 
     await async_shift_time(hass)
 
     # test short flashing the lights from the HA
     await async_test_flash_from_hass(
-        hass, group_cluster_identify, group_entity_id, FLASH_SHORT, expected_tries=1
+        hass, group_cluster_identify, group_entity_id, FLASH_SHORT
     )
 
     await async_shift_time(hass)
@@ -1678,7 +1663,6 @@ async def test_zha_group_light_entity(
         group_cluster_level,
         group_entity_id,
         expected_default_transition=1,  # a Sengled light is in that group and needs a minimum 0.1s transition
-        expected_tries=1,
     )
 
     await async_shift_time(hass)
@@ -1699,7 +1683,7 @@ async def test_zha_group_light_entity(
 
     # test long flashing the lights from the HA
     await async_test_flash_from_hass(
-        hass, group_cluster_identify, group_entity_id, FLASH_LONG, expected_tries=1
+        hass, group_cluster_identify, group_entity_id, FLASH_LONG
     )
 
     await async_shift_time(hass)

--- a/tests/components/zha/test_switch.py
+++ b/tests/components/zha/test_switch.py
@@ -176,7 +176,7 @@ async def test_switch(
             cluster.commands_by_name["on"].schema,
             expect_reply=True,
             manufacturer=None,
-            tries=3,
+            tries=1,
             tsn=None,
         )
 
@@ -196,7 +196,7 @@ async def test_switch(
             cluster.commands_by_name["off"].schema,
             expect_reply=True,
             manufacturer=None,
-            tries=3,
+            tries=1,
             tsn=None,
         )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Reverts #93877.

The above PR breaks a few Tuya devices and requires a fix that depends on far too many changes to drop into a final beta release (#93989, `+6,590 −5,175` within a library). Furthermore, retries need to be disabled for ZNP coordinators to avoid excessive delays.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #93955
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
