### PR TITLE
Migrate homekit_controller entity naming to new standards

### DIFF
--- a/homeassistant/components/homekit_controller/binary_sensor.py
+++ b/homeassistant/components/homekit_controller/binary_sensor.py
@@ -113,17 +113,11 @@ class HomeKitBatteryLowSensor(HomeKitEntity, BinarySensorEntity):
 
     _attr_device_class = BinarySensorDeviceClass.BATTERY
     _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_name = "Low Battery"
 
     def get_characteristic_types(self) -> list[str]:
         """Define the homekit characteristics the entity is tracking."""
         return [CharacteristicsTypes.STATUS_LO_BATT]
-
-    @property
-    def name(self) -> str:
-        """Return the name of the sensor."""
-        if name := self.accessory.name:
-            return f"{name} Low Battery"
-        return "Low Battery"
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/homekit_controller/button.py
+++ b/homeassistant/components/homekit_controller/button.py
@@ -111,13 +111,6 @@ class HomeKitButton(CharacteristicEntity, ButtonEntity):
         """Define the homekit characteristics the entity is tracking."""
         return [self._char.type]
 
-    @property
-    def name(self) -> str:
-        """Return the name of the device if any."""
-        if name := self.accessory.name:
-            return f"{name} {self.entity_description.name}"
-        return f"{self.entity_description.name}"
-
     async def async_press(self) -> None:
         """Press the button."""
         key = self.entity_description.key
@@ -128,17 +121,11 @@ class HomeKitButton(CharacteristicEntity, ButtonEntity):
 class HomeKitEcobeeClearHoldButton(CharacteristicEntity, ButtonEntity):
     """Representation of a Button control for Ecobee clear hold request."""
 
+    _attr_name = "Clear Hold"
+
     def get_characteristic_types(self) -> list[str]:
         """Define the homekit characteristics the entity is tracking."""
         return []
-
-    @property
-    def name(self) -> str:
-        """Return the name of the device if any."""
-        prefix = ""
-        if name := super().name:
-            prefix = name
-        return f"{prefix} Clear Hold"
 
     async def async_press(self) -> None:
         """Press the button."""
@@ -158,18 +145,11 @@ class HomeKitProvisionPreferredThreadCredentials(CharacteristicEntity, ButtonEnt
     """A button users can press to migrate their HomeKit BLE device to Thread."""
 
     _attr_entity_category = EntityCategory.CONFIG
+    _attr_name = "Provision Preferred Thread Credentials"
 
     def get_characteristic_types(self) -> list[str]:
         """Define the homekit characteristics the entity is tracking."""
         return []
-
-    @property
-    def name(self) -> str:
-        """Return the name of the device if any."""
-        prefix = ""
-        if name := super().name:
-            prefix = name
-        return f"{prefix} Provision Preferred Thread Credentials"
 
     async def async_press(self) -> None:
         """Press the button."""

--- a/homeassistant/components/homekit_controller/entity.py
+++ b/homeassistant/components/homekit_controller/entity.py
@@ -165,6 +165,11 @@ class HomeKitEntity(Entity):
             ):
                 return device_name
 
+            # Handle cases like VOCOlinc-Flowerbud-0d324b FLOWERBUD
+            # (service name is FLOWERBUD)
+            if folded_device_name in folded_accessory_name:
+                return None
+
             # If the service name is an exact superset of the device name, we can safely chop
             # the prefix off and return the service name.
             if device_name.startswith(accessory_name):

--- a/homeassistant/components/homekit_controller/entity.py
+++ b/homeassistant/components/homekit_controller/entity.py
@@ -145,7 +145,9 @@ class HomeKitEntity(Entity):
         accessory_name = self.accessory.name
         # If the service has a name char, use that, if not
         # fallback to the default name provided by the subclass
-        if entity_description := getattr(self, "entity_description", None):
+        if device_name := getattr(self, "_attr_name", None):
+            pass
+        elif entity_description := getattr(self, "entity_description", None):
             device_name = entity_description.name
         else:
             device_name = self._char_name or self.default_name

--- a/homeassistant/components/homekit_controller/entity.py
+++ b/homeassistant/components/homekit_controller/entity.py
@@ -143,14 +143,16 @@ class HomeKitEntity(Entity):
     def name(self) -> str | None:
         """Return the name of the device if any."""
         accessory_name = self.accessory.name
