### PR TITLE
Teach device_tracker device trigger about entity registry ids

### DIFF
--- a/homeassistant/components/device_tracker/device_trigger.py
+++ b/homeassistant/components/device_tracker/device_trigger.py
@@ -27,7 +27,7 @@ TRIGGER_TYPES: Final[set[str]] = {"enters", "leaves"}
 
 TRIGGER_SCHEMA: Final = DEVICE_TRIGGER_BASE_SCHEMA.extend(
     {
-        vol.Required(CONF_ENTITY_ID): cv.entity_id,
+        vol.Required(CONF_ENTITY_ID): cv.entity_id_or_uuid,
         vol.Required(CONF_TYPE): vol.In(TRIGGER_TYPES),
         vol.Required(CONF_ZONE): cv.entity_domain(DOMAIN_ZONE),
     }
@@ -51,7 +51,7 @@ async def async_get_triggers(
                 CONF_PLATFORM: "device",
                 CONF_DEVICE_ID: device_id,
                 CONF_DOMAIN: DOMAIN,
-                CONF_ENTITY_ID: entry.entity_id,
+                CONF_ENTITY_ID: entry.id,
                 CONF_TYPE: "enters",
             }
         )
@@ -60,7 +60,7 @@ async def async_get_triggers(
                 CONF_PLATFORM: "device",
                 CONF_DEVICE_ID: device_id,
                 CONF_DOMAIN: DOMAIN,
-                CONF_ENTITY_ID: entry.entity_id,
+                CONF_ENTITY_ID: entry.id,
                 CONF_TYPE: "leaves",
             }
         )

