### PR TITLE
Fix ness alarm armed_home state appearing as disarmed/armed_away

### DIFF
--- a/homeassistant/components/ness_alarm/__init__.py
+++ b/homeassistant/components/ness_alarm/__init__.py
@@ -3,7 +3,7 @@ from collections import namedtuple
 import datetime
 import logging
 
-from nessclient import ArmingState, Client
+from nessclient import ArmingMode, ArmingState, Client
 import voluptuous as vol
 
 from homeassistant.components.binary_sensor import (
@@ -136,9 +136,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             hass, SIGNAL_ZONE_CHANGED, ZoneChangedData(zone_id=zone_id, state=state)
         )
 
-    def on_state_change(arming_state: ArmingState):
+    def on_state_change(arming_state: ArmingState, arming_mode: ArmingMode | None):
         """Receives and propagates arming state updates."""
-        async_dispatcher_send(hass, SIGNAL_ARMING_STATE_CHANGED, arming_state)
+        async_dispatcher_send(
+            hass, SIGNAL_ARMING_STATE_CHANGED, arming_state, arming_mode
+        )
 
     client.on_zone_change(on_zone_change)
     client.on_state_change(on_state_change)

--- a/homeassistant/components/ness_alarm/alarm_control_panel.py
+++ b/homeassistant/components/ness_alarm/alarm_control_panel.py
@@ -26,6 +26,15 @@ from . import DATA_NESS, SIGNAL_ARMING_STATE_CHANGED
 
 _LOGGER = logging.getLogger(__name__)
 
