### PR TITLE
Update KNX frontend - add Group monitor telegram detail view

### DIFF
--- a/homeassistant/components/knx/const.py
+++ b/homeassistant/components/knx/const.py
@@ -114,20 +114,6 @@ class KNXConfigEntryData(TypedDict, total=False):
     telegram_log_size: int  # not required
 
 
-class KNXBusMonitorMessage(TypedDict):
-    """KNX bus monitor message."""
-
-    destination_address: str
-    destination_text: str | None
-    payload: str
-    type: str
-    value: str | None
-    source_address: str
-    source_text: str | None
-    direction: str
-    timestamp: str
-
-
 class ColorTempModes(Enum):
     """Color temperature modes for config validation."""
 

--- a/homeassistant/components/knx/manifest.json
+++ b/homeassistant/components/knx/manifest.json
@@ -13,6 +13,6 @@
   "requirements": [
     "xknx==2.10.0",
     "xknxproject==3.2.0",
-    "knx-frontend==2023.6.9.195839"
+    "knx-frontend==2023.6.23.191712"
   ]
 }

--- a/homeassistant/components/knx/websocket.py
+++ b/homeassistant/components/knx/websocket.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Final
 
-from knx_frontend import entrypoint_js, is_dev_build, locate_dir
+import knx_frontend as knx_panel
 import voluptuous as vol
 from xknxproject.exceptions import XknxProjectException
 
@@ -29,19 +29,18 @@ async def register_panel(hass: HomeAssistant) -> None:
     websocket_api.async_register_command(hass, ws_subscribe_telegram)
 
     if DOMAIN not in hass.data.get("frontend_panels", {}):
-        path = locate_dir()
         hass.http.register_static_path(
             URL_BASE,
-            path,
-            cache_headers=not is_dev_build(),
+            path=knx_panel.locate_dir(),
+            cache_headers=knx_panel.is_prod_build,
         )
         await panel_custom.async_register_panel(
             hass=hass,
             frontend_url_path=DOMAIN,
-            webcomponent_name="knx-frontend",
+            webcomponent_name=knx_panel.webcomponent_name,
             sidebar_title=DOMAIN.upper(),
             sidebar_icon="mdi:bus-electric",
-            module_url=f"{URL_BASE}/{entrypoint_js()}",
+            module_url=f"{URL_BASE}/{knx_panel.entrypoint_js}",
             embed_iframe=True,
             require_admin=True,
         )

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1089,7 +1089,7 @@ kegtron-ble==0.4.0
 kiwiki-client==0.1.1
 
 # homeassistant.components.knx
-knx-frontend==2023.6.9.195839
+knx-frontend==2023.6.23.191712
 
 # homeassistant.components.konnected
 konnected==1.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -842,7 +842,7 @@ justnimbus==0.6.0
 kegtron-ble==0.4.0
 
 # homeassistant.components.knx
-knx-frontend==2023.6.9.195839
+knx-frontend==2023.6.23.191712
 
 # homeassistant.components.konnected
 konnected==1.2.0

