### PR TITLE
Migrate Linn / Openhome integration to SSDP config flow

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -885,6 +885,7 @@ build.json @home-assistant/supervisor
 /homeassistant/components/opengarage/ @danielhiversen
 /tests/components/opengarage/ @danielhiversen
 /homeassistant/components/openhome/ @bazwilliams
+/tests/components/openhome/ @bazwilliams
 /homeassistant/components/opensky/ @joostlek
 /homeassistant/components/opentherm_gw/ @mvn23
 /tests/components/opentherm_gw/ @mvn23

--- a/homeassistant/components/openhome/__init__.py
+++ b/homeassistant/components/openhome/__init__.py
@@ -1,26 +1,51 @@
 """The openhome component."""
 
+import asyncio
 import logging
 
+import aiohttp
+from async_upnp_client.client import UpnpError
+from openhomedevice.device import Device
+
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import Platform
+from homeassistant.const import CONF_HOST, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
+
+from .const import DOMAIN
+from .media_player import OpenhomeDevice
 
 _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS = [Platform.MEDIA_PLAYER]
 
 
-async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
-    """Set up openhome from a config entry."""
-    _LOGGER.debug("Setting up config entry: %s", config_entry.unique_id)
-
-    await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
-
-    return True
-
-
 async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     # Forward to the same platform as async_setup_entry did
     return await hass.config_entries.async_unload_platforms(config_entry, PLATFORMS)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+) -> bool:
+    """Set up the configuration config entry."""
+    _LOGGER.debug("Setting up config entry: %s", config_entry.unique_id)
+
+    device = await hass.async_add_executor_job(Device, config_entry.data[CONF_HOST])
+
+    try:
+        await device.init()
+    except (asyncio.TimeoutError, aiohttp.ClientError, UpnpError) as exc:
+        raise ConfigEntryNotReady from exc
+
+    _LOGGER.debug("Initialised device: %s", device.uuid())
+
+    entity = OpenhomeDevice(hass, device)
+
+    hass.data.setdefault(DOMAIN, {})[config_entry.entry_id] = entity
+
+    await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
+
+    return True

--- a/homeassistant/components/openhome/__init__.py
+++ b/homeassistant/components/openhome/__init__.py
@@ -1,1 +1,26 @@
 """The openhome component."""
+
+import logging
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+
+_LOGGER = logging.getLogger(__name__)
+
+PLATFORMS = [Platform.MEDIA_PLAYER]
+
+
+async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    """Set up openhome from a config entry."""
+    _LOGGER.debug("Setting up config entry: %s", config_entry.unique_id)
+
+    await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    # Forward to the same platform as async_setup_entry did
+    return await hass.config_entries.async_unload_platforms(config_entry, PLATFORMS)

--- a/homeassistant/components/openhome/__init__.py
+++ b/homeassistant/components/openhome/__init__.py
@@ -12,7 +12,6 @@ from homeassistant.const import CONF_HOST, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN
 
@@ -21,12 +20,6 @@ _LOGGER = logging.getLogger(__name__)
 PLATFORMS = [Platform.MEDIA_PLAYER]
 
 CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
-
-
-async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up the component."""
-    hass.data[DOMAIN] = {}
-    return True
 
 
 async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
@@ -55,7 +48,7 @@ async def async_setup_entry(
 
     _LOGGER.debug("Initialised device: %s", device.uuid())
 
-    hass.data[DOMAIN][config_entry.entry_id] = device
+    hass.data.setdefault(DOMAIN, {})[config_entry.entry_id] = device
 
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
 

--- a/homeassistant/components/openhome/__init__.py
+++ b/homeassistant/components/openhome/__init__.py
@@ -11,6 +11,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN
@@ -18,6 +19,8 @@ from .const import DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS = [Platform.MEDIA_PLAYER]
+
+CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:

--- a/homeassistant/components/openhome/config_flow.py
+++ b/homeassistant/components/openhome/config_flow.py
@@ -1,0 +1,49 @@
+"""Config flow for Linn / OpenHome."""
+
+import logging
+
+from homeassistant.components.ssdp import (
+    ATTR_UPNP_FRIENDLY_NAME,
+    ATTR_UPNP_UDN,
+    SsdpServiceInfo,
+)
+from homeassistant.config_entries import ConfigFlow
+from homeassistant.const import CONF_HOST
+from homeassistant.data_entry_flow import FlowResult
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _is_complete_discovery(discovery_info: SsdpServiceInfo) -> bool:
+    """Test if discovery is complete and usable."""
+    return bool(ATTR_UPNP_UDN in discovery_info.upnp and discovery_info.ssdp_location)
+
+
+class OpenhomeConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle an Openhome config flow."""
+
+    async def async_step_ssdp(self, discovery_info: SsdpServiceInfo) -> FlowResult:
+        """Handle a flow initialized by discovery."""
+        _LOGGER.debug("async_step_ssdp: started")
+
+        if not _is_complete_discovery(discovery_info):
+            _LOGGER.debug("async_step_ssdp: Incomplete discovery, ignoring")
+            return self.async_abort(reason="incomplete_discovery")
+
+        _LOGGER.debug(
+            "async_step_ssdp: setting unique id %s", discovery_info.upnp[ATTR_UPNP_UDN]
+        )
+
+        await self.async_set_unique_id(discovery_info.upnp[ATTR_UPNP_UDN])
+        self._abort_if_unique_id_configured({CONF_HOST: discovery_info.ssdp_location})
+
+        _LOGGER.debug(
+            "async_step_ssdp: create entry %s", discovery_info.upnp[ATTR_UPNP_UDN]
+        )
+
+        return self.async_create_entry(
+            title=discovery_info.upnp[ATTR_UPNP_FRIENDLY_NAME],
+            data={CONF_HOST: discovery_info.ssdp_location},
+        )

