### PR TITLE
Migrate esphome number platform to use _on_static_info_update

### DIFF
--- a/homeassistant/components/esphome/number.py
+++ b/homeassistant/components/esphome/number.py
@@ -3,11 +3,16 @@ from __future__ import annotations
 
 import math
 
-from aioesphomeapi import NumberInfo, NumberMode as EsphomeNumberMode, NumberState
+from aioesphomeapi import (
+    EntityInfo,
+    NumberInfo,
+    NumberMode as EsphomeNumberMode,
+    NumberState,
+)
 
 from homeassistant.components.number import NumberDeviceClass, NumberEntity, NumberMode
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util.enum import try_parse_enum
 
@@ -44,48 +49,34 @@ NUMBER_MODES: EsphomeEnumMapper[EsphomeNumberMode, NumberMode] = EsphomeEnumMapp
 class EsphomeNumber(EsphomeEntity[NumberInfo, NumberState], NumberEntity):
     """A number implementation for esphome."""
 
-    @property
-    def device_class(self) -> NumberDeviceClass | None:
-        """Return the class of this entity."""
-        return try_parse_enum(NumberDeviceClass, self._static_info.device_class)
-
-    @property
-    def native_min_value(self) -> float:
-        """Return the minimum value."""
-        return self._static_info.min_value
-
-    @property
-    def native_max_value(self) -> float:
-        """Return the maximum value."""
-        return self._static_info.max_value
-
-    @property
-    def native_step(self) -> float:
-        """Return the increment/decrement step."""
-        return self._static_info.step
-
-    @property
-    def native_unit_of_measurement(self) -> str | None:
-        """Return the unit of measurement."""
-        return self._static_info.unit_of_measurement
-
-    @property
-    def mode(self) -> NumberMode:
-        """Return the mode of the entity."""
-        if self._static_info.mode:
-            return NUMBER_MODES.from_esphome(self._static_info.mode)
-        return NumberMode.AUTO
+    @callback
+    def _on_static_info_update(self, static_info: EntityInfo) -> None:
+        """Set attrs from static info."""
+        super()._on_static_info_update(static_info)
+        static_info = self._static_info
+        self._attr_device_class = try_parse_enum(
+            NumberDeviceClass, self._static_info.device_class
+        )
+        self._attr_native_min_value = static_info.min_value
+        self._attr_native_max_value = static_info.max_value
+        self._attr_native_step = static_info.step
+        self._attr_native_unit_of_measurement = static_info.unit_of_measurement
+        if mode := static_info.mode:
+            self._attr_mode = NUMBER_MODES.from_esphome(mode)
+        else:
+            self._attr_mode = NumberMode.AUTO
 
     @property
     @esphome_state_property
     def native_value(self) -> float | None:
         """Return the state of the entity."""
-        if math.isnan(self._state.state):
+        state = self._state
+        if math.isnan(state.state):
             return None
-        if self._state.missing_state:
+        if state.missing_state:
             return None
-        return self._state.state
+        return state.state
 
     async def async_set_native_value(self, value: float) -> None:
         """Update the current value."""
-        await self._client.number_command(self._static_info.key, value)
+        await self._client.number_command(self._key, value)


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
followup to #94930


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
