### PR TITLE
Add new attributes into Template Weather

### DIFF
--- a/homeassistant/components/template/weather.py
+++ b/homeassistant/components/template/weather.py
@@ -72,6 +72,10 @@ CONF_PRESSURE_UNIT = "pressure_unit"
 CONF_WIND_SPEED_UNIT = "wind_speed_unit"
 CONF_VISIBILITY_UNIT = "visibility_unit"
 CONF_PRECIPITATION_UNIT = "precipitation_unit"
+CONF_WIND_GUST_SPEED_TEMPLATE = "wind_gust_speed_template"
+CONF_CLOUD_COVERAGE_TEMPLATE = "cloud_coverage_template"
+CONF_DEW_POINT_TEMPLATE = "dew_point_template"
+CONF_APPARENT_TEMPERATURE_TEMPLATE = "apparent_temperature_template"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
@@ -92,6 +96,10 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_WIND_SPEED_UNIT): vol.In(SpeedConverter.VALID_UNITS),
         vol.Optional(CONF_VISIBILITY_UNIT): vol.In(DistanceConverter.VALID_UNITS),
         vol.Optional(CONF_PRECIPITATION_UNIT): vol.In(DistanceConverter.VALID_UNITS),
+        vol.Optional(CONF_WIND_GUST_SPEED_TEMPLATE): cv.template,
+        vol.Optional(CONF_CLOUD_COVERAGE_TEMPLATE): cv.template,
+        vol.Optional(CONF_DEW_POINT_TEMPLATE): cv.template,
+        vol.Optional(CONF_APPARENT_TEMPERATURE_TEMPLATE): cv.template,
     }
 )
 
@@ -143,6 +151,12 @@ class WeatherTemplate(TemplateEntity, WeatherEntity):
         self._ozone_template = config.get(CONF_OZONE_TEMPLATE)
         self._visibility_template = config.get(CONF_VISIBILITY_TEMPLATE)
         self._forecast_template = config.get(CONF_FORECAST_TEMPLATE)
+        self._wind_gust_speed_template = config.get(CONF_WIND_GUST_SPEED_TEMPLATE)
+        self._cloud_coverage_template = config.get(CONF_CLOUD_COVERAGE_TEMPLATE)
+        self._dew_point_template = config.get(CONF_DEW_POINT_TEMPLATE)
+        self._apparent_temperature_template = config.get(
+            CONF_APPARENT_TEMPERATURE_TEMPLATE
+        )
 
         self._attr_native_precipitation_unit = config.get(CONF_PRECIPITATION_UNIT)
         self._attr_native_pressure_unit = config.get(CONF_PRESSURE_UNIT)
@@ -161,6 +175,10 @@ class WeatherTemplate(TemplateEntity, WeatherEntity):
         self._wind_bearing = None
         self._ozone = None
         self._visibility = None
+        self._wind_gust_speed = None
+        self._cloud_coverage = None
+        self._dew_point = None
+        self._apparent_temperature = None
         self._forecast: list[Forecast] = []
 
     @property
@@ -202,6 +220,26 @@ class WeatherTemplate(TemplateEntity, WeatherEntity):
     def native_pressure(self) -> float | None:
         """Return the air pressure."""
         return self._pressure
+
+    @property
+    def native_wind_gust_speed(self) -> float | None:
+        """Return the wind gust speed."""
+        return self._wind_gust_speed
+
+    @property
+    def cloud_coverage(self) -> float | None:
+        """Return the cloud coverage."""
+        return self._cloud_coverage
+
+    @property
+    def native_dew_point(self) -> float | None:
+        """Return the dew point."""
+        return self._dew_point
+
+    @property
+    def native_apparent_temperature(self) -> float | None:
+        """Return the apparent temperature."""
+        return self._apparent_temperature
 
     @property
     def forecast(self) -> list[Forecast]:
@@ -263,6 +301,26 @@ class WeatherTemplate(TemplateEntity, WeatherEntity):
             self.add_template_attribute(
                 "_visibility",
                 self._visibility_template,
+            )
+        if self._wind_gust_speed_template:
+            self.add_template_attribute(
+                "_wind_gust_speed",
+                self._wind_gust_speed_template,
+            )
+        if self._cloud_coverage_template:
+            self.add_template_attribute(
+                "_cloud_coverage",
+                self._cloud_coverage_template,
+            )
+        if self._dew_point_template:
+            self.add_template_attribute(
+                "_dew_point",
+                self._dew_point_template,
+            )
+        if self._apparent_temperature_template:
+            self.add_template_attribute(
+                "_apparent_temperature",
+                self._apparent_temperature_template,
             )
         if self._forecast_template:
             self.add_template_attribute(

--- a/tests/components/template/test_weather.py
+++ b/tests/components/template/test_weather.py
@@ -2,12 +2,16 @@
 import pytest
 
 from homeassistant.components.weather import (
+    ATTR_WEATHER_APPARENT_TEMPERATURE,
+    ATTR_WEATHER_CLOUD_COVERAGE,
+    ATTR_WEATHER_DEW_POINT,
     ATTR_WEATHER_HUMIDITY,
     ATTR_WEATHER_OZONE,
     ATTR_WEATHER_PRESSURE,
     ATTR_WEATHER_TEMPERATURE,
     ATTR_WEATHER_VISIBILITY,
     ATTR_WEATHER_WIND_BEARING,
+    ATTR_WEATHER_WIND_GUST_SPEED,
     ATTR_WEATHER_WIND_SPEED,
     DOMAIN,
 )
@@ -35,6 +39,10 @@ from homeassistant.core import HomeAssistant
                     "wind_bearing_template": "{{ states('sensor.windbearing') }}",
                     "ozone_template": "{{ states('sensor.ozone') }}",
                     "visibility_template": "{{ states('sensor.visibility') }}",
+                    "wind_gust_speed_template": "{{ states('sensor.wind_gust_speed') }}",
+                    "cloud_coverage_template": "{{ states('sensor.cloud_coverage') }}",
+                    "dew_point_template": "{{ states('sensor.dew_point') }}",
+                    "apparent_temperature_template": "{{ states('sensor.apparent_temperature') }}",
                 },
             ]
         },
@@ -55,6 +63,10 @@ async def test_template_state_text(hass: HomeAssistant, start_ha) -> None:
         ("sensor.windbearing", ATTR_WEATHER_WIND_BEARING, 180),
         ("sensor.ozone", ATTR_WEATHER_OZONE, 25),
         ("sensor.visibility", ATTR_WEATHER_VISIBILITY, 4.6),
+        ("sensor.wind_gust_speed", ATTR_WEATHER_WIND_GUST_SPEED, 30),
+        ("sensor.cloud_coverage", ATTR_WEATHER_CLOUD_COVERAGE, 75),
+        ("sensor.dew_point", ATTR_WEATHER_DEW_POINT, 2.2),
+        ("sensor.apparent_temperature", ATTR_WEATHER_APPARENT_TEMPERATURE, 25),
     ]:
         hass.states.async_set(attr, value)
         await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds the newly added attributes into Template Weather
- `wind_gust_speed`
- `cloud_coverage`
- `dew_point`
- `apparent_temperature`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/27936

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
