### PR TITLE
Teach binary_sensor device trigger about entity registry ids

### DIFF
--- a/homeassistant/components/binary_sensor/device_trigger.py
+++ b/homeassistant/components/binary_sensor/device_trigger.py
@@ -195,7 +195,7 @@ TURNED_OFF = [trigger[1][CONF_TYPE] for trigger in ENTITY_TRIGGERS.values()]
 
 TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
     {
-        vol.Required(CONF_ENTITY_ID): cv.entity_id,
+        vol.Required(CONF_ENTITY_ID): cv.entity_id_or_uuid,
         vol.Required(CONF_TYPE): vol.In(TURNED_OFF + TURNED_ON),
         vol.Optional(CONF_FOR): cv.positive_time_period_dict,
     }
@@ -254,7 +254,7 @@ async def async_get_triggers(
                 **automation,
                 "platform": "device",
                 "device_id": device_id,
-                "entity_id": entry.entity_id,
+                "entity_id": entry.id,
                 "domain": DOMAIN,
             }
             for automation in templates

--- a/tests/components/binary_sensor/test_device_trigger.py
+++ b/tests/components/binary_sensor/test_device_trigger.py
@@ -41,6 +41,7 @@ async def test_get_triggers(
     enable_custom_integrations: None,
 ) -> None:
     """Test we get the expected triggers from a binary_sensor."""
