### PR TITLE
Use Chat GPT to execute actions on integrated devices

### DIFF
--- a/homeassistant/components/openai_conversation/__init__.py
+++ b/homeassistant/components/openai_conversation/__init__.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 from functools import partial
+import inspect
+import json
 import logging
 from typing import Literal
 
@@ -16,18 +18,16 @@ from homeassistant.exceptions import ConfigEntryNotReady, TemplateError
 from homeassistant.helpers import intent, template
 from homeassistant.util import ulid
 
+from .actions import Actions
 from .const import (
     CONF_CHAT_MODEL,
     CONF_MAX_TOKENS,
     CONF_PROMPT,
-    CONF_TEMPERATURE,
-    CONF_TOP_P,
     DEFAULT_CHAT_MODEL,
     DEFAULT_MAX_TOKENS,
     DEFAULT_PROMPT,
-    DEFAULT_TEMPERATURE,
-    DEFAULT_TOP_P,
 )
+from .queries import Queries
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -47,6 +47,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         raise ConfigEntryNotReady(err) from err
 
     conversation.async_set_agent(hass, entry, OpenAIAgent(hass, entry))
+
     return True
 
 
@@ -64,7 +65,14 @@ class OpenAIAgent(conversation.AbstractConversationAgent):
         """Initialize the agent."""
         self.hass = hass
         self.entry = entry
+        self.queries = Queries(hass, entry)
+        self.actions = Actions(hass, entry)
         self.history: dict[str, list[dict]] = {}
+
+        _LOGGER.debug(
+            "Functions for openai conversation: %s",
+            json.dumps(self._get_methods_and_descriptions()),
+        )
 
     @property
     def attribution(self):
@@ -81,10 +89,6 @@ class OpenAIAgent(conversation.AbstractConversationAgent):
     ) -> conversation.ConversationResult:
         """Process a sentence."""
         raw_prompt = self.entry.options.get(CONF_PROMPT, DEFAULT_PROMPT)
-        model = self.entry.options.get(CONF_CHAT_MODEL, DEFAULT_CHAT_MODEL)
-        max_tokens = self.entry.options.get(CONF_MAX_TOKENS, DEFAULT_MAX_TOKENS)
-        top_p = self.entry.options.get(CONF_TOP_P, DEFAULT_TOP_P)
-        temperature = self.entry.options.get(CONF_TEMPERATURE, DEFAULT_TEMPERATURE)
 
         if user_input.conversation_id in self.history:
             conversation_id = user_input.conversation_id
@@ -107,19 +111,33 @@ class OpenAIAgent(conversation.AbstractConversationAgent):
 
         messages.append({"role": "user", "content": user_input.text})
 
+        return await self._call_gpt(
+            messages,
+            conversation_id,
+            language=user_input.language,
+        )
+
+    async def _call_gpt(self, messages, conversation_id, language):
+        model = self.entry.options.get(CONF_CHAT_MODEL, DEFAULT_CHAT_MODEL)
+        max_tokens = self.entry.options.get(CONF_MAX_TOKENS, DEFAULT_MAX_TOKENS)
+        # top_p = self.entry.options.get(CONF_TOP_P, DEFAULT_TOP_P)
+        # temperature = self.entry.options.get(CONF_TEMPERATURE, DEFAULT_TEMPERATURE)
+
         _LOGGER.debug("Prompt for %s: %s", model, messages)
 
         try:
             result = await openai.ChatCompletion.acreate(
                 model=model,
                 messages=messages,
+                functions=self.queries.functions + self.actions.functions,
+                function_call="auto",
                 max_tokens=max_tokens,
-                top_p=top_p,
-                temperature=temperature,
+                # top_p=top_p,
+                # temperature=temperature,
                 user=conversation_id,
             )
         except error.OpenAIError as err:
-            intent_response = intent.IntentResponse(language=user_input.language)
+            intent_response = intent.IntentResponse(language=language)
             intent_response.async_set_error(
                 intent.IntentResponseErrorCode.UNKNOWN,
                 f"Sorry, I had a problem talking to OpenAI: {err}",
@@ -128,22 +146,92 @@ class OpenAIAgent(conversation.AbstractConversationAgent):
                 response=intent_response, conversation_id=conversation_id
             )
 
-        _LOGGER.debug("Response %s", result)
+        _LOGGER.debug("Response is this: %s", result)
         response = result["choices"][0]["message"]
+
         messages.append(response)
         self.history[conversation_id] = messages
 
