### PR TITLE
Tag Aranet diagnostic entities appropriately

### DIFF
--- a/homeassistant/components/aranet/sensor.py
+++ b/homeassistant/components/aranet/sensor.py
@@ -90,6 +90,8 @@ SENSOR_DESCRIPTIONS = {
         device_class=SensorDeviceClass.DURATION,
         native_unit_of_measurement=UnitOfTime.SECONDS,
         state_class=SensorStateClass.MEASUREMENT,
+        # The interval setting is not a generally useful entity for most users.
+        entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
 }

--- a/homeassistant/components/aranet/sensor.py
+++ b/homeassistant/components/aranet/sensor.py
@@ -25,6 +25,7 @@ from homeassistant.const import (
     ATTR_SW_VERSION,
     CONCENTRATION_PARTS_PER_MILLION,
     PERCENTAGE,
+    EntityCategory,
     UnitOfPressure,
     UnitOfTemperature,
     UnitOfTime,
@@ -81,6 +82,7 @@ SENSOR_DESCRIPTIONS = {
         device_class=SensorDeviceClass.BATTERY,
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     "interval": AranetSensorEntityDescription(
         key="update_interval",
@@ -88,8 +90,7 @@ SENSOR_DESCRIPTIONS = {
         device_class=SensorDeviceClass.DURATION,
         native_unit_of_measurement=UnitOfTime.SECONDS,
         state_class=SensorStateClass.MEASUREMENT,
-        # The interval setting is not a generally useful entity for most users.
-        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
 }
 

--- a/tests/components/aranet/test_sensor.py
+++ b/tests/components/aranet/test_sensor.py
@@ -10,7 +10,9 @@ from tests.common import MockConfigEntry
 from tests.components.bluetooth import inject_bluetooth_service_info
 
 
-async def test_sensors(hass: HomeAssistant) -> None:
+async def test_sensors(
+    hass: HomeAssistant, entity_registry_enabled_by_default: None
+) -> None:
     """Test setting up creates the sensors."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -72,7 +74,9 @@ async def test_sensors(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
 
-async def test_smart_home_integration_disabled(hass: HomeAssistant) -> None:
+async def test_smart_home_integration_disabled(
+    hass: HomeAssistant, entity_registry_enabled_by_default: None
+) -> None:
     """Test disabling smart home integration marks entities as unavailable."""
     entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/aranet/test_sensor.py
+++ b/tests/components/aranet/test_sensor.py
@@ -24,7 +24,7 @@ async def test_sensors(hass: HomeAssistant) -> None:
     assert len(hass.states.async_all("sensor")) == 0
     inject_bluetooth_service_info(hass, VALID_DATA_SERVICE_INFO)
     await hass.async_block_till_done()
-    assert len(hass.states.async_all("sensor")) == 5
+    assert len(hass.states.async_all("sensor")) == 6
 
     batt_sensor = hass.states.get("sensor.aranet4_12345_battery")
     batt_sensor_attrs = batt_sensor.attributes
@@ -61,6 +61,13 @@ async def test_sensors(hass: HomeAssistant) -> None:
     assert press_sensor_attrs[ATTR_UNIT_OF_MEASUREMENT] == "hPa"
     assert press_sensor_attrs[ATTR_STATE_CLASS] == "measurement"
 
+    interval_sensor = hass.states.get("sensor.aranet4_12345_update_interval")
+    interval_sensor_attrs = interval_sensor.attributes
+    assert interval_sensor.state == "300"
+    assert interval_sensor_attrs[ATTR_FRIENDLY_NAME] == "Aranet4 12345 Update Interval"
+    assert interval_sensor_attrs[ATTR_UNIT_OF_MEASUREMENT] == "s"
+    assert interval_sensor_attrs[ATTR_STATE_CLASS] == "measurement"
+
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
 
@@ -79,7 +86,7 @@ async def test_smart_home_integration_disabled(hass: HomeAssistant) -> None:
     assert len(hass.states.async_all("sensor")) == 0
     inject_bluetooth_service_info(hass, DISABLED_INTEGRATIONS_SERVICE_INFO)
     await hass.async_block_till_done()
-    assert len(hass.states.async_all("sensor")) == 5
+    assert len(hass.states.async_all("sensor")) == 6
 
     batt_sensor = hass.states.get("sensor.aranet4_12345_battery")
     assert batt_sensor.state == "unavailable"

--- a/tests/components/aranet/test_sensor.py
+++ b/tests/components/aranet/test_sensor.py
@@ -10,7 +10,9 @@ from tests.common import MockConfigEntry
 from tests.components.bluetooth import inject_bluetooth_service_info
 
 
-async def test_sensors(hass: HomeAssistant) -> None:
+async def test_sensors(
+    hass: HomeAssistant, entity_registry_enabled_by_default: None
+) -> None:
     """Test setting up creates the sensors."""
     entry = MockConfigEntry(
         domain=DOMAIN,


### PR DESCRIPTION
## Proposed change
Turn the Aranet battery and interval sensors into diagnostic sensors, and enable the interval sensor by default.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #95197
- I have not made a documentation change PR, as while this does slightly change user-visible behavior (1-2 sensors will move to the diagnostic section), it does not change any current documented behavior.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
