### PR TITLE
Add `device_class` and `state_class` in config flow for SQL

### DIFF
--- a/homeassistant/components/sql/config_flow.py
+++ b/homeassistant/components/sql/config_flow.py
@@ -179,9 +179,9 @@ class SQLConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 options[CONF_UNIT_OF_MEASUREMENT] = uom
             if value_template := user_input.get(CONF_VALUE_TEMPLATE):
                 options[CONF_VALUE_TEMPLATE] = value_template
-            if (device_class := user_input.get(CONF_DEVICE_CLASS)) != NONE_SENTINEL:
+            if (device_class := user_input[CONF_DEVICE_CLASS]) != NONE_SENTINEL:
                 options[CONF_DEVICE_CLASS] = device_class
-            if (state_class := user_input.get(CONF_STATE_CLASS)) != NONE_SENTINEL:
+            if (state_class := user_input[CONF_STATE_CLASS]) != NONE_SENTINEL:
                 options[CONF_STATE_CLASS] = state_class
             if db_url_for_validation != get_instance(self.hass).db_url:
                 options[CONF_DB_URL] = db_url_for_validation
@@ -248,9 +248,9 @@ class SQLOptionsFlowHandler(config_entries.OptionsFlowWithConfigEntry):
                     options[CONF_UNIT_OF_MEASUREMENT] = uom
                 if value_template := user_input.get(CONF_VALUE_TEMPLATE):
                     options[CONF_VALUE_TEMPLATE] = value_template
-                if (device_class := user_input.get(CONF_DEVICE_CLASS)) != NONE_SENTINEL:
+                if (device_class := user_input[CONF_DEVICE_CLASS]) != NONE_SENTINEL:
                     options[CONF_DEVICE_CLASS] = device_class
-                if (state_class := user_input.get(CONF_STATE_CLASS)) != NONE_SENTINEL:
+                if (state_class := user_input[CONF_STATE_CLASS]) != NONE_SENTINEL:
                     options[CONF_STATE_CLASS] = state_class
                 if db_url_for_validation != get_instance(self.hass).db_url:
                     options[CONF_DB_URL] = db_url_for_validation

