### PR TITLE
Use new attributes in Smhi

### DIFF
--- a/homeassistant/components/smhi/const.py
+++ b/homeassistant/components/smhi/const.py
@@ -3,8 +3,6 @@ from typing import Final
 
 from homeassistant.components.weather import DOMAIN as WEATHER_DOMAIN
 
-ATTR_SMHI_CLOUDINESS: Final = "cloudiness"
-ATTR_SMHI_WIND_GUST_SPEED: Final = "wind_gust_speed"
 ATTR_SMHI_THUNDER_PROBABILITY: Final = "thunder_probability"
 
 DOMAIN = "smhi"

--- a/homeassistant/components/smhi/weather.py
+++ b/homeassistant/components/smhi/weather.py
@@ -27,15 +27,17 @@ from homeassistant.components.weather import (
     ATTR_CONDITION_SUNNY,
     ATTR_CONDITION_WINDY,
     ATTR_CONDITION_WINDY_VARIANT,
+    ATTR_FORECAST_CLOUD_COVERAGE,
     ATTR_FORECAST_CONDITION,
+    ATTR_FORECAST_HUMIDITY,
     ATTR_FORECAST_NATIVE_PRECIPITATION,
     ATTR_FORECAST_NATIVE_PRESSURE,
     ATTR_FORECAST_NATIVE_TEMP,
     ATTR_FORECAST_NATIVE_TEMP_LOW,
+    ATTR_FORECAST_NATIVE_WIND_GUST_SPEED,
     ATTR_FORECAST_NATIVE_WIND_SPEED,
     ATTR_FORECAST_TIME,
     ATTR_FORECAST_WIND_BEARING,
-    ROUNDING_PRECISION,
     Forecast,
     WeatherEntity,
 )
@@ -58,12 +60,9 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_call_later
 from homeassistant.util import Throttle, slugify
-from homeassistant.util.unit_conversion import SpeedConverter
 
 from .const import (
-    ATTR_SMHI_CLOUDINESS,
     ATTR_SMHI_THUNDER_PROBABILITY,
-    ATTR_SMHI_WIND_GUST_SPEED,
     DOMAIN,
     ENTITY_ID_SENSOR_FORMAT,
 )
@@ -156,14 +155,7 @@ class SmhiWeather(WeatherEntity):
     def extra_state_attributes(self) -> Mapping[str, Any] | None:
         """Return additional attributes."""
         if self._forecasts:
-            wind_gust = SpeedConverter.convert(
-                self._forecasts[0].wind_gust,
-                UnitOfSpeed.METERS_PER_SECOND,
-                self._wind_speed_unit,
-            )
             return {
-                ATTR_SMHI_CLOUDINESS: self._forecasts[0].cloudiness,
-                ATTR_SMHI_WIND_GUST_SPEED: round(wind_gust, ROUNDING_PRECISION),
                 ATTR_SMHI_THUNDER_PROBABILITY: self._forecasts[0].thunder,
             }
         return None
@@ -189,6 +181,8 @@ class SmhiWeather(WeatherEntity):
             self._attr_wind_bearing = self._forecasts[0].wind_direction
             self._attr_native_visibility = self._forecasts[0].horizontal_visibility
             self._attr_native_pressure = self._forecasts[0].pressure
+            self._attr_native_wind_gust_speed = self._forecasts[0].wind_gust
+            self._attr_cloud_coverage = self._forecasts[0].cloudiness
             self._attr_condition = next(
                 (
                     k
@@ -227,6 +221,9 @@ class SmhiWeather(WeatherEntity):
                     ATTR_FORECAST_NATIVE_PRESSURE: forecast.pressure,
                     ATTR_FORECAST_WIND_BEARING: forecast.wind_direction,
                     ATTR_FORECAST_NATIVE_WIND_SPEED: forecast.wind_speed,
+                    ATTR_FORECAST_HUMIDITY: forecast.humidity,
+                    ATTR_FORECAST_NATIVE_WIND_GUST_SPEED: forecast.wind_gust,
+                    ATTR_FORECAST_CLOUD_COVERAGE: forecast.cloudiness,
                 }
             )
 

--- a/tests/components/smhi/test_weather.py
+++ b/tests/components/smhi/test_weather.py
@@ -6,14 +6,11 @@ from unittest.mock import patch
 import pytest
 from smhi.smhi_lib import APIURL_TEMPLATE, SmhiForecast, SmhiForecastException
 