--- a/tests/components/knx/test_websocket.py
+++ b/tests/components/knx/test_websocket.py
@@ -183,22 +183,22 @@ async def test_knx_subscribe_telegrams_command_recent_telegrams(
 
     recent_tgs = res["result"]["recent_telegrams"]
     assert len(recent_tgs) == 2
-    # telegrams are sorted from newest to oldest
-    assert recent_tgs[0]["destination_address"] == "1/2/4"
-    assert recent_tgs[0]["payload"] == "1"
-    assert recent_tgs[0]["type"] == "GroupValueWrite"
-    assert (
-        recent_tgs[0]["source_address"] == "0.0.0"
-    )  # needs to be the IA currently connected to
-    assert recent_tgs[0]["direction"] == "group_monitor_outgoing"
-    assert recent_tgs[0]["timestamp"] is not None
+    # telegrams are sorted from oldest to newest
+    assert recent_tgs[0]["destination"] == "1/3/4"
+    assert recent_tgs[0]["payload"] == 1
+    assert recent_tgs[0]["telegramtype"] == "GroupValueWrite"
+    assert recent_tgs[0]["source"] == "1.2.3"
+    assert recent_tgs[0]["direction"] == "Incoming"
+    assert isinstance(recent_tgs[0]["timestamp"], str)
 
-    assert recent_tgs[1]["destination_address"] == "1/3/4"
-    assert recent_tgs[1]["payload"] == "1"
-    assert recent_tgs[1]["type"] == "GroupValueWrite"
-    assert recent_tgs[1]["source_address"] == "1.2.3"
-    assert recent_tgs[1]["direction"] == "group_monitor_incoming"
-    assert recent_tgs[1]["timestamp"] is not None
+    assert recent_tgs[1]["destination"] == "1/2/4"
+    assert recent_tgs[1]["payload"] == 1
+    assert recent_tgs[1]["telegramtype"] == "GroupValueWrite"
+    assert (
+        recent_tgs[1]["source"] == "0.0.0"
+    )  # needs to be the IA currently connected to
+    assert recent_tgs[1]["direction"] == "Outgoing"
+    assert isinstance(recent_tgs[1]["timestamp"], str)
 
 
 async def test_knx_subscribe_telegrams_command_no_project(
@@ -231,45 +231,45 @@ async def test_knx_subscribe_telegrams_command_no_project(
 
     # receive events
     res = await client.receive_json()
-    assert res["event"]["destination_address"] == "1/2/3"
-    assert res["event"]["payload"] == ""
-    assert res["event"]["type"] == "GroupValueRead"
-    assert res["event"]["source_address"] == "1.2.3"
-    assert res["event"]["direction"] == "group_monitor_incoming"
+    assert res["event"]["destination"] == "1/2/3"
+    assert res["event"]["payload"] is None
+    assert res["event"]["telegramtype"] == "GroupValueRead"
+    assert res["event"]["source"] == "1.2.3"
+    assert res["event"]["direction"] == "Incoming"
     assert res["event"]["timestamp"] is not None
 
     res = await client.receive_json()
-    assert res["event"]["destination_address"] == "1/3/4"
-    assert res["event"]["payload"] == "1"
-    assert res["event"]["type"] == "GroupValueWrite"
-    assert res["event"]["source_address"] == "1.2.3"
-    assert res["event"]["direction"] == "group_monitor_incoming"
+    assert res["event"]["destination"] == "1/3/4"
+    assert res["event"]["payload"] == 1
+    assert res["event"]["telegramtype"] == "GroupValueWrite"
+    assert res["event"]["source"] == "1.2.3"
+    assert res["event"]["direction"] == "Incoming"
     assert res["event"]["timestamp"] is not None
 
     res = await client.receive_json()
-    assert res["event"]["destination_address"] == "1/3/4"
-    assert res["event"]["payload"] == "0"
-    assert res["event"]["type"] == "GroupValueWrite"
-    assert res["event"]["source_address"] == "1.2.3"
-    assert res["event"]["direction"] == "group_monitor_incoming"
+    assert res["event"]["destination"] == "1/3/4"
+    assert res["event"]["payload"] == 0
+    assert res["event"]["telegramtype"] == "GroupValueWrite"
+    assert res["event"]["source"] == "1.2.3"
+    assert res["event"]["direction"] == "Incoming"
     assert res["event"]["timestamp"] is not None
 
     res = await client.receive_json()
-    assert res["event"]["destination_address"] == "1/3/8"
-    assert res["event"]["payload"] == "0x3445"
-    assert res["event"]["type"] == "GroupValueWrite"
-    assert res["event"]["source_address"] == "1.2.3"
-    assert res["event"]["direction"] == "group_monitor_incoming"
+    assert res["event"]["destination"] == "1/3/8"
+    assert res["event"]["payload"] == [52, 69]
+    assert res["event"]["telegramtype"] == "GroupValueWrite"
+    assert res["event"]["source"] == "1.2.3"
+    assert res["event"]["direction"] == "Incoming"
     assert res["event"]["timestamp"] is not None
 
     res = await client.receive_json()
-    assert res["event"]["destination_address"] == "1/2/4"
-    assert res["event"]["payload"] == "1"
-    assert res["event"]["type"] == "GroupValueWrite"
+    assert res["event"]["destination"] == "1/2/4"
+    assert res["event"]["payload"] == 1
+    assert res["event"]["telegramtype"] == "GroupValueWrite"
     assert (
-        res["event"]["source_address"] == "0.0.0"
+        res["event"]["source"] == "0.0.0"
     )  # needs to be the IA currently connected to
-    assert res["event"]["direction"] == "group_monitor_outgoing"
+    assert res["event"]["direction"] == "Outgoing"
     assert res["event"]["timestamp"] is not None
 
 
@@ -289,42 +289,45 @@ async def test_knx_subscribe_telegrams_command_project(
     # incoming DPT 1 telegram
     await knx.receive_write("0/0/1", True)
     res = await client.receive_json()
-    assert res["event"]["destination_address"] == "0/0/1"
-    assert res["event"]["destination_text"] == "Binary"
-    assert res["event"]["payload"] == "1"
-    assert res["event"]["type"] == "GroupValueWrite"
-    assert res["event"]["source_address"] == "1.2.3"
-    assert res["event"]["direction"] == "group_monitor_incoming"
+    assert res["event"]["destination"] == "0/0/1"
+    assert res["event"]["destination_name"] == "Binary"
+    assert res["event"]["payload"] == 1
+    assert res["event"]["telegramtype"] == "GroupValueWrite"
+    assert res["event"]["source"] == "1.2.3"
+    assert res["event"]["direction"] == "Incoming"
     assert res["event"]["timestamp"] is not None
 
     # incoming DPT 5 telegram
     await knx.receive_write("0/1/1", (0x50,), source="1.1.6")
     res = await client.receive_json()
-    assert res["event"]["destination_address"] == "0/1/1"
-    assert res["event"]["destination_text"] == "percent"
-    assert res["event"]["payload"] == "0x50"
-    assert res["event"]["value"] == "31 %"
-    assert res["event"]["type"] == "GroupValueWrite"
-    assert res["event"]["source_address"] == "1.1.6"
+    assert res["event"]["destination"] == "0/1/1"
+    assert res["event"]["destination_name"] == "percent"
+    assert res["event"]["payload"] == [
+        80,
+    ]
+    assert res["event"]["value"] == 31
+    assert res["event"]["unit"] == "%"
+    assert res["event"]["telegramtype"] == "GroupValueWrite"
+    assert res["event"]["source"] == "1.1.6"
     assert (
-        res["event"]["source_text"]
+        res["event"]["source_name"]
         == "Enertex Bayern GmbH Enertex KNX LED Dimmsequenzer 20A/5x REG"
     )
-    assert res["event"]["direction"] == "group_monitor_incoming"
+    assert res["event"]["direction"] == "Incoming"
     assert res["event"]["timestamp"] is not None
 
     # incoming undecodable telegram (wrong payload type)
     await knx.receive_write("0/1/1", True, source="1.1.6")
     res = await client.receive_json()
-    assert res["event"]["destination_address"] == "0/1/1"
-    assert res["event"]["destination_text"] == "percent"
-    assert res["event"]["payload"] == "1"
+    assert res["event"]["destination"] == "0/1/1"
+    assert res["event"]["destination_name"] == "percent"
+    assert res["event"]["payload"] == 1
     assert res["event"]["value"] == "Error decoding value"
-    assert res["event"]["type"] == "GroupValueWrite"
-    assert res["event"]["source_address"] == "1.1.6"
+    assert res["event"]["telegramtype"] == "GroupValueWrite"
+    assert res["event"]["source"] == "1.1.6"
     assert (
-        res["event"]["source_text"]
+        res["event"]["source_name"]
         == "Enertex Bayern GmbH Enertex KNX LED Dimmsequenzer 20A/5x REG"
     )
-    assert res["event"]["direction"] == "group_monitor_incoming"
+    assert res["event"]["direction"] == "Incoming"
     assert res["event"]["timestamp"] is not None


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update `knx_frontend` to 2023.6.23.191712 https://github.com/XKNX/knx-frontend/releases/tag/2023.6.23.191712

- The rows in the group monitor are now clickable to spawn a detail view of a single telegram. This is especially helpful on mobile where we can't render all columns of the table.
- `knx_frontend` now uses `TelegramDict` (which we are already working with in the backend) instead of a dedicated `KNXBusMonitorMessage` dict format. String manipulations (eg. timestamp formatting) happen in frontend now.
- add `dpt_main`, `dpt_sub` and `dpt_name` fields to `TelegramDict` (this is used in the Group monitor telegram detail view)
- static values needed to load the panel are loaded from the frontend module (`entrypoint_js` name, `webcomponent_name` etc.)

<img width="1728" alt="Bildschirmfoto 2023-06-23 um 21 32 37" src="https://github.com/home-assistant/core/assets/12422879/a3f08a2e-7ae2-4764-9697-aed8aa511043">

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
