### PR TITLE
Teach humidifier device trigger about entity registry ids

### DIFF
--- a/homeassistant/components/humidifier/device_trigger.py
+++ b/homeassistant/components/humidifier/device_trigger.py
@@ -46,7 +46,7 @@ CURRENT_TRIGGER_SCHEMA = vol.All(
 HUMIDIFIER_TRIGGER_SCHEMA = vol.All(
     DEVICE_TRIGGER_BASE_SCHEMA.extend(
         {
-            vol.Required(CONF_ENTITY_ID): cv.entity_id,
+            vol.Required(CONF_ENTITY_ID): cv.entity_id_or_uuid,
             vol.Required(CONF_TYPE): "target_humidity_changed",
             vol.Optional(CONF_BELOW): vol.Any(vol.Coerce(int)),
             vol.Optional(CONF_ABOVE): vol.Any(vol.Coerce(int)),
@@ -85,7 +85,7 @@ async def async_get_triggers(
             CONF_PLATFORM: "device",
             CONF_DEVICE_ID: device_id,
             CONF_DOMAIN: DOMAIN,
-            CONF_ENTITY_ID: entry.entity_id,
+            CONF_ENTITY_ID: entry.id,
         }
 
         triggers.append(

--- a/tests/components/humidifier/test_device_trigger.py
+++ b/tests/components/humidifier/test_device_trigger.py
@@ -56,12 +56,11 @@ async def test_get_triggers(
         config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
-    entity_registry.async_get_or_create(
+    entity_entry = entity_registry.async_get_or_create(
         DOMAIN, "test", "5678", device_id=device_entry.id
     )
-    entity_id = f"{DOMAIN}.test_5678"
     hass.states.async_set(
-        entity_id,
+        entity_entry.entity_id,
         STATE_ON,
         {
             const.ATTR_HUMIDITY: 23,
@@ -71,22 +70,29 @@ async def test_get_triggers(
             ATTR_SUPPORTED_FEATURES: 1,
         },
     )
+    humidifier_trigger_types = ["current_humidity_changed", "target_humidity_changed"]
+    toggle_trigger_types = ["turned_on", "turned_off", "changed_states"]
     expected_triggers = [
         {
             "platform": "device",
             "domain": DOMAIN,
             "type": trigger,
             "device_id": device_entry.id,
-            "entity_id": entity_id,
+            "entity_id": entity_entry.id,
             "metadata": {"secondary": False},
         }
-        for trigger in [
-            "current_humidity_changed",
-            "target_humidity_changed",
-            "turned_off",
-            "turned_on",
-            "changed_states",
-        ]
+        for trigger in humidifier_trigger_types
+    ]
+    expected_triggers += [
+        {
+            "platform": "device",
+            "domain": DOMAIN,
+            "type": trigger,
+            "device_id": device_entry.id,
+            "entity_id": entity_entry.entity_id,
+            "metadata": {"secondary": False},
+        }
+        for trigger in toggle_trigger_types
     ]
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_entry.id
@@ -117,7 +123,7 @@ async def test_get_triggers_hidden_auxiliary(
         config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
-    entity_registry.async_get_or_create(
+    entity_entry = entity_registry.async_get_or_create(
         DOMAIN,
         "test",
         "5678",
@@ -125,21 +131,29 @@ async def test_get_triggers_hidden_auxiliary(
         entity_category=entity_category,
         hidden_by=hidden_by,
     )
+    humidifier_trigger_types = ["target_humidity_changed"]
+    toggle_trigger_types = ["turned_on", "turned_off", "changed_states"]
     expected_triggers = [
         {
             "platform": "device",
             "domain": DOMAIN,
             "type": trigger,
             "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
+            "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
-        for trigger in [
-            "target_humidity_changed",
-            "turned_off",
-            "turned_on",
-            "changed_states",
-        ]
+        for trigger in humidifier_trigger_types
+    ]
+    expected_triggers += [
+        {
+            "platform": "device",
+            "domain": DOMAIN,
+            "type": trigger,
+            "device_id": device_entry.id,
+            "entity_id": entity_entry.entity_id,
+            "metadata": {"secondary": True},
+        }
+        for trigger in toggle_trigger_types
     ]
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_entry.id
@@ -147,10 +161,14 @@ async def test_get_triggers_hidden_auxiliary(
     assert triggers == unordered(expected_triggers)
 
 
-async def test_if_fires_on_state_change(hass: HomeAssistant, calls) -> None:
+async def test_if_fires_on_state_change(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, calls
+) -> None:
     """Test for turn_on and turn_off triggers firing."""
+    entry = entity_registry.async_get_or_create(DOMAIN, "test", "5678")
+
     hass.states.async_set(
-        "humidifier.entity",
+        entry.entity_id,
         STATE_ON,
         {
             const.ATTR_HUMIDITY: 23,
@@ -170,7 +188,7 @@ async def test_if_fires_on_state_change(hass: HomeAssistant, calls) -> None:
                         "platform": "device",
                         "domain": DOMAIN,
                         "device_id": "",
-                        "entity_id": "humidifier.entity",
+                        "entity_id": entry.id,
                         "type": "target_humidity_changed",
                         "below": 20,
                     },
@@ -184,7 +202,7 @@ async def test_if_fires_on_state_change(hass: HomeAssistant, calls) -> None:
                         "platform": "device",
                         "domain": DOMAIN,
                         "device_id": "",
-                        "entity_id": "humidifier.entity",
+                        "entity_id": entry.id,
                         "type": "target_humidity_changed",
                         "above": 30,
                     },
@@ -198,7 +216,7 @@ async def test_if_fires_on_state_change(hass: HomeAssistant, calls) -> None:
                         "platform": "device",
                         "domain": DOMAIN,
                         "device_id": "",
-                        "entity_id": "humidifier.entity",
+                        "entity_id": entry.id,
                         "type": "target_humidity_changed",
                         "above": 30,
                         "for": {"seconds": 5},
@@ -213,7 +231,7 @@ async def test_if_fires_on_state_change(hass: HomeAssistant, calls) -> None:
                         "platform": "device",
                         "domain": DOMAIN,
                         "device_id": "",
-                        "entity_id": "humidifier.entity",
+                        "entity_id": entry.entity_id,
                         "type": "turned_on",
                     },
                     "action": {
@@ -237,7 +255,7 @@ async def test_if_fires_on_state_change(hass: HomeAssistant, calls) -> None:
                         "platform": "device",
                         "domain": DOMAIN,
                         "device_id": "",
-                        "entity_id": "humidifier.entity",
+                        "entity_id": entry.entity_id,
                         "type": "turned_off",
                     },
                     "action": {
@@ -261,7 +279,7 @@ async def test_if_fires_on_state_change(hass: HomeAssistant, calls) -> None:
                         "platform": "device",
                         "domain": DOMAIN,
                         "device_id": "",
-                        "entity_id": "humidifier.entity",
+                        "entity_id": entry.entity_id,
                         "type": "changed_states",
                     },
                     "action": {
@@ -285,13 +303,13 @@ async def test_if_fires_on_state_change(hass: HomeAssistant, calls) -> None:
     )
 
     # Fake that the humidity is changing
-    hass.states.async_set("humidifier.entity", STATE_ON, {const.ATTR_HUMIDITY: 7})
+    hass.states.async_set(entry.entity_id, STATE_ON, {const.ATTR_HUMIDITY: 7})
     await hass.async_block_till_done()
     assert len(calls) == 1
     assert calls[0].data["some"] == "target_humidity_changed_below"
 
     # Fake that the humidity is changing
-    hass.states.async_set("humidifier.entity", STATE_ON, {const.ATTR_HUMIDITY: 37})
+    hass.states.async_set(entry.entity_id, STATE_ON, {const.ATTR_HUMIDITY: 37})
     await hass.async_block_till_done()
     assert len(calls) == 2
     assert calls[1].data["some"] == "target_humidity_changed_above"
@@ -303,28 +321,32 @@ async def test_if_fires_on_state_change(hass: HomeAssistant, calls) -> None:
     assert calls[2].data["some"] == "target_humidity_changed_above_for"
 
     # Fake turn off
-    hass.states.async_set("humidifier.entity", STATE_OFF, {const.ATTR_HUMIDITY: 37})
+    hass.states.async_set(entry.entity_id, STATE_OFF, {const.ATTR_HUMIDITY: 37})
     await hass.async_block_till_done()
     assert len(calls) == 5
     assert {calls[3].data["some"], calls[4].data["some"]} == {
-        "turn_off device - humidifier.entity - on - off - None",
-        "turn_on_or_off device - humidifier.entity - on - off - None",
+        "turn_off device - humidifier.test_5678 - on - off - None",
+        "turn_on_or_off device - humidifier.test_5678 - on - off - None",
     }
 
     # Fake turn on
-    hass.states.async_set("humidifier.entity", STATE_ON, {const.ATTR_HUMIDITY: 37})
+    hass.states.async_set(entry.entity_id, STATE_ON, {const.ATTR_HUMIDITY: 37})
     await hass.async_block_till_done()
     assert len(calls) == 7
     assert {calls[5].data["some"], calls[6].data["some"]} == {
-        "turn_on device - humidifier.entity - off - on - None",
-        "turn_on_or_off device - humidifier.entity - off - on - None",
+        "turn_on device - humidifier.test_5678 - off - on - None",
+        "turn_on_or_off device - humidifier.test_5678 - off - on - None",
     }
 
 
-async def test_invalid_config(hass: HomeAssistant, calls) -> None:
+async def test_invalid_config(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, calls
+) -> None:
     """Test for turn_on and turn_off triggers firing."""
+    entry = entity_registry.async_get_or_create(DOMAIN, "test", "5678")
+
     hass.states.async_set(
-        "humidifier.entity",
+        entry.entity_id,
         STATE_ON,
         {
             const.ATTR_HUMIDITY: 23,
@@ -344,7 +366,7 @@ async def test_invalid_config(hass: HomeAssistant, calls) -> None:
                         "platform": "device",
                         "domain": DOMAIN,
                         "device_id": "",
-                        "entity_id": "humidifier.entity",
+                        "entity_id": entry.id,
                         "type": "target_humidity_changed",
                         "below": 20,
                         "invalid": "invalid",
@@ -359,7 +381,7 @@ async def test_invalid_config(hass: HomeAssistant, calls) -> None:
     )
 
     # Fake that the humidity is changing
-    hass.states.async_set("humidifier.entity", STATE_ON, {const.ATTR_HUMIDITY: 7})
+    hass.states.async_set(entry.entity_id, STATE_ON, {const.ATTR_HUMIDITY: 7})
     await hass.async_block_till_done()
     # Should not trigger for invalid config
     assert len(calls) == 0
@@ -373,7 +395,7 @@ async def test_get_trigger_capabilities_on(hass: HomeAssistant) -> None:
             "platform": "device",
             "domain": "humidifier",
             "type": "turned_on",
-            "entity_id": "humidifier.upstairs",
+            "entity_id": "01234568901234568901234568901",
             "above": "23",
         },
     )
@@ -393,7 +415,7 @@ async def test_get_trigger_capabilities_off(hass: HomeAssistant) -> None:
             "platform": "device",
             "domain": "humidifier",
             "type": "turned_off",
-            "entity_id": "humidifier.upstairs",
+            "entity_id": "01234568901234568901234568901",
             "above": "23",
         },
     )
@@ -413,7 +435,7 @@ async def test_get_trigger_capabilities_humidity(hass: HomeAssistant) -> None:
             "platform": "device",
             "domain": "humidifier",
             "type": "target_humidity_changed",
-            "entity_id": "humidifier.upstairs",
+            "entity_id": "01234568901234568901234568901",
             "above": "23",
         },
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Teach humidifier device trigger about entity registry ids

#### Background:
When a device automation is configured by the user, the user picks a device without specifying an `entity_id`. If the user then changes the `entity_id` of that entity, the configured device automation no longer works.
By instead referencing the entity registry id of the entity, the device automation is still valid.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
