### PR TITLE
Improve mqtt climate turn_on and turn_off service

### DIFF
--- a/homeassistant/components/mqtt/abbreviations.py
+++ b/homeassistant/components/mqtt/abbreviations.py
@@ -159,6 +159,7 @@ ABBREVIATIONS = {
     "pos_clsd": "position_closed",
     "pos_open": "position_open",
     "pow_cmd_t": "power_command_topic",
+    "pow_cmd_tpl": "power_command_template",
     "pow_stat_t": "power_state_topic",
     "pow_stat_tpl": "power_state_template",
     "pr_mode_cmd_t": "preset_mode_command_topic",

--- a/homeassistant/components/mqtt/climate.py
+++ b/homeassistant/components/mqtt/climate.py
@@ -109,13 +109,15 @@ CONF_HUMIDITY_STATE_TOPIC = "target_humidity_state_topic"
 CONF_HUMIDITY_MAX = "max_humidity"
 CONF_HUMIDITY_MIN = "min_humidity"
 
-# CONF_POWER_COMMAND_TOPIC, CONF_POWER_STATE_TOPIC and CONF_POWER_STATE_TEMPLATE
+# CONF_POWER_STATE_TOPIC and CONF_POWER_STATE_TEMPLATE
 # are deprecated, support for CONF_POWER_STATE_TOPIC and CONF_POWER_STATE_TEMPLATE
 # was already removed or never added support was deprecated with release 2023.2
 # and will be removed with release 2023.8
-CONF_POWER_COMMAND_TOPIC = "power_command_topic"
 CONF_POWER_STATE_TEMPLATE = "power_state_template"
 CONF_POWER_STATE_TOPIC = "power_state_topic"
+
+CONF_POWER_COMMAND_TOPIC = "power_command_topic"
+CONF_POWER_COMMAND_TEMPLATE = "power_command_template"
 CONF_PRESET_MODE_STATE_TOPIC = "preset_mode_state_topic"
 CONF_PRESET_MODE_COMMAND_TOPIC = "preset_mode_command_topic"
 CONF_PRESET_MODE_VALUE_TEMPLATE = "preset_mode_value_template"
@@ -183,6 +185,7 @@ COMMAND_TEMPLATE_KEYS = {
     CONF_FAN_MODE_COMMAND_TEMPLATE,
     CONF_HUMIDITY_COMMAND_TEMPLATE,
     CONF_MODE_COMMAND_TEMPLATE,
+    CONF_POWER_COMMAND_TEMPLATE,
     CONF_PRESET_MODE_COMMAND_TEMPLATE,
     CONF_SWING_MODE_COMMAND_TEMPLATE,
     CONF_TEMP_COMMAND_TEMPLATE,
@@ -300,6 +303,7 @@ _PLATFORM_SCHEMA_BASE = MQTT_BASE_SCHEMA.extend(
         vol.Optional(CONF_PAYLOAD_ON, default="ON"): cv.string,
         vol.Optional(CONF_PAYLOAD_OFF, default="OFF"): cv.string,
         vol.Optional(CONF_POWER_COMMAND_TOPIC): valid_publish_topic,
+        vol.Optional(CONF_POWER_COMMAND_TEMPLATE): cv.template,
         vol.Optional(CONF_POWER_STATE_TEMPLATE): cv.template,
         vol.Optional(CONF_POWER_STATE_TOPIC): valid_subscribe_topic,
         vol.Optional(CONF_PRECISION): vol.In(
@@ -348,11 +352,10 @@ _PLATFORM_SCHEMA_BASE = MQTT_BASE_SCHEMA.extend(
 ).extend(MQTT_ENTITY_COMMON_SCHEMA.schema)
 
 PLATFORM_SCHEMA_MODERN = vol.All(
-    # CONF_POWER_COMMAND_TOPIC, CONF_POWER_STATE_TOPIC and CONF_POWER_STATE_TEMPLATE
+    # CONF_POWER_STATE_TOPIC and CONF_POWER_STATE_TEMPLATE
     # are deprecated, support for CONF_POWER_STATE_TOPIC and CONF_POWER_STATE_TEMPLATE
     # was already removed or never added support was deprecated with release 2023.2
     # and will be removed with release 2023.8
-    cv.deprecated(CONF_POWER_COMMAND_TOPIC),
     cv.deprecated(CONF_POWER_STATE_TEMPLATE),
     cv.deprecated(CONF_POWER_STATE_TOPIC),
     _PLATFORM_SCHEMA_BASE,
@@ -365,10 +368,9 @@ _DISCOVERY_SCHEMA_BASE = _PLATFORM_SCHEMA_BASE.extend({}, extra=vol.REMOVE_EXTRA
 
 DISCOVERY_SCHEMA = vol.All(
     _DISCOVERY_SCHEMA_BASE,
-    # CONF_POWER_COMMAND_TOPIC, CONF_POWER_STATE_TOPIC and CONF_POWER_STATE_TEMPLATE are deprecated,
+    # CONF_POWER_STATE_TOPIC and CONF_POWER_STATE_TEMPLATE are deprecated,
     # support for CONF_POWER_STATE_TOPIC and CONF_POWER_STATE_TEMPLATE was already removed or never added
     # support was deprecated with release 2023.2 and will be removed with release 2023.8
-    cv.deprecated(CONF_POWER_COMMAND_TOPIC),
     cv.deprecated(CONF_POWER_STATE_TEMPLATE),
     cv.deprecated(CONF_POWER_STATE_TOPIC),
     valid_preset_mode_configuration,
@@ -962,12 +964,11 @@ class MqttClimate(MqttTemperatureControlEntity, ClimateEntity):
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new operation mode."""
-        if hvac_mode == HVACMode.OFF:
-            await self._publish(
-                CONF_POWER_COMMAND_TOPIC, self._config[CONF_PAYLOAD_OFF]
-            )
-        else:
-            await self._publish(CONF_POWER_COMMAND_TOPIC, self._config[CONF_PAYLOAD_ON])
+        if CONF_POWER_COMMAND_TOPIC in self._config:
+            if hvac_mode == HVACMode.OFF:
+                await self.async_turn_off()
+            else:
+                await self.async_turn_on()
 
         payload = self._command_templates[CONF_MODE_COMMAND_TEMPLATE](hvac_mode)
         await self._publish(CONF_MODE_COMMAND_TOPIC, payload)
@@ -1013,3 +1014,33 @@ class MqttClimate(MqttTemperatureControlEntity, ClimateEntity):
     async def async_turn_aux_heat_off(self) -> None:
         """Turn auxiliary heater off."""
         await self._set_aux_heat(False)
+
+    async def async_turn_on(self) -> None:
+        """Turn the entity on."""
+        if CONF_POWER_COMMAND_TOPIC in self._config:
+            mqtt_payload = self._command_templates[CONF_POWER_COMMAND_TEMPLATE](
+                self._config[CONF_PAYLOAD_ON]
+            )
+            await self._publish(CONF_POWER_COMMAND_TOPIC, mqtt_payload)
+            return
+        # Fall back to default behavior without power command topic
+        for mode in (HVACMode.HEAT_COOL, HVACMode.HEAT, HVACMode.COOL):
+            if mode not in self.hvac_modes:
+                continue
+            await self.async_set_hvac_mode(mode)
+            break
+
+    async def async_turn_off(self) -> None:
+        """Turn the entity off."""
+        if CONF_POWER_COMMAND_TOPIC in self._config:
+            mqtt_payload = self._command_templates[CONF_POWER_COMMAND_TEMPLATE](
+                self._config[CONF_PAYLOAD_OFF]
+            )
+            await self._publish(CONF_POWER_COMMAND_TOPIC, mqtt_payload)
+            if self._optimistic:
+                self._attr_hvac_mode = HVACMode.OFF
+                self.async_write_ha_state()
+            return
+        # Fall back to default behavior without power command topic
+        if HVACMode.OFF in self.hvac_modes:
+            await self.async_set_hvac_mode(HVACMode.OFF)

--- a/homeassistant/components/mqtt/climate.py
+++ b/homeassistant/components/mqtt/climate.py
@@ -964,12 +964,6 @@ class MqttClimate(MqttTemperatureControlEntity, ClimateEntity):
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new operation mode."""
-        if CONF_POWER_COMMAND_TOPIC in self._config:
-            if hvac_mode == HVACMode.OFF:
-                await self.async_turn_off()
-            else:
-                await self.async_turn_on()
-
         payload = self._command_templates[CONF_MODE_COMMAND_TEMPLATE](hvac_mode)
         await self._publish(CONF_MODE_COMMAND_TOPIC, payload)
 

--- a/homeassistant/components/mqtt/climate.py
+++ b/homeassistant/components/mqtt/climate.py
@@ -1018,11 +1018,7 @@ class MqttClimate(MqttTemperatureControlEntity, ClimateEntity):
             await self._publish(CONF_POWER_COMMAND_TOPIC, mqtt_payload)
             return
         # Fall back to default behavior without power command topic
-        for mode in (HVACMode.HEAT_COOL, HVACMode.HEAT, HVACMode.COOL):
-            if mode not in self.hvac_modes:
-                continue
-            await self.async_set_hvac_mode(mode)
-            break
+        await super().async_turn_on()
 
     async def async_turn_off(self) -> None:
         """Turn the entity off."""
@@ -1036,5 +1032,4 @@ class MqttClimate(MqttTemperatureControlEntity, ClimateEntity):
                 self.async_write_ha_state()
             return
         # Fall back to default behavior without power command topic
-        if HVACMode.OFF in self.hvac_modes:
-            await self.async_set_hvac_mode(HVACMode.OFF)
+        await super().async_turn_off()

--- a/tests/components/mqtt/test_climate.py
+++ b/tests/components/mqtt/test_climate.py
@@ -374,17 +374,13 @@ async def test_set_operation_with_power_command(
     await common.async_set_hvac_mode(hass, "cool", ENTITY_CLIMATE)
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.state == "cool"
-    mqtt_mock.async_publish.assert_has_calls(
-        [call("power-command", "ON", 0, False), call("mode-topic", "cool", 0, False)]
-    )
+    mqtt_mock.async_publish.assert_has_calls([call("mode-topic", "cool", 0, False)])
     mqtt_mock.async_publish.reset_mock()
 
     await common.async_set_hvac_mode(hass, "off", ENTITY_CLIMATE)
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.state == "off"
-    mqtt_mock.async_publish.assert_has_calls(
-        [call("power-command", "OFF", 0, False), call("mode-topic", "off", 0, False)]
-    )
+    mqtt_mock.async_publish.assert_has_calls([call("mode-topic", "off", 0, False)])
     mqtt_mock.async_publish.reset_mock()
 
     await common.async_turn_on(hass, ENTITY_CLIMATE)
@@ -420,9 +416,7 @@ async def test_turn_on_and_off_optimistic_with_power_command(
     await common.async_set_hvac_mode(hass, "cool", ENTITY_CLIMATE)
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.state == "cool"
-    mqtt_mock.async_publish.assert_has_calls(
-        [call("power-command", "ON", 0, False), call("mode-topic", "cool", 0, False)]
-    )
+    mqtt_mock.async_publish.assert_has_calls([call("mode-topic", "cool", 0, False)])
     mqtt_mock.async_publish.reset_mock()
     await common.async_set_hvac_mode(hass, "off", ENTITY_CLIMATE)
     state = hass.states.get(ENTITY_CLIMATE)
@@ -1663,16 +1657,14 @@ async def test_set_and_templates(
     # Mode
     await common.async_set_hvac_mode(hass, "cool", ENTITY_CLIMATE)
     mqtt_mock.async_publish.assert_any_call("mode-topic", "mode: cool", 0, False)
-    mqtt_mock.async_publish.assert_any_call("power-topic", "power: ON", 0, False)
-    assert mqtt_mock.async_publish.call_count == 2
+    assert mqtt_mock.async_publish.call_count == 1
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.state == "cool"
 
     await common.async_set_hvac_mode(hass, "off", ENTITY_CLIMATE)
     mqtt_mock.async_publish.assert_any_call("mode-topic", "mode: off", 0, False)
-    mqtt_mock.async_publish.assert_any_call("power-topic", "power: OFF", 0, False)
-    assert mqtt_mock.async_publish.call_count == 2
+    assert mqtt_mock.async_publish.call_count == 1
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.state == "off"
@@ -2299,20 +2291,6 @@ async def test_precision_whole(
             "power_command_topic",
             {},
             "OFF",
-            None,
-        ),
-        (
-            climate.SERVICE_SET_HVAC_MODE,
-            "power_command_topic",
-            {"hvac_mode": "off"},
-            "OFF",
-            None,
-        ),
-        (
-            climate.SERVICE_SET_HVAC_MODE,
-            "power_command_topic",
-            {"hvac_mode": "dry"},
-            "ON",
             None,
         ),
         (

--- a/tests/components/mqtt/test_climate.py
+++ b/tests/components/mqtt/test_climate.py
@@ -355,9 +355,6 @@ async def test_set_operation_optimistic(
     assert state.state == "heat"
 
 
-# CONF_POWER_COMMAND_TOPIC, CONF_POWER_STATE_TOPIC and CONF_POWER_STATE_TEMPLATE are deprecated,
-# support for CONF_POWER_STATE_TOPIC and CONF_POWER_STATE_TEMPLATE was already removed or never added
-# support was deprecated with release 2023.2 and will be removed with release 2023.8
 @pytest.mark.parametrize(
     "hass_config",
     [
@@ -388,6 +385,129 @@ async def test_set_operation_with_power_command(
     mqtt_mock.async_publish.assert_has_calls(
         [call("power-command", "OFF", 0, False), call("mode-topic", "off", 0, False)]
     )
+    mqtt_mock.async_publish.reset_mock()
+
+    await common.async_turn_on(hass, ENTITY_CLIMATE)
+    # the hvac_mode is not updated optimistically as this is not supported
+    state = hass.states.get(ENTITY_CLIMATE)
+    assert state.state == "off"
+    mqtt_mock.async_publish.assert_has_calls([call("power-command", "ON", 0, False)])
+    mqtt_mock.async_publish.reset_mock()
+
+    await common.async_turn_off(hass, ENTITY_CLIMATE)
+    mqtt_mock.async_publish.assert_has_calls([call("power-command", "OFF", 0, False)])
+    mqtt_mock.async_publish.reset_mock()
+
+
+@pytest.mark.parametrize(
+    "hass_config",
+    [
+        help_custom_config(
+            climate.DOMAIN,
+            DEFAULT_CONFIG,
+            ({"power_command_topic": "power-command", "optimistic": True},),
+        )
+    ],
+)
+async def test_turn_on_and_off_optimistic_with_power_command(
+    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
+) -> None:
+    """Test setting of turn on/off with power command enabled."""
+    mqtt_mock = await mqtt_mock_entry()
+
+    state = hass.states.get(ENTITY_CLIMATE)
+    assert state.state == "off"
+    await common.async_set_hvac_mode(hass, "cool", ENTITY_CLIMATE)
+    state = hass.states.get(ENTITY_CLIMATE)
+    assert state.state == "cool"
+    mqtt_mock.async_publish.assert_has_calls(
+        [call("power-command", "ON", 0, False), call("mode-topic", "cool", 0, False)]
+    )
+    mqtt_mock.async_publish.reset_mock()
+    await common.async_set_hvac_mode(hass, "off", ENTITY_CLIMATE)
+    state = hass.states.get(ENTITY_CLIMATE)
+    assert state.state == "off"
+
+    await common.async_turn_on(hass, ENTITY_CLIMATE)
+    # the hvac_mode is not updated optimistically as this is not supported
+    state = hass.states.get(ENTITY_CLIMATE)
+    assert state.state == "off"
+    mqtt_mock.async_publish.assert_has_calls([call("power-command", "ON", 0, False)])
+    mqtt_mock.async_publish.reset_mock()
+
+    await common.async_set_hvac_mode(hass, "cool", ENTITY_CLIMATE)
+    state = hass.states.get(ENTITY_CLIMATE)
+    assert state.state == "cool"
+    await common.async_turn_off(hass, ENTITY_CLIMATE)
+    # the hvac_mode is updated optimistically
+    state = hass.states.get(ENTITY_CLIMATE)
+    assert state.state == "off"
+    mqtt_mock.async_publish.assert_has_calls([call("power-command", "OFF", 0, False)])
+    mqtt_mock.async_publish.reset_mock()
+
+
+@pytest.mark.parametrize(
+    ("hass_config", "climate_on", "climate_off"),
+    [
+        (
+            help_custom_config(
+                climate.DOMAIN, DEFAULT_CONFIG, ({"modes": ["heat", "cool"]},)
+            ),
+            "heat",
+            None,
+        ),
+        (
+            help_custom_config(
+                climate.DOMAIN, DEFAULT_CONFIG, ({"modes": ["off", "dry"]},)
+            ),
+            None,
+            "off",
+        ),
+        (
+            help_custom_config(
+                climate.DOMAIN, DEFAULT_CONFIG, ({"modes": ["off", "cool"]},)
+            ),
+            "cool",
+            "off",
+        ),
+    ],
+)
+async def test_turn_on_and_off_without_power_command(
+    hass: HomeAssistant,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+    climate_on: str | None,
+    climate_off: str | None,
+) -> None:
+    """Test setting of turn on/off with power command enabled."""
+    mqtt_mock = await mqtt_mock_entry()
+
+    state = hass.states.get(ENTITY_CLIMATE)
+    assert state.state == "off"
+
+    await common.async_turn_on(hass, ENTITY_CLIMATE)
+    state = hass.states.get(ENTITY_CLIMATE)
+    assert climate_on is None or state.state == climate_on
+    if climate_on:
+        mqtt_mock.async_publish.assert_has_calls(
+            [call("mode-topic", climate_on, 0, False)]
+        )
+    else:
+        mqtt_mock.async_publish.assert_has_calls([])
+
+    await common.async_set_hvac_mode(hass, "cool", ENTITY_CLIMATE)
+    state = hass.states.get(ENTITY_CLIMATE)
+    assert state.state == "cool"
+    mqtt_mock.async_publish.reset_mock()
+
+    await common.async_turn_off(hass, ENTITY_CLIMATE)
+    state = hass.states.get(ENTITY_CLIMATE)
+    assert climate_off is None or state.state == climate_off
+    if climate_off:
+        assert state.state == "off"
+        mqtt_mock.async_publish.assert_has_calls([call("mode-topic", "off", 0, False)])
+    else:
+        assert state.state == "cool"
+        mqtt_mock.async_publish.assert_has_calls([])
     mqtt_mock.async_publish.reset_mock()
 
 
@@ -1480,6 +1600,7 @@ async def test_get_with_templates(
                 climate.DOMAIN: {
                     "name": "test",
                     "mode_command_topic": "mode-topic",
+                    "power_command_topic": "power-topic",
                     "target_humidity_command_topic": "humidity-topic",
                     "temperature_command_topic": "temperature-topic",
                     "temperature_low_command_topic": "temperature-low-topic",
@@ -1499,6 +1620,7 @@ async def test_get_with_templates(
                     ],
                     # Create simple templates
                     "fan_mode_command_template": "fan_mode: {{ value }}",
+                    "power_command_template": "power: {{ value }}",
                     "preset_mode_command_template": "preset_mode: {{ value }}",
                     "mode_command_template": "mode: {{ value }}",
                     "swing_mode_command_template": "swing_mode: {{ value }}",
@@ -1540,12 +1662,39 @@ async def test_set_and_templates(
 
     # Mode
     await common.async_set_hvac_mode(hass, "cool", ENTITY_CLIMATE)
-    mqtt_mock.async_publish.assert_called_once_with(
-        "mode-topic", "mode: cool", 0, False
-    )
+    mqtt_mock.async_publish.assert_any_call("mode-topic", "mode: cool", 0, False)
+    mqtt_mock.async_publish.assert_any_call("power-topic", "power: ON", 0, False)
+    assert mqtt_mock.async_publish.call_count == 2
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.state == "cool"
+
+    await common.async_set_hvac_mode(hass, "off", ENTITY_CLIMATE)
+    mqtt_mock.async_publish.assert_any_call("mode-topic", "mode: off", 0, False)
+    mqtt_mock.async_publish.assert_any_call("power-topic", "power: OFF", 0, False)
+    assert mqtt_mock.async_publish.call_count == 2
+    mqtt_mock.async_publish.reset_mock()
+    state = hass.states.get(ENTITY_CLIMATE)
+    assert state.state == "off"
+
+    # Power
+    await common.async_turn_on(hass, ENTITY_CLIMATE)
+    mqtt_mock.async_publish.assert_any_call("power-topic", "power: ON", 0, False)
+    # Only power command is sent
+    # the mode is not updated when power_command_topic is set
+    assert mqtt_mock.async_publish.call_count == 1
+    mqtt_mock.async_publish.reset_mock()
+    state = hass.states.get(ENTITY_CLIMATE)
+    assert state.state == "off"
+
+    await common.async_turn_off(hass, ENTITY_CLIMATE)
+    mqtt_mock.async_publish.assert_any_call("power-topic", "power: OFF", 0, False)
+    # Only power command is sent
+    # the mode is not updated when power_command_topic is set
+    assert mqtt_mock.async_publish.call_count == 1
+    mqtt_mock.async_publish.reset_mock()
+    state = hass.states.get(ENTITY_CLIMATE)
+    assert state.state == "off"
 
     # Swing Mode
     await common.async_set_swing_mode(hass, "on", ENTITY_CLIMATE)
@@ -2141,7 +2290,28 @@ async def test_precision_whole(
         (
             climate.SERVICE_TURN_ON,
             "power_command_topic",
+            {},
+            "ON",
             None,
+        ),
+        (
+            climate.SERVICE_TURN_OFF,
+            "power_command_topic",
+            {},
+            "OFF",
+            None,
+        ),
+        (
+            climate.SERVICE_SET_HVAC_MODE,
+            "power_command_topic",
+            {"hvac_mode": "off"},
+            "OFF",
+            None,
+        ),
+        (
+            climate.SERVICE_SET_HVAC_MODE,
+            "power_command_topic",
+            {"hvac_mode": "dry"},
             "ON",
             None,
         ),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The behavior of MQTT climate when `power_command_topic` is set has been changed:
 - The `hvac_mode` state attribute is no longer optimistically set if `power_command_topic` is defined and `climate.turn_on` or `climate.turn_off` is called.
 - When `hvac_mode` is changed, `payload_on` or `payload_off` messages will not be published on the `power_command_topic`.

This also means `power_command_topic`  is no longer deprecated.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Re-instate the previous deprecated `power_command_topic` for mqtt climate and implement climate.turn_on/turn_off.
The current `hvac_mode` is determined from `mode_state_topic`, hence there is no power state topic.

The system mode is not known when the climate device is turned off, hence the `climate.turn_on` service only sends the power on command message to the device, and can not update the `hvac_mode` (in optimistic mode) as only the device can report back the system mode after it is turned on.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes 
- This PR is related to issue: #94114
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/27915

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
