### PR TITLE
Reduce overhead to update esphome entities

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -356,8 +356,8 @@ build.json @home-assistant/supervisor
 /homeassistant/components/eq3btsmart/ @rytilahti
 /homeassistant/components/escea/ @lazdavila
 /tests/components/escea/ @lazdavila
-/homeassistant/components/esphome/ @OttoWinter @jesserockz
-/tests/components/esphome/ @OttoWinter @jesserockz
+/homeassistant/components/esphome/ @OttoWinter @jesserockz @bdraco
+/tests/components/esphome/ @OttoWinter @jesserockz @bdraco
 /homeassistant/components/eufylife_ble/ @bdr99
 /tests/components/eufylife_ble/ @bdr99
 /homeassistant/components/evil_genius_labs/ @balloob

--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -893,7 +893,7 @@ class EsphomeEntity(Entity, Generic[_InfoT, _StateT]):
     def _on_device_update(self) -> None:
         """Update the entity state when device info has changed."""
         self._on_entry_data_changed()
-        if self._entry_data.available:
+        if not self._entry_data.available:
             # Don't update the HA state yet when the device comes online.
             # Only update the HA state when the full state arrives
             # through the next entity state packet.

--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -814,34 +814,34 @@ class EsphomeEntity(Entity, Generic[_InfoT, _StateT]):
 
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""
+        entry_data = self._entry_data
+        hass = self.hass
+        component_key = self._component_key
+        key = self._key
+
         self.async_on_remove(
             async_dispatcher_connect(
-                self.hass,
-                f"esphome_{self._entry_id}_remove_{self._component_key}_{self._key}",
+                hass,
+                f"esphome_{self._entry_id}_remove_{component_key}_{key}",
                 functools.partial(self.async_remove, force_remove=True),
             )
         )
-
         self.async_on_remove(
             async_dispatcher_connect(
-                self.hass,
-                self._entry_data.signal_device_updated,
+                hass,
+                entry_data.signal_device_updated,
                 self._on_device_update,
             )
         )
-
         self.async_on_remove(
-            self._entry_data.async_subscribe_state_update(
-                self._state_type, self._key, self._on_state_update
+            entry_data.async_subscribe_state_update(
+                self._state_type, key, self._on_state_update
             )
         )
-
         self.async_on_remove(
             async_dispatcher_connect(
-                self.hass,
-                self._entry_data.signal_component_key_static_info_updated(
-                    self._component_key, self._key
-                ),
+                hass,
+                entry_data.signal_component_key_static_info_updated(component_key, key),
                 self._on_static_info_update,
             )
         )

--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -811,7 +811,6 @@ class EsphomeEntity(Entity, Generic[_InfoT, _StateT]):
             connections={(dr.CONNECTION_NETWORK_MAC, device_info.mac_address)}
         )
         self._entry_id = entry_data.entry_id
-        self._was_available = self.available
 
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""
@@ -900,15 +899,12 @@ class EsphomeEntity(Entity, Generic[_InfoT, _StateT]):
     def _on_device_update(self) -> None:
         """Call when device updates or entry data changes."""
         self._on_entry_data_changed()
-        available = self.available
-        was_available = self._was_available
-        self._was_available = available
-        if was_available == available:
-            # Don't update the HA state yet when the device comes online.
-            # Only update the HA state when the full state arrives
+        if not self.available:
+            # Only write state if the device has gone unavailable
+            # since _on_state_update will be called if the device
+            # is available when the full state arrives
             # through the next entity state packet.
-            return
-        self.async_write_ha_state()
+            self.async_write_ha_state()
 
     @property
     def available(self) -> bool:

--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -857,12 +857,14 @@ class EsphomeEntity(Entity, Generic[_InfoT, _StateT]):
         self._attr_unique_id = static_info.unique_id
         self._attr_entity_registry_enabled_default = not static_info.disabled_by_default
         self._attr_name = static_info.name
-        if static_info.entity_category:
-            self._attr_entity_category = ENTITY_CATEGORIES.from_esphome(
-                static_info.entity_category
-            )
-        if static_info.icon:
-            self._attr_icon = cast(str, ICON_SCHEMA(self._static_info.icon))
+        if entity_category := static_info.entity_category:
+            self._attr_entity_category = ENTITY_CATEGORIES.from_esphome(entity_category)
+        else:
+            self._attr_entity_category = None
+        if icon := static_info.icon:
+            self._attr_icon = cast(str, ICON_SCHEMA(icon))
+        else:
+            self._attr_icon = None
 
     @callback
     def _on_state_update(self) -> None:

--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -893,12 +893,11 @@ class EsphomeEntity(Entity, Generic[_InfoT, _StateT]):
     def _on_device_update(self) -> None:
         """Update the entity state when device info has changed."""
         self._on_entry_data_changed()
-        if not self._entry_data.available:
+        if self._entry_data.available:
             # Don't update the HA state yet when the device comes online.
             # Only update the HA state when the full state arrives
             # through the next entity state packet.
