### PR TITLE
Teach vacuum device trigger about entity registry ids

### DIFF
--- a/homeassistant/components/vacuum/device_trigger.py
+++ b/homeassistant/components/vacuum/device_trigger.py
@@ -24,7 +24,7 @@ TRIGGER_TYPES = {"cleaning", "docked"}
 
 TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
     {
-        vol.Required(CONF_ENTITY_ID): cv.entity_id,
+        vol.Required(CONF_ENTITY_ID): cv.entity_id_or_uuid,
         vol.Required(CONF_TYPE): vol.In(TRIGGER_TYPES),
         vol.Optional(CONF_FOR): cv.positive_time_period_dict,
     }
@@ -48,7 +48,7 @@ async def async_get_triggers(
                 CONF_PLATFORM: "device",
                 CONF_DEVICE_ID: device_id,
                 CONF_DOMAIN: DOMAIN,
-                CONF_ENTITY_ID: entry.entity_id,
+                CONF_ENTITY_ID: entry.id,
                 CONF_TYPE: trigger,
             }
             for trigger in TRIGGER_TYPES

--- a/tests/components/vacuum/test_device_trigger.py
+++ b/tests/components/vacuum/test_device_trigger.py
@@ -46,7 +46,7 @@ async def test_get_triggers(
         config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
-    entity_registry.async_get_or_create(
+    entity_entry = entity_registry.async_get_or_create(
         DOMAIN, "test", "5678", device_id=device_entry.id
     )
     expected_triggers = [
@@ -55,7 +55,7 @@ async def test_get_triggers(
             "domain": DOMAIN,
             "type": trigger,
             "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
+            "entity_id": entity_entry.id,
             "metadata": {"secondary": False},
         }
         for trigger in ["cleaning", "docked"]
@@ -89,7 +89,7 @@ async def test_get_triggers_hidden_auxiliary(
         config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
-    entity_registry.async_get_or_create(
+    entity_entry = entity_registry.async_get_or_create(
         DOMAIN,
         "test",
         "5678",
@@ -103,7 +103,7 @@ async def test_get_triggers_hidden_auxiliary(
             "domain": DOMAIN,
             "type": trigger,
             "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
+            "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
         for trigger in ["cleaning", "docked"]
@@ -145,9 +145,45 @@ async def test_get_trigger_capabilities(
         }
 
 
-async def test_if_fires_on_state_change(hass: HomeAssistant, calls) -> None:
+async def test_get_trigger_capabilities_legacy(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test we get the expected capabilities from a vacuum device."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_registry.async_get_or_create(
+        DOMAIN, "test", "5678", device_id=device_entry.id
+    )
+
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device_entry.id
+    )
+    assert len(triggers) == 2
+    for trigger in triggers:
+        trigger["entity_id"] = entity_registry.async_get(trigger["entity_id"]).entity_id
+        capabilities = await async_get_device_automation_capabilities(
+            hass, DeviceAutomationType.TRIGGER, trigger
+        )
+        assert capabilities == {
+            "extra_fields": [
+                {"name": "for", "optional": True, "type": "positive_time_period_dict"}
+            ]
+        }
+
+
+async def test_if_fires_on_state_change(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, calls
+) -> None:
     """Test for turn_on and turn_off triggers firing."""
-    hass.states.async_set("vacuum.entity", STATE_DOCKED)
+    entry = entity_registry.async_get_or_create(DOMAIN, "test", "5678")
+
+    hass.states.async_set(entry.entity_id, STATE_DOCKED)
 
     assert await async_setup_component(
         hass,
@@ -159,7 +195,7 @@ async def test_if_fires_on_state_change(hass: HomeAssistant, calls) -> None:
                         "platform": "device",
                         "domain": DOMAIN,
                         "device_id": "",
-                        "entity_id": "vacuum.entity",
+                        "entity_id": entry.id,
                         "type": "cleaning",
                     },
                     "action": {
@@ -178,7 +214,7 @@ async def test_if_fires_on_state_change(hass: HomeAssistant, calls) -> None:
                         "platform": "device",
                         "domain": DOMAIN,
                         "device_id": "",
-                        "entity_id": "vacuum.entity",
+                        "entity_id": entry.id,
                         "type": "docked",
                     },
                     "action": {
@@ -197,26 +233,31 @@ async def test_if_fires_on_state_change(hass: HomeAssistant, calls) -> None:
     )
 
     # Fake that the entity is cleaning
-    hass.states.async_set("vacuum.entity", STATE_CLEANING)
+    hass.states.async_set(entry.entity_id, STATE_CLEANING)
     await hass.async_block_till_done()
     assert len(calls) == 1
     assert (
-        calls[0].data["some"] == "cleaning - device - vacuum.entity - docked - cleaning"
+        calls[0].data["some"]
+        == f"cleaning - device - {entry.entity_id} - docked - cleaning"
     )
 
     # Fake that the entity is docked
-    hass.states.async_set("vacuum.entity", STATE_DOCKED)
+    hass.states.async_set(entry.entity_id, STATE_DOCKED)
     await hass.async_block_till_done()
     assert len(calls) == 2
     assert (
-        calls[1].data["some"] == "docked - device - vacuum.entity - cleaning - docked"
+        calls[1].data["some"]
+        == f"docked - device - {entry.entity_id} - cleaning - docked"
     )
 
 
-async def test_if_fires_on_state_change_with_for(hass: HomeAssistant, calls) -> None:
-    """Test for triggers firing with delay."""
-    entity_id = f"{DOMAIN}.entity"
-    hass.states.async_set(entity_id, STATE_DOCKED)
+async def test_if_fires_on_state_change_legacy(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, calls
+) -> None:
+    """Test for turn_on and turn_off triggers firing."""
+    entry = entity_registry.async_get_or_create(DOMAIN, "test", "5678")
+
+    hass.states.async_set(entry.entity_id, STATE_DOCKED)
 
     assert await async_setup_component(
         hass,
@@ -228,7 +269,53 @@ async def test_if_fires_on_state_change_with_for(hass: HomeAssistant, calls) -> 
                         "platform": "device",
                         "domain": DOMAIN,
                         "device_id": "",
-                        "entity_id": entity_id,
+                        "entity_id": entry.entity_id,
+                        "type": "cleaning",
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": (
+                                "cleaning - {{ trigger.platform}} - "
+                                "{{ trigger.entity_id}} - {{ trigger.from_state.state}} - "
+                                "{{ trigger.to_state.state}}"
+                            )
+                        },
+                    },
+                },
+            ]
+        },
+    )
+
+    # Fake that the entity is cleaning
+    hass.states.async_set(entry.entity_id, STATE_CLEANING)
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    assert (
+        calls[0].data["some"]
+        == f"cleaning - device - {entry.entity_id} - docked - cleaning"
+    )
+
+
+async def test_if_fires_on_state_change_with_for(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, calls
+) -> None:
+    """Test for triggers firing with delay."""
+    entry = entity_registry.async_get_or_create(DOMAIN, "test", "5678")
+
+    hass.states.async_set(entry.entity_id, STATE_DOCKED)
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "platform": "device",
+                        "domain": DOMAIN,
+                        "device_id": "",
+                        "entity_id": entry.id,
                         "type": "cleaning",
                         "for": {"seconds": 5},
                     },
@@ -252,10 +339,9 @@ async def test_if_fires_on_state_change_with_for(hass: HomeAssistant, calls) -> 
         },
     )
     await hass.async_block_till_done()
-    assert hass.states.get(entity_id).state == STATE_DOCKED
     assert len(calls) == 0
 
-    hass.states.async_set(entity_id, STATE_CLEANING)
+    hass.states.async_set(entry.entity_id, STATE_CLEANING)
     await hass.async_block_till_done()
     assert len(calls) == 0
     async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=10))
@@ -264,5 +350,5 @@ async def test_if_fires_on_state_change_with_for(hass: HomeAssistant, calls) -> 
     await hass.async_block_till_done()
     assert (
         calls[0].data["some"]
-        == f"turn_off device - {entity_id} - docked - cleaning - 0:00:05"
+        == f"turn_off device - {entry.entity_id} - docked - cleaning - 0:00:05"
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Teach vacuum device trigger about entity registry ids

#### Background:
When a device automation is configured by the user, the user picks a device without specifying an `entity_id`. If the user then changes the `entity_id` of that entity, the configured device automation no longer works.
By instead referencing the entity registry id of the entity, the device automation is still valid.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
