### PR TITLE
Add inverse switch to switch_as_x helper

### DIFF
--- a/homeassistant/components/switch_as_x/config_flow.py
+++ b/homeassistant/components/switch_as_x/config_flow.py
@@ -23,7 +23,6 @@ TARGET_DOMAIN_OPTIONS = [
     selector.SelectOptionDict(value=Platform.LOCK, label="Lock"),
     selector.SelectOptionDict(value=Platform.SIREN, label="Siren"),
     selector.SelectOptionDict(value=Platform.SWITCH, label="Inverse"),
-
 ]
 
 CONFIG_FLOW = {

--- a/homeassistant/components/switch_as_x/config_flow.py
+++ b/homeassistant/components/switch_as_x/config_flow.py
@@ -22,6 +22,8 @@ TARGET_DOMAIN_OPTIONS = [
     selector.SelectOptionDict(value=Platform.LIGHT, label="Light"),
     selector.SelectOptionDict(value=Platform.LOCK, label="Lock"),
     selector.SelectOptionDict(value=Platform.SIREN, label="Siren"),
+    selector.SelectOptionDict(value=Platform.SWITCH, label="Inverse"),
+
 ]
 
 CONFIG_FLOW = {

--- a/homeassistant/components/switch_as_x/switch.py
+++ b/homeassistant/components/switch_as_x/switch.py
@@ -1,0 +1,50 @@
+"""Inverse support for switch entities."""
+from __future__ import annotations
+
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN, SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_ENTITY_ID
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .entity import BaseToggleEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Initialize Inverse Switch config entry."""
+    registry = er.async_get(hass)
+    entity_id = er.async_validate_entity_id(
+        registry, config_entry.options[CONF_ENTITY_ID]
+    )
+
+    async_add_entities(
+        [
+            InvertSwitch(
+                hass,
+                config_entry.title,
+                SWITCH_DOMAIN,
+                entity_id,
+                config_entry.entry_id,
+            )
+        ]
+    )
+
+
+class InvertSwitch(BaseToggleEntity, SwitchEntity):
+    """Represents a Switch as Inversed."""
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return true if the entity is off."""
+        return not self._attr_is_on
+
+    async def async_turn_on(self) -> None:
+        await super().async_turn_off()
+    
+    async def async_turn_off(self) -> None:
+        await super().async_turn_on()

--- a/homeassistant/components/switch_as_x/switch.py
+++ b/homeassistant/components/switch_as_x/switch.py
@@ -41,7 +41,7 @@ class InvertSwitch(BaseToggleEntity, SwitchEntity):
     """Represents a Switch as Inversed."""
 
     @property
-    def is_on(self, **kwargs: Any) -> bool | None:
+    def is_on(self) -> bool | None:
         """Return true if the entity is off."""
         return not self._attr_is_on
 
@@ -49,6 +49,6 @@ class InvertSwitch(BaseToggleEntity, SwitchEntity):
         """Turn off original switch."""
         await super().async_turn_off()
 
-    async def async_turn_off(self) -> None:
+    async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn on original switch."""
         await super().async_turn_on()

--- a/homeassistant/components/switch_as_x/switch.py
+++ b/homeassistant/components/switch_as_x/switch.py
@@ -1,6 +1,8 @@
 """Inverse support for switch entities."""
 from __future__ import annotations
 
+from typing import Any
+
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN, SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ENTITY_ID
@@ -44,9 +46,9 @@ class InvertSwitch(BaseToggleEntity, SwitchEntity):
         return not self._attr_is_on
 
     async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn off original switch"""
+        """Turn off original switch."""
         await super().async_turn_off()
 
     async def async_turn_off(self) -> None:
-        """Turn on original switch"""
+        """Turn on original switch."""
         await super().async_turn_on()

--- a/homeassistant/components/switch_as_x/switch.py
+++ b/homeassistant/components/switch_as_x/switch.py
@@ -39,12 +39,14 @@ class InvertSwitch(BaseToggleEntity, SwitchEntity):
     """Represents a Switch as Inversed."""
 
     @property
-    def is_on(self) -> bool | None:
+    def is_on(self, **kwargs: Any) -> bool | None:
         """Return true if the entity is off."""
         return not self._attr_is_on
 
-    async def async_turn_on(self) -> None:
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn off original switch"""
         await super().async_turn_off()
-    
+
     async def async_turn_off(self) -> None:
+        """Turn on original switch"""
         await super().async_turn_on()

--- a/tests/components/switch_as_x/test_init.py
+++ b/tests/components/switch_as_x/test_init.py
@@ -36,6 +36,7 @@ PLATFORMS_TO_TEST = (
     Platform.LIGHT,
     Platform.LOCK,
     Platform.SIREN,
+    Platform.SWITCH,
 )
 
 
@@ -72,6 +73,7 @@ async def test_config_entry_unregistered_uuid(
         (Platform.LIGHT, STATE_ON, STATE_OFF),
         (Platform.LOCK, STATE_UNLOCKED, STATE_LOCKED),
         (Platform.SIREN, STATE_ON, STATE_OFF),
+        (Platform.SWITCH, STATE_ON, STATE_OFF),
     ),
 )
 async def test_entity_registry_events(

--- a/tests/components/switch_as_x/test_switch.py
+++ b/tests/components/switch_as_x/test_switch.py
@@ -1,0 +1,111 @@
+"""Tests for the Switch as X Switch platform."""
+from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.components.switch_as_x.const import CONF_TARGET_DOMAIN, DOMAIN
+from homeassistant.const import (
+    CONF_ENTITY_ID,
+    SERVICE_LOCK,
+    SERVICE_TOGGLE,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    SERVICE_UNLOCK,
+    STATE_LOCKED,
+    STATE_OFF,
+    STATE_ON,
+    STATE_UNLOCKED,
+    Platform,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry
+
+
+async def test_default_state(hass: HomeAssistant) -> None:
+    """Test switch default state."""
+    config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            CONF_ENTITY_ID: "switch.test",
+            CONF_TARGET_DOMAIN: Platform.SWITCH,
+        },
+        title="candy_bar`",
+    )
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("switch.candy_bar")
+    assert state is not None
+    assert state.state == "unavailable"
+
+
+async def test_service_calls(hass: HomeAssistant) -> None:
+    """Test service calls affecting the switch as inverse entity."""
+    await async_setup_component(hass, "switch", {"switch": [{"platform": "demo"}]})
+    await hass.async_block_till_done()
+    config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            CONF_ENTITY_ID: "switch.decorative_lights",
+            CONF_TARGET_DOMAIN: Platform.SWITCH,
+        },
+        title="Title is ignored",
+    )
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("switch.decorative_lights").state == STATE_OFF
+
+    await hass.services.async_call(
+        LOCK_DOMAIN,
+        SERVICE_LOCK,
+        {CONF_ENTITY_ID: "lock.decorative_lights"},
+        blocking=True,
+    )
+
+    assert hass.states.get("switch.decorative_lights").state == STATE_OFF
+    assert hass.states.get("lock.decorative_lights").state == STATE_LOCKED
+
+    await hass.services.async_call(
+        LOCK_DOMAIN,
+        SERVICE_UNLOCK,
+        {CONF_ENTITY_ID: "lock.decorative_lights"},
+        blocking=True,
+    )
+
+    assert hass.states.get("switch.decorative_lights").state == STATE_ON
+    assert hass.states.get("lock.decorative_lights").state == STATE_UNLOCKED
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        {CONF_ENTITY_ID: "switch.decorative_lights"},
+        blocking=True,
+    )
+
+    assert hass.states.get("switch.decorative_lights").state == STATE_OFF
+    assert hass.states.get("lock.decorative_lights").state == STATE_LOCKED
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_ON,
+        {CONF_ENTITY_ID: "switch.decorative_lights"},
+        blocking=True,
+    )
+
+    assert hass.states.get("switch.decorative_lights").state == STATE_ON
+    assert hass.states.get("lock.decorative_lights").state == STATE_UNLOCKED
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TOGGLE,
+        {CONF_ENTITY_ID: "switch.decorative_lights"},
+        blocking=True,
+    )
+
+    assert hass.states.get("switch.decorative_lights").state == STATE_OFF
+    assert hass.states.get("lock.decorative_lights").state == STATE_LOCKED


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Change the orientation of a switch from the UI helpers menu. This switch platform will inverse an existing switch and hide the original entity.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/27908

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