-            return
-        self._on_state_update()
+            self._on_state_update()
 
     @callback
     def _on_entry_data_changed(self) -> None:

--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -899,7 +899,7 @@ class EsphomeEntity(Entity, Generic[_InfoT, _StateT]):
     def _on_device_update(self) -> None:
         """Call when device updates or entry data changes."""
         self._on_entry_data_changed()
-        if not self.available:
+        if not self._entry_data.available:
             # Only write state if the device has gone unavailable
             # since _on_state_update will be called if the device
             # is available when the full state arrives

--- a/homeassistant/components/esphome/binary_sensor.py
+++ b/homeassistant/components/esphome/binary_sensor.py
@@ -9,7 +9,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntityDescription,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util.enum import try_parse_enum
 
@@ -55,10 +55,13 @@ class EsphomeBinarySensor(
             return None
         return self._state.state
 
-    @property
-    def device_class(self) -> BinarySensorDeviceClass | None:
-        """Return the class of this device, from component DEVICE_CLASSES."""
-        return try_parse_enum(BinarySensorDeviceClass, self._static_info.device_class)
+    @callback
+    def _on_static_info_update(self) -> None:
+        """Set attrs from static info."""
+        super()._on_static_info_update()
+        self._attr_device_class = try_parse_enum(
+            BinarySensorDeviceClass, self._static_info.device_class
+        )
 
     @property
     def available(self) -> bool:

--- a/homeassistant/components/esphome/binary_sensor.py
+++ b/homeassistant/components/esphome/binary_sensor.py
@@ -1,7 +1,7 @@
 """Support for ESPHome binary sensors."""
 from __future__ import annotations
 
-from aioesphomeapi import BinarySensorInfo, BinarySensorState
+from aioesphomeapi import BinarySensorInfo, BinarySensorState, EntityInfo
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -56,9 +56,9 @@ class EsphomeBinarySensor(
         return self._state.state
 
     @callback
-    def _on_static_info_update(self) -> None:
+    def _on_static_info_update(self, static_info: EntityInfo) -> None:
         """Set attrs from static info."""
-        super()._on_static_info_update()
+        super()._on_static_info_update(static_info)
         self._attr_device_class = try_parse_enum(
             BinarySensorDeviceClass, self._static_info.device_class
         )

--- a/homeassistant/components/esphome/entry_data.py
+++ b/homeassistant/components/esphome/entry_data.py
@@ -129,9 +129,11 @@ class RuntimeEntryData:
         """Return the signal to listen to for updates on static info."""
         return f"esphome_{self.entry_id}_on_list"
 
-    def signal_component_static_info_updated(self, component_key: str) -> str:
-        """Return the signal to listen to for updates on static info for a specific component_key."""
-        return f"esphome_{self.entry_id}_static_info_updated_{component_key}"
+    def signal_component_key_static_info_updated(
+        self, component_key: str, key: int
+    ) -> str:
+        """Return the signal to listen to for updates on static info for a specific component_key and key."""
+        return f"esphome_{self.entry_id}_static_info_updated_{component_key}_{key}"
 
     @callback
     def async_update_ble_connection_limits(self, free: int, limit: int) -> None:

--- a/homeassistant/components/esphome/manifest.json
+++ b/homeassistant/components/esphome/manifest.json
@@ -2,7 +2,7 @@
   "domain": "esphome",
   "name": "ESPHome",
   "after_dependencies": ["zeroconf", "tag"],
-  "codeowners": ["@OttoWinter", "@jesserockz"],
+  "codeowners": ["@OttoWinter", "@jesserockz", "@bdraco"],
   "config_flow": true,
   "dependencies": ["assist_pipeline", "bluetooth"],
   "dhcp": [

--- a/homeassistant/components/esphome/sensor.py
+++ b/homeassistant/components/esphome/sensor.py
@@ -5,6 +5,7 @@ from datetime import datetime
 import math
 
 from aioesphomeapi import (
+    EntityInfo,
     SensorInfo,
     SensorState,
     SensorStateClass as EsphomeSensorStateClass,
@@ -68,9 +69,9 @@ class EsphomeSensor(EsphomeEntity[SensorInfo, SensorState], SensorEntity):
     """A sensor implementation for esphome."""
 
     @callback
-    def _on_static_info_update(self) -> None:
+    def _on_static_info_update(self, static_info: EntityInfo) -> None:
         """Set attrs from static info."""
-        super()._on_static_info_update()
+        super()._on_static_info_update(static_info)
         static_info = self._static_info
         self._attr_force_update = static_info.force_update
         self._attr_native_unit_of_measurement = static_info.unit_of_measurement

--- a/homeassistant/components/esphome/sensor.py
+++ b/homeassistant/components/esphome/sensor.py
@@ -5,6 +5,7 @@ from datetime import datetime
 import math
 
 from aioesphomeapi import (
+    EntityInfo,
     SensorInfo,
     SensorState,
     SensorStateClass as EsphomeSensorStateClass,
@@ -19,7 +20,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util import dt as dt_util
 from homeassistant.util.enum import try_parse_enum
@@ -67,10 +68,27 @@ _STATE_CLASSES: EsphomeEnumMapper[
 class EsphomeSensor(EsphomeEntity[SensorInfo, SensorState], SensorEntity):
     """A sensor implementation for esphome."""
 
-    @property
-    def force_update(self) -> bool:
-        """Return if this sensor should force a state update."""
-        return self._static_info.force_update
+    @callback
+    def _on_static_info_update(self, static_infos: dict[int, EntityInfo]) -> None:
+        """Set attrs from static info."""
+        super()._on_static_info_update(static_infos)
+        static_info = self._static_info
+        self._attr_force_update = static_info.force_update
+        self._attr_native_unit_of_measurement = static_info.unit_of_measurement
+        self._attr_device_class = try_parse_enum(
+            SensorDeviceClass, static_info.device_class
+        )
+        if not (state_class := static_info.state_class):
+            return
+        if (
+            state_class == EsphomeSensorStateClass.MEASUREMENT
+            and static_info.last_reset_type == LastResetType.AUTO
+        ):
+            # Legacy, last_reset_type auto was the equivalent to the
+            # TOTAL_INCREASING state class
+            self._attr_state_class = SensorStateClass.TOTAL_INCREASING
+        else:
+            self._attr_state_class = _STATE_CLASSES.from_esphome(state_class)
 
     @property
     @esphome_state_property
@@ -80,37 +98,9 @@ class EsphomeSensor(EsphomeEntity[SensorInfo, SensorState], SensorEntity):
             return None
         if self._state.missing_state:
             return None
-        if self.device_class == SensorDeviceClass.TIMESTAMP:
+        if self._attr_device_class == SensorDeviceClass.TIMESTAMP:
             return dt_util.utc_from_timestamp(self._state.state)
         return f"{self._state.state:.{self._static_info.accuracy_decimals}f}"
-
-    @property
-    def native_unit_of_measurement(self) -> str | None:
-        """Return the unit the value is expressed in."""
-        if not self._static_info.unit_of_measurement:
-            return None
-        return self._static_info.unit_of_measurement
-
-    @property
-    def device_class(self) -> SensorDeviceClass | None:
-        """Return the class of this device, from component DEVICE_CLASSES."""
-        return try_parse_enum(SensorDeviceClass, self._static_info.device_class)
-
-    @property
-    def state_class(self) -> SensorStateClass | None:
-        """Return the state class of this entity."""
-        if not self._static_info.state_class:
-            return None
-        state_class = self._static_info.state_class
-        reset_type = self._static_info.last_reset_type
-        if (
-            state_class == EsphomeSensorStateClass.MEASUREMENT
-            and reset_type == LastResetType.AUTO
-        ):
-            # Legacy, last_reset_type auto was the equivalent to the
-            # TOTAL_INCREASING state class
-            return SensorStateClass.TOTAL_INCREASING
-        return _STATE_CLASSES.from_esphome(self._static_info.state_class)
 
 
 class EsphomeTextSensor(EsphomeEntity[TextSensorInfo, TextSensorState], SensorEntity):

--- a/homeassistant/components/esphome/sensor.py
+++ b/homeassistant/components/esphome/sensor.py
@@ -5,7 +5,6 @@ from datetime import datetime
 import math
 
 from aioesphomeapi import (
-    EntityInfo,
     SensorInfo,
     SensorState,
     SensorStateClass as EsphomeSensorStateClass,
@@ -69,9 +68,9 @@ class EsphomeSensor(EsphomeEntity[SensorInfo, SensorState], SensorEntity):
     """A sensor implementation for esphome."""
 
     @callback
-    def _on_static_info_update(self, static_infos: dict[int, EntityInfo]) -> None:
+    def _on_static_info_update(self) -> None:
         """Set attrs from static info."""
-        super()._on_static_info_update(static_infos)
+        super()._on_static_info_update()
         static_info = self._static_info
         self._attr_force_update = static_info.force_update
         self._attr_native_unit_of_measurement = static_info.unit_of_measurement


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Reduce overhead to update esphome entities

There were lots of property/attrs lookups for static info values that rarely change. We can update the attrs when we get the dispatch instead.  

I also changed the recently added `_on_static_info_update` to dispatch indexed by `component_key` and `key` to avoid the pattern where each entity has to reject the dispatch if it doesn't match the `key`

I did `sensor` first since power sensors are usually one or two orders of magnitude more updates than anything else. I also did `binary_sensor` to make sure the pattern would work beyond just sensor since it was the simplest platform to modify and it had special cases for the connected sensor

Also pickup codeowner for `esphome` to make sure this doesn't have any unexpected fallout and since I've been working through a lot of the esphome issues in the queue anyways.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
