### PR TITLE
Use entity registry id in toggle_entity device automations

### DIFF
--- a/homeassistant/components/device_automation/__init__.py
+++ b/homeassistant/components/device_automation/__init__.py
@@ -19,6 +19,7 @@ from homeassistant.const import (
     ATTR_ENTITY_ID,
     CONF_DEVICE_ID,
     CONF_DOMAIN,
+    CONF_ENTITY_ID,
     CONF_PLATFORM,
 )
 from homeassistant.core import HomeAssistant, callback
@@ -338,6 +339,21 @@ def async_get_entity_registry_entry_or_raise(
     if entry is None:
         raise EntityNotFound
     return entry
+
+
+@callback
+def async_validate_entity_schema(
+    hass: HomeAssistant, config: ConfigType, schema: vol.Schema
+) -> ConfigType:
+    """Validate schema and resolve entity registry entry id to entity_id."""
+    config = schema(config)
+
+    registry = er.async_get(hass)
+    config[CONF_ENTITY_ID] = er.async_resolve_entity_id(
+        registry, config[CONF_ENTITY_ID]
+    )
+
+    return config
 
 
 def handle_device_errors(

--- a/homeassistant/components/device_automation/entity.py
+++ b/homeassistant/components/device_automation/entity.py
@@ -23,7 +23,7 @@ ENTITY_TRIGGERS = [
 
 TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
     {
-        vol.Required(CONF_ENTITY_ID): cv.entity_id,
+        vol.Required(CONF_ENTITY_ID): cv.entity_id_or_uuid,
         vol.Required(CONF_TYPE): vol.In([CONF_CHANGED_STATES]),
         vol.Optional(CONF_FOR): cv.positive_time_period_dict,
     }
@@ -73,7 +73,7 @@ async def _async_get_automations(
             {
                 **template,
                 "device_id": device_id,
-                "entity_id": entry.entity_id,
+                "entity_id": entry.id,
                 "domain": domain,
             }
             for template in automation_templates

--- a/homeassistant/components/device_automation/helpers.py
+++ b/homeassistant/components/device_automation/helpers.py
@@ -25,6 +25,8 @@ STATIC_VALIDATOR = {
     DeviceAutomationType.TRIGGER: "TRIGGER_SCHEMA",
 }
 
+TOGGLE_ENTITY_DOMAINS = {"fan", "humidifier", "light", "remote", "switch"}
+
 
 async def async_validate_device_automation_config(
     hass: HomeAssistant,
@@ -41,6 +43,16 @@ async def async_validate_device_automation_config(
         # Pass the unvalidated config to avoid mutating the raw config twice
         return cast(
             ConfigType, getattr(platform, STATIC_VALIDATOR[automation_type])(config)
+        )
+
+    # Bypass checks for toggle entity domains
+    if (
+        automation_type == DeviceAutomationType.ACTION
+        and validated_config[CONF_DOMAIN] in TOGGLE_ENTITY_DOMAINS
+    ):
+        return cast(
+            ConfigType,
+            await getattr(platform, DYNAMIC_VALIDATOR[automation_type])(hass, config),
         )
 
     # Only call the dynamic validator if the referenced device exists and the relevant

--- a/homeassistant/components/device_automation/toggle_entity.py
+++ b/homeassistant/components/device_automation/toggle_entity.py
@@ -78,14 +78,14 @@ DEVICE_ACTION_TYPES = [CONF_TOGGLE, CONF_TURN_OFF, CONF_TURN_ON]
 
 ACTION_SCHEMA = cv.DEVICE_ACTION_BASE_SCHEMA.extend(
     {
-        vol.Required(CONF_ENTITY_ID): cv.entity_id,
+        vol.Required(CONF_ENTITY_ID): cv.entity_id_or_uuid,
         vol.Required(CONF_TYPE): vol.In(DEVICE_ACTION_TYPES),
     }
 )
 
 CONDITION_SCHEMA = cv.DEVICE_CONDITION_BASE_SCHEMA.extend(
     {
-        vol.Required(CONF_ENTITY_ID): cv.entity_id,
+        vol.Required(CONF_ENTITY_ID): cv.entity_id_or_uuid,
         vol.Required(CONF_TYPE): vol.In([CONF_IS_OFF, CONF_IS_ON]),
         vol.Optional(CONF_FOR): cv.positive_time_period_dict,
     }
@@ -93,7 +93,7 @@ CONDITION_SCHEMA = cv.DEVICE_CONDITION_BASE_SCHEMA.extend(
 
 _TOGGLE_TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
     {
-        vol.Required(CONF_ENTITY_ID): cv.entity_id,
+        vol.Required(CONF_ENTITY_ID): cv.entity_id_or_uuid,
         vol.Required(CONF_TYPE): vol.In([CONF_TURNED_OFF, CONF_TURNED_ON]),
         vol.Optional(CONF_FOR): cv.positive_time_period_dict,
     }
@@ -196,7 +196,7 @@ async def _async_get_automations(
             {
                 **template,
                 "device_id": device_id,
-                "entity_id": entry.entity_id,
+                "entity_id": entry.id,
                 "domain": domain,
             }
             for template in automation_templates

--- a/homeassistant/components/humidifier/device_action.py
+++ b/homeassistant/components/humidifier/device_action.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 
 import voluptuous as vol
 
-from homeassistant.components.device_automation import toggle_entity
+from homeassistant.components.device_automation import (
+    async_validate_entity_schema,
+    toggle_entity,
+)
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_MODE,
@@ -41,7 +44,14 @@ SET_MODE_SCHEMA = cv.DEVICE_ACTION_BASE_SCHEMA.extend(
 
 ONOFF_SCHEMA = toggle_entity.ACTION_SCHEMA.extend({vol.Required(CONF_DOMAIN): DOMAIN})
 
-ACTION_SCHEMA = vol.Any(SET_HUMIDITY_SCHEMA, SET_MODE_SCHEMA, ONOFF_SCHEMA)
+_ACTION_SCHEMA = vol.Any(SET_HUMIDITY_SCHEMA, SET_MODE_SCHEMA, ONOFF_SCHEMA)
+
+
+async def async_validate_action_config(
+    hass: HomeAssistant, config: ConfigType
+) -> ConfigType:
+    """Validate config."""
+    return async_validate_entity_schema(hass, config, _ACTION_SCHEMA)
 
 
 async def async_get_actions(

--- a/homeassistant/components/remote/device_action.py
+++ b/homeassistant/components/remote/device_action.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 
 import voluptuous as vol
 
-from homeassistant.components.device_automation import toggle_entity
+from homeassistant.components.device_automation import (
+    async_validate_entity_schema,
+    toggle_entity,
+)
 from homeassistant.const import CONF_DOMAIN
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.helpers.typing import ConfigType, TemplateVarsType
@@ -12,7 +15,14 @@ from . import DOMAIN
 
 # mypy: disallow-any-generics
 
-ACTION_SCHEMA = toggle_entity.ACTION_SCHEMA.extend({vol.Required(CONF_DOMAIN): DOMAIN})
+_ACTION_SCHEMA = toggle_entity.ACTION_SCHEMA.extend({vol.Required(CONF_DOMAIN): DOMAIN})
+
+
+async def async_validate_action_config(
+    hass: HomeAssistant, config: ConfigType
+) -> ConfigType:
+    """Validate config."""
+    return async_validate_entity_schema(hass, config, _ACTION_SCHEMA)
 
 
 async def async_call_action_from_config(

--- a/homeassistant/components/switch/device_action.py
+++ b/homeassistant/components/switch/device_action.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 
 import voluptuous as vol
 
-from homeassistant.components.device_automation import toggle_entity
+from homeassistant.components.device_automation import (
+    async_validate_entity_schema,
+    toggle_entity,
+)
 from homeassistant.const import CONF_DOMAIN
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.helpers.typing import ConfigType, TemplateVarsType
@@ -12,7 +15,14 @@ from . import DOMAIN
 
 # mypy: disallow-any-generics
 
-ACTION_SCHEMA = toggle_entity.ACTION_SCHEMA.extend({vol.Required(CONF_DOMAIN): DOMAIN})
+_ACTION_SCHEMA = toggle_entity.ACTION_SCHEMA.extend({vol.Required(CONF_DOMAIN): DOMAIN})
+
+
+async def async_validate_action_config(
+    hass: HomeAssistant, config: ConfigType
+) -> ConfigType:
+    """Validate config."""
+    return async_validate_entity_schema(hass, config, _ACTION_SCHEMA)
 
 
 async def async_call_action_from_config(

--- a/tests/components/device_automation/test_init.py
+++ b/tests/components/device_automation/test_init.py
@@ -114,7 +114,7 @@ async def test_websocket_get_actions(
         config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
-    entity_registry.async_get_or_create(
+    entity_entry = entity_registry.async_get_or_create(
         "fake_integration", "test", "5678", device_id=device_entry.id
     )
     expected_actions = [
@@ -122,21 +122,21 @@ async def test_websocket_get_actions(
             "domain": "fake_integration",
             "type": "turn_off",
             "device_id": device_entry.id,
-            "entity_id": "fake_integration.test_5678",
+            "entity_id": entity_entry.id,
             "metadata": {"secondary": False},
         },
         {
             "domain": "fake_integration",
             "type": "turn_on",
             "device_id": device_entry.id,
-            "entity_id": "fake_integration.test_5678",
+            "entity_id": entity_entry.id,
             "metadata": {"secondary": False},
         },
         {
             "domain": "fake_integration",
             "type": "toggle",
             "device_id": device_entry.id,
-            "entity_id": "fake_integration.test_5678",
+            "entity_id": entity_entry.id,
             "metadata": {"secondary": False},
         },
     ]
@@ -169,7 +169,7 @@ async def test_websocket_get_conditions(
         config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
-    entity_registry.async_get_or_create(
+    entity_entry = entity_registry.async_get_or_create(
         "fake_integration", "test", "5678", device_id=device_entry.id
     )
     expected_conditions = [
@@ -178,7 +178,7 @@ async def test_websocket_get_conditions(
             "domain": "fake_integration",
             "type": "is_off",
             "device_id": device_entry.id,
-            "entity_id": "fake_integration.test_5678",
+            "entity_id": entity_entry.id,
             "metadata": {"secondary": False},
         },
         {
@@ -186,7 +186,7 @@ async def test_websocket_get_conditions(
             "domain": "fake_integration",
             "type": "is_on",
             "device_id": device_entry.id,
-            "entity_id": "fake_integration.test_5678",
+            "entity_id": entity_entry.id,
             "metadata": {"secondary": False},
         },
     ]
@@ -223,7 +223,7 @@ async def test_websocket_get_triggers(
         config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
-    entity_registry.async_get_or_create(
+    entity_entry = entity_registry.async_get_or_create(
         "fake_integration", "test", "5678", device_id=device_entry.id
     )
     expected_triggers = [
@@ -232,7 +232,7 @@ async def test_websocket_get_triggers(
             "domain": "fake_integration",
             "type": "changed_states",
             "device_id": device_entry.id,
-            "entity_id": "fake_integration.test_5678",
+            "entity_id": entity_entry.id,
             "metadata": {"secondary": False},
         },
         {
@@ -240,7 +240,7 @@ async def test_websocket_get_triggers(
             "domain": "fake_integration",
             "type": "turned_off",
             "device_id": device_entry.id,
-            "entity_id": "fake_integration.test_5678",
+            "entity_id": entity_entry.id,
             "metadata": {"secondary": False},
         },
         {
@@ -248,7 +248,7 @@ async def test_websocket_get_triggers(
             "domain": "fake_integration",
             "type": "turned_on",
             "device_id": device_entry.id,
-            "entity_id": "fake_integration.test_5678",
+            "entity_id": entity_entry.id,
             "metadata": {"secondary": False},
         },
     ]

--- a/tests/components/fan/test_device_action.py
+++ b/tests/components/fan/test_device_action.py
@@ -35,7 +35,7 @@ async def test_get_actions(
         config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
-    entity_registry.async_get_or_create(
+    entity_entry = entity_registry.async_get_or_create(
         DOMAIN, "test", "5678", device_id=device_entry.id
     )
     expected_actions = []
@@ -44,7 +44,7 @@ async def test_get_actions(
             "domain": DOMAIN,
             "type": action,
             "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
+            "entity_id": entity_entry.id,
             "metadata": {"secondary": False},
         }
         for action in ["turn_on", "turn_off", "toggle"]
@@ -78,7 +78,7 @@ async def test_get_actions_hidden_auxiliary(
         config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
-    entity_registry.async_get_or_create(
+    entity_entry = entity_registry.async_get_or_create(
         DOMAIN,
         "test",
         "5678",
@@ -92,7 +92,7 @@ async def test_get_actions_hidden_auxiliary(
             "domain": DOMAIN,
             "type": action,
             "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
+            "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
         for action in ["turn_on", "turn_off", "toggle"]
@@ -103,8 +103,10 @@ async def test_get_actions_hidden_auxiliary(
     assert actions == unordered(expected_actions)
 
 
-async def test_action(hass: HomeAssistant) -> None:
+async def test_action(hass: HomeAssistant, entity_registry: er.EntityRegistry) -> None:
     """Test for turn_on and turn_off actions."""
+    entry = entity_registry.async_get_or_create(DOMAIN, "test", "5678")
+
     assert await async_setup_component(
         hass,
         automation.DOMAIN,
@@ -118,7 +120,7 @@ async def test_action(hass: HomeAssistant) -> None:
                     "action": {
                         "domain": DOMAIN,
                         "device_id": "abcdefgh",
-                        "entity_id": "fan.entity",
+                        "entity_id": entry.id,
                         "type": "turn_off",
                     },
                 },
@@ -130,7 +132,7 @@ async def test_action(hass: HomeAssistant) -> None:
                     "action": {
                         "domain": DOMAIN,
                         "device_id": "abcdefgh",
-                        "entity_id": "fan.entity",
+                        "entity_id": entry.id,
                         "type": "turn_on",
                     },
                 },
@@ -142,7 +144,7 @@ async def test_action(hass: HomeAssistant) -> None:
                     "action": {
                         "domain": DOMAIN,
                         "device_id": "abcdefgh",
-                        "entity_id": "fan.entity",
+                        "entity_id": entry.id,
                         "type": "toggle",
                     },
                 },
@@ -171,3 +173,37 @@ async def test_action(hass: HomeAssistant) -> None:
     assert len(turn_off_calls) == 1
     assert len(turn_on_calls) == 1
     assert len(toggle_calls) == 1
+
+
+async def test_action_legacy(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test for turn_on and turn_off actions."""
+    entry = entity_registry.async_get_or_create(DOMAIN, "test", "5678")
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "platform": "event",
+                        "event_type": "test_event_turn_off",
+                    },
+                    "action": {
+                        "domain": DOMAIN,
+                        "device_id": "abcdefgh",
+                        "entity_id": entry.entity_id,
+                        "type": "turn_off",
+                    },
+                },
+            ]
+        },
+    )
+
+    turn_off_calls = async_mock_service(hass, "fan", "turn_off")
+
+    hass.bus.async_fire("test_event_turn_off")
+    await hass.async_block_till_done()
+    assert len(turn_off_calls) == 1

--- a/tests/components/fan/test_device_trigger.py
+++ b/tests/components/fan/test_device_trigger.py
@@ -46,7 +46,7 @@ async def test_get_triggers(
         config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
-    entity_registry.async_get_or_create(
+    entity_entry = entity_registry.async_get_or_create(
         DOMAIN, "test", "5678", device_id=device_entry.id
     )
     expected_triggers = [
@@ -55,7 +55,7 @@ async def test_get_triggers(
             "domain": DOMAIN,
             "type": trigger,
             "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
+            "entity_id": entity_entry.id,
             "metadata": {"secondary": False},
         }
         for trigger in ["turned_off", "turned_on", "changed_states"]
@@ -89,7 +89,7 @@ async def test_get_triggers_hidden_auxiliary(
         config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
-    entity_registry.async_get_or_create(
+    entity_entry = entity_registry.async_get_or_create(
         DOMAIN,
         "test",
         "5678",
@@ -103,7 +103,7 @@ async def test_get_triggers_hidden_auxiliary(
             "domain": DOMAIN,
             "type": trigger,
             "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
+            "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
         for trigger in ["turned_off", "turned_on", "changed_states"]
@@ -144,9 +144,44 @@ async def test_get_trigger_capabilities(
         assert capabilities == expected_capabilities
 
 
-async def test_if_fires_on_state_change(hass: HomeAssistant, calls) -> None:
+async def test_get_trigger_capabilities_legacy(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test we get the expected capabilities from a switch trigger."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_registry.async_get_or_create(
+        DOMAIN, "test", "5678", device_id=device_entry.id
+    )
+    expected_capabilities = {
+        "extra_fields": [
+            {"name": "for", "optional": True, "type": "positive_time_period_dict"}
+        ]
+    }
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device_entry.id
+    )
+    for trigger in triggers:
+        trigger["entity_id"] = entity_registry.async_get(trigger["entity_id"]).entity_id
+        capabilities = await async_get_device_automation_capabilities(
+            hass, DeviceAutomationType.TRIGGER, trigger
+        )
+        assert capabilities == expected_capabilities
+
+
+async def test_if_fires_on_state_change(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, calls
+) -> None:
     """Test for turn_on and turn_off triggers firing."""
-    hass.states.async_set("fan.entity", STATE_OFF)
+    entry = entity_registry.async_get_or_create(DOMAIN, "test", "5678")
+
+    hass.states.async_set(entry.entity_id, STATE_OFF)
 
     assert await async_setup_component(
         hass,
@@ -158,7 +193,7 @@ async def test_if_fires_on_state_change(hass: HomeAssistant, calls) -> None:
                         "platform": "device",
                         "domain": DOMAIN,
                         "device_id": "",
-                        "entity_id": "fan.entity",
+                        "entity_id": entry.id,
                         "type": "turned_on",
                     },
                     "action": {
@@ -180,7 +215,7 @@ async def test_if_fires_on_state_change(hass: HomeAssistant, calls) -> None:
                         "platform": "device",
                         "domain": DOMAIN,
                         "device_id": "",
-                        "entity_id": "fan.entity",
+                        "entity_id": entry.id,
                         "type": "turned_off",
                     },
                     "action": {
@@ -202,7 +237,7 @@ async def test_if_fires_on_state_change(hass: HomeAssistant, calls) -> None:
                         "platform": "device",
                         "domain": DOMAIN,
                         "device_id": "",
-                        "entity_id": "fan.entity",
+                        "entity_id": entry.id,
                         "type": "changed_states",
                     },
                     "action": {
@@ -224,28 +259,31 @@ async def test_if_fires_on_state_change(hass: HomeAssistant, calls) -> None:
     )
 
     # Fake that the entity is turning on.
-    hass.states.async_set("fan.entity", STATE_ON)
+    hass.states.async_set(entry.entity_id, STATE_ON)
     await hass.async_block_till_done()
     assert len(calls) == 2
     assert {calls[0].data["some"], calls[1].data["some"]} == {
-        "turn_on - device - fan.entity - off - on - None",
-        "turn_on_or_off - device - fan.entity - off - on - None",
+        f"turn_on - device - {entry.entity_id} - off - on - None",
+        f"turn_on_or_off - device - {entry.entity_id} - off - on - None",
     }
 
     # Fake that the entity is turning off.
-    hass.states.async_set("fan.entity", STATE_OFF)
+    hass.states.async_set(entry.entity_id, STATE_OFF)
     await hass.async_block_till_done()
     assert len(calls) == 4
     assert {calls[2].data["some"], calls[3].data["some"]} == {
-        "turn_off - device - fan.entity - on - off - None",
-        "turn_on_or_off - device - fan.entity - on - off - None",
+        f"turn_off - device - {entry.entity_id} - on - off - None",
+        f"turn_on_or_off - device - {entry.entity_id} - on - off - None",
     }
 
 
-async def test_if_fires_on_state_change_with_for(hass: HomeAssistant, calls) -> None:
-    """Test for triggers firing with delay."""
-    entity_id = "fan.entity"
-    hass.states.async_set(entity_id, STATE_ON)
+async def test_if_fires_on_state_change_legacy(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, calls
+) -> None:
+    """Test for turn_on and turn_off triggers firing."""
+    entry = entity_registry.async_get_or_create(DOMAIN, "test", "5678")
+
+    hass.states.async_set(entry.entity_id, STATE_OFF)
 
     assert await async_setup_component(
         hass,
@@ -257,7 +295,56 @@ async def test_if_fires_on_state_change_with_for(hass: HomeAssistant, calls) -> 
                         "platform": "device",
                         "domain": DOMAIN,
                         "device_id": "",
-                        "entity_id": entity_id,
+                        "entity_id": entry.id,
+                        "type": "turned_on",
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": (
+                                "turn_on "
+                                "- {{ trigger.platform }} "
+                                "- {{ trigger.entity_id }} "
+                                "- {{ trigger.from_state.state }} "
+                                "- {{ trigger.to_state.state }} "
+                                "- {{ trigger.for }}"
+                            )
+                        },
+                    },
+                },
+            ]
+        },
+    )
+
+    # Fake that the entity is turning on.
+    hass.states.async_set(entry.entity_id, STATE_ON)
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    assert (
+        calls[0].data["some"]
+        == f"turn_on - device - {entry.entity_id} - off - on - None"
+    )
+
+
+async def test_if_fires_on_state_change_with_for(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, calls
+) -> None:
+    """Test for triggers firing with delay."""
+    entry = entity_registry.async_get_or_create(DOMAIN, "test", "5678")
+
+    hass.states.async_set(entry.entity_id, STATE_ON)
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "platform": "device",
+                        "domain": DOMAIN,
+                        "device_id": "",
+                        "entity_id": entry.id,
                         "type": "turned_off",
                         "for": {"seconds": 5},
                     },
@@ -281,10 +368,9 @@ async def test_if_fires_on_state_change_with_for(hass: HomeAssistant, calls) -> 
         },
     )
     await hass.async_block_till_done()
-    assert hass.states.get(entity_id).state == STATE_ON
     assert len(calls) == 0
 
-    hass.states.async_set(entity_id, STATE_OFF)
+    hass.states.async_set(entry.entity_id, STATE_OFF)
     await hass.async_block_till_done()
     assert len(calls) == 0
     async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=10))
@@ -292,5 +378,6 @@ async def test_if_fires_on_state_change_with_for(hass: HomeAssistant, calls) -> 
     assert len(calls) == 1
     await hass.async_block_till_done()
     assert (
-        calls[0].data["some"] == f"turn_off device - {entity_id} - on - off - 0:00:05"
+        calls[0].data["some"]
+        == f"turn_off device - {entry.entity_id} - on - off - 0:00:05"
     )

--- a/tests/components/humidifier/test_device_trigger.py
+++ b/tests/components/humidifier/test_device_trigger.py
@@ -89,7 +89,7 @@ async def test_get_triggers(
             "domain": DOMAIN,
             "type": trigger,
             "device_id": device_entry.id,
-            "entity_id": entity_entry.entity_id,
+            "entity_id": entity_entry.id,
             "metadata": {"secondary": False},
         }
         for trigger in toggle_trigger_types
@@ -150,7 +150,7 @@ async def test_get_triggers_hidden_auxiliary(
             "domain": DOMAIN,
             "type": trigger,
             "device_id": device_entry.id,
-            "entity_id": entity_entry.entity_id,
+            "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
         for trigger in toggle_trigger_types
@@ -231,7 +231,7 @@ async def test_if_fires_on_state_change(
                         "platform": "device",
                         "domain": DOMAIN,
                         "device_id": "",
-                        "entity_id": entry.entity_id,
+                        "entity_id": entry.id,
                         "type": "turned_on",
                     },
                     "action": {
@@ -255,7 +255,7 @@ async def test_if_fires_on_state_change(
                         "platform": "device",
                         "domain": DOMAIN,
                         "device_id": "",
-                        "entity_id": entry.entity_id,
+                        "entity_id": entry.id,
                         "type": "turned_off",
                     },
                     "action": {
@@ -279,7 +279,7 @@ async def test_if_fires_on_state_change(
                         "platform": "device",
                         "domain": DOMAIN,
                         "device_id": "",
-                        "entity_id": entry.entity_id,
+                        "entity_id": entry.id,
                         "type": "changed_states",
                     },
                     "action": {

--- a/tests/components/light/test_device_condition.py
+++ b/tests/components/light/test_device_condition.py
@@ -46,7 +46,7 @@ async def test_get_conditions(
         config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
-    entity_registry.async_get_or_create(
+    entity_entry = entity_registry.async_get_or_create(
         DOMAIN, "test", "5678", device_id=device_entry.id
     )
     expected_conditions = [
@@ -55,7 +55,7 @@ async def test_get_conditions(
             "domain": DOMAIN,
             "type": condition,
             "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
+            "entity_id": entity_entry.id,
             "metadata": {"secondary": False},
         }
         for condition in ["is_off", "is_on"]
@@ -89,7 +89,7 @@ async def test_get_conditions_hidden_auxiliary(
         config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
-    entity_registry.async_get_or_create(
+    entity_entry = entity_registry.async_get_or_create(
         DOMAIN,
         "test",
         "5678",
@@ -103,7 +103,7 @@ async def test_get_conditions_hidden_auxiliary(
             "domain": DOMAIN,
             "type": condition,
             "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
+            "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
         for condition in ["is_off", "is_on"]
@@ -144,17 +144,49 @@ async def test_get_condition_capabilities(
         assert capabilities == expected_capabilities
 
 
+async def test_get_condition_capabilities_legacy(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test we get the expected capabilities from a light condition."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_registry.async_get_or_create(
+        DOMAIN, "test", "5678", device_id=device_entry.id
+    )
+    expected_capabilities = {
+        "extra_fields": [
+            {"name": "for", "optional": True, "type": "positive_time_period_dict"}
+        ]
+    }
+    conditions = await async_get_device_automations(
+        hass, DeviceAutomationType.CONDITION, device_entry.id
+    )
+    for condition in conditions:
+        condition["entity_id"] = entity_registry.async_get(
+            condition["entity_id"]
+        ).entity_id
+        capabilities = await async_get_device_automation_capabilities(
+            hass, DeviceAutomationType.CONDITION, condition
+        )
+        assert capabilities == expected_capabilities
+
+
 async def test_if_state(
-    hass: HomeAssistant, calls, enable_custom_integrations: None
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    calls,
+    enable_custom_integrations: None,
 ) -> None:
     """Test for turn_on and turn_off conditions."""
-    platform = getattr(hass.components, f"test.{DOMAIN}")
+    entry = entity_registry.async_get_or_create(DOMAIN, "test", "5678")
 
-    platform.init()
-    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
-    await hass.async_block_till_done()
-
-    ent1, ent2, ent3 = platform.ENTITIES
+    hass.states.async_set(entry.entity_id, STATE_ON)
 
     assert await async_setup_component(
         hass,
@@ -168,7 +200,7 @@ async def test_if_state(
                             "condition": "device",
                             "domain": DOMAIN,
                             "device_id": "",
-                            "entity_id": ent1.entity_id,
+                            "entity_id": entry.id,
                             "type": "is_on",
                         }
                     ],
@@ -187,7 +219,7 @@ async def test_if_state(
                             "condition": "device",
                             "domain": DOMAIN,
                             "device_id": "",
-                            "entity_id": ent1.entity_id,
+                            "entity_id": entry.id,
                             "type": "is_off",
                         }
                     ],
@@ -203,7 +235,6 @@ async def test_if_state(
         },
     )
     await hass.async_block_till_done()
-    assert hass.states.get(ent1.entity_id).state == STATE_ON
     assert len(calls) == 0
 
     hass.bus.async_fire("test_event1")
@@ -212,7 +243,7 @@ async def test_if_state(
     assert len(calls) == 1
     assert calls[0].data["some"] == "is_on event - test_event1"
 
-    hass.states.async_set(ent1.entity_id, STATE_OFF)
+    hass.states.async_set(entry.entity_id, STATE_OFF)
     hass.bus.async_fire("test_event1")
     hass.bus.async_fire("test_event2")
     await hass.async_block_till_done()
@@ -220,10 +251,65 @@ async def test_if_state(
     assert calls[1].data["some"] == "is_off event - test_event2"
 
 
+async def test_if_state_legacy(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    calls,
+    enable_custom_integrations: None,
+) -> None:
+    """Test for turn_on and turn_off conditions."""
+    entry = entity_registry.async_get_or_create(DOMAIN, "test", "5678")
+
+    hass.states.async_set(entry.entity_id, STATE_ON)
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {"platform": "event", "event_type": "test_event1"},
+                    "condition": [
+                        {
+                            "condition": "device",
+                            "domain": DOMAIN,
+                            "device_id": "",
+                            "entity_id": entry.entity_id,
+                            "type": "is_on",
+                        }
+                    ],
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": "is_on {{ trigger.%s }}"
+                            % "}} - {{ trigger.".join(("platform", "event.event_type"))
+                        },
+                    },
+                },
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+    assert len(calls) == 0
+
+    hass.bus.async_fire("test_event1")
+    hass.bus.async_fire("test_event2")
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    assert calls[0].data["some"] == "is_on event - test_event1"
+
+
 async def test_if_fires_on_for_condition(
-    hass: HomeAssistant, calls, enable_custom_integrations: None
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    calls,
+    enable_custom_integrations: None,
 ) -> None:
     """Test for firing if condition is on with delay."""
+    entry = entity_registry.async_get_or_create(DOMAIN, "test", "5678")
+
+    hass.states.async_set(entry.entity_id, STATE_ON)
+
     point1 = dt_util.utcnow()
     point2 = point1 + timedelta(seconds=10)
     point3 = point2 + timedelta(seconds=10)
@@ -248,7 +334,7 @@ async def test_if_fires_on_for_condition(
                             "condition": "device",
                             "domain": DOMAIN,
                             "device_id": "",
-                            "entity_id": ent1.entity_id,
+                            "entity_id": entry.id,
                             "type": "is_off",
                             "for": {"seconds": 5},
                         },
@@ -266,7 +352,6 @@ async def test_if_fires_on_for_condition(
             },
         )
         await hass.async_block_till_done()
-        assert hass.states.get(ent1.entity_id).state == STATE_ON
         assert len(calls) == 0
 
         hass.bus.async_fire("test_event1")
@@ -279,7 +364,7 @@ async def test_if_fires_on_for_condition(
         await hass.async_block_till_done()
         assert len(calls) == 0
 
-        hass.states.async_set(ent1.entity_id, STATE_OFF)
+        hass.states.async_set(entry.entity_id, STATE_OFF)
         hass.bus.async_fire("test_event1")
         await hass.async_block_till_done()
         assert len(calls) == 0

--- a/tests/components/light/test_device_trigger.py
+++ b/tests/components/light/test_device_trigger.py
@@ -7,7 +7,7 @@ from pytest_unordered import unordered
 import homeassistant.components.automation as automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.light import DOMAIN
-from homeassistant.const import CONF_PLATFORM, STATE_OFF, STATE_ON, EntityCategory
+from homeassistant.const import STATE_OFF, STATE_ON, EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
@@ -46,7 +46,7 @@ async def test_get_triggers(
         config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
-    entity_registry.async_get_or_create(
+    entity_entry = entity_registry.async_get_or_create(
         DOMAIN, "test", "5678", device_id=device_entry.id
     )
     expected_triggers = [
@@ -55,7 +55,7 @@ async def test_get_triggers(
             "domain": DOMAIN,
             "type": trigger,
             "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
+            "entity_id": entity_entry.id,
             "metadata": {"secondary": False},
         }
         for trigger in ["changed_states", "turned_off", "turned_on"]
@@ -89,7 +89,7 @@ async def test_get_triggers_hidden_auxiliary(
         config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
-    entity_registry.async_get_or_create(
+    entity_entry = entity_registry.async_get_or_create(
         DOMAIN,
         "test",
         "5678",
@@ -103,7 +103,7 @@ async def test_get_triggers_hidden_auxiliary(
             "domain": DOMAIN,
             "type": trigger,
             "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
+            "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
         for trigger in ["changed_states", "turned_off", "turned_on"]
@@ -144,19 +144,47 @@ async def test_get_trigger_capabilities(
         assert capabilities == expected_capabilities
 
 
+async def test_get_trigger_capabilities_legacy(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test we get the expected capabilities from a light trigger."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_registry.async_get_or_create(
+        DOMAIN, "test", "5678", device_id=device_entry.id
+    )
+    expected_capabilities = {
+        "extra_fields": [
+            {"name": "for", "optional": True, "type": "positive_time_period_dict"}
+        ]
+    }
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device_entry.id
+    )
+    for trigger in triggers:
+        trigger["entity_id"] = entity_registry.async_get(trigger["entity_id"]).entity_id
+        capabilities = await async_get_device_automation_capabilities(
+            hass, DeviceAutomationType.TRIGGER, trigger
+        )
+        assert capabilities == expected_capabilities
+
+
 async def test_if_fires_on_state_change(
-    hass: HomeAssistant, calls, enable_custom_integrations: None
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    calls,
+    enable_custom_integrations: None,
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
-    platform = getattr(hass.components, f"test.{DOMAIN}")
+    entry = entity_registry.async_get_or_create(DOMAIN, "test", "5678")
 
-    platform.init()
-    await hass.async_block_till_done()
-
-    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
-    await hass.async_block_till_done()
-
-    ent1, ent2, ent3 = platform.ENTITIES
+    hass.states.async_set(entry.entity_id, STATE_ON)
 
     assert await async_setup_component(
         hass,
@@ -168,7 +196,7 @@ async def test_if_fires_on_state_change(
                         "platform": "device",
                         "domain": DOMAIN,
                         "device_id": "",
-                        "entity_id": ent1.entity_id,
+                        "entity_id": entry.id,
                         "type": "turned_on",
                     },
                     "action": {
@@ -192,7 +220,7 @@ async def test_if_fires_on_state_change(
                         "platform": "device",
                         "domain": DOMAIN,
                         "device_id": "",
-                        "entity_id": ent1.entity_id,
+                        "entity_id": entry.id,
                         "type": "turned_off",
                     },
                     "action": {
@@ -216,7 +244,7 @@ async def test_if_fires_on_state_change(
                         "platform": "device",
                         "domain": DOMAIN,
                         "device_id": "",
-                        "entity_id": ent1.entity_id,
+                        "entity_id": entry.id,
                         "type": "changed_states",
                     },
                     "action": {
@@ -239,39 +267,35 @@ async def test_if_fires_on_state_change(
         },
     )
     await hass.async_block_till_done()
-    assert hass.states.get(ent1.entity_id).state == STATE_ON
     assert len(calls) == 0
 
-    hass.states.async_set(ent1.entity_id, STATE_OFF)
+    hass.states.async_set(entry.entity_id, STATE_OFF)
     await hass.async_block_till_done()
     assert len(calls) == 2
     assert {calls[0].data["some"], calls[1].data["some"]} == {
-        f"turn_off device - {ent1.entity_id} - on - off - None",
-        f"turn_on_or_off device - {ent1.entity_id} - on - off - None",
+        f"turn_off device - {entry.entity_id} - on - off - None",
+        f"turn_on_or_off device - {entry.entity_id} - on - off - None",
     }
 
-    hass.states.async_set(ent1.entity_id, STATE_ON)
+    hass.states.async_set(entry.entity_id, STATE_ON)
     await hass.async_block_till_done()
     assert len(calls) == 4
     assert {calls[2].data["some"], calls[3].data["some"]} == {
-        f"turn_on device - {ent1.entity_id} - off - on - None",
-        f"turn_on_or_off device - {ent1.entity_id} - off - on - None",
+        f"turn_on device - {entry.entity_id} - off - on - None",
+        f"turn_on_or_off device - {entry.entity_id} - off - on - None",
     }
 
 
-async def test_if_fires_on_state_change_with_for(
-    hass: HomeAssistant, calls, enable_custom_integrations: None
+async def test_if_fires_on_state_change_legacy(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    calls,
+    enable_custom_integrations: None,
 ) -> None:
-    """Test for triggers firing with delay."""
-    platform = getattr(hass.components, f"test.{DOMAIN}")
+    """Test for turn_on and turn_off triggers firing."""
+    entry = entity_registry.async_get_or_create(DOMAIN, "test", "5678")
 
-    platform.init()
-    await hass.async_block_till_done()
-
-    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
-    await hass.async_block_till_done()
-
-    ent1, ent2, ent3 = platform.ENTITIES
+    hass.states.async_set(entry.entity_id, STATE_ON)
 
     assert await async_setup_component(
         hass,
@@ -283,7 +307,61 @@ async def test_if_fires_on_state_change_with_for(
                         "platform": "device",
                         "domain": DOMAIN,
                         "device_id": "",
-                        "entity_id": ent1.entity_id,
+                        "entity_id": entry.entity_id,
+                        "type": "turned_off",
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": "turn_on {{ trigger.%s }}"
+                            % "}} - {{ trigger.".join(
+                                (
+                                    "platform",
+                                    "entity_id",
+                                    "from_state.state",
+                                    "to_state.state",
+                                    "for",
+                                )
+                            )
+                        },
+                    },
+                },
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+    assert len(calls) == 0
+
+    hass.states.async_set(entry.entity_id, STATE_OFF)
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    assert (
+        calls[0].data["some"] == f"turn_on device - {entry.entity_id} - on - off - None"
+    )
+
+
+async def test_if_fires_on_state_change_with_for(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    calls,
+    enable_custom_integrations: None,
+) -> None:
+    """Test for triggers firing with delay."""
+    entry = entity_registry.async_get_or_create(DOMAIN, "test", "5678")
+
+    hass.states.async_set(entry.entity_id, STATE_ON)
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "platform": "device",
+                        "domain": DOMAIN,
+                        "device_id": "",
+                        "entity_id": entry.id,
                         "type": "turned_off",
                         "for": {"seconds": 5},
                     },
@@ -307,16 +385,16 @@ async def test_if_fires_on_state_change_with_for(
         },
     )
     await hass.async_block_till_done()
-    assert hass.states.get(ent1.entity_id).state == STATE_ON
     assert len(calls) == 0
 
-    hass.states.async_set(ent1.entity_id, STATE_OFF)
+    hass.states.async_set(entry.entity_id, STATE_OFF)
     await hass.async_block_till_done()
     assert len(calls) == 0
     async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=10))
     await hass.async_block_till_done()
     assert len(calls) == 1
     await hass.async_block_till_done()
-    assert calls[0].data["some"] == "turn_off device - {} - on - off - 0:00:05".format(
-        ent1.entity_id
+    assert (
+        calls[0].data["some"]
+        == f"turn_off device - {entry.entity_id} - on - off - 0:00:05"
     )

--- a/tests/components/media_player/test_device_trigger.py
+++ b/tests/components/media_player/test_device_trigger.py
@@ -58,11 +58,9 @@ async def test_get_triggers(
         DOMAIN, "test", "5678", device_id=device_entry.id
     )
 
-    entity_trigger_types = {
-        "changed_states",
-    }
     trigger_types = {
         "buffering",
+        "changed_states",
         "idle",
         "paused",
         "playing",
@@ -79,17 +77,6 @@ async def test_get_triggers(
             "metadata": {"secondary": False},
         }
         for trigger in trigger_types
-    ]
-    expected_triggers += [
-        {
-            "platform": "device",
-            "domain": DOMAIN,
-            "type": trigger,
-            "device_id": device_entry.id,
-            "entity_id": entity_entry.entity_id,
-            "metadata": {"secondary": False},
-        }
-        for trigger in entity_trigger_types
     ]
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_entry.id
@@ -128,11 +115,9 @@ async def test_get_triggers_hidden_auxiliary(
         entity_category=entity_category,
         hidden_by=hidden_by,
     )
-    entity_trigger_types = {
-        "changed_states",
-    }
     trigger_types = {
         "buffering",
+        "changed_states",
         "idle",
         "paused",
         "playing",
@@ -149,17 +134,6 @@ async def test_get_triggers_hidden_auxiliary(
             "metadata": {"secondary": True},
         }
         for trigger in trigger_types
-    ]
-    expected_triggers += [
-        {
-            "platform": "device",
-            "domain": DOMAIN,
-            "type": trigger,
-            "device_id": device_entry.id,
-            "entity_id": entity_entry.entity_id,
-            "metadata": {"secondary": True},
-        }
-        for trigger in entity_trigger_types
     ]
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_entry.id
@@ -263,9 +237,7 @@ async def test_if_fires_on_state_change(
                         "platform": "device",
                         "domain": DOMAIN,
                         "device_id": "",
-                        "entity_id": entry.entity_id
-                        if trigger == "changed_states"
-                        else entry.id,
+                        "entity_id": entry.id,
                         "type": trigger,
                     },
                     "action": {

--- a/tests/components/remote/test_device_condition.py
+++ b/tests/components/remote/test_device_condition.py
@@ -8,7 +8,7 @@ from pytest_unordered import unordered
 import homeassistant.components.automation as automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.remote import DOMAIN
-from homeassistant.const import CONF_PLATFORM, STATE_OFF, STATE_ON, EntityCategory
+from homeassistant.const import STATE_OFF, STATE_ON, EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
@@ -46,7 +46,7 @@ async def test_get_conditions(
         config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
-    entity_registry.async_get_or_create(
+    entity_entry = entity_registry.async_get_or_create(
         DOMAIN, "test", "5678", device_id=device_entry.id
     )
     expected_conditions = [
@@ -55,7 +55,7 @@ async def test_get_conditions(
             "domain": DOMAIN,
             "type": condition,
             "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
+            "entity_id": entity_entry.id,
             "metadata": {"secondary": False},
         }
         for condition in ["is_off", "is_on"]
@@ -89,7 +89,7 @@ async def test_get_conditions_hidden_auxiliary(
         config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
-    entity_registry.async_get_or_create(
+    entity_entry = entity_registry.async_get_or_create(
         DOMAIN,
         "test",
         "5678",
@@ -103,7 +103,7 @@ async def test_get_conditions_hidden_auxiliary(
             "domain": DOMAIN,
             "type": condition,
             "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
+            "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
         for condition in ["is_off", "is_on"]
@@ -144,17 +144,49 @@ async def test_get_condition_capabilities(
         assert capabilities == expected_capabilities
 
 
+async def test_get_condition_capabilities_legacy(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test we get the expected capabilities from a remote condition."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_registry.async_get_or_create(
+        DOMAIN, "test", "5678", device_id=device_entry.id
+    )
+    expected_capabilities = {
+        "extra_fields": [
+            {"name": "for", "optional": True, "type": "positive_time_period_dict"}
+        ]
+    }
+    conditions = await async_get_device_automations(
+        hass, DeviceAutomationType.CONDITION, device_entry.id
+    )
+    for condition in conditions:
+        condition["entity_id"] = entity_registry.async_get(
+            condition["entity_id"]
+        ).entity_id
+        capabilities = await async_get_device_automation_capabilities(
+            hass, DeviceAutomationType.CONDITION, condition
+        )
+        assert capabilities == expected_capabilities
+
+
 async def test_if_state(
-    hass: HomeAssistant, calls, enable_custom_integrations: None
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    calls,
+    enable_custom_integrations: None,
 ) -> None:
     """Test for turn_on and turn_off conditions."""
-    platform = getattr(hass.components, f"test.{DOMAIN}")
+    entry = entity_registry.async_get_or_create(DOMAIN, "test", "5678")
 
-    platform.init()
-    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
-    await hass.async_block_till_done()
-
-    ent1, ent2, ent3 = platform.ENTITIES
+    hass.states.async_set(entry.entity_id, STATE_ON)
 
     assert await async_setup_component(
         hass,
@@ -168,7 +200,7 @@ async def test_if_state(
                             "condition": "device",
                             "domain": DOMAIN,
                             "device_id": "",
-                            "entity_id": ent1.entity_id,
+                            "entity_id": entry.id,
                             "type": "is_on",
                         }
                     ],
@@ -187,7 +219,7 @@ async def test_if_state(
                             "condition": "device",
                             "domain": DOMAIN,
                             "device_id": "",
-                            "entity_id": ent1.entity_id,
+                            "entity_id": entry.id,
                             "type": "is_off",
                         }
                     ],
@@ -203,7 +235,6 @@ async def test_if_state(
         },
     )
     await hass.async_block_till_done()
-    assert hass.states.get(ent1.entity_id).state == STATE_ON
     assert len(calls) == 0
 
     hass.bus.async_fire("test_event1")
@@ -212,7 +243,7 @@ async def test_if_state(
     assert len(calls) == 1
     assert calls[0].data["some"] == "is_on event - test_event1"
 
-    hass.states.async_set(ent1.entity_id, STATE_OFF)
+    hass.states.async_set(entry.entity_id, STATE_OFF)
     hass.bus.async_fire("test_event1")
     hass.bus.async_fire("test_event2")
     await hass.async_block_till_done()
@@ -220,21 +251,68 @@ async def test_if_state(
     assert calls[1].data["some"] == "is_off event - test_event2"
 
 
+async def test_if_state_legacy(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    calls,
+    enable_custom_integrations: None,
+) -> None:
+    """Test for turn_on and turn_off conditions."""
+    entry = entity_registry.async_get_or_create(DOMAIN, "test", "5678")
+
+    hass.states.async_set(entry.entity_id, STATE_ON)
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {"platform": "event", "event_type": "test_event1"},
+                    "condition": [
+                        {
+                            "condition": "device",
+                            "domain": DOMAIN,
+                            "device_id": "",
+                            "entity_id": entry.entity_id,
+                            "type": "is_on",
+                        }
+                    ],
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": "is_on {{ trigger.%s }}"
+                            % "}} - {{ trigger.".join(("platform", "event.event_type"))
+                        },
+                    },
+                },
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+    assert len(calls) == 0
+
+    hass.bus.async_fire("test_event1")
+    hass.bus.async_fire("test_event2")
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    assert calls[0].data["some"] == "is_on event - test_event1"
+
+
 async def test_if_fires_on_for_condition(
-    hass: HomeAssistant, calls, enable_custom_integrations: None
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    calls,
+    enable_custom_integrations: None,
 ) -> None:
     """Test for firing if condition is on with delay."""
     point1 = dt_util.utcnow()
     point2 = point1 + timedelta(seconds=10)
     point3 = point2 + timedelta(seconds=10)
 
-    platform = getattr(hass.components, f"test.{DOMAIN}")
+    entry = entity_registry.async_get_or_create(DOMAIN, "test", "5678")
 
-    platform.init()
-    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
-    await hass.async_block_till_done()
-
-    ent1, ent2, ent3 = platform.ENTITIES
+    hass.states.async_set(entry.entity_id, STATE_ON)
 
     with freeze_time(point1) as freezer:
         assert await async_setup_component(
@@ -248,7 +326,7 @@ async def test_if_fires_on_for_condition(
                             "condition": "device",
                             "domain": DOMAIN,
                             "device_id": "",
-                            "entity_id": ent1.entity_id,
+                            "entity_id": entry.id,
                             "type": "is_off",
                             "for": {"seconds": 5},
                         },
@@ -266,7 +344,6 @@ async def test_if_fires_on_for_condition(
             },
         )
         await hass.async_block_till_done()
-        assert hass.states.get(ent1.entity_id).state == STATE_ON
         assert len(calls) == 0
 
         hass.bus.async_fire("test_event1")
@@ -279,7 +356,7 @@ async def test_if_fires_on_for_condition(
         await hass.async_block_till_done()
         assert len(calls) == 0
 
-        hass.states.async_set(ent1.entity_id, STATE_OFF)
+        hass.states.async_set(entry.entity_id, STATE_OFF)
         hass.bus.async_fire("test_event1")
         await hass.async_block_till_done()
         assert len(calls) == 0

--- a/tests/components/remote/test_device_trigger.py
+++ b/tests/components/remote/test_device_trigger.py
@@ -7,7 +7,7 @@ from pytest_unordered import unordered
 import homeassistant.components.automation as automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.remote import DOMAIN
-from homeassistant.const import CONF_PLATFORM, STATE_OFF, STATE_ON, EntityCategory
+from homeassistant.const import STATE_OFF, STATE_ON, EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
@@ -46,7 +46,7 @@ async def test_get_triggers(
         config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
-    entity_registry.async_get_or_create(
+    entity_entry = entity_registry.async_get_or_create(
         DOMAIN, "test", "5678", device_id=device_entry.id
     )
     expected_triggers = [
@@ -55,7 +55,7 @@ async def test_get_triggers(
             "domain": DOMAIN,
             "type": trigger,
             "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
+            "entity_id": entity_entry.id,
             "metadata": {"secondary": False},
         }
         for trigger in ["changed_states", "turned_off", "turned_on"]
@@ -89,7 +89,7 @@ async def test_get_triggers_hidden_auxiliary(
         config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
-    entity_registry.async_get_or_create(
+    entity_entry = entity_registry.async_get_or_create(
         DOMAIN,
         "test",
         "5678",
@@ -103,7 +103,7 @@ async def test_get_triggers_hidden_auxiliary(
             "domain": DOMAIN,
             "type": trigger,
             "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
+            "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
         for trigger in ["changed_states", "turned_off", "turned_on"]
@@ -144,17 +144,47 @@ async def test_get_trigger_capabilities(
         assert capabilities == expected_capabilities
 
 
+async def test_get_trigger_capabilities_legacy(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test we get the expected capabilities from a remote trigger."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_registry.async_get_or_create(
+        DOMAIN, "test", "5678", device_id=device_entry.id
+    )
+    expected_capabilities = {
+        "extra_fields": [
+            {"name": "for", "optional": True, "type": "positive_time_period_dict"}
+        ]
+    }
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device_entry.id
+    )
+    for trigger in triggers:
+        trigger["entity_id"] = entity_registry.async_get(trigger["entity_id"]).entity_id
+        capabilities = await async_get_device_automation_capabilities(
+            hass, DeviceAutomationType.TRIGGER, trigger
+        )
+        assert capabilities == expected_capabilities
+
+
 async def test_if_fires_on_state_change(
-    hass: HomeAssistant, calls, enable_custom_integrations: None
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    calls,
+    enable_custom_integrations: None,
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
-    platform = getattr(hass.components, f"test.{DOMAIN}")
+    entry = entity_registry.async_get_or_create(DOMAIN, "test", "5678")
 
-    platform.init()
-    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
-    await hass.async_block_till_done()
-
-    ent1, ent2, ent3 = platform.ENTITIES
+    hass.states.async_set(entry.entity_id, STATE_ON)
 
     assert await async_setup_component(
         hass,
@@ -166,7 +196,7 @@ async def test_if_fires_on_state_change(
                         "platform": "device",
                         "domain": DOMAIN,
                         "device_id": "",
-                        "entity_id": ent1.entity_id,
+                        "entity_id": entry.id,
                         "type": "turned_on",
                     },
                     "action": {
@@ -190,7 +220,7 @@ async def test_if_fires_on_state_change(
                         "platform": "device",
                         "domain": DOMAIN,
                         "device_id": "",
-                        "entity_id": ent1.entity_id,
+                        "entity_id": entry.id,
                         "type": "turned_off",
                     },
                     "action": {
@@ -214,7 +244,7 @@ async def test_if_fires_on_state_change(
                         "platform": "device",
                         "domain": DOMAIN,
                         "device_id": "",
-                        "entity_id": ent1.entity_id,
+                        "entity_id": entry.id,
                         "type": "changed_states",
                     },
                     "action": {
@@ -236,38 +266,35 @@ async def test_if_fires_on_state_change(
             ]
         },
     )
-    await hass.async_block_till_done()
-    assert hass.states.get(ent1.entity_id).state == STATE_ON
     assert len(calls) == 0
 
-    hass.states.async_set(ent1.entity_id, STATE_OFF)
+    hass.states.async_set(entry.entity_id, STATE_OFF)
     await hass.async_block_till_done()
     assert len(calls) == 2
     assert {calls[0].data["some"], calls[1].data["some"]} == {
-        f"turn_off device - {ent1.entity_id} - on - off - None",
-        f"turn_on_or_off device - {ent1.entity_id} - on - off - None",
+        f"turn_off device - {entry.entity_id} - on - off - None",
+        f"turn_on_or_off device - {entry.entity_id} - on - off - None",
     }
 
-    hass.states.async_set(ent1.entity_id, STATE_ON)
+    hass.states.async_set(entry.entity_id, STATE_ON)
     await hass.async_block_till_done()
     assert len(calls) == 4
     assert {calls[2].data["some"], calls[3].data["some"]} == {
-        f"turn_on device - {ent1.entity_id} - off - on - None",
-        f"turn_on_or_off device - {ent1.entity_id} - off - on - None",
+        f"turn_on device - {entry.entity_id} - off - on - None",
+        f"turn_on_or_off device - {entry.entity_id} - off - on - None",
     }
 
 
-async def test_if_fires_on_state_change_with_for(
-    hass: HomeAssistant, calls, enable_custom_integrations: None
+async def test_if_fires_on_state_change_legacy(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    calls,
+    enable_custom_integrations: None,
 ) -> None:
-    """Test for triggers firing with delay."""
-    platform = getattr(hass.components, f"test.{DOMAIN}")
+    """Test for turn_on and turn_off triggers firing."""
+    entry = entity_registry.async_get_or_create(DOMAIN, "test", "5678")
 
-    platform.init()
-    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
-    await hass.async_block_till_done()
-
-    ent1, ent2, ent3 = platform.ENTITIES
+    hass.states.async_set(entry.entity_id, STATE_ON)
 
     assert await async_setup_component(
         hass,
@@ -279,7 +306,61 @@ async def test_if_fires_on_state_change_with_for(
                         "platform": "device",
                         "domain": DOMAIN,
                         "device_id": "",
-                        "entity_id": ent1.entity_id,
+                        "entity_id": entry.entity_id,
+                        "type": "turned_off",
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": "turn_off {{ trigger.%s }}"
+                            % "}} - {{ trigger.".join(
+                                (
+                                    "platform",
+                                    "entity_id",
+                                    "from_state.state",
+                                    "to_state.state",
+                                    "for",
+                                )
+                            )
+                        },
+                    },
+                },
+            ]
+        },
+    )
+    assert len(calls) == 0
+
+    hass.states.async_set(entry.entity_id, STATE_OFF)
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    assert (
+        calls[0].data["some"]
+        == f"turn_off device - {entry.entity_id} - on - off - None"
+    )
+
+
+async def test_if_fires_on_state_change_with_for(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    calls,
+    enable_custom_integrations: None,
+) -> None:
+    """Test for triggers firing with delay."""
+    entry = entity_registry.async_get_or_create(DOMAIN, "test", "5678")
+
+    hass.states.async_set(entry.entity_id, STATE_ON)
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "platform": "device",
+                        "domain": DOMAIN,
+                        "device_id": "",
+                        "entity_id": entry.id,
                         "type": "turned_off",
                         "for": {"seconds": 5},
                     },
@@ -303,16 +384,16 @@ async def test_if_fires_on_state_change_with_for(
         },
     )
     await hass.async_block_till_done()
-    assert hass.states.get(ent1.entity_id).state == STATE_ON
     assert len(calls) == 0
 
-    hass.states.async_set(ent1.entity_id, STATE_OFF)
+    hass.states.async_set(entry.entity_id, STATE_OFF)
     await hass.async_block_till_done()
     assert len(calls) == 0
     async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=10))
     await hass.async_block_till_done()
     assert len(calls) == 1
     await hass.async_block_till_done()
-    assert calls[0].data["some"] == "turn_off device - {} - on - off - 0:00:05".format(
-        ent1.entity_id
+    assert (
+        calls[0].data["some"]
+        == f"turn_off device - {entry.entity_id} - on - off - 0:00:05"
     )

--- a/tests/components/switch/test_device_action.py
+++ b/tests/components/switch/test_device_action.py
@@ -5,7 +5,7 @@ from pytest_unordered import unordered
 import homeassistant.components.automation as automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.switch import DOMAIN
-from homeassistant.const import CONF_PLATFORM, STATE_OFF, STATE_ON, EntityCategory
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
@@ -41,7 +41,7 @@ async def test_get_actions(
         config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
-    entity_registry.async_get_or_create(
+    entity_entry = entity_registry.async_get_or_create(
         DOMAIN, "test", "5678", device_id=device_entry.id
     )
     expected_actions = []
@@ -50,7 +50,7 @@ async def test_get_actions(
             "domain": DOMAIN,
             "type": action,
             "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
+            "entity_id": entity_entry.id,
             "metadata": {"secondary": False},
         }
         for action in ["turn_off", "turn_on", "toggle"]
@@ -84,7 +84,7 @@ async def test_get_actions_hidden_auxiliary(
         config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
-    entity_registry.async_get_or_create(
+    entity_entry = entity_registry.async_get_or_create(
         DOMAIN,
         "test",
         "5678",
@@ -98,7 +98,7 @@ async def test_get_actions_hidden_auxiliary(
             "domain": DOMAIN,
             "type": action,
             "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
+            "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
         for action in ["turn_off", "turn_on", "toggle"]
@@ -110,16 +110,13 @@ async def test_get_actions_hidden_auxiliary(
 
 
 async def test_action(
-    hass: HomeAssistant, calls, enable_custom_integrations: None
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    calls,
+    enable_custom_integrations: None,
 ) -> None:
     """Test for turn_on and turn_off actions."""
-    platform = getattr(hass.components, f"test.{DOMAIN}")
-
-    platform.init()
-    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
-    await hass.async_block_till_done()
-
-    ent1, ent2, ent3 = platform.ENTITIES
+    entry = entity_registry.async_get_or_create(DOMAIN, "test", "5678")
 
     assert await async_setup_component(
         hass,
@@ -127,29 +124,29 @@ async def test_action(
         {
             automation.DOMAIN: [
                 {
-                    "trigger": {"platform": "event", "event_type": "test_event1"},
+                    "trigger": {"platform": "event", "event_type": "test_off"},
                     "action": {
                         "domain": DOMAIN,
                         "device_id": "",
-                        "entity_id": ent1.entity_id,
+                        "entity_id": entry.id,
                         "type": "turn_off",
                     },
                 },
                 {
-                    "trigger": {"platform": "event", "event_type": "test_event2"},
+                    "trigger": {"platform": "event", "event_type": "test_on"},
                     "action": {
                         "domain": DOMAIN,
                         "device_id": "",
-                        "entity_id": ent1.entity_id,
+                        "entity_id": entry.id,
                         "type": "turn_on",
                     },
                 },
                 {
-                    "trigger": {"platform": "event", "event_type": "test_event3"},
+                    "trigger": {"platform": "event", "event_type": "test_toggle"},
                     "action": {
                         "domain": DOMAIN,
                         "device_id": "",
-                        "entity_id": ent1.entity_id,
+                        "entity_id": entry.id,
                         "type": "toggle",
                     },
                 },
@@ -157,29 +154,58 @@ async def test_action(
         },
     )
     await hass.async_block_till_done()
-    assert hass.states.get(ent1.entity_id).state == STATE_ON
-    assert len(calls) == 0
 
-    hass.bus.async_fire("test_event1")
-    await hass.async_block_till_done()
-    assert hass.states.get(ent1.entity_id).state == STATE_OFF
+    turn_on_calls = async_mock_service(hass, DOMAIN, "turn_on")
+    turn_off_calls = async_mock_service(hass, DOMAIN, "turn_off")
+    toggle_calls = async_mock_service(hass, DOMAIN, "toggle")
 
-    hass.bus.async_fire("test_event1")
+    hass.bus.async_fire("test_toggle")
     await hass.async_block_till_done()
-    assert hass.states.get(ent1.entity_id).state == STATE_OFF
+    assert len(toggle_calls) == 1
+    assert toggle_calls[-1].data == {"entity_id": entry.entity_id}
 
-    hass.bus.async_fire("test_event2")
+    hass.bus.async_fire("test_off")
     await hass.async_block_till_done()
-    assert hass.states.get(ent1.entity_id).state == STATE_ON
+    assert len(turn_off_calls) == 1
+    assert turn_off_calls[-1].data == {"entity_id": entry.entity_id}
 
-    hass.bus.async_fire("test_event2")
+    hass.bus.async_fire("test_on")
     await hass.async_block_till_done()
-    assert hass.states.get(ent1.entity_id).state == STATE_ON
+    assert len(turn_on_calls) == 1
+    assert turn_on_calls[-1].data == {"entity_id": entry.entity_id}
 
-    hass.bus.async_fire("test_event3")
-    await hass.async_block_till_done()
-    assert hass.states.get(ent1.entity_id).state == STATE_OFF
 
-    hass.bus.async_fire("test_event3")
+async def test_action_legacy(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    calls,
+    enable_custom_integrations: None,
+) -> None:
+    """Test for turn_on and turn_off actions."""
+    entry = entity_registry.async_get_or_create(DOMAIN, "test", "5678")
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {"platform": "event", "event_type": "test_off"},
+                    "action": {
+                        "domain": DOMAIN,
+                        "device_id": "",
+                        "entity_id": entry.id,
+                        "type": "turn_off",
+                    },
+                },
+            ]
+        },
+    )
     await hass.async_block_till_done()
-    assert hass.states.get(ent1.entity_id).state == STATE_ON
+
+    turn_off_calls = async_mock_service(hass, DOMAIN, "turn_off")
+
+    hass.bus.async_fire("test_off")
+    await hass.async_block_till_done()
+    assert len(turn_off_calls) == 1
+    assert turn_off_calls[-1].data == {"entity_id": entry.entity_id}

--- a/tests/components/switch/test_device_condition.py
+++ b/tests/components/switch/test_device_condition.py
@@ -8,7 +8,7 @@ from pytest_unordered import unordered
 import homeassistant.components.automation as automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.switch import DOMAIN
-from homeassistant.const import CONF_PLATFORM, STATE_OFF, STATE_ON, EntityCategory
+from homeassistant.const import STATE_OFF, STATE_ON, EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
@@ -46,7 +46,7 @@ async def test_get_conditions(
         config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
-    entity_registry.async_get_or_create(
+    entity_entry = entity_registry.async_get_or_create(
         DOMAIN, "test", "5678", device_id=device_entry.id
     )
     expected_conditions = [
@@ -55,7 +55,7 @@ async def test_get_conditions(
             "domain": DOMAIN,
             "type": condition,
             "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
+            "entity_id": entity_entry.id,
             "metadata": {"secondary": False},
         }
         for condition in ["is_off", "is_on"]
@@ -89,7 +89,7 @@ async def test_get_conditions_hidden_auxiliary(
         config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
-    entity_registry.async_get_or_create(
+    entity_entry = entity_registry.async_get_or_create(
         DOMAIN,
         "test",
         "5678",
@@ -103,7 +103,7 @@ async def test_get_conditions_hidden_auxiliary(
             "domain": DOMAIN,
             "type": condition,
             "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
+            "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
         for condition in ["is_off", "is_on"]
@@ -144,17 +144,49 @@ async def test_get_condition_capabilities(
         assert capabilities == expected_capabilities
 
 
+async def test_get_condition_capabilities_legacy(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test we get the expected capabilities from a switch condition."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_registry.async_get_or_create(
+        DOMAIN, "test", "5678", device_id=device_entry.id
+    )
+    expected_capabilities = {
+        "extra_fields": [
+            {"name": "for", "optional": True, "type": "positive_time_period_dict"}
+        ]
+    }
+    conditions = await async_get_device_automations(
+        hass, DeviceAutomationType.CONDITION, device_entry.id
+    )
+    for condition in conditions:
+        condition["entity_id"] = entity_registry.async_get(
+            condition["entity_id"]
+        ).entity_id
+        capabilities = await async_get_device_automation_capabilities(
+            hass, DeviceAutomationType.CONDITION, condition
+        )
+        assert capabilities == expected_capabilities
+
+
 async def test_if_state(
-    hass: HomeAssistant, calls, enable_custom_integrations: None
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    calls,
+    enable_custom_integrations: None,
 ) -> None:
     """Test for turn_on and turn_off conditions."""
-    platform = getattr(hass.components, f"test.{DOMAIN}")
+    entry = entity_registry.async_get_or_create(DOMAIN, "test", "5678")
 
-    platform.init()
-    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
-    await hass.async_block_till_done()
-
-    ent1, ent2, ent3 = platform.ENTITIES
+    hass.states.async_set(entry.entity_id, STATE_ON)
 
     assert await async_setup_component(
         hass,
@@ -168,7 +200,7 @@ async def test_if_state(
                             "condition": "device",
                             "domain": DOMAIN,
                             "device_id": "",
-                            "entity_id": ent1.entity_id,
+                            "entity_id": entry.id,
                             "type": "is_on",
                         }
                     ],
@@ -187,7 +219,7 @@ async def test_if_state(
                             "condition": "device",
                             "domain": DOMAIN,
                             "device_id": "",
-                            "entity_id": ent1.entity_id,
+                            "entity_id": entry.id,
                             "type": "is_off",
                         }
                     ],
@@ -203,7 +235,6 @@ async def test_if_state(
         },
     )
     await hass.async_block_till_done()
-    assert hass.states.get(ent1.entity_id).state == STATE_ON
     assert len(calls) == 0
 
     hass.bus.async_fire("test_event1")
@@ -212,7 +243,7 @@ async def test_if_state(
     assert len(calls) == 1
     assert calls[0].data["some"] == "is_on event - test_event1"
 
-    hass.states.async_set(ent1.entity_id, STATE_OFF)
+    hass.states.async_set(entry.entity_id, STATE_OFF)
     hass.bus.async_fire("test_event1")
     hass.bus.async_fire("test_event2")
     await hass.async_block_till_done()
@@ -220,21 +251,67 @@ async def test_if_state(
     assert calls[1].data["some"] == "is_off event - test_event2"
 
 
+async def test_if_state_legacy(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    calls,
+    enable_custom_integrations: None,
+) -> None:
+    """Test for turn_on and turn_off conditions."""
+    entry = entity_registry.async_get_or_create(DOMAIN, "test", "5678")
+
+    hass.states.async_set(entry.entity_id, STATE_ON)
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {"platform": "event", "event_type": "test_event1"},
+                    "condition": [
+                        {
+                            "condition": "device",
+                            "domain": DOMAIN,
+                            "device_id": "",
+                            "entity_id": entry.entity_id,
+                            "type": "is_on",
+                        }
+                    ],
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": "is_on {{ trigger.%s }}"
+                            % "}} - {{ trigger.".join(("platform", "event.event_type"))
+                        },
+                    },
+                },
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+    assert len(calls) == 0
+
+    hass.bus.async_fire("test_event1")
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    assert calls[0].data["some"] == "is_on event - test_event1"
+
+
 async def test_if_fires_on_for_condition(
-    hass: HomeAssistant, calls, enable_custom_integrations: None
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    calls,
+    enable_custom_integrations: None,
 ) -> None:
     """Test for firing if condition is on with delay."""
     point1 = dt_util.utcnow()
     point2 = point1 + timedelta(seconds=10)
     point3 = point2 + timedelta(seconds=10)
 
-    platform = getattr(hass.components, f"test.{DOMAIN}")
+    entry = entity_registry.async_get_or_create(DOMAIN, "test", "5678")
 
-    platform.init()
-    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
-    await hass.async_block_till_done()
-
-    ent1, ent2, ent3 = platform.ENTITIES
+    hass.states.async_set(entry.entity_id, STATE_ON)
 
     with freeze_time(point1) as freezer:
         assert await async_setup_component(
@@ -248,7 +325,7 @@ async def test_if_fires_on_for_condition(
                             "condition": "device",
                             "domain": DOMAIN,
                             "device_id": "",
-                            "entity_id": ent1.entity_id,
+                            "entity_id": entry.id,
                             "type": "is_off",
                             "for": {"seconds": 5},
                         },
@@ -266,7 +343,6 @@ async def test_if_fires_on_for_condition(
             },
         )
         await hass.async_block_till_done()
-        assert hass.states.get(ent1.entity_id).state == STATE_ON
         assert len(calls) == 0
 
         hass.bus.async_fire("test_event1")
@@ -279,7 +355,7 @@ async def test_if_fires_on_for_condition(
         await hass.async_block_till_done()
         assert len(calls) == 0
 
-        hass.states.async_set(ent1.entity_id, STATE_OFF)
+        hass.states.async_set(entry.entity_id, STATE_OFF)
         hass.bus.async_fire("test_event1")
         await hass.async_block_till_done()
         assert len(calls) == 0

--- a/tests/components/switch/test_device_trigger.py
+++ b/tests/components/switch/test_device_trigger.py
@@ -7,7 +7,7 @@ from pytest_unordered import unordered
 import homeassistant.components.automation as automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.switch import DOMAIN
-from homeassistant.const import CONF_PLATFORM, STATE_OFF, STATE_ON, EntityCategory
+from homeassistant.const import STATE_OFF, STATE_ON, EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
@@ -46,7 +46,7 @@ async def test_get_triggers(
         config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
-    entity_registry.async_get_or_create(
+    entity_entry = entity_registry.async_get_or_create(
         DOMAIN, "test", "5678", device_id=device_entry.id
     )
     expected_triggers = [
@@ -55,7 +55,7 @@ async def test_get_triggers(
             "domain": DOMAIN,
             "type": trigger,
             "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
+            "entity_id": entity_entry.id,
             "metadata": {"secondary": False},
         }
         for trigger in ["changed_states", "turned_off", "turned_on"]
@@ -89,7 +89,7 @@ async def test_get_triggers_hidden_auxiliary(
         config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
-    entity_registry.async_get_or_create(
+    entity_entry = entity_registry.async_get_or_create(
         DOMAIN,
         "test",
         "5678",
@@ -103,7 +103,7 @@ async def test_get_triggers_hidden_auxiliary(
             "domain": DOMAIN,
             "type": trigger,
             "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
+            "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
         for trigger in ["changed_states", "turned_off", "turned_on"]
@@ -144,17 +144,47 @@ async def test_get_trigger_capabilities(
         assert capabilities == expected_capabilities
 
 
+async def test_get_trigger_capabilities_legacy(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test we get the expected capabilities from a switch trigger."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_registry.async_get_or_create(
+        DOMAIN, "test", "5678", device_id=device_entry.id
+    )
+    expected_capabilities = {
+        "extra_fields": [
+            {"name": "for", "optional": True, "type": "positive_time_period_dict"}
+        ]
+    }
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device_entry.id
+    )
+    for trigger in triggers:
+        trigger["entity_id"] = entity_registry.async_get(trigger["entity_id"]).entity_id
+        capabilities = await async_get_device_automation_capabilities(
+            hass, DeviceAutomationType.TRIGGER, trigger
+        )
+        assert capabilities == expected_capabilities
+
+
 async def test_if_fires_on_state_change(
-    hass: HomeAssistant, calls, enable_custom_integrations: None
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    calls,
+    enable_custom_integrations: None,
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
-    platform = getattr(hass.components, f"test.{DOMAIN}")
+    entry = entity_registry.async_get_or_create(DOMAIN, "test", "5678")
 
-    platform.init()
-    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
-    await hass.async_block_till_done()
-
-    ent1, ent2, ent3 = platform.ENTITIES
+    hass.states.async_set(entry.entity_id, STATE_ON)
 
     assert await async_setup_component(
         hass,
@@ -166,7 +196,7 @@ async def test_if_fires_on_state_change(
                         "platform": "device",
                         "domain": DOMAIN,
                         "device_id": "",
-                        "entity_id": ent1.entity_id,
+                        "entity_id": entry.id,
                         "type": "turned_on",
                     },
                     "action": {
@@ -190,7 +220,7 @@ async def test_if_fires_on_state_change(
                         "platform": "device",
                         "domain": DOMAIN,
                         "device_id": "",
-                        "entity_id": ent1.entity_id,
+                        "entity_id": entry.id,
                         "type": "turned_off",
                     },
                     "action": {
@@ -214,7 +244,7 @@ async def test_if_fires_on_state_change(
                         "platform": "device",
                         "domain": DOMAIN,
                         "device_id": "",
-                        "entity_id": ent1.entity_id,
+                        "entity_id": entry.id,
                         "type": "changed_states",
                     },
                     "action": {
@@ -237,37 +267,35 @@ async def test_if_fires_on_state_change(
         },
     )
     await hass.async_block_till_done()
-    assert hass.states.get(ent1.entity_id).state == STATE_ON
     assert len(calls) == 0
 
-    hass.states.async_set(ent1.entity_id, STATE_OFF)
+    hass.states.async_set(entry.entity_id, STATE_OFF)
     await hass.async_block_till_done()
     assert len(calls) == 2
     assert {calls[0].data["some"], calls[1].data["some"]} == {
-        f"turn_off device - {ent1.entity_id} - on - off - None",
-        f"turn_on_or_off device - {ent1.entity_id} - on - off - None",
+        f"turn_off device - {entry.entity_id} - on - off - None",
+        f"turn_on_or_off device - {entry.entity_id} - on - off - None",
     }
 
-    hass.states.async_set(ent1.entity_id, STATE_ON)
+    hass.states.async_set(entry.entity_id, STATE_ON)
     await hass.async_block_till_done()
     assert len(calls) == 4
     assert {calls[2].data["some"], calls[3].data["some"]} == {
-        f"turn_on device - {ent1.entity_id} - off - on - None",
-        f"turn_on_or_off device - {ent1.entity_id} - off - on - None",
+        f"turn_on device - {entry.entity_id} - off - on - None",
+        f"turn_on_or_off device - {entry.entity_id} - off - on - None",
     }
 
 
-async def test_if_fires_on_state_change_with_for(
-    hass: HomeAssistant, calls, enable_custom_integrations: None
+async def test_if_fires_on_state_change_legacy(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    calls,
+    enable_custom_integrations: None,
 ) -> None:
-    """Test for triggers firing with delay."""
-    platform = getattr(hass.components, f"test.{DOMAIN}")
+    """Test for turn_on and turn_off triggers firing."""
+    entry = entity_registry.async_get_or_create(DOMAIN, "test", "5678")
 
-    platform.init()
-    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
-    await hass.async_block_till_done()
-
-    ent1, ent2, ent3 = platform.ENTITIES
+    hass.states.async_set(entry.entity_id, STATE_ON)
 
     assert await async_setup_component(
         hass,
@@ -279,7 +307,62 @@ async def test_if_fires_on_state_change_with_for(
                         "platform": "device",
                         "domain": DOMAIN,
                         "device_id": "",
-                        "entity_id": ent1.entity_id,
+                        "entity_id": entry.entity_id,
+                        "type": "turned_off",
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": "turn_off {{ trigger.%s }}"
+                            % "}} - {{ trigger.".join(
+                                (
+                                    "platform",
+                                    "entity_id",
+                                    "from_state.state",
+                                    "to_state.state",
+                                    "for",
+                                )
+                            )
+                        },
+                    },
+                },
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+    assert len(calls) == 0
+
+    hass.states.async_set(entry.entity_id, STATE_OFF)
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    assert (
+        calls[0].data["some"]
+        == f"turn_off device - {entry.entity_id} - on - off - None"
+    )
+
+
+async def test_if_fires_on_state_change_with_for(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    calls,
+    enable_custom_integrations: None,
+) -> None:
+    """Test for triggers firing with delay."""
+    entry = entity_registry.async_get_or_create(DOMAIN, "test", "5678")
+
+    hass.states.async_set(entry.entity_id, STATE_ON)
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "platform": "device",
+                        "domain": DOMAIN,
+                        "device_id": "",
+                        "entity_id": entry.id,
                         "type": "turned_off",
                         "for": {"seconds": 5},
                     },
@@ -303,16 +386,16 @@ async def test_if_fires_on_state_change_with_for(
         },
     )
     await hass.async_block_till_done()
-    assert hass.states.get(ent1.entity_id).state == STATE_ON
     assert len(calls) == 0
 
-    hass.states.async_set(ent1.entity_id, STATE_OFF)
+    hass.states.async_set(entry.entity_id, STATE_OFF)
     await hass.async_block_till_done()
     assert len(calls) == 0
     async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=10))
     await hass.async_block_till_done()
     assert len(calls) == 1
     await hass.async_block_till_done()
-    assert calls[0].data["some"] == "turn_off device - {} - on - off - 0:00:05".format(
-        ent1.entity_id
+    assert (
+        calls[0].data["some"]
+        == f"turn_off device - {entry.entity_id} - on - off - 0:00:05"
     )

--- a/tests/components/update/test_device_trigger.py
+++ b/tests/components/update/test_device_trigger.py
@@ -45,7 +45,7 @@ async def test_get_triggers(
         config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
-    entity_registry.async_get_or_create(
+    entity_entry = entity_registry.async_get_or_create(
         DOMAIN, "test", "5678", device_id=device_entry.id
     )
     expected_triggers = [
@@ -54,7 +54,7 @@ async def test_get_triggers(
             "domain": DOMAIN,
             "type": trigger,
             "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
+            "entity_id": entity_entry.id,
             "metadata": {"secondary": False},
         }
         for trigger in ["changed_states", "turned_off", "turned_on"]
@@ -88,7 +88,7 @@ async def test_get_triggers_hidden_auxiliary(
         config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
-    entity_registry.async_get_or_create(
+    entity_entry = entity_registry.async_get_or_create(
         DOMAIN,
         "test",
         "5678",
@@ -102,7 +102,7 @@ async def test_get_triggers_hidden_auxiliary(
             "domain": DOMAIN,
             "type": trigger,
             "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
+            "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
         for trigger in ["changed_states", "turned_off", "turned_on"]
@@ -143,8 +143,42 @@ async def test_get_trigger_capabilities(
         assert capabilities == expected_capabilities
 
 
+async def test_get_trigger_capabilities_legacy(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test we get the expected capabilities from a update trigger."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_registry.async_get_or_create(
+        DOMAIN, "test", "5678", device_id=device_entry.id
+    )
+    expected_capabilities = {
+        "extra_fields": [
+            {"name": "for", "optional": True, "type": "positive_time_period_dict"}
+        ]
+    }
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device_entry.id
+    )
+    for trigger in triggers:
+        trigger["entity_id"] = entity_registry.async_get(trigger["entity_id"]).entity_id
+        capabilities = await async_get_device_automation_capabilities(
+            hass, DeviceAutomationType.TRIGGER, trigger
+        )
+        assert capabilities == expected_capabilities
+
+
 async def test_if_fires_on_state_change(
-    hass: HomeAssistant, calls: list[ServiceCall], enable_custom_integrations: None
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    calls: list[ServiceCall],
+    enable_custom_integrations: None,
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
     platform = getattr(hass.components, f"test.{DOMAIN}")
@@ -152,6 +186,8 @@ async def test_if_fires_on_state_change(
     platform.init()
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
     await hass.async_block_till_done()
+
+    entry = entity_registry.async_get("update.update_available")
 
     assert await async_setup_component(
         hass,
@@ -163,7 +199,7 @@ async def test_if_fires_on_state_change(
                         "platform": "device",
                         "domain": DOMAIN,
                         "device_id": "",
-                        "entity_id": "update.update_available",
+                        "entity_id": entry.id,
                         "type": "turned_on",
                     },
                     "action": {
@@ -232,15 +268,20 @@ async def test_if_fires_on_state_change(
     )
 
 
-async def test_if_fires_on_state_change_with_for(
-    hass: HomeAssistant, calls: list[ServiceCall], enable_custom_integrations: None
+async def test_if_fires_on_state_change_legacy(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    calls: list[ServiceCall],
+    enable_custom_integrations: None,
 ) -> None:
-    """Test for triggers firing with delay."""
+    """Test for turn_on and turn_off triggers firing."""
     platform = getattr(hass.components, f"test.{DOMAIN}")
 
     platform.init()
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
     await hass.async_block_till_done()
+
+    entry = entity_registry.async_get("update.update_available")
 
     assert await async_setup_component(
         hass,
@@ -252,7 +293,69 @@ async def test_if_fires_on_state_change_with_for(
                         "platform": "device",
                         "domain": DOMAIN,
                         "device_id": "",
-                        "entity_id": "update.update_available",
+                        "entity_id": entry.entity_id,
+                        "type": "turned_off",
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": "no_update {{ trigger.%s }}"
+                            % "}} - {{ trigger.".join(
+                                (
+                                    "platform",
+                                    "entity_id",
+                                    "from_state.state",
+                                    "to_state.state",
+                                    "for",
+                                )
+                            )
+                        },
+                    },
+                },
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("update.update_available")
+    assert state
+    assert state.state == STATE_ON
+    assert not calls
+
+    hass.states.async_set("update.update_available", STATE_OFF)
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    assert (
+        calls[0].data["some"]
+        == "no_update device - update.update_available - on - off - None"
+    )
+
+
+async def test_if_fires_on_state_change_with_for(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    calls: list[ServiceCall],
+    enable_custom_integrations: None,
+) -> None:
+    """Test for triggers firing with delay."""
+    platform = getattr(hass.components, f"test.{DOMAIN}")
+
+    platform.init()
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
+
+    entry = entity_registry.async_get("update.update_available")
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "platform": "device",
+                        "domain": DOMAIN,
+                        "device_id": "",
+                        "entity_id": entry.id,
                         "type": "turned_off",
                         "for": {"seconds": 5},
                     },

--- a/tests/components/wemo/test_device_trigger.py
+++ b/tests/components/wemo/test_device_trigger.py
@@ -71,7 +71,7 @@ async def test_get_triggers(hass: HomeAssistant, wemo_entity) -> None:
         {
             CONF_DEVICE_ID: wemo_entity.device_id,
             CONF_DOMAIN: Platform.SWITCH,
-            CONF_ENTITY_ID: wemo_entity.entity_id,
+            CONF_ENTITY_ID: wemo_entity.id,
             CONF_PLATFORM: "device",
             CONF_TYPE: "changed_states",
             "metadata": {"secondary": False},
@@ -79,7 +79,7 @@ async def test_get_triggers(hass: HomeAssistant, wemo_entity) -> None:
         {
             CONF_DEVICE_ID: wemo_entity.device_id,
             CONF_DOMAIN: Platform.SWITCH,
-            CONF_ENTITY_ID: wemo_entity.entity_id,
+            CONF_ENTITY_ID: wemo_entity.id,
             CONF_PLATFORM: "device",
             CONF_TYPE: "turned_off",
             "metadata": {"secondary": False},
@@ -87,7 +87,7 @@ async def test_get_triggers(hass: HomeAssistant, wemo_entity) -> None:
         {
             CONF_DEVICE_ID: wemo_entity.device_id,
             CONF_DOMAIN: Platform.SWITCH,
-            CONF_ENTITY_ID: wemo_entity.entity_id,
+            CONF_ENTITY_ID: wemo_entity.id,
             CONF_PLATFORM: "device",
             CONF_TYPE: "turned_on",
             "metadata": {"secondary": False},

--- a/tests/components/zha/test_device_action.py
+++ b/tests/components/zha/test_device_action.py
@@ -14,7 +14,7 @@ from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.zha import DOMAIN
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from .conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_TYPE
@@ -164,6 +164,8 @@ async def test_get_inovelli_actions(hass: HomeAssistant, device_inovelli) -> Non
     inovelli_reg_device = ha_device_registry.async_get_device(
         {(DOMAIN, inovelli_ieee_address)}
     )
+    ha_entity_registry = er.async_get(hass)
+    inovelli_light = ha_entity_registry.async_get("light.inovelli_vzm31_sn_light")
 
     actions = await async_get_device_automations(
         hass, DeviceAutomationType.ACTION, inovelli_reg_device.id
@@ -192,21 +194,21 @@ async def test_get_inovelli_actions(hass: HomeAssistant, device_inovelli) -> Non
         {
             "device_id": inovelli_reg_device.id,
             "domain": Platform.LIGHT,
-            "entity_id": "light.inovelli_vzm31_sn_light",
+            "entity_id": inovelli_light.id,
             "metadata": {"secondary": False},
             "type": "turn_off",
         },
         {
             "device_id": inovelli_reg_device.id,
             "domain": Platform.LIGHT,
-            "entity_id": "light.inovelli_vzm31_sn_light",
+            "entity_id": inovelli_light.id,
             "metadata": {"secondary": False},
             "type": "turn_on",
         },
         {
             "device_id": inovelli_reg_device.id,
             "domain": Platform.LIGHT,
-            "entity_id": "light.inovelli_vzm31_sn_light",
+            "entity_id": inovelli_light.id,
             "metadata": {"secondary": False},
             "type": "toggle",
         },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use entity registry id in toggle_entity device automations

#### Background:
When a device automation is configured by the user, the user picks a device without specifying an `entity_id`. If the user then changes the `entity_id` of that entity, the configured device automation no longer works.
By instead referencing the entity registry id of the entity, the device automation is still valid.

~Needs https://github.com/home-assistant/core/pull/95009 for tests to pass~

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
