### PR TITLE
Use snapshots in devolo Home Network button tests

### DIFF
--- a/tests/components/devolo_home_network/snapshots/test_button.ambr
+++ b/tests/components/devolo_home_network/snapshots/test_button.ambr
@@ -1,0 +1,345 @@
+# serializer version: 1
+# name: test_button[identify_device_with_a_blinking_led-async_identify_device_start]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title Identify device with a blinking LED',
+      'icon': 'mdi:led-on',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.mock_title_identify_device_with_a_blinking_led',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_button[identify_device_with_a_blinking_led-async_identify_device_start].1
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'button.mock_title_identify_device_with_a_blinking_led',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:led-on',
+    'original_name': 'Identify device with a blinking LED',
+    'platform': 'devolo_home_network',
+    'supported_features': 0,
+    'translation_key': 'identify',
+    'unique_id': '1234567890_identify',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_button[identify_device_with_a_blinking_led-plcnet-async_identify_device_start]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title Identify device with a blinking LED',
+      'icon': 'mdi:led-on',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.mock_title_identify_device_with_a_blinking_led',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_button[identify_device_with_a_blinking_led-plcnet-async_identify_device_start].1
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'button.mock_title_identify_device_with_a_blinking_led',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:led-on',
+    'original_name': 'Identify device with a blinking LED',
+    'platform': 'devolo_home_network',
+    'supported_features': 0,
+    'translation_key': 'identify',
+    'unique_id': '1234567890_identify',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_button[restart_device-async_restart]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'restart',
+      'friendly_name': 'Mock Title Restart device',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.mock_title_restart_device',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_button[restart_device-async_restart].1
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'button.mock_title_restart_device',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <ButtonDeviceClass.RESTART: 'restart'>,
+    'original_icon': None,
+    'original_name': 'Restart device',
+    'platform': 'devolo_home_network',
+    'supported_features': 0,
+    'translation_key': 'restart',
+    'unique_id': '1234567890_restart',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_button[restart_device-device-async_restart]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'restart',
+      'friendly_name': 'Mock Title Restart device',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.mock_title_restart_device',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_button[restart_device-device-async_restart].1
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'button.mock_title_restart_device',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <ButtonDeviceClass.RESTART: 'restart'>,
+    'original_icon': None,
+    'original_name': 'Restart device',
+    'platform': 'devolo_home_network',
+    'supported_features': 0,
+    'translation_key': 'restart',
+    'unique_id': '1234567890_restart',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_button[start_plc_pairing-async_pair_device]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title Start PLC pairing',
+      'icon': 'mdi:plus-network-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.mock_title_start_plc_pairing',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_button[start_plc_pairing-async_pair_device].1
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.mock_title_start_plc_pairing',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:plus-network-outline',
+    'original_name': 'Start PLC pairing',
+    'platform': 'devolo_home_network',
+    'supported_features': 0,
+    'translation_key': 'pairing',
+    'unique_id': '1234567890_pairing',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_button[start_plc_pairing-plcnet-async_pair_device]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title Start PLC pairing',
+      'icon': 'mdi:plus-network-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.mock_title_start_plc_pairing',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_button[start_plc_pairing-plcnet-async_pair_device].1
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.mock_title_start_plc_pairing',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:plus-network-outline',
+    'original_name': 'Start PLC pairing',
+    'platform': 'devolo_home_network',
+    'supported_features': 0,
+    'translation_key': 'pairing',
+    'unique_id': '1234567890_pairing',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_button[start_wps-async_start_wps]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title Start WPS',
+      'icon': 'mdi:wifi-plus',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.mock_title_start_wps',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_button[start_wps-async_start_wps].1
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.mock_title_start_wps',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:wifi-plus',
+    'original_name': 'Start WPS',
+    'platform': 'devolo_home_network',
+    'supported_features': 0,
+    'translation_key': 'start_wps',
+    'unique_id': '1234567890_start_wps',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_button[start_wps-device-async_start_wps]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title Start WPS',
+      'icon': 'mdi:wifi-plus',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.mock_title_start_wps',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_button[start_wps-device-async_start_wps].1
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.mock_title_start_wps',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:wifi-plus',
+    'original_name': 'Start WPS',
+    'platform': 'devolo_home_network',
+    'supported_features': 0,
+    'translation_key': 'start_wps',
+    'unique_id': '1234567890_start_wps',
+    'unit_of_measurement': None,
+  })
+# ---

