### PR TITLE
Add textual representation entities for Fronius status codes

### DIFF
--- a/homeassistant/components/fronius/const.py
+++ b/homeassistant/components/fronius/const.py
@@ -82,11 +82,7 @@ class MeterLocationCodeOption(StrEnum):
 
 def get_meter_location_description(code: StateType) -> MeterLocationCodeOption | None:
     """Return a location_description for a given location code."""
-    try:
-        code = int(code)  # type: ignore[arg-type]
-    except ValueError:
-        return None
-    match code:
+    match int(code):  # type: ignore[arg-type]
         case 0:
             return MeterLocationCodeOption.FEED_IN
         case 1:

--- a/homeassistant/components/fronius/const.py
+++ b/homeassistant/components/fronius/const.py
@@ -98,3 +98,30 @@ def get_meter_location_description(code: StateType) -> MeterLocationCodeOption |
         case _ as _code if 256 <= _code <= 511:
             return MeterLocationCodeOption.SUBLOAD
     return None
+
+
+class OhmPilotStateCodeOption(StrEnum):
+    """OhmPilot state codes for Fronius inverters."""
+
+    # these are keys for state translations - so snake_case is used
+    UP_AND_RUNNING = "up_and_running"
+    KEEP_MINIMUM_TEMPERATURE = "keep_minimum_temperature"
+    LEGIONELLA_PROTECTION = "legionella_protection"
+    CRITICAL_FAULT = "critical_fault"
+    FAULT = "fault"
+    BOOST_MODE = "boost_mode"
+
+
+_OHMPILOT_STATE_CODES: Final[dict[int, OhmPilotStateCodeOption]] = {
+    0: OhmPilotStateCodeOption.UP_AND_RUNNING,
+    1: OhmPilotStateCodeOption.KEEP_MINIMUM_TEMPERATURE,
+    2: OhmPilotStateCodeOption.LEGIONELLA_PROTECTION,
+    3: OhmPilotStateCodeOption.CRITICAL_FAULT,
+    4: OhmPilotStateCodeOption.FAULT,
+    5: OhmPilotStateCodeOption.BOOST_MODE,
+}
+
+
+def get_ohmpilot_state_message(code: StateType) -> OhmPilotStateCodeOption | None:
+    """Return a status message for a given status code."""
+    return _OHMPILOT_STATE_CODES.get(code)  # type: ignore[arg-type]

--- a/homeassistant/components/fronius/const.py
+++ b/homeassistant/components/fronius/const.py
@@ -76,6 +76,7 @@ class MeterLocationCodeOption(StrEnum):
     FEED_IN = "feed_in"
     CONSUMPTION_PATH = "consumption_path"
     GENERATOR = "external_generator"
+    EXT_BATTERY = "external_battery"
     SUBLOAD = "subload"
 
 
@@ -92,6 +93,8 @@ def get_meter_location_description(code: StateType) -> MeterLocationCodeOption |
             return MeterLocationCodeOption.CONSUMPTION_PATH
         case 3:
             return MeterLocationCodeOption.GENERATOR
+        case 4:
+            return MeterLocationCodeOption.EXT_BATTERY
         case _ as _code if 256 <= _code <= 511:
             return MeterLocationCodeOption.SUBLOAD
     return None

