### PR TITLE
Migrate esphome fan platform to use _on_static_info_update

### DIFF
--- a/homeassistant/components/esphome/fan.py
+++ b/homeassistant/components/esphome/fan.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import math
 from typing import Any
 
-from aioesphomeapi import FanDirection, FanInfo, FanSpeed, FanState
+from aioesphomeapi import EntityInfo, FanDirection, FanInfo, FanSpeed, FanState
 
 from homeassistant.components.fan import (
     DIRECTION_FORWARD,
@@ -13,7 +13,7 @@ from homeassistant.components.fan import (
     FanEntityFeature,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util.percentage import (
     ordered_list_item_to_percentage,
@@ -68,7 +68,7 @@ class EsphomeFan(EsphomeEntity[FanInfo, FanState], FanEntity):
             await self.async_turn_off()
             return
 
-        data: dict[str, Any] = {"key": self._static_info.key, "state": True}
+        data: dict[str, Any] = {"key": self._key, "state": True}
         if percentage is not None:
             if self._supports_speed_levels:
                 data["speed_level"] = math.ceil(
@@ -94,18 +94,16 @@ class EsphomeFan(EsphomeEntity[FanInfo, FanState], FanEntity):
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the fan."""
-        await self._client.fan_command(key=self._static_info.key, state=False)
+        await self._client.fan_command(key=self._key, state=False)
 
     async def async_oscillate(self, oscillating: bool) -> None:
         """Oscillate the fan."""
-        await self._client.fan_command(
-            key=self._static_info.key, oscillating=oscillating
-        )
+        await self._client.fan_command(key=self._key, oscillating=oscillating)
 
     async def async_set_direction(self, direction: str) -> None:
         """Set direction of the fan."""
         await self._client.fan_command(
-            key=self._static_info.key, direction=_FAN_DIRECTIONS.from_hass(direction)
+            key=self._key, direction=_FAN_DIRECTIONS.from_hass(direction)
         )
 
     @property
@@ -153,14 +151,16 @@ class EsphomeFan(EsphomeEntity[FanInfo, FanState], FanEntity):
             return None
         return _FAN_DIRECTIONS.from_esphome(self._state.direction)
 
-    @property
-    def supported_features(self) -> FanEntityFeature:
-        """Flag supported features."""
+    @callback
+    def _on_static_info_update(self, static_info: EntityInfo) -> None:
+        """Set attrs from static info."""
+        super()._on_static_info_update(static_info)
+        static_info = self._static_info
         flags = FanEntityFeature(0)
-        if self._static_info.supports_oscillation:
+        if static_info.supports_oscillation:
             flags |= FanEntityFeature.OSCILLATE
-        if self._static_info.supports_speed:
+        if static_info.supports_speed:
             flags |= FanEntityFeature.SET_SPEED
-        if self._static_info.supports_direction:
+        if static_info.supports_direction:
             flags |= FanEntityFeature.DIRECTION
-        return flags
+        self._attr_supported_features = flags


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
followup to #94930

was waiting for #95025 since I have no production fan entities

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
