### PR TITLE
Fix timestamps for bluetooth scanners that bundle advertisements

### DIFF
--- a/homeassistant/components/bluetooth/__init__.py
+++ b/homeassistant/components/bluetooth/__init__.py
@@ -76,7 +76,7 @@ from .models import (
     BluetoothScanningMode,
     HaBluetoothConnector,
 )
-from .scanner import HaScanner, ScannerStartError
+from .scanner import MONOTONIC_TIME, HaScanner, ScannerStartError
 from .storage import BluetoothStorage
 
 if TYPE_CHECKING:
@@ -108,6 +108,7 @@ __all__ = [
     "HaBluetoothConnector",
     "SOURCE_LOCAL",
     "FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS",
+    "MONOTONIC_TIME",
 ]
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/bluetooth/base_scanner.py
+++ b/homeassistant/components/bluetooth/base_scanner.py
@@ -299,10 +299,10 @@ class BaseHaRemoteScanner(BaseHaScanner):
         manufacturer_data: dict[int, bytes],
         tx_power: int | None,
         details: dict[Any, Any],
+        advertisement_monotonic_time: float,
     ) -> None:
         """Call the registered callback."""
-        now = MONOTONIC_TIME()
-        self._last_detection = now
+        self._last_detection = advertisement_monotonic_time
         if prev_discovery := self._discovered_device_advertisement_datas.get(address):
             # Merge the new data with the old data
             # to function the same as BlueZ which
@@ -365,7 +365,7 @@ class BaseHaRemoteScanner(BaseHaScanner):
             device,
             advertisement_data,
         )
-        self._discovered_device_timestamps[address] = now
+        self._discovered_device_timestamps[address] = advertisement_monotonic_time
         self._new_info_callback(
             BluetoothServiceInfoBleak(
                 name=local_name or address,
@@ -378,7 +378,7 @@ class BaseHaRemoteScanner(BaseHaScanner):
                 device=device,
                 advertisement=advertisement_data,
                 connectable=self.connectable,
-                time=now,
+                time=advertisement_monotonic_time,
             )
         )
 

--- a/homeassistant/components/esphome/bluetooth/scanner.py
+++ b/homeassistant/components/esphome/bluetooth/scanner.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from aioesphomeapi import BluetoothLEAdvertisement, BluetoothLERawAdvertisement
 from bluetooth_data_tools import int_to_bluetooth_address, parse_advertisement_data
 
-from homeassistant.components.bluetooth import BaseHaRemoteScanner
+from homeassistant.components.bluetooth import MONOTONIC_TIME, BaseHaRemoteScanner
 from homeassistant.core import callback
 
 
@@ -24,6 +24,7 @@ class ESPHomeScanner(BaseHaRemoteScanner):
             adv.manufacturer_data,
             None,
             {"address_type": adv.address_type},
+            MONOTONIC_TIME(),
         )
 
     @callback
@@ -31,6 +32,7 @@ class ESPHomeScanner(BaseHaRemoteScanner):
         self, advertisements: list[BluetoothLERawAdvertisement]
     ) -> None:
         """Call the registered callback."""
+        now = MONOTONIC_TIME()
         for adv in advertisements:
             parsed = parse_advertisement_data((adv.data,))
             self._async_on_advertisement(
@@ -42,4 +44,5 @@ class ESPHomeScanner(BaseHaRemoteScanner):
                 parsed.manufacturer_data,
                 None,
                 {"address_type": adv.address_type},
+                now,
             )

