### PR TITLE
Fix zwave_js device diagnostics dump

### DIFF
--- a/tests/components/zwave_js/test_diagnostics.py
+++ b/tests/components/zwave_js/test_diagnostics.py
@@ -72,7 +72,7 @@ async def test_device_diagnostics(
         "test",
         "test_integration",
         "test_unique_id",
-        suggested_object_id="test",
+        suggested_object_id="unrelated_entity",
         config_entry=mock_config_entry,
         device_id=device.id,
     )

--- a/tests/components/zwave_js/test_diagnostics.py
+++ b/tests/components/zwave_js/test_diagnostics.py
@@ -76,7 +76,7 @@ async def test_device_diagnostics(
         config_entry=mock_config_entry,
         device_id=device.id,
     )
-    assert ent_reg.async_get("test.test")
+    assert ent_reg.async_get("test.unrelated_entity")
 
     # Update a value and ensure it is reflected in the node state
     event = Event(

--- a/tests/components/zwave_js/test_diagnostics.py
+++ b/tests/components/zwave_js/test_diagnostics.py
@@ -117,7 +117,7 @@ async def test_device_diagnostics(
     # Explicitly check that the entity that is not part of this config entry is not
     # in the dump.
     assert not any(
-        entity["entity_id"] == "test.test" for entity in diagnostics_data["entities"]
+        entity["entity_id"] == "test.unrelated_entity" for entity in diagnostics_data["entities"]
     )
     assert diagnostics_data["state"] == multisensor_6.data
 

--- a/tests/components/zwave_js/test_diagnostics.py
+++ b/tests/components/zwave_js/test_diagnostics.py
@@ -63,7 +63,7 @@ async def test_device_diagnostics(
     assert device
 
     # Create mock config entry for fake entity
-    mock_config_entry = MockConfigEntry(domain="test", unique_id="test")
+    mock_config_entry = MockConfigEntry(domain="test_integration")
     mock_config_entry.add_to_hass(hass)
 
     # Add an entity entry to the device that is not part of this config entry

--- a/tests/components/zwave_js/test_diagnostics.py
+++ b/tests/components/zwave_js/test_diagnostics.py
@@ -70,7 +70,7 @@ async def test_device_diagnostics(
     ent_reg = async_get_ent_reg(hass)
     ent_reg.async_get_or_create(
         "test",
-        "test",
+        "test_integration",
         "test",
         suggested_object_id="test",
         config_entry=mock_config_entry,

--- a/tests/components/zwave_js/test_diagnostics.py
+++ b/tests/components/zwave_js/test_diagnostics.py
@@ -71,7 +71,7 @@ async def test_device_diagnostics(
     ent_reg.async_get_or_create(
         "test",
         "test_integration",
-        "test",
+        "test_unique_id",
         suggested_object_id="test",
         config_entry=mock_config_entry,
         device_id=device.id,


### PR DESCRIPTION
## Proposed change
Picking up https://github.com/home-assistant/core/pull/89243 to exclude non `zwave_js` entities from the diagnostics dump because:
- it breaks assumptions in the diagnostics logic
- they are not relevant to troubleshooting `zwave_js` issues


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
