### PR TITLE
Fix debouncer not scheduling timer when wrapped function raises

### DIFF
--- a/homeassistant/helpers/debounce.py
+++ b/homeassistant/helpers/debounce.py
@@ -90,11 +90,12 @@ class Debouncer(Generic[_R_co]):
             if self._timer_task:
                 return
 
-            task = self.hass.async_run_hass_job(self._job)
-            if task:
-                await task
-
-            self._schedule_timer()
+            try:
+                task = self.hass.async_run_hass_job(self._job)
+                if task:
+                    await task
+            finally:
+                self._schedule_timer()
 
     async def _handle_timer_finish(self) -> None:
         """Handle a finished timer."""
@@ -117,9 +118,9 @@ class Debouncer(Generic[_R_co]):
                     await task
             except Exception:  # pylint: disable=broad-except
                 self.logger.exception("Unexpected exception from %s", self.function)
-
-            # Schedule a new timer to prevent new runs during cooldown
-            self._schedule_timer()
+            finally:
+                # Schedule a new timer to prevent new runs during cooldown
+                self._schedule_timer()
 
     async def async_shutdown(self) -> None:
         """Cancel any scheduled call, and prevent new runs."""

--- a/homeassistant/helpers/debounce.py
+++ b/homeassistant/helpers/debounce.py
@@ -91,8 +91,7 @@ class Debouncer(Generic[_R_co]):
                 return
 
             try:
-                task = self.hass.async_run_hass_job(self._job)
-                if task:
+                if task := self.hass.async_run_hass_job(self._job):
                     await task
             finally:
                 self._schedule_timer()
@@ -113,8 +112,7 @@ class Debouncer(Generic[_R_co]):
                 return
 
             try:
-                task = self.hass.async_run_hass_job(self._job)
-                if task:
+                if task := self.hass.async_run_hass_job(self._job):
                     await task
             except Exception:  # pylint: disable=broad-except
                 self.logger.exception("Unexpected exception from %s", self.function)

--- a/tests/helpers/test_debounce.py
+++ b/tests/helpers/test_debounce.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import debounce
 from homeassistant.util.dt import utcnow
 
@@ -50,6 +50,68 @@ async def test_immediate_works(hass: HomeAssistant) -> None:
 
     # Call and let timer run out
     await debouncer.async_call()
+    assert len(calls) == 2
+    async_fire_time_changed(hass, utcnow() + timedelta(seconds=1))
+    await hass.async_block_till_done()
+    assert len(calls) == 2
+    assert debouncer._timer_task is None
+    assert debouncer._execute_at_end_of_timer is False
+    assert debouncer._job.target == debouncer.function
+    assert debouncer._job == before_job
+
+    # Test calling doesn't execute/cooldown if currently executing.
+    await debouncer._execute_lock.acquire()
+    await debouncer.async_call()
+    assert len(calls) == 2
+    assert debouncer._timer_task is None
+    assert debouncer._execute_at_end_of_timer is False
+    debouncer._execute_lock.release()
+    assert debouncer._job.target == debouncer.function
+
+
+async def test_immediate_works_with_passd_function_raises(hass: HomeAssistant) -> None:
+    """Test immediate works."""
+    calls = []
+
+    @callback
+    def _append_and_raise() -> None:
+        calls.append(None)
+        raise RuntimeError("forced_raise")
+
+    debouncer = debounce.Debouncer(
+        hass,
+        _LOGGER,
+        cooldown=0.01,
+        immediate=True,
+        function=_append_and_raise,
+    )
+
+    # Call when nothing happening
+    with pytest.raises(RuntimeError, match="forced_raise"):
+        await debouncer.async_call()
+    assert len(calls) == 1
+    assert debouncer._timer_task is not None
+    assert debouncer._execute_at_end_of_timer is False
+    assert debouncer._job.target == debouncer.function
+
+    # Call when cooldown active setting execute at end to True
+    await debouncer.async_call()
+    assert len(calls) == 1
+    assert debouncer._timer_task is not None
+    assert debouncer._execute_at_end_of_timer is True
+    assert debouncer._job.target == debouncer.function
+
+    # Canceling debounce in cooldown
+    debouncer.async_cancel()
+    assert debouncer._timer_task is None
+    assert debouncer._execute_at_end_of_timer is False
+    assert debouncer._job.target == debouncer.function
+
+    before_job = debouncer._job
+
+    # Call and let timer run out
+    with pytest.raises(RuntimeError, match="forced_raise"):
+        await debouncer.async_call()
     assert len(calls) == 2
     async_fire_time_changed(hass, utcnow() + timedelta(seconds=1))
     await hass.async_block_till_done()

--- a/tests/helpers/test_debounce.py
+++ b/tests/helpers/test_debounce.py
@@ -69,12 +69,77 @@ async def test_immediate_works(hass: HomeAssistant) -> None:
     assert debouncer._job.target == debouncer.function
 
 
-async def test_immediate_works_with_passd_function_raises(hass: HomeAssistant) -> None:
-    """Test immediate works."""
+async def test_immediate_works_with_passed_callback_function_raises(
+    hass: HomeAssistant,
+) -> None:
+    """Test immediate works with a callback function that raises."""
     calls = []
 
     @callback
     def _append_and_raise() -> None:
+        calls.append(None)
+        raise RuntimeError("forced_raise")
+
+    debouncer = debounce.Debouncer(
+        hass,
+        _LOGGER,
+        cooldown=0.01,
+        immediate=True,
+        function=_append_and_raise,
+    )
+
+    # Call when nothing happening
+    with pytest.raises(RuntimeError, match="forced_raise"):
+        await debouncer.async_call()
+    assert len(calls) == 1
+    assert debouncer._timer_task is not None
+    assert debouncer._execute_at_end_of_timer is False
+    assert debouncer._job.target == debouncer.function
+
+    # Call when cooldown active setting execute at end to True
+    await debouncer.async_call()
+    assert len(calls) == 1
+    assert debouncer._timer_task is not None
+    assert debouncer._execute_at_end_of_timer is True
+    assert debouncer._job.target == debouncer.function
+
+    # Canceling debounce in cooldown
+    debouncer.async_cancel()
+    assert debouncer._timer_task is None
+    assert debouncer._execute_at_end_of_timer is False
+    assert debouncer._job.target == debouncer.function
+
+    before_job = debouncer._job
+
+    # Call and let timer run out
+    with pytest.raises(RuntimeError, match="forced_raise"):
+        await debouncer.async_call()
+    assert len(calls) == 2
+    async_fire_time_changed(hass, utcnow() + timedelta(seconds=1))
+    await hass.async_block_till_done()
+    assert len(calls) == 2
+    assert debouncer._timer_task is None
+    assert debouncer._execute_at_end_of_timer is False
+    assert debouncer._job.target == debouncer.function
+    assert debouncer._job == before_job
+
+    # Test calling doesn't execute/cooldown if currently executing.
+    await debouncer._execute_lock.acquire()
+    await debouncer.async_call()
+    assert len(calls) == 2
+    assert debouncer._timer_task is None
+    assert debouncer._execute_at_end_of_timer is False
+    debouncer._execute_lock.release()
+    assert debouncer._job.target == debouncer.function
+
+
+async def test_immediate_works_with_passed_coroutine_raises(
+    hass: HomeAssistant,
+) -> None:
+    """Test immediate works with a coroutine that raises."""
+    calls = []
+
+    async def _append_and_raise() -> None:
         calls.append(None)
         raise RuntimeError("forced_raise")
 


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix debouncer not scheduling timer when the wrapped function raises

This might explain why sometimes integrations stop updating without a reload

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