--- a/homeassistant/components/sql/config_flow.py
+++ b/homeassistant/components/sql/config_flow.py
@@ -53,6 +53,7 @@ OPTIONS_SCHEMA: vol.Schema = vol.Schema(
         ): selector.TemplateSelector(),
         vol.Optional(
             CONF_DEVICE_CLASS,
+            default=NONE_SENTINEL,
         ): selector.SelectSelector(
             selector.SelectSelectorConfig(
                 options=[NONE_SENTINEL]
@@ -67,7 +68,10 @@ OPTIONS_SCHEMA: vol.Schema = vol.Schema(
                 translation_key="device_class",
             )
         ),
-        vol.Optional(CONF_STATE_CLASS): selector.SelectSelector(
+        vol.Optional(
+            CONF_STATE_CLASS,
+            default=NONE_SENTINEL,
+        ): selector.SelectSelector(
             selector.SelectSelectorConfig(
                 options=[NONE_SENTINEL]
                 + sorted([cls.value for cls in SensorStateClass]),
@@ -175,9 +179,9 @@ class SQLConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 options[CONF_UNIT_OF_MEASUREMENT] = uom
             if value_template := user_input.get(CONF_VALUE_TEMPLATE):
                 options[CONF_VALUE_TEMPLATE] = value_template
-            if device_class := user_input.get(CONF_DEVICE_CLASS):
+            if (device_class := user_input.get(CONF_DEVICE_CLASS)) != NONE_SENTINEL:
                 options[CONF_DEVICE_CLASS] = device_class
-            if state_class := user_input.get(CONF_STATE_CLASS):
+            if (state_class := user_input.get(CONF_STATE_CLASS)) != NONE_SENTINEL:
                 options[CONF_STATE_CLASS] = state_class
             if db_url_for_validation != get_instance(self.hass).db_url:
                 options[CONF_DB_URL] = db_url_for_validation
@@ -244,9 +248,9 @@ class SQLOptionsFlowHandler(config_entries.OptionsFlowWithConfigEntry):
                     options[CONF_UNIT_OF_MEASUREMENT] = uom
                 if value_template := user_input.get(CONF_VALUE_TEMPLATE):
                     options[CONF_VALUE_TEMPLATE] = value_template
-                if device_class := user_input.get(CONF_DEVICE_CLASS):
+                if (device_class := user_input.get(CONF_DEVICE_CLASS)) != NONE_SENTINEL:
                     options[CONF_DEVICE_CLASS] = device_class
-                if state_class := user_input.get(CONF_STATE_CLASS):
+                if (state_class := user_input.get(CONF_STATE_CLASS)) != NONE_SENTINEL:
                     options[CONF_STATE_CLASS] = state_class
                 if db_url_for_validation != get_instance(self.hass).db_url:
                     options[CONF_DB_URL] = db_url_for_validation

--- a/homeassistant/components/sql/config_flow.py
+++ b/homeassistant/components/sql/config_flow.py
@@ -12,7 +12,17 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.components.recorder import CONF_DB_URL, get_instance
-from homeassistant.const import CONF_NAME, CONF_UNIT_OF_MEASUREMENT, CONF_VALUE_TEMPLATE
+from homeassistant.components.sensor import (
+    CONF_STATE_CLASS,
+    SensorDeviceClass,
+    SensorStateClass,
+)
+from homeassistant.const import (
+    CONF_DEVICE_CLASS,
+    CONF_NAME,
+    CONF_UNIT_OF_MEASUREMENT,
+    CONF_VALUE_TEMPLATE,
+)
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import selector
@@ -21,6 +31,8 @@ from .const import CONF_COLUMN_NAME, CONF_QUERY, DOMAIN
 from .util import resolve_db_url
 
 _LOGGER = logging.getLogger(__name__)
+
+NONE_SENTINEL = "none"
 
 OPTIONS_SCHEMA: vol.Schema = vol.Schema(
     {
@@ -39,6 +51,30 @@ OPTIONS_SCHEMA: vol.Schema = vol.Schema(
         vol.Optional(
             CONF_VALUE_TEMPLATE,
         ): selector.TemplateSelector(),
+        vol.Optional(
+            CONF_DEVICE_CLASS,
+        ): selector.SelectSelector(
+            selector.SelectSelectorConfig(
+                options=[NONE_SENTINEL]
+                + sorted(
+                    [
+                        cls.value
+                        for cls in SensorDeviceClass
+                        if cls != SensorDeviceClass.ENUM
+                    ]
+                ),
+                mode=selector.SelectSelectorMode.DROPDOWN,
+                translation_key="device_class",
+            )
+        ),
+        vol.Optional(CONF_STATE_CLASS): selector.SelectSelector(
+            selector.SelectSelectorConfig(
+                options=[NONE_SENTINEL]
+                + sorted([cls.value for cls in SensorStateClass]),
+                mode=selector.SelectSelectorMode.DROPDOWN,
+                translation_key="state_class",
+            )
+        ),
     }
 )
 
@@ -139,6 +175,10 @@ class SQLConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 options[CONF_UNIT_OF_MEASUREMENT] = uom
             if value_template := user_input.get(CONF_VALUE_TEMPLATE):
                 options[CONF_VALUE_TEMPLATE] = value_template
+            if device_class := user_input.get(CONF_DEVICE_CLASS):
+                options[CONF_DEVICE_CLASS] = device_class
+            if state_class := user_input.get(CONF_STATE_CLASS):
+                options[CONF_STATE_CLASS] = state_class
             if db_url_for_validation != get_instance(self.hass).db_url:
                 options[CONF_DB_URL] = db_url_for_validation
 
@@ -204,6 +244,10 @@ class SQLOptionsFlowHandler(config_entries.OptionsFlowWithConfigEntry):
                     options[CONF_UNIT_OF_MEASUREMENT] = uom
                 if value_template := user_input.get(CONF_VALUE_TEMPLATE):
                     options[CONF_VALUE_TEMPLATE] = value_template
+                if device_class := user_input.get(CONF_DEVICE_CLASS):
+                    options[CONF_DEVICE_CLASS] = device_class
+                if state_class := user_input.get(CONF_STATE_CLASS):
+                    options[CONF_STATE_CLASS] = state_class
                 if db_url_for_validation != get_instance(self.hass).db_url:
                     options[CONF_DB_URL] = db_url_for_validation
 

--- a/homeassistant/components/sql/sensor.py
+++ b/homeassistant/components/sql/sensor.py
@@ -101,6 +101,8 @@ async def async_setup_entry(
     unit: str | None = entry.options.get(CONF_UNIT_OF_MEASUREMENT)
     template: str | None = entry.options.get(CONF_VALUE_TEMPLATE)
     column_name: str = entry.options[CONF_COLUMN_NAME]
+    device_class: SensorDeviceClass | None = entry.options.get(CONF_DEVICE_CLASS, None)
+    state_class: SensorStateClass | None = entry.options.get(CONF_STATE_CLASS, None)
 
     value_template: Template | None = None
     if template is not None:
@@ -122,8 +124,8 @@ async def async_setup_entry(
         entry.entry_id,
         db_url,
         False,
-        None,
-        None,
+        device_class,
+        state_class,
         async_add_entities,
     )
 

--- a/homeassistant/components/sql/strings.json
+++ b/homeassistant/components/sql/strings.json
@@ -16,7 +16,9 @@
           "query": "Select Query",
           "column": "Column",
           "unit_of_measurement": "Unit of Measure",
-          "value_template": "Value Template"
+          "value_template": "Value Template",
+          "device_class": "Device Class",
+          "state_class": "State Class"
         },
         "data_description": {
           "db_url": "Database URL, leave empty to use HA recorder database",
@@ -24,7 +26,9 @@
           "query": "Query to run, needs to start with 'SELECT'",
           "column": "Column for returned query to present as state",
           "unit_of_measurement": "Unit of Measure (optional)",
-          "value_template": "Value Template (optional)"
+          "value_template": "Value Template (optional)",
+          "device_class": "The type/class of the sensor to set the icon in the frontend",
+          "state_class": "The state_class of the sensor"
         }
       }
     }
@@ -38,7 +42,9 @@
           "query": "[%key:component::sql::config::step::user::data::query%]",
           "column": "[%key:component::sql::config::step::user::data::column%]",
           "unit_of_measurement": "[%key:component::sql::config::step::user::data::unit_of_measurement%]",
-          "value_template": "[%key:component::sql::config::step::user::data::value_template%]"
+          "value_template": "[%key:component::sql::config::step::user::data::value_template%]",
+          "device_class": "[%key:component::sql::config::step::user::data::device_class%]",
+          "state_class": "[%key:component::sql::config::step::user::data::state_class%]"
         },
         "data_description": {
           "db_url": "[%key:component::sql::config::step::user::data_description::db_url%]",
@@ -46,7 +52,9 @@
           "query": "[%key:component::sql::config::step::user::data_description::query%]",
           "column": "[%key:component::sql::config::step::user::data_description::column%]",
           "unit_of_measurement": "[%key:component::sql::config::step::user::data_description::unit_of_measurement%]",
-          "value_template": "[%key:component::sql::config::step::user::data_description::value_template%]"
+          "value_template": "[%key:component::sql::config::step::user::data_description::value_template%]",
+          "device_class": "[%key:component::sql::config::step::user::data_description::device_class%]",
+          "state_class": "[%key:component::sql::config::step::user::data_description::state_class%]"
         }
       }
     },
