### PR TITLE
Sync Climate min/max temp with Google Assistant

### DIFF
--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -922,9 +922,28 @@ class TemperatureSettingTrait(_Trait):
     def sync_attributes(self):
         """Return temperature point and modes attributes for a sync request."""
         response = {}
-        response["thermostatTemperatureUnit"] = _google_temp_unit(
-            self.hass.config.units.temperature_unit
+        attrs = self.state.attributes
+        unit = self.hass.config.units.temperature_unit
+        response["thermostatTemperatureUnit"] = _google_temp_unit(unit)
+
+        min_temp = round(
+            TemperatureConverter.convert(
+                float(attrs[climate.ATTR_MIN_TEMP]),
+                unit,
+                UnitOfTemperature.CELSIUS,
+            )
         )
+        max_temp = round(
+            TemperatureConverter.convert(
+                float(attrs[climate.ATTR_MAX_TEMP]),
+                unit,
+                UnitOfTemperature.CELSIUS,
+            )
+        )
+        response["thermostatTemperatureRange"] = {
+            "minThresholdCelsius": min_temp,
+            "maxThresholdCelsius": max_temp,
+        }
 
         modes = self.climate_google_modes
 

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -854,14 +854,18 @@ async def test_temperature_setting_climate_onoff(hass: HomeAssistant) -> None:
                     climate.HVACMode.HEAT,
                     climate.HVACMode.HEAT_COOL,
                 ],
-                climate.ATTR_MIN_TEMP: None,
-                climate.ATTR_MAX_TEMP: None,
+                climate.ATTR_MIN_TEMP: 45,
+                climate.ATTR_MAX_TEMP: 95,
             },
         ),
         BASIC_CONFIG,
     )
     assert trt.sync_attributes() == {
         "availableThermostatModes": ["off", "cool", "heat", "heatcool", "on"],
+        "thermostatTemperatureRange": {
+            "minThresholdCelsius": 7,
+            "maxThresholdCelsius": 35,
+        },
         "thermostatTemperatureUnit": "F",
     }
     assert trt.can_execute(trait.COMMAND_THERMOSTAT_SET_MODE, {})
@@ -893,14 +897,18 @@ async def test_temperature_setting_climate_no_modes(hass: HomeAssistant) -> None
             climate.HVACMode.AUTO,
             {
                 climate.ATTR_HVAC_MODES: [],
-                climate.ATTR_MIN_TEMP: None,
-                climate.ATTR_MAX_TEMP: None,
+                climate.ATTR_MIN_TEMP: climate.DEFAULT_MIN_TEMP,
+                climate.ATTR_MAX_TEMP: climate.DEFAULT_MAX_TEMP,
             },
         ),
         BASIC_CONFIG,
     )
     assert trt.sync_attributes() == {
         "availableThermostatModes": ["heat"],
+        "thermostatTemperatureRange": {
+            "minThresholdCelsius": climate.DEFAULT_MIN_TEMP,
+            "maxThresholdCelsius": climate.DEFAULT_MAX_TEMP,
+        },
         "thermostatTemperatureUnit": "C",
     }
 
@@ -937,6 +945,10 @@ async def test_temperature_setting_climate_range(hass: HomeAssistant) -> None:
     )
     assert trt.sync_attributes() == {
         "availableThermostatModes": ["off", "cool", "heat", "auto", "on"],
+        "thermostatTemperatureRange": {
+            "minThresholdCelsius": 10,
+            "maxThresholdCelsius": 27,
+        },
         "thermostatTemperatureUnit": "F",
     }
     assert trt.query_attributes() == {
@@ -1011,6 +1023,10 @@ async def test_temperature_setting_climate_setpoint(hass: HomeAssistant) -> None
     )
     assert trt.sync_attributes() == {
         "availableThermostatModes": ["off", "cool", "on"],
+        "thermostatTemperatureRange": {
+            "minThresholdCelsius": 10,
+            "maxThresholdCelsius": 30,
+        },
         "thermostatTemperatureUnit": "C",
     }
     assert trt.query_attributes() == {
@@ -1068,6 +1084,10 @@ async def test_temperature_setting_climate_setpoint_auto(hass: HomeAssistant) ->
     )
     assert trt.sync_attributes() == {
         "availableThermostatModes": ["off", "heatcool", "on"],
+        "thermostatTemperatureRange": {
+            "minThresholdCelsius": 10,
+            "maxThresholdCelsius": 30,
+        },
         "thermostatTemperatureUnit": "C",
     }
     assert trt.query_attributes() == {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
A change to the `TempetureSettingTrait` in the Google Assistant integration to also return the `min_temp` and `max_temp` attributes during a sync request. Both temps are converted into Celsius for the request and tests have been modified to suit this change.
I couldn't see any documentation that makes a note of this functionality.
 
This was identified by @balloob during [this PR](https://github.com/home-assistant/core/pull/93648#discussion_r1211674744) for the water heater platform. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request: 
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/pull/93648#discussion_r1211674744 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