+ARMING_MODE_TO_STATE = {
+    ArmingMode.ARMED_AWAY: STATE_ALARM_ARMED_AWAY,
+    ArmingMode.ARMED_HOME: STATE_ALARM_ARMED_HOME,
+    ArmingMode.ARMED_DAY: STATE_ALARM_ARMED_AWAY,  # no applicable state, fallback to away
+    ArmingMode.ARMED_NIGHT: STATE_ALARM_ARMED_NIGHT,
+    ArmingMode.ARMED_VACATION: STATE_ALARM_ARMED_VACATION,
+    ArmingMode.ARMED_HIGHEST: STATE_ALARM_ARMED_AWAY,  # no applicable state, fallback to away
+}
+
 
 async def async_setup_platform(
     hass: HomeAssistant,
@@ -96,7 +105,9 @@ class NessAlarmPanel(alarm.AlarmControlPanelEntity):
         elif arming_state == ArmingState.EXIT_DELAY:
             self._attr_state = STATE_ALARM_ARMING
         elif arming_state == ArmingState.ARMED:
-            self._attr_state = _get_state_for_arming_mode(arming_mode)
+            self._attr_state = ARMING_MODE_TO_STATE.get(
+                arming_mode, STATE_ALARM_ARMED_AWAY
+            )
         elif arming_state == ArmingState.ENTRY_DELAY:
             self._attr_state = STATE_ALARM_PENDING
         elif arming_state == ArmingState.TRIGGERED:
@@ -105,15 +116,3 @@ class NessAlarmPanel(alarm.AlarmControlPanelEntity):
             _LOGGER.warning("Unhandled arming state: %s", arming_state)
 
         self.async_write_ha_state()
-
-
-def _get_state_for_arming_mode(arming_mode: ArmingMode):
-    arming_mode_to_state_map = {
-        ArmingMode.ARMED_AWAY: STATE_ALARM_ARMED_AWAY,
-        ArmingMode.ARMED_HOME: STATE_ALARM_ARMED_HOME,
-        ArmingMode.ARMED_DAY: STATE_ALARM_ARMED_AWAY,  # no applicable state, fallback to away
-        ArmingMode.ARMED_NIGHT: STATE_ALARM_ARMED_NIGHT,
-        ArmingMode.ARMED_VACATION: STATE_ALARM_ARMED_VACATION,
-        ArmingMode.ARMED_HIGHEST: STATE_ALARM_ARMED_AWAY,  # no applicable state, fallback to away
-    }
-    return arming_mode_to_state_map.get(arming_mode, STATE_ALARM_ARMED_AWAY)

--- a/homeassistant/components/ness_alarm/alarm_control_panel.py
+++ b/homeassistant/components/ness_alarm/alarm_control_panel.py
@@ -26,15 +26,6 @@ from . import DATA_NESS, SIGNAL_ARMING_STATE_CHANGED
 
 _LOGGER = logging.getLogger(__name__)
 
-ARMING_MODE_TO_STATE = {
-    ArmingMode.ARMED_AWAY: STATE_ALARM_ARMED_AWAY,
-    ArmingMode.ARMED_HOME: STATE_ALARM_ARMED_HOME,
-    ArmingMode.ARMED_DAY: STATE_ALARM_ARMED_AWAY,  # no applicable state, fallback to away
-    ArmingMode.ARMED_NIGHT: STATE_ALARM_ARMED_NIGHT,
-    ArmingMode.ARMED_VACATION: STATE_ALARM_ARMED_VACATION,
-    ArmingMode.ARMED_HIGHEST: STATE_ALARM_ARMED_AWAY,  # no applicable state, fallback to away
-}
-
 
 async def async_setup_platform(
     hass: HomeAssistant,
@@ -105,9 +96,7 @@ class NessAlarmPanel(alarm.AlarmControlPanelEntity):
         elif arming_state == ArmingState.EXIT_DELAY:
             self._attr_state = STATE_ALARM_ARMING
         elif arming_state == ArmingState.ARMED:
-            self._attr_state = ARMING_MODE_TO_STATE.get(
-                arming_mode, STATE_ALARM_ARMED_AWAY
-            )
+            self._attr_state = _get_state_for_arming_mode(arming_mode)
         elif arming_state == ArmingState.ENTRY_DELAY:
             self._attr_state = STATE_ALARM_PENDING
         elif arming_state == ArmingState.TRIGGERED:
@@ -116,3 +105,15 @@ class NessAlarmPanel(alarm.AlarmControlPanelEntity):
             _LOGGER.warning("Unhandled arming state: %s", arming_state)
 
         self.async_write_ha_state()
+
+
+def _get_state_for_arming_mode(arming_mode: ArmingMode):
+    arming_mode_to_state_map = {
+        ArmingMode.ARMED_AWAY: STATE_ALARM_ARMED_AWAY,
+        ArmingMode.ARMED_HOME: STATE_ALARM_ARMED_HOME,
+        ArmingMode.ARMED_DAY: STATE_ALARM_ARMED_AWAY,  # no applicable state, fallback to away
+        ArmingMode.ARMED_NIGHT: STATE_ALARM_ARMED_NIGHT,
+        ArmingMode.ARMED_VACATION: STATE_ALARM_ARMED_VACATION,
+        ArmingMode.ARMED_HIGHEST: STATE_ALARM_ARMED_AWAY,  # no applicable state, fallback to away
+    }
+    return arming_mode_to_state_map.get(arming_mode, STATE_ALARM_ARMED_AWAY)

--- a/homeassistant/components/ness_alarm/manifest.json
+++ b/homeassistant/components/ness_alarm/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "https://www.home-assistant.io/integrations/ness_alarm",
   "iot_class": "local_push",
   "loggers": ["nessclient"],
-  "requirements": ["nessclient==0.10.0"]
+  "requirements": ["nessclient==1.0.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1240,7 +1240,7 @@ nad-receiver==0.3.0
 ndms2-client==0.1.2
 
 # homeassistant.components.ness_alarm
-nessclient==0.10.0
+nessclient==1.0.0
 
 # homeassistant.components.netdata
 netdata==1.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -951,7 +951,7 @@ mutesync==0.0.1
 ndms2-client==0.1.2
 
 # homeassistant.components.ness_alarm
-nessclient==0.10.0
+nessclient==1.0.0
 
 # homeassistant.components.nmap_tracker
 netmap==0.7.0.2

--- a/tests/components/ness_alarm/test_init.py
+++ b/tests/components/ness_alarm/test_init.py
@@ -216,10 +216,7 @@ class MockArmingMode(Enum):
 
     ARMED_AWAY = "ARMED_AWAY"
     ARMED_HOME = "ARMED_HOME"
-    ARMED_DAY = "ARMED_DAY"
     ARMED_NIGHT = "ARMED_NIGHT"
-    ARMED_VACATION = "ARMED_VACATION"
-    ARMED_HIGHEST = "ARMED_HIGHEST"
 
 
 class MockClient:
@@ -272,12 +269,7 @@ def mock_nessclient():
     ), patch(
         "homeassistant.components.ness_alarm.ArmingState", new=MockArmingState
     ), patch(
-        "homeassistant.components.ness_alarm.ArmingMode", new=MockArmingMode
-    ), patch(
         "homeassistant.components.ness_alarm.alarm_control_panel.ArmingState",
         new=MockArmingState,
-    ), patch(
-        "homeassistant.components.ness_alarm.alarm_control_panel.ArmingMode",
-        new=MockArmingMode,
     ):
         yield _mock_instance

--- a/tests/components/ness_alarm/test_init.py
+++ b/tests/components/ness_alarm/test_init.py
@@ -216,7 +216,10 @@ class MockArmingMode(Enum):
 
     ARMED_AWAY = "ARMED_AWAY"
     ARMED_HOME = "ARMED_HOME"
+    ARMED_DAY = "ARMED_DAY"
     ARMED_NIGHT = "ARMED_NIGHT"
+    ARMED_VACATION = "ARMED_VACATION"
+    ARMED_HIGHEST = "ARMED_HIGHEST"
 
 
 class MockClient:
@@ -269,7 +272,12 @@ def mock_nessclient():
     ), patch(
         "homeassistant.components.ness_alarm.ArmingState", new=MockArmingState
     ), patch(
+        "homeassistant.components.ness_alarm.ArmingMode", new=MockArmingMode
+    ), patch(
         "homeassistant.components.ness_alarm.alarm_control_panel.ArmingState",
         new=MockArmingState,
+    ), patch(
+        "homeassistant.components.ness_alarm.alarm_control_panel.ArmingMode",
+        new=MockArmingMode,
     ):
         yield _mock_instance

--- a/tests/components/ness_alarm/test_init.py
+++ b/tests/components/ness_alarm/test_init.py
@@ -1,7 +1,7 @@
 """Tests for the ness_alarm component."""
-from enum import Enum
 from unittest.mock import MagicMock, patch
 
+from nessclient import ArmingMode, ArmingState
 import pytest
 
 from homeassistant.components import alarm_control_panel
@@ -86,7 +86,7 @@ async def test_dispatch_state_change(hass: HomeAssistant, mock_nessclient) -> No
     await hass.async_block_till_done()
 
     on_state_change = mock_nessclient.on_state_change.call_args[0][0]
-    on_state_change(MockArmingState.ARMING, None)
+    on_state_change(ArmingState.ARMING, None)
 
     await hass.async_block_till_done()
     assert hass.states.is_state("alarm_control_panel.alarm_panel", STATE_ALARM_ARMING)
@@ -176,16 +176,16 @@ async def test_dispatch_zone_change(hass: HomeAssistant, mock_nessclient) -> Non
 async def test_arming_state_change(hass: HomeAssistant, mock_nessclient) -> None:
     """Test arming state change handing."""
     states = [
-        (MockArmingState.UNKNOWN, None, STATE_UNKNOWN),
-        (MockArmingState.DISARMED, None, STATE_ALARM_DISARMED),
-        (MockArmingState.ARMING, None, STATE_ALARM_ARMING),
-        (MockArmingState.EXIT_DELAY, None, STATE_ALARM_ARMING),
-        (MockArmingState.ARMED, None, STATE_ALARM_ARMED_AWAY),
-        (MockArmingState.ARMED, MockArmingMode.ARMED_AWAY, STATE_ALARM_ARMED_AWAY),
-        (MockArmingState.ARMED, MockArmingMode.ARMED_HOME, STATE_ALARM_ARMED_HOME),
-        (MockArmingState.ARMED, MockArmingMode.ARMED_NIGHT, STATE_ALARM_ARMED_NIGHT),
-        (MockArmingState.ENTRY_DELAY, None, STATE_ALARM_PENDING),
-        (MockArmingState.TRIGGERED, None, STATE_ALARM_TRIGGERED),
+        (ArmingState.UNKNOWN, None, STATE_UNKNOWN),
+        (ArmingState.DISARMED, None, STATE_ALARM_DISARMED),
+        (ArmingState.ARMING, None, STATE_ALARM_ARMING),
+        (ArmingState.EXIT_DELAY, None, STATE_ALARM_ARMING),
+        (ArmingState.ARMED, None, STATE_ALARM_ARMED_AWAY),
+        (ArmingState.ARMED, ArmingMode.ARMED_AWAY, STATE_ALARM_ARMED_AWAY),
+        (ArmingState.ARMED, ArmingMode.ARMED_HOME, STATE_ALARM_ARMED_HOME),
+        (ArmingState.ARMED, ArmingMode.ARMED_NIGHT, STATE_ALARM_ARMED_NIGHT),
+        (ArmingState.ENTRY_DELAY, None, STATE_ALARM_PENDING),
+        (ArmingState.TRIGGERED, None, STATE_ALARM_TRIGGERED),
     ]
 
     await async_setup_component(hass, DOMAIN, VALID_CONFIG)
@@ -197,26 +197,6 @@ async def test_arming_state_change(hass: HomeAssistant, mock_nessclient) -> None
         on_state_change(arming_state, arming_mode)
         await hass.async_block_till_done()
         assert hass.states.is_state("alarm_control_panel.alarm_panel", expected_state)
-
-
-class MockArmingState(Enum):
-    """Mock nessclient.ArmingState enum."""
-
-    UNKNOWN = "UNKNOWN"
-    DISARMED = "DISARMED"
-    ARMING = "ARMING"
-    EXIT_DELAY = "EXIT_DELAY"
-    ARMED = "ARMED"
-    ENTRY_DELAY = "ENTRY_DELAY"
-    TRIGGERED = "TRIGGERED"
-
-
-class MockArmingMode(Enum):
-    """Mock nessclient.ArmingMode enum."""
-
-    ARMED_AWAY = "ARMED_AWAY"
-    ARMED_HOME = "ARMED_HOME"
-    ARMED_NIGHT = "ARMED_NIGHT"
 
 
 class MockClient:
@@ -266,10 +246,5 @@ def mock_nessclient():
 
     with patch(
         "homeassistant.components.ness_alarm.Client", new=_mock_factory, create=True
-    ), patch(
-        "homeassistant.components.ness_alarm.ArmingState", new=MockArmingState
-    ), patch(
-        "homeassistant.components.ness_alarm.alarm_control_panel.ArmingState",
-        new=MockArmingState,
     ):
         yield _mock_instance


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fixes the alarm panel incorrectly displaying as `armed_away` when it has been put into another state (e.g. `armed_home`)

The dependency (`nessclient`) has had changes to fix this issue: https://github.com/nickw444/nessclient/releases/tag/1.0.0

| Before | After |
|---|---|
| ![2023-06-15 20 31 55](https://github.com/home-assistant/core/assets/1289759/5af2cf4d-9863-4595-a3bc-12e77bdb2fa3) |  ![2023-06-15 20 30 09](https://github.com/home-assistant/core/assets/1289759/d491c9dd-4fa0-4a4b-ae10-79bd602b3350)|

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #93310, #42329
- This PR is related to issue: N/A
- Link to documentation pull request:  N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] ~Documentation added/updated for [www.home-assistant.io][docs-repository]~

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