@@ -54,6 +62,68 @@
       "db_url_invalid": "[%key:component::sql::config::error::db_url_invalid%]",
       "query_invalid": "[%key:component::sql::config::error::query_invalid%]",
       "column_invalid": "[%key:component::sql::config::error::column_invalid%]"
+    }
+  },
+  "selector": {
+    "device_class": {
+      "options": {
+        "none": "No device class",
+        "date": "[%key:component::sensor::entity_component::date::name%]",
+        "duration": "[%key:component::sensor::entity_component::duration::name%]",
+        "apparent_power": "[%key:component::sensor::entity_component::apparent_power::name%]",
+        "aqi": "[%key:component::sensor::entity_component::aqi::name%]",
+        "atmospheric_pressure": "[%key:component::sensor::entity_component::atmospheric_pressure::name%]",
+        "battery": "[%key:component::sensor::entity_component::battery::name%]",
+        "carbon_monoxide": "[%key:component::sensor::entity_component::carbon_monoxide::name%]",
+        "carbon_dioxide": "[%key:component::sensor::entity_component::carbon_dioxide::name%]",
+        "current": "[%key:component::sensor::entity_component::current::name%]",
+        "data_rate": "[%key:component::sensor::entity_component::data_rate::name%]",
+        "data_size": "[%key:component::sensor::entity_component::data_size::name%]",
+        "distance": "[%key:component::sensor::entity_component::distance::name%]",
+        "energy": "[%key:component::sensor::entity_component::energy::name%]",
+        "energy_storage": "[%key:component::sensor::entity_component::energy_storage::name%]",
+        "frequency": "[%key:component::sensor::entity_component::frequency::name%]",
+        "gas": "[%key:component::sensor::entity_component::gas::name%]",
+        "humidity": "[%key:component::sensor::entity_component::humidity::name%]",
+        "illuminance": "[%key:component::sensor::entity_component::illuminance::name%]",
+        "irradiance": "[%key:component::sensor::entity_component::irradiance::name%]",
+        "moisture": "[%key:component::sensor::entity_component::moisture::name%]",
+        "monetary": "[%key:component::sensor::entity_component::monetary::name%]",
+        "nitrogen_dioxide": "[%key:component::sensor::entity_component::nitrogen_dioxide::name%]",
+        "nitrogen_monoxide": "[%key:component::sensor::entity_component::nitrogen_monoxide::name%]",
+        "nitrous_oxide": "[%key:component::sensor::entity_component::nitrous_oxide::name%]",
+        "ozone": "[%key:component::sensor::entity_component::ozone::name%]",
+        "pm1": "[%key:component::sensor::entity_component::pm1::name%]",
+        "pm10": "[%key:component::sensor::entity_component::pm10::name%]",
+        "pm25": "[%key:component::sensor::entity_component::pm25::name%]",
+        "power_factor": "[%key:component::sensor::entity_component::power_factor::name%]",
+        "power": "[%key:component::sensor::entity_component::power::name%]",
+        "precipitation": "[%key:component::sensor::entity_component::precipitation::name%]",
+        "precipitation_intensity": "[%key:component::sensor::entity_component::precipitation_intensity::name%]",
+        "pressure": "[%key:component::sensor::entity_component::pressure::name%]",
+        "reactive_power": "[%key:component::sensor::entity_component::reactive_power::name%]",
+        "signal_strength": "[%key:component::sensor::entity_component::signal_strength::name%]",
+        "sound_pressure": "[%key:component::sensor::entity_component::sound_pressure::name%]",
+        "speed": "[%key:component::sensor::entity_component::speed::name%]",
+        "sulphur_dioxide": "[%key:component::sensor::entity_component::sulphur_dioxide::name%]",
+        "temperature": "[%key:component::sensor::entity_component::temperature::name%]",
+        "timestamp": "[%key:component::sensor::entity_component::timestamp::name%]",
+        "volatile_organic_compounds": "[%key:component::sensor::entity_component::volatile_organic_compounds::name%]",
+        "voltage": "[%key:component::sensor::entity_component::voltage::name%]",
+        "volume": "[%key:component::sensor::entity_component::volume::name%]",
+        "volume_storage": "[%key:component::sensor::entity_component::volume_storage::name%]",
+        "water": "[%key:component::sensor::entity_component::water::name%]",
+        "weight": "[%key:component::sensor::entity_component::weight::name%]",
+        "wind_speed": "[%key:component::sensor::entity_component::wind_speed::name%]"
+      }
+    },
+    "state_class": {
+      "options": {
+        "none": "No state class",
+        "measurement": "[%key:component::sensor::entity_component::_::state_attributes::state_class::state::measurement%]",
+        "total": "[%key:component::sensor::entity_component::_::state_attributes::state_class::state::total%]",
+        "total_increasing": "[%key:component::sensor::entity_component::_::state_attributes::state_class::state::total_increasing%]"
+      }
     }
   },
   "issues": {

--- a/homeassistant/components/sql/strings.json
+++ b/homeassistant/components/sql/strings.json
@@ -109,6 +109,7 @@
         "temperature": "[%key:component::sensor::entity_component::temperature::name%]",
         "timestamp": "[%key:component::sensor::entity_component::timestamp::name%]",
         "volatile_organic_compounds": "[%key:component::sensor::entity_component::volatile_organic_compounds::name%]",
+        "volatile_organic_compounds_parts": "[%key:component::sensor::entity_component::volatile_organic_compounds_parts::name%]",
         "voltage": "[%key:component::sensor::entity_component::voltage::name%]",
         "volume": "[%key:component::sensor::entity_component::volume::name%]",
         "volume_storage": "[%key:component::sensor::entity_component::volume_storage::name%]",

--- a/tests/components/sql/__init__.py
+++ b/tests/components/sql/__init__.py
@@ -27,8 +27,8 @@ ENTRY_CONFIG = {
     CONF_QUERY: "SELECT 5 as value",
     CONF_COLUMN_NAME: "value",
     CONF_UNIT_OF_MEASUREMENT: "MiB",
-    CONF_DEVICE_CLASS: "data_size",
-    CONF_STATE_CLASS: "total",
+    CONF_DEVICE_CLASS: SensorDeviceClass.DATA_SIZE,
+    CONF_STATE_CLASS: SensorStateClass.TOTAL,
 }
 
 ENTRY_CONFIG_WITH_VALUE_TEMPLATE = {

--- a/tests/components/sql/__init__.py
+++ b/tests/components/sql/__init__.py
@@ -27,6 +27,8 @@ ENTRY_CONFIG = {
     CONF_QUERY: "SELECT 5 as value",
     CONF_COLUMN_NAME: "value",
     CONF_UNIT_OF_MEASUREMENT: "MiB",
+    CONF_DEVICE_CLASS: "data_size",
+    CONF_STATE_CLASS: "total",
 }
 
 ENTRY_CONFIG_WITH_VALUE_TEMPLATE = {

--- a/tests/components/sql/test_config_flow.py
+++ b/tests/components/sql/test_config_flow.py
@@ -21,7 +21,6 @@ from . import (
     ENTRY_CONFIG_INVALID_QUERY_OPT,
     ENTRY_CONFIG_NO_RESULTS,
     ENTRY_CONFIG_WITH_VALUE_TEMPLATE,
-    init_integration,
 )
 
 from tests.common import MockConfigEntry
@@ -656,14 +655,6 @@ async def test_device_state_class(recorder_mock: Recorder, hass: HomeAssistant) 
         "state_class": SensorStateClass.TOTAL,
     }
 
-    await init_integration(hass, result2["data"], entry_id=entry.entry_id)
-
-    state = hass.states.get("sensor.get_value")
-    assert state.state == "5"
-    assert state.attributes["device_class"] == SensorDeviceClass.DATA_SIZE
-    assert state.attributes["state_class"] == SensorStateClass.TOTAL
-    assert state.attributes["unit_of_measurement"] == "MiB"
-
     result = await hass.config_entries.options.async_init(entry.entry_id)
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "init"
@@ -685,17 +676,11 @@ async def test_device_state_class(recorder_mock: Recorder, hass: HomeAssistant) 
         await hass.async_block_till_done()
 
     assert result3["type"] == FlowResultType.CREATE_ENTRY
+    assert "device_class" not in result3["data"]
+    assert "state_class" not in result3["data"]
     assert result3["data"] == {
         "name": "Get Value",
         "query": "SELECT 5 as value",
         "column": "value",
         "unit_of_measurement": "MiB",
     }
-
-    await init_integration(hass, result3["data"], entry_id=entry.entry_id)
-
-    state = hass.states.get("sensor.get_value")
-    assert state.state == "5"
-    assert "device_class" not in state.attributes
-    assert "state_class" not in state.attributes
-    assert state.attributes["unit_of_measurement"] == "MiB"

--- a/tests/components/sql/test_config_flow.py
+++ b/tests/components/sql/test_config_flow.py
@@ -21,6 +21,7 @@ from . import (
     ENTRY_CONFIG_INVALID_QUERY_OPT,
     ENTRY_CONFIG_NO_RESULTS,
     ENTRY_CONFIG_WITH_VALUE_TEMPLATE,
+    init_integration,
 )
 
 from tests.common import MockConfigEntry
@@ -655,6 +656,14 @@ async def test_device_state_class(recorder_mock: Recorder, hass: HomeAssistant) 
         "state_class": SensorStateClass.TOTAL,
     }
 
+    await init_integration(hass, result2["data"], entry_id=entry.entry_id)
+
+    state = hass.states.get("sensor.get_value")
+    assert state.state == "5"
+    assert state.attributes["device_class"] == SensorDeviceClass.DATA_SIZE
+    assert state.attributes["state_class"] == SensorStateClass.TOTAL
+    assert state.attributes["unit_of_measurement"] == "MiB"
+
     result = await hass.config_entries.options.async_init(entry.entry_id)
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "init"
@@ -682,3 +691,11 @@ async def test_device_state_class(recorder_mock: Recorder, hass: HomeAssistant) 
         "column": "value",
         "unit_of_measurement": "MiB",
     }
