### PR TITLE
Add new properties to the weather entity in Accuweather integration

### DIFF
--- a/homeassistant/components/accuweather/weather.py
+++ b/homeassistant/components/accuweather/weather.py
@@ -32,7 +32,16 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util.dt import utc_from_timestamp
 
 from . import AccuWeatherDataUpdateCoordinator
-from .const import API_METRIC, ATTR_FORECAST, ATTRIBUTION, CONDITION_CLASSES, DOMAIN
+from .const import (
+    API_METRIC,
+    ATTR_DIRECTION,
+    ATTR_FORECAST,
+    ATTR_SPEED,
+    ATTR_VALUE,
+    ATTRIBUTION,
+    CONDITION_CLASSES,
+    DOMAIN,
+)
 
 PARALLEL_UPDATES = 1
 
@@ -91,23 +100,23 @@ class AccuWeatherEntity(
     def native_apparent_temperature(self) -> float:
         """Return the apparent temperature."""
         return cast(
-            float, self.coordinator.data["ApparentTemperature"][API_METRIC]["Value"]
+            float, self.coordinator.data["ApparentTemperature"][API_METRIC][ATTR_VALUE]
         )
 
     @property
     def native_temperature(self) -> float:
         """Return the temperature."""
-        return cast(float, self.coordinator.data["Temperature"][API_METRIC]["Value"])
+        return cast(float, self.coordinator.data["Temperature"][API_METRIC][ATTR_VALUE])
 
     @property
     def native_pressure(self) -> float:
         """Return the pressure."""
-        return cast(float, self.coordinator.data["Pressure"][API_METRIC]["Value"])
+        return cast(float, self.coordinator.data["Pressure"][API_METRIC][ATTR_VALUE])
 
     @property
     def native_dew_point(self) -> float:
         """Return the dew point."""
-        return cast(float, self.coordinator.data["DewPoint"][API_METRIC]["Value"])
+        return cast(float, self.coordinator.data["DewPoint"][API_METRIC][ATTR_VALUE])
 
     @property
     def humidity(self) -> int:
@@ -118,23 +127,25 @@ class AccuWeatherEntity(
     def native_wind_gust_speed(self) -> float:
         """Return the wind gust speed."""
         return cast(
-            float, self.coordinator.data["WindGust"]["Speed"][API_METRIC]["Value"]
+            float, self.coordinator.data["WindGust"][ATTR_SPEED][API_METRIC][ATTR_VALUE]
         )
 
     @property
     def native_wind_speed(self) -> float:
         """Return the wind speed."""
-        return cast(float, self.coordinator.data["Wind"]["Speed"][API_METRIC]["Value"])
+        return cast(
+            float, self.coordinator.data["Wind"][ATTR_SPEED][API_METRIC][ATTR_VALUE]
+        )
 
     @property
     def wind_bearing(self) -> int:
         """Return the wind bearing."""
-        return cast(int, self.coordinator.data["Wind"]["Direction"]["Degrees"])
+        return cast(int, self.coordinator.data["Wind"][ATTR_DIRECTION]["Degrees"])
 
     @property
     def native_visibility(self) -> float:
         """Return the visibility."""
-        return cast(float, self.coordinator.data["Visibility"][API_METRIC]["Value"])
+        return cast(float, self.coordinator.data["Visibility"][API_METRIC][ATTR_VALUE])
 
     @property
     def forecast(self) -> list[Forecast] | None:
@@ -146,20 +157,22 @@ class AccuWeatherEntity(
             {
                 ATTR_FORECAST_TIME: utc_from_timestamp(item["EpochDate"]).isoformat(),
                 ATTR_FORECAST_CLOUD_COVERAGE: item["CloudCoverDay"],
-                ATTR_FORECAST_NATIVE_TEMP: item["TemperatureMax"]["Value"],
-                ATTR_FORECAST_NATIVE_TEMP_LOW: item["TemperatureMin"]["Value"],
+                ATTR_FORECAST_NATIVE_TEMP: item["TemperatureMax"][ATTR_VALUE],
+                ATTR_FORECAST_NATIVE_TEMP_LOW: item["TemperatureMin"][ATTR_VALUE],
                 ATTR_FORECAST_NATIVE_APPARENT_TEMP: item["RealFeelTemperatureMax"][
-                    "Value"
+                    ATTR_VALUE
                 ],
-                ATTR_FORECAST_NATIVE_PRECIPITATION: item["TotalLiquidDay"]["Value"],
+                ATTR_FORECAST_NATIVE_PRECIPITATION: item["TotalLiquidDay"][ATTR_VALUE],
                 ATTR_FORECAST_PRECIPITATION_PROBABILITY: item[
                     "PrecipitationProbabilityDay"
                 ],
-                ATTR_FORECAST_NATIVE_WIND_SPEED: item["WindDay"]["Speed"]["Value"],
-                ATTR_FORECAST_NATIVE_WIND_GUST_SPEED: item["WindGustDay"]["Speed"][
-                    "Value"
+                ATTR_FORECAST_NATIVE_WIND_SPEED: item["WindDay"][ATTR_SPEED][
+                    ATTR_VALUE
                 ],
-                ATTR_FORECAST_WIND_BEARING: item["WindDay"]["Direction"]["Degrees"],
+                ATTR_FORECAST_NATIVE_WIND_GUST_SPEED: item["WindGustDay"][ATTR_SPEED][
+                    ATTR_VALUE
+                ],
+                ATTR_FORECAST_WIND_BEARING: item["WindDay"][ATTR_DIRECTION]["Degrees"],
                 ATTR_FORECAST_CONDITION: [
                     k for k, v in CONDITION_CLASSES.items() if item["IconDay"] in v
                 ][0],

--- a/homeassistant/components/accuweather/weather.py
+++ b/homeassistant/components/accuweather/weather.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 from typing import cast
 
 from homeassistant.components.weather import (
+    ATTR_FORECAST_CLOUD_COVERAGE,
     ATTR_FORECAST_CONDITION,
+    ATTR_FORECAST_NATIVE_APPARENT_TEMP,
     ATTR_FORECAST_NATIVE_PRECIPITATION,
     ATTR_FORECAST_NATIVE_TEMP,
     ATTR_FORECAST_NATIVE_TEMP_LOW,
+    ATTR_FORECAST_NATIVE_WIND_GUST_SPEED,
     ATTR_FORECAST_NATIVE_WIND_SPEED,
     ATTR_FORECAST_PRECIPITATION_PROBABILITY,
     ATTR_FORECAST_TIME,
@@ -142,13 +145,20 @@ class AccuWeatherEntity(
         return [
             {
                 ATTR_FORECAST_TIME: utc_from_timestamp(item["EpochDate"]).isoformat(),
+                ATTR_FORECAST_CLOUD_COVERAGE: item["CloudCoverDay"],
                 ATTR_FORECAST_NATIVE_TEMP: item["TemperatureMax"]["Value"],
                 ATTR_FORECAST_NATIVE_TEMP_LOW: item["TemperatureMin"]["Value"],
+                ATTR_FORECAST_NATIVE_APPARENT_TEMP: item["RealFeelTemperatureMax"][
+                    "Value"
+                ],
                 ATTR_FORECAST_NATIVE_PRECIPITATION: item["TotalLiquidDay"]["Value"],
                 ATTR_FORECAST_PRECIPITATION_PROBABILITY: item[
                     "PrecipitationProbabilityDay"
                 ],
                 ATTR_FORECAST_NATIVE_WIND_SPEED: item["WindDay"]["Speed"]["Value"],
+                ATTR_FORECAST_NATIVE_WIND_GUST_SPEED: item["WindGustDay"]["Speed"][
+                    "Value"
+                ],
                 ATTR_FORECAST_WIND_BEARING: item["WindDay"]["Direction"]["Degrees"],
                 ATTR_FORECAST_CONDITION: [
                     k for k, v in CONDITION_CLASSES.items() if item["IconDay"] in v

--- a/homeassistant/components/accuweather/weather.py
+++ b/homeassistant/components/accuweather/weather.py
@@ -80,6 +80,18 @@ class AccuWeatherEntity(
             return None
 
     @property
+    def cloud_coverage(self) -> float:
+        """Return the Cloud coverage in %."""
+        return cast(float, self.coordinator.data["CloudCover"])
+
+    @property
+    def native_apparent_temperature(self) -> float:
+        """Return the apparent temperature."""
+        return cast(
+            float, self.coordinator.data["ApparentTemperature"][API_METRIC]["Value"]
+        )
+
+    @property
     def native_temperature(self) -> float:
         """Return the temperature."""
         return cast(float, self.coordinator.data["Temperature"][API_METRIC]["Value"])
@@ -90,9 +102,21 @@ class AccuWeatherEntity(
         return cast(float, self.coordinator.data["Pressure"][API_METRIC]["Value"])
 
     @property
+    def native_dew_point(self) -> float:
+        """Return the dew point."""
+        return cast(float, self.coordinator.data["DewPoint"][API_METRIC]["Value"])
+
+    @property
     def humidity(self) -> int:
         """Return the humidity."""
         return cast(int, self.coordinator.data["RelativeHumidity"])
+
+    @property
+    def native_wind_gust_speed(self) -> float:
+        """Return the wind gust speed."""
+        return cast(
+            float, self.coordinator.data["WindGust"]["Speed"][API_METRIC]["Value"]
+        )
 
     @property
     def native_wind_speed(self) -> float:

--- a/tests/components/accuweather/test_weather.py
+++ b/tests/components/accuweather/test_weather.py
@@ -5,6 +5,8 @@ from unittest.mock import PropertyMock, patch
 from homeassistant.components.accuweather.const import ATTRIBUTION
 from homeassistant.components.weather import (
     ATTR_FORECAST,
+    ATTR_FORECAST_APPARENT_TEMP,
+    ATTR_FORECAST_CLOUD_COVERAGE,
     ATTR_FORECAST_CONDITION,
     ATTR_FORECAST_PRECIPITATION,
     ATTR_FORECAST_PRECIPITATION_PROBABILITY,
@@ -12,12 +14,17 @@ from homeassistant.components.weather import (
     ATTR_FORECAST_TEMP_LOW,
     ATTR_FORECAST_TIME,
     ATTR_FORECAST_WIND_BEARING,
+    ATTR_FORECAST_WIND_GUST_SPEED,
     ATTR_FORECAST_WIND_SPEED,
+    ATTR_WEATHER_APPARENT_TEMPERATURE,
+    ATTR_WEATHER_CLOUD_COVERAGE,
+    ATTR_WEATHER_DEW_POINT,
     ATTR_WEATHER_HUMIDITY,
     ATTR_WEATHER_PRESSURE,
     ATTR_WEATHER_TEMPERATURE,
     ATTR_WEATHER_VISIBILITY,
     ATTR_WEATHER_WIND_BEARING,
+    ATTR_WEATHER_WIND_GUST_SPEED,
     ATTR_WEATHER_WIND_SPEED,
 )
 from homeassistant.const import ATTR_ATTRIBUTION, ATTR_ENTITY_ID, STATE_UNAVAILABLE
@@ -50,6 +57,10 @@ async def test_weather_without_forecast(hass: HomeAssistant) -> None:
     assert state.attributes.get(ATTR_WEATHER_VISIBILITY) == 16.1
     assert state.attributes.get(ATTR_WEATHER_WIND_BEARING) == 180
     assert state.attributes.get(ATTR_WEATHER_WIND_SPEED) == 14.5  # 4.03 m/s -> km/h
+    assert state.attributes.get(ATTR_WEATHER_APPARENT_TEMPERATURE) == 22.8
+    assert state.attributes.get(ATTR_WEATHER_DEW_POINT) == 16.2
+    assert state.attributes.get(ATTR_WEATHER_CLOUD_COVERAGE) == 10
+    assert state.attributes.get(ATTR_WEATHER_WIND_GUST_SPEED) == 20.3
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
 
     entry = registry.async_get("weather.home")
@@ -71,6 +82,10 @@ async def test_weather_with_forecast(hass: HomeAssistant) -> None:
     assert state.attributes.get(ATTR_WEATHER_VISIBILITY) == 16.1
     assert state.attributes.get(ATTR_WEATHER_WIND_BEARING) == 180
     assert state.attributes.get(ATTR_WEATHER_WIND_SPEED) == 14.5  # 4.03 m/s -> km/h
+    assert state.attributes.get(ATTR_WEATHER_APPARENT_TEMPERATURE) == 22.8
+    assert state.attributes.get(ATTR_WEATHER_DEW_POINT) == 16.2
+    assert state.attributes.get(ATTR_WEATHER_CLOUD_COVERAGE) == 10
+    assert state.attributes.get(ATTR_WEATHER_WIND_GUST_SPEED) == 20.3
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
     forecast = state.attributes.get(ATTR_FORECAST)[0]
     assert forecast.get(ATTR_FORECAST_CONDITION) == "lightning-rainy"
@@ -81,6 +96,9 @@ async def test_weather_with_forecast(hass: HomeAssistant) -> None:
     assert forecast.get(ATTR_FORECAST_TIME) == "2020-07-26T05:00:00+00:00"
     assert forecast.get(ATTR_FORECAST_WIND_BEARING) == 166
     assert forecast.get(ATTR_FORECAST_WIND_SPEED) == 13.0  # 3.61 m/s -> km/h
+    assert forecast.get(ATTR_FORECAST_CLOUD_COVERAGE) == 58
+    assert forecast.get(ATTR_FORECAST_APPARENT_TEMP) == 29.8
+    assert forecast.get(ATTR_FORECAST_WIND_GUST_SPEED) == 29.6
 
     entry = registry.async_get("weather.home")
     assert entry


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds new properties `apparent_temperature`, `cloud_cover`, `dev_point` and `wind_gust_speed` to the weather entity.

Waiting for https://github.com/home-assistant/core/pull/95108

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
