### PR TITLE
Add compatibility with sleeping Shelly gen2 devices with firmware 1.0.0

### DIFF
--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -44,6 +44,7 @@ from .utils import (
     get_coap_context,
     get_device_entry_gen,
     get_rpc_device_sleep_period,
+    get_rpc_device_wakeup_period,
     get_ws_context,
 )
 
@@ -258,7 +259,9 @@ async def _async_setup_rpc_entry(hass: HomeAssistant, entry: ConfigEntry) -> boo
 
         if sleep_period is None:
             data = {**entry.data}
-            data[CONF_SLEEP_PERIOD] = get_rpc_device_sleep_period(device.config)
+            data[CONF_SLEEP_PERIOD] = get_rpc_device_sleep_period(
+                device.config
+            ) or get_rpc_device_wakeup_period(device.status)
             hass.config_entries.async_update_entry(entry, data=data)
 
         hass.async_create_task(_async_rpc_device_setup())

--- a/homeassistant/components/shelly/config_flow.py
+++ b/homeassistant/components/shelly/config_flow.py
@@ -39,6 +39,7 @@ from .utils import (
     get_info_gen,
     get_model_name,
     get_rpc_device_sleep_period,
+    get_rpc_device_wakeup_period,
     get_ws_context,
     mac_address_from_name,
 )
@@ -76,9 +77,13 @@ async def validate_input(
         )
         await rpc_device.shutdown()
 
+        sleep_period = get_rpc_device_sleep_period(
+            rpc_device.config
+        ) or get_rpc_device_wakeup_period(rpc_device.status)
+
         return {
             "title": rpc_device.name,
-            CONF_SLEEP_PERIOD: get_rpc_device_sleep_period(rpc_device.config),
+            CONF_SLEEP_PERIOD: sleep_period,
             "model": rpc_device.shelly.get("model"),
             "gen": 2,
         }

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -255,7 +255,11 @@ def get_block_device_sleep_period(settings: dict[str, Any]) -> int:
 
 
 def get_rpc_device_sleep_period(config: dict[str, Any]) -> int:
-    """Return the device sleep period in seconds or 0 for non sleeping devices."""
+    """Return the device sleep period in seconds or 0 for non sleeping devices.
+
+    sys.sleep.wakeup_period value is deprecated and not available in Shelly
+    firmware 1.0.0 or later.
+    """
     return cast(int, config["sys"].get("sleep", {}).get("wakeup_period", 0))
 
 

--- a/tests/components/shelly/test_config_flow.py
+++ b/tests/components/shelly/test_config_flow.py
@@ -1122,7 +1122,7 @@ async def test_zeroconf_sleeping_device_not_triggers_refresh(
 async def test_sleeping_device_gen2_with_new_firmware(
     hass: HomeAssistant, mock_rpc_device, monkeypatch
 ) -> None:
-    """Test sleeping device Gen2 with firmware 1.0.0 (no wakeup_period in Shelly.GetConfig response)."""
+    """Test sleeping device Gen2 with firmware 1.0.0 or later."""
     monkeypatch.setitem(mock_rpc_device.status["sys"], "wakeup_period", 666)
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}

--- a/tests/components/shelly/test_config_flow.py
+++ b/tests/components/shelly/test_config_flow.py
@@ -1117,3 +1117,35 @@ async def test_zeroconf_sleeping_device_not_triggers_refresh(
     await hass.async_block_till_done()
     assert len(mock_rpc_device.initialize.mock_calls) == 0
     assert "device did not update" not in caplog.text
+
+
+async def test_sleeping_device_gen2_with_new_firmware(
+    hass: HomeAssistant, mock_rpc_device, monkeypatch
+) -> None:
+    """Test sleeping device Gen2 with firmware 1.0.0 (no wakeup_period in Shelly.GetConfig response)."""
+    monkeypatch.setitem(mock_rpc_device.status["sys"], "wakeup_period", 666)
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == "form"
+    assert result["errors"] == {}
+
+    with patch(
+        "homeassistant.components.shelly.config_flow.get_info",
+        return_value={"mac": "test-mac", "gen": 2},
+    ), patch("homeassistant.components.shelly.async_setup", return_value=True), patch(
+        "homeassistant.components.shelly.async_setup_entry",
+        return_value=True,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"host": "1.1.1.1"},
+        )
+        await hass.async_block_till_done()
+
+    assert result["data"] == {
+        "host": "1.1.1.1",
+        "model": "SNSW-002P16EU",
+        "sleep_period": 666,
+        "gen": 2,
+    }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
For the upcoming Shelly firmware 1.0.0 `wakeup_period` value will not be available in `Shelly.GetConfig` response. This causes problems with sleeping gen2 devices.
With this change, the integration looks for `wakeup_period` values in `Shelly.GetConfig` and `Shelly.GetStatus` responses.

Tested with Plus HT with firmware 0.14.1 and 1.0.0 beta 4.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
