### PR TITLE
Add additional coverage for ESPHome sensor and number

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -312,7 +312,6 @@ omit =
     homeassistant/components/esphome/domain_data.py
     homeassistant/components/esphome/entry_data.py
     homeassistant/components/esphome/light.py
-    homeassistant/components/esphome/number.py
     homeassistant/components/esphome/switch.py
     homeassistant/components/etherscan/sensor.py
     homeassistant/components/eufy/*

--- a/homeassistant/components/esphome/number.py
+++ b/homeassistant/components/esphome/number.py
@@ -74,9 +74,7 @@ class EsphomeNumber(EsphomeEntity[NumberInfo, NumberState], NumberEntity):
     def native_value(self) -> float | None:
         """Return the state of the entity."""
         state = self._state
-        if math.isnan(state.state):
-            return None
-        if state.missing_state:
+        if state.missing_state or math.isnan(state.state):
             return None
         return state.state
 

--- a/tests/components/esphome/test_number.py
+++ b/tests/components/esphome/test_number.py
@@ -1,0 +1,57 @@
+"""Test ESPHome numbers."""
+
+from unittest.mock import call
+
+from aioesphomeapi import (
+    APIClient,
+    NumberInfo,
+    NumberState,
+)
+
+from homeassistant.components.number import (
+    ATTR_VALUE,
+    DOMAIN as NUMBER_DOMAIN,
+    SERVICE_SET_VALUE,
+)
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
+
+
+async def test_generic_numeric_entity(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_generic_device_entry,
+) -> None:
+    """Test a generic number entity."""
+    entity_info = [
+        NumberInfo(
+            object_id="mynumber",
+            key=1,
+            name="my number",
+            unique_id="my_number",
+            max_value=100,
+            min_value=0,
+            step=1,
+            unit_of_measurement="%",
+        )
+    ]
+    states = [NumberState(key=1, state=50)]
+    user_service = []
+    await mock_generic_device_entry(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        user_service=user_service,
+        states=states,
+    )
+    state = hass.states.get("number.test_my_number")
+    assert state is not None
+    assert state.state == "50"
+
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: "number.test_my_number", ATTR_VALUE: 50},
+        blocking=True,
+    )
+    mock_client.number_command.assert_has_calls([call(1, 50)])
+    mock_client.number_command.reset_mock()

--- a/tests/components/esphome/test_number.py
+++ b/tests/components/esphome/test_number.py
@@ -1,10 +1,12 @@
 """Test ESPHome numbers."""
 
+import math
 from unittest.mock import call
 
 from aioesphomeapi import (
     APIClient,
     NumberInfo,
+    NumberMode as ESPHomeNumberMode,
     NumberState,
 )
 
@@ -13,11 +15,11 @@ from homeassistant.components.number import (
     DOMAIN as NUMBER_DOMAIN,
     SERVICE_SET_VALUE,
 )
-from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 
 
-async def test_generic_numeric_entity(
+async def test_generic_number_entity(
     hass: HomeAssistant,
     mock_client: APIClient,
     mock_generic_device_entry,
@@ -55,3 +57,35 @@ async def test_generic_numeric_entity(
     )
     mock_client.number_command.assert_has_calls([call(1, 50)])
     mock_client.number_command.reset_mock()
+
+
+async def test_generic_number_nan(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_generic_device_entry,
+) -> None:
+    """Test a generic number entity with nan state."""
+    entity_info = [
+        NumberInfo(
+            object_id="mynumber",
+            key=1,
+            name="my number",
+            unique_id="my_number",
+            max_value=100,
+            min_value=0,
+            step=1,
+            unit_of_measurement="%",
+            mode=ESPHomeNumberMode.SLIDER,
+        )
+    ]
+    states = [NumberState(key=1, state=math.nan)]
+    user_service = []
+    await mock_generic_device_entry(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        user_service=user_service,
+        states=states,
+    )
+    state = hass.states.get("number.test_my_number")
+    assert state is not None
+    assert state.state == STATE_UNKNOWN

--- a/tests/components/esphome/test_sensor.py
+++ b/tests/components/esphome/test_sensor.py
@@ -1,6 +1,7 @@
 """Test ESPHome sensors."""
 from aioesphomeapi import (
     APIClient,
+    EntityCategory as ESPHomeEntityCategory,
     LastResetType,
     SensorInfo,
     SensorState,
@@ -10,8 +11,10 @@ from aioesphomeapi import (
 )
 
 from homeassistant.components.sensor import ATTR_STATE_CLASS, SensorStateClass
-from homeassistant.const import STATE_UNKNOWN
+from homeassistant.const import ATTR_ICON, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.entity import EntityCategory
 
 
 async def test_generic_numeric_sensor(
@@ -39,6 +42,41 @@ async def test_generic_numeric_sensor(
     state = hass.states.get("sensor.test_my_sensor")
     assert state is not None
     assert state.state == "50"
+
+
+async def test_generic_numeric_sensor_with_entity_category_and_icon(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_generic_device_entry,
+) -> None:
+    """Test a generic sensor entity."""
+    entity_info = [
+        SensorInfo(
+            object_id="mysensor",
+            key=1,
+            name="my sensor",
+            unique_id="my_sensor",
+            entity_category=ESPHomeEntityCategory.CONFIG,
+            icon="mdi:leaf",
+        )
+    ]
+    states = [SensorState(key=1, state=50)]
+    user_service = []
+    await mock_generic_device_entry(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        user_service=user_service,
+        states=states,
+    )
+    state = hass.states.get("sensor.test_my_sensor")
+    assert state is not None
+    assert state.state == "50"
+    assert state.attributes[ATTR_ICON] == "mdi:leaf"
+    entity_reg = er.async_get(hass)
+    entry = entity_reg.async_get("sensor.test_my_sensor")
+    assert entry is not None
+    assert entry.unique_id == "my_sensor"
+    assert entry.entity_category is EntityCategory.CONFIG
 
 
 async def test_generic_numeric_sensor_state_class_measurement(
@@ -70,6 +108,11 @@ async def test_generic_numeric_sensor_state_class_measurement(
     assert state is not None
     assert state.state == "50"
     assert state.attributes[ATTR_STATE_CLASS] == SensorStateClass.MEASUREMENT
+    entity_reg = er.async_get(hass)
+    entry = entity_reg.async_get("sensor.test_my_sensor")
+    assert entry is not None
+    assert entry.unique_id == "my_sensor"
+    assert entry.entity_category is None
 
 
 async def test_generic_numeric_sensor_device_class_timestamp(

--- a/tests/components/esphome/test_sensor.py
+++ b/tests/components/esphome/test_sensor.py
@@ -1,4 +1,6 @@
 """Test ESPHome sensors."""
+import math
+
 from aioesphomeapi import (
     APIClient,
     EntityCategory as ESPHomeEntityCategory,
@@ -171,6 +173,56 @@ async def test_generic_numeric_sensor_legacy_last_reset_convert(
     assert state is not None
     assert state.state == "50"
     assert state.attributes[ATTR_STATE_CLASS] == SensorStateClass.TOTAL_INCREASING
+
+
+async def test_generic_numeric_sensor_no_state(
+    hass: HomeAssistant, mock_client: APIClient, mock_generic_device_entry
+) -> None:
+    """Test a generic numeric sensor that has no state."""
+    entity_info = [
+        SensorInfo(
+            object_id="mysensor",
+            key=1,
+            name="my sensor",
+            unique_id="my_sensor",
+        )
+    ]
+    states = []
+    user_service = []
+    await mock_generic_device_entry(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        user_service=user_service,
+        states=states,
+    )
+    state = hass.states.get("sensor.test_my_sensor")
+    assert state is not None
+    assert state.state == STATE_UNKNOWN
+
+
+async def test_generic_numeric_sensor_nan_state(
+    hass: HomeAssistant, mock_client: APIClient, mock_generic_device_entry
+) -> None:
+    """Test a generic numeric sensor that has nan state."""
+    entity_info = [
+        SensorInfo(
+            object_id="mysensor",
+            key=1,
+            name="my sensor",
+            unique_id="my_sensor",
+        )
+    ]
+    states = [SensorState(key=1, state=math.nan, missing_state=False)]
+    user_service = []
+    await mock_generic_device_entry(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        user_service=user_service,
+        states=states,
+    )
+    state = hass.states.get("sensor.test_my_sensor")
+    assert state is not None
+    assert state.state == STATE_UNKNOWN
 
 
 async def test_generic_numeric_sensor_missing_state(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add additional coverage for ESPHome `entity.py` via `sensor/number`
 
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
