### PR TITLE
Verify that the MAC address that Fully Kiosk reported is usable

### DIFF
--- a/homeassistant/components/fully_kiosk/entity.py
+++ b/homeassistant/components/fully_kiosk/entity.py
@@ -9,6 +9,18 @@ from .const import DOMAIN
 from .coordinator import FullyKioskDataUpdateCoordinator
 
 
+def valid_global_mac_address(mac: str | None) -> bool:
+    """Check if a MAC address is valid, non-locally administered address."""
+    if not isinstance(mac, str):
+        return False
+    try:
+        first_octet = int(mac.split(":")[0], 16)
+        # If the second least-significant bit is set, it's a locally administered address, should not be used as an ID
+        return not bool(first_octet & 0x2)
+    except ValueError:
+        return False
+
+
 class FullyKioskEntity(CoordinatorEntity[FullyKioskDataUpdateCoordinator], Entity):
     """Defines a Fully Kiosk Browser entity."""
 
@@ -25,7 +37,9 @@ class FullyKioskEntity(CoordinatorEntity[FullyKioskDataUpdateCoordinator], Entit
             sw_version=coordinator.data["appVersionName"],
             configuration_url=f"http://{coordinator.data['ip4']}:2323",
         )
-        if "Mac" in coordinator.data and coordinator.data["Mac"]:
+        if "Mac" in coordinator.data and valid_global_mac_address(
+            coordinator.data["Mac"]
+        ):
             device_info["connections"] = {
                 (CONNECTION_NETWORK_MAC, coordinator.data["Mac"])
             }

--- a/tests/components/fully_kiosk/test_init.py
+++ b/tests/components/fully_kiosk/test_init.py
@@ -7,6 +7,7 @@ from fullykiosk import FullyKioskError
 import pytest
 
 from homeassistant.components.fully_kiosk.const import DOMAIN
+from homeassistant.components.fully_kiosk.entity import valid_global_mac_address
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_HOST, CONF_MAC, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
@@ -134,3 +135,11 @@ async def test_multiple_kiosk_with_empty_mac(
     assert device2
 
     assert device1 != device2
+
+
+async def test_valid_global_mac_address() -> None:
+    """Test valid_global_mac_address function."""
+    assert valid_global_mac_address("aa:bb:cc:dd:ee:ff")
+    assert not valid_global_mac_address("02:00:00:00:00:00")
+    assert not valid_global_mac_address(None)
+    assert not valid_global_mac_address("foobar")

--- a/tests/components/fully_kiosk/test_init.py
+++ b/tests/components/fully_kiosk/test_init.py
@@ -139,7 +139,7 @@ async def test_multiple_kiosk_with_empty_mac(
 
 async def test_valid_global_mac_address() -> None:
     """Test valid_global_mac_address function."""
-    assert valid_global_mac_address("aa:bb:cc:dd:ee:ff")
+    assert valid_global_mac_address("a1:bb:cc:dd:ee:ff")
     assert not valid_global_mac_address("02:00:00:00:00:00")
     assert not valid_global_mac_address(None)
     assert not valid_global_mac_address("foobar")


### PR DESCRIPTION
## Proposed change

On modern Android devices, the real MAC address is not exposed to applications, therefore, what Fully Kiosk reports is usually not usable as an ID.

On Android 13 (Samsung Galaxy Tab A7 Lite), Fully Kiosk reports "02:00:00:00:00:00" if "randomized MAC" is disabled, which leads to merging unrelated issues (similar issue to #77722).

This PR enhances MAC validation: if the second least significant bit is set in the MAC address, it's a locally administered MAC and should not be used as an identifier in HA.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
I contacted Fully Kiosk author about this issue, and here is what he said:
> HA shouldn't treat any Mac address reported by Android as unique identifier. Every mac address on a modern Android device is fake and can change unpredictably unless you make device provisioning.


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
