### PR TITLE
Fix KNX device trigger passing info data

### DIFF
--- a/homeassistant/components/knx/device_trigger.py
+++ b/homeassistant/components/knx/device_trigger.py
@@ -84,6 +84,7 @@ async def async_attach_trigger(
     trigger_info: TriggerInfo,
 ) -> CALLBACK_TYPE:
     """Attach a trigger."""
+    trigger_data = trigger_info["trigger_data"]
     dst_addresses: list[str] = config.get(EXTRA_FIELD_DESTINATION, [])
     job = HassJob(action, f"KNX device trigger {trigger_info}")
     knx: KNXModule = hass.data[DOMAIN]
@@ -95,7 +96,7 @@ async def async_attach_trigger(
             return
         hass.async_run_hass_job(
             job,
-            {"trigger": telegram},
+            {"trigger": {**trigger_data, **telegram}},
         )
 
     return knx.telegrams.async_listen_telegram(

--- a/tests/components/knx/test_device_trigger.py
+++ b/tests/components/knx/test_device_trigger.py
@@ -56,6 +56,7 @@ async def test_if_fires_on_telegram(
         identifiers={(DOMAIN, f"_{knx.mock_config_entry.entry_id}_interface")}
     )
 
+    # "id" field added to action to test if `trigger_data` passed correctly in `async_attach_trigger`
     assert await async_setup_component(
         hass,
         automation.DOMAIN,
@@ -71,7 +72,8 @@ async def test_if_fires_on_telegram(
                     "action": {
                         "service": "test.automation",
                         "data_template": {
-                            "catch_all": ("telegram - {{ trigger.destination }}")
+                            "catch_all": ("telegram - {{ trigger.destination }}"),
+                            "id": (" {{ trigger.id }}"),
                         },
                     },
                 },
@@ -82,11 +84,13 @@ async def test_if_fires_on_telegram(
                         "device_id": device_entry.id,
                         "type": "telegram",
                         "destination": ["1/2/3", "1/2/4"],
+                        "id": "test-id",
                     },
                     "action": {
                         "service": "test.automation",
                         "data_template": {
-                            "specific": ("telegram - {{ trigger.destination }}")
+                            "specific": ("telegram - {{ trigger.destination }}"),
+                            "id": (" {{ trigger.id }}"),
                         },
                     },
                 },
@@ -96,12 +100,18 @@ async def test_if_fires_on_telegram(
 
     await knx.receive_write("0/0/1", (0x03, 0x2F))
     assert len(calls) == 1
-    assert calls.pop().data["catch_all"] == "telegram - 0/0/1"
+    test_call = calls.pop()
+    assert test_call.data["catch_all"] == "telegram - 0/0/1"
+    assert test_call.data["id"] == 0
 
     await knx.receive_write("1/2/4", (0x03, 0x2F))
     assert len(calls) == 2
-    assert calls.pop().data["specific"] == "telegram - 1/2/4"
-    assert calls.pop().data["catch_all"] == "telegram - 1/2/4"
+    test_call = calls.pop()
+    assert test_call.data["specific"] == "telegram - 1/2/4"
+    assert test_call.data["id"] == "test-id"
+    test_call = calls.pop()
+    assert test_call.data["catch_all"] == "telegram - 1/2/4"
+    assert test_call.data["id"] == 0
 
 
 async def test_remove_device_trigger(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix KNX device trigger passing `trigger_info["trigger_data"]`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #95015
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
