### PR TITLE
Change conversation default agent behavior

### DIFF
--- a/homeassistant/components/conversation/__init__.py
+++ b/homeassistant/components/conversation/__init__.py
@@ -529,12 +529,8 @@ class AgentManager:
     def async_set_agent(self, agent_id: str, agent: AbstractConversationAgent) -> None:
         """Set the agent."""
         self._agents[agent_id] = agent
-        if self.default_agent == HOME_ASSISTANT_AGENT:
-            self.default_agent = agent_id
 
     @core.callback
     def async_unset_agent(self, agent_id: str) -> None:
         """Unset the agent."""
-        if self.default_agent == agent_id:
-            self.default_agent = HOME_ASSISTANT_AGENT
         self._agents.pop(agent_id, None)

--- a/tests/components/conversation/snapshots/test_init.ambr
+++ b/tests/components/conversation/snapshots/test_init.ambr
@@ -1,20 +1,20 @@
 # serializer version: 1
 # name: test_get_agent_info
   dict({
-    'id': 'mock-entry',
-    'name': 'Mock Title',
-  })
-# ---
-# name: test_get_agent_info.1
-  dict({
     'id': 'homeassistant',
     'name': 'Home Assistant',
   })
 # ---
-# name: test_get_agent_info.2
+# name: test_get_agent_info.1
   dict({
     'id': 'mock-entry',
     'name': 'Mock Title',
+  })
+# ---
+# name: test_get_agent_info.2
+  dict({
+    'id': 'homeassistant',
+    'name': 'Home Assistant',
   })
 # ---
 # name: test_get_agent_info.3
@@ -344,10 +344,7 @@
 # ---
 # name: test_ws_get_agent_info
   dict({
-    'attribution': dict({
-      'name': 'Mock assistant',
-      'url': 'https://assist.me',
-    }),
+    'attribution': None,
   })
 # ---
 # name: test_ws_get_agent_info.1

--- a/tests/components/conversation/test_init.py
+++ b/tests/components/conversation/test_init.py
@@ -1059,7 +1059,6 @@ async def test_custom_agent(
     hass_client: ClientSessionGenerator,
     hass_admin_user: MockUser,
     mock_agent,
-    agent_id,
 ) -> None:
     """Test a custom conversation agent."""
     assert await async_setup_component(hass, "homeassistant", {})
@@ -1072,7 +1071,7 @@ async def test_custom_agent(
         "text": "Test Text",
         "conversation_id": "test-conv-id",
         "language": "test-language",
-        "agent_id": agent_id,
+        "agent_id": mock_agent.agent_id,
     }
 
     resp = await client.post("/api/conversation/process", json=data)

