### PR TITLE
Remove deprecated non-native number support

### DIFF
--- a/homeassistant/components/number/__init__.py
+++ b/homeassistant/components/number/__init__.py
@@ -135,39 +135,6 @@ class NumberEntityDescription(EntityDescription):
     step: None = None
     unit_of_measurement: None = None  # Type override, use native_unit_of_measurement
 
-    def __post_init__(self) -> None:
-        """Post initialisation processing."""
-        if (
-            self.max_value is not None
-            or self.min_value is not None
-            or self.step is not None
-            or self.unit_of_measurement is not None
-        ):
-            if (  # type: ignore[unreachable]
-                self.__class__.__name__ == "NumberEntityDescription"
-            ):
-                caller = inspect.stack()[2]
-                module = inspect.getmodule(caller[0])
-            else:
-                module = inspect.getmodule(self)
-            if module and module.__file__ and "custom_components" in module.__file__:
-                report_issue = "report it to the custom integration author."
-            else:
-                report_issue = (
-                    "create a bug report at "
-                    "https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue"
-                )
-            _LOGGER.warning(
-                (
-                    "%s is setting deprecated attributes on an instance of"
-                    " NumberEntityDescription, this is not valid and will be"
-                    " unsupported from Home Assistant 2022.10. Please %s"
-                ),
-                module.__name__ if module else self.__class__.__name__,
-                report_issue,
-            )
-            self.native_unit_of_measurement = self.unit_of_measurement
-
 
 def ceil_decimal(value: float, precision: float = 0) -> float:
     """Return the ceiling of f with d decimals.
@@ -252,8 +219,10 @@ class NumberEntity(Entity):
     def capability_attributes(self) -> dict[str, Any]:
         """Return capability attributes."""
         return {
-            ATTR_MIN: self.min_value,
-            ATTR_MAX: self.max_value,
+            ATTR_MIN: self._convert_to_state_value(
+                self.native_min_value, floor_decimal
+            ),
+            ATTR_MAX: self._convert_to_state_value(self.native_max_value, ceil_decimal),
             ATTR_STEP: self.step,
             ATTR_MODE: self.mode,
         }
@@ -290,15 +259,6 @@ class NumberEntity(Entity):
     @final
     def min_value(self) -> float:
         """Return the minimum value."""
-        if hasattr(self, "_attr_min_value"):
-            self._report_deprecated_number_entity()
-            return self._attr_min_value  # type: ignore[return-value]
-        if (
-            hasattr(self, "entity_description")
-            and self.entity_description.min_value is not None
-        ):
-            self._report_deprecated_number_entity()  # type: ignore[unreachable]
-            return self.entity_description.min_value
         return self._convert_to_state_value(self.native_min_value, floor_decimal)
 
     @property
@@ -317,15 +277,6 @@ class NumberEntity(Entity):
     @final
     def max_value(self) -> float:
         """Return the maximum value."""
-        if hasattr(self, "_attr_max_value"):
-            self._report_deprecated_number_entity()
-            return self._attr_max_value  # type: ignore[return-value]
-        if (
-            hasattr(self, "entity_description")
-            and self.entity_description.max_value is not None
-        ):
-            self._report_deprecated_number_entity()  # type: ignore[unreachable]
-            return self.entity_description.max_value
         return self._convert_to_state_value(self.native_max_value, ceil_decimal)
 
     @property
@@ -342,15 +293,6 @@ class NumberEntity(Entity):
     @final
     def step(self) -> float:
         """Return the increment/decrement step."""
-        if hasattr(self, "_attr_step"):
-            self._report_deprecated_number_entity()
-            return self._attr_step  # type: ignore[return-value]
-        if (
-            hasattr(self, "entity_description")
-            and self.entity_description.step is not None
-        ):
-            self._report_deprecated_number_entity()  # type: ignore[unreachable]
-            return self.entity_description.step
         if hasattr(self, "_attr_native_step"):
             return self._attr_native_step
         if (native_step := self.native_step) is not None:
@@ -396,17 +338,6 @@ class NumberEntity(Entity):
         if self._number_option_unit_of_measurement:
             return self._number_option_unit_of_measurement
 
-        if hasattr(self, "_attr_unit_of_measurement"):
-            self._report_deprecated_number_entity()
-            return self._attr_unit_of_measurement
-        if (
-            hasattr(self, "entity_description")
-            and self.entity_description.unit_of_measurement is not None
-        ):
-            return (  # type: ignore[unreachable]
-                self.entity_description.unit_of_measurement
-            )
-
         native_unit_of_measurement = self.native_unit_of_measurement
 
         if (
@@ -427,10 +358,6 @@ class NumberEntity(Entity):
     @final
     def value(self) -> float | None:
         """Return the entity value to represent the entity state."""
-        if hasattr(self, "_attr_value"):
-            self._report_deprecated_number_entity()
-            return self._attr_value
-
         if (native_value := self.native_value) is None:
             return native_value
         return self._convert_to_state_value(native_value, round)
@@ -457,7 +384,6 @@ class NumberEntity(Entity):
         self, value: float, method: Callable[[float, int], float]
     ) -> float:
         """Convert a value in the number's native unit to the configured unit."""