--- a/tests/components/devolo_home_network/test_button.py
+++ b/tests/components/devolo_home_network/test_button.py
@@ -3,19 +3,18 @@ from unittest.mock import AsyncMock
 
 from devolo_plc_api.exceptions.device import DevicePasswordProtected, DeviceUnavailable
 import pytest
+from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.button import (
     DOMAIN as PLATFORM,
     SERVICE_PRESS,
-    ButtonDeviceClass,
 )
 from homeassistant.components.devolo_home_network.const import DOMAIN
 from homeassistant.config_entries import SOURCE_REAUTH
-from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN
+from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.entity import EntityCategory
 
 from . import configure_integration
 from .mock import MockDevice
@@ -40,164 +39,68 @@ async def test_button_setup(hass: HomeAssistant) -> None:
     await hass.config_entries.async_unload(entry.entry_id)
 
 
-@pytest.mark.freeze_time("2023-01-13 12:00:00+00:00")
-async def test_identify_device(
-    hass: HomeAssistant, mock_device: MockDevice, entity_registry: er.EntityRegistry
-) -> None:
-    """Test start PLC pairing button."""
-    entry = configure_integration(hass)
-    device_name = entry.title.replace(" ", "_").lower()
-    state_key = f"{PLATFORM}.{device_name}_identify_device_with_a_blinking_led"
-    await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
-
-    state = hass.states.get(state_key)
-    assert state is not None
-    assert state.state == STATE_UNKNOWN
-    assert (
-        entity_registry.async_get(state_key).entity_category
-        is EntityCategory.DIAGNOSTIC
-    )
-
-    # Emulate button press
-    await hass.services.async_call(
-        PLATFORM,
-        SERVICE_PRESS,
-        {ATTR_ENTITY_ID: state_key},
-        blocking=True,
-    )
-    await hass.async_block_till_done()
-
-    state = hass.states.get(state_key)
-    assert state.state == "2023-01-13T12:00:00+00:00"
-    assert mock_device.plcnet.async_identify_device_start.call_count == 1
-
-    await hass.config_entries.async_unload(entry.entry_id)
-
-
-@pytest.mark.freeze_time("2023-01-13 12:00:00+00:00")
-async def test_start_plc_pairing(hass: HomeAssistant, mock_device: MockDevice) -> None:
-    """Test start PLC pairing button."""
-    entry = configure_integration(hass)
-    device_name = entry.title.replace(" ", "_").lower()
-    state_key = f"{PLATFORM}.{device_name}_start_plc_pairing"
-    await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
-
-    state = hass.states.get(state_key)
-    assert state is not None
-    assert state.state == STATE_UNKNOWN
-
-    # Emulate button press
-    await hass.services.async_call(
-        PLATFORM,
-        SERVICE_PRESS,
-        {ATTR_ENTITY_ID: state_key},
-        blocking=True,
-    )
-    await hass.async_block_till_done()
-
-    state = hass.states.get(state_key)
-    assert state.state == "2023-01-13T12:00:00+00:00"
-    assert mock_device.plcnet.async_pair_device.call_count == 1
-
-    await hass.config_entries.async_unload(entry.entry_id)
-
-
-@pytest.mark.freeze_time("2023-01-13 12:00:00+00:00")
-async def test_restart(
-    hass: HomeAssistant, mock_device: MockDevice, entity_registry: er.EntityRegistry
-) -> None:
-    """Test restart button."""
-    entry = configure_integration(hass)
-    device_name = entry.title.replace(" ", "_").lower()
-    state_key = f"{PLATFORM}.{device_name}_restart_device"
-    await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
-
-    state = hass.states.get(state_key)
-    assert state is not None
-    assert state.state == STATE_UNKNOWN
-    assert state.attributes["device_class"] == ButtonDeviceClass.RESTART
-    assert entity_registry.async_get(state_key).entity_category is EntityCategory.CONFIG
-
-    # Emulate button press
-    await hass.services.async_call(
-        PLATFORM,
-        SERVICE_PRESS,
-        {ATTR_ENTITY_ID: state_key},
-        blocking=True,
-    )
-    await hass.async_block_till_done()
-
-    state = hass.states.get(state_key)
-    assert state.state == "2023-01-13T12:00:00+00:00"
-    assert mock_device.device.async_restart.call_count == 1
-
-    await hass.config_entries.async_unload(entry.entry_id)
-
-
-@pytest.mark.freeze_time("2023-01-13 12:00:00+00:00")
-async def test_start_wps(hass: HomeAssistant, mock_device: MockDevice) -> None:
-    """Test start WPS button."""
-    entry = configure_integration(hass)
-    device_name = entry.title.replace(" ", "_").lower()
-    state_key = f"{PLATFORM}.{device_name}_start_wps"
-
-    await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
-
-    state = hass.states.get(state_key)
-    assert state is not None
-    assert state.state == STATE_UNKNOWN
-
-    # Emulate button press
-    await hass.services.async_call(
-        PLATFORM,
-        SERVICE_PRESS,
-        {ATTR_ENTITY_ID: state_key},
-        blocking=True,
-    )
-    await hass.async_block_till_done()
-
-    state = hass.states.get(state_key)
-    assert state.state == "2023-01-13T12:00:00+00:00"
-    assert mock_device.device.async_start_wps.call_count == 1
-
-    await hass.config_entries.async_unload(entry.entry_id)
-
-
 @pytest.mark.parametrize(
-    ("name", "trigger_method"),
+    ("name", "api_name", "trigger_method"),
     [
-        ["identify_device_with_a_blinking_led", "async_identify_device_start"],
-        ["start_plc_pairing", "async_pair_device"],
-        ["restart_device", "async_restart"],
-        ["start_wps", "async_start_wps"],
+        [
+            "identify_device_with_a_blinking_led",
+            "plcnet",
+            "async_identify_device_start",
+        ],
+        [
+            "start_plc_pairing",
+            "plcnet",
+            "async_pair_device",
+        ],
+        [
+            "restart_device",
+            "device",
+            "async_restart",
+        ],
+        [
+            "start_wps",
+            "device",
+            "async_start_wps",
+        ],
     ],
 )
