### PR TITLE
Fix use_device_name in case device device class translations are used

### DIFF
--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -355,14 +355,14 @@ class Entity(ABC):
         if hasattr(self, "entity_description"):
             if not (name := self.entity_description.name):
                 return True
-            if name is UNDEFINED:
+            if name is UNDEFINED and not self._default_to_device_class_name():
                 # Backwards compatibility with leaving EntityDescription.name unassigned
                 # for device name.
                 # Deprecated in HA Core 2023.6, remove in HA Core 2023.9
                 report_implicit_device_name()
                 return True
             return False
-        if self.name is UNDEFINED:
+        if self.name is UNDEFINED and not self._default_to_device_class_name():
             # Backwards compatibility with not overriding name property for device name.
             # Deprecated in HA Core 2023.6, remove in HA Core 2023.9
             report_implicit_device_name()

--- a/tests/components/sensor/test_init.py
+++ b/tests/components/sensor/test_init.py
@@ -2311,18 +2311,22 @@ async def test_name(hass: HomeAssistant) -> None:
 
     # Unnamed sensor without device class -> no name
     entity1 = SensorEntity()
+    entity1.entity_id = "sensor.test1"
 
     # Unnamed sensor with device class but has_entity_name False -> no name
     entity2 = SensorEntity()
+    entity2.entity_id = "sensor.test2"
     entity2._attr_device_class = SensorDeviceClass.BATTERY
 
     # Unnamed sensor with device class and has_entity_name True -> named
     entity3 = SensorEntity()
+    entity3.entity_id = "sensor.test3"
     entity3._attr_device_class = SensorDeviceClass.BATTERY
     entity3._attr_has_entity_name = True
 
     # Unnamed sensor with device class and has_entity_name True -> named
     entity4 = SensorEntity()
+    entity4.entity_id = "sensor.test4"
     entity4.entity_description = SensorEntityDescription(
         "test",
         SensorDeviceClass.BATTERY,
@@ -2331,7 +2335,9 @@ async def test_name(hass: HomeAssistant) -> None:
 
     # Unnamed sensor with device class + device info + has_entity_name True -> named
     entity5 = SensorEntity()
+    entity5.entity_id = "sensor.test5"
     entity5._attr_device_class = SensorDeviceClass.BATTERY
+    entity5._attr_unique_id = "entity5"
     entity5._attr_device_info = DeviceInfo(
         name="Fluxcapacitor",
         identifiers={("delorean", "VIN#500")},
@@ -2340,6 +2346,8 @@ async def test_name(hass: HomeAssistant) -> None:
 
     # Unnamed sensor with device class + device info + has_entity_name True -> named
     entity6 = SensorEntity()
+    entity6.entity_id = "sensor.test6"
+    entity6._attr_unique_id = "entity6"
     entity6._attr_device_info = DeviceInfo(
         name="Fluxcapacitor",
         identifiers={("delorean", "VIN#500")},
@@ -2383,7 +2391,13 @@ async def test_name(hass: HomeAssistant) -> None:
     assert state.attributes == {"device_class": "battery", "friendly_name": "Battery"}
 
     state = hass.states.get(entity5.entity_id)
-    assert state.attributes == {"device_class": "battery", "friendly_name": "Battery"}
+    assert state.attributes == {
+        "device_class": "battery",
+        "friendly_name": "Fluxcapacitor Battery",
+    }
 
     state = hass.states.get(entity6.entity_id)
-    assert state.attributes == {"device_class": "battery", "friendly_name": "Battery"}
+    assert state.attributes == {
+        "device_class": "battery",
+        "friendly_name": "Fluxcapacitor Battery",
+    }

--- a/tests/components/sensor/test_init.py
+++ b/tests/components/sensor/test_init.py
@@ -35,7 +35,6 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import STORAGE_KEY as RESTORE_STATE_KEY
 from homeassistant.setup import async_setup_component
@@ -2333,39 +2332,13 @@ async def test_name(hass: HomeAssistant) -> None:
         has_entity_name=True,
     )
 
-    # Unnamed sensor with device class + device info + has_entity_name True -> named
-    entity5 = SensorEntity()
-    entity5.entity_id = "sensor.test5"
-    entity5._attr_device_class = SensorDeviceClass.BATTERY
-    entity5._attr_unique_id = "entity5"
-    entity5._attr_device_info = DeviceInfo(
-        name="Fluxcapacitor",
-        identifiers={("delorean", "VIN#500")},
-    )
-    entity5._attr_has_entity_name = True
-
-    # Unnamed sensor with device class + device info + has_entity_name True -> named
-    entity6 = SensorEntity()
-    entity6.entity_id = "sensor.test6"
-    entity6._attr_unique_id = "entity6"
-    entity6._attr_device_info = DeviceInfo(
-        name="Fluxcapacitor",
-        identifiers={("delorean", "VIN#500")},
-    )
-    entity6.entity_description = SensorEntityDescription(
-        "test",
-        SensorDeviceClass.BATTERY,
-        has_entity_name=True,
-    )
-    entity6._attr_has_entity_name = True
-
     async def async_setup_entry_platform(
         hass: HomeAssistant,
         config_entry: ConfigEntry,
         async_add_entities: AddEntitiesCallback,
     ) -> None:
         """Set up test stt platform via config entry."""
-        async_add_entities([entity1, entity2, entity3, entity4, entity5, entity6])
+        async_add_entities([entity1, entity2, entity3, entity4])
 
     mock_platform(
         hass,
@@ -2389,15 +2362,3 @@ async def test_name(hass: HomeAssistant) -> None:
 
     state = hass.states.get(entity4.entity_id)
     assert state.attributes == {"device_class": "battery", "friendly_name": "Battery"}
-
-    state = hass.states.get(entity5.entity_id)
-    assert state.attributes == {
-        "device_class": "battery",
-        "friendly_name": "Fluxcapacitor Battery",
-    }
-
-    state = hass.states.get(entity6.entity_id)
-    assert state.attributes == {
-        "device_class": "battery",
-        "friendly_name": "Fluxcapacitor Battery",
-    }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fixes `Entity.use_device_name()`, when the entity is part of a device, this method is used to determine if the device name should be used as the entity name. This however, didn't take the new device class translation into account.

This issue was introduced in #90767, which is currently only on the `dev` branch.

Discovered during clean-up translations in #95011, which now has failing tests.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
