### PR TITLE
Update holidays to 0.28

### DIFF
--- a/homeassistant/components/workday/binary_sensor.py
+++ b/homeassistant/components/workday/binary_sensor.py
@@ -120,15 +120,16 @@ async def async_setup_entry(
     sensor_name: str = entry.options[CONF_NAME]
     workdays: list[str] = entry.options[CONF_WORKDAYS]
 
+    cls: HolidayBase = getattr(holidays, country)
     year: int = (dt_util.now() + timedelta(days=days_offset)).year
-    obj_holidays: HolidayBase = getattr(holidays, country)(years=year)
 
-    if province:
-        try:
-            obj_holidays = getattr(holidays, country)(subdiv=province, years=year)
-        except NotImplementedError:
-            LOGGER.error("There is no subdivision %s in country %s", province, country)
-            return
+    if province and province not in cls.subdivisions:
+        LOGGER.error("There is no subdivision %s in country %s", province, country)
+        return
+
+    obj_holidays = cls(
+        subdiv=province, years=year, language=cls.default_language
+    )  # type: ignore[operator]
 
     # Add custom holidays
     try:

--- a/homeassistant/components/workday/config_flow.py
+++ b/homeassistant/components/workday/config_flow.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from holidays import country_holidays, list_supported_countries
+import holidays
+from holidays import HolidayBase, list_supported_countries
 import voluptuous as vol
 
 from homeassistant.config_entries import (
@@ -76,10 +77,12 @@ def validate_custom_dates(user_input: dict[str, Any]) -> None:
         if dt_util.parse_date(add_date) is None:
             raise AddDatesError("Incorrect date")
 
+    cls: HolidayBase = getattr(holidays, user_input[CONF_COUNTRY])
     year: int = dt_util.now().year
-    obj_holidays = country_holidays(
-        user_input[CONF_COUNTRY], user_input.get(CONF_PROVINCE), year
-    )
+
+    obj_holidays = cls(
+        subdiv=user_input.get(CONF_PROVINCE), years=year, language=cls.default_language
+    )  # type: ignore[operator]
 
     for remove_date in user_input[CONF_REMOVE_HOLIDAYS]:
         if dt_util.parse_date(remove_date) is None:

--- a/homeassistant/components/workday/manifest.json
+++ b/homeassistant/components/workday/manifest.json
@@ -5,12 +5,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/workday",
   "iot_class": "local_polling",
-  "loggers": [
-    "convertdate",
-    "hijri_converter",
-    "holidays",
-    "korean_lunar_calendar"
-  ],
+  "loggers": ["holidays"],
   "quality_scale": "internal",
-  "requirements": ["holidays==0.21.13"]
+  "requirements": ["holidays==0.28"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -977,7 +977,7 @@ hlk-sw16==0.0.9
 hole==0.8.0
 
 # homeassistant.components.workday
-holidays==0.21.13
+holidays==0.28
 
 # homeassistant.components.frontend
 home-assistant-frontend==20230703.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -760,7 +760,7 @@ hlk-sw16==0.0.9
 hole==0.8.0
 
 # homeassistant.components.workday
-holidays==0.21.13
+holidays==0.28
 
 # homeassistant.components.frontend
 home-assistant-frontend==20230703.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bump holidays version from 0.21.13 to the latest 0.28.

The release notes:
  - https://github.com/dr-prodigy/python-holidays/releases/tag/v.0.28
  - https://github.com/dr-prodigy/python-holidays/releases/tag/v.0.27.1
  - https://github.com/dr-prodigy/python-holidays/releases/tag/v.0.27
  - https://github.com/dr-prodigy/python-holidays/releases/tag/v.0.26
  - https://github.com/dr-prodigy/python-holidays/releases/tag/v.0.25
  - https://github.com/dr-prodigy/python-holidays/releases/tag/v.0.24
  - https://github.com/dr-prodigy/python-holidays/releases/tag/v.0.23
  - https://github.com/dr-prodigy/python-holidays/releases/tag/v.0.22


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