+
+    await init_integration(hass, result3["data"], entry_id=entry.entry_id)
+
+    state = hass.states.get("sensor.get_value")
+    assert state.state == "5"
+    assert "device_class" not in state.attributes
+    assert "state_class" not in state.attributes
+    assert state.attributes["unit_of_measurement"] == "MiB"

--- a/tests/components/sql/test_config_flow.py
+++ b/tests/components/sql/test_config_flow.py
@@ -7,6 +7,7 @@ from sqlalchemy.exc import SQLAlchemyError
 
 from homeassistant import config_entries
 from homeassistant.components.recorder import Recorder
+from homeassistant.components.sensor.const import SensorDeviceClass, SensorStateClass
 from homeassistant.components.sql.config_flow import NONE_SENTINEL
 from homeassistant.components.sql.const import DOMAIN
 from homeassistant.core import HomeAssistant
@@ -51,8 +52,8 @@ async def test_form(recorder_mock: Recorder, hass: HomeAssistant) -> None:
         "query": "SELECT 5 as value",
         "column": "value",
         "unit_of_measurement": "MiB",
-        "device_class": "data_size",
-        "state_class": "total",
+        "device_class": SensorDeviceClass.DATA_SIZE,
+        "state_class": SensorStateClass.TOTAL,
     }
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -154,8 +155,8 @@ async def test_flow_fails_invalid_query(
         "query": "SELECT 5 as value",
         "column": "value",
         "unit_of_measurement": "MiB",
-        "device_class": "data_size",
-        "state_class": "total",
+        "device_class": SensorDeviceClass.DATA_SIZE,
+        "state_class": SensorStateClass.TOTAL,
     }
 
 