-        # If the service has a name char, use that, if not
-        # fallback to the default name provided by the subclass
-        if device_name := getattr(self, "_attr_name", None):
-            pass
-        elif entity_description := getattr(self, "entity_description", None):
-            device_name = entity_description.name
-        else:
-            device_name = self._char_name or self.default_name
+
+        # If entity has _attr_name, don't try and use service Name characteristic
+        if entity_name := getattr(self, "_attr_name", None):
+            return entity_name
+
+        # If entity has entity description, don't try and use service Name characteristic
+        if entity_description := getattr(self, "entity_description", None):
+            return entity_description.name
+
+        device_name = self._char_name or self.default_name
 
         folded_device_name = folded_name(device_name or "")
         folded_accessory_name = folded_name(accessory_name)

--- a/homeassistant/components/homekit_controller/entity.py
+++ b/homeassistant/components/homekit_controller/entity.py
@@ -154,13 +154,19 @@ class HomeKitEntity(Entity):
 
         device_name = self._char_name or self.default_name
 
-        folded_device_name = folded_name(device_name or "")
-        folded_accessory_name = folded_name(accessory_name)
+        # For entities backed by a "Service" (like an outlet) there are devices where an accessory
+        # can have multiple instances of that service (for example, a 4-way power bank). We want to defer
+        # to the Name characteristic of that service in those cases.
 
-        if folded_device_name == folded_accessory_name:
-            return None
+        # However, in those cases we might find the device name is fully or partially repeated in the Service
+        # name. And that could lead to friendly names like "VOCOlinc-Flowerbud-0d324b VOCOlinc-Flowerbud-0d324b Oulet"
+
+        # Try to respect the Service name where possible, filtering out the duplicate parts of the name.
 
         if device_name:
