### PR TITLE
Teach climate device trigger about entity registry ids

### DIFF
--- a/homeassistant/components/climate/device_trigger.py
+++ b/homeassistant/components/climate/device_trigger.py
@@ -34,7 +34,7 @@ TRIGGER_TYPES = {
 
 HVAC_MODE_TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
     {
-        vol.Required(CONF_ENTITY_ID): cv.entity_id,
+        vol.Required(CONF_ENTITY_ID): cv.entity_id_or_uuid,
         vol.Required(CONF_TYPE): "hvac_mode_changed",
         vol.Required(state_trigger.CONF_TO): vol.In(const.HVAC_MODES),
     }
@@ -43,7 +43,7 @@ HVAC_MODE_TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
 CURRENT_TRIGGER_SCHEMA = vol.All(
     DEVICE_TRIGGER_BASE_SCHEMA.extend(
         {
-            vol.Required(CONF_ENTITY_ID): cv.entity_id,
+            vol.Required(CONF_ENTITY_ID): cv.entity_id_or_uuid,
             vol.Required(CONF_TYPE): vol.In(
                 ["current_temperature_changed", "current_humidity_changed"]
             ),
@@ -77,7 +77,7 @@ async def async_get_triggers(
             CONF_PLATFORM: "device",
             CONF_DEVICE_ID: device_id,
             CONF_DOMAIN: DOMAIN,
-            CONF_ENTITY_ID: entry.entity_id,
+            CONF_ENTITY_ID: entry.id,
         }
 
         triggers.append(

--- a/tests/components/climate/test_device_trigger.py
+++ b/tests/components/climate/test_device_trigger.py
@@ -52,13 +52,12 @@ async def test_get_triggers(
         config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
-    entity_registry.async_get_or_create(
+    entity_entry = entity_registry.async_get_or_create(
         DOMAIN, "test", "5678", device_id=device_entry.id
     )
-    entity_id = f"{DOMAIN}.test_5678"
     hass.states.async_set(
-        entity_id,
-        HVACMode.COOL,
+        entity_entry.entity_id,
+        const.HVAC_MODE_COOL,
         {
             const.ATTR_HVAC_ACTION: HVACAction.IDLE,
             const.ATTR_CURRENT_HUMIDITY: 23,
@@ -71,7 +70,7 @@ async def test_get_triggers(
             "domain": DOMAIN,
             "type": trigger,
             "device_id": device_entry.id,
-            "entity_id": entity_id,
+            "entity_id": entity_entry.id,
             "metadata": {"secondary": False},
         }
         for trigger in [
@@ -109,7 +108,7 @@ async def test_get_triggers_hidden_auxiliary(
         config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
-    entity_registry.async_get_or_create(
+    entity_entry = entity_registry.async_get_or_create(
         DOMAIN,
         "test",
         "5678",
@@ -117,9 +116,8 @@ async def test_get_triggers_hidden_auxiliary(
         entity_category=entity_category,
         hidden_by=hidden_by,
     )
-    entity_id = f"{DOMAIN}.test_5678"
     hass.states.async_set(
-        entity_id,
+        entity_entry.entity_id,
         HVACMode.COOL,
         {
             const.ATTR_HVAC_ACTION: HVACAction.IDLE,
@@ -133,7 +131,7 @@ async def test_get_triggers_hidden_auxiliary(
             "domain": DOMAIN,
             "type": trigger,
             "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
+            "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
         for trigger in [
@@ -148,10 +146,14 @@ async def test_get_triggers_hidden_auxiliary(
     assert triggers == unordered(expected_triggers)
 
 
-async def test_if_fires_on_state_change(hass: HomeAssistant, calls) -> None:
+async def test_if_fires_on_state_change(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, calls
+) -> None:
     """Test for turn_on and turn_off triggers firing."""
+    entry = entity_registry.async_get_or_create(DOMAIN, "test", "5678")
+
     hass.states.async_set(
-        "climate.entity",
+        entry.entity_id,
         HVACMode.COOL,
         {
             const.ATTR_HVAC_ACTION: HVACAction.IDLE,
@@ -170,7 +172,7 @@ async def test_if_fires_on_state_change(hass: HomeAssistant, calls) -> None:
                         "platform": "device",
                         "domain": DOMAIN,
                         "device_id": "",
-                        "entity_id": "climate.entity",
+                        "entity_id": entry.id,
                         "type": "hvac_mode_changed",
                         "to": HVACMode.AUTO,
                     },
@@ -184,7 +186,7 @@ async def test_if_fires_on_state_change(hass: HomeAssistant, calls) -> None:
                         "platform": "device",
                         "domain": DOMAIN,
                         "device_id": "",
-                        "entity_id": "climate.entity",
+                        "entity_id": entry.id,
                         "type": "current_temperature_changed",
                         "above": 20,
                     },
@@ -198,7 +200,7 @@ async def test_if_fires_on_state_change(hass: HomeAssistant, calls) -> None:
                         "platform": "device",
                         "domain": DOMAIN,
                         "device_id": "",
-                        "entity_id": "climate.entity",
+                        "entity_id": entry.id,
                         "type": "current_humidity_changed",
                         "below": 10,
                     },
@@ -213,7 +215,7 @@ async def test_if_fires_on_state_change(hass: HomeAssistant, calls) -> None:
 
     # Fake that the HVAC mode is changing
     hass.states.async_set(
-        "climate.entity",
+        entry.entity_id,
         HVACMode.AUTO,
         {
             const.ATTR_HVAC_ACTION: HVACAction.COOLING,
@@ -227,7 +229,7 @@ async def test_if_fires_on_state_change(hass: HomeAssistant, calls) -> None:
 
     # Fake that the temperature is changing
     hass.states.async_set(
-        "climate.entity",
+        entry.entity_id,
         HVACMode.AUTO,
         {
             const.ATTR_HVAC_ACTION: HVACAction.COOLING,
@@ -241,7 +243,7 @@ async def test_if_fires_on_state_change(hass: HomeAssistant, calls) -> None:
 
     # Fake that the humidity is changing
     hass.states.async_set(
-        "climate.entity",
+        entry.entity_id,
         HVACMode.AUTO,
         {
             const.ATTR_HVAC_ACTION: HVACAction.COOLING,
@@ -254,6 +256,60 @@ async def test_if_fires_on_state_change(hass: HomeAssistant, calls) -> None:
     assert calls[2].data["some"] == "current_humidity_changed"
 
 
+async def test_if_fires_on_state_change_legacy(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, calls
+) -> None:
+    """Test for turn_on and turn_off triggers firing."""
+    entry = entity_registry.async_get_or_create(DOMAIN, "test", "5678")
+
+    hass.states.async_set(
+        entry.entity_id,
+        HVACMode.COOL,
+        {
+            const.ATTR_HVAC_ACTION: HVACAction.IDLE,
+            const.ATTR_CURRENT_HUMIDITY: 23,
+            const.ATTR_CURRENT_TEMPERATURE: 18,
+        },
+    )
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "platform": "device",
+                        "domain": DOMAIN,
+                        "device_id": "",
+                        "entity_id": entry.entity_id,
+                        "type": "hvac_mode_changed",
+                        "to": HVACMode.AUTO,
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {"some": "hvac_mode_changed"},
+                    },
+                },
+            ]
+        },
+    )
+
+    # Fake that the HVAC mode is changing
+    hass.states.async_set(
+        entry.entity_id,
+        HVACMode.AUTO,
+        {
+            const.ATTR_HVAC_ACTION: HVACAction.COOLING,
+            const.ATTR_CURRENT_HUMIDITY: 23,
+            const.ATTR_CURRENT_TEMPERATURE: 18,
+        },
+    )
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    assert calls[0].data["some"] == "hvac_mode_changed"
+
+
 async def test_get_trigger_capabilities_hvac_mode(hass: HomeAssistant) -> None:
     """Test we get the expected capabilities from a climate trigger."""
     capabilities = await device_trigger.async_get_trigger_capabilities(
@@ -262,7 +318,7 @@ async def test_get_trigger_capabilities_hvac_mode(hass: HomeAssistant) -> None:
             "platform": "device",
             "domain": "climate",
             "type": "hvac_mode_changed",
-            "entity_id": "climate.upstairs",
+            "entity_id": "01234567890123456789012345678901",
             "to": "heat",
         },
     )
@@ -290,17 +346,23 @@ async def test_get_trigger_capabilities_hvac_mode(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "type", ["current_temperature_changed", "current_humidity_changed"]
+    ("type", "suffix"),
+    [
+        ("current_temperature_changed", UnitOfTemperature.CELSIUS),
+        ("current_humidity_changed", "%"),
+    ],
 )
-async def test_get_trigger_capabilities_temp_humid(hass: HomeAssistant, type) -> None:
+async def test_get_trigger_capabilities_temp_humid(
+    hass: HomeAssistant, type, suffix
+) -> None:
     """Test we get the expected capabilities from a climate trigger."""
     capabilities = await device_trigger.async_get_trigger_capabilities(
         hass,
         {
             "platform": "device",
             "domain": "climate",
-            "type": "current_temperature_changed",
-            "entity_id": "climate.upstairs",
+            "type": type,
+            "entity_id": "01234567890123456789012345678901",
             "above": "23",
         },
     )
@@ -311,13 +373,13 @@ async def test_get_trigger_capabilities_temp_humid(hass: HomeAssistant, type) ->
         capabilities["extra_fields"], custom_serializer=cv.custom_serializer
     ) == [
         {
-            "description": {"suffix": UnitOfTemperature.CELSIUS},
+            "description": {"suffix": suffix},
             "name": "above",
             "optional": True,
             "type": "float",
         },
         {
-            "description": {"suffix": UnitOfTemperature.CELSIUS},
+            "description": {"suffix": suffix},
             "name": "below",
             "optional": True,
             "type": "float",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Teach climate device trigger about entity registry ids

#### Background:
When a device automation is configured by the user, the user picks a device without specifying an `entity_id`. If the user then changes the `entity_id` of that entity, the configured device automation no longer works.
By instead referencing the entity registry id of the entity, the device automation is still valid.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