@@ -192,8 +193,8 @@ async def test_flow_fails_invalid_column_name(
         "query": "SELECT 5 as value",
         "column": "value",
         "unit_of_measurement": "MiB",
-        "device_class": "data_size",
-        "state_class": "total",
+        "device_class": SensorDeviceClass.DATA_SIZE,
+        "state_class": SensorStateClass.TOTAL,
     }
 
 
@@ -208,8 +209,8 @@ async def test_options_flow(recorder_mock: Recorder, hass: HomeAssistant) -> Non
             "query": "SELECT 5 as value",
             "column": "value",
             "unit_of_measurement": "MiB",
-            "device_class": "data_size",
-            "state_class": "total",
+            "device_class": SensorDeviceClass.DATA_SIZE,
+            "state_class": SensorStateClass.TOTAL,
         },
     )
     entry.add_to_hass(hass)
@@ -234,8 +235,8 @@ async def test_options_flow(recorder_mock: Recorder, hass: HomeAssistant) -> Non
             "column": "size",
             "unit_of_measurement": "MiB",
             "value_template": "{{ value }}",
-            "device_class": "data_size",
-            "state_class": "total",
+            "device_class": SensorDeviceClass.DATA_SIZE,
+            "state_class": SensorStateClass.TOTAL,
         },
     )
 
