### PR TITLE
Migrate esphome light platform to use _on_static_info_update

### DIFF
--- a/homeassistant/components/esphome/light.py
+++ b/homeassistant/components/esphome/light.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 
 from typing import Any, cast
 
-from aioesphomeapi import APIVersion, LightColorCapability, LightInfo, LightState
+from aioesphomeapi import (
+    APIVersion,
+    EntityInfo,
+    LightColorCapability,
+    LightInfo,
+    LightState,
+)
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
@@ -22,7 +28,7 @@ from homeassistant.components.light import (
     LightEntityFeature,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import EsphomeEntity, esphome_state_property, platform_async_setup_entry
@@ -128,6 +134,8 @@ def _filter_color_modes(
 class EsphomeLight(EsphomeEntity[LightInfo, LightState], LightEntity):
     """A light implementation for ESPHome."""
 
+    _native_supported_color_modes: list[int]
+
     @property
     def _supports_color_mode(self) -> bool:
         """Return whether the client supports the new color mode system natively."""
@@ -141,7 +149,7 @@ class EsphomeLight(EsphomeEntity[LightInfo, LightState], LightEntity):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
-        data: dict[str, Any] = {"key": self._static_info.key, "state": True}
+        data: dict[str, Any] = {"key": self._key, "state": True}
         # The list of color modes that would fit this service call
         color_modes = self._native_supported_color_modes
         try_keep_current_mode = True
@@ -259,7 +267,7 @@ class EsphomeLight(EsphomeEntity[LightInfo, LightState], LightEntity):
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
-        data: dict[str, Any] = {"key": self._static_info.key, "state": False}
+        data: dict[str, Any] = {"key": self._key, "state": False}
         if ATTR_FLASH in kwargs:
             data["flash_length"] = FLASH_LENGTHS[kwargs[ATTR_FLASH]]
         if ATTR_TRANSITION in kwargs:
@@ -287,17 +295,18 @@ class EsphomeLight(EsphomeEntity[LightInfo, LightState], LightEntity):
     @esphome_state_property
     def rgb_color(self) -> tuple[int, int, int] | None:
         """Return the rgb color value [int, int, int]."""
+        state = self._state
         if not self._supports_color_mode:
             return (
-                round(self._state.red * 255),
-                round(self._state.green * 255),
-                round(self._state.blue * 255),
+                round(state.red * 255),
+                round(state.green * 255),
+                round(state.blue * 255),
             )
 
         return (
-            round(self._state.red * self._state.color_brightness * 255),
-            round(self._state.green * self._state.color_brightness * 255),
-            round(self._state.blue * self._state.color_brightness * 255),
+            round(state.red * state.color_brightness * 255),
+            round(state.green * state.color_brightness * 255),
+            round(state.blue * state.color_brightness * 255),
         )
 
     @property
@@ -312,15 +321,17 @@ class EsphomeLight(EsphomeEntity[LightInfo, LightState], LightEntity):
     @esphome_state_property
     def rgbww_color(self) -> tuple[int, int, int, int, int] | None:
         """Return the rgbww color value [int, int, int, int, int]."""
+        state = self._state
         rgb = cast("tuple[int, int, int]", self.rgb_color)
         if not _filter_color_modes(
             self._native_supported_color_modes, LightColorCapability.COLD_WARM_WHITE
         ):
             # Try to reverse white + color temp to cwww
-            min_ct = self._static_info.min_mireds
-            max_ct = self._static_info.max_mireds
-            color_temp = min(max(self._state.color_temperature, min_ct), max_ct)
-            white = self._state.white
+            static_info = self._static_info
+            min_ct = static_info.min_mireds
+            max_ct = static_info.max_mireds
+            color_temp = min(max(state.color_temperature, min_ct), max_ct)
+            white = state.white
 
             ww_frac = (color_temp - min_ct) / (max_ct - min_ct)
             cw_frac = 1 - ww_frac
@@ -332,8 +343,8 @@ class EsphomeLight(EsphomeEntity[LightInfo, LightState], LightEntity):
             )
         return (
             *rgb,
-            round(self._state.cold_white * 255),
-            round(self._state.warm_white * 255),
+            round(state.cold_white * 255),
+            round(state.warm_white * 255),
         )
 
     @property
@@ -348,26 +359,24 @@ class EsphomeLight(EsphomeEntity[LightInfo, LightState], LightEntity):
         """Return the current effect."""
         return self._state.effect
 
-    @property
-    def _native_supported_color_modes(self) -> list[int]:
-        return self._static_info.supported_color_modes_compat(self._api_version)
-
-    @property
-    def supported_features(self) -> LightEntityFeature:
-        """Flag supported features."""
+    @callback
+    def _on_static_info_update(self, static_info: EntityInfo) -> None:
+        """Set attrs from static info."""
+        super()._on_static_info_update(static_info)
+        static_info = self._static_info
+        self._native_supported_color_modes = static_info.supported_color_modes_compat(
+            self._api_version
+        )
         flags = LightEntityFeature.FLASH
 
         # All color modes except UNKNOWN,ON_OFF support transition
         modes = self._native_supported_color_modes
         if any(m not in (0, LightColorCapability.ON_OFF) for m in modes):
             flags |= LightEntityFeature.TRANSITION
-        if self._static_info.effects:
+        if static_info.effects:
             flags |= LightEntityFeature.EFFECT
-        return flags
+        self._attr_supported_features = flags
 
-    @property
-    def supported_color_modes(self) -> set[str] | None:
-        """Flag supported color modes."""
         supported = set(map(_color_mode_to_ha, self._native_supported_color_modes))
         if ColorMode.ONOFF in supported and len(supported) > 1:
             supported.remove(ColorMode.ONOFF)
@@ -375,19 +384,7 @@ class EsphomeLight(EsphomeEntity[LightInfo, LightState], LightEntity):
             supported.remove(ColorMode.BRIGHTNESS)
         if ColorMode.WHITE in supported and len(supported) == 1:
             supported.remove(ColorMode.WHITE)
-        return supported
-
-    @property
-    def effect_list(self) -> list[str]:
-        """Return the list of supported effects."""
-        return self._static_info.effects
-
-    @property
-    def min_mireds(self) -> int:
-        """Return the coldest color_temp that this light supports."""
-        return round(self._static_info.min_mireds)
-
-    @property
-    def max_mireds(self) -> int:
-        """Return the warmest color_temp that this light supports."""
-        return round(self._static_info.max_mireds)
+        self._attr_supported_color_modes = supported
+        self._attr_effect_list = static_info.effects
+        self._attr_min_mireds = round(static_info.min_mireds)
+        self._attr_max_mireds = round(static_info.max_mireds)


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
followup to #94930

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
