### PR TITLE
Bump reolink-aio to 0.6.0

### DIFF
--- a/homeassistant/components/reolink/__init__.py
+++ b/homeassistant/components/reolink/__init__.py
@@ -8,7 +8,6 @@ from datetime import timedelta
 import logging
 from typing import Literal
 
-from aiohttp import ClientConnectorError
 import async_timeout
 from reolink_aio.exceptions import CredentialsInvalidError, ReolinkError
 
@@ -58,8 +57,6 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         await host.stop()
         raise ConfigEntryAuthFailed(err) from err
     except (
-        ClientConnectorError,
-        asyncio.TimeoutError,
         ReolinkException,
         ReolinkError,
     ) as err:

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -222,11 +222,7 @@ class ReolinkHost:
         """Disconnect from the API, so the connection will be released."""
         try:
             await self._api.unsubscribe()
-        except (
-            aiohttp.ClientConnectorError,
-            asyncio.TimeoutError,
-            ReolinkError,
-        ) as err:
+        except ReolinkError as err:
             _LOGGER.error(
                 "Reolink error while unsubscribing from host %s:%s: %s",
                 self._api.host,
@@ -236,11 +232,7 @@ class ReolinkHost:
 
         try:
             await self._api.logout()
-        except (
-            aiohttp.ClientConnectorError,
-            asyncio.TimeoutError,
-            ReolinkError,
-        ) as err:
+        except ReolinkError as err:
             _LOGGER.error(
                 "Reolink error while logging out for host %s:%s: %s",
                 self._api.host,
@@ -396,21 +388,12 @@ class ReolinkHost:
 
         try:
             await self._api.get_motion_state_all_ch()
-        except (
-            aiohttp.ClientConnectorError,
-            ReolinkError,
-        ) as err:
+        except ReolinkError as err:
             _LOGGER.error(
                 "Reolink error while polling motion state for host %s:%s: %s",
                 self._api.host,
                 self._api.port,
                 str(err),
-            )
-        except asyncio.TimeoutError:
-            _LOGGER.error(
-                "Reolink timeout error while polling motion state for host %s:%s",
-                self._api.host,
-                self._api.port,
             )
         finally:
             # schedule next poll

--- a/homeassistant/components/reolink/manifest.json
+++ b/homeassistant/components/reolink/manifest.json
@@ -18,5 +18,5 @@
   "documentation": "https://www.home-assistant.io/integrations/reolink",
   "iot_class": "local_push",
   "loggers": ["reolink_aio"],
-  "requirements": ["reolink-aio==0.5.16"]
+  "requirements": ["reolink-aio==0.6.0"]
 }

--- a/homeassistant/components/reolink/update.py
+++ b/homeassistant/components/reolink/update.py
@@ -30,8 +30,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up update entities for Reolink component."""
     reolink_data: ReolinkData = hass.data[DOMAIN][config_entry.entry_id]
-    if reolink_data.host.api.supported(None, "update"):
-        async_add_entities([ReolinkUpdateEntity(reolink_data)])
+    async_add_entities([ReolinkUpdateEntity(reolink_data)])
 
 
 class ReolinkUpdateEntity(
@@ -64,7 +63,10 @@ class ReolinkUpdateEntity(
         if not self.coordinator.data:
             return self.installed_version
 
-        return self.coordinator.data
+        if isinstance(self.coordinator.data, str):
+            return self.coordinator.data
+
+        self.coordinator.data.version_string
 
     async def async_install(
         self, version: str | None, backup: bool, **kwargs: Any

--- a/homeassistant/components/reolink/update.py
+++ b/homeassistant/components/reolink/update.py
@@ -66,7 +66,7 @@ class ReolinkUpdateEntity(
         if isinstance(self.coordinator.data, str):
             return self.coordinator.data
 
-        self.coordinator.data.version_string
+        return self.coordinator.data.version_string
 
     async def async_install(
         self, version: str | None, backup: bool, **kwargs: Any

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2265,7 +2265,7 @@ regenmaschine==2023.05.1
 renault-api==0.1.13
 
 # homeassistant.components.reolink
-reolink-aio==0.5.16
+reolink-aio==0.6.0
 
 # homeassistant.components.idteck_prox
 rfk101py==0.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1652,7 +1652,7 @@ regenmaschine==2023.05.1
 renault-api==0.1.13
 
 # homeassistant.components.reolink
-reolink-aio==0.5.16
+reolink-aio==0.6.0
 
 # homeassistant.components.rflink
 rflink==0.0.65


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Since aiohttp.ClientConnectorError and asyncio.TimeoutError are now wrapped in ReolinkConnectionError and ReolinkTimeoutError which is derived from ReolinkError, the error handeling can be simplifyed quite a bit.

The output of the check_new_firmware has changed, needing a small adjustment in HomeAssistant.

Bump reolink-aio to 0.6.0:
**Full Changelog**: https://github.com/starkillerOG/reolink_aio/compare/0.5.16...0.6.0

Breaking changes:
- aiohttp.ClientConnectorError is not raised anymore but ReolinkConnectionError is raised instead.
- check_new_firmware does now return `bool | NewSoftwareVersion | str` instead of only `bool | str`

Additions:
* Add set_image command for bright, contrast, sat, hue, sharp
* Video download support
* Add ReolinkConnectionError and ReolinkTimeoutError exceptions
* Add firmware cheking from the reolink.com server


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