@@ -246,8 +247,8 @@ async def test_options_flow(recorder_mock: Recorder, hass: HomeAssistant) -> Non
         "column": "size",
         "unit_of_measurement": "MiB",
         "value_template": "{{ value }}",
-        "device_class": "data_size",
-        "state_class": "total",
+        "device_class": SensorDeviceClass.DATA_SIZE,
+        "state_class": SensorStateClass.TOTAL,
     }
 
 
@@ -638,8 +639,8 @@ async def test_device_state_class(recorder_mock: Recorder, hass: HomeAssistant) 
                 "query": "SELECT 5 as value",
                 "column": "value",
                 "unit_of_measurement": "MiB",
-                "device_class": "data_size",
-                "state_class": "total",
+                "device_class": SensorDeviceClass.DATA_SIZE,
+                "state_class": SensorStateClass.TOTAL,
             },
         )
         await hass.async_block_till_done()
@@ -650,8 +651,8 @@ async def test_device_state_class(recorder_mock: Recorder, hass: HomeAssistant) 
         "query": "SELECT 5 as value",
         "column": "value",
         "unit_of_measurement": "MiB",
-        "device_class": "data_size",
-        "state_class": "total",
+        "device_class": SensorDeviceClass.DATA_SIZE,
+        "state_class": SensorStateClass.TOTAL,
     }
 
     result = await hass.config_entries.options.async_init(entry.entry_id)

