### PR TITLE
Allow using `!include` with arbitrary types

### DIFF
--- a/homeassistant/util/yaml/loader.py
+++ b/homeassistant/util/yaml/loader.py
@@ -203,12 +203,16 @@ def _parse_yaml(
     secrets: Secrets | None = None,
 ) -> JSON_TYPE:
     """Load a YAML file."""
-    # If configuration file is empty YAML returns None
-    # We convert that to an empty dict
-    return (
-        yaml.load(content, Loader=lambda stream: loader(stream, secrets))
-        or NodeDictClass()
-    )
+    doc = yaml.load(content, Loader=lambda stream: loader(stream, secrets))
+    if doc is None:
+        # If configuration file is empty, YAML returns `None
+        # We convert that to an empty dict
+        # This means we don't support a document whose only value is `null`,
+        # Adding `None` checks didn't seem worth it, and `wrap_for_setattr`
+        # doesn't work with `NoneType` as it is not a valid base type
+        return NodeDictClass()
+
+    return doc
 
 
 @overload

--- a/homeassistant/util/yaml/objects.py
+++ b/homeassistant/util/yaml/objects.py
@@ -10,12 +10,22 @@ class NodeListClass(list):
     """Wrapper class to be able to add attributes on a list."""
 
 
-class NodeStrClass(str):
-    """Wrapper class to be able to add attributes on a string."""
-
-
 class NodeDictClass(dict):
     """Wrapper class to be able to add attributes on a dict."""
+
+
+def wrap_for_setattr(obj):  # type: ignore[no-untyped-def]
+    """Wrap an arbitrary object to be able to add attributes to it."""
+    if isinstance(obj, list):
+        return NodeListClass(obj)
+
+    typ = type(obj)
+
+    # Create a subclass of `typ` to be able to add attributes
+    cls = type(f"DynamicNode{typ.__name__.capitalize()}Class", (typ,), {})
+
+    # Return an instance of `cls` with value `obj`
+    return cls(obj)
 
 
 @dataclass(slots=True, frozen=True)

--- a/tests/util/yaml/test_init.py
+++ b/tests/util/yaml/test_init.py
@@ -109,12 +109,30 @@ def test_invalid_environment_variable(try_both_loaders) -> None:
 
 
 @pytest.mark.parametrize(
+    ("hass_config_yaml", "expected"),
+    [
+        ("", {}),
+        ("null", {}),
+        ("''", ""),
+        ("0", 0),
+    ],
+)
+def test_parse_yaml_falsey_values(
+    try_both_loaders, hass_config_yaml: str, expected: Any
+) -> None:
+    """Test load yaml falsey values."""
+    doc = yaml_loader.parse_yaml(hass_config_yaml)
+    assert doc == expected
+
+
+@pytest.mark.parametrize(
     ("hass_config_yaml_files", "value"),
     [
         ({"test.yaml": "value"}, "value"),
         ({"test.yaml": None}, {}),  # missing file
         ({"test.yaml": ""}, {}),  # empty file
         ({"test.yaml": "null"}, {}),  # null document
+        ({"test.yaml": "0"}, 0),  # falsey value
         ({"test.yaml": "1.0"}, 1.0),
     ],
 )

--- a/tests/util/yaml/test_init.py
+++ b/tests/util/yaml/test_init.py
@@ -110,10 +110,16 @@ def test_invalid_environment_variable(try_both_loaders) -> None:
 
 @pytest.mark.parametrize(
     ("hass_config_yaml_files", "value"),
-    [({"test.yaml": "value"}, "value"), ({"test.yaml": None}, {})],
+    [
+        ({"test.yaml": "value"}, "value"),
+        ({"test.yaml": None}, {}),  # missing file
+        ({"test.yaml": ""}, {}),  # empty file
+        ({"test.yaml": "null"}, {}),  # null document
+        ({"test.yaml": "1.0"}, 1.0),
+    ],
 )
 def test_include_yaml(
-    try_both_loaders, mock_hass_config_yaml: None, value: Any
+    try_both_loaders, mock_hass_config_yaml: None, hass_config_yaml_files, value: Any
 ) -> None:
     """Test include yaml."""
     conf = "key: !include test.yaml"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I want to be able to use `!include` in more places, and thus want it to support all possible types.

EDIT: added more details in the following paragraphs.

Basically the whole picture is I manage my secrets outside of HM. I store each value individually because I don't want to have one giant secret blob that ends up being the `secrets.yaml` file. This also makes it so when a single secret changes, only that one needs to be encrypted and updated, the others continue using their existing encrypted file.  
Before HM starts, each secret is decrypted and written to a file in `/run` so it's guaranteed to never be written to disk (matters on SSDs where there's no way to erase the backing storage). I want to include those single files in the config.

I can already do that for lists, dictionaries and strings, but I'd like it to work with other fields. For instance `homeassistant.latitude` and `.longitude`. Right now  HM fails with `AttributeError: '<type>' object has no attribute '__config_file__'`.  
If, like implemented in this PR, instead of having to implement a `NodeClass` for each type we want to allow we use a generic type, we allow the user to use (almost) everything. The exception being `null`/`None`, but that doesn't have too much value.

Here's an example that matches my actual use case:
```yaml
# configuration.yaml
homeassistant:
  country: !include /run/secrets/hm-country.yml
  latitude: !include /run/secrets/hm-latitude.yml
  longitude: !include /run/secrets/hm-longitude.yml
```

```yaml
# /run/secrets/hm-country.yml
"CountryCode" # this works with the existing code (as with every YAML document, the quotes are optional)
```

```yaml
# /run/secrets/hm-latitude.yml
0.01 # current code fails with: AttributeError: 'float' object has no attribute '__config_file__`
```

```yaml
# /run/secrets/hm-longitude.yml
10 # current code fails with: AttributeError: 'int' object has no attribute '__config_file__`
```

(Doesn't really matter for this PR, but my `configuration.yaml` is actually generated by the secrets manager that also merges in my non secret config values. I don't manually write all the `!include`s.)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- ~This PR fixes or closes issue: fixes #~
- ~This PR is related to issue:~
- ~Link to documentation pull request:~

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

~If the code communicates with devices, web services, or third-party tools:~

- [ ] ~The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.~
- [ ] ~New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.~
- [ ] ~For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.~
- [ ] ~Untested files have been added to `.coveragerc`.~

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
