### PR TITLE
Remove `base_url` configuration option from `tts`

### DIFF
--- a/homeassistant/components/cast/media_player.py
+++ b/homeassistant/components/cast/media_player.py
@@ -362,15 +362,7 @@ class CastMediaPlayerEntity(CastDevice, MediaPlayerEntity):
         ):
             external_url = None
             internal_url = None
-            tts_base_url = None
             url_description = ""
-            if "tts" in self.hass.config.components:
-                # pylint: disable-next=[import-outside-toplevel]
-                from homeassistant.components import tts
-
-                with suppress(KeyError):  # base_url not configured
-                    tts_base_url = tts.get_base_url(self.hass)
-
             with suppress(NoURLAvailableError):  # external_url not configured
                 external_url = get_url(self.hass, allow_internal=False)
 
@@ -378,8 +370,6 @@ class CastMediaPlayerEntity(CastDevice, MediaPlayerEntity):
                 internal_url = get_url(self.hass, allow_external=False)
 
             if media_status.content_id:
-                if tts_base_url and media_status.content_id.startswith(tts_base_url):
-                    url_description = f" from tts.base_url ({tts_base_url})"
                 if external_url and media_status.content_id.startswith(external_url):
                     url_description = f" from external_url ({external_url})"
                 if internal_url and media_status.content_id.startswith(internal_url):

--- a/homeassistant/components/tts/const.py
+++ b/homeassistant/components/tts/const.py
@@ -4,7 +4,6 @@ ATTR_LANGUAGE = "language"
 ATTR_MESSAGE = "message"
 ATTR_OPTIONS = "options"
 
-CONF_BASE_URL = "base_url"
 CONF_CACHE = "cache"
 CONF_CACHE_DIR = "cache_dir"
 CONF_FIELDS = "fields"

--- a/homeassistant/components/tts/legacy.py
+++ b/homeassistant/components/tts/legacy.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 import voluptuous as vol
-import yarl
 
 from homeassistant.components.media_player import (
     ATTR_MEDIA_ANNOUNCE,
@@ -31,7 +30,6 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.service import async_set_service_schema
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.setup import async_prepare_setup_platform
-from homeassistant.util.network import normalize_url
 from homeassistant.util.yaml import load_yaml
 
 from .const import (
@@ -39,7 +37,6 @@ from .const import (
     ATTR_LANGUAGE,
     ATTR_MESSAGE,
     ATTR_OPTIONS,
-    CONF_BASE_URL,
     CONF_CACHE,
     CONF_CACHE_DIR,
     CONF_FIELDS,
@@ -72,16 +69,6 @@ def _deprecated_platform(value: str) -> str:
     return value
 
 
-def _valid_base_url(value: str) -> str:
-    """Validate base url, return value."""
-    url = yarl.URL(cv.url(value))
-
-    if url.path != "/":
-        raise vol.Invalid("Path should be empty")
-
-    return normalize_url(value)
-
-
 PLATFORM_SCHEMA = cv.PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_PLATFORM): vol.All(cv.string, _deprecated_platform),
@@ -90,7 +77,6 @@ PLATFORM_SCHEMA = cv.PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_TIME_MEMORY, default=DEFAULT_TIME_MEMORY): vol.All(
             vol.Coerce(int), vol.Range(min=60, max=57600)
         ),
-        vol.Optional(CONF_BASE_URL): _valid_base_url,
         vol.Optional(CONF_SERVICE_NAME): cv.string,
     }
 )

--- a/homeassistant/components/tts/media_source.py
+++ b/homeassistant/components/tts/media_source.py
@@ -18,7 +18,6 @@ from homeassistant.components.media_source import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_component import EntityComponent
-from homeassistant.helpers.network import get_url
 
 from .const import DATA_TTS_MANAGER, DOMAIN
 from .helper import get_engine_instance
@@ -123,9 +122,6 @@ class TTSMediaSource(MediaSource):
             raise Unresolvable(str(err)) from err
 
         mime_type = mimetypes.guess_type(url)[0] or "audio/mpeg"
-
-        if manager.base_url and manager.base_url != get_url(self.hass):
-            url = f"{manager.base_url}{url}"
 
         return PlayMedia(url, mime_type)
 

