### PR TITLE
Fix ZHA binding api to actually return responses

### DIFF
--- a/homeassistant/components/zha/websocket_api.py
+++ b/homeassistant/components/zha/websocket_api.py
@@ -907,6 +907,7 @@ async def websocket_bind_devices(
         ATTR_TARGET_IEEE,
         target_ieee,
     )
+    connection.send_result(msg[ID])
 
 
 @websocket_api.require_admin
@@ -935,6 +936,7 @@ async def websocket_unbind_devices(
         ATTR_TARGET_IEEE,
         target_ieee,
     )
+    connection.send_result(msg[ID])
 
 
 @websocket_api.require_admin
@@ -951,13 +953,14 @@ async def websocket_bind_group(
     hass: HomeAssistant, connection: ActiveConnection, msg: dict[str, Any]
 ) -> None:
     """Directly bind a device to a group."""
-    zha_gateway: ZHAGateway = hass.data[DATA_ZHA][DATA_ZHA_GATEWAY]
+    zha_gateway: ZHAGateway = get_gateway(hass)
     source_ieee: EUI64 = msg[ATTR_SOURCE_IEEE]
     group_id: int = msg[GROUP_ID]
     bindings: list[ClusterBinding] = msg[BINDINGS]
     source_device = zha_gateway.get_device(source_ieee)
     assert source_device
     await source_device.async_bind_to_group(group_id, bindings)
+    connection.send_result(msg[ID])
 
 
 @websocket_api.require_admin
@@ -974,13 +977,19 @@ async def websocket_unbind_group(
     hass: HomeAssistant, connection: ActiveConnection, msg: dict[str, Any]
 ) -> None:
     """Unbind a device from a group."""
-    zha_gateway: ZHAGateway = hass.data[DATA_ZHA][DATA_ZHA_GATEWAY]
+    zha_gateway: ZHAGateway = get_gateway(hass)
     source_ieee: EUI64 = msg[ATTR_SOURCE_IEEE]
     group_id: int = msg[GROUP_ID]
     bindings: list[ClusterBinding] = msg[BINDINGS]
     source_device = zha_gateway.get_device(source_ieee)
     assert source_device
     await source_device.async_unbind_from_group(group_id, bindings)
+    connection.send_result(msg[ID])
+
+
+def get_gateway(hass: HomeAssistant) -> ZHAGateway:
+    """Return Gateway, mainly as fixture for mocking during testing."""
+    return hass.data[DATA_ZHA][DATA_ZHA_GATEWAY]
 
 
 async def async_binding_operation(

--- a/tests/components/zha/test_websocket_api.py
+++ b/tests/components/zha/test_websocket_api.py
@@ -4,15 +4,17 @@ from __future__ import annotations
 from binascii import unhexlify
 from copy import deepcopy
 from typing import TYPE_CHECKING
-from unittest.mock import ANY, AsyncMock, call, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, call, patch
 
 import pytest
 import voluptuous as vol
 import zigpy.backups
 import zigpy.profiles.zha
 import zigpy.types
+from zigpy.types.named import EUI64
 import zigpy.zcl.clusters.general as general
 import zigpy.zcl.clusters.security as security
+import zigpy.zdo.types as zdo_types
 
 from homeassistant.components.websocket_api import const
 from homeassistant.components.zha import DOMAIN
@@ -26,6 +28,8 @@ from homeassistant.components.zha.core.const import (
     ATTR_MODEL,
     ATTR_NEIGHBORS,
     ATTR_QUIRK_APPLIED,
+    ATTR_TYPE,
+    BINDINGS,
     CLUSTER_TYPE_IN,
     EZSP_OVERWRITE_EUI64,
     GROUP_ID,
@@ -37,6 +41,7 @@ from homeassistant.components.zha.websocket_api import (
     ATTR_INSTALL_CODE,
     ATTR_QR_CODE,
     ATTR_SOURCE_IEEE,
+    ATTR_TARGET_IEEE,
     ID,
     SERVICE_PERMIT,
     TYPE,
@@ -884,3 +889,90 @@ async def test_websocket_change_channel(
     assert msg["success"]
 
     change_channel_mock.mock_calls == [call(ANY, new_channel)]
+
+
+@pytest.mark.parametrize(
+    "operation",
+    [("bind", zdo_types.ZDOCmd.Bind_req), ("unbind", zdo_types.ZDOCmd.Unbind_req)],
+)
+async def test_websocket_bind_unbind_devices(
+    operation: tuple[str, zdo_types.ZDOCmd],
+    app_controller: ControllerApplication,
+    zha_client,
+) -> None:
+    """Test websocket API for binding and unbinding devices to devices."""
+
+    command_type, req = operation
+    with patch(
+        "homeassistant.components.zha.websocket_api.async_binding_operation",
+        autospec=True,
+    ) as binding_operation_mock:
+        await zha_client.send_json(
+            {
+                ID: 27,
+                TYPE: f"zha/devices/{command_type}",
+                ATTR_SOURCE_IEEE: IEEE_SWITCH_DEVICE,
+                ATTR_TARGET_IEEE: IEEE_GROUPABLE_DEVICE,
+            }
+        )
+        msg = await zha_client.receive_json()
+
+    assert msg["id"] == 27
+    assert msg["type"] == const.TYPE_RESULT
+    assert msg["success"]
+    assert binding_operation_mock.mock_calls == [
+        call(
+            ANY,
+            EUI64.convert(IEEE_SWITCH_DEVICE),
+            EUI64.convert(IEEE_GROUPABLE_DEVICE),
+            req,
+        )
+    ]
+
+
+@pytest.mark.parametrize("command_type", ["bind", "unbind"])
+async def test_websocket_bind_unbind_group(
+    command_type: str,
+    app_controller: ControllerApplication,
+    zha_client,
+) -> None:
+    """Test websocket API for binding and unbinding devices to groups."""
+
+    test_group_id = 0x0001
+    gateway_mock = MagicMock()
+    with patch(
+        "homeassistant.components.zha.websocket_api.get_gateway",
+        return_value=gateway_mock,
+    ):
+        device_mock = MagicMock()
+        bind_mock = AsyncMock()
+        unbind_mock = AsyncMock()
+        device_mock.async_bind_to_group = bind_mock
+        device_mock.async_unbind_from_group = unbind_mock
+        gateway_mock.get_device = MagicMock()
+        gateway_mock.get_device.return_value = device_mock
+        await zha_client.send_json(
+            {
+                ID: 27,
+                TYPE: f"zha/groups/{command_type}",
+                ATTR_SOURCE_IEEE: IEEE_SWITCH_DEVICE,
+                GROUP_ID: test_group_id,
+                BINDINGS: [
+                    {
+                        ATTR_ENDPOINT_ID: 1,
+                        ID: 6,
+                        ATTR_NAME: "OnOff",
+                        ATTR_TYPE: "out",
+                    },
+                ],
+            }
+        )
+        msg = await zha_client.receive_json()
+
+    assert msg["id"] == 27
+    assert msg["type"] == const.TYPE_RESULT
+    assert msg["success"]
+    if command_type == "bind":
+        assert bind_mock.mock_calls == [call(test_group_id, ANY)]
+    elif command_type == "unbind":
+        assert unbind_mock.mock_calls == [call(test_group_id, ANY)]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes #94379 by having bind methods return an empty response upon completion (rather than just dropping). Could be enhanced in the future by returning whether the request succeeded or failed, but that's out of scope for this change.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #94379

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