-        intent_response = intent.IntentResponse(language=user_input.language)
-        intent_response.async_set_speech(response["content"])
+        if response.get("function_call"):
+            function_name = response["function_call"]["name"]
+            try:
+                function_response_s = await self._process_query_or_action(response)
+            except Exception:  # pylint: disable=broad-exception-caught
+                intent_response = intent.IntentResponse(language=language)
+                intent_response.async_set_error(
+                    intent.IntentResponseErrorCode.UNKNOWN,
+                    "Error executing a function",
+                )
+                return conversation.ConversationResult(
+                    response=intent_response, conversation_id=conversation_id
+                )
+
+            messages.append(
+                {
+                    "role": "function",
+                    "name": function_name,
+                    "content": function_response_s,
+                }
+            )
+            return await self._call_gpt(messages, conversation_id, language)
+
+        if response["content"]:
+            intent_response = intent.IntentResponse(language=language)
+            intent_response.async_set_speech(response["content"])
+            return conversation.ConversationResult(
+                response=intent_response, conversation_id=conversation_id
+            )
+
+        intent_response = intent.IntentResponse(language=language)
+        intent_response.async_set_speech("Something went wrong.")
         return conversation.ConversationResult(
             response=intent_response, conversation_id=conversation_id
         )
+
+    async def _process_query_or_action(self, response):
+        function_name = response["function_call"]["name"]
+        function_args = response["function_call"]["arguments"]
+
+        _LOGGER.debug("GPT calling function %s: %s", function_name, function_args)
+        if function_name == "query_all_entities":
+            return await self.queries.query_all_entities()
+        if function_name == "query_weather_report":
+            return await self.queries.query_weather_report()
+        if function_name == "exec_control_switch":
+            args = json.loads(function_args)
+            return await self.actions.exec_control_switch(
+                entity=args.get("entity"),
+                action=args.get("action"),
+            )
+        if function_name == "exec_manage_shopping_list":
+            args = json.loads(function_args)
+            return await self.actions.exec_manage_shopping_list(
+                action=args.get("action"),
+                items=args.get("items"),
+            )
+
+    def _get_methods_and_descriptions(self):
+        """Take a class object as an argument and returns a dictionary where keys are method names and values are their docstrings."""
+        methods = []
+        for class_obj in (Queries, Actions):
+            for name, member in inspect.getmembers(class_obj):
+                if (
+                    inspect.isfunction(member) or inspect.ismethod(member)
+                ) and name != "__init__":
+                    methods.append(
+                        {
+                            "name": name,
+                            "description": member.__doc__,
+                        }
+                    )
+        return methods
 
     def _async_generate_prompt(self, raw_prompt: str) -> str:
         """Generate a prompt for the user."""
         return template.Template(raw_prompt, self.hass).async_render(
             {
                 "ha_name": self.hass.config.location_name,
+                "functions": self._get_methods_and_descriptions(),
             },
             parse_result=False,
         )

--- a/homeassistant/components/openai_conversation/actions.py
+++ b/homeassistant/components/openai_conversation/actions.py
@@ -1,0 +1,101 @@
+"""OpenAI callable executable functions."""
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+
+class Actions:
+    """Actions exectutable against hass."""
+
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
+        """Initialize the agent."""
+        self.hass = hass
+        self.entry = entry
+        self.functions = [
+            {
+                "name": "exec_control_switch",
+                "description": "Execute an action to control a switch by turning it on, off, or toggling",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "entity": {
+                            "type": "string",
+                            "description": "ID of the entity without the switch prefix",
+                        },
+                        "action": {
+                            "type": "string",
+                            "enum": ["turn_on", "turn_off", "toggle"],
+                            "description": "Action to perform on the entity",
+                        },
+                    },
+                    "required": ["entity", "action"],
+                },
+            },
+            {
+                "name": "exec_manage_shopping_list",
+                "description": "Execute an action to add or remove items from a shopping list",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "action": {
+                            "type": "string",
+                            "enum": ["add", "remove"],
+                            "description": "Action to perform on the shopping list",
+                        },
+                        "items": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": "List of items to add or remove",
+                        },
+                    },
+                    "required": ["action", "items"],
+                },
+            },
+            # {
+            #     "name": "exec_adjust_temperature",
+            #     "description": "Set the temperature of a thermostat or air conditioning device",
+            #     "parameters": {
+            #         "type": "object",
+            #         "properties": {
+            #             "entity": {
+            #                 "type": "string",
+            #                 "description": "ID of the entity without the climate prefix",
+            #             },
+            #             "temperature": {
+            #                 "type": "number",
+            #                 "description": "Desired temperature in degrees",
+            #             },
+            #             "unit": {
+            #                 "type": "string",
+            #                 "enum": ["celsius", "fahrenheit"],
+            #                 "description": "Unit of the temperature",
+            #             },
+            #         },
+            #         "required": ["device", "temperature", "unit"],
+            #     },
+            # },
+        ]
+
+    async def exec_control_switch(self, entity, action):
+        """Control a switch by turning it on, off, or toggling."""
+        state = self.hass.states.get("switch." + entity)
+        if state is None:
+            return "This entity does not exist, find the correct one via the query_all_entities function"
+
+        await self.hass.services.async_call(
+            "switch", action, {"entity_id": "switch." + entity}, False
+        )
+        return "Switch control executed"
+
+    async def exec_manage_shopping_list(self, action, items):
+        """Add or remove items from a shopping list."""
+        for item in items:
+            await self.hass.services.async_call(
+                "shopping_list", action, {"name": item}, False
+            )
+        return "Shopping list updated"
+
+    # async def exec_adjust_temperature(self, action):
+    #     """Turn the hallway light on or off"""
+    #     await self.hass.services.async_call(
+    #         "switch", action, {"entity_id": "switch.stairway_light"}, False
+    #     )

