### PR TITLE
Mobile app to use Assist Pipeline

### DIFF
--- a/homeassistant/components/mobile_app/manifest.json
+++ b/homeassistant/components/mobile_app/manifest.json
@@ -4,7 +4,14 @@
   "after_dependencies": ["cloud", "camera", "conversation", "notify"],
   "codeowners": ["@home-assistant/core"],
   "config_flow": true,
-  "dependencies": ["http", "webhook", "person", "tag", "websocket_api"],
+  "dependencies": [
+    "assist_pipeline",
+    "http",
+    "person",
+    "tag",
+    "webhook",
+    "websocket_api"
+  ],
   "documentation": "https://www.home-assistant.io/integrations/mobile_app",
   "iot_class": "local_push",
   "loggers": ["nacl"],

--- a/tests/components/mobile_app/test_webhook.py
+++ b/tests/components/mobile_app/test_webhook.py
@@ -1026,15 +1026,19 @@ async def test_webhook_handle_conversation_process(
     """Test that we can converse."""
     webhook_client.server.app.router._frozen = False
 
-    resp = await webhook_client.post(
-        "/api/webhook/{}".format(create_registrations[1]["webhook_id"]),
-        json={
-            "type": "conversation_process",
-            "data": {
-                "text": "Turn the kitchen light off",
+    with patch(
+        "homeassistant.components.conversation.AgentManager.async_get_agent",
+        return_value=mock_agent,
+    ):
+        resp = await webhook_client.post(
+            "/api/webhook/{}".format(create_registrations[1]["webhook_id"]),
+            json={
+                "type": "conversation_process",
+                "data": {
+                    "text": "Turn the kitchen light off",
+                },
             },
-        },
-    )
+        )
 
     assert resp.status == HTTPStatus.OK
     json = await resp.json()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change (for devs)
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Mobile apps that use `conversation_process` (currently iOS) will need to update their UI to no longer offer passing in language.

Instead, it could allow the user to pick a pipeline (pipelines fetched via WS API `assist_pipeline/pipeline/list`). Passing `null` will use the preferred pipeline.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update mobile app webhook `conversation_process` to use the preferred Assist Pipeline by default instead of using the conversation integration directly.

The conversation integration uses the last registered one as default. So if a user uses OpenAI or Google LLM, Assist shortcut won't work.

This removes the `language` parameter and replaces it with `pipeline_id`.

Requires https://github.com/home-assistant/core/pull/95223

**Note**: now that I have written it like this, I am wondering if we shouldn't just remove the conversation agent weird default instead.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