--- a/tests/components/cast/test_media_player.py
+++ b/tests/components/cast/test_media_player.py
@@ -1894,7 +1894,7 @@ async def test_failed_cast_other_url(
         assert await async_setup_component(
             hass,
             tts.DOMAIN,
-            {tts.DOMAIN: {"platform": "demo", "base_url": "http://example.local:8123"}},
+            {tts.DOMAIN: {"platform": "demo"}},
         )
 
     info = get_fake_chromecast_info()
@@ -1951,7 +1951,7 @@ async def test_failed_cast_external_url(
         assert await async_setup_component(
             hass,
             tts.DOMAIN,
-            {tts.DOMAIN: {"platform": "demo", "base_url": "http://example.com:8123"}},
+            {tts.DOMAIN: {"platform": "demo"}},
         )
 
     info = get_fake_chromecast_info()
@@ -1965,33 +1965,6 @@ async def test_failed_cast_external_url(
     media_status_cb(media_status)
     assert (
         "Failed to cast media http://example.com:8123/tts.mp3 from external_url"
-        in caplog.text
-    )
-
-
-async def test_failed_cast_tts_base_url(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
-) -> None:
-    """Test warning when casting from tts.base_url fails."""
-    await async_setup_component(hass, "homeassistant", {})
-    with assert_setup_component(1, tts.DOMAIN):
-        assert await async_setup_component(
-            hass,
-            tts.DOMAIN,
-            {tts.DOMAIN: {"platform": "demo", "base_url": "http://example.local:8123"}},
-        )
-
-    info = get_fake_chromecast_info()
-    chromecast, _ = await async_setup_media_player_cast(hass, info)
-    _, _, media_status_cb = get_status_callbacks(chromecast)
-
-    media_status = MagicMock(images=None)
-    media_status.player_is_idle = True
-    media_status.idle_reason = "ERROR"
-    media_status.content_id = "http://example.local:8123/tts.mp3"
-    media_status_cb(media_status)
-    assert (
-        "Failed to cast media http://example.local:8123/tts.mp3 from tts.base_url"
         in caplog.text
     )
 

--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -5,7 +5,6 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
-import voluptuous as vol
 
 from homeassistant.components import tts
 from homeassistant.components.media_player import (
@@ -17,7 +16,6 @@ from homeassistant.components.media_player import (
     MediaType,
 )
 from homeassistant.components.media_source import Unresolvable
-from homeassistant.components.tts.legacy import _valid_base_url
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant, State
@@ -25,7 +23,6 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.typing import UNDEFINED
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
-from homeassistant.util.network import normalize_url
 
 from .common import (
     DEFAULT_LANG,
@@ -1313,44 +1310,6 @@ async def test_tags_with_wave() -> None:
     )
 
     assert tagged_data != tts_data
-
-
-@pytest.mark.parametrize(
-    "value",
-    (
-        "http://example.local:8123",
-        "http://example.local",
-        "http://example.local:80",
-        "https://example.com",
-        "https://example.com:443",
-        "https://example.com:8123",
-    ),
-)
-def test_valid_base_url(value) -> None:
-    """Test we validate base urls."""
-    assert _valid_base_url(value) == normalize_url(value)
-    # Test we strip trailing `/`
-    assert _valid_base_url(value + "/") == normalize_url(value)
-
-
-@pytest.mark.parametrize(
-    "value",
-    (
-        "http://example.local:8123/sub-path",
-        "http://example.local/sub-path",
-        "https://example.com/sub-path",
-        "https://example.com:8123/sub-path",
-        "mailto:some@email",
-        "http:example.com",
-        "http:/example.com",
-        "http//example.com",
-        "example.com",
-    ),
-)
-def test_invalid_base_url(value) -> None:
-    """Test we catch bad base urls."""
-    with pytest.raises(vol.Invalid):
-        _valid_base_url(value)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/tts/test_legacy.py
+++ b/tests/components/tts/test_legacy.py
@@ -4,11 +4,8 @@ from __future__ import annotations
 import pytest
 
 from homeassistant.components.media_player import (
-    ATTR_MEDIA_CONTENT_ID,
-    ATTR_MEDIA_CONTENT_TYPE,
     DOMAIN as DOMAIN_MP,
     SERVICE_PLAY_MEDIA,
-    MediaType,
 )
 from homeassistant.components.tts import ATTR_MESSAGE, DOMAIN, Provider
 from homeassistant.const import ATTR_ENTITY_ID
@@ -17,7 +14,7 @@ from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.setup import async_setup_component
 
-from .common import SUPPORT_LANGUAGES, MockProvider, MockTTS, get_media_source_url
+from .common import SUPPORT_LANGUAGES, MockProvider, MockTTS
 
 from tests.common import (
     MockModule,
@@ -138,34 +135,6 @@ async def test_platform_setup_with_error(
     await hass.async_block_till_done()
 
     assert "Error setting up platform: bad_tts" in caplog.text
-
-
-async def test_service_base_url_set(hass: HomeAssistant, mock_tts) -> None:
-    """Set up a TTS platform with ``base_url`` set and call service."""
-    calls = async_mock_service(hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
-
-    config = {DOMAIN: {"platform": "test", "base_url": "http://fnord"}}
-
-    with assert_setup_component(1, DOMAIN):
-        assert await async_setup_component(hass, DOMAIN, config)
-
-    await hass.services.async_call(
-        DOMAIN,
-        "test_say",
-        {
-            ATTR_ENTITY_ID: "media_player.something",
-            ATTR_MESSAGE: "There is someone at the door.",
-        },
-        blocking=True,
-    )
-    assert len(calls) == 1
-    assert calls[0].data[ATTR_MEDIA_CONTENT_TYPE] == MediaType.MUSIC
-    assert (
-        await get_media_source_url(hass, calls[0].data[ATTR_MEDIA_CONTENT_ID])
-        == "http://fnord"
-        "/api/tts_proxy/42f18378fd4393d18c8dd11d03fa9563c1e54491"
-        "_en-us_-_test.mp3"
-    )
 
 
 async def test_service_without_cache_config(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The TTS `base_url` option which was deprecated in Home Assistant Core 2022.5 has now been removed. Configure internal/external URL instead.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove deprecated `base_url` configuration option from `tts`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
