### PR TITLE
Fire persistent_notifications_updated event

### DIFF
--- a/homeassistant/components/persistent_notification/__init__.py
+++ b/homeassistant/components/persistent_notification/__init__.py
@@ -108,7 +108,7 @@ def async_create(
         UpdateType.ADDED,
         {notification_id: notifications[notification_id]},
     )
-    hass.bus.fire(
+    hass.bus.async_fire(
         EVENT_PERSISTENT_NOTIFICATION_CREATED,
         cast(dict[str, Any], notifications[notification_id]),
     )
@@ -134,7 +134,7 @@ def async_dismiss(hass: HomeAssistant, notification_id: str) -> None:
         UpdateType.REMOVED,
         {notification_id: notification},
     )
-    hass.bus.fire(
+    hass.bus.async_fire(
         EVENT_PERSISTENT_NOTIFICATION_DISMISSED, cast(dict[str, Any], notification)
     )
 

--- a/homeassistant/components/persistent_notification/__init__.py
+++ b/homeassistant/components/persistent_notification/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from datetime import datetime
 import logging
-from typing import Any, Final, TypedDict
+from typing import Any, Final, TypedDict, cast
 
 import voluptuous as vol
 
@@ -105,6 +105,9 @@ def async_create(
         UpdateType.ADDED,
         {notification_id: notifications[notification_id]},
     )
+    notification_update = cast(dict[str, Any], notifications[notification_id])
+    notification_update["type"] = str(UpdateType.ADDED)
+    hass.bus.fire(EVENT_PERSISTENT_NOTIFICATIONS_UPDATED, notification_update)
 
 
 @callback
@@ -127,6 +130,9 @@ def async_dismiss(hass: HomeAssistant, notification_id: str) -> None:
         UpdateType.REMOVED,
         {notification_id: notification},
     )
+    notification_update = cast(dict[str, Any], notification)
+    notification_update["type"] = str(UpdateType.REMOVED)
+    hass.bus.fire(EVENT_PERSISTENT_NOTIFICATIONS_UPDATED, notification_update)
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:

--- a/homeassistant/components/persistent_notification/__init__.py
+++ b/homeassistant/components/persistent_notification/__init__.py
@@ -33,6 +33,9 @@ ATTR_STATUS: Final = "status"
 # Remove EVENT_PERSISTENT_NOTIFICATIONS_UPDATED in Home Assistant 2023.9
 EVENT_PERSISTENT_NOTIFICATIONS_UPDATED = "persistent_notifications_updated"
 
+EVENT_PERSISTENT_NOTIFICATION_CREATED = "persistent_notification_created"
+EVENT_PERSISTENT_NOTIFICATION_DISMISSED = "persistent_notification_dismissed"
+
 
 class Notification(TypedDict):
     """Persistent notification."""
@@ -105,9 +108,10 @@ def async_create(
         UpdateType.ADDED,
         {notification_id: notifications[notification_id]},
     )
-    notification_update = cast(dict[str, Any], notifications[notification_id])
-    notification_update["type"] = str(UpdateType.ADDED)
-    hass.bus.fire(EVENT_PERSISTENT_NOTIFICATIONS_UPDATED, notification_update)
+    hass.bus.fire(
+        EVENT_PERSISTENT_NOTIFICATION_CREATED,
+        cast(dict[str, Any], notifications[notification_id]),
+    )
 
 
 @callback
@@ -130,9 +134,9 @@ def async_dismiss(hass: HomeAssistant, notification_id: str) -> None:
         UpdateType.REMOVED,
         {notification_id: notification},
     )
-    notification_update = cast(dict[str, Any], notification)
-    notification_update["type"] = str(UpdateType.REMOVED)
-    hass.bus.fire(EVENT_PERSISTENT_NOTIFICATIONS_UPDATED, notification_update)
+    hass.bus.fire(
+        EVENT_PERSISTENT_NOTIFICATION_DISMISSED, cast(dict[str, Any], notification)
+    )
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Since the update of `2023.6.x` users are no longer able to trigger automations on internally fired `persistent_notification` events.
This PR adds the firing of the `persistent_notifications_updated` event upon the creation or dismissal of a persistant notification to bring back this functionality without having to rely on the hidden entities that were used before `2023.6.x`.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: [Community Thread](https://community.home-assistant.io/t/heads-up-2023-6-longer-has-persistent-notifications-in-states-what-to-do/)
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
