### PR TITLE
Improve service response data APIs

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1659,7 +1659,7 @@ class SupportsResponse(StrEnum):
     """Service call response configuration."""
 
     NONE = "none"
-    """The service does not support responses (the default)"""
+    """The service does not support responses (the default)."""
 
     OPTIONAL = "optional"
     """The service optionally returns response data when asked by the caller."""

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1658,13 +1658,13 @@ class StateMachine:
 class SupportsResponse(enum.Enum):
     """Service call response configuration."""
 
-    NONE = "none"
+    NONE = enum.auto()
     """The service does not support responses (the default)"""
 
-    OPTIONAL = "optional"
+    OPTIONAL = enum.auto()
     """The service optionally returns response data when asked by the caller."""
 
-    ONLY = "only"
+    ONLY = enum.auto()
     """The service is read-only and the caller must always ask for response data."""
 
 

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1655,16 +1655,16 @@ class StateMachine:
         )
 
 
-class SupportsResponse(enum.Enum):
+class SupportsResponse(StrEnum):
     """Service call response configuration."""
 
-    NONE = enum.auto()
+    NONE = "none"
     """The service does not support responses (the default)"""
 
-    OPTIONAL = enum.auto()
+    OPTIONAL = "optional"
     """The service optionally returns response data when asked by the caller."""
 
-    ONLY = enum.auto()
+    ONLY = "only"
     """The service is read-only and the caller must always ask for response data."""
 
 

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -131,7 +131,7 @@ DOMAIN = "homeassistant"
 # How long to wait to log tasks that are blocking
 BLOCK_LOG_TIMEOUT = 60
 
-ServiceResult = JsonObjectType | None
+ServiceResponse = JsonObjectType | None
 
 
 class ConfigSource(StrEnum):
@@ -1658,25 +1658,27 @@ class StateMachine:
 class Service:
     """Representation of a callable service."""
 
-    __slots__ = ["job", "schema", "domain", "service"]
+    __slots__ = ["job", "schema", "domain", "service", "supports_response"]
 
     def __init__(
         self,
-        func: Callable[[ServiceCall], Coroutine[Any, Any, ServiceResult] | None],
+        func: Callable[[ServiceCall], Coroutine[Any, Any, ServiceResponse] | None],
         schema: vol.Schema | None,
         domain: str,
         service: str,
         context: Context | None = None,
+        supports_response: bool = False,
     ) -> None:
         """Initialize a service."""
         self.job = HassJob(func, f"service {domain}.{service}")
         self.schema = schema
+        self.supports_response = supports_response
 
 
 class ServiceCall:
     """Representation of a call to a service."""
 
-    __slots__ = ["domain", "service", "data", "context", "return_values"]
+    __slots__ = ["domain", "service", "data", "context", "return_response"]
 
     def __init__(
         self,
@@ -1684,14 +1686,14 @@ class ServiceCall:
         service: str,
         data: dict[str, Any] | None = None,
         context: Context | None = None,
-        return_values: bool = False,
+        return_response: bool = False,
     ) -> None:
         """Initialize a service call."""
         self.domain = domain.lower()
         self.service = service.lower()
         self.data = ReadOnlyDict(data or {})
         self.context = context or Context()
-        self.return_values = return_values
+        self.return_response = return_response
 
     def __repr__(self) -> str:
         """Return the representation of the service."""
@@ -1738,7 +1740,7 @@ class ServiceRegistry:
         service: str,
         service_func: Callable[
             [ServiceCall],
-            Coroutine[Any, Any, ServiceResult] | None,
+            Coroutine[Any, Any, ServiceResponse] | None,
         ],
         schema: vol.Schema | None = None,
     ) -> None:
@@ -1756,9 +1758,10 @@ class ServiceRegistry:
         domain: str,
         service: str,
         service_func: Callable[
-            [ServiceCall], Coroutine[Any, Any, ServiceResult] | None
+            [ServiceCall], Coroutine[Any, Any, ServiceResponse] | None
         ],
         schema: vol.Schema | None = None,
+        supports_response: bool = False,
     ) -> None:
         """Register a service.
 
@@ -1768,7 +1771,9 @@ class ServiceRegistry:
         """
         domain = domain.lower()
         service = service.lower()
-        service_obj = Service(service_func, schema, domain, service)
+        service_obj = Service(
+            service_func, schema, domain, service, supports_response=supports_response
+        )
 
         if domain in self._services:
             self._services[domain][service] = service_obj
@@ -1815,8 +1820,8 @@ class ServiceRegistry:
         blocking: bool = False,
         context: Context | None = None,
         target: dict[str, Any] | None = None,
-        return_values: bool = False,
-    ) -> ServiceResult:
+        return_response: bool = False,
+    ) -> ServiceResponse:
         """Call a service.
 
         See description of async_call for details.
@@ -1829,7 +1834,7 @@ class ServiceRegistry:
                 blocking,
                 context,
                 target,
-                return_values,
+                return_response,
             ),
             self._hass.loop,
         ).result()
@@ -1842,13 +1847,13 @@ class ServiceRegistry:
         blocking: bool = False,
         context: Context | None = None,
         target: dict[str, Any] | None = None,
-        return_values: bool = False,
-    ) -> ServiceResult:
+        return_response: bool = False,
+    ) -> ServiceResponse:
         """Call a service.
 
         Specify blocking=True to wait until service is executed.
 
-        If return_values=True, indicates that the caller can consume return values
+        If return_response=True, indicates that the caller can consume return values
         from the service, if any. Return values are a dict that can be returned by the
         standard JSON serialization process. Return values can only be used with blocking=True.
 