--- a/homeassistant/components/ruuvi_gateway/bluetooth.py
+++ b/homeassistant/components/ruuvi_gateway/bluetooth.py
@@ -9,6 +9,7 @@ from home_assistant_bluetooth import BluetoothServiceInfoBleak
 
 from homeassistant.components.bluetooth import (
     FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS,
+    MONOTONIC_TIME,
     BaseHaRemoteScanner,
     async_get_advertisement_callback,
     async_register_scanner,
@@ -47,6 +48,7 @@ class RuuviGatewayScanner(BaseHaRemoteScanner):
     @callback
     def _async_handle_new_data(self) -> None:
         now = time.time()
+        monotonic_now = MONOTONIC_TIME()
         for tag_data in self.coordinator.data:
             data_age_seconds = now - tag_data.timestamp  # Both are Unix time
             if data_age_seconds > FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS:
@@ -62,6 +64,7 @@ class RuuviGatewayScanner(BaseHaRemoteScanner):
                 manufacturer_data=anno.manufacturer_data,
                 tx_power=anno.tx_power,
                 details={},
+                advertisement_monotonic_time=monotonic_now - data_age_seconds,
             )
 
     @callback

--- a/homeassistant/components/shelly/bluetooth/scanner.py
+++ b/homeassistant/components/shelly/bluetooth/scanner.py
@@ -6,7 +6,7 @@ from typing import Any
 from aioshelly.ble import parse_ble_scan_result_event
 from aioshelly.ble.const import BLE_SCAN_RESULT_EVENT, BLE_SCAN_RESULT_VERSION
 
-from homeassistant.components.bluetooth import BaseHaRemoteScanner
+from homeassistant.components.bluetooth import MONOTONIC_TIME, BaseHaRemoteScanner
 from homeassistant.core import callback
 
 from ..const import LOGGER
@@ -44,4 +44,5 @@ class ShellyBLEScanner(BaseHaRemoteScanner):
             parsed.manufacturer_data,
             parsed.tx_power,
             {},
+            MONOTONIC_TIME(),
         )

--- a/tests/components/bluetooth/test_api.py
+++ b/tests/components/bluetooth/test_api.py
@@ -1,8 +1,12 @@
 """Tests for the Bluetooth integration API."""
+import time
+
 from bleak.backends.scanner import AdvertisementData, BLEDevice