-
         native_unit_of_measurement = self.native_unit_of_measurement
         unit_of_measurement = self.unit_of_measurement
         device_class = self.device_class
@@ -487,7 +413,6 @@ class NumberEntity(Entity):
 
     def convert_to_native_value(self, value: float) -> float:
         """Convert a value to the number's native unit."""
-
         native_unit_of_measurement = self.native_unit_of_measurement
         unit_of_measurement = self.unit_of_measurement
         device_class = self.device_class
@@ -507,21 +432,6 @@ class NumberEntity(Entity):
             )
 
         return value
-
-    def _report_deprecated_number_entity(self) -> None:
-        """Report that the number entity has not been upgraded."""
-        if not self._deprecated_number_entity_reported:
-            self._deprecated_number_entity_reported = True
-            report_issue = self._suggest_report_issue()
-            _LOGGER.warning(
-                (
-                    "Entity %s (%s) is using deprecated NumberEntity features which"
-                    " will be unsupported from Home Assistant Core 2022.10, please %s"
-                ),
-                self.entity_id,
-                type(self),
-                report_issue,
-            )
 
     @callback
     def async_registry_entry_updated(self) -> None:

--- a/homeassistant/components/number/__init__.py
+++ b/homeassistant/components/number/__init__.py
@@ -219,10 +219,8 @@ class NumberEntity(Entity):
     def capability_attributes(self) -> dict[str, Any]:
         """Return capability attributes."""
         return {
-            ATTR_MIN: self._convert_to_state_value(
-                self.native_min_value, floor_decimal
-            ),
-            ATTR_MAX: self._convert_to_state_value(self.native_max_value, ceil_decimal),
+            ATTR_MIN: self.min_value,
+            ATTR_MAX: self.max_value,
             ATTR_STEP: self.step,
             ATTR_MODE: self.mode,
         }

