### PR TITLE
Remove Verisure default lock code

### DIFF
--- a/homeassistant/components/verisure/__init__.py
+++ b/homeassistant/components/verisure/__init__.py
@@ -14,7 +14,7 @@ from homeassistant.helpers import entity_registry as er
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.storage import STORAGE_DIR
 
-from .const import CONF_LOCK_DEFAULT_CODE, DOMAIN
+from .const import CONF_LOCK_DEFAULT_CODE, DOMAIN, LOGGER
 from .coordinator import VerisureDataUpdateCoordinator
 
 PLATFORMS = [
@@ -44,19 +44,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data[DOMAIN][entry.entry_id] = coordinator
 
     # Migrate lock default code from config entry to lock entity
-    if config_entry_default_code := entry.options.get(CONF_LOCK_DEFAULT_CODE):
-        entity_reg = er.async_get(hass)
-        entries = er.async_entries_for_config_entry(entity_reg, entry.entry_id)
-        for entity in entries:
-            if entity.entity_id.startswith("lock"):
-                entity_reg.async_update_entity_options(
-                    entity.entity_id,
-                    LOCK_DOMAIN,
-                    {CONF_DEFAULT_CODE: config_entry_default_code},
-                )
-        new_options = entry.options.copy()
-        del new_options[CONF_LOCK_DEFAULT_CODE]
-        hass.config_entries.async_update_entry(entry, options=new_options)
 
     # Set up all platforms for this device/entry.
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
@@ -89,3 +76,29 @@ def migrate_cookie_files(hass: HomeAssistant, entry: ConfigEntry) -> None:
         cookie_file.rename(
             hass.config.path(STORAGE_DIR, f"verisure_{entry.data[CONF_EMAIL]}")
         )
+
+
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Migrate old entry."""
+    LOGGER.debug("Migrating from version %s", entry.version)
+
+    if entry.version == 1:
+        config_entry_default_code = entry.options.get(CONF_LOCK_DEFAULT_CODE)
+        entity_reg = er.async_get(hass)
+        entries = er.async_entries_for_config_entry(entity_reg, entry.entry_id)
+        for entity in entries:
+            if entity.entity_id.startswith("lock"):
+                entity_reg.async_update_entity_options(
+                    entity.entity_id,
+                    LOCK_DOMAIN,
+                    {CONF_DEFAULT_CODE: config_entry_default_code},
+                )
+        new_options = entry.options.copy()
+        del new_options[CONF_LOCK_DEFAULT_CODE]
+
+        entry.version = 2
+        hass.config_entries.async_update_entry(entry, options=new_options)
+
+    LOGGER.info("Migration to version %s successful", entry.version)
+
+    return True

--- a/homeassistant/components/verisure/__init__.py
+++ b/homeassistant/components/verisure/__init__.py
@@ -5,14 +5,16 @@ from contextlib import suppress
 import os
 from pathlib import Path
 
+from homeassistant.components.lock import CONF_DEFAULT_CODE, DOMAIN as LOCK_DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_EMAIL, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import entity_registry as er
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.storage import STORAGE_DIR
 
-from .const import DOMAIN
+from .const import CONF_LOCK_DEFAULT_CODE, DOMAIN
 from .coordinator import VerisureDataUpdateCoordinator
 
 PLATFORMS = [
@@ -40,6 +42,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = coordinator
+
+    # Migrate lock default code from config entry to lock entity
+    if config_entry_default_code := entry.options.get(CONF_LOCK_DEFAULT_CODE):
+        entity_reg = er.async_get(hass)
+        entries = er.async_entries_for_config_entry(entity_reg, entry.entry_id)
+        for entity in entries:
+            if entity.entity_id.startswith("lock"):
+                entity_reg.async_update_entity_options(
+                    entity.entity_id,
+                    LOCK_DOMAIN,
+                    {CONF_DEFAULT_CODE: config_entry_default_code},
+                )
+        new_options = entry.options.copy()
+        del new_options[CONF_LOCK_DEFAULT_CODE]
+        hass.config_entries.async_update_entry(entry, options=new_options)
 
     # Set up all platforms for this device/entry.
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/homeassistant/components/verisure/config_flow.py
+++ b/homeassistant/components/verisure/config_flow.py
@@ -30,7 +30,7 @@ from .const import (
 class VerisureConfigFlowHandler(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Verisure."""
 
-    VERSION = 1
+    VERSION = 2
 
     email: str
     entry: ConfigEntry

--- a/homeassistant/components/verisure/config_flow.py
+++ b/homeassistant/components/verisure/config_flow.py
@@ -21,7 +21,6 @@ from homeassistant.helpers.storage import STORAGE_DIR
 from .const import (
     CONF_GIID,
     CONF_LOCK_CODE_DIGITS,
-    CONF_LOCK_DEFAULT_CODE,
     DEFAULT_LOCK_CODE_DIGITS,
     DOMAIN,
     LOGGER,
@@ -306,16 +305,10 @@ class VerisureOptionsFlowHandler(OptionsFlow):
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Manage Verisure options."""
-        errors = {}
+        errors: dict[str, Any] = {}
 
         if user_input is not None:
-            if len(user_input[CONF_LOCK_DEFAULT_CODE]) not in [
-                0,
-                user_input[CONF_LOCK_CODE_DIGITS],
-            ]:
-                errors["base"] = "code_format_mismatch"
-            else:
-                return self.async_create_entry(title="", data=user_input)
+            return self.async_create_entry(data=user_input)
 
         return self.async_show_form(
             step_id="init",
@@ -323,14 +316,13 @@ class VerisureOptionsFlowHandler(OptionsFlow):
                 {
                     vol.Optional(
                         CONF_LOCK_CODE_DIGITS,
-                        default=self.entry.options.get(
-                            CONF_LOCK_CODE_DIGITS, DEFAULT_LOCK_CODE_DIGITS
-                        ),
+                        description={
+                            "suggested_value": self.entry.options.get(
+                                CONF_LOCK_CODE_DIGITS
+                            )
+                            or DEFAULT_LOCK_CODE_DIGITS
+                        },
                     ): int,
-                    vol.Optional(
-                        CONF_LOCK_DEFAULT_CODE,
-                        default=self.entry.options.get(CONF_LOCK_DEFAULT_CODE, ""),
-                    ): str,
                 }
             ),
             errors=errors,

--- a/homeassistant/components/verisure/config_flow.py
+++ b/homeassistant/components/verisure/config_flow.py
@@ -318,9 +318,8 @@ class VerisureOptionsFlowHandler(OptionsFlow):
                         CONF_LOCK_CODE_DIGITS,
                         description={
                             "suggested_value": self.entry.options.get(
-                                CONF_LOCK_CODE_DIGITS
+                                CONF_LOCK_CODE_DIGITS, DEFAULT_LOCK_CODE_DIGITS
                             )
-                            or DEFAULT_LOCK_CODE_DIGITS
                         },
                     ): int,
                 }

--- a/homeassistant/components/verisure/const.py
+++ b/homeassistant/components/verisure/const.py
@@ -15,7 +15,6 @@ LOGGER = logging.getLogger(__package__)
 
 CONF_GIID = "giid"
 CONF_LOCK_CODE_DIGITS = "lock_code_digits"
-CONF_LOCK_DEFAULT_CODE = "lock_default_code"
 
 DEFAULT_SCAN_INTERVAL = timedelta(minutes=1)
 DEFAULT_LOCK_CODE_DIGITS = 4

--- a/homeassistant/components/verisure/const.py
+++ b/homeassistant/components/verisure/const.py
@@ -15,6 +15,7 @@ LOGGER = logging.getLogger(__package__)
 
 CONF_GIID = "giid"
 CONF_LOCK_CODE_DIGITS = "lock_code_digits"
+CONF_LOCK_DEFAULT_CODE = "lock_default_code"
 
 DEFAULT_SCAN_INTERVAL = timedelta(minutes=1)
 DEFAULT_LOCK_CODE_DIGITS = 4

--- a/homeassistant/components/verisure/lock.py
+++ b/homeassistant/components/verisure/lock.py
@@ -20,7 +20,6 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import (
     CONF_GIID,
     CONF_LOCK_CODE_DIGITS,
-    CONF_LOCK_DEFAULT_CODE,
     DEFAULT_LOCK_CODE_DIGITS,
     DOMAIN,
     LOGGER,
@@ -129,25 +128,15 @@ class VerisureDoorlock(CoordinatorEntity[VerisureDataUpdateCoordinator], LockEnt
 
     async def async_unlock(self, **kwargs: Any) -> None:
         """Send unlock command."""
-        code = kwargs.get(
-            ATTR_CODE, self.coordinator.entry.options.get(CONF_LOCK_DEFAULT_CODE)
-        )
-        if code is None:
-            LOGGER.error("Code required but none provided")
-            return
-
-        await self.async_set_lock_state(code, STATE_UNLOCKED)
+        code = kwargs.get(ATTR_CODE)
+        if code:
+            await self.async_set_lock_state(code, STATE_UNLOCKED)
 
     async def async_lock(self, **kwargs: Any) -> None:
         """Send lock command."""
-        code = kwargs.get(
-            ATTR_CODE, self.coordinator.entry.options.get(CONF_LOCK_DEFAULT_CODE)
-        )
-        if code is None:
-            LOGGER.error("Code required but none provided")
-            return
-
-        await self.async_set_lock_state(code, STATE_LOCKED)
+        code = kwargs.get(ATTR_CODE)
+        if code:
+            await self.async_set_lock_state(code, STATE_LOCKED)
 
     async def async_set_lock_state(self, code: str, state: str) -> None:
         """Send set lock state command."""

--- a/homeassistant/components/verisure/strings.json
+++ b/homeassistant/components/verisure/strings.json
@@ -48,13 +48,9 @@
     "step": {
       "init": {
         "data": {
-          "lock_code_digits": "Number of digits in PIN code for locks",
-          "lock_default_code": "Default PIN code for locks, used if none is given"
+          "lock_code_digits": "Number of digits in PIN code for locks"
         }
       }
-    },
-    "error": {
-      "code_format_mismatch": "The default PIN code does not match the required number of digits"
     }
   },
   "entity": {

--- a/tests/components/verisure/conftest.py
+++ b/tests/components/verisure/conftest.py
@@ -23,6 +23,7 @@ def mock_config_entry() -> MockConfigEntry:
             CONF_GIID: "12345",
             CONF_PASSWORD: "SuperS3cr3t!",
         },
+        version=2,
     )
 
 

--- a/tests/components/verisure/test_config_flow.py
+++ b/tests/components/verisure/test_config_flow.py
@@ -562,11 +562,7 @@ async def test_reauth_flow_errors(
 
 async def test_options_flow(hass: HomeAssistant) -> None:
     """Test options config flow."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        unique_id="12345",
-        data={},
-    )
+    entry = MockConfigEntry(domain=DOMAIN, unique_id="12345", data={}, version=2)
     entry.add_to_hass(hass)
 
     with patch(

--- a/tests/components/verisure/test_config_flow.py
+++ b/tests/components/verisure/test_config_flow.py
@@ -11,7 +11,6 @@ from homeassistant.components import dhcp
 from homeassistant.components.verisure.const import (
     CONF_GIID,
     CONF_LOCK_CODE_DIGITS,
-    CONF_LOCK_DEFAULT_CODE,
     DEFAULT_LOCK_CODE_DIGITS,
     DOMAIN,
 )
@@ -561,42 +560,7 @@ async def test_reauth_flow_errors(
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-@pytest.mark.parametrize(
-    ("input", "output"),
-    [
-        (
-            {
-                CONF_LOCK_CODE_DIGITS: 5,
-                CONF_LOCK_DEFAULT_CODE: "12345",
-            },
-            {
-                CONF_LOCK_CODE_DIGITS: 5,
-                CONF_LOCK_DEFAULT_CODE: "12345",
-            },
-        ),
-        (
-            {
-                CONF_LOCK_DEFAULT_CODE: "",
-            },
-            {
-                CONF_LOCK_DEFAULT_CODE: "",
-                CONF_LOCK_CODE_DIGITS: DEFAULT_LOCK_CODE_DIGITS,
-            },
-        ),
-        (
-            {
-                CONF_LOCK_CODE_DIGITS: 5,
-            },
-            {
-                CONF_LOCK_CODE_DIGITS: 5,
-                CONF_LOCK_DEFAULT_CODE: "",
-            },
-        ),
-    ],
-)
-async def test_options_flow(
-    hass: HomeAssistant, input: dict[str, int | str], output: dict[str, int | str]
-) -> None:
+async def test_options_flow(hass: HomeAssistant) -> None:
     """Test options config flow."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -619,43 +583,8 @@ async def test_options_flow(
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
-        user_input=input,
+        user_input={CONF_LOCK_CODE_DIGITS: 4},
     )
 
     assert result.get("type") == FlowResultType.CREATE_ENTRY
-    assert result.get("data") == output
-
-
-async def test_options_flow_code_format_mismatch(hass: HomeAssistant) -> None:
-    """Test options config flow with a code format mismatch."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        unique_id="12345",
-        data={},
-    )
-    entry.add_to_hass(hass)
-
-    with patch(
-        "homeassistant.components.verisure.async_setup_entry",
-        return_value=True,
-    ):
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-    result = await hass.config_entries.options.async_init(entry.entry_id)
-
-    assert result.get("type") == FlowResultType.FORM
-    assert result.get("step_id") == "init"
-    assert result.get("errors") == {}
-
-    result = await hass.config_entries.options.async_configure(
-        result["flow_id"],
-        user_input={
-            CONF_LOCK_CODE_DIGITS: 5,
-            CONF_LOCK_DEFAULT_CODE: "123",
-        },
-    )
-
-    assert result.get("type") == FlowResultType.FORM
-    assert result.get("step_id") == "init"
-    assert result.get("errors") == {"base": "code_format_mismatch"}
+    assert result.get("data") == {CONF_LOCK_CODE_DIGITS: DEFAULT_LOCK_CODE_DIGITS}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove setting default code in OptionsFlow for Verisure
Default code can now be configured on the entity directly

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
