### PR TITLE
Add test coverage for esphome lock platform

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -316,7 +316,6 @@ omit =
     homeassistant/components/esphome/entry_data.py
     homeassistant/components/esphome/fan.py
     homeassistant/components/esphome/light.py
-    homeassistant/components/esphome/lock.py
     homeassistant/components/esphome/media_player.py
     homeassistant/components/esphome/number.py
     homeassistant/components/esphome/sensor.py

--- a/tests/components/esphome/test_lock.py
+++ b/tests/components/esphome/test_lock.py
@@ -1,0 +1,132 @@
+"""Test ESPHome locks."""
+
+
+from unittest.mock import call
+
+from aioesphomeapi import APIClient, LockCommand, LockEntityState, LockInfo, LockState
+
+from homeassistant.components.lock import (
+    DOMAIN as LOCK_DOMAIN,
+    SERVICE_LOCK,
+    SERVICE_OPEN,
+    SERVICE_UNLOCK,
+    STATE_LOCKED,
+    STATE_LOCKING,
+    STATE_UNLOCKING,
+)
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
+
+
+async def test_lock_entity_no_open(
+    hass: HomeAssistant, mock_client: APIClient, mock_generic_device_entry
+) -> None:
+    """Test a generic lock entity that does not support open."""
+    entity_info = [
+        LockInfo(
+            object_id="mylock",
+            key=1,
+            name="my lock",
+            unique_id="my_lock",
+            supports_open=False,
+            requires_code=False,
+        )
+    ]
+    states = [LockEntityState(key=1, state=LockState.UNLOCKING)]
+    user_service = []
+    await mock_generic_device_entry(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        user_service=user_service,
+        states=states,
+    )
+    state = hass.states.get("lock.test_my_lock")
+    assert state is not None
+    assert state.state == STATE_UNLOCKING
+
+    await hass.services.async_call(
+        LOCK_DOMAIN,
+        SERVICE_LOCK,
+        {ATTR_ENTITY_ID: "lock.test_my_lock"},
+        blocking=True,
+    )
+    mock_client.lock_command.assert_has_calls([call(1, LockCommand.LOCK)])
+    mock_client.lock_command.reset_mock()
+
+
+async def test_lock_entity_start_locked(
+    hass: HomeAssistant, mock_client: APIClient, mock_generic_device_entry
+) -> None:
+    """Test a generic lock entity that does not support open."""
+    entity_info = [
+        LockInfo(
+            object_id="mylock",
+            key=1,
+            name="my lock",
+            unique_id="my_lock",
+        )
+    ]
+    states = [LockEntityState(key=1, state=LockState.LOCKED)]
+    user_service = []
+    await mock_generic_device_entry(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        user_service=user_service,
+        states=states,
+    )
+    state = hass.states.get("lock.test_my_lock")
+    assert state is not None
+    assert state.state == STATE_LOCKED
+
+
+async def test_lock_entity_supports_open(
+    hass: HomeAssistant, mock_client: APIClient, mock_generic_device_entry
+) -> None:
+    """Test a generic lock entity that supports open."""
+    entity_info = [
+        LockInfo(
+            object_id="mylock",
+            key=1,
+            name="my lock",
+            unique_id="my_lock",
+            supports_open=True,
+            requires_code=True,
+        )
+    ]
+    states = [LockEntityState(key=1, state=LockState.LOCKING)]
+    user_service = []
+    await mock_generic_device_entry(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        user_service=user_service,
+        states=states,
+    )
+    state = hass.states.get("lock.test_my_lock")
+    assert state is not None
+    assert state.state == STATE_LOCKING
+
+    await hass.services.async_call(
+        LOCK_DOMAIN,
+        SERVICE_LOCK,
+        {ATTR_ENTITY_ID: "lock.test_my_lock"},
+        blocking=True,
+    )
+    mock_client.lock_command.assert_has_calls([call(1, LockCommand.LOCK)])
+    mock_client.lock_command.reset_mock()
+
+    await hass.services.async_call(
+        LOCK_DOMAIN,
+        SERVICE_UNLOCK,
+        {ATTR_ENTITY_ID: "lock.test_my_lock"},
+        blocking=True,
+    )
+    mock_client.lock_command.assert_has_calls([call(1, LockCommand.UNLOCK, None)])
+
+    mock_client.lock_command.reset_mock()
+    await hass.services.async_call(
+        LOCK_DOMAIN,
+        SERVICE_OPEN,
+        {ATTR_ENTITY_ID: "lock.test_my_lock"},
+        blocking=True,
+    )
+    mock_client.lock_command.assert_has_calls([call(1, LockCommand.OPEN)])


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add test coverage for esphome lock platform

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
