### PR TITLE
Add service response data for listing calendar events

### DIFF
--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -775,7 +775,7 @@ async def async_create_event(entity: CalendarEntity, call: ServiceCall) -> None:
 async def async_list_events_service(
     calendar: CalendarEntity, service_call: ServiceCall
 ) -> ServiceResponse:
-    """Handle snapshot services calls."""
+    """List events on a calendar during a time drange."""
     start = service_call.data.get(EVENT_START_DATETIME, dt_util.now())
     if EVENT_DURATION in service_call.data:
         end = start + service_call.data[EVENT_DURATION]

--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -259,6 +259,7 @@ CALENDAR_EVENT_SCHEMA = vol.Schema(
 
 SERVICE_LIST_EVENTS: Final = "list_events"
 SERVICE_LIST_EVENTS_SCHEMA: Final = vol.All(
+    cv.has_at_least_one_key(EVENT_END_DATETIME, EVENT_DURATION),
     cv.has_at_most_one_key(EVENT_END_DATETIME, EVENT_DURATION),
     cv.make_entity_service_schema(
         {

--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -252,8 +252,8 @@ CALENDAR_EVENT_SCHEMA = vol.Schema(
 
 SERVICE_LIST_EVENTS: Final = "list_events"
 SERVICE_LIST_EVENTS_SCHEMA: Final = {
-    vol.Required("start"): datetime.datetime,
-    vol.Required("end"): datetime.datetime,
+    vol.Required("start_date_time"): datetime.datetime,
+    vol.Required("end_date_time"): datetime.datetime,
 }
 
 
@@ -763,8 +763,8 @@ async def async_list_events_service(
         raise ValueError(
             "Service call did not request response data, but the list_events service requires it"
         )
-    start = service_call.data["start"]
-    end = service_call.data["end"]
+    start = service_call.data["start_date_time"]
+    end = service_call.data["end_date_time"]
     calendar_event_list = await calendar.async_get_events(calendar.hass, start, end)
     return {
         "events": [

--- a/homeassistant/components/calendar/const.py
+++ b/homeassistant/components/calendar/const.py
@@ -40,3 +40,4 @@ EVENT_TIME_FIELDS = {
     EVENT_IN,
 }
 EVENT_TYPES = "event_types"
+EVENT_DURATION = "duration"

--- a/homeassistant/components/calendar/services.yaml
+++ b/homeassistant/components/calendar/services.yaml
@@ -67,7 +67,7 @@ list_events:
         datetime:
     end_date_time:
       name: End time
-      description: Return active events before this time (exclusive). Cannot be used with 'in'.
+      description: Return active events before this time (exclusive). Cannot be used with 'duration'.
       example: "2022-03-22 22:00:00"
       selector:
         datetime:

--- a/homeassistant/components/calendar/services.yaml
+++ b/homeassistant/components/calendar/services.yaml
@@ -52,3 +52,22 @@ create_event:
       example: "Conference Room - F123, Bldg. 002"
       selector:
         text:
+list_events:
+  name: List event
+  description: List events on a calendar within a time range.
+  target:
+    entity:
+      domain: calendar
+  fields:
+    start_date_time:
+      name: Start time
+      description: Return events that are active after this time (exclusive).
+      example: "2022-03-22 20:00:00"
+      selector:
+        datetime:
+    end_date_time:
+      name: End time
+      description: Return events that are active before this time (exclusive).
+      example: "2022-03-22 22:00:00"
+      selector:
+        datetime:

--- a/homeassistant/components/calendar/services.yaml
+++ b/homeassistant/components/calendar/services.yaml
@@ -61,13 +61,18 @@ list_events:
   fields:
     start_date_time:
       name: Start time
-      description: Return events that are active after this time (exclusive).
+      description: Return active events after this time (exclusive). When not set, defaults to now.
       example: "2022-03-22 20:00:00"
       selector:
         datetime:
     end_date_time:
       name: End time
-      description: Return events that are active before this time (exclusive).
+      description: Return active events before this time (exclusive). Cannot be used with 'in'.
       example: "2022-03-22 22:00:00"
       selector:
         datetime:
+    duration:
+      name: Duration
+      description: Return active events from start_date_time until the specified duration.
+      selector:
+        duration:

--- a/homeassistant/components/demo/calendar.py
+++ b/homeassistant/components/demo/calendar.py
@@ -27,10 +27,10 @@ def setup_platform(
 
 def calendar_data_future() -> CalendarEvent:
     """Representation of a Demo Calendar for a future event."""
-    one_hour_from_now = dt_util.now() + datetime.timedelta(minutes=30)
+    half_hour_from_now = dt_util.now() + datetime.timedelta(minutes=30)
     return CalendarEvent(
-        start=one_hour_from_now,
-        end=one_hour_from_now + datetime.timedelta(minutes=60),
+        start=half_hour_from_now,
+        end=half_hour_from_now + datetime.timedelta(minutes=60),
         summary="Future Event",
         description="Future Description",
         location="Future Location",
@@ -67,4 +67,9 @@ class DemoCalendar(CalendarEntity):
         end_date: datetime.datetime,
     ) -> list[CalendarEvent]:
         """Return calendar events within a datetime range."""
+        assert start_date < end_date
+        if self._event.start_datetime_local >= end_date:
+            return []
+        if self._event.end_datetime_local < start_date:
+            return []
         return [self._event]

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -12,7 +12,7 @@ import logging
 import math
 import sys
 from timeit import default_timer as timer
-from typing import TYPE_CHECKING, Any, Final, Literal, TypedDict, final
+from typing import TYPE_CHECKING, Any, Final, Literal, TypedDict, TypeVar, final
 
 import voluptuous as vol
 
@@ -48,6 +48,9 @@ from .typing import UNDEFINED, StateType, UndefinedType
 
 if TYPE_CHECKING:
     from .entity_platform import EntityPlatform
+
+
+_T = TypeVar("_T")
 
 _LOGGER = logging.getLogger(__name__)
 SLOW_UPDATE_WARNING = 10
@@ -1130,13 +1133,13 @@ class Entity(ABC):
         """Return the representation."""
         return f"<entity {self.entity_id}={self._stringify_state(self.available)}>"
 
-    async def async_request_call(self, coro: Coroutine[Any, Any, Any]) -> None:
+    async def async_request_call(self, coro: Coroutine[Any, Any, _T]) -> _T:
         """Process request batched."""
         if self.parallel_updates:
             await self.parallel_updates.acquire()
 
         try:
-            await coro
+            return await coro
         finally:
             if self.parallel_updates:
                 self.parallel_updates.release()

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -236,8 +236,6 @@ class EntityComponent(Generic[_EntityT]):
             )
             if not call.return_response:
                 return None
-            # The entity service call above zero or more entities, but we expect to match
-            # exactly one.
             if not response_data:
                 raise HomeAssistantError(
                     "Service call requested response data but did not match any entities"

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -231,21 +231,9 @@ class EntityComponent(Generic[_EntityT]):
 
         async def handle_service(call: ServiceCall) -> ServiceResponse:
             """Handle the service."""
-            response_data = await service.entity_service_call(
+            return await service.entity_service_call(
                 self.hass, self._platforms.values(), func, call, required_features
             )
-            if not call.return_response:
-                return None
-            if not response_data:
-                raise HomeAssistantError(
-                    "Service call requested response data but did not match any entities"
-                )
-            values = list(response_data.values())
-            if len(values) != 1:
-                raise HomeAssistantError(
-                    "Service call requested response data but matched more than one entity"
-                )
-            return values[0]
 
         self.hass.services.async_register(
             self.domain, name, handle_service, schema, supports_response

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -814,10 +814,7 @@ async def entity_service_call(  # noqa: C901
 
     response_data: dict[str, ServiceResponse] = {}
     for entity, task in zip(entities, done):
-        response = task.result()  # pop exception if have
-        if not call.return_response:
-            continue
-        response_data[entity.entity_id] = response
+        response_data[entity.entity_id] = task.result()  # pop exception if have
 
     tasks: list[asyncio.Task[None]] = []
 

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -684,8 +684,9 @@ async def entity_service_call(  # noqa: C901
 ) -> dict[str, ServiceResponse] | None:
     """Handle an entity service call.
 
-    Calls all platforms simultaneously. The service call may request response data which will
-    result in returning a dictionary of entity ids to the service response data.
+    Calls all platforms simultaneously. The service call may request
+    response data which will return a dictionary of entity
+    ids to the service response data.
     """
     entity_perms: None | (Callable[[str, str], bool]) = None
     if call.context.user_id:

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -819,10 +819,10 @@ async def entity_service_call(  # noqa: C901
         response = task.result()  # pop exception if have
         if not call.return_values:
             continue
-        if not isinstance(response, dict):
-            raise HomeAssistantError(
-                f"Service response data expected a dictionary, was {type(response)}"
-            )
+        # if not isinstance(response, dict):
+        #    raise HomeAssistantError(
+        #        f"Service response data expected a dictionary, was {type(response)}"
+        #    )
         response_data[entity.entity_id] = response
 
     tasks: list[asyncio.Task[None]] = []

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -684,9 +684,7 @@ async def entity_service_call(  # noqa: C901
 ) -> ServiceResponse | None:
     """Handle an entity service call.
 
-    Calls all platforms simultaneously. The service call may request
-    response data which will return a dictionary of entity
-    ids to the service response data.
+    Calls all platforms simultaneously.
     """
     entity_perms: None | (Callable[[str, str], bool]) = None
     if call.context.user_id:

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -686,8 +686,8 @@ async def entity_service_call(  # noqa: C901
 ) -> dict[str, ServiceResult] | None:
     """Handle an entity service call.
 
-    Calls all platforms simultaneously. The service call may request response data which will result in returning
-    a dictionary of entity ids to the service response data.
+    Calls all platforms simultaneously. The service call may request response data which will
+    result in returning a dictionary of entity ids to the service response data.
     """
     entity_perms: None | (Callable[[str, str], bool]) = None
     if call.context.user_id:

--- a/tests/components/calendar/test_init.py
+++ b/tests/components/calendar/test_init.py
@@ -386,9 +386,7 @@ async def test_create_event_service_invalid_params(
         )
 
 
-async def test_list_events_service(
-    hass: HomeAssistant,
-) -> None:
+async def test_list_events_service(hass: HomeAssistant) -> None:
     """Test listing events from the service call from the calendar demo."""
     await async_setup_component(hass, "calendar", {"calendar": {"platform": "demo"}})
     await hass.async_block_till_done()
@@ -405,7 +403,7 @@ async def test_list_events_service(
             "end_date_time": end,
         },
         blocking=True,
-        return_values=True,
+        return_response=True,
     )
     assert response
     assert "events" in response
@@ -443,7 +441,7 @@ async def test_list_events_service_duration(
             "duration": duration,
         },
         blocking=True,
-        return_values=True,
+        return_response=True,
     )
     assert response
     assert "events" in response
@@ -465,7 +463,7 @@ async def test_list_events_positive_duration(hass: HomeAssistant) -> None:
                 "duration": "-01:00:00",
             },
             blocking=True,
-            return_values=True,
+            return_response=True,
         )
 
 
@@ -486,5 +484,5 @@ async def test_list_events_exclusive_fields(hass: HomeAssistant) -> None:
                 "duration": "01:00:00",
             },
             blocking=True,
-            return_values=True,
+            return_response=True,
         )

--- a/tests/components/calendar/test_init.py
+++ b/tests/components/calendar/test_init.py
@@ -412,3 +412,79 @@ async def test_list_events_service(
     events = response["events"]
     assert len(events) == 1
     assert events[0]["summary"] == "Future Event"
+
+
+@pytest.mark.parametrize(
+    ("entity", "duration", "expected_events"),
+    [
+        # Calendar 1 has an hour long event starting in 30 minutes. No events in the
+        # next 15 minutes, but it shows up an hour from now.
+        ("calendar.calendar_1", "00:15:00", []),
+        ("calendar.calendar_1", "01:00:00", ["Future Event"]),
+        # Calendar 2 has a active event right now
+        ("calendar.calendar_2", "00:15:00", ["Current Event"]),
+    ],
+)
+async def test_list_events_service_duration(
+    hass: HomeAssistant,
+    entity: str,
+    duration: str,
+    expected_events: list[str],
+) -> None:
+    """Test listing events from the service call from the calendar demo."""
+    await async_setup_component(hass, "calendar", {"calendar": {"platform": "demo"}})
+    await hass.async_block_till_done()
+
+    response = await hass.services.async_call(
+        DOMAIN,
+        SERVICE_LIST_EVENTS,
+        {
+            "entity_id": entity,
+            "duration": duration,
+        },
+        blocking=True,
+        return_values=True,
+    )
+    assert response
+    assert "events" in response
+    events = response["events"]
+    assert [event["summary"] for event in events] == expected_events
+
+
+async def test_list_events_positive_duration(hass: HomeAssistant) -> None:
+    """Test listing events from the service call from the calendar demo."""
+    await async_setup_component(hass, "calendar", {"calendar": {"platform": "demo"}})
+    await hass.async_block_till_done()
+
+    with pytest.raises(vol.Invalid, match="should be positive"):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_LIST_EVENTS,
+            {
+                "entity_id": "calendar.calendar_1",
+                "duration": "-01:00:00",
+            },
+            blocking=True,
+            return_values=True,
+        )
+
+
+async def test_list_events_exclusive_fields(hass: HomeAssistant) -> None:
+    """Test listing events from the service call from the calendar demo."""
+    await async_setup_component(hass, "calendar", {"calendar": {"platform": "demo"}})
+    await hass.async_block_till_done()
+
+    end = dt_util.now() + timedelta(days=1)
+
+    with pytest.raises(vol.Invalid, match="at most one of"):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_LIST_EVENTS,
+            {
+                "entity_id": "calendar.calendar_1",
+                "end_date_time": end,
+                "duration": "01:00:00",
+            },
+            blocking=True,
+            return_values=True,
+        )

--- a/tests/components/calendar/test_init.py
+++ b/tests/components/calendar/test_init.py
@@ -401,8 +401,8 @@ async def test_list_events_service(
         SERVICE_LIST_EVENTS,
         {
             "entity_id": "calendar.calendar_1",
-            "start": start,
-            "end": end,
+            "start_date_time": start,
+            "end_date_time": end,
         },
         blocking=True,
         return_values=True,

--- a/tests/components/calendar/test_init.py
+++ b/tests/components/calendar/test_init.py
@@ -10,7 +10,7 @@ import pytest
 import voluptuous as vol
 
 from homeassistant.bootstrap import async_setup_component
-from homeassistant.components.calendar import DOMAIN
+from homeassistant.components.calendar import DOMAIN, SERVICE_LIST_EVENTS
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 import homeassistant.util.dt as dt_util
@@ -384,3 +384,31 @@ async def test_create_event_service_invalid_params(
             target={"entity_id": "calendar.calendar_1"},
             blocking=True,
         )
+
+
+async def test_list_events_service(
+    hass: HomeAssistant,
+) -> None:
+    """Test listing events from the service call from the calendar demo."""
+    await async_setup_component(hass, "calendar", {"calendar": {"platform": "demo"}})
+    await hass.async_block_till_done()
+
+    start = dt_util.now()
+    end = start + timedelta(days=1)
+
+    response = await hass.services.async_call(
+        DOMAIN,
+        SERVICE_LIST_EVENTS,
+        {
+            "entity_id": "calendar.calendar_1",
+            "start": start,
+            "end": end,
+        },
+        blocking=True,
+        return_values=True,
+    )
+    assert response
+    assert "events" in response
+    events = response["events"]
+    assert len(events) == 1
+    assert events[0]["summary"] == "Future Event"

--- a/tests/components/calendar/test_init.py
+++ b/tests/components/calendar/test_init.py
@@ -387,7 +387,7 @@ async def test_create_event_service_invalid_params(
 
 
 async def test_list_events_service(hass: HomeAssistant) -> None:
-    """Test listing events from the service call from the calendar demo."""
+    """Test listing events from the service call using exlplicit start and end time."""
     await async_setup_component(hass, "calendar", {"calendar": {"platform": "demo"}})
     await hass.async_block_till_done()
 
@@ -429,7 +429,7 @@ async def test_list_events_service_duration(
     duration: str,
     expected_events: list[str],
 ) -> None:
-    """Test listing events from the service call from the calendar demo."""
+    """Test listing events using a time duration."""
     await async_setup_component(hass, "calendar", {"calendar": {"platform": "demo"}})
     await hass.async_block_till_done()
 
@@ -450,7 +450,7 @@ async def test_list_events_service_duration(
 
 
 async def test_list_events_positive_duration(hass: HomeAssistant) -> None:
-    """Test listing events from the service call from the calendar demo."""
+    """Test listing events requires a positive duration."""
     await async_setup_component(hass, "calendar", {"calendar": {"platform": "demo"}})
     await hass.async_block_till_done()
 
@@ -468,7 +468,7 @@ async def test_list_events_positive_duration(hass: HomeAssistant) -> None:
 
 
 async def test_list_events_exclusive_fields(hass: HomeAssistant) -> None:
-    """Test listing events from the service call from the calendar demo."""
+    """Test listing events specifying fields that are exclusive."""
     await async_setup_component(hass, "calendar", {"calendar": {"platform": "demo"}})
     await hass.async_block_till_done()
 
@@ -482,6 +482,23 @@ async def test_list_events_exclusive_fields(hass: HomeAssistant) -> None:
                 "entity_id": "calendar.calendar_1",
                 "end_date_time": end,
                 "duration": "01:00:00",
+            },
+            blocking=True,
+            return_response=True,
+        )
+
+
+async def test_list_events_missing_fields(hass: HomeAssistant) -> None:
+    """Test listing events missing some required fields."""
+    await async_setup_component(hass, "calendar", {"calendar": {"platform": "demo"}})
+    await hass.async_block_till_done()
+
+    with pytest.raises(vol.Invalid, match="at least one of"):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_LIST_EVENTS,
+            {
+                "entity_id": "calendar.calendar_1",
             },
             blocking=True,
             return_response=True,

--- a/tests/helpers/test_entity_component.py
+++ b/tests/helpers/test_entity_component.py
@@ -571,8 +571,7 @@ async def test_register_entity_service_response_data_multiple_matches(
     async def generate_response(
         target: MockEntity, call: ServiceCall
     ) -> ServiceResponse:
-        assert call.return_response
-        return None
+        raise ValueError("Should not be invoked")
 
     component = EntityComponent(_LOGGER, DOMAIN, hass)
     await component.async_setup({})


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add the capability of response data for for the entity component.

The entity call function supports returning values for multiple entities, however the entity component only supports return values for one entity. (This is somewhat arbitrary, but reduces scope).

Add a service description for the calendar list event service call. Note that a service description of the response is pending.

Work items:
- [X] End to end working
- [ ] More test coverage for events service (e.g. no matches)
- [ ] More test coverage for entity component (no services, too many services, no return values, etc) 
- [ ] End user documentation for return values


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- https://github.com/home-assistant/home-assistant.io/pull/27863
- https://github.com/home-assistant/home-assistant.io/pull/27934

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