--- a/homeassistant/components/openhome/manifest.json
+++ b/homeassistant/components/openhome/manifest.json
@@ -2,8 +2,23 @@
   "domain": "openhome",
   "name": "Linn / OpenHome",
   "codeowners": ["@bazwilliams"],
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/openhome",
   "iot_class": "local_polling",
   "loggers": ["async_upnp_client", "openhomedevice"],
-  "requirements": ["openhomedevice==2.0.2"]
+  "requirements": ["openhomedevice==2.0.2"],
+  "ssdp": [
+    {
+      "st": "urn:av-openhome-org:service:Product:1"
+    },
+    {
+      "st": "urn:av-openhome-org:service:Product:2"
+    },
+    {
+      "st": "urn:av-openhome-org:service:Product:3"
+    },
+    {
+      "st": "urn:av-openhome-org:service:Product:4"
+    }
+  ]
 }

--- a/homeassistant/components/openhome/media_player.py
+++ b/homeassistant/components/openhome/media_player.py
@@ -21,12 +21,15 @@ from homeassistant.components.media_player import (
     MediaType,
     async_process_play_media_url,
 )
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, entity_platform
+from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from .const import ATTR_PIN_INDEX, DATA_OPENHOME, SERVICE_INVOKE_PIN
+from .const import ATTR_PIN_INDEX, DATA_OPENHOME, DOMAIN, SERVICE_INVOKE_PIN
 
 _OpenhomeDeviceT = TypeVar("_OpenhomeDeviceT", bound="OpenhomeDevice")
 _R = TypeVar("_R")
