### PR TITLE
Fix control4 light switches on OS 3.3+

### DIFF
--- a/homeassistant/components/control4/light.py
+++ b/homeassistant/components/control4/light.py
@@ -193,6 +193,7 @@ class Control4Light(Control4Entity, LightEntity):
             for var in CONTROL4_DIMMER_VARS:
                 if var in self.coordinator.data[self._idx]:
                     return self.coordinator.data[self._idx][var] > 0
+            raise RuntimeError("Dimmer Variable Not Found")
         return self.coordinator.data[self._idx][CONTROL4_NON_DIMMER_VAR] > 0
 
     @property

--- a/homeassistant/components/control4/light.py
+++ b/homeassistant/components/control4/light.py
@@ -30,7 +30,7 @@ _LOGGER = logging.getLogger(__name__)
 
 CONTROL4_CATEGORY = "lights"
 CONTROL4_NON_DIMMER_VAR = "LIGHT_STATE"
-CONTROL4_DIMMER_VAR = "LIGHT_LEVEL"
+CONTROL4_DIMMER_VARS = ["LIGHT_LEVEL", "Brightness Percent"]
 
 
 async def async_setup_entry(
@@ -57,7 +57,7 @@ async def async_setup_entry(
         """Fetch data from Control4 director for dimmer lights."""
         try:
             return await update_variables_for_config_entry(
-                hass, entry, {CONTROL4_DIMMER_VAR}
+                hass, entry, {*CONTROL4_DIMMER_VARS}
             )
         except C4Exception as err:
             raise UpdateFailed(f"Error communicating with API: {err}") from err
@@ -190,14 +190,18 @@ class Control4Light(Control4Entity, LightEntity):
     def is_on(self):
         """Return whether this light is on or off."""
         if self._is_dimmer:
-            return self.coordinator.data[self._idx][CONTROL4_DIMMER_VAR] > 0
+            for var in CONTROL4_DIMMER_VARS:
+                if var in self.coordinator.data[self._idx]:
+                    return self.coordinator.data[self._idx][var] > 0
         return self.coordinator.data[self._idx][CONTROL4_NON_DIMMER_VAR] > 0
 
     @property
     def brightness(self):
         """Return the brightness of this light between 0..255."""
         if self._is_dimmer:
-            return round(self.coordinator.data[self._idx][CONTROL4_DIMMER_VAR] * 2.55)
+            for var in CONTROL4_DIMMER_VARS:
+                if var in self.coordinator.data[self._idx]:
+                    return round(self.coordinator.data[self._idx][var] * 2.55)
         return None
 
     @property


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add new light level variable name that was introduced in OS 3.3+ fixes an old bug documented in https://github.com/home-assistant/core/issues/73353

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #73353
- This PR is related to issue: https://github.com/home-assistant/core/issues/73353
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