--- a/tests/components/sql/test_config_flow.py
+++ b/tests/components/sql/test_config_flow.py
@@ -50,6 +50,8 @@ async def test_form(recorder_mock: Recorder, hass: HomeAssistant) -> None:
         "query": "SELECT 5 as value",
         "column": "value",
         "unit_of_measurement": "MiB",
+        "device_class": "data_size",
+        "state_class": "total",
     }
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -151,6 +153,8 @@ async def test_flow_fails_invalid_query(
         "query": "SELECT 5 as value",
         "column": "value",
         "unit_of_measurement": "MiB",
+        "device_class": "data_size",
+        "state_class": "total",
     }
 
 
@@ -187,6 +191,8 @@ async def test_flow_fails_invalid_column_name(
         "query": "SELECT 5 as value",
         "column": "value",
         "unit_of_measurement": "MiB",
+        "device_class": "data_size",
+        "state_class": "total",
     }
 
 
@@ -201,6 +207,8 @@ async def test_options_flow(recorder_mock: Recorder, hass: HomeAssistant) -> Non
             "query": "SELECT 5 as value",
             "column": "value",
             "unit_of_measurement": "MiB",
+            "device_class": "data_size",
+            "state_class": "total",
         },
     )
     entry.add_to_hass(hass)
@@ -225,6 +233,8 @@ async def test_options_flow(recorder_mock: Recorder, hass: HomeAssistant) -> Non
             "column": "size",
             "unit_of_measurement": "MiB",
             "value_template": "{{ value }}",
+            "device_class": "data_size",
+            "state_class": "total",
         },
     )
 
@@ -235,6 +245,8 @@ async def test_options_flow(recorder_mock: Recorder, hass: HomeAssistant) -> Non
         "column": "size",
         "unit_of_measurement": "MiB",
         "value_template": "{{ value }}",
+        "device_class": "data_size",
+        "state_class": "total",
     }
 
 

