### PR TITLE
Fix keyboard_remote for python 3.11

### DIFF
--- a/homeassistant/components/keyboard_remote/__init__.py
+++ b/homeassistant/components/keyboard_remote/__init__.py
@@ -1,10 +1,12 @@
 """Receive signals from a keyboard and use it as a remote control."""
 # pylint: disable=import-error
+from __future__ import annotations
+
 import asyncio
 from contextlib import suppress
 import logging
 import os
-from __future__ import annotations
+from typing import Any
 
 from asyncinotify import Inotify, Mask
 from evdev import InputDevice, categorize, ecodes, list_devices
@@ -65,9 +67,9 @@ CONFIG_SCHEMA = vol.Schema(
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the keyboard_remote."""
-    config = config[DOMAIN]
+    domain_config: list[dict[str, Any]] = config[DOMAIN]
 
-    remote = KeyboardRemote(hass, config)
+    remote = KeyboardRemote(hass, domain_config)
     remote.setup()
 
     return True
@@ -76,7 +78,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 class KeyboardRemote:
     """Manage device connection/disconnection using inotify to asynchronously monitor."""
 
-    def __init__(self, hass: HomeAssistant, config) -> None:
+    def __init__(self, hass: HomeAssistant, config: list[dict[str, Any]]) -> None:
         """Create handlers and setup dictionaries to keep track of them."""
         self.hass = hass
         self.handlers_by_name = {}
@@ -231,15 +233,15 @@ class KeyboardRemote:
 
             self.hass = hass
 
-            key_types = dev_block.get(TYPE)
+            key_types = dev_block[TYPE]
 
             self.key_values = set()
             for key_type in key_types:
                 self.key_values.add(KEY_VALUE[key_type])
 
-            self.emulate_key_hold = dev_block.get(EMULATE_KEY_HOLD)
-            self.emulate_key_hold_delay = dev_block.get(EMULATE_KEY_HOLD_DELAY)
-            self.emulate_key_hold_repeat = dev_block.get(EMULATE_KEY_HOLD_REPEAT)
+            self.emulate_key_hold = dev_block[EMULATE_KEY_HOLD]
+            self.emulate_key_hold_delay = dev_block[EMULATE_KEY_HOLD_DELAY]
+            self.emulate_key_hold_repeat = dev_block[EMULATE_KEY_HOLD_REPEAT]
             self.monitor_task = None
             self.dev = None
 

--- a/homeassistant/components/keyboard_remote/__init__.py
+++ b/homeassistant/components/keyboard_remote/__init__.py
@@ -4,6 +4,7 @@ import asyncio
 from contextlib import suppress
 import logging
 import os
+from __future__ import annotations
 
 from asyncinotify import Inotify, Mask
 from evdev import InputDevice, categorize, ecodes, list_devices

--- a/homeassistant/components/keyboard_remote/__init__.py
+++ b/homeassistant/components/keyboard_remote/__init__.py
@@ -132,7 +132,9 @@ class KeyboardRemote:
                 continue
 
             self.active_handlers_by_descriptor[descriptor] = handler
-            initial_start_monitoring.add(handler.async_device_start_monitoring(dev))
+            initial_start_monitoring.add(
+                asyncio.create_task(handler.async_device_start_monitoring(dev))
+            )
 
         if initial_start_monitoring:
             await asyncio.wait(initial_start_monitoring)
@@ -155,7 +157,9 @@ class KeyboardRemote:
 
         handler_stop_monitoring = set()
         for handler in self.active_handlers_by_descriptor.values():
-            handler_stop_monitoring.add(handler.async_device_stop_monitoring())
+            handler_stop_monitoring.add(
+                asyncio.create_task(handler.async_device_stop_monitoring())
+            )
         if handler_stop_monitoring:
             await asyncio.wait(handler_stop_monitoring)
 

--- a/homeassistant/components/keyboard_remote/__init__.py
+++ b/homeassistant/components/keyboard_remote/__init__.py
@@ -75,7 +75,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 class KeyboardRemote:
     """Manage device connection/disconnection using inotify to asynchronously monitor."""
 
-    def __init__(self, hass, config):
+    def __init__(self, hass: HomeAssistant, config) -> None:
         """Create handlers and setup dictionaries to keep track of them."""
         self.hass = hass
         self.handlers_by_name = {}
@@ -110,6 +110,8 @@ class KeyboardRemote:
         connected, and start monitoring for device connection/disconnection.
         """
 
+        _LOGGER.debug("Start monitoring")
+
         # start watching
         self.watcher = aionotify.Watcher()
         self.watcher.watch(
@@ -134,7 +136,7 @@ class KeyboardRemote:
                 continue
 
             self.active_handlers_by_descriptor[descriptor] = handler
-            initial_start_monitoring.add(handler.async_start_monitoring(dev))
+            initial_start_monitoring.add(await handler.async_start_monitoring(dev))
 
         if initial_start_monitoring:
             await asyncio.wait(initial_start_monitoring)
@@ -153,7 +155,7 @@ class KeyboardRemote:
 
         handler_stop_monitoring = set()
         for handler in self.active_handlers_by_descriptor.values():
-            handler_stop_monitoring.add(handler.async_stop_monitoring())
+            handler_stop_monitoring.add(await handler.async_stop_monitoring())
 
         if handler_stop_monitoring:
             await asyncio.wait(handler_stop_monitoring)
@@ -215,7 +217,7 @@ class KeyboardRemote:
     class DeviceHandler:
         """Manage input events using evdev with asyncio."""
 
-        def __init__(self, hass, dev_block):
+        def __init__(self, hass: HomeAssistant, dev_block) -> None:
             """Fill configuration data."""
 
             self.hass = hass
@@ -250,6 +252,7 @@ class KeyboardRemote:
 
         async def async_start_monitoring(self, dev):
             """Start event monitoring task and issue event."""
+            _LOGGER.debug("Keyboard async_start_monitoring, %s", dev.name)
             if self.monitor_task is None:
                 self.dev = dev
                 self.monitor_task = self.hass.async_create_task(

--- a/homeassistant/components/keyboard_remote/__init__.py
+++ b/homeassistant/components/keyboard_remote/__init__.py
@@ -5,7 +5,6 @@ from contextlib import suppress
 import logging
 import os
 
-# import aionotify
 from asyncinotify import Inotify, Mask
 from evdev import InputDevice, categorize, ecodes, list_devices
 import voluptuous as vol

--- a/homeassistant/components/keyboard_remote/__init__.py
+++ b/homeassistant/components/keyboard_remote/__init__.py
@@ -225,7 +225,7 @@ class KeyboardRemote:
     class DeviceHandler:
         """Manage input events using evdev with asyncio."""
 
-        def __init__(self, hass: HomeAssistant, dev_block) -> None:
+        def __init__(self, hass: HomeAssistant, dev_block: dict[str, Any]) -> None:
             """Fill configuration data."""
 
             self.hass = hass

--- a/homeassistant/components/keyboard_remote/manifest.json
+++ b/homeassistant/components/keyboard_remote/manifest.json
@@ -5,8 +5,5 @@
   "documentation": "https://www.home-assistant.io/integrations/keyboard_remote",
   "iot_class": "local_push",
   "loggers": ["aionotify", "evdev"],
-  "requirements": [
-    "evdev==1.6.1",
-    "aionotify @ git+https://github.com/rickwierenga/aionotify@master"
-  ]
+  "requirements": ["evdev==1.6.1", "asyncinotify==4.0.2"]
 }

--- a/homeassistant/components/keyboard_remote/manifest.json
+++ b/homeassistant/components/keyboard_remote/manifest.json
@@ -5,5 +5,8 @@
   "documentation": "https://www.home-assistant.io/integrations/keyboard_remote",
   "iot_class": "local_push",
   "loggers": ["aionotify", "evdev"],
-  "requirements": ["evdev==1.4.0", "aionotify==0.2.0"]
+  "requirements": [
+    "evdev==1.6.1",
+    "aionotify @ git+https://github.com/rickwierenga/aionotify@master"
+  ]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -297,9 +297,6 @@ aiomusiccast==0.14.8
 # homeassistant.components.nanoleaf
 aionanoleaf==0.2.1
 
-# homeassistant.components.keyboard_remote
-aionotify @ git+https://github.com/rickwierenga/aionotify@master
-
 # homeassistant.components.notion
 aionotion==2023.05.5
 
@@ -450,6 +447,9 @@ asterisk-mbox==0.5.0
 # homeassistant.components.upnp
 # homeassistant.components.yeelight
 async-upnp-client==0.33.2
+
+# homeassistant.components.keyboard_remote
+asyncinotify==4.0.2
 
 # homeassistant.components.supla
 asyncpysupla==0.0.5
@@ -758,7 +758,7 @@ eternalegypt==0.0.16
 eufylife-ble-client==0.1.7
 
 # homeassistant.components.keyboard_remote
-evdev==1.6.1
+# evdev==1.6.1
 
 # homeassistant.components.evohome
 evohome-async==0.3.15

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -298,7 +298,7 @@ aiomusiccast==0.14.8
 aionanoleaf==0.2.1
 
 # homeassistant.components.keyboard_remote
-aionotify==0.2.0
+aionotify @ git+https://github.com/rickwierenga/aionotify@master
 
 # homeassistant.components.notion
 aionotion==2023.05.5
@@ -758,7 +758,7 @@ eternalegypt==0.0.16
 eufylife-ble-client==0.1.7
 
 # homeassistant.components.keyboard_remote
-# evdev==1.4.0
+evdev==1.6.1
 
 # homeassistant.components.evohome
 evohome-async==0.3.15


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
With the upgrade to Python 3.11 the `keyboard_remote` integration broke. 

This PR changes the underlying library from `aionotify` which lacked python 3.11 support to `asyncinotify` which is fully supported.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #94215

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