+            folded_device_name = folded_name(device_name)
+            folded_accessory_name = folded_name(accessory_name)
+
             # If there is definitely no overlap between the name characteristic
             # and the device name, return the contents of the name characteristic
             if (

--- a/homeassistant/components/homekit_controller/entity.py
+++ b/homeassistant/components/homekit_controller/entity.py
@@ -183,7 +183,7 @@ class HomeKitEntity(Entity):
             # If the service name is an exact superset of the device name, we can safely chop
             # the prefix off and return the service name.
             if device_name.startswith(accessory_name):
-                return device_name[len(accessory_name):].strip()
+                return device_name[len(accessory_name) :].strip()
 
             # Otherwise, the service name strongly overlaps the device name but we can't safely
             # unpick them

--- a/homeassistant/components/homekit_controller/number.py
+++ b/homeassistant/components/homekit_controller/number.py
@@ -96,13 +96,6 @@ class HomeKitNumber(CharacteristicEntity, NumberEntity):
         self.entity_description = description
         super().__init__(conn, info, char)
 
-    @property
-    def name(self) -> str:
-        """Return the name of the device if any."""
-        if name := self.accessory.name:
-            return f"{name} {self.entity_description.name}"
-        return f"{self.entity_description.name}"
-
     def get_characteristic_types(self) -> list[str]:
         """Define the homekit characteristics the entity is tracking."""
         return [self._char.type]

--- a/homeassistant/components/homekit_controller/select.py
+++ b/homeassistant/components/homekit_controller/select.py
@@ -26,13 +26,7 @@ class EcobeeModeSelect(CharacteristicEntity, SelectEntity):
 
     _attr_options = ["home", "sleep", "away"]
     _attr_translation_key = "ecobee_mode"
-
-    @property
-    def name(self) -> str:
-        """Return the name of the device if any."""
-        if name := super().name:
-            return f"{name} Current Mode"
-        return "Current Mode"
+    _attr_name = "Current Mode"
 
     def get_characteristic_types(self) -> list[str]:
         """Define the homekit characteristics the entity cares about."""

--- a/homeassistant/components/homekit_controller/sensor.py
+++ b/homeassistant/components/homekit_controller/sensor.py
@@ -345,19 +345,6 @@ class HomeKitSensor(HomeKitEntity, SensorEntity):
 
     _attr_state_class = SensorStateClass.MEASUREMENT
 
-    @property
-    def name(self) -> str | None:
-        """Return the name of the device."""
-        full_name = super().name
-        default_name = self.default_name
-        if (
-            default_name
-            and full_name
-            and folded_name(default_name) not in folded_name(full_name)
-        ):
-            return f"{full_name} {default_name}"
-        return full_name
-
 
 class HomeKitHumiditySensor(HomeKitSensor):
     """Representation of a Homekit humidity sensor."""
@@ -532,13 +519,6 @@ class SimpleSensor(CharacteristicEntity, SensorEntity):
         return [self._char.type]
 
     @property
-    def name(self) -> str:
-        """Return the name of the device if any."""
-        if name := self.accessory.name:
-            return f"{name} {self.entity_description.name}"
-        return f"{self.entity_description.name}"
-
-    @property
     def native_value(self) -> str | int | float:
         """Return the current sensor value."""
         val = self._char.value
@@ -567,7 +547,6 @@ class RSSISensor(HomeKitEntity, SensorEntity):
     _attr_device_class = SensorDeviceClass.SIGNAL_STRENGTH
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_entity_registry_enabled_default = False
-    _attr_has_entity_name = True
     _attr_native_unit_of_measurement = SIGNAL_STRENGTH_DECIBELS_MILLIWATT
     _attr_should_poll = False
 

--- a/homeassistant/components/homekit_controller/sensor.py
+++ b/homeassistant/components/homekit_controller/sensor.py
@@ -345,6 +345,19 @@ class HomeKitSensor(HomeKitEntity, SensorEntity):
 
     _attr_state_class = SensorStateClass.MEASUREMENT
 
+    @property
+    def name(self) -> str | None:
+        """Return the name of the device."""
+        full_name = super().name
+        default_name = self.default_name
+        if (
+            default_name
+            and full_name
+            and folded_name(default_name) not in folded_name(full_name)
+        ):
+            return f"{full_name} {default_name}"
+        return full_name
+
 
 class HomeKitHumiditySensor(HomeKitSensor):
     """Representation of a Homekit humidity sensor."""

--- a/homeassistant/components/homekit_controller/sensor.py
+++ b/homeassistant/components/homekit_controller/sensor.py
@@ -350,6 +350,8 @@ class HomeKitSensor(HomeKitEntity, SensorEntity):
         """Return the name of the device."""
         full_name = super().name
         default_name = self.default_name
+        if not full_name:
+            return default_name
         if (
             default_name
             and full_name

--- a/homeassistant/components/homekit_controller/switch.py
+++ b/homeassistant/components/homekit_controller/switch.py
@@ -165,13 +165,6 @@ class DeclarativeCharacteristicSwitch(CharacteristicEntity, SwitchEntity):
         self.entity_description: DeclarativeSwitchEntityDescription = description
         super().__init__(conn, info, char)
 
-    @property
-    def name(self) -> str:
-        """Return the name of the device if any."""
-        if name := self.accessory.name:
-            return f"{name} {self.entity_description.name}"
-        return f"{self.entity_description.name}"
-
     def get_characteristic_types(self) -> list[str]:
         """Define the homekit characteristics the entity cares about."""
         return [self._char.type]

--- a/tests/components/homekit_controller/test_diagnostics.py
+++ b/tests/components/homekit_controller/test_diagnostics.py
@@ -244,7 +244,7 @@ async def test_config_entry(
                         "icon": None,
                         "original_device_class": None,
                         "original_icon": None,
-                        "original_name": "Koogeek-LS1-20833F Identify",
+                        "original_name": "Identify",
                         "state": {
                             "attributes": {
                                 "friendly_name": "Koogeek-LS1-20833F Identify"
@@ -264,7 +264,7 @@ async def test_config_entry(
                         "icon": None,
                         "original_device_class": None,
                         "original_icon": None,
-                        "original_name": "Koogeek-LS1-20833F Light Strip",
+                        "original_name": "Light Strip",
                         "state": {
                             "attributes": {
                                 "friendly_name": "Koogeek-LS1-20833F Light Strip",
@@ -517,7 +517,7 @@ async def test_device(
                     "icon": None,
                     "original_device_class": None,
                     "original_icon": None,
-                    "original_name": "Koogeek-LS1-20833F Identify",
+                    "original_name": "Identify",
                     "state": {
                         "attributes": {
                             "friendly_name": "Koogeek-LS1-20833F " "Identify"
@@ -537,7 +537,7 @@ async def test_device(
                     "icon": None,
                     "original_device_class": None,
                     "original_icon": None,
-                    "original_name": "Koogeek-LS1-20833F Light Strip",
+                    "original_name": "Light Strip",
                     "state": {
                         "attributes": {
                             "friendly_name": "Koogeek-LS1-20833F Light Strip",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Update homekit_controller to follow https://developers.home-assistant.io/blog/2022/07/10/entity_naming/.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
