### PR TITLE
Fix multiple smart detects firing at once for UniFi Protect

### DIFF
--- a/homeassistant/components/unifiprotect/binary_sensor.py
+++ b/homeassistant/components/unifiprotect/binary_sensor.py
@@ -14,8 +14,6 @@ from pyunifiprotect.data import (
     ProtectAdoptableDeviceModel,
     ProtectModelWithId,
     Sensor,
-    SmartDetectAudioType,
-    SmartDetectObjectType,
 )
 from pyunifiprotect.data.nvr import UOSDisk
 

--- a/homeassistant/components/unifiprotect/binary_sensor.py
+++ b/homeassistant/components/unifiprotect/binary_sensor.py
@@ -364,8 +364,7 @@ EVENT_SENSORS: tuple[ProtectBinaryEventEntityDescription, ...] = (
         ufp_value="is_smart_detected",
         ufp_required_field="can_detect_person",
         ufp_enabled="is_person_detection_on",
-        ufp_event_obj="last_smart_detect_event",
-        ufp_smart_type=SmartDetectObjectType.PERSON,
+        ufp_event_obj="last_person_detect_event",
     ),
     ProtectBinaryEventEntityDescription(
         key="smart_obj_vehicle",
@@ -374,8 +373,7 @@ EVENT_SENSORS: tuple[ProtectBinaryEventEntityDescription, ...] = (
         ufp_value="is_smart_detected",
         ufp_required_field="can_detect_vehicle",
         ufp_enabled="is_vehicle_detection_on",
-        ufp_event_obj="last_smart_detect_event",
-        ufp_smart_type=SmartDetectObjectType.VEHICLE,
+        ufp_event_obj="last_vehicle_detect_event",
     ),
     ProtectBinaryEventEntityDescription(
         key="smart_obj_face",
@@ -384,8 +382,7 @@ EVENT_SENSORS: tuple[ProtectBinaryEventEntityDescription, ...] = (
         ufp_value="is_smart_detected",
         ufp_required_field="can_detect_face",
         ufp_enabled="is_face_detection_on",
-        ufp_event_obj="last_smart_detect_event",
-        ufp_smart_type=SmartDetectObjectType.FACE,
+        ufp_event_obj="last_face_detect_event",
     ),
     ProtectBinaryEventEntityDescription(
         key="smart_obj_package",
@@ -394,8 +391,7 @@ EVENT_SENSORS: tuple[ProtectBinaryEventEntityDescription, ...] = (
         ufp_value="is_smart_detected",
         ufp_required_field="can_detect_package",
         ufp_enabled="is_package_detection_on",
-        ufp_event_obj="last_smart_detect_event",
-        ufp_smart_type=SmartDetectObjectType.PACKAGE,
+        ufp_event_obj="last_package_detect_event",
     ),
     ProtectBinaryEventEntityDescription(
         key="smart_audio_any",
@@ -412,8 +408,7 @@ EVENT_SENSORS: tuple[ProtectBinaryEventEntityDescription, ...] = (
         ufp_value="is_smart_detected",
         ufp_required_field="can_detect_smoke",
         ufp_enabled="is_smoke_detection_on",
-        ufp_event_obj="last_smart_audio_detect_event",
-        ufp_smart_type=SmartDetectAudioType.SMOKE,
+        ufp_event_obj="last_smoke_detect_event",
     ),
     ProtectBinaryEventEntityDescription(
         key="smart_audio_cmonx",
@@ -422,8 +417,7 @@ EVENT_SENSORS: tuple[ProtectBinaryEventEntityDescription, ...] = (
         ufp_value="is_smart_detected",
         ufp_required_field="can_detect_smoke",
         ufp_enabled="is_smoke_detection_on",
-        ufp_event_obj="last_smart_audio_detect_event",
-        ufp_smart_type=SmartDetectAudioType.CMONX,
+        ufp_event_obj="last_cmonx_detect_event",
     ),
 )
 

--- a/homeassistant/components/unifiprotect/data.py
+++ b/homeassistant/components/unifiprotect/data.py
@@ -229,22 +229,23 @@ class ProtectData:
         # trigger updates for camera that the event references
         elif isinstance(obj, Event):
             if obj.type in SMART_EVENTS:
-                if obj.end is None:
-                    _LOGGER.debug(
-                        "%s (%s): New smart detection started for %s (%s)",
-                        obj.camera.name,
-                        obj.camera.mac,
-                        obj.smart_detect_types,
-                        obj.id,
-                    )
-                else:
-                    _LOGGER.debug(
-                        "%s (%s): Smart detection ended for %s (%s)",
-                        obj.camera.name,
-                        obj.camera.mac,
-                        obj.smart_detect_types,
-                        obj.id,
-                    )
+                if obj.camera is not None:
+                    if obj.end is None:
+                        _LOGGER.debug(
+                            "%s (%s): New smart detection started for %s (%s)",
+                            obj.camera.name,
+                            obj.camera.mac,
+                            obj.smart_detect_types,
+                            obj.id,
+                        )
+                    else:
+                        _LOGGER.debug(
+                            "%s (%s): Smart detection ended for %s (%s)",
+                            obj.camera.name,
+                            obj.camera.mac,
+                            obj.smart_detect_types,
+                            obj.id,
+                        )
 
             if obj.type == EventType.DEVICE_ADOPTED:
                 if obj.metadata is not None and obj.metadata.device_id is not None:

--- a/homeassistant/components/unifiprotect/data.py
+++ b/homeassistant/components/unifiprotect/data.py
@@ -40,6 +40,11 @@ from .utils import async_dispatch_id as _ufpd, async_get_devices_by_type
 
 _LOGGER = logging.getLogger(__name__)
 ProtectDeviceType = ProtectAdoptableDeviceModel | NVR
+SMART_EVENTS = {
+    EventType.SMART_DETECT,
+    EventType.SMART_AUDIO_DETECT,
+    EventType.SMART_DETECT_LINE,
+}
 
 
 @callback
@@ -223,6 +228,24 @@ class ProtectData:
 
         # trigger updates for camera that the event references
         elif isinstance(obj, Event):
+            if obj.type in SMART_EVENTS:
+                if obj.end is None:
+                    _LOGGER.debug(
+                        "%s (%s): New smart detection started for %s (%s)",
+                        obj.camera.name,
+                        obj.camera.mac,
+                        obj.smart_detect_types,
+                        obj.id,
+                    )
+                else:
+                    _LOGGER.debug(
+                        "%s (%s): Smart detection ended for %s (%s)",
+                        obj.camera.name,
+                        obj.camera.mac,
+                        obj.smart_detect_types,
+                        obj.id,
+                    )
+
             if obj.type == EventType.DEVICE_ADOPTED:
                 if obj.metadata is not None and obj.metadata.device_id is not None:
                     device = self.api.bootstrap.get_device_from_id(

--- a/homeassistant/components/unifiprotect/manifest.json
+++ b/homeassistant/components/unifiprotect/manifest.json
@@ -41,7 +41,7 @@
   "iot_class": "local_push",
   "loggers": ["pyunifiprotect", "unifi_discovery"],
   "quality_scale": "platinum",
-  "requirements": ["pyunifiprotect==4.9.1", "unifi-discovery==1.1.7"],
+  "requirements": ["pyunifiprotect==4.10.0", "unifi-discovery==1.1.7"],
   "ssdp": [
     {
       "manufacturer": "Ubiquiti Networks",

--- a/homeassistant/components/unifiprotect/models.py
+++ b/homeassistant/components/unifiprotect/models.py
@@ -86,7 +86,7 @@ class ProtectEventMixin(ProtectRequiredKeysMixin[T]):
             _LOGGER.debug("%s (%s): missing event", self.name, obj.mac)
         else:
             value = now > event.start
-            if event.end is not None and now > event.end:
+            if value and event.end is not None and now > event.end:
                 value = False
                 _LOGGER.debug(
                     "%s (%s): end ended at %s",

--- a/homeassistant/components/unifiprotect/models.py
+++ b/homeassistant/components/unifiprotect/models.py
@@ -10,7 +10,7 @@ from typing import Any, Generic, TypeVar, cast
 from pyunifiprotect.data import NVR, Event, ProtectAdoptableDeviceModel
 
 from homeassistant.helpers.entity import EntityDescription
-from homeassistant.util import dt as date_util
+from homeassistant.util import dt as dt_util
 
 from .utils import get_nested_attr
 
@@ -80,20 +80,16 @@ class ProtectEventMixin(ProtectRequiredKeysMixin[T]):
         """Return value if event is active."""
 
         event = self.get_event_obj(obj)
-        now = date_util.utcnow()
-        if event is None:
+        now = dt_util.utcnow()
+        value = event is not None and now > event.start
+        if value and event.end is not None and now > event.end:
             value = False
-            _LOGGER.debug("%s (%s): missing event", self.name, obj.mac)
-        else:
-            value = now > event.start
-            if value and event.end is not None and now > event.end:
-                value = False
-                _LOGGER.debug(
-                    "%s (%s): end ended at %s",
-                    self.name,
-                    obj.mac,
-                    event.end.isoformat(),
-                )
+            _LOGGER.debug(
+                "%s (%s): end ended at %s",
+                self.name,
+                obj.mac,
+                event.end.isoformat(),
+            )
 
         if value:
             _LOGGER.debug("%s (%s): value is on", self.name, obj.mac)

--- a/homeassistant/components/unifiprotect/models.py
+++ b/homeassistant/components/unifiprotect/models.py
@@ -10,6 +10,7 @@ from typing import Any, Generic, TypeVar, cast
 from pyunifiprotect.data import NVR, Event, ProtectAdoptableDeviceModel
 
 from homeassistant.helpers.entity import EntityDescription
+from homeassistant.util import dt as date_util
 
 from .utils import get_nested_attr
 
@@ -67,7 +68,6 @@ class ProtectEventMixin(ProtectRequiredKeysMixin[T]):
     """Mixin for events."""
 
     ufp_event_obj: str | None = None
-    ufp_smart_type: str | None = None
 
     def get_event_obj(self, obj: T) -> Event | None:
         """Return value from UniFi Protect device."""
@@ -79,23 +79,21 @@ class ProtectEventMixin(ProtectRequiredKeysMixin[T]):
     def get_is_on(self, obj: T) -> bool:
         """Return value if event is active."""
 
-        value = bool(self.get_ufp_value(obj))
-        if value:
-            event = self.get_event_obj(obj)
-            value = event is not None
-            if not value:
-                _LOGGER.debug("%s (%s): missing event", self.name, obj.mac)
-
-            if event is not None and self.ufp_smart_type is not None:
-                value = self.ufp_smart_type in event.smart_detect_types
-                if not value:
-                    _LOGGER.debug(
-                        "%s (%s): %s not in %s",
-                        self.name,
-                        obj.mac,
-                        self.ufp_smart_type,
-                        event.smart_detect_types,
-                    )
+        event = self.get_event_obj(obj)
+        now = date_util.utcnow()
+        if event is None:
+            value = False
+            _LOGGER.debug("%s (%s): missing event", self.name, obj.mac)
+        else:
+            value = now > event.start
+            if event.end is not None and now > event.end:
+                value = False
+                _LOGGER.debug(
+                    "%s (%s): end ended at %s",
+                    self.name,
+                    obj.mac,
+                    event.end.isoformat(),
+                )
 
         if value:
             _LOGGER.debug("%s (%s): value is on", self.name, obj.mac)

--- a/homeassistant/components/unifiprotect/sensor.py
+++ b/homeassistant/components/unifiprotect/sensor.py
@@ -528,10 +528,9 @@ EVENT_SENSORS: tuple[ProtectSensorEventEntityDescription, ...] = (
         name="License Plate Detected",
         icon="mdi:car",
         translation_key="license_plate",
-        ufp_smart_type=SmartDetectObjectType.LICENSE_PLATE,
         ufp_value="is_smart_detected",
         ufp_required_field="can_detect_license_plate",
-        ufp_event_obj="last_smart_detect_event",
+        ufp_event_obj="last_license_plate_detect_event",
     ),
 )
 
@@ -767,8 +766,7 @@ class ProtectEventSensor(EventEntityMixin, SensorEntity):
         EventEntityMixin._async_update_device_from_protect(self, device)
         is_on = self.entity_description.get_is_on(device)
         is_license_plate = (
-            self.entity_description.ufp_smart_type
-            == SmartDetectObjectType.LICENSE_PLATE
+            self.entity_description.ufp_event_obj == "last_license_plate_detect_event"
         )
         if (
             not is_on

--- a/homeassistant/components/unifiprotect/sensor.py
+++ b/homeassistant/components/unifiprotect/sensor.py
@@ -15,7 +15,6 @@ from pyunifiprotect.data import (
     ProtectDeviceModel,
     ProtectModelWithId,
     Sensor,
-    SmartDetectObjectType,
 )
 
 from homeassistant.components.sensor import (

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2187,7 +2187,7 @@ pytrafikverket==0.3.3
 pyudev==0.23.2
 
 # homeassistant.components.unifiprotect
-pyunifiprotect==4.9.1
+pyunifiprotect==4.10.0
 
 # homeassistant.components.uptimerobot
 pyuptimerobot==22.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1598,7 +1598,7 @@ pytrafikverket==0.3.3
 pyudev==0.23.2
 
 # homeassistant.components.unifiprotect
-pyunifiprotect==4.9.1
+pyunifiprotect==4.10.0
 
 # homeassistant.components.uptimerobot
 pyuptimerobot==22.2.0

--- a/tests/components/unifiprotect/test_sensor.py
+++ b/tests/components/unifiprotect/test_sensor.py
@@ -537,7 +537,9 @@ async def test_camera_update_licenseplate(
 
     new_camera = camera.copy()
     new_camera.is_smart_detected = True
-    new_camera.last_smart_detect_event_id = event.id
+    new_camera.last_smart_detect_event_ids[
+        SmartDetectObjectType.LICENSE_PLATE
+    ] = event.id
 
     mock_msg = Mock()
     mock_msg.changed_data = {}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Changelog: https://github.com/AngellusMortis/pyunifiprotect/releases/tag/v4.10.0

If multiple smart detect events came in at once with different detections, it could not detect them properly before. This changes things up to use the new attributes added in the new version of pyunifiprotect to only consider the last event for the a given smart detection for triggering the sensor instead of looking at `is_smart_detected` and the last overall smart detection.

Also adds more debug logging to troubleshoot smart detection issues.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
