### PR TITLE
Bump reolink-aio to 0.7.1

### DIFF
--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -9,8 +9,8 @@ from typing import Any
 import aiohttp
 from aiohttp.web import Request
 from reolink_aio.api import Host
-from reolink_aio.exceptions import ReolinkError, SubscriptionError
 from reolink_aio.enums import SubType
+from reolink_aio.exceptions import ReolinkError, SubscriptionError
 
 from homeassistant.components import webhook
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -10,6 +10,7 @@ import aiohttp
 from aiohttp.web import Request
 from reolink_aio.api import Host
 from reolink_aio.exceptions import ReolinkError, SubscriptionError
+from reolink_aio.enums import SubType
 
 from homeassistant.components import webhook
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -256,7 +256,7 @@ class ReolinkHost:
         if self.webhook_id is None:
             self.register_webhook()
 
-        if self._api.subscribed:
+        if self._api.subscribed(SubType.push):
             _LOGGER.debug(
                 "Host %s: is already subscribed to webhook %s",
                 self._api.host,
@@ -275,7 +275,7 @@ class ReolinkHost:
     async def renew(self) -> None:
         """Renew the subscription of motion events (lease time is 15 minutes)."""
         try:
-            await self._renew()
+            await self._renew(SubType.push)
         except SubscriptionError as err:
             if not self._lost_subscription:
                 self._lost_subscription = True
@@ -287,22 +287,24 @@ class ReolinkHost:
         else:
             self._lost_subscription = False
 
-    async def _renew(self) -> None:
+    async def _renew(self, sub_type: SubType) -> None:
         """Execute the renew of the subscription."""
-        if not self._api.subscribed:
+        if not self._api.subscribed(sub_type):
             _LOGGER.debug(
-                "Host %s: requested to renew a non-existing Reolink subscription, "
+                "Host %s: requested to renew a non-existing Reolink %s subscription, "
                 "trying to subscribe from scratch",
                 self._api.host,
+                sub_type,
             )
             await self.subscribe()
             return
 
-        timer = self._api.renewtimer
+        timer = self._api.renewtimer(sub_type)
         _LOGGER.debug(
-            "Host %s:%s should renew subscription in: %i seconds",
+            "Host %s:%s should renew %s subscription in: %i seconds",
             self._api.host,
             self._api.port,
+            sub_type,
             timer,
         )
         if timer > SUBSCRIPTION_RENEW_THRESHOLD:
@@ -310,25 +312,29 @@ class ReolinkHost:
 
         if timer > 0:
             try:
-                await self._api.renew()
+                await self._api.renew(sub_type)
             except SubscriptionError as err:
                 _LOGGER.debug(
-                    "Host %s: error renewing Reolink subscription, "
+                    "Host %s: error renewing Reolink %s subscription, "
                     "trying to subscribe again: %s",
                     self._api.host,
+                    sub_type,
                     err,
                 )
             else:
                 _LOGGER.debug(
-                    "Host %s successfully renewed Reolink subscription", self._api.host
+                    "Host %s successfully renewed Reolink %s subscription",
+                    self._api.host,
+                    sub_type,
                 )
                 return
 
-        await self._api.subscribe(self._webhook_url)
+        await self._api.subscribe(self._webhook_url, sub_type)
 
         _LOGGER.debug(
-            "Host %s: Reolink re-subscription successful after it was expired",
+            "Host %s: Reolink %s re-subscription successful after it was expired",
             self._api.host,
+            sub_type,
         )
 
     def register_webhook(self) -> None:

--- a/homeassistant/components/reolink/manifest.json
+++ b/homeassistant/components/reolink/manifest.json
@@ -18,5 +18,5 @@
   "documentation": "https://www.home-assistant.io/integrations/reolink",
   "iot_class": "local_push",
   "loggers": ["reolink_aio"],
-  "requirements": ["reolink-aio==0.7.0"]
+  "requirements": ["reolink-aio==0.7.1"]
 }

--- a/homeassistant/components/reolink/manifest.json
+++ b/homeassistant/components/reolink/manifest.json
@@ -18,5 +18,5 @@
   "documentation": "https://www.home-assistant.io/integrations/reolink",
   "iot_class": "local_push",
   "loggers": ["reolink_aio"],
-  "requirements": ["reolink-aio==0.6.0"]
+  "requirements": ["reolink-aio==0.7.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2268,7 +2268,7 @@ renault-api==0.1.13
 renson-endura-delta==1.5.0
 
 # homeassistant.components.reolink
-reolink-aio==0.6.0
+reolink-aio==0.7.0
 
 # homeassistant.components.idteck_prox
 rfk101py==0.0.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2268,7 +2268,7 @@ renault-api==0.1.13
 renson-endura-delta==1.5.0
 
 # homeassistant.components.reolink
-reolink-aio==0.7.0
+reolink-aio==0.7.1
 
 # homeassistant.components.idteck_prox
 rfk101py==0.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1655,7 +1655,7 @@ renault-api==0.1.13
 renson-endura-delta==1.5.0
 
 # homeassistant.components.reolink
-reolink-aio==0.7.0
+reolink-aio==0.7.1
 
 # homeassistant.components.rflink
 rflink==0.0.65

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1655,7 +1655,7 @@ renault-api==0.1.13
 renson-endura-delta==1.5.0
 
 # homeassistant.components.reolink
-reolink-aio==0.6.0
+reolink-aio==0.7.0
 
 # homeassistant.components.rflink
 rflink==0.0.65

--- a/tests/components/reolink/conftest.py
+++ b/tests/components/reolink/conftest.py
@@ -59,7 +59,7 @@ def reolink_connect(mock_get_source_ip: None) -> Generator[MagicMock, None, None
         host_mock.user_level = "admin"
         host_mock.sw_version_update_required = False
         host_mock.timeout = 60
-        host_mock.renewtimer = 600
+        host_mock.renewtimer.return_value = 600
         yield host_mock
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump reolink-aio to 0.7.1 in order to prepare for the implementation of ONVIF long polling see https://github.com/home-assistant/core/pull/94770.
The changes to the code are to accommodate the changes in the upstream library (subscription can now be push or long_polling so the related methods need to identify which subsciption to act upon).

Bump reolink-aio to 0.7.1:
**Breaking changes:**
- `subscribed` from property to method
- `renewtimer` from property to method

**Additions:**
- [Implement ONVIF long polling](https://github.com/starkillerOG/reolink_aio/pull/35)
- [Add wifi_signal property](https://github.com/starkillerOG/reolink_aio/commit/69097feb54d7a431480a24b8db03098ba98587fe)
- [Add reboot command](https://github.com/starkillerOG/reolink_aio/commit/6895362b3fff8b6b180010eb501e1b65afd6d5cc)

**Optimizations:**
- [Simplify subscription_send by raising errors](https://github.com/starkillerOG/reolink_aio/commit/8cbd93017d85b1371248793574b2f09f23de6eb7)
- [Re-use existing aiohttp session in subscription_send](https://github.com/starkillerOG/reolink_aio/commit/b5adb82959d3dc039d73a88c4a46c81552ff7aa8)
- [Increase long poll timeout to 5 minutes](https://github.com/starkillerOG/reolink_aio/commit/06668b66029a058476e93eb5782c952c6f7aa12e)

**Full Changelog**: https://github.com/starkillerOG/reolink_aio/compare/0.6.0...0.7.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