--- a/tests/components/device_tracker/test_device_trigger.py
+++ b/tests/components/device_tracker/test_device_trigger.py
@@ -73,7 +73,7 @@ async def test_get_triggers(
         config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
-    entity_registry.async_get_or_create(
+    entity_entry = entity_registry.async_get_or_create(
         DOMAIN, "test", "5678", device_id=device_entry.id
     )
     expected_triggers = [
@@ -82,7 +82,7 @@ async def test_get_triggers(
             "domain": DOMAIN,
             "type": trigger,
             "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
+            "entity_id": entity_entry.id,
             "metadata": {"secondary": False},
         }
         for trigger in ["leaves", "enters"]
@@ -116,7 +116,7 @@ async def test_get_triggers_hidden_auxiliary(
         config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
-    entity_registry.async_get_or_create(
+    entity_entry = entity_registry.async_get_or_create(
         DOMAIN,
         "test",
         "5678",
@@ -130,7 +130,7 @@ async def test_get_triggers_hidden_auxiliary(
             "domain": DOMAIN,
             "type": trigger,
             "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
+            "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
         for trigger in ["leaves", "enters"]
@@ -141,10 +141,14 @@ async def test_get_triggers_hidden_auxiliary(
     assert triggers == unordered(expected_triggers)
 
 
-async def test_if_fires_on_zone_change(hass: HomeAssistant, calls) -> None:
+async def test_if_fires_on_zone_change(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, calls
+) -> None:
     """Test for enter and leave triggers firing."""
+    entry = entity_registry.async_get_or_create(DOMAIN, "test", "5678")
+
     hass.states.async_set(
-        "device_tracker.entity",
+        entry.entity_id,
         "state",
         {"latitude": AWAY_LATITUDE, "longitude": AWAY_LONGITUDE},
     )
@@ -159,7 +163,7 @@ async def test_if_fires_on_zone_change(hass: HomeAssistant, calls) -> None:
                         "platform": "device",
                         "domain": DOMAIN,
                         "device_id": "",
-                        "entity_id": "device_tracker.entity",
+                        "entity_id": entry.id,
                         "type": "enters",
                         "zone": "zone.test",
                     },
@@ -183,7 +187,7 @@ async def test_if_fires_on_zone_change(hass: HomeAssistant, calls) -> None:
                         "platform": "device",
                         "domain": DOMAIN,
                         "device_id": "",
-                        "entity_id": "device_tracker.entity",
+                        "entity_id": entry.id,
                         "type": "leaves",
                         "zone": "zone.test",
                     },
@@ -208,26 +212,87 @@ async def test_if_fires_on_zone_change(hass: HomeAssistant, calls) -> None:
 
     # Fake that the entity is entering.
     hass.states.async_set(
-        "device_tracker.entity",
+        entry.entity_id,
         "state",
         {"latitude": HOME_LATITUDE, "longitude": HOME_LONGITUDE},
     )
     await hass.async_block_till_done()
     assert len(calls) == 1
-    assert calls[0].data["some"] == "enter - device - {} - -117.235 - -117.238".format(
-        "device_tracker.entity"
+    assert (
+        calls[0].data["some"]
+        == f"enter - device - {entry.entity_id} - -117.235 - -117.238"
     )
 
     # Fake that the entity is leaving.
     hass.states.async_set(
-        "device_tracker.entity",
+        entry.entity_id,
         "state",
         {"latitude": AWAY_LATITUDE, "longitude": AWAY_LONGITUDE},
     )
     await hass.async_block_till_done()
     assert len(calls) == 2
-    assert calls[1].data["some"] == "leave - device - {} - -117.238 - -117.235".format(
-        "device_tracker.entity"
+    assert (
+        calls[1].data["some"]
+        == f"leave - device - {entry.entity_id} - -117.238 - -117.235"
+    )
+
+
+async def test_if_fires_on_zone_change_legacy(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, calls
+) -> None:
+    """Test for enter and leave triggers firing."""
+    entry = entity_registry.async_get_or_create(DOMAIN, "test", "5678")
+
+    hass.states.async_set(
+        entry.entity_id,
+        "state",
+        {"latitude": AWAY_LATITUDE, "longitude": AWAY_LONGITUDE},
+    )
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "platform": "device",
+                        "domain": DOMAIN,
+                        "device_id": "",
+                        "entity_id": entry.entity_id,
+                        "type": "enters",
+                        "zone": "zone.test",
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": (
+                                "enter "
+                                "- {{ trigger.platform }} "
+                                "- {{ trigger.entity_id }} "
+                                "- {{ "
+                                "    trigger.from_state.attributes.longitude|round(3) "
+                                "  }} "
+                                "- {{ trigger.to_state.attributes.longitude|round(3) }}"
+                            )
+                        },
+                    },
+                },
+            ]
+        },
+    )
+
+    # Fake that the entity is entering.
+    hass.states.async_set(
+        entry.entity_id,
+        "state",
+        {"latitude": HOME_LATITUDE, "longitude": HOME_LONGITUDE},
+    )
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    assert (
+        calls[0].data["some"]
+        == f"enter - device - {entry.entity_id} - -117.235 - -117.238"
     )
 
 
@@ -243,7 +308,7 @@ async def test_get_trigger_capabilities(
         config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
-    entity_registry.async_get_or_create(
+    entity_entry = entity_registry.async_get_or_create(
         DOMAIN, "test", "5678", device_id=device_entry.id
     )
     capabilities = await device_trigger.async_get_trigger_capabilities(
@@ -253,7 +318,46 @@ async def test_get_trigger_capabilities(
             "domain": DOMAIN,
             "type": "enters",
             "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
+            "entity_id": entity_entry.id,
+        },
+    )
+    assert capabilities and "extra_fields" in capabilities
+
+    assert voluptuous_serialize.convert(
+        capabilities["extra_fields"], custom_serializer=cv.custom_serializer
+    ) == [
+        {
+            "name": "zone",
+            "required": True,
+            "type": "select",
+            "options": [("zone.test", "test"), ("zone.home", "test home")],
+        }
+    ]
+
+
+async def test_get_trigger_capabilities_legacy(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test we get the expected capabilities from a device_tracker trigger."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_entry = entity_registry.async_get_or_create(
+        DOMAIN, "test", "5678", device_id=device_entry.id
+    )
+    capabilities = await device_trigger.async_get_trigger_capabilities(
+        hass,
+        {
+            "platform": "device",
+            "domain": DOMAIN,
+            "type": "enters",
+            "device_id": device_entry.id,
+            "entity_id": entity_entry.entity_id,
         },
     )
     assert capabilities and "extra_fields" in capabilities


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Teach device_tracker device trigger about entity registry ids

#### Background:
When a device automation is configured by the user, the user picks a device without specifying an `entity_id`. If the user then changes the `entity_id` of that entity, the configured device automation no longer works.
By instead referencing the entity registry id of the entity, the device automation is still valid.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
