### PR TITLE
Add time entity for sleep mode start time to Litter-Robot 3

### DIFF
--- a/homeassistant/components/litterrobot/__init__.py
+++ b/homeassistant/components/litterrobot/__init__.py
@@ -18,7 +18,7 @@ PLATFORMS_BY_TYPE = {
         Platform.SWITCH,
     ),
     LitterRobot: (Platform.VACUUM,),
-    LitterRobot3: (Platform.BUTTON,),
+    LitterRobot3: (Platform.BUTTON, Platform.TIME),
     LitterRobot4: (Platform.UPDATE,),
     FeederRobot: (Platform.BUTTON,),
 }

--- a/homeassistant/components/litterrobot/strings.json
+++ b/homeassistant/components/litterrobot/strings.json
@@ -128,6 +128,11 @@
         "name": "Panel lockout"
       }
     },
+    "time": {
+      "sleep_mode_start_time": {
+        "name": "Sleep mode start time"
+      }
+    },
     "vacuum": {
       "litter_box": {
         "name": "Litter box"

--- a/homeassistant/components/litterrobot/time.py
+++ b/homeassistant/components/litterrobot/time.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
-from datetime import time
+from datetime import datetime, time
 from typing import Any, Generic
 
 from pylitterbot import LitterRobot3
@@ -33,13 +33,16 @@ class RobotTimeEntityDescription(TimeEntityDescription, RequiredKeysMixin[_Robot
     """A class that describes robot time entities."""
 
 
+def _as_local_time(start: datetime | None) -> time | None:
+    """Return a datetime as local time."""
+    return dt_util.as_local(start).time() if start else None
+
+
 LITTER_ROBOT_3_SLEEP_START = RobotTimeEntityDescription[LitterRobot3](
     key="sleep_mode_start_time",
-    name="Sleep mode start time",
+    translation_key="sleep_mode_start_time",
     entity_category=EntityCategory.CONFIG,
-    value_fn=lambda robot: dt_util.as_local(start).time()
-    if (start := robot.sleep_mode_start_time)
-    else None,
+    value_fn=lambda robot: _as_local_time(robot.sleep_mode_start_time),
     set_fn=lambda robot, value: robot.set_sleep_mode(
         robot.sleep_mode_enabled, value.replace(tzinfo=dt_util.DEFAULT_TIME_ZONE)
     ),

--- a/homeassistant/components/litterrobot/time.py
+++ b/homeassistant/components/litterrobot/time.py
@@ -1,0 +1,79 @@
+"""Support for Litter-Robot time."""
+from __future__ import annotations
+
+from collections.abc import Callable, Coroutine
+from dataclasses import dataclass
+from datetime import time
+from typing import Any, Generic
+
+from pylitterbot import LitterRobot3
+
+from homeassistant.components.time import TimeEntity, TimeEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+import homeassistant.util.dt as dt_util
+
+from .const import DOMAIN
+from .entity import LitterRobotEntity, _RobotT
+from .hub import LitterRobotHub
+
+
+@dataclass
+class RequiredKeysMixin(Generic[_RobotT]):
+    """A class that describes robot time entity required keys."""
+
+    value_fn: Callable[[_RobotT], time | None]
+    set_fn: Callable[[_RobotT, time], Coroutine[Any, Any, bool]]
+
+
+@dataclass
+class RobotTimeEntityDescription(TimeEntityDescription, RequiredKeysMixin[_RobotT]):
+    """A class that describes robot time entities."""
+
+
+LITTER_ROBOT_3_SLEEP_START = RobotTimeEntityDescription[LitterRobot3](
+    key="sleep_mode_start_time",
+    name="Sleep mode start time",
+    entity_category=EntityCategory.CONFIG,
+    value_fn=lambda robot: dt_util.as_local(start).time()
+    if (start := robot.sleep_mode_start_time)
+    else None,
+    set_fn=lambda robot, value: robot.set_sleep_mode(
+        robot.sleep_mode_enabled, value.replace(tzinfo=dt_util.DEFAULT_TIME_ZONE)
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Litter-Robot cleaner using config entry."""
+    hub: LitterRobotHub = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities(
+        [
+            LitterRobotTimeEntity(
+                robot=robot, hub=hub, description=LITTER_ROBOT_3_SLEEP_START
+            )
+            for robot in hub.litter_robots()
+            if isinstance(robot, LitterRobot3)
+        ]
+    )
+
+
+class LitterRobotTimeEntity(LitterRobotEntity[_RobotT], TimeEntity):
+    """Litter-Robot time entity."""
+
+    entity_description: RobotTimeEntityDescription[_RobotT]
+
+    @property
+    def native_value(self) -> time | None:
+        """Return the value reported by the time."""
+        return self.entity_description.value_fn(self.robot)
+
+    async def async_set_value(self, value: time) -> None:
+        """Update the current value."""
+        await self.entity_description.set_fn(self.robot, value)

--- a/tests/components/litterrobot/test_time.py
+++ b/tests/components/litterrobot/test_time.py
@@ -1,0 +1,35 @@
+"""Test the Litter-Robot time entity."""
+from __future__ import annotations
+
+from datetime import time
+from unittest.mock import MagicMock
+
+from pylitterbot import LitterRobot3
+
+from homeassistant.components.time import DOMAIN as PLATFORM_DOMAIN
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
+
+from .conftest import setup_integration
+
+SLEEP_START_TIME_ENTITY_ID = "time.test_sleep_mode_start_time"
+
+
+async def test_sleep_mode_start_time(
+    hass: HomeAssistant, mock_account: MagicMock
+) -> None:
+    """Tests the sleep mode start time."""
+    await setup_integration(hass, mock_account, PLATFORM_DOMAIN)
+
+    entity = hass.states.get(SLEEP_START_TIME_ENTITY_ID)
+    assert entity
+    assert entity.state == "17:16:00"
+
+    robot: LitterRobot3 = mock_account.robots[0]
+    await hass.services.async_call(
+        PLATFORM_DOMAIN,
+        "set_value",
+        {ATTR_ENTITY_ID: SLEEP_START_TIME_ENTITY_ID, "time": time(23, 0)},
+        blocking=True,
+    )
+    robot.set_sleep_mode.assert_awaited_once_with(True, time(23, 0))


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds a time entity to Litter-Robot 3 to adjust the sleep mode start time

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
