### PR TITLE
Callback esphome EntityInfo by platform instead of all platforms

### DIFF
--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -703,10 +703,6 @@ async def platform_async_setup_entry(
         new_infos: dict[int, EntityInfo] = {}
         add_entities: list[_EntityT] = []
         for info in infos:
-            if not isinstance(info, info_type):
-                # Filter out infos that don't belong to this platform.
-                continue
-
             if info.key in old_infos:
                 # Update existing entity
                 old_infos.pop(info.key)

--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -737,9 +737,7 @@ async def platform_async_setup_entry(
             async_add_entities(add_entities)
 
     entry_data.cleanup_callbacks.append(
-        async_dispatcher_connect(
-            hass, entry_data.signal_static_info_updated, async_list_entities
-        )
+        entry_data.async_register_static_info_callback(info_type, async_list_entities)
     )
 
 

--- a/homeassistant/components/esphome/entry_data.py
+++ b/homeassistant/components/esphome/entry_data.py
@@ -35,7 +35,7 @@ from aioesphomeapi.model import ButtonInfo
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.storage import Store
 
@@ -106,6 +106,9 @@ class RuntimeEntryData:
         default_factory=list
     )
     assist_pipeline_state: bool = False
+    entity_info_callbacks: dict[
+        type[EntityInfo], list[Callable[[list[EntityInfo]], None]]
+    ] = field(default_factory=dict)
 
     @property
     def name(self) -> str:
@@ -134,6 +137,21 @@ class RuntimeEntryData:
     ) -> str:
         """Return the signal to listen to for updates on static info for a specific component_key and key."""
         return f"esphome_{self.entry_id}_static_info_updated_{component_key}_{key}"
+
+    @callback
+    def async_register_static_info_callback(
+        self,
+        entity_info_type: type[EntityInfo],
+        callback_: Callable[[list[EntityInfo]], None],
+    ) -> CALLBACK_TYPE:
+        """Register to receive callbacks when static info changes for an EntityInfo type."""
+        callbacks = self.entity_info_callbacks.setdefault(entity_info_type, [])
+        callbacks.append(callback_)
+
+        def _unsub() -> None:
+            callbacks.remove(callback_)
+
+        return _unsub
 
     @callback
     def async_update_ble_connection_limits(self, free: int, limit: int) -> None:
@@ -221,6 +239,21 @@ class RuntimeEntryData:
                     needed_platforms.add(platform)
                     break
         await self._ensure_platforms_loaded(hass, entry, needed_platforms)
+
+        # Make a dict of the EntityInfo by type and send
+        # them to the listeners for each specific EntityInfo type
+        infos_by_type: dict[type[EntityInfo], list[EntityInfo]] = {}
+        for info in infos:
+            info_type = type(info)
+            if info_type not in infos_by_type:
+                infos_by_type[info_type] = []
+            infos_by_type[info_type].append(info)
+
+        callbacks_by_type = self.entity_info_callbacks
+        for type_, entity_infos in infos_by_type.items():
+            if callbacks_ := callbacks_by_type.get(type_):
+                for callback_ in callbacks_:
+                    callback_(entity_infos)
 
         # Then send dispatcher event
         async_dispatcher_send(hass, self.signal_static_info_updated, infos)


### PR DESCRIPTION
Noticed while adding coverage in https://github.com/home-assistant/core/pull/95019

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
We would send the EntityInfo to every platform and the platform would have to reject the ones it did not want.

We now send only send the specific EntityInfo for the platform to each platform so it only has to be sorted out once instead of each platform enumerating the data and rejecting the ones it doesn't want.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
