### PR TITLE
Allow passing in device_id to pipeline run WS API

### DIFF
--- a/homeassistant/components/assist_pipeline/pipeline.py
+++ b/homeassistant/components/assist_pipeline/pipeline.py
@@ -512,6 +512,8 @@ class PipelineRun:
                     "engine": self.intent_agent,
                     "language": self.pipeline.conversation_language,
                     "intent_input": intent_input,
+                    "conversation_id": conversation_id,
+                    "device_id": device_id,
                 },
             )
         )

--- a/homeassistant/components/assist_pipeline/websocket_api.py
+++ b/homeassistant/components/assist_pipeline/websocket_api.py
@@ -56,6 +56,7 @@ def async_register_websocket_api(hass: HomeAssistant) -> None:
                 vol.Optional("input"): dict,
                 vol.Optional("pipeline"): str,
                 vol.Optional("conversation_id"): vol.Any(str, None),
+                vol.Optional("device_id"): vol.Any(str, None),
                 vol.Optional("timeout"): vol.Any(float, int),
             },
         ),
@@ -105,6 +106,7 @@ async def websocket_run(
     # Arguments to PipelineInput
     input_args: dict[str, Any] = {
         "conversation_id": msg.get("conversation_id"),
+        "device_id": msg.get("device_id"),
     }
 
     if start_stage == PipelineStage.STT:

--- a/tests/components/assist_pipeline/snapshots/test_init.ambr
+++ b/tests/components/assist_pipeline/snapshots/test_init.ambr
@@ -32,6 +32,8 @@
     }),
     dict({
       'data': dict({
+        'conversation_id': None,
+        'device_id': None,
         'engine': 'homeassistant',
         'intent_input': 'test transcript',
         'language': 'en',
@@ -119,6 +121,8 @@
     }),
     dict({
       'data': dict({
+        'conversation_id': None,
+        'device_id': None,
         'engine': 'homeassistant',
         'intent_input': 'test transcript',
         'language': 'en-US',
@@ -206,6 +210,8 @@
     }),
     dict({
       'data': dict({
+        'conversation_id': None,
+        'device_id': None,
         'engine': 'homeassistant',
         'intent_input': 'test transcript',
         'language': 'en-US',

--- a/tests/components/assist_pipeline/snapshots/test_websocket.ambr
+++ b/tests/components/assist_pipeline/snapshots/test_websocket.ambr
@@ -31,6 +31,8 @@
 # ---
 # name: test_audio_pipeline.3
   dict({
+    'conversation_id': None,
+    'device_id': None,
     'engine': 'homeassistant',
     'intent_input': 'test transcript',
     'language': 'en',
@@ -107,6 +109,8 @@
 # ---
 # name: test_audio_pipeline_debug.3
   dict({
+    'conversation_id': None,
+    'device_id': None,
     'engine': 'homeassistant',
     'intent_input': 'test transcript',
     'language': 'en',
@@ -163,6 +167,8 @@
 # ---
 # name: test_intent_failed.1
   dict({
+    'conversation_id': None,
+    'device_id': None,
     'engine': 'homeassistant',
     'intent_input': 'Are the lights on?',
     'language': 'en',
@@ -180,6 +186,8 @@
 # ---
 # name: test_intent_timeout.1
   dict({
+    'conversation_id': None,
+    'device_id': None,
     'engine': 'homeassistant',
     'intent_input': 'Are the lights on?',
     'language': 'en',
@@ -249,6 +257,8 @@
 # ---
 # name: test_text_only_pipeline.1
   dict({
+    'conversation_id': 'mock-conversation-id',
+    'device_id': 'mock-device-id',
     'engine': 'homeassistant',
     'intent_input': 'Are the lights on?',
     'language': 'en',

--- a/tests/components/assist_pipeline/test_websocket.py
+++ b/tests/components/assist_pipeline/test_websocket.py
@@ -28,6 +28,8 @@ async def test_text_only_pipeline(
             "start_stage": "intent",
             "end_stage": "intent",
             "input": {"text": "Are the lights on?"},
+            "conversation_id": "mock-conversation-id",
+            "device_id": "mock-device-id",
         }
     )
 
@@ -954,7 +956,6 @@ async def test_list_pipelines(
 ) -> None:
     """Test we can list pipelines."""
     client = await hass_ws_client(hass)
-    hass.data[DOMAIN]
 
     await client.send_json_auto_id({"type": "assist_pipeline/pipeline/list"})
     msg = await client.receive_json()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow passing in the device ID of the device that initiated the assist pipeline run. This will be used in the future to contextualize commands like "Turn on the lights"

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
