### PR TITLE
Dispatch when esphome static info changes

### DIFF
--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -837,7 +837,11 @@ class EsphomeEntity(Entity, Generic[_InfoT, _StateT]):
 
     @callback
     def _on_static_info_update(self, static_infos: dict[int, EntityInfo]) -> None:
-        """Save the static info for this entity when it changes."""
+        """Save the static info for this entity when it changes.
+
+        This method can be overridden in child classes to know
+        when the static info changes.
+        """
         self._static_info = static_infos[self._key]
 
     @callback

--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -45,7 +45,10 @@ from homeassistant.helpers import template
 import homeassistant.helpers.config_validation as cv
 import homeassistant.helpers.device_registry as dr
 from homeassistant.helpers.device_registry import format_mac
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.dispatcher import (
+    async_dispatcher_connect,
+    async_dispatcher_send,
+)
 from homeassistant.helpers.entity import DeviceInfo, Entity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_state_change_event
@@ -722,8 +725,15 @@ async def platform_async_setup_entry(
         # Then update the actual info
         entry_data.info[component_key] = new_infos
 
-        # Add entities to Home Assistant
-        async_add_entities(add_entities)
+        async_dispatcher_send(
+            hass,
+            entry_data.signal_component_static_info_updated(component_key),
+            new_infos,
+        )
+
+        if add_entities:
+            # Add entities to Home Assistant
+            async_add_entities(add_entities)
 
     entry_data.cleanup_callbacks.append(
         async_dispatcher_connect(
@@ -786,6 +796,7 @@ class EsphomeEntity(Entity, Generic[_InfoT, _StateT]):
         self._entry_data = entry_data
         self._component_key = component_key
         self._key = key
+        self._static_info = entry_data.info[component_key][key]
         self._state_type = state_type
         if entry_data.device_info is not None and entry_data.device_info.friendly_name:
             self._attr_has_entity_name = True
@@ -814,6 +825,21 @@ class EsphomeEntity(Entity, Generic[_InfoT, _StateT]):
             )
         )
 
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                self._entry_data.signal_component_static_info_updated(
+                    self._component_key
+                ),
+                self._on_static_info_update,
+            )
+        )
+
+    @callback
+    def _on_static_info_update(self, static_infos: dict[int, EntityInfo]) -> None:
+        """Save the static info for this entity when it changes."""
+        self._static_info = static_infos[self._key]
+
     @callback
     def _on_state_update(self) -> None:
         # Behavior can be changed in child classes
@@ -836,16 +862,6 @@ class EsphomeEntity(Entity, Generic[_InfoT, _StateT]):
     @property
     def _api_version(self) -> APIVersion:
         return self._entry_data.api_version
-
-    @property
-    def _static_info(self) -> _InfoT:
-        # Check if value is in info database. Use a single lookup.
-        info = self._entry_data.info[self._component_key].get(self._key)
-        if info is not None:
-            return cast(_InfoT, info)
-        # This entity is in the removal project and has been removed from .info
-        # already, look in old_info
-        return cast(_InfoT, self._entry_data.old_info[self._component_key][self._key])
 
     @property
     def _device_info(self) -> EsphomeDeviceInfo:

--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -784,6 +784,7 @@ class EsphomeEntity(Entity, Generic[_InfoT, _StateT]):
     """Define a base esphome entity."""
 
     _attr_should_poll = False
