### PR TITLE
Teach select device trigger about entity registry ids

### DIFF
--- a/homeassistant/components/device_automation/__init__.py
+++ b/homeassistant/components/device_automation/__init__.py
@@ -40,7 +40,7 @@ from .const import (  # noqa: F401
     CONF_TURNED_OFF,
     CONF_TURNED_ON,
 )
-from .exceptions import DeviceNotFound, InvalidDeviceAutomationConfig
+from .exceptions import DeviceNotFound, EntityNotFound, InvalidDeviceAutomationConfig
 
 if TYPE_CHECKING:
     from .action import DeviceAutomationActionProtocol
@@ -313,7 +313,7 @@ async def _async_get_device_automation_capabilities(
 
     try:
         capabilities = await getattr(platform, function_name)(hass, automation)
-    except InvalidDeviceAutomationConfig:
+    except (EntityNotFound, InvalidDeviceAutomationConfig):
         return {}
 
     capabilities = capabilities.copy()
@@ -326,6 +326,18 @@ async def _async_get_device_automation_capabilities(
         )
 
     return capabilities  # type: ignore[no-any-return]
+
+
+@callback
+def async_get_entity_registry_entry_or_raise(
+    hass: HomeAssistant, entity_registry_id: str
+) -> er.RegistryEntry:
+    """Get an entity registry entry from entry ID or raise."""
+    entity_registry = er.async_get(hass)
+    entry = entity_registry.async_get(entity_registry_id)
+    if entry is None:
+        raise EntityNotFound
+    return entry
 
 
 def handle_device_errors(

--- a/homeassistant/components/device_automation/exceptions.py
+++ b/homeassistant/components/device_automation/exceptions.py
@@ -8,3 +8,7 @@ class InvalidDeviceAutomationConfig(HomeAssistantError):
 
 class DeviceNotFound(HomeAssistantError):
     """When referenced device not found."""
+
+
+class EntityNotFound(HomeAssistantError):
+    """When referenced entity not found."""

--- a/tests/components/select/test_device_trigger.py
+++ b/tests/components/select/test_device_trigger.py
@@ -45,7 +45,7 @@ async def test_get_triggers(
         config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
-    entity_registry.async_get_or_create(
+    entity_entry = entity_registry.async_get_or_create(
         DOMAIN, "test", "5678", device_id=device_entry.id
     )
     expected_triggers = [
@@ -54,7 +54,7 @@ async def test_get_triggers(
             "domain": DOMAIN,
             "type": "current_option_changed",
             "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
+            "entity_id": entity_entry.id,
             "metadata": {"secondary": False},
         }
     ]
@@ -87,7 +87,7 @@ async def test_get_triggers_hidden_auxiliary(
         config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
-    entity_registry.async_get_or_create(
+    entity_entry = entity_registry.async_get_or_create(
         DOMAIN,
         "test",
         "5678",
@@ -101,7 +101,7 @@ async def test_get_triggers_hidden_auxiliary(
             "domain": DOMAIN,
             "type": trigger,
             "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
+            "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
         for trigger in ["current_option_changed"]
@@ -112,10 +112,14 @@ async def test_get_triggers_hidden_auxiliary(
     assert triggers == unordered(expected_triggers)
 
 
-async def test_if_fires_on_state_change(hass: HomeAssistant, calls) -> None:
+async def test_if_fires_on_state_change(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, calls
+) -> None:
     """Test for turn_on and turn_off triggers firing."""
+    entry = entity_registry.async_get_or_create(DOMAIN, "test", "5678")
+
     hass.states.async_set(
-        "select.entity", "option1", {"options": ["option1", "option2", "option3"]}
+        entry.entity_id, "option1", {"options": ["option1", "option2", "option3"]}
     )
 
     assert await async_setup_component(
@@ -128,7 +132,7 @@ async def test_if_fires_on_state_change(hass: HomeAssistant, calls) -> None:
                         "platform": "device",
                         "domain": DOMAIN,
                         "device_id": "",
-                        "entity_id": "select.entity",
+                        "entity_id": entry.id,
                         "type": "current_option_changed",
                         "to": "option2",
                     },
@@ -149,7 +153,7 @@ async def test_if_fires_on_state_change(hass: HomeAssistant, calls) -> None:
                         "platform": "device",
                         "domain": DOMAIN,
                         "device_id": "",
-                        "entity_id": "select.entity",
+                        "entity_id": entry.id,
                         "type": "current_option_changed",
                         "from": "option2",
                     },
@@ -170,7 +174,7 @@ async def test_if_fires_on_state_change(hass: HomeAssistant, calls) -> None:
                         "platform": "device",
                         "domain": DOMAIN,
                         "device_id": "",
-                        "entity_id": "select.entity",
+                        "entity_id": entry.id,
                         "type": "current_option_changed",
                         "from": "option3",
                         "to": "option1",
@@ -192,37 +196,94 @@ async def test_if_fires_on_state_change(hass: HomeAssistant, calls) -> None:
     )
 
     # Test triggering device trigger with a to state
-    hass.states.async_set("select.entity", "option2")
+    hass.states.async_set(entry.entity_id, "option2")
     await hass.async_block_till_done()
     assert len(calls) == 1
-    assert calls[0].data[
-        "some"
-    ] == "to - device - {} - option1 - option2 - None - 0".format("select.entity")
+    assert (
+        calls[0].data["some"]
+        == f"to - device - {entry.entity_id} - option1 - option2 - None - 0"
+    )
 
     # Test triggering device trigger with a from state
-    hass.states.async_set("select.entity", "option3")
+    hass.states.async_set(entry.entity_id, "option3")
     await hass.async_block_till_done()
     assert len(calls) == 2
-    assert calls[1].data[
-        "some"
-    ] == "from - device - {} - option2 - option3 - None - 0".format("select.entity")
+    assert (
+        calls[1].data["some"]
+        == f"from - device - {entry.entity_id} - option2 - option3 - None - 0"
+    )
 
     # Test triggering device trigger with both a from and to state
-    hass.states.async_set("select.entity", "option1")
+    hass.states.async_set(entry.entity_id, "option1")
     await hass.async_block_till_done()
     assert len(calls) == 3
-    assert calls[2].data[
-        "some"
-    ] == "from-to - device - {} - option3 - option1 - None - 0".format("select.entity")
+    assert (
+        calls[2].data["some"]
+        == f"from-to - device - {entry.entity_id} - option3 - option1 - None - 0"
+    )
 
 
-async def test_get_trigger_capabilities(hass: HomeAssistant) -> None:
+async def test_if_fires_on_state_change_legacy(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, calls
+) -> None:
+    """Test for turn_on and turn_off triggers firing."""
+    entry = entity_registry.async_get_or_create(DOMAIN, "test", "5678")
+
+    hass.states.async_set(
+        entry.entity_id, "option1", {"options": ["option1", "option2", "option3"]}
+    )
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "platform": "device",
+                        "domain": DOMAIN,
+                        "device_id": "",
+                        "entity_id": entry.entity_id,
+                        "type": "current_option_changed",
+                        "to": "option2",
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data": {
+                            "some": (
+                                "to - {{ trigger.platform}} - "
+                                "{{ trigger.entity_id}} - {{ trigger.from_state.state}} - "
+                                "{{ trigger.to_state.state}} - {{ trigger.for }} - "
+                                "{{ trigger.id}}"
+                            )
+                        },
+                    },
+                },
+            ]
+        },
+    )
+
+    # Test triggering device trigger with a to state
+    hass.states.async_set(entry.entity_id, "option2")
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    assert (
+        calls[0].data["some"]
+        == f"to - device - {entry.entity_id} - option1 - option2 - None - 0"
+    )
+
+
+async def test_get_trigger_capabilities(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test we get the expected capabilities from a select trigger."""
+    entry = entity_registry.async_get_or_create(DOMAIN, "test", "5678")
+
     config = {
         "platform": "device",
         "domain": DOMAIN,
         "type": "current_option_changed",
-        "entity_id": "select.test",
+        "entity_id": entry.id,
         "to": "option1",
     }
 
@@ -253,7 +314,120 @@ async def test_get_trigger_capabilities(hass: HomeAssistant) -> None:
     ]
 
     # Mock an entity
-    hass.states.async_set("select.test", "option1", {"options": ["option1", "option2"]})
+    hass.states.async_set(
+        entry.entity_id, "option1", {"options": ["option1", "option2"]}
+    )
+
+    # Test if we get the right capabilities now
+    capabilities = await async_get_trigger_capabilities(hass, config)
+    assert capabilities
+    assert "extra_fields" in capabilities
+    assert voluptuous_serialize.convert(
+        capabilities["extra_fields"], custom_serializer=cv.custom_serializer
+    ) == [
+        {
+            "name": "from",
+            "optional": True,
+            "type": "select",
+            "options": [("option1", "option1"), ("option2", "option2")],
+        },
+        {
+            "name": "to",
+            "optional": True,
+            "type": "select",
+            "options": [("option1", "option1"), ("option2", "option2")],
+        },
+        {
+            "name": "for",
+            "optional": True,
+            "type": "positive_time_period_dict",
+        },
+    ]
+
+
+async def test_get_trigger_capabilities_unknown(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test we get the expected capabilities from a select trigger."""
+    config = {
+        "platform": "device",
+        "domain": DOMAIN,
+        "type": "current_option_changed",
+        "entity_id": "12345",
+        "to": "option1",
+    }
+
+    # Test when entity doesn't exists
+    capabilities = await async_get_trigger_capabilities(hass, config)
+    assert capabilities
+    assert "extra_fields" in capabilities
+    assert voluptuous_serialize.convert(
+        capabilities["extra_fields"], custom_serializer=cv.custom_serializer
+    ) == [
+        {
+            "name": "from",
+            "optional": True,
+            "type": "select",
+            "options": [],
+        },
+        {
+            "name": "to",
+            "optional": True,
+            "type": "select",
+            "options": [],
+        },
+        {
+            "name": "for",
+            "optional": True,
+            "type": "positive_time_period_dict",
+        },
+    ]
+
+
+async def test_get_trigger_capabilities_legacy(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test we get the expected capabilities from a select trigger."""
+    entry = entity_registry.async_get_or_create(DOMAIN, "test", "5678")
+
+    config = {
+        "platform": "device",
+        "domain": DOMAIN,
+        "type": "current_option_changed",
+        "entity_id": entry.entity_id,
+        "to": "option1",
+    }
+
+    # Test when entity doesn't exists
+    capabilities = await async_get_trigger_capabilities(hass, config)
+    assert capabilities
+    assert "extra_fields" in capabilities
+    assert voluptuous_serialize.convert(
+        capabilities["extra_fields"], custom_serializer=cv.custom_serializer
+    ) == [
+        {
+            "name": "from",
+            "optional": True,
+            "type": "select",
+            "options": [],
+        },
+        {
+            "name": "to",
+            "optional": True,
+            "type": "select",
+            "options": [],
+        },
+        {
+            "name": "for",
+            "optional": True,
+            "type": "positive_time_period_dict",
+        },
+    ]
+
+    # Mock an entity
+    hass.states.async_set(
+        entry.entity_id, "option1", {"options": ["option1", "option2"]}
+    )
 
     # Test if we get the right capabilities now
     capabilities = await async_get_trigger_capabilities(hass, config)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Teach select device trigger about entity registry ids

#### Background:
When a device automation is configured by the user, the user picks a device without specifying an `entity_id`. If the user then changes the `entity_id` of that entity, the configured device automation no longer works.
By instead referencing the entity registry id of the entity, the device automation is still valid.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
