### PR TITLE
Use entity name in Airzone Cloud sensors

### DIFF
--- a/homeassistant/components/airzone_cloud/sensor.py
+++ b/homeassistant/components/airzone_cloud/sensor.py
@@ -52,7 +52,6 @@ WEBSERVER_SENSOR_TYPES: Final[tuple[SensorEntityDescription, ...]] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
         key=AZD_WIFI_RSSI,
-        name="RSSI",
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
         state_class=SensorStateClass.MEASUREMENT,
     ),

--- a/homeassistant/components/airzone_cloud/sensor.py
+++ b/homeassistant/components/airzone_cloud/sensor.py
@@ -6,7 +6,6 @@ from typing import Any, Final
 from aioairzone_cloud.const import (
     AZD_AIDOOS,
     AZD_HUMIDITY,
-    AZD_NAME,
     AZD_TEMP,
     AZD_WEBSERVERS,
     AZD_WIFI_RSSI,
@@ -41,6 +40,7 @@ from .entity import (
 AIDOO_SENSOR_TYPES: Final[tuple[SensorEntityDescription, ...]] = (
     SensorEntityDescription(
         device_class=SensorDeviceClass.TEMPERATURE,
+        has_entity_name=True,
         key=AZD_TEMP,
         name="Temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
@@ -64,6 +64,7 @@ WEBSERVER_SENSOR_TYPES: Final[tuple[SensorEntityDescription, ...]] = (
 ZONE_SENSOR_TYPES: Final[tuple[SensorEntityDescription, ...]] = (
     SensorEntityDescription(
         device_class=SensorDeviceClass.TEMPERATURE,
+        has_entity_name=True,
         key=AZD_TEMP,
         name="Temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
@@ -71,6 +72,7 @@ ZONE_SENSOR_TYPES: Final[tuple[SensorEntityDescription, ...]] = (
     ),
     SensorEntityDescription(
         device_class=SensorDeviceClass.HUMIDITY,
+        has_entity_name=True,
         key=AZD_HUMIDITY,
         name="Humidity",
         native_unit_of_measurement=PERCENTAGE,
@@ -161,7 +163,6 @@ class AirzoneAidooSensor(AirzoneAidooEntity, AirzoneSensor):
         """Initialize."""
         super().__init__(coordinator, entry, aidoo_id, aidoo_data)
 
-        self._attr_name = f"{aidoo_data[AZD_NAME]} {description.name}"
         self._attr_unique_id = f"{aidoo_id}_{description.key}"
         self.entity_description = description
 
@@ -202,7 +203,6 @@ class AirzoneZoneSensor(AirzoneZoneEntity, AirzoneSensor):
         """Initialize."""
         super().__init__(coordinator, entry, zone_id, zone_data)
 
-        self._attr_name = f"{zone_data[AZD_NAME]} {description.name}"
         self._attr_unique_id = f"{zone_id}_{description.key}"
         self.entity_description = description
 

--- a/homeassistant/components/airzone_cloud/sensor.py
+++ b/homeassistant/components/airzone_cloud/sensor.py
@@ -40,9 +40,7 @@ from .entity import (
 AIDOO_SENSOR_TYPES: Final[tuple[SensorEntityDescription, ...]] = (
     SensorEntityDescription(
         device_class=SensorDeviceClass.TEMPERATURE,
-        has_entity_name=True,
         key=AZD_TEMP,
-        name="Temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         state_class=SensorStateClass.MEASUREMENT,
     ),
@@ -53,7 +51,6 @@ WEBSERVER_SENSOR_TYPES: Final[tuple[SensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.SIGNAL_STRENGTH,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
-        has_entity_name=True,
         key=AZD_WIFI_RSSI,
         name="RSSI",
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
@@ -64,17 +61,13 @@ WEBSERVER_SENSOR_TYPES: Final[tuple[SensorEntityDescription, ...]] = (
 ZONE_SENSOR_TYPES: Final[tuple[SensorEntityDescription, ...]] = (
     SensorEntityDescription(
         device_class=SensorDeviceClass.TEMPERATURE,
-        has_entity_name=True,
         key=AZD_TEMP,
-        name="Temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(
         device_class=SensorDeviceClass.HUMIDITY,
-        has_entity_name=True,
         key=AZD_HUMIDITY,
-        name="Humidity",
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
     ),
@@ -163,6 +156,7 @@ class AirzoneAidooSensor(AirzoneAidooEntity, AirzoneSensor):
         """Initialize."""
         super().__init__(coordinator, entry, aidoo_id, aidoo_data)
 
+        self._attr_has_entity_name = True
         self._attr_unique_id = f"{aidoo_id}_{description.key}"
         self.entity_description = description
 
@@ -183,6 +177,7 @@ class AirzoneWebServerSensor(AirzoneWebServerEntity, AirzoneSensor):
         """Initialize."""
         super().__init__(coordinator, entry, ws_id, ws_data)
 
+        self._attr_has_entity_name = True
         self._attr_unique_id = f"{ws_id}_{description.key}"
         self.entity_description = description
 
@@ -203,6 +198,7 @@ class AirzoneZoneSensor(AirzoneZoneEntity, AirzoneSensor):
         """Initialize."""
         super().__init__(coordinator, entry, zone_id, zone_data)
 
+        self._attr_has_entity_name = True
         self._attr_unique_id = f"{zone_id}_{description.key}"
         self.entity_description = description
 

--- a/tests/components/airzone_cloud/test_sensor.py
+++ b/tests/components/airzone_cloud/test_sensor.py
@@ -17,10 +17,10 @@ async def test_airzone_create_sensors(
     assert state.state == "21.0"
 
     # WebServers
-    state = hass.states.get("sensor.webserver_11_22_33_44_55_66_rssi")
+    state = hass.states.get("sensor.webserver_11_22_33_44_55_66_signal_strength")
     assert state.state == "-56"
 
-    state = hass.states.get("sensor.webserver_11_22_33_44_55_67_rssi")
+    state = hass.states.get("sensor.webserver_11_22_33_44_55_67_signal_strength")
     assert state.state == "-77"
 
     # Zones


### PR DESCRIPTION
## Proposed change
Use entity name in Airzone Cloud sensors.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
