### PR TITLE
pyWeMo serialnumber is deprecated, use serial_number

### DIFF
--- a/homeassistant/components/wemo/__init__.py
+++ b/homeassistant/components/wemo/__init__.py
@@ -154,14 +154,14 @@ class WemoDispatcher:
         self, hass: HomeAssistant, wemo: pywemo.WeMoDevice
     ) -> None:
         """Add a WeMo device to hass if it has not already been added."""
-        if wemo.serialnumber in self._added_serial_numbers:
+        if wemo.serial_number in self._added_serial_numbers:
             return
 
         try:
             coordinator = await async_register_device(hass, self._config_entry, wemo)
         except pywemo.PyWeMoException as err:
-            if wemo.serialnumber not in self._failed_serial_numbers:
-                self._failed_serial_numbers.add(wemo.serialnumber)
+            if wemo.serial_number not in self._failed_serial_numbers:
+                self._failed_serial_numbers.add(wemo.serial_number)
                 _LOGGER.error(
                     "Unable to add WeMo %s %s: %s", repr(wemo), wemo.host, err
                 )
@@ -194,8 +194,8 @@ class WemoDispatcher:
                     coordinator,
                 )
 
-        self._added_serial_numbers.add(wemo.serialnumber)
-        self._failed_serial_numbers.discard(wemo.serialnumber)
+        self._added_serial_numbers.add(wemo.serial_number)
+        self._failed_serial_numbers.discard(wemo.serial_number)
 
 
 class WemoDiscovery:

--- a/homeassistant/components/wemo/entity.py
+++ b/homeassistant/components/wemo/entity.py
@@ -53,7 +53,7 @@ class WemoEntity(CoordinatorEntity[DeviceCoordinator]):
     @property
     def unique_id(self) -> str:
         """Return the id of this WeMo device."""
-        serial_number: str = self.wemo.serialnumber
+        serial_number: str = self.wemo.serial_number
         if suffix := self.unique_id_suffix:
             return f"{serial_number}_{suffix}"
         return serial_number

--- a/homeassistant/components/wemo/wemo_device.py
+++ b/homeassistant/components/wemo/wemo_device.py
@@ -61,7 +61,7 @@ class DeviceCoordinator(DataUpdateCoordinator[None]):
                     CONF_NAME: self.wemo.name,
                     CONF_TYPE: event_type,
                     CONF_PARAMS: params,
-                    CONF_UNIQUE_ID: self.wemo.serialnumber,
+                    CONF_UNIQUE_ID: self.wemo.serial_number,
                 },
             )
         else:
@@ -131,14 +131,14 @@ def _create_device_info(wemo: WeMoDevice) -> DeviceInfo:
     _dev_info = _device_info(wemo)
     if wemo.model_name == "DLI emulated Belkin Socket":
         _dev_info[ATTR_CONFIGURATION_URL] = f"http://{wemo.host}"