--- a/homeassistant/components/fronius/const.py
+++ b/homeassistant/components/fronius/const.py
@@ -67,3 +67,31 @@ _INVERTER_STATUS_CODES: Final[dict[int, InverterStatusCodeOption]] = {
 def get_inverter_status_message(code: StateType) -> InverterStatusCodeOption:
     """Return a status message for a given status code."""
     return _INVERTER_STATUS_CODES.get(code, InverterStatusCodeOption.INVALID)  # type: ignore[arg-type]
+
+
+class MeterLocationCodeOption(StrEnum):
+    """Meter location codes for Fronius meters."""
+
+    # these are keys for state translations - so snake_case is used
+    FEED_IN = "feed_in"
+    CONSUMPTION_PATH = "consumption_path"
+    GENERATOR = "external_generator"
+    SUBLOAD = "subload"
+
+
+def get_meter_location_description(code: StateType) -> MeterLocationCodeOption | None:
+    """Return a location_description for a given location code."""
+    try:
+        code = int(code)  # type: ignore[arg-type]
+    except ValueError:
+        return None
+    match code:
+        case 0:
+            return MeterLocationCodeOption.FEED_IN
+        case 1:
+            return MeterLocationCodeOption.CONSUMPTION_PATH
+        case 3:
+            return MeterLocationCodeOption.GENERATOR
+        case _ as _code if 256 <= _code <= 511:
+            return MeterLocationCodeOption.SUBLOAD
+    return None

--- a/homeassistant/components/fronius/const.py
+++ b/homeassistant/components/fronius/const.py
@@ -1,7 +1,9 @@
 """Constants for the Fronius integration."""
 from typing import Final, NamedTuple, TypedDict
 
+from homeassistant.backports.enum import StrEnum
 from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.typing import StateType
 
 DOMAIN: Final = "fronius"
 
@@ -25,3 +27,43 @@ class FroniusDeviceInfo(NamedTuple):
     device_info: DeviceInfo
     solar_net_id: SolarNetId
     unique_id: str
+
+
+class InverterStatusCodeOption(StrEnum):
+    """Status codes for Fronius inverters."""
+
+    # these are keys for state translations - so snake_case is used
+    STARTUP = "startup"
+    RUNNING = "running"
+    STANDBY = "standby"
+    BOOTLOADING = "bootloading"
+    ERROR = "error"
+    IDLE = "idle"
+    READY = "ready"
+    SLEEPING = "sleeping"
+    UNKNOWN = "unknown"
+    INVALID = "invalid"
+
+
+_INVERTER_STATUS_CODES: Final[dict[int, InverterStatusCodeOption]] = {
+    0: InverterStatusCodeOption.STARTUP,
+    1: InverterStatusCodeOption.STARTUP,
+    2: InverterStatusCodeOption.STARTUP,
+    3: InverterStatusCodeOption.STARTUP,
+    4: InverterStatusCodeOption.STARTUP,
+    5: InverterStatusCodeOption.STARTUP,
+    6: InverterStatusCodeOption.STARTUP,
+    7: InverterStatusCodeOption.RUNNING,
+    8: InverterStatusCodeOption.STANDBY,
+    9: InverterStatusCodeOption.BOOTLOADING,
+    10: InverterStatusCodeOption.ERROR,
+    11: InverterStatusCodeOption.IDLE,
+    12: InverterStatusCodeOption.READY,
+    13: InverterStatusCodeOption.SLEEPING,
+    255: InverterStatusCodeOption.UNKNOWN,
+}
+
+
+def get_inverter_status_message(code: StateType) -> InverterStatusCodeOption:
+    """Return a status message for a given status code."""
+    return _INVERTER_STATUS_CODES.get(code, InverterStatusCodeOption.INVALID)  # type: ignore[arg-type]

--- a/homeassistant/components/fronius/const.py
+++ b/homeassistant/components/fronius/const.py
@@ -1,7 +1,7 @@
 """Constants for the Fronius integration."""
+from enum import StrEnum
 from typing import Final, NamedTuple, TypedDict
 
-from homeassistant.backports.enum import StrEnum
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.typing import StateType
 

--- a/homeassistant/components/fronius/coordinator.py
+++ b/homeassistant/components/fronius/coordinator.py
@@ -49,8 +49,10 @@ class FroniusCoordinatorBase(
         """Set up the FroniusCoordinatorBase class."""
         self._failed_update_count = 0
         self.solar_net = solar_net
-        # unregistered_keys are used to create entities in platform module
-        self.unregistered_keys: dict[SolarNetId, set[str]] = {}
+        # unregistered_descriptors are used to create entities in platform module
+        self.unregistered_descriptors: dict[
+            SolarNetId, list[FroniusSensorEntityDescription]
+        ] = {}
         super().__init__(*args, update_interval=self.default_interval, **kwargs)
 
     @abstractmethod
@@ -73,11 +75,11 @@ class FroniusCoordinatorBase(
                 self.update_interval = self.default_interval
 
             for solar_net_id in data:
-                if solar_net_id not in self.unregistered_keys:
+                if solar_net_id not in self.unregistered_descriptors:
                     # id seen for the first time
-                    self.unregistered_keys[solar_net_id] = {
-                        desc.key for desc in self.valid_descriptions
-                    }
+                    self.unregistered_descriptors[
+                        solar_net_id
+                    ] = self.valid_descriptions.copy()
             return data
 
     @callback
@@ -92,22 +94,34 @@ class FroniusCoordinatorBase(
         """
 
         @callback
-        def _add_entities_for_unregistered_keys() -> None:
+        def _add_entities_for_unregistered_descriptors() -> None:
             """Add entities for keys seen for the first time."""
-            new_entities: list = []
+            new_entities: list[_FroniusEntityT] = []
             for solar_net_id, device_data in self.data.items():
-                for key in self.unregistered_keys[solar_net_id].intersection(
-                    device_data
-                ):
-                    if device_data[key]["value"] is None:
+                remaining_unregistered_descriptors = []
+                for description in self.unregistered_descriptors[solar_net_id]:
+                    key = description.response_key or description.key
+                    if key not in device_data:
+                        remaining_unregistered_descriptors.append(description)
                         continue
-                    new_entities.append(entity_constructor(self, key, solar_net_id))
-                    self.unregistered_keys[solar_net_id].remove(key)
+                    if device_data[key]["value"] is None:
+                        remaining_unregistered_descriptors.append(description)
+                        continue
+                    new_entities.append(
+                        entity_constructor(
+                            coordinator=self,
+                            description=description,
+                            solar_net_id=solar_net_id,
+                        )
+                    )
+                self.unregistered_descriptors[
+                    solar_net_id
+                ] = remaining_unregistered_descriptors
             async_add_entities(new_entities)
 
-        _add_entities_for_unregistered_keys()
+        _add_entities_for_unregistered_descriptors()
         self.solar_net.cleanup_callbacks.append(
-            self.async_add_listener(_add_entities_for_unregistered_keys)
+            self.async_add_listener(_add_entities_for_unregistered_descriptors)
         )
 
 

--- a/homeassistant/components/fronius/sensor.py
+++ b/homeassistant/components/fronius/sensor.py
@@ -35,7 +35,9 @@ from .const import (
     DOMAIN,
     SOLAR_NET_DISCOVERY_NEW,
     InverterStatusCodeOption,
+    MeterLocationCodeOption,
     get_inverter_status_message,
+    get_meter_location_description,
 )
 
 if TYPE_CHECKING:
@@ -323,6 +325,15 @@ METER_ENTITY_DESCRIPTIONS: list[FroniusSensorEntityDescription] = [
     FroniusSensorEntityDescription(
         key="meter_location",
         entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=int,  # type: ignore[arg-type]
+    ),
+    FroniusSensorEntityDescription(
+        key="meter_location_description",
+        response_key="meter_location",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        device_class=SensorDeviceClass.ENUM,
+        options=[opt.value for opt in MeterLocationCodeOption],
+        value_fn=get_meter_location_description,
     ),
     FroniusSensorEntityDescription(
         key="power_apparent_phase_1",

--- a/homeassistant/components/fronius/sensor.py
+++ b/homeassistant/components/fronius/sensor.py
@@ -36,8 +36,10 @@ from .const import (
     SOLAR_NET_DISCOVERY_NEW,
     InverterStatusCodeOption,
     MeterLocationCodeOption,
+    OhmPilotStateCodeOption,
     get_inverter_status_message,
     get_meter_location_description,
+    get_ohmpilot_state_message,
 )
 
 if TYPE_CHECKING:
@@ -523,7 +525,11 @@ OHMPILOT_ENTITY_DESCRIPTIONS: list[FroniusSensorEntityDescription] = [
     ),
     FroniusSensorEntityDescription(
         key="state_message",
+        response_key="state_code",
         entity_category=EntityCategory.DIAGNOSTIC,
+        device_class=SensorDeviceClass.ENUM,
+        options=[opt.value for opt in OhmPilotStateCodeOption],
+        value_fn=get_ohmpilot_state_message,
     ),
 ]
 

--- a/homeassistant/components/fronius/sensor.py
+++ b/homeassistant/components/fronius/sensor.py
@@ -31,7 +31,12 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, SOLAR_NET_DISCOVERY_NEW
+from .const import (
+    DOMAIN,
+    SOLAR_NET_DISCOVERY_NEW,
+    InverterStatusCodeOption,
+    get_inverter_status_message,
+)
 
 if TYPE_CHECKING:
     from . import FroniusSolarNet
@@ -201,6 +206,15 @@ INVERTER_ENTITY_DESCRIPTIONS: list[FroniusSensorEntityDescription] = [
     FroniusSensorEntityDescription(
         key="status_code",
         entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+    ),
+    FroniusSensorEntityDescription(
+        key="status_message",
+        response_key="status_code",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        device_class=SensorDeviceClass.ENUM,
+        options=[opt.value for opt in InverterStatusCodeOption],
+        value_fn=get_inverter_status_message,
     ),
     FroniusSensorEntityDescription(
         key="led_state",

--- a/homeassistant/components/fronius/sensor.py
+++ b/homeassistant/components/fronius/sensor.py
@@ -102,6 +102,7 @@ class FroniusSensorEntityDescription(SensorEntityDescription):
     # Gen24 devices may report 0 for total energy while doing firmware updates.
     # Handling such values shall mitigate spikes in delta calculations.
     invalid_when_falsy: bool = False
+    response_key: str | None = None
 
 
 INVERTER_ENTITY_DESCRIPTIONS: list[FroniusSensorEntityDescription] = [
@@ -630,24 +631,22 @@ class _FroniusSensorEntity(CoordinatorEntity["FroniusCoordinatorBase"], SensorEn
     """Defines a Fronius coordinator entity."""
 
     entity_description: FroniusSensorEntityDescription
-    entity_descriptions: list[FroniusSensorEntityDescription]
 
     _attr_has_entity_name = True
 
     def __init__(
         self,
         coordinator: FroniusCoordinatorBase,
-        key: str,
+        description: FroniusSensorEntityDescription,
         solar_net_id: str,
     ) -> None:
         """Set up an individual Fronius meter sensor."""
         super().__init__(coordinator)
-        self.entity_description = next(
-            desc for desc in self.entity_descriptions if desc.key == key
-        )
+        self.entity_description = description
+        self.response_key = description.response_key or description.key
         self.solar_net_id = solar_net_id
         self._attr_native_value = self._get_entity_value()
-        self._attr_translation_key = self.entity_description.key
+        self._attr_translation_key = description.key
 
     def _device_data(self) -> dict[str, Any]:
         """Extract information for SolarNet device from coordinator data."""
@@ -655,9 +654,7 @@ class _FroniusSensorEntity(CoordinatorEntity["FroniusCoordinatorBase"], SensorEn
 
     def _get_entity_value(self) -> Any:
         """Extract entity value from coordinator. Raises KeyError if not included in latest update."""
-        new_value = self.coordinator.data[self.solar_net_id][
-            self.entity_description.key
-        ]["value"]
+        new_value = self.coordinator.data[self.solar_net_id][self.response_key]["value"]
         if new_value is None:
             return self.entity_description.default_value
         if self.entity_description.invalid_when_falsy and not new_value:
@@ -681,54 +678,54 @@ class _FroniusSensorEntity(CoordinatorEntity["FroniusCoordinatorBase"], SensorEn
 class InverterSensor(_FroniusSensorEntity):
     """Defines a Fronius inverter device sensor entity."""
 
-    entity_descriptions = INVERTER_ENTITY_DESCRIPTIONS
-
     def __init__(
         self,
         coordinator: FroniusInverterUpdateCoordinator,
-        key: str,
+        description: FroniusSensorEntityDescription,
         solar_net_id: str,
     ) -> None:
         """Set up an individual Fronius inverter sensor."""
-        super().__init__(coordinator, key, solar_net_id)
+        super().__init__(coordinator, description, solar_net_id)
         # device_info created in __init__ from a `GetInverterInfo` request
         self._attr_device_info = coordinator.inverter_info.device_info
-        self._attr_unique_id = f"{coordinator.inverter_info.unique_id}-{key}"
+        self._attr_unique_id = (
+            f"{coordinator.inverter_info.unique_id}-{description.key}"
+        )
 
 
 class LoggerSensor(_FroniusSensorEntity):
     """Defines a Fronius logger device sensor entity."""
 
-    entity_descriptions = LOGGER_ENTITY_DESCRIPTIONS
-
     def __init__(
         self,
         coordinator: FroniusLoggerUpdateCoordinator,
-        key: str,
+        description: FroniusSensorEntityDescription,
         solar_net_id: str,
     ) -> None:
         """Set up an individual Fronius meter sensor."""
-        super().__init__(coordinator, key, solar_net_id)
+        super().__init__(coordinator, description, solar_net_id)
         logger_data = self._device_data()
         # Logger device is already created in FroniusSolarNet._create_solar_net_device
         self._attr_device_info = coordinator.solar_net.system_device_info
-        self._attr_native_unit_of_measurement = logger_data[key].get("unit")
-        self._attr_unique_id = f'{logger_data["unique_identifier"]["value"]}-{key}'
+        self._attr_native_unit_of_measurement = logger_data[self.response_key].get(
+            "unit"
+        )
+        self._attr_unique_id = (
+            f'{logger_data["unique_identifier"]["value"]}-{description.key}'
+        )
 
 
 class MeterSensor(_FroniusSensorEntity):
     """Defines a Fronius meter device sensor entity."""
 
-    entity_descriptions = METER_ENTITY_DESCRIPTIONS
-
     def __init__(
         self,
         coordinator: FroniusMeterUpdateCoordinator,
-        key: str,
+        description: FroniusSensorEntityDescription,
         solar_net_id: str,
     ) -> None:
         """Set up an individual Fronius meter sensor."""
-        super().__init__(coordinator, key, solar_net_id)
+        super().__init__(coordinator, description, solar_net_id)
         meter_data = self._device_data()
         # S0 meters connected directly to inverters respond "n.a." as serial number
         # `model` contains the inverter id: "S0 Meter at inverter 1"
@@ -745,22 +742,20 @@ class MeterSensor(_FroniusSensorEntity):
             name=meter_data["model"]["value"],
             via_device=(DOMAIN, coordinator.solar_net.solar_net_device_id),
         )
-        self._attr_unique_id = f"{meter_uid}-{key}"
+        self._attr_unique_id = f"{meter_uid}-{description.key}"
 
 
 class OhmpilotSensor(_FroniusSensorEntity):
     """Defines a Fronius Ohmpilot sensor entity."""
 
-    entity_descriptions = OHMPILOT_ENTITY_DESCRIPTIONS
-
     def __init__(
         self,
         coordinator: FroniusOhmpilotUpdateCoordinator,
-        key: str,
+        description: FroniusSensorEntityDescription,
         solar_net_id: str,
     ) -> None:
         """Set up an individual Fronius meter sensor."""
-        super().__init__(coordinator, key, solar_net_id)
+        super().__init__(coordinator, description, solar_net_id)
         device_data = self._device_data()
 
         self._attr_device_info = DeviceInfo(
@@ -771,45 +766,41 @@ class OhmpilotSensor(_FroniusSensorEntity):
             sw_version=device_data["software"]["value"],
             via_device=(DOMAIN, coordinator.solar_net.solar_net_device_id),
         )
-        self._attr_unique_id = f'{device_data["serial"]["value"]}-{key}'
+        self._attr_unique_id = f'{device_data["serial"]["value"]}-{description.key}'
 
 
 class PowerFlowSensor(_FroniusSensorEntity):
     """Defines a Fronius power flow sensor entity."""
 
-    entity_descriptions = POWER_FLOW_ENTITY_DESCRIPTIONS
-
     def __init__(
         self,
         coordinator: FroniusPowerFlowUpdateCoordinator,
-        key: str,
+        description: FroniusSensorEntityDescription,
         solar_net_id: str,
     ) -> None:
         """Set up an individual Fronius power flow sensor."""
-        super().__init__(coordinator, key, solar_net_id)
+        super().__init__(coordinator, description, solar_net_id)
         # SolarNet device is already created in FroniusSolarNet._create_solar_net_device
         self._attr_device_info = coordinator.solar_net.system_device_info
         self._attr_unique_id = (
-            f"{coordinator.solar_net.solar_net_device_id}-power_flow-{key}"
+            f"{coordinator.solar_net.solar_net_device_id}-power_flow-{description.key}"
         )
 
 
 class StorageSensor(_FroniusSensorEntity):
     """Defines a Fronius storage device sensor entity."""
 
-    entity_descriptions = STORAGE_ENTITY_DESCRIPTIONS
-
     def __init__(
         self,
         coordinator: FroniusStorageUpdateCoordinator,
-        key: str,
+        description: FroniusSensorEntityDescription,
         solar_net_id: str,
     ) -> None:
         """Set up an individual Fronius storage sensor."""
-        super().__init__(coordinator, key, solar_net_id)
+        super().__init__(coordinator, description, solar_net_id)
         storage_data = self._device_data()
 
-        self._attr_unique_id = f'{storage_data["serial"]["value"]}-{key}'
+        self._attr_unique_id = f'{storage_data["serial"]["value"]}-{description.key}'
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, storage_data["serial"]["value"])},
             manufacturer=storage_data["manufacturer"]["value"],

--- a/homeassistant/components/fronius/sensor.py
+++ b/homeassistant/components/fronius/sensor.py
@@ -1,6 +1,7 @@
 """Support for Fronius devices."""
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Final
 
@@ -103,6 +104,7 @@ class FroniusSensorEntityDescription(SensorEntityDescription):
     # Handling such values shall mitigate spikes in delta calculations.
     invalid_when_falsy: bool = False
     response_key: str | None = None
+    value_fn: Callable[[StateType], StateType] | None = None
 
 
 INVERTER_ENTITY_DESCRIPTIONS: list[FroniusSensorEntityDescription] = [
@@ -659,6 +661,8 @@ class _FroniusSensorEntity(CoordinatorEntity["FroniusCoordinatorBase"], SensorEn
             return self.entity_description.default_value
         if self.entity_description.invalid_when_falsy and not new_value:
             return None
+        if self.entity_description.value_fn is not None:
+            return self.entity_description.value_fn(new_value)
         if isinstance(new_value, float):
             return round(new_value, 4)
         return new_value

--- a/homeassistant/components/fronius/strings.json
+++ b/homeassistant/components/fronius/strings.json
@@ -218,7 +218,15 @@
         "name": "State code"
       },
       "state_message": {
-        "name": "State message"
+        "name": "State message",
+        "state": {
+          "up_and_running": "Up and running",
+          "keep_minimum_temperature": "Keep minimum temperature",
+          "legionella_protection": "Legionella protection",
+          "critical_fault": "Critical fault",
+          "fault": "Fault",
+          "boost_mode": "Boost mode"
+        }
       },
       "meter_mode": {
         "name": "Meter mode"

--- a/homeassistant/components/fronius/strings.json
+++ b/homeassistant/components/fronius/strings.json
@@ -129,6 +129,15 @@
       "meter_location": {
         "name": "Meter location"
       },
+      "meter_location_description": {
+        "name": "Meter location description",
+        "state": {
+          "feed_in": "Grid interconnection point",
+          "consumption_path": "Consumption path",
+          "external_generator": "External generator",
+          "subload": "Subload"
+        }
+      },
       "power_apparent_phase_1": {
         "name": "Apparent power phase 1"
       },

--- a/homeassistant/components/fronius/strings.json
+++ b/homeassistant/components/fronius/strings.json
@@ -66,6 +66,21 @@
       "status_code": {
         "name": "Status code"
       },
+      "status_message": {
+        "name": "Status message",
+        "state": {
+          "startup": "Startup",
+          "running": "Running",
+          "standby": "Standby",
+          "bootloading": "Bootloading",
+          "error": "Error",
+          "idle": "Idle",
+          "ready": "Ready",
+          "sleeping": "Sleeping",
+          "unknown": "Unknown",
+          "invalid": "Invalid"
+        }
+      },
       "led_state": {
         "name": "LED state"
       },

--- a/homeassistant/components/fronius/strings.json
+++ b/homeassistant/components/fronius/strings.json
@@ -135,6 +135,7 @@
           "feed_in": "Grid interconnection point",
           "consumption_path": "Consumption path",
           "external_generator": "External generator",
+          "external_battery": "External battery",
           "subload": "Subload"
         }
       },

--- a/tests/components/fronius/test_sensor.py
+++ b/tests/components/fronius/test_sensor.py
@@ -178,7 +178,6 @@ async def test_symo_meter(
 async def test_symo_meter_forged(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
-    freezer: FrozenDateTimeFactory,
     location_code: int | None,
     expected_code: int | str,
     expected_description: str,
@@ -204,22 +203,6 @@ async def test_symo_meter_forged(
     assert_state(
         "sensor.smart_meter_63a_meter_location_description", expected_description
     )
-    # location code returning null after entity was created
-    # would not create the entity if null was returned at setup
-    mock_responses(
-        aioclient_mock,
-        fixture_set="symo",
-        override_data={
-            "symo/GetMeterRealtimeData.json": [
-                (["Body", "Data", "0", "Meter_Location_Current"], None),
-            ],
-        },
-    )
-    freezer.tick(FroniusInverterUpdateCoordinator.default_interval)
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done()
-    assert_state("sensor.smart_meter_63a_meter_location", "unknown")
-    assert_state("sensor.smart_meter_63a_meter_location_description", "unknown")
 
 
 async def test_symo_power_flow(

--- a/tests/components/fronius/test_sensor.py
+++ b/tests/components/fronius/test_sensor.py
@@ -33,14 +33,14 @@ async def test_symo_inverter(
     mock_responses(aioclient_mock, night=True)
     config_entry = await setup_fronius_integration(hass)
 
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 20
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 21
     await enable_all_entities(
         hass,
         freezer,
         config_entry.entry_id,
         FroniusInverterUpdateCoordinator.default_interval,
     )
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 53
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 54
     assert_state("sensor.symo_20_dc_current", 0)
     assert_state("sensor.symo_20_energy_day", 10828)
     assert_state("sensor.symo_20_total_energy", 44186900)
@@ -53,14 +53,14 @@ async def test_symo_inverter(
     freezer.tick(FroniusInverterUpdateCoordinator.default_interval)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 57
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 58
     await enable_all_entities(
         hass,
         freezer,
         config_entry.entry_id,
         FroniusInverterUpdateCoordinator.default_interval,
     )
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 59
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 60
     # 4 additional AC entities
     assert_state("sensor.symo_20_dc_current", 2.19)
     assert_state("sensor.symo_20_energy_day", 1113)
@@ -96,7 +96,7 @@ async def test_symo_logger(
 
     mock_responses(aioclient_mock)
     await setup_fronius_integration(hass)
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 24
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 25
     # states are rounded to 4 decimals
     assert_state("sensor.solarnet_grid_export_tariff", 0.078)
     assert_state("sensor.solarnet_co2_factor", 0.53)
@@ -118,14 +118,14 @@ async def test_symo_meter(
     mock_responses(aioclient_mock)
     config_entry = await setup_fronius_integration(hass)
 
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 24
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 25
     await enable_all_entities(
         hass,
         freezer,
         config_entry.entry_id,
         FroniusMeterUpdateCoordinator.default_interval,
     )
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 59
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 60
     # states are rounded to 4 decimals
     assert_state("sensor.smart_meter_63a_current_phase_1", 7.755)
     assert_state("sensor.smart_meter_63a_current_phase_2", 6.68)
@@ -159,6 +159,8 @@ async def test_symo_meter(
     assert_state("sensor.smart_meter_63a_voltage_phase_1_2", 395.9)
     assert_state("sensor.smart_meter_63a_voltage_phase_2_3", 398)
     assert_state("sensor.smart_meter_63a_voltage_phase_3_1", 398)
+    assert_state("sensor.smart_meter_63a_meter_location", 0)
+    assert_state("sensor.smart_meter_63a_meter_location_description", "feed_in")
 
 
 async def test_symo_power_flow(
@@ -177,14 +179,14 @@ async def test_symo_power_flow(
     mock_responses(aioclient_mock, night=True)
     config_entry = await setup_fronius_integration(hass)
 
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 20
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 21
     await enable_all_entities(
         hass,
         freezer,
         config_entry.entry_id,
         FroniusInverterUpdateCoordinator.default_interval,
     )
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 53
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 54
     # states are rounded to 4 decimals
     assert_state("sensor.solarnet_energy_day", 10828)
     assert_state("sensor.solarnet_total_energy", 44186900)
@@ -199,7 +201,7 @@ async def test_symo_power_flow(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
     # 54 because power_flow `rel_SelfConsumption` and `P_PV` is not `null` anymore
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 55
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 56
     assert_state("sensor.solarnet_energy_day", 1101.7001)
     assert_state("sensor.solarnet_total_energy", 44188000)
     assert_state("sensor.solarnet_energy_year", 25508788)
@@ -214,7 +216,7 @@ async def test_symo_power_flow(
     freezer.tick(FroniusPowerFlowUpdateCoordinator.default_interval)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 55
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 56
     assert_state("sensor.solarnet_energy_day", 10828)
     assert_state("sensor.solarnet_total_energy", 44186900)
     assert_state("sensor.solarnet_energy_year", 25507686)
@@ -240,14 +242,14 @@ async def test_gen24(
     mock_responses(aioclient_mock, fixture_set="gen24")
     config_entry = await setup_fronius_integration(hass, is_logger=False)
 
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 22
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 23
     await enable_all_entities(
         hass,
         freezer,
         config_entry.entry_id,
         FroniusMeterUpdateCoordinator.default_interval,
     )
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 53
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 54
     # inverter 1
     assert_state("sensor.inverter_name_ac_current", 0.1589)
     assert_state("sensor.inverter_name_dc_current_2", 0.0754)
@@ -267,7 +269,8 @@ async def test_gen24(
     assert_state("sensor.smart_meter_ts_65a_3_real_energy_consumed", 2013105.0)
     assert_state("sensor.smart_meter_ts_65a_3_real_power", 653.1)
     assert_state("sensor.smart_meter_ts_65a_3_frequency_phase_average", 49.9)
-    assert_state("sensor.smart_meter_ts_65a_3_meter_location", 0.0)
+    assert_state("sensor.smart_meter_ts_65a_3_meter_location", 0)
+    assert_state("sensor.smart_meter_ts_65a_3_meter_location_description", "feed_in")
     assert_state("sensor.smart_meter_ts_65a_3_power_factor", 0.828)
     assert_state("sensor.smart_meter_ts_65a_3_reactive_energy_consumed", 88221.0)
     assert_state("sensor.smart_meter_ts_65a_3_real_energy_minus", 3863340.0)
@@ -339,14 +342,14 @@ async def test_gen24_storage(
         hass, is_logger=False, unique_id="12345678"
     )
 
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 34
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 35
     await enable_all_entities(
         hass,
         freezer,
         config_entry.entry_id,
         FroniusMeterUpdateCoordinator.default_interval,
     )
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 65
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 66
     # inverter 1
     assert_state("sensor.gen24_storage_dc_current", 0.3952)
     assert_state("sensor.gen24_storage_dc_voltage_2", 318.8103)
@@ -367,7 +370,8 @@ async def test_gen24_storage(
     assert_state("sensor.smart_meter_ts_65a_3_power_factor", 0.698)
     assert_state("sensor.smart_meter_ts_65a_3_real_energy_consumed", 1247204.0)
     assert_state("sensor.smart_meter_ts_65a_3_frequency_phase_average", 49.9)
-    assert_state("sensor.smart_meter_ts_65a_3_meter_location", 0.0)
+    assert_state("sensor.smart_meter_ts_65a_3_meter_location", 0)
+    assert_state("sensor.smart_meter_ts_65a_3_meter_location_description", "feed_in")
     assert_state("sensor.smart_meter_ts_65a_3_reactive_power", -501.5)
     assert_state("sensor.smart_meter_ts_65a_3_reactive_energy_produced", 3266105.0)
     assert_state("sensor.smart_meter_ts_65a_3_real_power_phase_3", 19.6)
@@ -467,14 +471,14 @@ async def test_primo_s0(
     mock_responses(aioclient_mock, fixture_set="primo_s0", inverter_ids=[1, 2])
     config_entry = await setup_fronius_integration(hass, is_logger=True)
 
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 29
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 30
     await enable_all_entities(
         hass,
         freezer,
         config_entry.entry_id,
         FroniusMeterUpdateCoordinator.default_interval,
     )
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 42
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 43
     # logger
     assert_state("sensor.solarnet_grid_export_tariff", 1)
     assert_state("sensor.solarnet_co2_factor", 0.53)
@@ -511,6 +515,9 @@ async def test_primo_s0(
     assert_state("sensor.primo_3_0_1_led_state", 0)
     # meter
     assert_state("sensor.s0_meter_at_inverter_1_meter_location", 1)
+    assert_state(
+        "sensor.s0_meter_at_inverter_1_meter_location_description", "consumption_path"
+    )
     assert_state("sensor.s0_meter_at_inverter_1_real_power", -2216.7487)
     # power_flow
     assert_state("sensor.solarnet_power_load", -2218.9349)

--- a/tests/components/fronius/test_sensor.py
+++ b/tests/components/fronius/test_sensor.py
@@ -40,26 +40,27 @@ async def test_symo_inverter(
         config_entry.entry_id,
         FroniusInverterUpdateCoordinator.default_interval,
     )
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 52
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 53
     assert_state("sensor.symo_20_dc_current", 0)
     assert_state("sensor.symo_20_energy_day", 10828)
     assert_state("sensor.symo_20_total_energy", 44186900)
     assert_state("sensor.symo_20_energy_year", 25507686)
     assert_state("sensor.symo_20_dc_voltage", 16)
+    assert_state("sensor.symo_20_status_message", "startup")
 
     # Second test at daytime when inverter is producing
     mock_responses(aioclient_mock, night=False)
     freezer.tick(FroniusInverterUpdateCoordinator.default_interval)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 56
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 57
     await enable_all_entities(
         hass,
         freezer,
         config_entry.entry_id,
         FroniusInverterUpdateCoordinator.default_interval,
     )
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 58
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 59
     # 4 additional AC entities
     assert_state("sensor.symo_20_dc_current", 2.19)
     assert_state("sensor.symo_20_energy_day", 1113)
@@ -70,6 +71,7 @@ async def test_symo_inverter(
     assert_state("sensor.symo_20_frequency", 49.94)
     assert_state("sensor.symo_20_ac_power", 1190)
     assert_state("sensor.symo_20_ac_voltage", 227.90)
+    assert_state("sensor.symo_20_status_message", "running")
 
     # Third test at nighttime - additional AC entities default to 0
     mock_responses(aioclient_mock, night=True)
@@ -123,7 +125,7 @@ async def test_symo_meter(
         config_entry.entry_id,
         FroniusMeterUpdateCoordinator.default_interval,
     )
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 58
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 59
     # states are rounded to 4 decimals
     assert_state("sensor.smart_meter_63a_current_phase_1", 7.755)
     assert_state("sensor.smart_meter_63a_current_phase_2", 6.68)
@@ -182,7 +184,7 @@ async def test_symo_power_flow(
         config_entry.entry_id,
         FroniusInverterUpdateCoordinator.default_interval,
     )
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 52
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 53
     # states are rounded to 4 decimals
     assert_state("sensor.solarnet_energy_day", 10828)
     assert_state("sensor.solarnet_total_energy", 44186900)
@@ -197,7 +199,7 @@ async def test_symo_power_flow(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
     # 54 because power_flow `rel_SelfConsumption` and `P_PV` is not `null` anymore
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 54
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 55
     assert_state("sensor.solarnet_energy_day", 1101.7001)
     assert_state("sensor.solarnet_total_energy", 44188000)
     assert_state("sensor.solarnet_energy_year", 25508788)
@@ -212,7 +214,7 @@ async def test_symo_power_flow(
     freezer.tick(FroniusPowerFlowUpdateCoordinator.default_interval)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 54
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 55
     assert_state("sensor.solarnet_energy_day", 10828)
     assert_state("sensor.solarnet_total_energy", 44186900)
     assert_state("sensor.solarnet_energy_year", 25507686)
@@ -245,11 +247,12 @@ async def test_gen24(
         config_entry.entry_id,
         FroniusMeterUpdateCoordinator.default_interval,
     )
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 52
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 53
     # inverter 1
     assert_state("sensor.inverter_name_ac_current", 0.1589)
     assert_state("sensor.inverter_name_dc_current_2", 0.0754)
     assert_state("sensor.inverter_name_status_code", 7)
+    assert_state("sensor.inverter_name_status_message", "running")
     assert_state("sensor.inverter_name_dc_current", 0.0783)
     assert_state("sensor.inverter_name_dc_voltage_2", 403.4312)
     assert_state("sensor.inverter_name_ac_power", 37.3204)
@@ -343,7 +346,7 @@ async def test_gen24_storage(
         config_entry.entry_id,
         FroniusMeterUpdateCoordinator.default_interval,
     )
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 64
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 65
     # inverter 1
     assert_state("sensor.gen24_storage_dc_current", 0.3952)
     assert_state("sensor.gen24_storage_dc_voltage_2", 318.8103)
@@ -352,6 +355,7 @@ async def test_gen24_storage(
     assert_state("sensor.gen24_storage_ac_power", 250.9093)
     assert_state("sensor.gen24_storage_error_code", 0)
     assert_state("sensor.gen24_storage_status_code", 7)
+    assert_state("sensor.gen24_storage_status_message", "running")
     assert_state("sensor.gen24_storage_total_energy", 7512794.0117)
     assert_state("sensor.gen24_storage_inverter_state", "Running")
     assert_state("sensor.gen24_storage_dc_voltage", 419.1009)
@@ -470,7 +474,7 @@ async def test_primo_s0(
         config_entry.entry_id,
         FroniusMeterUpdateCoordinator.default_interval,
     )
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 40
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 42
     # logger
     assert_state("sensor.solarnet_grid_export_tariff", 1)
     assert_state("sensor.solarnet_co2_factor", 0.53)
@@ -483,6 +487,7 @@ async def test_primo_s0(
     assert_state("sensor.primo_5_0_1_error_code", 0)
     assert_state("sensor.primo_5_0_1_dc_current", 4.23)
     assert_state("sensor.primo_5_0_1_status_code", 7)
+    assert_state("sensor.primo_5_0_1_status_message", "running")
     assert_state("sensor.primo_5_0_1_energy_year", 7532755.5)
     assert_state("sensor.primo_5_0_1_ac_current", 3.85)
     assert_state("sensor.primo_5_0_1_ac_voltage", 223.9)
@@ -497,6 +502,7 @@ async def test_primo_s0(
     assert_state("sensor.primo_3_0_1_error_code", 0)
     assert_state("sensor.primo_3_0_1_dc_current", 0.97)
     assert_state("sensor.primo_3_0_1_status_code", 7)
+    assert_state("sensor.primo_3_0_1_status_message", "running")
     assert_state("sensor.primo_3_0_1_energy_year", 3596193.25)
     assert_state("sensor.primo_3_0_1_ac_current", 1.32)
     assert_state("sensor.primo_3_0_1_ac_voltage", 223.6)

--- a/tests/components/fronius/test_sensor.py
+++ b/tests/components/fronius/test_sensor.py
@@ -404,7 +404,7 @@ async def test_gen24_storage(
     assert_state("sensor.ohmpilot_power", 0.0)
     assert_state("sensor.ohmpilot_temperature", 38.9)
     assert_state("sensor.ohmpilot_state_code", 0.0)
-    assert_state("sensor.ohmpilot_state_message", "Up and running")
+    assert_state("sensor.ohmpilot_state_message", "up_and_running")
     # power_flow
     assert_state("sensor.solarnet_power_grid", 2274.9)
     assert_state("sensor.solarnet_power_battery", 0.1591)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Refactorings to make it possible to have multiple entities for a single API response field:
- optionally decouple EntityDescription.key from API response key
- Add optional value_fn to EntityDescriptions eg. to be able to map a API response value to a different value (status_code -> message)

New entities:
- Inverter `staus_message` is a textual, translatable representation of "status_code" integer
- Meter `meter_location_description` is a textual, translatable representation of "meter_location" integer

Changed features:
- OhmPilots `status_message` entity state is now translatable (this was previously hardcoded english in the lib `pyfronius`)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