--- a/homeassistant/components/openai_conversation/const.py
+++ b/homeassistant/components/openai_conversation/const.py
@@ -3,25 +3,7 @@
 DOMAIN = "openai_conversation"
 CONF_PROMPT = "prompt"
 DEFAULT_PROMPT = """This smart home is controlled by Home Assistant.
-
-An overview of the areas and the devices in this smart home:
-{%- for area in areas() %}
-  {%- set area_info = namespace(printed=false) %}
-  {%- for device in area_devices(area) -%}
-    {%- if not device_attr(device, "disabled_by") and not device_attr(device, "entry_type") and device_attr(device, "name") %}
-      {%- if not area_info.printed %}
-
-{{ area_name(area) }}:
-        {%- set area_info.printed = true %}
-      {%- endif %}
-- {{ device_attr(device, "name") }}{% if device_attr(device, "model") and (device_attr(device, "model") | string) not in (device_attr(device, "name") | string) %} ({{ device_attr(device, "model") }}){% endif %}
-    {%- endif %}
-  {%- endfor %}
-{%- endfor %}
-
-Answer the user's questions about the world truthfully.
-
-If the user wants to control a device, reject the request and suggest using the Home Assistant app.
+Query functions for all required information before executing actions.
 """
 CONF_CHAT_MODEL = "chat_model"
 DEFAULT_CHAT_MODEL = "gpt-3.5-turbo"

