### PR TITLE
Bump aiobafi6 to 0.8.2

### DIFF
--- a/homeassistant/components/baf/manifest.json
+++ b/homeassistant/components/baf/manifest.json
@@ -5,7 +5,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/baf",
   "iot_class": "local_push",
-  "requirements": ["aiobafi6==0.8.0"],
+  "requirements": ["aiobafi6==0.8.2"],
   "zeroconf": [
     {
       "type": "_api._tcp.local.",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -212,7 +212,7 @@ aioasuswrt==1.4.0
 aioazuredevops==1.3.5
 
 # homeassistant.components.baf
-aiobafi6==0.8.0
+aiobafi6==0.8.2
 
 # homeassistant.components.aws
 aiobotocore==2.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -187,7 +187,7 @@ aioasuswrt==1.4.0
 aioazuredevops==1.3.5
 
 # homeassistant.components.baf
-aiobafi6==0.8.0
+aiobafi6==0.8.2
 
 # homeassistant.components.aws
 aiobotocore==2.1.0


### PR DESCRIPTION
## Proposed change
Bump aiobafi6 to 0.8.2. https://github.com/jfroy/aiobafi6/compare/0.8.0...0.8.2

## Type of change
- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #94047

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.
