### PR TITLE
Reduce overhead to set up and write entity state

### DIFF
--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -322,29 +322,28 @@ class Entity(ABC):
         """Return a unique ID."""
         return self._attr_unique_id
 
+    def _report_implicit_device_name(self) -> None:
+        """Report entities which use implicit device name."""
+        if self._implicit_device_name_reported:
+            return
+        report_issue = self._suggest_report_issue()
+        _LOGGER.warning(
+            (
+                "Entity %s (%s) is implicitly using device name by not setting its "
+                "name. Instead, the name should be set to None, please %s"
+            ),
+            self.entity_id,
+            type(self),
+            report_issue,
+        )
+        self._implicit_device_name_reported = True
+
     @property
     def use_device_name(self) -> bool:
         """Return if this entity does not have its own name.
 
         Should be True if the entity represents the single main feature of a device.
         """
-
-        def report_implicit_device_name() -> None:
-            """Report entities which use implicit device name."""
-            if self._implicit_device_name_reported:
-                return
-            report_issue = self._suggest_report_issue()
-            _LOGGER.warning(
-                (
-                    "Entity %s (%s) is implicitly using device name by not setting its "
-                    "name. Instead, the name should be set to None, please %s"
-                ),
-                self.entity_id,
-                type(self),
-                report_issue,
-            )
-            self._implicit_device_name_reported = True
-
         if hasattr(self, "_attr_name"):
             return not self._attr_name
 
@@ -359,13 +358,13 @@ class Entity(ABC):
                 # Backwards compatibility with leaving EntityDescription.name unassigned
                 # for device name.
                 # Deprecated in HA Core 2023.6, remove in HA Core 2023.9
-                report_implicit_device_name()
+                self._report_implicit_device_name()
                 return True
             return False
         if self.name is UNDEFINED and not self._default_to_device_class_name():
             # Backwards compatibility with not overriding name property for device name.
             # Deprecated in HA Core 2023.6, remove in HA Core 2023.9
-            report_implicit_device_name()
+            self._report_implicit_device_name()
             return True
         return not self.name
 
@@ -1090,6 +1089,19 @@ class Entity(ABC):
         self._unsub_device_updates = None
 
     @callback
+    def _async_device_registry_updated(self, event: Event) -> None:
+        """Handle device registry update."""
+        data = event.data
+
+        if data["action"] != "update":
+            return
+
+        if "name" not in data["changes"] and "name_by_user" not in data["changes"]:
+            return
+
+        self.async_write_ha_state()
+
+    @callback
     def _async_subscribe_device_updates(self) -> None:
         """Subscribe to device registry updates."""
         assert self.registry_entry
@@ -1102,23 +1114,10 @@ class Entity(ABC):
         if not self.has_entity_name:
             return
 
-        @callback
-        def async_device_registry_updated(event: Event) -> None:
-            """Handle device registry update."""
-            data = event.data
-
-            if data["action"] != "update":
-                return
-
-            if "name" not in data["changes"] and "name_by_user" not in data["changes"]:
-                return
-
-            self.async_write_ha_state()
-
         self._unsub_device_updates = async_track_device_registry_updated_event(
             self.hass,
             device_id,
-            async_device_registry_updated,
+            self._async_device_registry_updated,
         )
         if (
             not self._on_remove


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Move some functions that are created every time to be bound to the class instead of closures. This avoids creating a copy of these functions in memory every time an entity was created or state was written

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
