### PR TITLE
Fix ness_alarm tasks being fired before required sensors and panel are loaded asynchronously

### DIFF
--- a/homeassistant/components/ness_alarm/__init__.py
+++ b/homeassistant/components/ness_alarm/__init__.py
@@ -22,8 +22,8 @@ from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_send
-from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.start import async_at_started
+from homeassistant.helpers.typing import ConfigType
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/ness_alarm/__init__.py
+++ b/homeassistant/components/ness_alarm/__init__.py
@@ -1,7 +1,7 @@
 """Support for Ness D8X/D16X devices."""
 from collections import namedtuple
 import datetime
-import logging                            
+import logging
 
 from nessclient import ArmingState, Client
 import voluptuous as vol
@@ -15,7 +15,6 @@ from homeassistant.const import (
     ATTR_STATE,
     CONF_HOST,
     CONF_SCAN_INTERVAL,
-    EVENT_HOMEASSISTANT_STARTED,                                                                
     EVENT_HOMEASSISTANT_STOP,
     Platform,
 )
@@ -24,9 +23,10 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.typing import ConfigType
+from homeassistant.helpers.start import async_at_started
 
 _LOGGER = logging.getLogger(__name__)
-                                                                        
+
 DOMAIN = "ness_alarm"
 DATA_NESS = "ness_alarm"
 
@@ -115,11 +115,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     async def _started(event):
         # Force update for current arming status and current zone states (once Home Assistant has finished loading required sensors and panel)
-        _LOGGER.debug("%s event - invoking client keepalive() & update()", EVENT_HOMEASSISTANT_STARTED)
+        _LOGGER.debug("invoking client keepalive() & update()")
         hass.loop.create_task(client.keepalive())
         hass.loop.create_task(client.update())
 
-    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, _started)                              
+    async_at_started(hass, _started)
 
     hass.async_create_task(
         async_load_platform(

--- a/homeassistant/components/ness_alarm/__init__.py
+++ b/homeassistant/components/ness_alarm/__init__.py
@@ -1,6 +1,7 @@
 """Support for Ness D8X/D16X devices."""
 from collections import namedtuple
 import datetime
+import logging                            
 
 from nessclient import ArmingState, Client
 import voluptuous as vol
@@ -14,6 +15,7 @@ from homeassistant.const import (
     ATTR_STATE,
     CONF_HOST,
     CONF_SCAN_INTERVAL,
+    EVENT_HOMEASSISTANT_STARTED,                                                                
     EVENT_HOMEASSISTANT_STOP,
     Platform,
 )
@@ -23,6 +25,8 @@ from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.typing import ConfigType
 
+_LOGGER = logging.getLogger(__name__)
+                                                                        
 DOMAIN = "ness_alarm"
 DATA_NESS = "ness_alarm"
 
@@ -109,6 +113,14 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _close)
 
+    async def _started(event):
+        # Force update for current arming status and current zone states (once Home Assistant has finished loading required sensors and panel)
+        _LOGGER.debug("%s event - invoking client keepalive() & update()", EVENT_HOMEASSISTANT_STARTED)
+        hass.loop.create_task(client.keepalive())
+        hass.loop.create_task(client.update())
+
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, _started)                              
+
     hass.async_create_task(
         async_load_platform(
             hass, Platform.BINARY_SENSOR, DOMAIN, {CONF_ZONES: zones}, config
@@ -130,10 +142,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     client.on_zone_change(on_zone_change)
     client.on_state_change(on_state_change)
-
-    # Force update for current arming status and current zone states
-    hass.loop.create_task(client.keepalive())
-    hass.loop.create_task(client.update())
 
     async def handle_panic(call: ServiceCall) -> None:
         await client.panic(call.data[ATTR_CODE])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix ness_alarm tasks client.keepalive() and client.update() being fired before the required binary sensors and alarm panel have been loaded, but invoking the tasks from an event listener on EVENT_HOMEASSISTANT_STARTED


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #92851
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