--- a/homeassistant/components/openai_conversation/queries.py
+++ b/homeassistant/components/openai_conversation/queries.py
@@ -1,0 +1,89 @@
+"""OpenAI callable query functions."""
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import template
+
+
+class Queries:
+    """Queries exectutable against hass."""
+
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
+        """Initialize the agent."""
+        self.hass = hass
+        self.entry = entry
+        self.functions = [
+            {
+                "name": "query_all_entities",
+                "description": "Query to get all device entities that can be controlled and their current state",
+                "parameters": {
+                    "type": "object",
+                    "properties": {},
+                },
+            },
+            {
+                "name": "query_weather_report",
+                "description": "Query the current weather for a specified location",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "entity": {
+                            "type": "string",
+                            "description": "ID of the entity to query without the weather prefix",
+                        },
+                    },
+                    "required": ["entity"],
+                },
+            },
+        ]
+
+    async def query_all_entities(self):
+        """Get all device entities that can be controlled and their current state."""
+        return template.Template(
+            """
+            An overview of the areas and the devices in this smart home:
+            {%- for area in areas() %}
+            {%- set area_info = namespace(printed=false) %}
+            {%- for device in area_devices(area) -%}
+                {%- if not device_attr(device, "disabled_by") and not device_attr(device, "entry_type") and device_attr(device, "name") %}
+                {%- if not area_info.printed %}
+
+            {{ area_name(area) }}:
+                    {%- set area_info.printed = true %}
+                {%- endif %}
+            - {{device_entities(device)}}
+                {%- endif %}
+            {%- endfor %}
+            {%- endfor %}
+            """,
+            self.hass,
+        ).async_render(
+            {
+                "ha_name": self.hass.config.location_name,
+            },
+            parse_result=False,
+        )
+
+    async def query_weather_report(self):
+        """Query the current weather for a specified location."""
+        return template.Template(
+            """
+            {% set weather = states('weather.forecast_home') %}
+            {% set forecast = state_attr('weather.forecast_home', 'forecast') %}
+            {% set current_rain_chance = state_attr('weather.forecast_home', 'precipitation_probability') %}
+            {% set current_rain_unit = state_attr('weather.forecast_home', 'precipitation_unit') %}
+            {% set current_rain = state_attr('weather.forecast_home', 'rain') %}
+
+            The current weather is {{ weather }} with a temperature of {{ state_attr('weather.forecast_home', 'temperature') }}°F{% if current_rain %} and {{ current_rain }}{{ current_rain_unit }} of rain{% endif %}.
+
+            Forecast for the next three days:
+            {% for day in forecast[:3] %}
+            - {{ day.datetime }}: {{ day.condition }} with a high of {{ day.temperature }}°F and a low of {{ day.templow }}°F{% if day.precipitation %} and {{ day.precipitation }}% chance of rain{% endif %}.
+            {% endfor %}
+            """,
+            self.hass,
+        ).async_render(
+            {
+                "ha_name": self.hass.config.location_name,
+            },
+            parse_result=False,
+        )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR updates the OpenAI integration to use [Chat GPT's function calling](https://platform.openai.com/docs/guides/gpt/function-calling) to interface with devices. This code started as a "mess around with" thing but some basic testing has shown that it has the capability of being incredibly powerful. I'm opening the PR as a regular PR to get visibility on it, but I would request that mods switch it to a draft PR for further discussion. There are many architectural questions that should be answered before merge as well as code cleanup that needs to happen. If this isn't the right place for an architectural discussion, feel free to close this PR and direct me to where the discussion should happen. I'd be interested in contributing to the discussion and perhaps some code as per my availability.

I'll also preface by making some excuses that I haven't written python in more than a decade and I have only a glancing understanding of HA's architecture. Happy to review all the docs and make recommendations after a more thorough assessment over the course of weeks/months but also happy to just hand this PR over to someone who knows what they're doing.

Regarding the integration, the functionality itself works incredibly well. Better than Google Assistant or Alexa afaict in terms of processing and contextualizing natural language. The idea is that prompts fed into the Assist conversation API are passed to the integration: Chat GPT is fed a base prompt, the user's conversation prompt, and an array of functions split into: a) queries about the state of the system and the world and b) actions that can be executed to effect the state of the system. The goal is to have the LLM execute all the quries it can first to get full context, then execute whatever the desired action is.

Example of something that works:
```
Prompt: "If it's hot out, turn on all the fans in the house".
Execution: query or query_weather_report to figure out if it's hot, query of query_all_entities to get the entity id of the fans, execution of exec_control_switch on each of the fans.
```
Pretty spiffy.

Here are the primary questions I think need to be answered to make this thing truly worthwhile.
- How do we reduce the number of tokens sent to Chat GPT. The API charges per token and a lot of back and forth with the LLM can rack up the charges. At moderate home use even in its current state it would probably still be in the range of a few cents to a few dollars per month but we should keep in mind that token bloat comes at a cost.
  * As written, we're passing all functions into the GPT conversation API on each query. This is fine for now but is probably not reasonable if we have 20 functions. There are two potential solutions: a) make functions extremely abstract and driven by parameterization and b) figure out a way to contextualize sets of functions so that we only have to pass a subset of functions with a specific prompt. The real solution is probably a combination of A and B but needs some thought.
- How do we only expose devices that are marked as exposed in the Assist settings? I didn't see an API method for checking that but should be easy to implement in the executions and query functions.
- Currently this is written with the English language in mind, localization should probably be considered as an important part of the PR.
- What are all the integrations that can be brought into queries and actions?
- What are appropriate configurations that need to be added to HA for this integration? For example, turning functions on and off.
- There should be some kind of guide about what errors queries and actions throw and how those are best communicated as feedback to OpenAI.

Here are a few failed experiements that should be taken into account.

- Setting up a query for json schemas of other functions. This was the first thing I tried to reduce the number of functions passed. I tried to get the LLM to first query for the json schema of the function it needed next to be included in the subsequent prompt. It wasn't able to figure out a prompt that led it to do that.
- I tried to set up prompts to stress the importance of executing all queries needed for context before actions. GPT refuses to do this and will only execute a single query before trying to do an action. Instead, I had to set up validation to tell GPT that it needed to go back for more context. For example, it'll attempt to execute a turn_off of a switch on an entity ID it makes up. However, if it calls that function with the made up entity ID, and the function responds with a "entity not found validation" message, it'll go back and query for the entity id before trying again.

Further context:
- Chat GPT 3.5 used. Would be interesting to try with 4.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