-        _dev_info[ATTR_IDENTIFIERS] = {(DOMAIN, wemo.serialnumber[:-1])}
+        _dev_info[ATTR_IDENTIFIERS] = {(DOMAIN, wemo.serial_number[:-1])}
     return _dev_info
 
 
 def _device_info(wemo: WeMoDevice) -> DeviceInfo:
     return DeviceInfo(
         connections={(CONNECTION_UPNP, wemo.udn)},
-        identifiers={(DOMAIN, wemo.serialnumber)},
+        identifiers={(DOMAIN, wemo.serial_number)},
         manufacturer="Belkin",
         model=wemo.model_name,
         name=wemo.name,

--- a/tests/components/wemo/conftest.py
+++ b/tests/components/wemo/conftest.py
@@ -61,9 +61,9 @@ def create_pywemo_device(pywemo_registry, pywemo_model):
     device.host = MOCK_HOST
     device.port = MOCK_PORT
     device.name = MOCK_NAME
-    device.serialnumber = MOCK_SERIAL_NUMBER
+    device.serial_number = MOCK_SERIAL_NUMBER
     device.model_name = pywemo_model.replace("LongPress", "")
-    device.udn = f"uuid:{device.model_name}-1_0-{device.serialnumber}"
+    device.udn = f"uuid:{device.model_name}-1_0-{device.serial_number}"
     device.firmware_version = MOCK_FIRMWARE_VERSION
     device.get_state.return_value = 0  # Default to Off
     device.supports_long_press.return_value = cls.supports_long_press()
@@ -102,7 +102,7 @@ def pywemo_dli_device_fixture(pywemo_registry, pywemo_model):
     """Fixture for Digital Loggers emulated instances."""
     with create_pywemo_device(pywemo_registry, pywemo_model) as pywemo_dli_device:
         pywemo_dli_device.model_name = "DLI emulated Belkin Socket"
-        pywemo_dli_device.serialnumber = "1234567891"
+        pywemo_dli_device.serial_number = "1234567891"
         yield pywemo_dli_device
 
 

--- a/tests/components/wemo/test_init.py
+++ b/tests/components/wemo/test_init.py
@@ -138,9 +138,9 @@ async def test_discovery(hass: HomeAssistant, pywemo_registry) -> None:
         device.host = f"{MOCK_HOST}_{counter}"
         device.port = MOCK_PORT + counter
         device.name = f"{MOCK_NAME}_{counter}"
-        device.serialnumber = f"{MOCK_SERIAL_NUMBER}_{counter}"
+        device.serial_number = f"{MOCK_SERIAL_NUMBER}_{counter}"
         device.model_name = "Motion"
-        device.udn = f"uuid:{device.model_name}-1_0-{device.serialnumber}"
+        device.udn = f"uuid:{device.model_name}-1_0-{device.serial_number}"
         device.firmware_version = MOCK_FIRMWARE_VERSION
         device.get_state.return_value = 0  # Default to Off
         device.supports_long_press.return_value = False

--- a/tests/components/wemo/test_light_bridge.py
+++ b/tests/components/wemo/test_light_bridge.py
@@ -35,12 +35,12 @@ def pywemo_model():
 def pywemo_bridge_light_fixture(pywemo_device):
     """Fixture for Bridge.Light WeMoDevice instances."""
     light = create_autospec(pywemo.ouimeaux_device.bridge.Light, instance=True)
-    light.uniqueID = pywemo_device.serialnumber
+    light.uniqueID = pywemo_device.serial_number
     light.name = pywemo_device.name
     light.bridge = pywemo_device
     light.state = {"onoff": 0, "available": True}
     light.capabilities = ["onoff", "levelcontrol", "colortemperature"]
-    pywemo_device.Lights = {pywemo_device.serialnumber: light}
+    pywemo_device.Lights = {pywemo_device.serial_number: light}
     return light
 
 

--- a/tests/components/wemo/test_wemo_device.py
+++ b/tests/components/wemo/test_wemo_device.py
@@ -84,7 +84,7 @@ async def test_long_press_event(
         "name": device.wemo.name,
         "params": "testing_params",
         "type": EVENT_TYPE_LONG_PRESS,
-        "unique_id": device.wemo.serialnumber,
+        "unique_id": device.wemo.serial_number,
     }
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Rename `serialnumber` to `serial_number` in the wemo component. `serialnumber` was deprecated in pyWeMo [0.8.0](https://github.com/pywemo/pywemo/releases/tag/0.8.0) and will be removed in a future release.

HomeAssistant is currently using pywemo 0.9.1 which supports both `serialnumber` and `serial_number`.
https://github.com/home-assistant/core/blob/be638d3772599c566b798772b2247c0a7ac8f176/homeassistant/components/wemo/manifest.json#L12
`serialnumber` transitional wrapper: https://github.com/pywemo/pywemo/blob/0.9.1/pywemo/ouimeaux_device/__init__.py#L688

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