+    _static_info: _InfoT
 
     def __init__(
         self,
@@ -796,7 +797,7 @@ class EsphomeEntity(Entity, Generic[_InfoT, _StateT]):
         self._entry_data = entry_data
         self._component_key = component_key
         self._key = entity_info.key
-        self._static_info = entity_info
+        self._static_info = cast(_InfoT, entity_info)
         self._state_type = state_type
         if entry_data.device_info is not None and entry_data.device_info.friendly_name:
             self._attr_has_entity_name = True
@@ -842,7 +843,7 @@ class EsphomeEntity(Entity, Generic[_InfoT, _StateT]):
         This method can be overridden in child classes to know
         when the static info changes.
         """
-        self._static_info = static_infos[self._key]
+        self._static_info = cast(_InfoT, static_infos[self._key])
 
     @callback
     def _on_state_update(self) -> None:

--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -712,7 +712,7 @@ async def platform_async_setup_entry(
                 old_infos.pop(info.key)
             else:
                 # Create new entity
-                entity = entity_type(entry_data, component_key, info.key, state_type)
+                entity = entity_type(entry_data, component_key, info, state_type)
                 add_entities.append(entity)
             new_infos[info.key] = info
 
@@ -789,14 +789,14 @@ class EsphomeEntity(Entity, Generic[_InfoT, _StateT]):
         self,
         entry_data: RuntimeEntryData,
         component_key: str,
-        key: int,
+        entity_info: EntityInfo,
         state_type: type[_StateT],
     ) -> None:
         """Initialize."""
         self._entry_data = entry_data
         self._component_key = component_key
-        self._key = key
-        self._static_info = entry_data.info[component_key][key]
+        self._key = entity_info.key
+        self._static_info = entity_info
         self._state_type = state_type
         if entry_data.device_info is not None and entry_data.device_info.friendly_name:
             self._attr_has_entity_name = True

--- a/homeassistant/components/esphome/entry_data.py
+++ b/homeassistant/components/esphome/entry_data.py
@@ -127,6 +127,10 @@ class RuntimeEntryData:
         """Return the signal to listen to for updates on static info."""
         return f"esphome_{self.entry_id}_on_list"
 
+    def signal_component_static_info_updated(self, component_key: str) -> str:
+        """Return the signal to listen to for updates on static info for a specific component_key."""
+        return f"esphome_{self.entry_id}_static_info_updated_{component_key}"
+
     @callback
     def async_update_ble_connection_limits(self, free: int, limit: int) -> None:
         """Update the BLE connection limits."""

--- a/homeassistant/components/esphome/number.py
+++ b/homeassistant/components/esphome/number.py
@@ -44,6 +44,8 @@ NUMBER_MODES: EsphomeEnumMapper[EsphomeNumberMode, NumberMode] = EsphomeEnumMapp
 class EsphomeNumber(EsphomeEntity[NumberInfo, NumberState], NumberEntity):
     """A number implementation for esphome."""
 
+    _static_info: NumberInfo
+
     @property
     def device_class(self) -> NumberDeviceClass | None:
         """Return the class of this entity."""
@@ -52,22 +54,22 @@ class EsphomeNumber(EsphomeEntity[NumberInfo, NumberState], NumberEntity):
     @property
     def native_min_value(self) -> float:
         """Return the minimum value."""
-        return super()._static_info.min_value
+        return self._static_info.min_value
 
     @property
     def native_max_value(self) -> float:
         """Return the maximum value."""
-        return super()._static_info.max_value
+        return self._static_info.max_value
 
     @property
     def native_step(self) -> float:
         """Return the increment/decrement step."""
-        return super()._static_info.step
+        return self._static_info.step
 
     @property
     def native_unit_of_measurement(self) -> str | None:
         """Return the unit of measurement."""
-        return super()._static_info.unit_of_measurement
+        return self._static_info.unit_of_measurement
 
     @property
     def mode(self) -> NumberMode:

--- a/homeassistant/components/esphome/number.py
+++ b/homeassistant/components/esphome/number.py
@@ -44,8 +44,6 @@ NUMBER_MODES: EsphomeEnumMapper[EsphomeNumberMode, NumberMode] = EsphomeEnumMapp
 class EsphomeNumber(EsphomeEntity[NumberInfo, NumberState], NumberEntity):
     """A number implementation for esphome."""
 
-    _static_info: NumberInfo
-
     @property
     def device_class(self) -> NumberDeviceClass | None:
         """Return the class of this entity."""


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Dispatch when esphome static info changes.  Related PR discussion https://github.com/home-assistant/core/pull/92357#discussion_r1234362041

A new method `_on_static_info_update` is available for esphome entities for when the static info changes (ie device has been reflashed).

This will also allow us to avoid all the static info lookups when the bulk of the time it will never change.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
