### PR TITLE
Fix async_scanner_devices_by_address unexpectedly combining Bluetooth scanners

### DIFF
--- a/homeassistant/components/bluetooth/manager.py
+++ b/homeassistant/components/bluetooth/manager.py
@@ -100,11 +100,7 @@ def _dispatch_bleak_callback(
 
 
 class BluetoothManager:
-    """Manage Bluetooth.
-
-    This class is expected to be a singleton and should
-    never be instantiated more than once.
-    """
+    """Manage Bluetooth."""
 
     def __init__(
         self,

--- a/homeassistant/components/bluetooth/manager.py
+++ b/homeassistant/components/bluetooth/manager.py
@@ -246,9 +246,12 @@ class BluetoothManager:
         self, address: str, connectable: bool
     ) -> list[BluetoothScannerDevice]:
         """Get BluetoothScannerDevice by address."""
-        scanners = [*self._connectable_scanners]
         if not connectable:
-            scanners.extend(self._non_connectable_scanners)
+            scanners: Iterable[BaseHaScanner] = itertools.chain(
+                self._connectable_scanners, self._non_connectable_scanners
+            )
+        else:
+            scanners = self._connectable_scanners
         return [
             BluetoothScannerDevice(scanner, *device_adv)
             for scanner in scanners

--- a/homeassistant/components/bluetooth/manager.py
+++ b/homeassistant/components/bluetooth/manager.py
@@ -100,7 +100,11 @@ def _dispatch_bleak_callback(
 
 
 class BluetoothManager:
-    """Manage Bluetooth."""
+    """Manage Bluetooth.
+
+    This class is expected to be a singleton and should
+    never be instantiated more than once.
+    """
 
     def __init__(
         self,
@@ -246,9 +250,9 @@ class BluetoothManager:
         self, address: str, connectable: bool
     ) -> list[BluetoothScannerDevice]:
         """Get BluetoothScannerDevice by address."""
-        scanners = self._get_scanners_by_type(True)
+        scanners = [*self._connectable_scanners]
         if not connectable:
-            scanners.extend(self._get_scanners_by_type(False))
+            scanners.extend(self._non_connectable_scanners)
         return [
             BluetoothScannerDevice(scanner, *device_adv)
             for scanner in scanners
@@ -267,21 +271,19 @@ class BluetoothManager:
         """
         yield from itertools.chain.from_iterable(
             scanner.discovered_devices_and_advertisement_data
-            for scanner in self._get_scanners_by_type(True)
+            for scanner in self._connectable_scanners
         )
         if not connectable:
             yield from itertools.chain.from_iterable(
                 scanner.discovered_devices_and_advertisement_data
-                for scanner in self._get_scanners_by_type(False)
+                for scanner in self._non_connectable_scanners
             )
 
     @hass_callback
     def async_discovered_devices(self, connectable: bool) -> list[BLEDevice]:
         """Return all of combined best path to discovered from all the scanners."""
-        return [
-            history.device
-            for history in self._get_history_by_type(connectable).values()
-        ]
+        histories = self._connectable_history if connectable else self._all_history
+        return [history.device for history in histories.values()]
 
     @hass_callback
     def async_setup_unavailable_tracking(self) -> None:
@@ -303,7 +305,10 @@ class BluetoothManager:
         intervals = tracker.intervals
 
         for connectable in (True, False):
-            unavailable_callbacks = self._get_unavailable_callbacks_by_type(connectable)
+            if connectable:
+                unavailable_callbacks = self._connectable_unavailable_callbacks
+            else:
+                unavailable_callbacks = self._unavailable_callbacks
             history = connectable_history if connectable else all_history
             disappeared = set(history).difference(
                 self._async_all_discovered_addresses(connectable)
@@ -583,7 +588,10 @@ class BluetoothManager:
         connectable: bool,
     ) -> Callable[[], None]:
         """Register a callback."""
-        unavailable_callbacks = self._get_unavailable_callbacks_by_type(connectable)
+        if connectable:
+            unavailable_callbacks = self._connectable_unavailable_callbacks
+        else:
+            unavailable_callbacks = self._unavailable_callbacks
         unavailable_callbacks.setdefault(address, []).append(callback)
 
         @hass_callback
@@ -620,13 +628,13 @@ class BluetoothManager:
         # If we have history for the subscriber, we can trigger the callback
         # immediately with the last packet so the subscriber can see the
         # device.
-        all_history = self._get_history_by_type(connectable)
+        history = self._connectable_history if connectable else self._all_history
         service_infos: Iterable[BluetoothServiceInfoBleak] = []
         if address := callback_matcher.get(ADDRESS):
-            if service_info := all_history.get(address):
+            if service_info := history.get(address):
                 service_infos = [service_info]
         else:
-            service_infos = all_history.values()
+            service_infos = history.values()
 
         for service_info in service_infos:
             if ble_device_matches(callback_matcher, service_info):
@@ -642,29 +650,32 @@ class BluetoothManager:
         self, address: str, connectable: bool
     ) -> BLEDevice | None:
         """Return the BLEDevice if present."""
-        all_history = self._get_history_by_type(connectable)
-        if history := all_history.get(address):
+        histories = self._connectable_history if connectable else self._all_history
+        if history := histories.get(address):
             return history.device
         return None
 
     @hass_callback
     def async_address_present(self, address: str, connectable: bool) -> bool:
         """Return if the address is present."""
-        return address in self._get_history_by_type(connectable)
+        histories = self._connectable_history if connectable else self._all_history
+        return address in histories
 
     @hass_callback
     def async_discovered_service_info(
         self, connectable: bool
     ) -> Iterable[BluetoothServiceInfoBleak]:
         """Return all the discovered services info."""
-        return self._get_history_by_type(connectable).values()
+        histories = self._connectable_history if connectable else self._all_history
+        return histories.values()
 
     @hass_callback
     def async_last_service_info(
         self, address: str, connectable: bool
     ) -> BluetoothServiceInfoBleak | None:
         """Return the last service info for an address."""
-        return self._get_history_by_type(connectable).get(address)
+        histories = self._connectable_history if connectable else self._all_history
+        return histories.get(address)
 
     def _async_trigger_matching_discovery(
         self, service_info: BluetoothServiceInfoBleak
@@ -688,26 +699,6 @@ class BluetoothManager:
         if service_info := self._all_history.get(address):
             self._async_trigger_matching_discovery(service_info)
 
-    def _get_scanners_by_type(self, connectable: bool) -> list[BaseHaScanner]:
-        """Return the scanners by type."""
-        if connectable:
-            return self._connectable_scanners
-        return self._non_connectable_scanners
-
-    def _get_unavailable_callbacks_by_type(
-        self, connectable: bool
-    ) -> dict[str, list[Callable[[BluetoothServiceInfoBleak], None]]]:
-        """Return the unavailable callbacks by type."""
-        if connectable:
-            return self._connectable_unavailable_callbacks
-        return self._unavailable_callbacks
-
-    def _get_history_by_type(
-        self, connectable: bool
-    ) -> dict[str, BluetoothServiceInfoBleak]:
-        """Return the history by type."""
-        return self._connectable_history if connectable else self._all_history
-
     def async_register_scanner(
         self,
         scanner: BaseHaScanner,
@@ -716,7 +707,10 @@ class BluetoothManager:
     ) -> CALLBACK_TYPE:
         """Register a new scanner."""
         _LOGGER.debug("Registering scanner %s", scanner.name)
-        scanners = self._get_scanners_by_type(connectable)
+        if connectable:
+            scanners = self._connectable_scanners
+        else:
+            scanners = self._non_connectable_scanners
 
         def _unregister_scanner() -> None:
             _LOGGER.debug("Unregistering scanner %s", scanner.name)


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Since `_get_scanners_by_type` returned the scanners without making a copy, `async_scanner_devices_by_address` would extend the list of scanners and unexpectedly add the non-connectable ones to the connectable list.

Refactor to remove the _get_X_by_type functions to avoid this pattern

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