-from homeassistant.components.smhi.const import (
-    ATTR_SMHI_CLOUDINESS,
-    ATTR_SMHI_THUNDER_PROBABILITY,
-    ATTR_SMHI_WIND_GUST_SPEED,
-)
+from homeassistant.components.smhi.const import ATTR_SMHI_THUNDER_PROBABILITY
 from homeassistant.components.smhi.weather import CONDITION_CLASSES, RETRY_TIMEOUT
 from homeassistant.components.weather import (
     ATTR_FORECAST,
+    ATTR_FORECAST_CLOUD_COVERAGE,
     ATTR_FORECAST_CONDITION,
     ATTR_FORECAST_PRECIPITATION,
     ATTR_FORECAST_PRESSURE,
@@ -21,6 +18,7 @@ from homeassistant.components.weather import (
     ATTR_FORECAST_TEMP_LOW,
     ATTR_FORECAST_TIME,
     ATTR_FORECAST_WIND_BEARING,
+    ATTR_FORECAST_WIND_GUST_SPEED,
     ATTR_FORECAST_WIND_SPEED,
     ATTR_WEATHER_HUMIDITY,
     ATTR_WEATHER_PRESSURE,
@@ -30,6 +28,10 @@ from homeassistant.components.weather import (
     ATTR_WEATHER_WIND_SPEED,
     ATTR_WEATHER_WIND_SPEED_UNIT,
     DOMAIN as WEATHER_DOMAIN,
+)
+from homeassistant.components.weather.const import (
+    ATTR_WEATHER_CLOUD_COVERAGE,
+    ATTR_WEATHER_WIND_GUST_SPEED,
 )
 from homeassistant.const import ATTR_ATTRIBUTION, STATE_UNKNOWN, UnitOfSpeed
 from homeassistant.core import HomeAssistant
@@ -64,9 +66,9 @@ async def test_setup_hass(
 
     assert state
     assert state.state == "sunny"
-    assert state.attributes[ATTR_SMHI_CLOUDINESS] == 50
+    assert state.attributes[ATTR_WEATHER_CLOUD_COVERAGE] == 50
     assert state.attributes[ATTR_SMHI_THUNDER_PROBABILITY] == 33
-    assert state.attributes[ATTR_SMHI_WIND_GUST_SPEED] == 16.92
+    assert state.attributes[ATTR_WEATHER_WIND_GUST_SPEED] == 16.92
     assert state.attributes[ATTR_ATTRIBUTION].find("SMHI") >= 0
     assert state.attributes[ATTR_WEATHER_HUMIDITY] == 55
     assert state.attributes[ATTR_WEATHER_PRESSURE] == 1024
@@ -85,6 +87,8 @@ async def test_setup_hass(
     assert forecast[ATTR_FORECAST_PRESSURE] == 1026
     assert forecast[ATTR_FORECAST_WIND_BEARING] == 203
     assert forecast[ATTR_FORECAST_WIND_SPEED] == 6.12
+    assert forecast[ATTR_FORECAST_WIND_GUST_SPEED] == 18.36
+    assert forecast[ATTR_FORECAST_CLOUD_COVERAGE] == 100
 
 
 async def test_properties_no_data(hass: HomeAssistant) -> None:
@@ -112,9 +116,9 @@ async def test_properties_no_data(hass: HomeAssistant) -> None:
     assert ATTR_WEATHER_WIND_SPEED not in state.attributes
     assert ATTR_WEATHER_WIND_BEARING not in state.attributes
     assert ATTR_FORECAST not in state.attributes
-    assert ATTR_SMHI_CLOUDINESS not in state.attributes
+    assert ATTR_WEATHER_CLOUD_COVERAGE not in state.attributes
     assert ATTR_SMHI_THUNDER_PROBABILITY not in state.attributes
-    assert ATTR_SMHI_WIND_GUST_SPEED not in state.attributes
+    assert ATTR_WEATHER_WIND_GUST_SPEED not in state.attributes
 
 
 async def test_properties_unknown_symbol(hass: HomeAssistant) -> None:
@@ -337,7 +341,7 @@ async def test_custom_speed_unit(
 
     assert state
     assert state.name == "test"
-    assert state.attributes[ATTR_SMHI_WIND_GUST_SPEED] == 16.92
+    assert state.attributes[ATTR_WEATHER_WIND_GUST_SPEED] == 16.92
 
     entity_reg = er.async_get(hass)
     entity_reg.async_update_entity_options(
@@ -349,4 +353,4 @@ async def test_custom_speed_unit(
     await hass.async_block_till_done()
 
     state = hass.states.get(ENTITY_ID)
-    assert state.attributes[ATTR_SMHI_WIND_GUST_SPEED] == 4.7
+    assert state.attributes[ATTR_WEATHER_WIND_GUST_SPEED] == 4.7


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The attribute `cloudiness` has been replaced by the attribute `cloud_coverage`.
Please update any automation or scripts that is using this attribute to use the newly added `cloud_coverage` attribute

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use the new `weather` attributes in Smhi integration

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
