### PR TITLE
Fix Totalconnect BinarySensorDeviceClass logic

### DIFF
--- a/homeassistant/components/totalconnect/binary_sensor.py
+++ b/homeassistant/components/totalconnect/binary_sensor.py
@@ -81,15 +81,9 @@ class TotalConnectZoneSecurityBinarySensor(TotalConnectZoneBinarySensor):
             return BinarySensorDeviceClass.MOTION
         if self._zone.is_type_medical():
             return BinarySensorDeviceClass.SAFETY
-        # "security" type is a generic category so test for it last
-        if self._zone.is_type_security():
-            return BinarySensorDeviceClass.DOOR
-
-        _LOGGER.error(
-            "TotalConnect zone %s reported an unexpected device class",
-            self._zone.zoneid,
-        )
-        return None
+        if self._zone.is_type_temperature():
+            return BinarySensorDeviceClass.PROBLEM
+        return BinarySensorDeviceClass.DOOR
 
     def update(self):
         """Return the state of the device."""

--- a/tests/components/totalconnect/common.py
+++ b/tests/components/totalconnect/common.py
@@ -189,7 +189,7 @@ ZONE_5 = {
 # 99 is an unknown ZoneType
 ZONE_6 = {
     "ZoneID": "6",
-    "ZoneDescription": "Medical",
+    "ZoneDescription": "Unknown",
     "ZoneStatus": ZoneStatus.NORMAL,
     "ZoneTypeId": 99,
     "PartitionId": "1",

--- a/tests/components/totalconnect/common.py
+++ b/tests/components/totalconnect/common.py
@@ -196,7 +196,16 @@ ZONE_6 = {
     "CanBeBypassed": 0,
 }
 
-ZONE_INFO = [ZONE_NORMAL, ZONE_2, ZONE_3, ZONE_4, ZONE_5, ZONE_6]
+ZONE_7 = {
+    "ZoneID": 7,
+    "ZoneDescription": "Temperature",
+    "ZoneStatus": ZoneStatus.NORMAL,
+    "ZoneTypeId": ZoneType.MONITOR,
+    "PartitionId": "1",
+    "CanBeBypassed": 0,
+}
+
+ZONE_INFO = [ZONE_NORMAL, ZONE_2, ZONE_3, ZONE_4, ZONE_5, ZONE_6, ZONE_7]
 ZONES = {"ZoneInfo": ZONE_INFO}
 
 METADATA_DISARMED = {

--- a/tests/components/totalconnect/test_binary_sensor.py
+++ b/tests/components/totalconnect/test_binary_sensor.py
@@ -84,3 +84,12 @@ async def test_state_and_attributes(hass: HomeAssistant) -> None:
         assert state.state == STATE_OFF
         state = hass.states.get("binary_sensor.gas_tamper")
         assert state.state == STATE_ON
+
+        # Zone 7 is temperature
+        state = hass.states.get("binary_sensor.temperature")
+        assert state.state == STATE_OFF
+        assert state.attributes.get("device_class") == BinarySensorDeviceClass.PROBLEM
+        state = hass.states.get("binary_sensor.temperature_low_battery")
+        assert state.state == STATE_OFF
+        state = hass.states.get("binary_sensor.temperature_tamper")
+        assert state.state == STATE_OFF

--- a/tests/components/totalconnect/test_binary_sensor.py
+++ b/tests/components/totalconnect/test_binary_sensor.py
@@ -85,6 +85,15 @@ async def test_state_and_attributes(hass: HomeAssistant) -> None:
         state = hass.states.get("binary_sensor.gas_tamper")
         assert state.state == STATE_ON
 
+        # Zone 6 is unknown type, assume it is a security (door) sensor
+        state = hass.states.get("binary_sensor.unknown")
+        assert state.state == STATE_OFF
+        assert state.attributes.get("device_class") == BinarySensorDeviceClass.DOOR
+        state = hass.states.get("binary_sensor.unknown_low_battery")
+        assert state.state == STATE_OFF
+        state = hass.states.get("binary_sensor.unknown_tamper")
+        assert state.state == STATE_OFF
+
         # Zone 7 is temperature
         state = hass.states.get("binary_sensor.temperature")
         assert state.state == STATE_OFF


### PR DESCRIPTION
## Proposed change
Fix TotalConnect logic for setting BinarySensorDeviceClass for zones.  Temperature zones will be handled as `BinarySensorDeviceClass.PROBLEM` because they alarm after reaching a threshold, and we have no way to determine if they are hot or cold sensors.  All remaining zones will be assumed as `BinarySensorDeviceClass.DOOR` as was the previous logic.

Updates tests to include a temperature zone.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #94186
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository. (94764 and 94174)

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