+    registry_entries: dict[BinarySensorDeviceClass, er.RegistryEntry] = {}
     platform = getattr(hass.components, f"test.{DOMAIN}")
     platform.init()
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
@@ -53,7 +54,7 @@ async def test_get_triggers(
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
     for device_class in BinarySensorDeviceClass:
-        entity_registry.async_get_or_create(
+        registry_entries[device_class] = entity_registry.async_get_or_create(
             DOMAIN,
             "test",
             platform.ENTITIES[device_class].unique_id,
@@ -66,7 +67,7 @@ async def test_get_triggers(
             "domain": DOMAIN,
             "type": trigger["type"],
             "device_id": device_entry.id,
-            "entity_id": platform.ENTITIES[device_class].entity_id,
+            "entity_id": registry_entries[device_class].id,
             "metadata": {"secondary": False},
         }
         for device_class in BinarySensorDeviceClass
@@ -101,7 +102,7 @@ async def test_get_triggers_hidden_auxiliary(
         config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
-    entity_registry.async_get_or_create(
+    entry = entity_registry.async_get_or_create(
         DOMAIN,
         "test",
         "5678",
@@ -115,7 +116,7 @@ async def test_get_triggers_hidden_auxiliary(
             "domain": DOMAIN,
             "type": trigger,
             "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
+            "entity_id": entry.id,
             "metadata": {"secondary": True},
         }
         for trigger in ["turned_on", "turned_off"]
@@ -132,9 +133,9 @@ async def test_get_triggers_no_state(
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test we get the expected triggers from a binary_sensor."""
+    registry_entries: dict[BinarySensorDeviceClass, er.RegistryEntry] = {}
     platform = getattr(hass.components, f"test.{DOMAIN}")
     platform.init()
-    entity_ids = {}
 
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -143,13 +144,13 @@ async def test_get_triggers_no_state(
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
     for device_class in BinarySensorDeviceClass:
-        entity_ids[device_class] = entity_registry.async_get_or_create(
+        registry_entries[device_class] = entity_registry.async_get_or_create(
             DOMAIN,
             "test",
             f"5678_{device_class}",
             device_id=device_entry.id,
             original_device_class=device_class,
-        ).entity_id
+        )
 
     await hass.async_block_till_done()
 
@@ -159,7 +160,7 @@ async def test_get_triggers_no_state(
             "domain": DOMAIN,
             "type": trigger["type"],
             "device_id": device_entry.id,
-            "entity_id": entity_ids[device_class],
+            "entity_id": registry_entries[device_class].id,
             "metadata": {"secondary": False},
         }
         for device_class in BinarySensorDeviceClass
@@ -201,8 +202,42 @@ async def test_get_trigger_capabilities(
         assert capabilities == expected_capabilities
 
 
+async def test_get_trigger_capabilities_legacy(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test we get the expected capabilities from a binary_sensor trigger."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_registry.async_get_or_create(
+        DOMAIN, "test", "5678", device_id=device_entry.id
+    )
+    expected_capabilities = {
+        "extra_fields": [
+            {"name": "for", "optional": True, "type": "positive_time_period_dict"}
+        ]
+    }
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device_entry.id
+    )
+    for trigger in triggers:
+        trigger["entity_id"] = entity_registry.async_get(trigger["entity_id"]).entity_id
+        capabilities = await async_get_device_automation_capabilities(
+            hass, DeviceAutomationType.TRIGGER, trigger
+        )
+        assert capabilities == expected_capabilities
+
+
 async def test_if_fires_on_state_change(
-    hass: HomeAssistant, calls, enable_custom_integrations: None
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    calls,
+    enable_custom_integrations: None,
 ) -> None:
     """Test for on and off triggers firing."""
     platform = getattr(hass.components, f"test.{DOMAIN}")
@@ -210,7 +245,11 @@ async def test_if_fires_on_state_change(
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
     await hass.async_block_till_done()
 
-    sensor1 = platform.ENTITIES["battery"]
+    entry = entity_registry.async_get_or_create(
+        DOMAIN,
+        "test",
+        platform.ENTITIES["battery"].unique_id,
+    )
 
     assert await async_setup_component(
         hass,
@@ -222,7 +261,7 @@ async def test_if_fires_on_state_change(
                         "platform": "device",
                         "domain": DOMAIN,
                         "device_id": "",
-                        "entity_id": sensor1.entity_id,
+                        "entity_id": entry.id,
                         "type": "bat_low",
                     },
                     "action": {
@@ -246,7 +285,7 @@ async def test_if_fires_on_state_change(
                         "platform": "device",
                         "domain": DOMAIN,
                         "device_id": "",
-                        "entity_id": sensor1.entity_id,
+                        "entity_id": entry.id,
                         "type": "not_bat_low",
                     },
                     "action": {
@@ -269,26 +308,30 @@ async def test_if_fires_on_state_change(
         },
     )
     await hass.async_block_till_done()
-    assert hass.states.get(sensor1.entity_id).state == STATE_ON
+    assert hass.states.get(entry.entity_id).state == STATE_ON
     assert len(calls) == 0
 
-    hass.states.async_set(sensor1.entity_id, STATE_OFF)
+    hass.states.async_set(entry.entity_id, STATE_OFF)
     await hass.async_block_till_done()
     assert len(calls) == 1
-    assert calls[0].data["some"] == "not_bat_low device - {} - on - off - None".format(
-        sensor1.entity_id
+    assert (
+        calls[0].data["some"]
+        == f"not_bat_low device - {entry.entity_id} - on - off - None"
     )
 
-    hass.states.async_set(sensor1.entity_id, STATE_ON)
+    hass.states.async_set(entry.entity_id, STATE_ON)
     await hass.async_block_till_done()
     assert len(calls) == 2
-    assert calls[1].data["some"] == "bat_low device - {} - off - on - None".format(
-        sensor1.entity_id
+    assert (
+        calls[1].data["some"] == f"bat_low device - {entry.entity_id} - off - on - None"
     )
 
 
 async def test_if_fires_on_state_change_with_for(
-    hass: HomeAssistant, calls, enable_custom_integrations: None
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    calls,
+    enable_custom_integrations: None,
 ) -> None:
     """Test for triggers firing with delay."""
     platform = getattr(hass.components, f"test.{DOMAIN}")
@@ -297,7 +340,11 @@ async def test_if_fires_on_state_change_with_for(
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
     await hass.async_block_till_done()
 
-    sensor1 = platform.ENTITIES["battery"]
+    entry = entity_registry.async_get_or_create(
+        DOMAIN,
+        "test",
+        platform.ENTITIES["battery"].unique_id,
+    )
 
     assert await async_setup_component(
         hass,
@@ -309,7 +356,7 @@ async def test_if_fires_on_state_change_with_for(
                         "platform": "device",
                         "domain": DOMAIN,
                         "device_id": "",
-                        "entity_id": sensor1.entity_id,
+                        "entity_id": entry.id,
                         "type": "turned_off",
                         "for": {"seconds": 5},
                     },
@@ -333,16 +380,80 @@ async def test_if_fires_on_state_change_with_for(
         },
     )
     await hass.async_block_till_done()
-    assert hass.states.get(sensor1.entity_id).state == STATE_ON
+    assert hass.states.get(entry.entity_id).state == STATE_ON
     assert len(calls) == 0
 
-    hass.states.async_set(sensor1.entity_id, STATE_OFF)
+    hass.states.async_set(entry.entity_id, STATE_OFF)
     await hass.async_block_till_done()
     assert len(calls) == 0
     async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=10))
     await hass.async_block_till_done()
     assert len(calls) == 1
     await hass.async_block_till_done()
-    assert calls[0].data["some"] == "turn_off device - {} - on - off - 0:00:05".format(
-        sensor1.entity_id
+    assert (
+        calls[0].data["some"]
+        == f"turn_off device - {entry.entity_id} - on - off - 0:00:05"
+    )
+
+
+async def test_if_fires_on_state_change_legacy(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    calls,
+    enable_custom_integrations: None,
+) -> None:
+    """Test for triggers firing."""
+    platform = getattr(hass.components, f"test.{DOMAIN}")
+
+    platform.init()
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
+
+    entry = entity_registry.async_get_or_create(
+        DOMAIN,
+        "test",
+        platform.ENTITIES["battery"].unique_id,
+    )
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "platform": "device",
+                        "domain": DOMAIN,
+                        "device_id": "",
+                        "entity_id": entry.entity_id,
+                        "type": "turned_off",
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": "turn_off {{ trigger.%s }}"
+                            % "}} - {{ trigger.".join(
+                                (
+                                    "platform",
+                                    "entity_id",
+                                    "from_state.state",
+                                    "to_state.state",
+                                    "for",
+                                )
+                            )
+                        },
+                    },
+                }
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get(entry.entity_id).state == STATE_ON
+    assert len(calls) == 0
+
+    hass.states.async_set(entry.entity_id, STATE_OFF)
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    assert calls[0].data["some"] == "turn_off device - {} - on - off - None".format(
+        entry.entity_id
     )

--- a/tests/components/deconz/test_device_trigger.py
+++ b/tests/components/deconz/test_device_trigger.py
@@ -26,7 +26,7 @@ from homeassistant.const import (
     CONF_TYPE,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.trigger import async_initialize_triggers
 from homeassistant.setup import async_setup_component
 
@@ -192,6 +192,9 @@ async def test_get_triggers_for_alarm_event(
     device = device_registry.async_get_device(
         identifiers={(DECONZ_DOMAIN, "00:00:00:00:00:00:00:00")}
     )
+    entity_registry = er.async_get(hass)
+    low_bat_entity = entity_registry.async_get("binary_sensor.keypad_low_battery")
+    tamper_entity = entity_registry.async_get("binary_sensor.keypad_tampered")
 
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device.id
@@ -201,7 +204,7 @@ async def test_get_triggers_for_alarm_event(
         {
             CONF_DEVICE_ID: device.id,
             CONF_DOMAIN: BINARY_SENSOR_DOMAIN,
-            ATTR_ENTITY_ID: "binary_sensor.keypad_low_battery",
+            ATTR_ENTITY_ID: low_bat_entity.id,
             CONF_PLATFORM: "device",
             CONF_TYPE: CONF_BAT_LOW,
             "metadata": {"secondary": True},
@@ -209,7 +212,7 @@ async def test_get_triggers_for_alarm_event(
         {
             CONF_DEVICE_ID: device.id,
             CONF_DOMAIN: BINARY_SENSOR_DOMAIN,
-            ATTR_ENTITY_ID: "binary_sensor.keypad_low_battery",
+            ATTR_ENTITY_ID: low_bat_entity.id,
             CONF_PLATFORM: "device",
             CONF_TYPE: CONF_NOT_BAT_LOW,
             "metadata": {"secondary": True},
@@ -217,7 +220,7 @@ async def test_get_triggers_for_alarm_event(
         {
             CONF_DEVICE_ID: device.id,
             CONF_DOMAIN: BINARY_SENSOR_DOMAIN,
-            ATTR_ENTITY_ID: "binary_sensor.keypad_tampered",
+            ATTR_ENTITY_ID: tamper_entity.id,
             CONF_PLATFORM: "device",
             CONF_TYPE: CONF_TAMPERED,
             "metadata": {"secondary": True},
@@ -225,7 +228,7 @@ async def test_get_triggers_for_alarm_event(
         {
             CONF_DEVICE_ID: device.id,
             CONF_DOMAIN: BINARY_SENSOR_DOMAIN,
-            ATTR_ENTITY_ID: "binary_sensor.keypad_tampered",
+            ATTR_ENTITY_ID: tamper_entity.id,
             CONF_PLATFORM: "device",
             CONF_TYPE: CONF_NOT_TAMPERED,
             "metadata": {"secondary": True},


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Teach binary_sensor device trigger about entity registry ids

#### Background:
When a device automation is configured by the user, the user picks a device without specifying an `entity_id`. If the user then changes the `entity_id` of that entity, the configured device automation no longer works.
By instead referencing the entity registry id of the entity, the device automation is still valid.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