@@ -39,6 +42,37 @@ SUPPORT_OPENHOME = (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the configuration config entry."""
+
+    _LOGGER.debug("Setting up config entry: %s", config_entry.unique_id)
+
+    device = await hass.async_add_executor_job(Device, config_entry.data[CONF_HOST])
+
+    try:
+        await device.init()
+    except (asyncio.TimeoutError, aiohttp.ClientError, UpnpError):
+        return None
+
+    _LOGGER.debug("Initialised device: %s", device.uuid())
+
+    entity = OpenhomeDevice(hass, device)
+
+    async_add_entities([entity])
+
+    platform = entity_platform.async_get_current_platform()
+
+    platform.async_register_entity_service(
+        SERVICE_INVOKE_PIN,
+        {vol.Required(ATTR_PIN_INDEX): cv.positive_int},
+        "async_invoke_pin",
+    )
 
 
 async def async_setup_platform(
@@ -132,6 +166,18 @@ class OpenhomeDevice(MediaPlayerEntity):
         self._name = None
         self._attr_state = MediaPlayerState.PLAYING
         self._available = True
+
+    @property
+    def device_info(self):
+        """Return a device description for device registry."""
+        return DeviceInfo(
+            identifiers={
+                (DOMAIN, self._device.uuid()),
+            },
+            manufacturer=self._device.device.manufacturer,
+            model=self._device.device.model_name,
+            name=self._device.device.friendly_name,
+        )
 
     @property
     def available(self):

--- a/homeassistant/components/openhome/media_player.py
+++ b/homeassistant/components/openhome/media_player.py
@@ -46,7 +46,7 @@ async def async_setup_entry(
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up the configuration config entry."""
+    """Set up the Openhome config entry."""
 
     _LOGGER.debug("Setting up config entry: %s", config_entry.unique_id)
 

--- a/homeassistant/components/openhome/media_player.py
+++ b/homeassistant/components/openhome/media_player.py
@@ -22,7 +22,6 @@ from homeassistant.components.media_player import (
     async_process_play_media_url,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.entity import DeviceInfo
@@ -53,16 +52,7 @@ async def async_setup_entry(
 
     _LOGGER.debug("Setting up config entry: %s", config_entry.unique_id)
 
-    device = await hass.async_add_executor_job(Device, config_entry.data[CONF_HOST])
-
-    try:
-        await device.init()
-    except (asyncio.TimeoutError, aiohttp.ClientError, UpnpError):
-        return None
-
-    _LOGGER.debug("Initialised device: %s", device.uuid())
-
-    entity = OpenhomeDevice(hass, device)
+    entity = hass.data[DOMAIN][config_entry.entry_id]
 
     async_add_entities([entity])
 

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -319,6 +319,7 @@ FLOWS = {
         "openai_conversation",
         "openexchangerates",
         "opengarage",
+        "openhome",
         "opentherm_gw",
         "openuv",
         "openweathermap",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -3954,7 +3954,7 @@
     "openhome": {
       "name": "Linn / OpenHome",
       "integration_type": "hub",
-      "config_flow": false,
+      "config_flow": true,
       "iot_class": "local_polling"
     },
     "opensensemap": {

--- a/homeassistant/generated/ssdp.py
+++ b/homeassistant/generated/ssdp.py
@@ -224,6 +224,20 @@ SSDP = {
             "manufacturer": "The OctoPrint Project",
         },
     ],
+    "openhome": [
+        {
+            "st": "urn:av-openhome-org:service:Product:1",
+        },
+        {
+            "st": "urn:av-openhome-org:service:Product:2",
+        },
+        {
+            "st": "urn:av-openhome-org:service:Product:3",
+        },
+        {
+            "st": "urn:av-openhome-org:service:Product:4",
+        },
+    ],
     "roku": [
         {
             "deviceType": "urn:roku-com:device:player:1-0",

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1026,6 +1026,9 @@ openai==0.27.2
 # homeassistant.components.openerz
 openerz-api==0.2.0
 
+# homeassistant.components.openhome
+openhomedevice==2.0.2
+
 # homeassistant.components.oralb
 oralb-ble==0.17.6
 

--- a/tests/components/openhome/__init__.py
+++ b/tests/components/openhome/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Linn / OpenHome integration."""

--- a/tests/components/openhome/test_config_flow.py
+++ b/tests/components/openhome/test_config_flow.py
@@ -33,12 +33,20 @@ async def test_ssdp(hass: HomeAssistant) -> None:
 
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "confirm"
+    assert result["description_placeholders"] == {CONF_NAME: MOCK_FRIENDLY_NAME}
 
-    result2 = await hass.config_entries.flow.async_configure(result["flow_id"], None)
 
-    await hass.async_block_till_done()
+async def test_ssdp_confirm(hass: HomeAssistant) -> None:
+    """Test a confirmed ssdp import flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={CONF_SOURCE: SOURCE_SSDP},
+        data=MOCK_DISCOVER,
+    )
 
-    assert result2["description_placeholders"] == {CONF_NAME: MOCK_FRIENDLY_NAME}
+    result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+    assert result2["title"] == MOCK_FRIENDLY_NAME
+    assert result2["data"] == {CONF_HOST: MOCK_SSDP_LOCATION}
 
 
 async def test_device_exists(hass: HomeAssistant) -> None:

--- a/tests/components/openhome/test_config_flow.py
+++ b/tests/components/openhome/test_config_flow.py
@@ -1,0 +1,110 @@
+"""Tests for the Openhome config flow module."""
+
+from homeassistant import data_entry_flow
+from homeassistant.components import ssdp
+from homeassistant.components.openhome.const import DOMAIN
+from homeassistant.components.ssdp import ATTR_UPNP_FRIENDLY_NAME, ATTR_UPNP_UDN
+from homeassistant.config_entries import SOURCE_SSDP
+from homeassistant.const import CONF_HOST, CONF_SOURCE
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+MOCK_UDN = "uuid:4c494e4e-1234-ab12-abcd-01234567819f"
+MOCK_FRIENDLY_NAME = "Test Client"
+MOCK_SSDP_LOCATION = "http://device:12345/description.xml"
+
+MOCK_DISCOVER = ssdp.SsdpServiceInfo(
+    ssdp_usn="usn",
+    ssdp_st="st",
+    ssdp_location=MOCK_SSDP_LOCATION,
+    upnp={ATTR_UPNP_FRIENDLY_NAME: MOCK_FRIENDLY_NAME, ATTR_UPNP_UDN: MOCK_UDN},
+)
+
+
+async def test_ssdp(hass: HomeAssistant) -> None:
+    """Test a ssdp import flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={CONF_SOURCE: SOURCE_SSDP},
+        data=MOCK_DISCOVER,
+    )
+
+    assert result["title"] == MOCK_FRIENDLY_NAME
+    assert result["data"] == {CONF_HOST: MOCK_SSDP_LOCATION}
+
+
+async def test_device_exists(hass: HomeAssistant) -> None:
+    """Test a ssdp import where device already exists."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: MOCK_SSDP_LOCATION},
+        title=MOCK_FRIENDLY_NAME,
+        unique_id=MOCK_UDN,
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={CONF_SOURCE: SOURCE_SSDP},
+        data=MOCK_DISCOVER,
+    )
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_missing_udn(hass: HomeAssistant) -> None:
+    """Test a ssdp import where discovery is missing udn."""
+    broken_discovery = ssdp.SsdpServiceInfo(
+        ssdp_usn="usn",
+        ssdp_st="st",
+        ssdp_location=MOCK_SSDP_LOCATION,
+        upnp={
+            ATTR_UPNP_FRIENDLY_NAME: MOCK_FRIENDLY_NAME,
+        },
+    )
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={CONF_SOURCE: SOURCE_SSDP},
+        data=broken_discovery,
+    )
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["reason"] == "incomplete_discovery"
+
+
+async def test_missing_ssdp_location(hass: HomeAssistant) -> None:
+    """Test a ssdp import where discovery is missing udn."""
+    broken_discovery = ssdp.SsdpServiceInfo(
+        ssdp_usn="usn",
+        ssdp_st="st",
+        ssdp_location="",
+        upnp={ATTR_UPNP_FRIENDLY_NAME: MOCK_FRIENDLY_NAME, ATTR_UPNP_UDN: MOCK_UDN},
+    )
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={CONF_SOURCE: SOURCE_SSDP},
+        data=broken_discovery,
+    )
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["reason"] == "incomplete_discovery"
+
+
+async def test_host_updated(hass: HomeAssistant) -> None:
+    """Test a ssdp import flow where host changes."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "old_host"},
+        title=MOCK_FRIENDLY_NAME,
+        unique_id=MOCK_UDN,
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={CONF_SOURCE: SOURCE_SSDP},
+        data=MOCK_DISCOVER,
+    )
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+    assert entry.data[CONF_HOST] == MOCK_SSDP_LOCATION

--- a/tests/components/openhome/test_config_flow.py
+++ b/tests/components/openhome/test_config_flow.py
@@ -5,8 +5,9 @@ from homeassistant.components import ssdp
 from homeassistant.components.openhome.const import DOMAIN
 from homeassistant.components.ssdp import ATTR_UPNP_FRIENDLY_NAME, ATTR_UPNP_UDN
 from homeassistant.config_entries import SOURCE_SSDP
-from homeassistant.const import CONF_HOST, CONF_SOURCE
+from homeassistant.const import CONF_HOST, CONF_NAME, CONF_SOURCE
 from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
 
 from tests.common import MockConfigEntry
 
@@ -30,8 +31,14 @@ async def test_ssdp(hass: HomeAssistant) -> None:
         data=MOCK_DISCOVER,
     )
 
-    assert result["title"] == MOCK_FRIENDLY_NAME
-    assert result["data"] == {CONF_HOST: MOCK_SSDP_LOCATION}
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "confirm"
+
+    result2 = await hass.config_entries.flow.async_configure(result["flow_id"], None)
+
+    await hass.async_block_till_done()
+
+    assert result2["description_placeholders"] == {CONF_NAME: MOCK_FRIENDLY_NAME}
 
 
 async def test_device_exists(hass: HomeAssistant) -> None:

--- a/tests/components/openhome/test_config_flow.py
+++ b/tests/components/openhome/test_config_flow.py
@@ -35,15 +35,6 @@ async def test_ssdp(hass: HomeAssistant) -> None:
     assert result["step_id"] == "confirm"
     assert result["description_placeholders"] == {CONF_NAME: MOCK_FRIENDLY_NAME}
 
-
-async def test_ssdp_confirm(hass: HomeAssistant) -> None:
-    """Test a confirmed ssdp import flow."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={CONF_SOURCE: SOURCE_SSDP},
-        data=MOCK_DISCOVER,
-    )
-
     result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
     assert result2["title"] == MOCK_FRIENDLY_NAME
     assert result2["data"] == {CONF_HOST: MOCK_SSDP_LOCATION}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Linn have updated firmware on all of their products in a way that makes them undiscoverable by the old discovery integration. 

This PR makes Linn devices running both the new firmware and older discoverable using ssdp config flow. 

* Add SSDP Config Flow to the Linn / Openhome component and fixes #94494
* Add unit tests for openhome config flow
* Implement `DeviceInfo` in the media player to provide information about the discovered device

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #94494
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/27804

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
