### PR TITLE
Log a traceback when importing a component fails

### DIFF
--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -174,7 +174,7 @@ async def _async_setup_component(
     """
     integration: loader.Integration | None = None
 
-    def log_error(msg: str) -> None:
+    def log_error(msg: str, exc_info: Exception | None = None) -> None:
         """Log helper."""
         if integration is None:
             custom = ""
@@ -182,7 +182,9 @@ async def _async_setup_component(
         else:
             custom = "" if integration.is_built_in else "custom integration "
             link = integration.documentation
-        _LOGGER.error("Setup failed for %s%s: %s", custom, domain, msg)
+        _LOGGER.error(
+            "Setup failed for %s%s: %s", custom, domain, msg, exc_info=exc_info
+        )
         async_notify_setup_error(hass, domain, link)
 
     try:
@@ -212,7 +214,7 @@ async def _async_setup_component(
     try:
         component = integration.get_component()
     except ImportError as err:
-        log_error(f"Unable to import component: {err}")
+        log_error(f"Unable to import component: {err}", err)
         return False
 
     processed_config = await conf_util.async_process_component_config(


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
`2023-06-17 12:44:37.961 ERROR (MainThread) [homeassistant.setup] Setup failed for switchbot: Unable to import component: cannot import name DEFAULT_CIPHERS from urllib3.util.ssl_ (/Users/bdraco/home-assistant/venv/lib/python3.11/site-packages/urllib3/util/ssl_.py)` is not very helpful as it does not show which module tried to import.

adding a traceback makes it more obvious, and since ImportError is usually not something the user can easily solve, it makes issue reports much more helpful

```
DEFAULT_CIPHERS from urllib3.util.ssl_ (/Users/bdraco/home-assistant/venv/lib/python3.11/site-packages/urllib3/util/ssl_.py)
Traceback (most recent call last):
  File "/Users/bdraco/home-assistant/homeassistant/setup.py", line 213, in _async_setup_component
    component = integration.get_component()
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/bdraco/home-assistant/homeassistant/loader.py", line 813, in get_component
    ComponentProtocol, importlib.import_module(self.pkg_path)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.3/Frameworks/Python.framework/Versions/3.11/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1206, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1178, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1149, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/Users/bdraco/home-assistant/homeassistant/components/switchbot/__init__.py", line 5, in <module>
    import switchbot
  File "/Users/bdraco/home-assistant/venv/lib/python3.11/site-packages/switchbot/__init__.py", line 22, in <module>
    from .devices.lock import SwitchbotLock
  File "/Users/bdraco/home-assistant/venv/lib/python3.11/site-packages/switchbot/devices/lock.py", line 12, in <module>
    import boto3
  File "/Users/bdraco/home-assistant/venv/lib/python3.11/site-packages/boto3/__init__.py", line 16, in <module>
    from boto3.session import Session
  File "/Users/bdraco/home-assistant/venv/lib/python3.11/site-packages/boto3/session.py", line 17, in <module>
    import botocore.session
  File "/Users/bdraco/home-assistant/venv/lib/python3.11/site-packages/botocore/session.py", line 29, in <module>
    import botocore.credentials
  File "/Users/bdraco/home-assistant/venv/lib/python3.11/site-packages/botocore/credentials.py", line 34, in <module>
    from botocore.config import Config
  File "/Users/bdraco/home-assistant/venv/lib/python3.11/site-packages/botocore/config.py", line 16, in <module>
    from botocore.endpoint import DEFAULT_TIMEOUT, MAX_POOL_CONNECTIONS
  File "/Users/bdraco/home-assistant/venv/lib/python3.11/site-packages/botocore/endpoint.py", line 22, in <module>
    from botocore.awsrequest import create_request_object
  File "/Users/bdraco/home-assistant/venv/lib/python3.11/site-packages/botocore/awsrequest.py", line 24, in <module>
    import botocore.utils
  File "/Users/bdraco/home-assistant/venv/lib/python3.11/site-packages/botocore/utils.py", line 32, in <module>
    import botocore.httpsession
  File "/Users/bdraco/home-assistant/venv/lib/python3.11/site-packages/botocore/httpsession.py", line 10, in <module>
    from urllib3.util.ssl_ import (
ImportError: cannot import name DEFAULT_CIPHERS from urllib3.util.ssl_ (/Users/bdraco/home-assistant/venv/lib/python3.11/site-packages/urllib3/util/ssl_.py)
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