--- a/tests/components/conversation/test_init.py
+++ b/tests/components/conversation/test_init.py
@@ -1054,7 +1054,6 @@ async def test_http_api_wrong_data(
     assert resp.status == HTTPStatus.BAD_REQUEST
 
 
-@pytest.mark.parametrize("agent_id", (None, "mock-entry"))
 async def test_custom_agent(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
@@ -1063,7 +1062,9 @@ async def test_custom_agent(
     agent_id,
 ) -> None:
     """Test a custom conversation agent."""
+    assert await async_setup_component(hass, "homeassistant", {})
     assert await async_setup_component(hass, "conversation", {})
+    assert await async_setup_component(hass, "intent", {})
 
     client = await hass_client()
 
@@ -1071,9 +1072,8 @@ async def test_custom_agent(
         "text": "Test Text",
         "conversation_id": "test-conv-id",
         "language": "test-language",
+        "agent_id": agent_id,
     }
-    if agent_id is not None:
-        data["agent_id"] = agent_id
 
     resp = await client.post("/api/conversation/process", json=data)
     assert resp.status == HTTPStatus.OK
@@ -1599,8 +1599,7 @@ async def test_get_agent_info(
     """Test get agent info."""
     agent_info = conversation.async_get_agent_info(hass)
     # Test it's the default
-    assert agent_info.id == mock_agent.agent_id
-    assert agent_info == snapshot
+    assert conversation.async_get_agent_info(hass, "homeassistant") == agent_info
     assert conversation.async_get_agent_info(hass, "homeassistant") == snapshot
     assert conversation.async_get_agent_info(hass, mock_agent.agent_id) == snapshot
     assert conversation.async_get_agent_info(hass, "not exist") is None

--- a/tests/components/google_assistant_sdk/test_init.py
+++ b/tests/components/google_assistant_sdk/test_init.py
@@ -16,7 +16,7 @@ from homeassistant.util.dt import utcnow
 
 from .conftest import ComponentSetup, ExpectedCredentials
 
-from tests.common import async_fire_time_changed, async_mock_service
+from tests.common import MockConfigEntry, async_fire_time_changed, async_mock_service
 from tests.test_util.aiohttp import AiohttpClientMocker
 from tests.typing import ClientSessionGenerator
 
@@ -322,6 +322,7 @@ async def test_send_text_command_media_player(
 async def test_conversation_agent(
     hass: HomeAssistant,
     setup_integration: ComponentSetup,
+    config_entry: MockConfigEntry,
 ) -> None:
     """Test GoogleAssistantConversationAgent."""
     await setup_integration()
@@ -348,13 +349,13 @@ async def test_conversation_agent(
         await hass.services.async_call(
             "conversation",
             "process",
-            {"text": text1},
+            {"text": text1, "agent_id": config_entry.entry_id},
             blocking=True,
         )
         await hass.services.async_call(
             "conversation",
             "process",
-            {"text": text2},
+            {"text": text2, "agent_id": config_entry.entry_id},
             blocking=True,
         )
 
@@ -367,6 +368,7 @@ async def test_conversation_agent(
 
 async def test_conversation_agent_refresh_token(
     hass: HomeAssistant,
+    config_entry: MockConfigEntry,
     setup_integration: ComponentSetup,
     aioclient_mock: AiohttpClientMocker,
 ) -> None:
@@ -392,7 +394,7 @@ async def test_conversation_agent_refresh_token(
         await hass.services.async_call(
             "conversation",
             "process",
-            {"text": text1},
+            {"text": text1, "agent_id": config_entry.entry_id},
             blocking=True,
         )
 
@@ -412,7 +414,7 @@ async def test_conversation_agent_refresh_token(
         await hass.services.async_call(
             "conversation",
             "process",
-            {"text": text2},
+            {"text": text2, "agent_id": config_entry.entry_id},
             blocking=True,
         )
 

--- a/tests/components/mobile_app/test_webhook.py
+++ b/tests/components/mobile_app/test_webhook.py
@@ -1026,15 +1026,19 @@ async def test_webhook_handle_conversation_process(
     """Test that we can converse."""
     webhook_client.server.app.router._frozen = False
 
-    resp = await webhook_client.post(
-        "/api/webhook/{}".format(create_registrations[1]["webhook_id"]),
-        json={
-            "type": "conversation_process",
-            "data": {
-                "text": "Turn the kitchen light off",
+    with patch(
+        "homeassistant.components.conversation.AgentManager.async_get_agent",
+        return_value=mock_agent,
+    ):
+        resp = await webhook_client.post(
+            "/api/webhook/{}".format(create_registrations[1]["webhook_id"]),
+            json={
+                "type": "conversation_process",
+                "data": {
+                    "text": "Turn the kitchen light off",
+                },
             },
-        },
-    )
+        )
 
     assert resp.status == HTTPStatus.OK
     json = await resp.json()

--- a/tests/components/openai_conversation/test_init.py
+++ b/tests/components/openai_conversation/test_init.py
@@ -13,6 +13,7 @@ from tests.common import MockConfigEntry
 
 async def test_default_prompt(
     hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
     mock_init_component,
     area_registry: ar.AreaRegistry,
     device_registry: dr.DeviceRegistry,
@@ -101,18 +102,24 @@ async def test_default_prompt(
             ]
         },
     ) as mock_create:
-        result = await conversation.async_converse(hass, "hello", None, Context())
+        result = await conversation.async_converse(
+            hass, "hello", None, Context(), agent_id=mock_config_entry.entry_id
+        )
 
     assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
     assert mock_create.mock_calls[0][2]["messages"] == snapshot
 
 
-async def test_error_handling(hass: HomeAssistant, mock_init_component) -> None:
+async def test_error_handling(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry, mock_init_component
+) -> None:
     """Test that the default prompt works."""
     with patch(
         "openai.ChatCompletion.acreate", side_effect=error.ServiceUnavailableError
     ):
-        result = await conversation.async_converse(hass, "hello", None, Context())
+        result = await conversation.async_converse(
+            hass, "hello", None, Context(), agent_id=mock_config_entry.entry_id
+        )
 
     assert result.response.response_type == intent.IntentResponseType.ERROR, result
     assert result.response.error_code == "unknown", result
@@ -133,7 +140,9 @@ async def test_template_error(
     ), patch("openai.ChatCompletion.acreate"):
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
-        result = await conversation.async_converse(hass, "hello", None, Context())
+        result = await conversation.async_converse(
+            hass, "hello", None, Context(), agent_id=mock_config_entry.entry_id
+        )
 
     assert result.response.response_type == intent.IntentResponseType.ERROR, result
     assert result.response.error_code == "unknown", result


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

When using the Assist shortcut on iOS, it will now always talk to Home Assistant conversation agent even if the OpenAI or Google LLM conversation integrations are set up.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The conversation integration used to be used directly by the frontend and mobile apps. Now it's part of Assist Pipelines and only still used by iOS. Assist Pipelines allow to configure the conversation agent on a per-pipeline basis.

The conversation integration has a notion of "default agent". It's used when the conversation service is used without specifying an agent. It defaults to Home Assistant built-in agent, but is set to the first conversation agent that registers during startup. This means that if you use both Google and OpenAI LLM for Assist Pipeline, the conversation integration currently has a default agent that cannot control your house. And since startup sets up everything in parallel, it can change each startup which config entry was set up first.

So it's better to have the default always be Home Assistant if no agent is specified. This will also make sure that the upcoming service response values for the `conversation.process` service will not change its behavior.

This will be a breaking change for the Assist shortcut on iOS. On iOS, bringing back the option to talk to LLMs could be done using:

- Allow user to pick an agent from WS API `conversation/agent/list`
- Migrate to use Pipelines, using the [pipelines WS API](https://developers.home-assistant.io/docs/voice/pipelines/) and WS API `assist_pipeline/pipeline/list`

An alternative to the iOS breaking change is to merge https://github.com/home-assistant/core/pull/95224. It will switch the mobile app `conversation_process` webhook to use the conversation agent defined in the preferred pipeline. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