--- a/tests/components/number/test_init.py
+++ b/tests/components/number/test_init.py
@@ -40,7 +40,6 @@ from homeassistant.util.unit_system import METRIC_SYSTEM, US_CUSTOMARY_SYSTEM
 
 from tests.common import (
     MockConfigEntry,
-    MockEntityPlatform,
     MockModule,
     MockPlatform,
     async_mock_restore_state_shutdown_restart,
@@ -253,64 +252,6 @@ async def test_attributes(hass: HomeAssistant) -> None:
     assert number_4.value is None
 
 
-async def test_deprecation_warnings(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
-) -> None:
-    """Test overriding the deprecated attributes is possible and warnings are logged."""
-    number = MockDefaultNumberEntityDeprecated()
-    number.hass = hass
-    number.platform = MockEntityPlatform(hass)
-    assert number.max_value == 100.0
-    assert number.min_value == 0.0
-    assert number.step == 1.0
-    assert number.unit_of_measurement is None
-    assert number.value == 0.5
-
-    number_2 = MockNumberEntityDeprecated()
-    number_2.hass = hass
-    number_2.platform = MockEntityPlatform(hass)
-    assert number_2.max_value == 0.5
-    assert number_2.min_value == -0.5
-    assert number_2.step == 0.1
-    assert number_2.unit_of_measurement == "cats"
-    assert number_2.value == 0.5
-
-    number_3 = MockNumberEntityAttrDeprecated()
-    number_3.hass = hass
-    number_3.platform = MockEntityPlatform(hass)
-    assert number_3.max_value == 1000.0
-    assert number_3.min_value == -1000.0
-    assert number_3.step == 100.0
-    assert number_3.unit_of_measurement == "dogs"
-    assert number_3.value == 500.0
-
-    number_4 = MockNumberEntityDescrDeprecated()
-    number_4.hass = hass
-    number_4.platform = MockEntityPlatform(hass)
-    assert number_4.max_value == 10.0
-    assert number_4.min_value == -10.0
-    assert number_4.step == 2.0
-    assert number_4.unit_of_measurement == "rabbits"
-    assert number_4.value == 0.5
-
-    assert (
-        "tests.components.number.test_init::MockNumberEntityDeprecated is overriding "
-        " deprecated methods on an instance of NumberEntity"
-    )
-    assert (
-        "Entity None (<class 'tests.components.number.test_init.MockNumberEntityAttrDeprecated'>) "
-        "is using deprecated NumberEntity features" in caplog.text
-    )
-    assert (
-        "Entity None (<class 'tests.components.number.test_init.MockNumberEntityDescrDeprecated'>) "
-        "is using deprecated NumberEntity features" in caplog.text
-    )
-    assert (
-        "tests.components.number.test_init is setting deprecated attributes on an "
-        "instance of NumberEntityDescription" in caplog.text
-    )
-
-
 async def test_sync_set_value(hass: HomeAssistant) -> None:
     """Test if async set_value calls sync set_value."""
     number = MockDefaultNumberEntity()
@@ -358,104 +299,6 @@ async def test_set_value(hass: HomeAssistant, enable_custom_integrations: None) 
     await hass.async_block_till_done()
     state = hass.states.get("number.test")
     assert state.state == "60.0"
-
-
-async def test_deprecated_attributes(
-    hass: HomeAssistant, enable_custom_integrations: None
-) -> None:
-    """Test entity using deprecated attributes."""
-    platform = getattr(hass.components, f"test.{DOMAIN}")
-    platform.init(empty=True)
-    platform.ENTITIES.append(platform.LegacyMockNumberEntity())
-    entity = platform.ENTITIES[0]
-    entity._attr_name = "Test"
-    entity._attr_max_value = 25
-    entity._attr_min_value = -25
-    entity._attr_step = 2.5
-    entity._attr_value = 51.0
-
-    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
-    await hass.async_block_till_done()
-
-    state = hass.states.get("number.test")
-    assert state.state == "51.0"
-    assert state.attributes.get(ATTR_MAX) == 25.0
-    assert state.attributes.get(ATTR_MIN) == -25.0
-    assert state.attributes.get(ATTR_STEP) == 2.5
-
-    await hass.services.async_call(
-        DOMAIN,
-        SERVICE_SET_VALUE,
-        {ATTR_VALUE: 0.0, ATTR_ENTITY_ID: "number.test"},
-        blocking=True,
-    )
-    await hass.async_block_till_done()
-
-    state = hass.states.get("number.test")
-    assert state.state == "0.0"
-
-    # test ValueError trigger
-    with pytest.raises(ValueError):
-        await hass.services.async_call(
-            DOMAIN,
-            SERVICE_SET_VALUE,
-            {ATTR_VALUE: 110.0, ATTR_ENTITY_ID: "number.test"},
-            blocking=True,
-        )
-
-    await hass.async_block_till_done()
-    state = hass.states.get("number.test")
-    assert state.state == "0.0"
-
-
-async def test_deprecated_methods(
-    hass: HomeAssistant, enable_custom_integrations: None
-) -> None:
-    """Test entity using deprecated methods."""
-    platform = getattr(hass.components, f"test.{DOMAIN}")
-    platform.init(empty=True)
-    platform.ENTITIES.append(
-        platform.LegacyMockNumberEntity(
-            name="Test",
-            max_value=25.0,
-            min_value=-25.0,
-            step=2.5,
-            value=51.0,
-        )
-    )
-
-    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
-    await hass.async_block_till_done()
-
-    state = hass.states.get("number.test")
-    assert state.state == "51.0"
-    assert state.attributes.get(ATTR_MAX) == 25.0
-    assert state.attributes.get(ATTR_MIN) == -25.0
-    assert state.attributes.get(ATTR_STEP) == 2.5
-
-    await hass.services.async_call(
-        DOMAIN,
-        SERVICE_SET_VALUE,
-        {ATTR_VALUE: 0.0, ATTR_ENTITY_ID: "number.test"},
-        blocking=True,
-    )
-    await hass.async_block_till_done()
-
-    state = hass.states.get("number.test")
-    assert state.state == "0.0"
-
-    # test ValueError trigger
-    with pytest.raises(ValueError):
-        await hass.services.async_call(
-            DOMAIN,
-            SERVICE_SET_VALUE,
-            {ATTR_VALUE: 110.0, ATTR_ENTITY_ID: "number.test"},
-            blocking=True,
-        )
-
-    await hass.async_block_till_done()
-    state = hass.states.get("number.test")
-    assert state.state == "0.0"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

These were scheduled to be removed in 2022.10, and considered unsupported in 2023.1, but were left in to give custom component authors a bit more time.

Its been a year since they were deprecated so its time to remove the old code

https://developers.home-assistant.io/blog/2022/06/14/number_entity_refactoring/


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
