### PR TITLE
Add Update Entity for Linn devices

### DIFF
--- a/homeassistant/components/openhome/__init__.py
+++ b/homeassistant/components/openhome/__init__.py
@@ -17,7 +17,7 @@ from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = [Platform.MEDIA_PLAYER]
+PLATFORMS = [Platform.MEDIA_PLAYER, Platform.UPDATE]
 
 CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
 

--- a/homeassistant/components/openhome/manifest.json
+++ b/homeassistant/components/openhome/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://www.home-assistant.io/integrations/openhome",
   "iot_class": "local_polling",
   "loggers": ["async_upnp_client", "openhomedevice"],
-  "requirements": ["openhomedevice==2.0.2"],
+  "requirements": ["openhomedevice==2.1.0"],
   "ssdp": [
     {
       "st": "urn:av-openhome-org:service:Product:1"

--- a/homeassistant/components/openhome/manifest.json
+++ b/homeassistant/components/openhome/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://www.home-assistant.io/integrations/openhome",
   "iot_class": "local_polling",
   "loggers": ["async_upnp_client", "openhomedevice"],
-  "requirements": ["openhomedevice==2.1.0"],
+  "requirements": ["openhomedevice==2.2.0"],
   "ssdp": [
     {
       "st": "urn:av-openhome-org:service:Product:1"

--- a/homeassistant/components/openhome/media_player.py
+++ b/homeassistant/components/openhome/media_player.py
@@ -126,9 +126,9 @@ class OpenhomeDevice(MediaPlayerEntity):
             identifiers={
                 (DOMAIN, self._device.uuid()),
             },
-            manufacturer=self._device.device.manufacturer,
-            model=self._device.device.model_name,
-            name=self._device.device.friendly_name,
+            manufacturer=self._device.manufacturer(),
+            model=self._device.model_name(),
+            name=self._device.friendly_name(),
         )
 
     @property

--- a/homeassistant/components/openhome/update.py
+++ b/homeassistant/components/openhome/update.py
@@ -78,20 +78,16 @@ class OpenhomeUpdateEntity(UpdateEntity):
             self._attr_release_url = None
             return
 
-        self._attr_installed_version = software_status["current_software"][
-            "version"
-        ]
+        self._attr_installed_version = software_status["current_software"]["version"]
 
         if software_status["status"] == "update_available":
-            self._attr_latest_version = software_status["update_info"]["updates"][
-                0
-            ]["version"]
-            self._attr_release_summary = software_status["update_info"]["updates"][
-                0
-            ]["description"]
-            self._attr_release_url = software_status["update_info"][
-                "releasenotesuri"
+            self._attr_latest_version = software_status["update_info"]["updates"][0][
+                "version"
             ]
+            self._attr_release_summary = software_status["update_info"]["updates"][0][
+                "description"
+            ]
+            self._attr_release_url = software_status["update_info"]["releasenotesuri"]
 
     async def async_install(
         self, version: str | None, backup: bool, **kwargs: Any

--- a/homeassistant/components/openhome/update.py
+++ b/homeassistant/components/openhome/update.py
@@ -1,0 +1,128 @@
+"""Update entities for Linn devices."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.components.update import (
+    UpdateDeviceClass,
+    UpdateEntity,
+    UpdateEntityFeature,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up update entities for Reolink component."""
+
+    _LOGGER.debug("Setting up config entry: %s", config_entry.unique_id)
+
+    device = hass.data[DOMAIN][config_entry.entry_id]
+
+    entity = OpenhomeUpdateEntity(device)
+
+    await entity.async_update()
+
+    async_add_entities([entity])
+
+
+class OpenhomeUpdateEntity(UpdateEntity):
+    """Update entity for a Linn DS device."""
+
+    def __init__(self, device):
+        """Initialize a Linn DS update entity."""
+        self._attr_device_class = UpdateDeviceClass.FIRMWARE
+        self._attr_supported_features = UpdateEntityFeature.INSTALL
+        self._name = None
+        self._device = device
+        self._installed_version = None
+        self._latest_version = None
+        self._release_summary = None
+        self._release_url = None
+
+    @property
+    def unique_id(self):
+        """Return a unique ID."""
+        return f"{self._device.uuid()}-update"
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return f"{self._name} Firmware Update"
+
+    @property
+    def installed_version(self) -> str | None:
+        """Version currently in use."""
+        return self._installed_version
+
+    @property
+    def latest_version(self) -> str | None:
+        """Latest version available for install."""
+        return self._latest_version
+
+    @property
+    def release_summary(self) -> str | None:
+        """Description of the latest firmware release."""
+        return self._release_summary
+
+    @property
+    def release_url(self) -> str | None:
+        """URL to the full release notes of the latest version available."""
+        return self._release_url
+
+    @property
+    def device_info(self):
+        """Return a device description for device registry."""
+        return DeviceInfo(
+            identifiers={
+                (DOMAIN, self._device.uuid()),
+            },
+            manufacturer=self._device.device.manufacturer,
+            model=self._device.device.model_name,
+            name=self._device.device.friendly_name,
+        )
+
+    async def async_update(self) -> None:
+        """Update state of entity."""
+
+        self._name = await self._device.room()
+
+        software_status = await self._device.software_status()
+
+        if not software_status:
+            return
+
+        self._installed_version = software_status["current_software"]["version"]
+
+        if software_status["status"] == "update_available":
+            self._latest_version = software_status["update_info"]["updates"][0][
+                "version"
+            ]
+            self._release_summary = software_status["update_info"]["updates"][0][
+                "description"
+            ]
+            self._release_url = software_status["update_info"]["releasenotesuri"]
+
+    async def async_install(
+        self, version: str | None, backup: bool, **kwargs: Any
+    ) -> None:
+        """Install the latest firmware version."""
+        try:
+            if self.latest_version:
+                await self._device.update_firmware()
+        except Exception as err:
+            raise HomeAssistantError(
+                f"Error updating {self._device.device.friendly_name}: {err}"
+            ) from err

--- a/homeassistant/components/openhome/update.py
+++ b/homeassistant/components/openhome/update.py
@@ -70,9 +70,9 @@ class OpenhomeUpdateEntity(UpdateEntity):
             identifiers={
                 (DOMAIN, self._device.uuid()),
             },
-            manufacturer=self._device.device.manufacturer,
-            model=self._device.device.model_name,
-            name=self._device.device.friendly_name,
+            manufacturer=self._device.manufacturer(),
+            model=self._device.model_name(),
+            name=self._device.friendly_name(),
         )
 
     async def async_update(self) -> None:

--- a/homeassistant/components/openhome/update.py
+++ b/homeassistant/components/openhome/update.py
@@ -41,6 +41,9 @@ async def async_setup_entry(
 class OpenhomeUpdateEntity(UpdateEntity):
     """Update entity for a Linn DS device."""
 
+    _attr_has_entity_name = True
+    _attr_name = "Firmware Update"
+
     def __init__(self, device):
         """Initialize a Linn DS update entity."""
         self._attr_device_class = UpdateDeviceClass.FIRMWARE

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1348,7 +1348,7 @@ openerz-api==0.2.0
 openevsewifi==1.1.2
 
 # homeassistant.components.openhome
-openhomedevice==2.0.2
+openhomedevice==2.1.0
 
 # homeassistant.components.opensensemap
 opensensemap-api==0.2.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1348,7 +1348,7 @@ openerz-api==0.2.0
 openevsewifi==1.1.2
 
 # homeassistant.components.openhome
-openhomedevice==2.1.0
+openhomedevice==2.2.0
 
 # homeassistant.components.opensensemap
 opensensemap-api==0.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1026,7 +1026,7 @@ openai==0.27.2
 openerz-api==0.2.0
 
 # homeassistant.components.openhome
-openhomedevice==2.0.2
+openhomedevice==2.1.0
 
 # homeassistant.components.oralb
 oralb-ble==0.17.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1026,7 +1026,7 @@ openai==0.27.2
 openerz-api==0.2.0
 
 # homeassistant.components.openhome
-openhomedevice==2.1.0
+openhomedevice==2.2.0
 
 # homeassistant.components.oralb
 oralb-ble==0.17.6

--- a/tests/components/openhome/test_update.py
+++ b/tests/components/openhome/test_update.py
@@ -1,0 +1,106 @@
+"""Tests for the Openhome update platform."""
+from unittest.mock import AsyncMock
+
+from homeassistant.components.openhome.update import OpenhomeUpdateEntity
+
+LATEST_FIRMWARE_INSTALLED = {
+    "status": "on_latest",
+    "current_software": {"version": "4.100.502", "topic": "main", "channel": "release"},
+}
+
+FIRMWARE_UPDATE_AVAILABLE = {
+    "status": "update_available",
+    "current_software": {"version": "4.99.491", "topic": "main", "channel": "release"},
+    "update_info": {
+        "legal": {
+            "licenseurl": "http://products.linn.co.uk/VersionInfo/licenseV2.txt",
+            "privacyurl": "https://www.linn.co.uk/privacy",
+            "privacyuri": "https://products.linn.co.uk/VersionInfo/PrivacyV1.json",
+            "privacyversion": 1,
+        },
+        "releasenotesuri": "http://docs.linn.co.uk/wiki/index.php/ReleaseNotes",
+        "updates": [
+            {
+                "channel": "release",
+                "date": "07 Jun 2023 12:29:48",
+                "description": "Release build version 4.100.502 (07 Jun 2023 12:29:48)",
+                "exaktlink": "3",
+                "manifest": "https://cloud.linn.co.uk/update/components/836/4.100.502/manifest.json",
+                "topic": "main",
+                "variant": "836",
+                "version": "4.100.502",
+            }
+        ],
+        "exaktUpdates": [],
+    },
+}
+
+
+async def test_on_latest_firmware():
+    """Test device on latest firmware."""
+    mock_device = AsyncMock()
+
+    mock_device.software_status.return_value = LATEST_FIRMWARE_INSTALLED
+    entity = OpenhomeUpdateEntity(mock_device)
+    await entity.async_update()
+
+    assert entity.installed_version == "4.100.502"
+    assert entity.latest_version is None
+    assert entity.release_url is None
+    assert entity.release_summary is None
+
+
+async def test_update_available():
+    """Test device has firmware update available."""
+    mock_device = AsyncMock()
+
+    mock_device.software_status.return_value = FIRMWARE_UPDATE_AVAILABLE
+    entity = OpenhomeUpdateEntity(mock_device)
+    await entity.async_update()
+
+    assert entity.installed_version == "4.99.491"
+    assert entity.latest_version == "4.100.502"
+    assert entity.release_url == "http://docs.linn.co.uk/wiki/index.php/ReleaseNotes"
+    assert (
+        entity.release_summary
+        == "Release build version 4.100.502 (07 Jun 2023 12:29:48)"
+    )
+
+
+async def test_firmware_update():
+    """Test requesting firmware update."""
+    mock_device = AsyncMock()
+
+    mock_device.software_status.return_value = FIRMWARE_UPDATE_AVAILABLE
+    entity = OpenhomeUpdateEntity(mock_device)
+    await entity.async_update()
+    await entity.async_install(None, False)
+
+    mock_device.update_firmware.assert_called_once()
+
+
+async def test_not_supported():
+    """Ensure update entity works if service not supported."""
+    mock_device = AsyncMock()
+
+    mock_device.software_status.return_value = None
+    entity = OpenhomeUpdateEntity(mock_device)
+    await entity.async_update()
+    await entity.async_install(None, False)
+
+    assert entity.installed_version is None
+    assert entity.latest_version is None
+    assert entity.release_url is None
+    assert entity.release_summary is None
+    mock_device.update_firmware.assert_not_called()
+
+
+async def test_firmware_update_not_required():
+    """Ensure firmware install does nothing if up to date."""
+    mock_device = AsyncMock()
+
+    mock_device.software_status.return_value = LATEST_FIRMWARE_INSTALLED
+    entity = OpenhomeUpdateEntity(mock_device)
+    await entity.async_install(None, False)
+
+    mock_device.update_firmware.assert_not_called()

--- a/tests/components/openhome/test_update.py
+++ b/tests/components/openhome/test_update.py
@@ -93,7 +93,7 @@ async def test_not_supported(hass: HomeAssistant):
     update_firmware = AsyncMock()
     await setup_integration(hass, None, update_firmware)
 
-    state = hass.states.get("update.friendly_name_firmware_update")
+    state = hass.states.get("update.friendly_name")
 
     assert state
     assert state.state == STATE_UNKNOWN
@@ -111,7 +111,7 @@ async def test_on_latest_firmware(hass: HomeAssistant):
     update_firmware = AsyncMock()
     await setup_integration(hass, LATEST_FIRMWARE_INSTALLED, update_firmware)
 
-    state = hass.states.get("update.friendly_name_firmware_update")
+    state = hass.states.get("update.friendly_name")
 
     assert state
     assert state.state == STATE_UNKNOWN
@@ -129,7 +129,7 @@ async def test_update_available(hass: HomeAssistant):
     update_firmware = AsyncMock()
     await setup_integration(hass, FIRMWARE_UPDATE_AVAILABLE, update_firmware)
 
-    state = hass.states.get("update.friendly_name_firmware_update")
+    state = hass.states.get("update.friendly_name")
 
     assert state
     assert state.state == STATE_ON
@@ -148,7 +148,7 @@ async def test_update_available(hass: HomeAssistant):
     await hass.services.async_call(
         PLATFORM_DOMAIN,
         SERVICE_INSTALL,
-        {ATTR_ENTITY_ID: "update.friendly_name_firmware_update"},
+        {ATTR_ENTITY_ID: "update.friendly_name"},
         blocking=True,
     )
     await hass.async_block_till_done()
@@ -166,7 +166,7 @@ async def test_firmware_update_not_required(hass: HomeAssistant):
         await hass.services.async_call(
             PLATFORM_DOMAIN,
             SERVICE_INSTALL,
-            {ATTR_ENTITY_ID: "update.friendly_name_firmware_update"},
+            {ATTR_ENTITY_ID: "update.friendly_name"},
             blocking=True,
         )
     update_firmware.assert_not_called()

--- a/tests/components/openhome/test_update.py
+++ b/tests/components/openhome/test_update.py
@@ -169,4 +169,4 @@ async def test_firmware_update_not_required(hass: HomeAssistant):
             {ATTR_ENTITY_ID: "update.friendly_name_firmware_update"},
             blocking=True,
         )
-        update_firmware.assert_not_called()
+    update_firmware.assert_not_called()

--- a/tests/components/openhome/test_update.py
+++ b/tests/components/openhome/test_update.py
@@ -1,7 +1,30 @@
 """Tests for the Openhome update platform."""
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
-from homeassistant.components.openhome.update import OpenhomeUpdateEntity
+import pytest
+
+from homeassistant.components.openhome.const import DOMAIN
+from homeassistant.components.update import (
+    ATTR_INSTALLED_VERSION,
+    ATTR_LATEST_VERSION,
+    ATTR_RELEASE_SUMMARY,
+    ATTR_RELEASE_URL,
+    DOMAIN as PLATFORM_DOMAIN,
+    SERVICE_INSTALL,
+    UpdateDeviceClass,
+)
+from homeassistant.const import (
+    ATTR_DEVICE_CLASS,
+    ATTR_ENTITY_ID,
+    CONF_HOST,
+    STATE_ON,
+    STATE_UNKNOWN,
+    Platform,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+
+from tests.common import MockConfigEntry
 
 LATEST_FIRMWARE_INSTALLED = {
     "status": "on_latest",
@@ -36,71 +59,114 @@ FIRMWARE_UPDATE_AVAILABLE = {
 }
 
 
-async def test_on_latest_firmware():
+async def setup_integration(
+    hass: HomeAssistant,
+    software_status: dict,
+    update_firmware: AsyncMock,
+) -> None:
+    """Load an openhome platform with mocked device."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "http://localhost"},
+    )
+    entry.add_to_hass(hass)
+
+    with patch("homeassistant.components.openhome.PLATFORMS", [Platform.UPDATE]), patch(
+        "homeassistant.components.openhome.Device", MagicMock()
+    ) as mock_device:
+        mock_device.return_value.init = AsyncMock()
+        mock_device.return_value.uuid = MagicMock(return_value="uuid")
+        mock_device.return_value.manufacturer = MagicMock(return_value="manufacturer")
+        mock_device.return_value.model_name = MagicMock(return_value="model_name")
+        mock_device.return_value.friendly_name = MagicMock(return_value="friendly_name")
+        mock_device.return_value.software_status = AsyncMock(
+            return_value=software_status
+        )
+        mock_device.return_value.update_firmware = update_firmware
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+
+async def test_not_supported(hass: HomeAssistant):
+    """Ensure update entity works if service not supported."""
+
+    update_firmware = AsyncMock()
+    await setup_integration(hass, None, update_firmware)
+
+    state = hass.states.get("update.friendly_name_firmware_update")
+
+    assert state
+    assert state.state == STATE_UNKNOWN
+    assert state.attributes[ATTR_DEVICE_CLASS] == UpdateDeviceClass.FIRMWARE
+    assert state.attributes[ATTR_INSTALLED_VERSION] is None
+    assert state.attributes[ATTR_LATEST_VERSION] is None
+    assert state.attributes[ATTR_RELEASE_URL] is None
+    assert state.attributes[ATTR_RELEASE_SUMMARY] is None
+    update_firmware.assert_not_called()
+
+
+async def test_on_latest_firmware(hass: HomeAssistant):
     """Test device on latest firmware."""
-    mock_device = AsyncMock()
 
-    mock_device.software_status.return_value = LATEST_FIRMWARE_INSTALLED
-    entity = OpenhomeUpdateEntity(mock_device)
-    await entity.async_update()
+    update_firmware = AsyncMock()
+    await setup_integration(hass, LATEST_FIRMWARE_INSTALLED, update_firmware)
 
-    assert entity.installed_version == "4.100.502"
-    assert entity.latest_version is None
-    assert entity.release_url is None
-    assert entity.release_summary is None
+    state = hass.states.get("update.friendly_name_firmware_update")
+
+    assert state
+    assert state.state == STATE_UNKNOWN
+    assert state.attributes[ATTR_DEVICE_CLASS] == UpdateDeviceClass.FIRMWARE
+    assert state.attributes[ATTR_INSTALLED_VERSION] == "4.100.502"
+    assert state.attributes[ATTR_LATEST_VERSION] is None
+    assert state.attributes[ATTR_RELEASE_URL] is None
+    assert state.attributes[ATTR_RELEASE_SUMMARY] is None
+    update_firmware.assert_not_called()
 
 
-async def test_update_available():
+async def test_update_available(hass: HomeAssistant):
     """Test device has firmware update available."""
-    mock_device = AsyncMock()
 
-    mock_device.software_status.return_value = FIRMWARE_UPDATE_AVAILABLE
-    entity = OpenhomeUpdateEntity(mock_device)
-    await entity.async_update()
+    update_firmware = AsyncMock()
+    await setup_integration(hass, FIRMWARE_UPDATE_AVAILABLE, update_firmware)
 
-    assert entity.installed_version == "4.99.491"
-    assert entity.latest_version == "4.100.502"
-    assert entity.release_url == "http://docs.linn.co.uk/wiki/index.php/ReleaseNotes"
+    state = hass.states.get("update.friendly_name_firmware_update")
+
+    assert state
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_DEVICE_CLASS] == UpdateDeviceClass.FIRMWARE
+    assert state.attributes[ATTR_INSTALLED_VERSION] == "4.99.491"
+    assert state.attributes[ATTR_LATEST_VERSION] == "4.100.502"
     assert (
-        entity.release_summary
+        state.attributes[ATTR_RELEASE_URL]
+        == "http://docs.linn.co.uk/wiki/index.php/ReleaseNotes"
+    )
+    assert (
+        state.attributes[ATTR_RELEASE_SUMMARY]
         == "Release build version 4.100.502 (07 Jun 2023 12:29:48)"
     )
 
+    await hass.services.async_call(
+        PLATFORM_DOMAIN,
+        SERVICE_INSTALL,
+        {ATTR_ENTITY_ID: "update.friendly_name_firmware_update"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
 
-async def test_firmware_update():
-    """Test requesting firmware update."""
-    mock_device = AsyncMock()
-
-    mock_device.software_status.return_value = FIRMWARE_UPDATE_AVAILABLE
-    entity = OpenhomeUpdateEntity(mock_device)
-    await entity.async_update()
-    await entity.async_install(None, False)
-
-    mock_device.update_firmware.assert_called_once()
+    update_firmware.assert_called_once()
 
 
-async def test_not_supported():
-    """Ensure update entity works if service not supported."""
-    mock_device = AsyncMock()
-
-    mock_device.software_status.return_value = None
-    entity = OpenhomeUpdateEntity(mock_device)
-    await entity.async_update()
-    await entity.async_install(None, False)
-
-    assert entity.installed_version is None
-    assert entity.latest_version is None
-    assert entity.release_url is None
-    assert entity.release_summary is None
-    mock_device.update_firmware.assert_not_called()
-
-
-async def test_firmware_update_not_required():
+async def test_firmware_update_not_required(hass: HomeAssistant):
     """Ensure firmware install does nothing if up to date."""
-    mock_device = AsyncMock()
 
-    mock_device.software_status.return_value = LATEST_FIRMWARE_INSTALLED
-    entity = OpenhomeUpdateEntity(mock_device)
-    await entity.async_install(None, False)
+    update_firmware = AsyncMock()
+    await setup_integration(hass, LATEST_FIRMWARE_INSTALLED, update_firmware)
 
-    mock_device.update_firmware.assert_not_called()
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            PLATFORM_DOMAIN,
+            SERVICE_INSTALL,
+            {ATTR_ENTITY_ID: "update.friendly_name_firmware_update"},
+            blocking=True,
+        )
+        update_firmware.assert_not_called()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

New software on Linn devices offer Firmware update over the API. This PR adds an `UpdateEntity` for the `Openhome` integration which will show the currently running software and offer upgrade to the latest version if available. 

This requires a minor bump of the API library. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

None

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