@@ -1864,13 +1869,20 @@ class ServiceRegistry:
         context = context or Context()
         service_data = service_data or {}
 
-        if return_values and not blocking:
-            raise ValueError("Invalid argument return_values=True when blocking=False")
-
         try:
             handler = self._services[domain][service]
         except KeyError:
             raise ServiceNotFound(domain, service) from None
+
+        if return_response:
+            if not blocking:
+                raise ValueError(
+                    "Invalid argument return_response=True when blocking=False"
+                )
+            if not handler.supports_response:
+                raise ValueError(
+                    "Invalid argument return_response=True when handler does not support responses"
+                )
 
         if target:
             service_data.update(target)
@@ -1890,7 +1902,7 @@ class ServiceRegistry:
             processed_data = service_data
 
         service_call = ServiceCall(
-            domain, service, processed_data, context, return_values
+            domain, service, processed_data, context, return_response
         )
 
         self._hass.bus.async_fire(
@@ -1909,7 +1921,7 @@ class ServiceRegistry:
             return None
 
         response_data = await coro
-        if not return_values:
+        if not return_response:
             return None
         if not isinstance(response_data, dict):
             raise HomeAssistantError(
@@ -1945,19 +1957,19 @@ class ServiceRegistry:
 
     async def _execute_service(
         self, handler: Service, service_call: ServiceCall
-    ) -> ServiceResult:
+    ) -> ServiceResponse:
         """Execute a service."""
         if handler.job.job_type == HassJobType.Coroutinefunction:
             return await cast(
-                Callable[[ServiceCall], Awaitable[ServiceResult]],
+                Callable[[ServiceCall], Awaitable[ServiceResponse]],
                 handler.job.target,
             )(service_call)
         if handler.job.job_type == HassJobType.Callback:
-            return cast(Callable[[ServiceCall], ServiceResult], handler.job.target)(
+            return cast(Callable[[ServiceCall], ServiceResponse], handler.job.target)(
                 service_call
             )
         return await self._hass.async_add_executor_job(
-            cast(Callable[[ServiceCall], ServiceResult], handler.job.target),
+            cast(Callable[[ServiceCall], ServiceResponse], handler.job.target),
             service_call,
         )
 

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -674,7 +674,7 @@ class _ScriptRun:
                     **params,
                     blocking=True,
                     context=self._context,
-                    return_values=(response_variable is not None),
+                    return_response=(response_variable is not None),
                 )
             ),
         )

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -27,7 +27,7 @@ from homeassistant.core import (
     CoreState,
     HomeAssistant,
     ServiceCall,
-    ServiceResult,
+    ServiceResponse,
     callback,
 )
 from homeassistant.exceptions import ConditionError, HomeAssistantError, ServiceNotFound
@@ -330,19 +330,19 @@ async def test_calling_service_template(hass: HomeAssistant) -> None:
     )
 
 
-async def test_calling_service_return_values(
+async def test_calling_service_response_data(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test the calling of a service with return values."""
     context = Context()
 
-    def mock_service(call: ServiceCall) -> ServiceResult:
+    def mock_service(call: ServiceCall) -> ServiceResponse:
         """Mock service call."""
-        if call.return_values:
+        if call.return_response:
             return {"data": "value-12345"}
         return None
 
-    hass.services.async_register("test", "script", mock_service)
+    hass.services.async_register("test", "script", mock_service, supports_response=True)
     sequence = cv.SCRIPT_SCHEMA(
         [
             {

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1213,6 +1213,15 @@ async def test_serviceregistry_no_return_response(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
     assert not result
 
+    with pytest.raises(ValueError, match="not support responses"):
+        await hass.services.async_call(
+            "test_domain",
+            "test_service",
+            service_data={},
+            blocking=True,
+            return_response=True,
+        )
+
 
 async def test_config_defaults() -> None:
     """Test config defaults."""

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1127,7 +1127,7 @@ async def test_serviceregistry_async_return_response(
 async def test_services_call_return_response_requires_blocking(
     hass: HomeAssistant,
 ) -> None:
-    """Test that non-blocking service calls cannot return values."""
+    """Test that non-blocking service calls cannot ask for response data."""
     async_mock_service(hass, "test_domain", "test_service")
     with pytest.raises(ValueError, match="when blocking=False"):
         await hass.services.async_call(
@@ -1152,7 +1152,7 @@ async def test_services_call_return_response_requires_blocking(
 async def test_serviceregistry_return_response_invalid(
     hass: HomeAssistant, response_data: Any, expected_error: str
 ) -> None:
-    """Test service call return values are required to be json serializable objects."""
+    """Test service call response data must be json serializable objects."""
 
     def service_handler(call: ServiceCall) -> ServiceResponse:
         """Service handler coroutine."""
@@ -1189,7 +1189,7 @@ async def test_serviceregistry_return_response_arguments(
     return_response: bool,
     expected_error: str,
 ) -> None:
-    """Test service call data when not asked for return values."""
+    """Test service call response data invalid arguments."""
 
     hass.services.async_register(
         "test_domain",
@@ -1220,7 +1220,7 @@ async def test_serviceregistry_return_response_optional(
     return_response: bool,
     expected_response_data: Any,
 ) -> None:
-    """Test service call return values are not returned when there is no result schema."""
+    """Test optional service call response data."""
 
     def service_handler(call: ServiceCall) -> ServiceResponse:
         """Service handler coroutine."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Make the API naming more consistent, and require registration that a service supports response data so that we can better integrate with the UI and avoid user confusion with better error messages.  Specifically:
- Add a `supports_response` enum at registration time that is required to return response data
- Rename `return_values` to `return_response`
- Rename `ServiceResult` to `ServiceResponse`


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/1797

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
