### PR TITLE
Rename Local Media to My Media

### DIFF
--- a/homeassistant/components/media_source/local_source.py
+++ b/homeassistant/components/media_source/local_source.py
@@ -38,7 +38,7 @@ def async_setup(hass: HomeAssistant) -> None:
 class LocalSource(MediaSource):
     """Provide local directories as media sources."""
 
-    name: str = "Local Media"
+    name: str = "My Media"
 
     def __init__(self, hass: HomeAssistant) -> None:
         """Initialize local source."""

--- a/homeassistant/components/media_source/local_source.py
+++ b/homeassistant/components/media_source/local_source.py
@@ -38,7 +38,7 @@ def async_setup(hass: HomeAssistant) -> None:
 class LocalSource(MediaSource):
     """Provide local directories as media sources."""
 
-    name: str = "My Media"
+    name: str = "My media"
 
     def __init__(self, hass: HomeAssistant) -> None:
         """Initialize local source."""

--- a/tests/components/media_source/test_init.py
+++ b/tests/components/media_source/test_init.py
@@ -95,7 +95,7 @@ async def test_async_browse_media(hass: HomeAssistant) -> None:
     media = await media_source.async_browse_media(hass, const.URI_SCHEME)
     assert isinstance(media, media_source.models.BrowseMediaSource)
     assert len(media.children) == 1
-    assert media.children[0].title == "My Media"
+    assert media.children[0].title == "My media"
 
 
 async def test_async_resolve_media(hass: HomeAssistant) -> None:

--- a/tests/components/media_source/test_init.py
+++ b/tests/components/media_source/test_init.py
@@ -95,7 +95,7 @@ async def test_async_browse_media(hass: HomeAssistant) -> None:
     media = await media_source.async_browse_media(hass, const.URI_SCHEME)
     assert isinstance(media, media_source.models.BrowseMediaSource)
     assert len(media.children) == 1
-    assert media.children[0].title == "Local Media"
+    assert media.children[0].title == "My Media"
 
 
 async def test_async_resolve_media(hass: HomeAssistant) -> None:

--- a/tests/components/roku/test_media_player.py
+++ b/tests/components/roku/test_media_player.py
@@ -864,7 +864,7 @@ async def test_media_browse_local_source(
     assert msg["result"]["children"][0]["title"] == "Apps"
     assert msg["result"]["children"][0]["media_content_type"] == MediaType.APPS
 
-    assert msg["result"]["children"][1]["title"] == "My Media"
+    assert msg["result"]["children"][1]["title"] == "My media"
     assert msg["result"]["children"][1]["media_class"] == MediaClass.DIRECTORY
     assert msg["result"]["children"][1]["media_content_type"] is None
     assert (
@@ -892,7 +892,7 @@ async def test_media_browse_local_source(
     assert msg["success"]
 
     assert msg["result"]
-    assert msg["result"]["title"] == "My Media"
+    assert msg["result"]["title"] == "My media"
     assert msg["result"]["media_class"] == MediaClass.DIRECTORY
     assert msg["result"]["media_content_type"] is None
     assert len(msg["result"]["children"]) == 2

--- a/tests/components/roku/test_media_player.py
+++ b/tests/components/roku/test_media_player.py
@@ -864,7 +864,7 @@ async def test_media_browse_local_source(
     assert msg["result"]["children"][0]["title"] == "Apps"
     assert msg["result"]["children"][0]["media_content_type"] == MediaType.APPS
 
-    assert msg["result"]["children"][1]["title"] == "Local Media"
+    assert msg["result"]["children"][1]["title"] == "My Media"
     assert msg["result"]["children"][1]["media_class"] == MediaClass.DIRECTORY
     assert msg["result"]["children"][1]["media_content_type"] is None
     assert (
@@ -892,7 +892,7 @@ async def test_media_browse_local_source(
     assert msg["success"]
 
     assert msg["result"]
-    assert msg["result"]["title"] == "Local Media"
+    assert msg["result"]["title"] == "My Media"
     assert msg["result"]["media_class"] == MediaClass.DIRECTORY
     assert msg["result"]["media_content_type"] is None
     assert len(msg["result"]["children"]) == 2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This renames Local Media to My Media in the media browser. This is not a breaking change because the media source ID remains `media-source://` (it's the root, so empty identifier ([source](https://github.com/home-assistant/core/blob/dev/homeassistant/components/media_source/local_source.py#L115-L124)))

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