-async def test_device_failure(
+@pytest.mark.freeze_time("2023-01-13 12:00:00+00:00")
+async def test_button(
     hass: HomeAssistant,
     mock_device: MockDevice,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
     name: str,
+    api_name: str,
     trigger_method: str,
 ) -> None:
-    """Test device failure."""
+    """Test a button."""
     entry = configure_integration(hass)
     device_name = entry.title.replace(" ", "_").lower()
     state_key = f"{PLATFORM}.{device_name}_{name}"
-
-    setattr(mock_device.device, trigger_method, AsyncMock())
-    api = getattr(mock_device.device, trigger_method)
-    api.side_effect = DeviceUnavailable
-    setattr(mock_device.plcnet, trigger_method, AsyncMock())
-    api = getattr(mock_device.plcnet, trigger_method)
-    api.side_effect = DeviceUnavailable
-
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
+    assert hass.states.get(state_key) == snapshot
+    assert entity_registry.async_get(state_key) == snapshot
+
     # Emulate button press
+    await hass.services.async_call(
+        PLATFORM,
+        SERVICE_PRESS,
+        {ATTR_ENTITY_ID: state_key},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(state_key)
+    assert state.state == "2023-01-13T12:00:00+00:00"
+    api = getattr(mock_device, api_name)
+    assert getattr(api, trigger_method).call_count == 1
+
+    # Emulate device failure
+    setattr(api, trigger_method, AsyncMock())
+    getattr(api, trigger_method).side_effect = DeviceUnavailable
     with pytest.raises(HomeAssistantError):
         await hass.services.async_call(
             PLATFORM,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The button platform was merged before https://github.com/home-assistant/core/pull/88706 and therefore didn't us snapshots yet. Using them reduces a lot of code duplication.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
