### PR TITLE
Catch InvalidAuthError in `shutdown()` method for Shelly gen2 devices

### DIFF
--- a/homeassistant/components/shelly/coordinator.py
+++ b/homeassistant/components/shelly/coordinator.py
@@ -535,7 +535,10 @@ class ShellyRpcCoordinator(ShellyCoordinatorBase[RpcDevice]):
     async def shutdown(self) -> None:
         """Shutdown the coordinator."""
         if self.device.connected:
-            await async_stop_scanner(self.device)
+            try:
+                await async_stop_scanner(self.device)
+            except InvalidAuthError:
+                self.entry.async_start_reauth(self.hass)
         await self.device.shutdown()
         await self._async_disconnected()
 

--- a/tests/components/shelly/test_coordinator.py
+++ b/tests/components/shelly/test_coordinator.py
@@ -1,6 +1,6 @@
 """Tests for Shelly coordinator."""
 from datetime import timedelta
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 from aioshelly.exceptions import DeviceConnectionError, InvalidAuthError
 
@@ -326,13 +326,58 @@ async def test_rpc_reload_on_cfg_change(
 
     assert hass.states.get("switch.test_switch_0") is not None
 
-    # Wait for debouncer
-    async_fire_time_changed(
-        hass, dt_util.utcnow() + timedelta(seconds=ENTRY_RELOAD_COOLDOWN)
-    )
-    await hass.async_block_till_done()
 
-    assert hass.states.get("switch.test_switch_0") is None
+async def test_rpc_reload_with_invalid_auth(
+    hass: HomeAssistant, mock_rpc_device, monkeypatch
+) -> None:
+    """Test RPC when InvalidAuthError is raising during config entry reload."""
+    with patch(
+        "homeassistant.components.shelly.coordinator.async_stop_scanner",
+        side_effect=[None, InvalidAuthError, None],
+    ):
+        entry = await init_integration(hass, 2)
+
+        inject_rpc_device_event(
+            monkeypatch,
+            mock_rpc_device,
+            {
+                "events": [
+                    {
+                        "data": [],
+                        "event": "config_changed",
+                        "id": 1,
+                        "ts": 1668522399.2,
+                    },
+                    {
+                        "data": [],
+                        "id": 2,
+                        "ts": 1668522399.2,
+                    },
+                ],
+                "ts": 1668522399.2,
+            },
+        )
+
+        await hass.async_block_till_done()
+
+        # Move time to generate reconnect
+        async_fire_time_changed(
+            hass, dt_util.utcnow() + timedelta(seconds=RPC_RECONNECT_INTERVAL)
+        )
+        await hass.async_block_till_done()
+
+    assert entry.state == ConfigEntryState.LOADED
+
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+
+    flow = flows[0]
+    assert flow.get("step_id") == "reauth_confirm"
+    assert flow.get("handler") == DOMAIN
+
+    assert "context" in flow
+    assert flow["context"].get("source") == SOURCE_REAUTH
+    assert flow["context"].get("entry_id") == entry.entry_id
 
 
 async def test_rpc_click_event(

--- a/tests/components/shelly/test_coordinator.py
+++ b/tests/components/shelly/test_coordinator.py
@@ -326,6 +326,14 @@ async def test_rpc_reload_on_cfg_change(
 
     assert hass.states.get("switch.test_switch_0") is not None
 
+    # Wait for debouncer
+    async_fire_time_changed(
+        hass, dt_util.utcnow() + timedelta(seconds=ENTRY_RELOAD_COOLDOWN)
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get("switch.test_switch_0") is None
+
 
 async def test_rpc_reload_with_invalid_auth(
     hass: HomeAssistant, mock_rpc_device, monkeypatch


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Catch `InvalidAuthError` in `shutdown()` method and start reauth flow.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #94562
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
