### PR TITLE
Add name and default name to device info of APCUPSD sensors

### DIFF
--- a/homeassistant/components/apcupsd/__init__.py
+++ b/homeassistant/components/apcupsd/__init__.py
@@ -100,8 +100,7 @@ class APCUPSdData:
             identifiers={(DOMAIN, self.serial_no)},
             model=self.model,
             manufacturer="APC",
-            name=self.name,
-            default_name="APC UPS",
+            name=self.name if self.name is not None else "APC UPS",
             hw_version=self.status.get("FIRMWARE"),
             sw_version=self.status.get("VERSION"),
         )

--- a/homeassistant/components/apcupsd/__init__.py
+++ b/homeassistant/components/apcupsd/__init__.py
@@ -11,6 +11,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PORT, Platform
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.util import Throttle
 
 _LOGGER = logging.getLogger(__name__)
@@ -80,16 +81,6 @@ class APCUPSdData:
         return None
 
     @property
-    def sw_version(self) -> str | None:
-        """Return the software version of the APCUPSd, if available."""
-        return self.status.get("VERSION")
-
-    @property
-    def hw_version(self) -> str | None:
-        """Return the firmware version of the UPS, if available."""
-        return self.status.get("FIRMWARE")
-
-    @property
     def serial_no(self) -> str | None:
         """Return the unique serial number of the UPS, if available."""
         return self.status.get("SERIALNO")
@@ -98,6 +89,22 @@ class APCUPSdData:
     def statflag(self) -> str | None:
         """Return the STATFLAG indicating the status of the UPS, if available."""
         return self.status.get("STATFLAG")
+
+    @property
+    def device_info(self) -> DeviceInfo | None:
+        """Return the DeviceInfo of this APC UPS for the sensors, if serial number is available."""
+        if self.serial_no is None:
+            return None
+
+        return DeviceInfo(
+            identifiers={(DOMAIN, self.serial_no)},
+            model=self.model,
+            manufacturer="APC",
+            name=self.name,
+            default_name="APC UPS",
+            hw_version=self.status.get("FIRMWARE"),
+            sw_version=self.status.get("VERSION"),
+        )
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self, **kwargs: Any) -> None:

--- a/homeassistant/components/apcupsd/binary_sensor.py
+++ b/homeassistant/components/apcupsd/binary_sensor.py
@@ -9,7 +9,6 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import DOMAIN, VALUE_ONLINE, APCUPSdData
@@ -53,13 +52,8 @@ class OnlineStatus(BinarySensorEntity):
         # Set up unique id and device info if serial number is available.
         if (serial_no := data_service.serial_no) is not None:
             self._attr_unique_id = f"{serial_no}_{description.key}"
-            self._attr_device_info = DeviceInfo(
-                identifiers={(DOMAIN, serial_no)},
-                model=data_service.model,
-                manufacturer="APC",
-                hw_version=data_service.hw_version,
-                sw_version=data_service.sw_version,
-            )
+        self._attr_device_info = data_service.device_info
+
         self.entity_description = description
         self._data_service = data_service
 

--- a/homeassistant/components/apcupsd/sensor.py
+++ b/homeassistant/components/apcupsd/sensor.py
@@ -21,7 +21,6 @@ from homeassistant.const import (
     UnitOfTime,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import DOMAIN, APCUPSdData
@@ -496,13 +495,7 @@ class APCUPSdSensor(SensorEntity):
         # Set up unique id and device info if serial number is available.
         if (serial_no := data_service.serial_no) is not None:
             self._attr_unique_id = f"{serial_no}_{description.key}"
-            self._attr_device_info = DeviceInfo(
-                identifiers={(DOMAIN, serial_no)},
-                model=data_service.model,
-                manufacturer="APC",
-                hw_version=data_service.hw_version,
-                sw_version=data_service.sw_version,
-            )
+        self._attr_device_info = data_service.device_info
 
         self.entity_description = description
         self._data_service = data_service

--- a/tests/components/apcupsd/__init__.py
+++ b/tests/components/apcupsd/__init__.py
@@ -20,6 +20,7 @@ MOCK_STATUS: Final = OrderedDict(
         ("CABLE", "USB Cable"),
         ("DRIVER", "USB UPS Driver"),
         ("UPSMODE", "Stand Alone"),
+        ("UPSNAME", "MyUPS"),
         ("MODEL", "Back-UPS ES 600"),
         ("STATUS", "ONLINE"),
         ("LINEV", "124.0 Volts"),

--- a/tests/components/apcupsd/test_config_flow.py
+++ b/tests/components/apcupsd/test_config_flow.py
@@ -124,7 +124,7 @@ async def test_flow_works(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
         assert result["type"] == FlowResultType.CREATE_ENTRY
-        assert result["title"] == MOCK_STATUS["MODEL"]
+        assert result["title"] == MOCK_STATUS["UPSNAME"]
         assert result["data"] == CONF_DATA
 
         mock_setup.assert_called_once()

--- a/tests/components/apcupsd/test_init.py
+++ b/tests/components/apcupsd/test_init.py
@@ -44,7 +44,7 @@ async def test_async_setup_entry(hass: HomeAssistant, status: OrderedDict) -> No
 )
 async def test_device_entry(hass: HomeAssistant, status: OrderedDict) -> None:
     """Test successful setup of device entries."""
-    await init_integration(hass, status=status)
+    await async_init_integration(hass, status=status)
 
     # Verify device info is properly set up.
     device_entries = dr.async_get(hass)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The device names for APCUPSD sensors are now properly populated. Value in UPSNAME field will be used if it is available from APC UPS Daemon. Otherwise, the device name will default to "APC UPS".


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds logic to properly populate `name` and `default_name` fields in `DeviceInfo` for sensors in APCUPSD integration. Also, this PR extracts this logic to the common data object `APCUPSd` so that all sensors can share the same logic instead of having it duplicated for sensors and binary_sensors.

New tests are also added to check if device info is correctly populated by the integration.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
