### PR TITLE
Re-add "deactivate air conditioning" button to bmw_connected_drive

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -122,7 +122,6 @@ omit =
     homeassistant/components/bluetooth_tracker/*
     homeassistant/components/bmw_connected_drive/__init__.py
     homeassistant/components/bmw_connected_drive/binary_sensor.py
-    homeassistant/components/bmw_connected_drive/button.py
     homeassistant/components/bmw_connected_drive/coordinator.py
     homeassistant/components/bmw_connected_drive/lock.py
     homeassistant/components/bmw_connected_drive/notify.py

--- a/homeassistant/components/bmw_connected_drive/button.py
+++ b/homeassistant/components/bmw_connected_drive/button.py
@@ -32,6 +32,7 @@ class BMWButtonEntityDescription(ButtonEntityDescription):
         [MyBMWVehicle], Coroutine[Any, Any, RemoteServiceStatus]
     ] | None = None
     account_function: Callable[[BMWDataUpdateCoordinator], Coroutine] | None = None
+    is_available: Callable[[MyBMWVehicle], bool] = lambda _: True
 
 
 BUTTON_TYPES: tuple[BMWButtonEntityDescription, ...] = (
@@ -52,6 +53,13 @@ BUTTON_TYPES: tuple[BMWButtonEntityDescription, ...] = (
         icon="mdi:hvac",
         name="Activate air conditioning",
         remote_function=lambda vehicle: vehicle.remote_services.trigger_remote_air_conditioning(),
+    ),
+    BMWButtonEntityDescription(
+        key="deactivate_air_conditioning",
+        icon="mdi:hvac-off",
+        name="Deactivate air conditioning",
+        remote_function=lambda vehicle: vehicle.remote_services.trigger_remote_air_conditioning_stop(),
+        is_available=lambda vehicle: vehicle.is_remote_climate_stop_enabled,
     ),
     BMWButtonEntityDescription(
         key="find_vehicle",
@@ -84,7 +92,7 @@ async def async_setup_entry(
             [
                 BMWButton(coordinator, vehicle, description)
                 for description in BUTTON_TYPES
-                if not coordinator.read_only
+                if (not coordinator.read_only and description.is_available(vehicle))
                 or (coordinator.read_only and description.enabled_when_read_only)
             ]
         )

--- a/tests/components/bmw_connected_drive/__init__.py
+++ b/tests/components/bmw_connected_drive/__init__.py
@@ -1,9 +1,11 @@
 """Tests for the for the BMW Connected Drive integration."""
 
 from pathlib import Path
+from urllib.parse import urlparse
 
 from bimmer_connected.api.authentication import MyBMWAuthentication
 from bimmer_connected.const import (
+    REMOTE_SERVICE_POSITION_URL,
     VEHICLE_CHARGING_DETAILS_URL,
     VEHICLE_STATE_URL,
     VEHICLES_URL,
@@ -115,6 +117,18 @@ def mock_vehicles() -> respx.Router:
     router.get(VEHICLE_CHARGING_DETAILS_URL).mock(
         side_effect=vehicle_charging_sideeffect
     )
+
+    # Get vehicle position after remote service
+    router.post(urlparse(REMOTE_SERVICE_POSITION_URL).netloc).mock(
+        httpx.Response(
+            200,
+            json=load_json_object_fixture(
+                FIXTURE_PATH / "remote_service" / "eventposition.json",
+                integration=BMW_DOMAIN,
+            ),
+        )
+    )
+
     return router
 
 

--- a/tests/components/bmw_connected_drive/fixtures/remote_service/eventposition.json
+++ b/tests/components/bmw_connected_drive/fixtures/remote_service/eventposition.json
@@ -1,0 +1,12 @@
+{
+  "positionData": {
+    "status": "OK",
+    "position": {
+      "latitude": 123.456,
+      "longitude": 34.5678,
+      "formattedAddress": "some_formatted_address",
+      "heading": 121
+    }
+  },
+  "errorDetails": null
+}

--- a/tests/components/bmw_connected_drive/snapshots/test_button.ambr
+++ b/tests/components/bmw_connected_drive/snapshots/test_button.ambr
@@ -1,0 +1,137 @@
+# serializer version: 1
+# name: test_entity_state_attrs
+  list([
+    StateSnapshot({
+      'attributes': ReadOnlyDict({
+        'attribution': 'Data provided by MyBMW',
+        'friendly_name': 'i4 eDrive40 Flash lights',
+        'icon': 'mdi:car-light-alert',
+      }),
+      'context': <ANY>,
+      'entity_id': 'button.i4_edrive40_flash_lights',
+      'last_changed': <ANY>,
+      'last_updated': <ANY>,
+      'state': 'unknown',
+    }),
+    StateSnapshot({
+      'attributes': ReadOnlyDict({
+        'attribution': 'Data provided by MyBMW',
+        'friendly_name': 'i4 eDrive40 Sound horn',
+        'icon': 'mdi:bullhorn',
+      }),
+      'context': <ANY>,
+      'entity_id': 'button.i4_edrive40_sound_horn',
+      'last_changed': <ANY>,
+      'last_updated': <ANY>,
+      'state': 'unknown',
+    }),
+    StateSnapshot({
+      'attributes': ReadOnlyDict({
+        'attribution': 'Data provided by MyBMW',
+        'friendly_name': 'i4 eDrive40 Activate air conditioning',
+        'icon': 'mdi:hvac',
+      }),
+      'context': <ANY>,
+      'entity_id': 'button.i4_edrive40_activate_air_conditioning',
+      'last_changed': <ANY>,
+      'last_updated': <ANY>,
+      'state': 'unknown',
+    }),
+    StateSnapshot({
+      'attributes': ReadOnlyDict({
+        'attribution': 'Data provided by MyBMW',
+        'friendly_name': 'i4 eDrive40 Deactivate air conditioning',
+        'icon': 'mdi:hvac-off',
+      }),
+      'context': <ANY>,
+      'entity_id': 'button.i4_edrive40_deactivate_air_conditioning',
+      'last_changed': <ANY>,
+      'last_updated': <ANY>,
+      'state': 'unknown',
+    }),
+    StateSnapshot({
+      'attributes': ReadOnlyDict({
+        'attribution': 'Data provided by MyBMW',
+        'friendly_name': 'i4 eDrive40 Find vehicle',
+        'icon': 'mdi:crosshairs-question',
+      }),
+      'context': <ANY>,
+      'entity_id': 'button.i4_edrive40_find_vehicle',
+      'last_changed': <ANY>,
+      'last_updated': <ANY>,
+      'state': 'unknown',
+    }),
+    StateSnapshot({
+      'attributes': ReadOnlyDict({
+        'attribution': 'Data provided by MyBMW',
+        'friendly_name': 'i4 eDrive40 Refresh from cloud',
+        'icon': 'mdi:refresh',
+      }),
+      'context': <ANY>,
+      'entity_id': 'button.i4_edrive40_refresh_from_cloud',
+      'last_changed': <ANY>,
+      'last_updated': <ANY>,
+      'state': 'unknown',
+    }),
+    StateSnapshot({
+      'attributes': ReadOnlyDict({
+        'attribution': 'Data provided by MyBMW',
+        'friendly_name': 'i3 (+ REX) Flash lights',
+        'icon': 'mdi:car-light-alert',
+      }),
+      'context': <ANY>,
+      'entity_id': 'button.i3_rex_flash_lights',
+      'last_changed': <ANY>,
+      'last_updated': <ANY>,
+      'state': 'unknown',
+    }),
+    StateSnapshot({
+      'attributes': ReadOnlyDict({
+        'attribution': 'Data provided by MyBMW',
+        'friendly_name': 'i3 (+ REX) Sound horn',
+        'icon': 'mdi:bullhorn',
+      }),
+      'context': <ANY>,
+      'entity_id': 'button.i3_rex_sound_horn',
+      'last_changed': <ANY>,
+      'last_updated': <ANY>,
+      'state': 'unknown',
+    }),
+    StateSnapshot({
+      'attributes': ReadOnlyDict({
+        'attribution': 'Data provided by MyBMW',
+        'friendly_name': 'i3 (+ REX) Activate air conditioning',
+        'icon': 'mdi:hvac',
+      }),
+      'context': <ANY>,
+      'entity_id': 'button.i3_rex_activate_air_conditioning',
+      'last_changed': <ANY>,
+      'last_updated': <ANY>,
+      'state': 'unknown',
+    }),
+    StateSnapshot({
+      'attributes': ReadOnlyDict({
+        'attribution': 'Data provided by MyBMW',
+        'friendly_name': 'i3 (+ REX) Find vehicle',
+        'icon': 'mdi:crosshairs-question',
+      }),
+      'context': <ANY>,
+      'entity_id': 'button.i3_rex_find_vehicle',
+      'last_changed': <ANY>,
+      'last_updated': <ANY>,
+      'state': 'unknown',
+    }),
+    StateSnapshot({
+      'attributes': ReadOnlyDict({
+        'attribution': 'Data provided by MyBMW',
+        'friendly_name': 'i3 (+ REX) Refresh from cloud',
+        'icon': 'mdi:refresh',
+      }),
+      'context': <ANY>,
+      'entity_id': 'button.i3_rex_refresh_from_cloud',
+      'last_changed': <ANY>,
+      'last_updated': <ANY>,
+      'state': 'unknown',
+    }),
+  ])
+# ---

--- a/tests/components/bmw_connected_drive/test_button.py
+++ b/tests/components/bmw_connected_drive/test_button.py
@@ -1,0 +1,79 @@
+"""Test BMW buttons."""
+from bimmer_connected.vehicle.remote_services import RemoteServices
+import pytest
+import respx
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.bmw_connected_drive.coordinator import (
+    BMWDataUpdateCoordinator,
+)
+from homeassistant.core import HomeAssistant
+
+from . import setup_mocked_integration
+
+
+async def test_entity_state_attrs(
+    hass: HomeAssistant,
+    bmw_fixture: respx.Router,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test button options and values."""
+
+    # Setup component
+    assert await setup_mocked_integration(hass)
+
+    # Get all button entities
+    assert hass.states.async_all("button") == snapshot
+
+
+@pytest.mark.parametrize(
+    ("entity_id"),
+    [
+        ("button.i4_edrive40_flash_lights"),
+        ("button.i4_edrive40_sound_horn"),
+        ("button.i4_edrive40_activate_air_conditioning"),
+        ("button.i4_edrive40_deactivate_air_conditioning"),
+        ("button.i4_edrive40_find_vehicle"),
+    ],
+)
+async def test_update_triggers_success(
+    hass: HomeAssistant,
+    entity_id: str,
+    bmw_fixture: respx.Router,
+) -> None:
+    """Test button press."""
+
+    # Setup component
+    assert await setup_mocked_integration(hass)
+    BMWDataUpdateCoordinator.async_update_listeners.reset_mock()
+
+    # Test
+    await hass.services.async_call(
+        "button",
+        "press",
+        blocking=True,
+        target={"entity_id": entity_id},
+    )
+    assert RemoteServices.trigger_remote_service.call_count == 1
+    assert BMWDataUpdateCoordinator.async_update_listeners.call_count == 1
+
+
+async def test_refresh_from_cloud(
+    hass: HomeAssistant,
+    bmw_fixture: respx.Router,
+) -> None:
+    """Test button press for deprecated service."""
+
+    # Setup component
+    assert await setup_mocked_integration(hass)
+    BMWDataUpdateCoordinator.async_update_listeners.reset_mock()
+
+    # Test
+    await hass.services.async_call(
+        "button",
+        "press",
+        blocking=True,
+        target={"entity_id": "button.i4_edrive40_refresh_from_cloud"},
+    )
+    assert RemoteServices.trigger_remote_service.call_count == 0
+    assert BMWDataUpdateCoordinator.async_update_listeners.call_count == 2


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR reverts part of https://github.com/home-assistant/core/pull/92962 (removal of "deactivate air conditioning" button).

As I'm adding the functionality to show the button only on selected vehicles (if the vehicle supports it), I have also implemented full test coverage for the button entity.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/94364
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x]  The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