--- a/tests/components/sql/test_sensor.py
+++ b/tests/components/sql/test_sensor.py
@@ -457,3 +457,47 @@ async def test_engine_is_disposed_at_stop(
         await hass.async_stop()
 
     assert mock_engine_dispose.call_count == 2
+
+
+async def test_attributes_from_entry_config(
+    recorder_mock: Recorder, hass: HomeAssistant
+) -> None:
+    """Test attributes from entry config."""
+
+    await init_integration(
+        hass,
+        config={
+            "name": "Get Value - With",
+            "query": "SELECT 5 as value",
+            "column": "value",
+            "unit_of_measurement": "MiB",
+            "device_class": SensorDeviceClass.DATA_SIZE,
+            "state_class": SensorStateClass.TOTAL,
+        },
+        entry_id="8693d4782ced4fb1ecca4743f29ab8f1",
+    )
+
+    state = hass.states.get("sensor.get_value_with")
+    assert state.state == "5"
+    assert state.attributes["value"] == 5
+    assert state.attributes["unit_of_measurement"] == "MiB"
+    assert state.attributes["device_class"] == SensorDeviceClass.DATA_SIZE
+    assert state.attributes["state_class"] == SensorStateClass.TOTAL
+
+    await init_integration(
+        hass,
+        config={
+            "name": "Get Value - Without",
+            "query": "SELECT 5 as value",
+            "column": "value",
+            "unit_of_measurement": "MiB",
+        },
+        entry_id="7aec7cd8045fba4778bb0621469e3cd9",
+    )
+
+    state = hass.states.get("sensor.get_value_without")
+    assert state.state == "5"
+    assert state.attributes["value"] == 5
+    assert state.attributes["unit_of_measurement"] == "MiB"
+    assert "device_class" not in state.attributes
+    assert "state_class" not in state.attributes

--- a/tests/components/sql/test_sensor.py
+++ b/tests/components/sql/test_sensor.py
@@ -457,26 +457,3 @@ async def test_engine_is_disposed_at_stop(
         await hass.async_stop()
 
     assert mock_engine_dispose.call_count == 2
-
-
-async def test_attributes_from_entry_config(
-    recorder_mock: Recorder, hass: HomeAssistant
-) -> None:
-    """Test attributes from entry config."""
-
-    config = {
-        "name": "Get Value",
-        "query": "SELECT 5 as value",
-        "column": "value",
-        "unit_of_measurement": "MiB",
-        "device_class": SensorDeviceClass.DATA_SIZE,
-        "state_class": SensorStateClass.TOTAL,
-    }
-    await init_integration(hass, config)
-
-    state = hass.states.get("sensor.get_value")
-
-    assert state.state == "5"
-    assert state.attributes["device_class"] == SensorDeviceClass.DATA_SIZE
-    assert state.attributes["state_class"] == SensorStateClass.TOTAL
-    assert state.attributes["unit_of_measurement"] == "MiB"

--- a/tests/components/sql/test_sensor.py
+++ b/tests/components/sql/test_sensor.py
@@ -457,3 +457,26 @@ async def test_engine_is_disposed_at_stop(
         await hass.async_stop()
 
     assert mock_engine_dispose.call_count == 2
+
+
+async def test_attributes_from_entry_config(
+    recorder_mock: Recorder, hass: HomeAssistant
+) -> None:
+    """Test attributes from entry config."""
+
+    config = {
+        "name": "Get Value",
+        "query": "SELECT 5 as value",
+        "column": "value",
+        "unit_of_measurement": "MiB",
+        "device_class": SensorDeviceClass.DATA_SIZE,
+        "state_class": SensorStateClass.TOTAL,
+    }
+    await init_integration(hass, config)
+
+    state = hass.states.get("sensor.get_value")
+
+    assert state.state == "5"
+    assert state.attributes["device_class"] == SensorDeviceClass.DATA_SIZE
+    assert state.attributes["state_class"] == SensorStateClass.TOTAL
+    assert state.attributes["unit_of_measurement"] == "MiB"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
None

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add `device_class` and `state_class` in config flow for SQL.

The selectors for Device Class and State Class were based on the one used in the `scrape` integration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/95073
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
