### PR TITLE
Limit cache size of EntityValues

### DIFF
--- a/homeassistant/helpers/entity_values.py
+++ b/homeassistant/helpers/entity_values.py
@@ -17,6 +17,9 @@ class EntityValues:
 
     This class is expected to only be used infrequently
     as it caches all entity ids up to _MAX_EXPECTED_ENTITIES.
+
+    The cache includes `self` so it is important to
+    only use this in places were its usage is immortal.
     """
 
     def __init__(

--- a/homeassistant/helpers/entity_values.py
+++ b/homeassistant/helpers/entity_values.py
@@ -3,14 +3,21 @@ from __future__ import annotations
 
 from collections import OrderedDict
 import fnmatch
+from functools import lru_cache
 import re
 from typing import Any
 
 from homeassistant.core import split_entity_id
 
+_MAX_EXPECTED_ENTITIES = 16384
+
 
 class EntityValues:
-    """Class to store entity id based values."""
+    """Class to store entity id based values.
+
+    This class is expected to only be used infrequently
+    as it caches all entity ids up to _MAX_EXPECTED_ENTITIES.
+    """
 
     def __init__(
         self,
@@ -19,7 +26,6 @@ class EntityValues:
         glob: dict[str, dict[str, str]] | None = None,
     ) -> None:
         """Initialize an EntityConfigDict."""
-        self._cache: dict[str, dict[str, str]] = {}
         self._exact = exact
         self._domain = domain
 
@@ -32,13 +38,11 @@ class EntityValues:
 
         self._glob = compiled
 
+    @lru_cache(maxsize=_MAX_EXPECTED_ENTITIES)
     def get(self, entity_id: str) -> dict[str, str]:
         """Get config for an entity id."""
-        if entity_id in self._cache:
-            return self._cache[entity_id]
-
         domain, _ = split_entity_id(entity_id)
-        result = self._cache[entity_id] = {}
+        result: dict[str, str] = {}
 
         if self._domain is not None and domain in self._domain:
             result.update(self._domain[domain])

--- a/homeassistant/helpers/entity_values.py
+++ b/homeassistant/helpers/entity_values.py
@@ -19,7 +19,7 @@ class EntityValues:
     as it caches all entity ids up to _MAX_EXPECTED_ENTITIES.
 
     The cache includes `self` so it is important to
-    only use this in places were its usage is immortal.
+    only use this in places where usage of `EntityValues` is immortal.
     """
 
     def __init__(

--- a/tests/helpers/test_entity_values.py
+++ b/tests/helpers/test_entity_values.py
@@ -10,9 +10,12 @@ def test_override_single_value() -> None:
     """Test values with exact match."""
     store = EV({ent: {"key": "value"}})
     assert store.get(ent) == {"key": "value"}
-    assert len(store._cache) == 1
+    assert store.get.cache_info().currsize == 1
+    assert store.get.cache_info().misses == 1
     assert store.get(ent) == {"key": "value"}
-    assert len(store._cache) == 1
+    assert store.get.cache_info().currsize == 1
+    assert store.get.cache_info().misses == 1
+    assert store.get.cache_info().hits == 1
 
 
 def test_override_by_domain() -> None:


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- The cache grew without bound and was hard to track
- Switch to using lru_cache since it avoids python overhead (much faster on cache hit than a function enter, dict lookup, return which will be 99.9% of cases) and we can look a how the cache is working

Note: this will include `self` in the cache but since all use cases are immortal this is not a problem. 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