+import pytest
 
 from homeassistant.components import bluetooth
 from homeassistant.components.bluetooth import (
+    MONOTONIC_TIME,
     BaseHaRemoteScanner,
     BaseHaScanner,
     HaBluetoothConnector,
@@ -31,6 +35,11 @@ async def test_scanner_by_source(hass: HomeAssistant, enable_bluetooth: None) ->
     assert async_scanner_by_source(hass, "hci2") is None
 
 
+async def test_monotonic_time() -> None:
+    """Test monotonic time."""
+    assert MONOTONIC_TIME() == pytest.approx(time.monotonic(), abs=0.1)
+
+
 async def test_async_scanner_devices_by_address_connectable(
     hass: HomeAssistant, enable_bluetooth: None
 ) -> None:
@@ -51,6 +60,7 @@ async def test_async_scanner_devices_by_address_connectable(
                 advertisement_data.manufacturer_data,
                 advertisement_data.tx_power,
                 {"scanner_specific_data": "test"},
+                MONOTONIC_TIME(),
             )
 
     new_info_callback = manager.scanner_adv_received

--- a/tests/components/bluetooth/test_base_scanner.py
+++ b/tests/components/bluetooth/test_base_scanner.py
@@ -12,6 +12,7 @@ import pytest
 
 from homeassistant.components import bluetooth
 from homeassistant.components.bluetooth import (
+    MONOTONIC_TIME,
     BaseHaRemoteScanner,
     HaBluetoothConnector,
     storage,
@@ -84,6 +85,7 @@ async def test_remote_scanner(hass: HomeAssistant, enable_bluetooth: None) -> No
                 advertisement_data.manufacturer_data,
                 advertisement_data.tx_power,
                 {"scanner_specific_data": "test"},
+                MONOTONIC_TIME(),
             )
 
     new_info_callback = manager.scanner_adv_received
@@ -158,6 +160,7 @@ async def test_remote_scanner_expires_connectable(
                 advertisement_data.manufacturer_data,
                 advertisement_data.tx_power,
                 {"scanner_specific_data": "test"},
+                MONOTONIC_TIME(),
             )
 
     new_info_callback = manager.scanner_adv_received
@@ -232,6 +235,7 @@ async def test_remote_scanner_expires_non_connectable(
                 advertisement_data.manufacturer_data,
                 advertisement_data.tx_power,
                 {"scanner_specific_data": "test"},
+                MONOTONIC_TIME(),
             )
 
     new_info_callback = manager.scanner_adv_received
@@ -329,6 +333,7 @@ async def test_base_scanner_connecting_behavior(
                 advertisement_data.manufacturer_data,
                 advertisement_data.tx_power,
                 {"scanner_specific_data": "test"},
+                MONOTONIC_TIME(),
             )
 
     new_info_callback = manager.scanner_adv_received
@@ -452,6 +457,7 @@ async def test_device_with_ten_minute_advertising_interval(
                 advertisement_data.manufacturer_data,
                 advertisement_data.tx_power,
                 {"scanner_specific_data": "test"},
+                MONOTONIC_TIME(),
             )
 
     new_info_callback = manager.scanner_adv_received

--- a/tests/components/bluetooth/test_diagnostics.py
+++ b/tests/components/bluetooth/test_diagnostics.py
@@ -5,7 +5,11 @@ from bleak.backends.scanner import AdvertisementData, BLEDevice
 from bluetooth_adapters import DEFAULT_ADDRESS
 
 from homeassistant.components import bluetooth
-from homeassistant.components.bluetooth import BaseHaRemoteScanner, HaBluetoothConnector
+from homeassistant.components.bluetooth import (
+    MONOTONIC_TIME,
+    BaseHaRemoteScanner,
+    HaBluetoothConnector,
+)
 from homeassistant.core import HomeAssistant
 
 from . import (
@@ -450,6 +454,7 @@ async def test_diagnostics_remote_adapter(
                 advertisement_data.manufacturer_data,
                 advertisement_data.tx_power,
                 {"scanner_specific_data": "test"},
+                MONOTONIC_TIME(),
             )
 
     with patch(

--- a/tests/components/bluetooth/test_manager.py
+++ b/tests/components/bluetooth/test_manager.py
@@ -11,6 +11,7 @@ import pytest
 
 from homeassistant.components import bluetooth
 from homeassistant.components.bluetooth import (
+    MONOTONIC_TIME,
     BaseHaRemoteScanner,
     BluetoothChange,
     BluetoothScanningMode,
@@ -711,6 +712,7 @@ async def test_goes_unavailable_connectable_only_and_recovers(
                 advertisement_data.manufacturer_data,
                 advertisement_data.tx_power,
                 {"scanner_specific_data": "test"},
+                MONOTONIC_TIME(),
             )
 
     new_info_callback = async_get_advertisement_callback(hass)
@@ -883,6 +885,7 @@ async def test_goes_unavailable_dismisses_discovery_and_makes_discoverable(
                 advertisement_data.manufacturer_data,
                 advertisement_data.tx_power,
                 {"scanner_specific_data": "test"},
+                MONOTONIC_TIME(),
             )
 
         def clear_all_devices(self) -> None:

--- a/tests/components/bluetooth/test_wrappers.py
+++ b/tests/components/bluetooth/test_wrappers.py
@@ -10,6 +10,7 @@ from bleak.backends.scanner import AdvertisementData
 import pytest
 
 from homeassistant.components.bluetooth import (
+    MONOTONIC_TIME,
     BaseHaRemoteScanner,
     BluetoothServiceInfoBleak,
     HaBluetoothConnector,
@@ -59,6 +60,7 @@ class FakeScanner(BaseHaRemoteScanner):
             advertisement_data.manufacturer_data,
             advertisement_data.tx_power,
             device.details | {"scanner_specific_data": "test"},
+            MONOTONIC_TIME(),
         )
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
#94138 added support for raw/bundled advertisements. We should use the same monotonic time for all advertisements in the bundle if not time is passed, or calculate the timestamp and pass it if its known.  This avoids future potential issues with `scanner_adv_received` comparing data between scanners to see if it should switch source for failover.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
