### PR TITLE
Use entity registry id in binary_sensor device conditions

### DIFF
--- a/homeassistant/components/binary_sensor/device_condition.py
+++ b/homeassistant/components/binary_sensor/device_condition.py
@@ -256,7 +256,7 @@ ENTITY_CONDITIONS = {
 
 CONDITION_SCHEMA = cv.DEVICE_CONDITION_BASE_SCHEMA.extend(
     {
-        vol.Required(CONF_ENTITY_ID): cv.entity_id,
+        vol.Required(CONF_ENTITY_ID): cv.entity_id_or_uuid,
         vol.Required(CONF_TYPE): vol.In(IS_OFF + IS_ON),
         vol.Optional(CONF_FOR): cv.positive_time_period_dict,
     }
@@ -287,7 +287,7 @@ async def async_get_conditions(
                 **template,
                 "condition": "device",
                 "device_id": device_id,
-                "entity_id": entry.entity_id,
+                "entity_id": entry.id,
                 "domain": DOMAIN,
             }
             for template in templates

--- a/tests/components/binary_sensor/test_device_condition.py
+++ b/tests/components/binary_sensor/test_device_condition.py
@@ -45,6 +45,7 @@ async def test_get_conditions(
     platform.init()
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
     await hass.async_block_till_done()
+    binary_sensor_entries = {}
 
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -53,7 +54,7 @@ async def test_get_conditions(
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
     for device_class in BinarySensorDeviceClass:
-        entity_registry.async_get_or_create(
+        binary_sensor_entries[device_class] = entity_registry.async_get_or_create(
             DOMAIN,
             "test",
             platform.ENTITIES[device_class].unique_id,
@@ -66,7 +67,7 @@ async def test_get_conditions(
             "domain": DOMAIN,
             "type": condition["type"],
             "device_id": device_entry.id,
-            "entity_id": platform.ENTITIES[device_class].entity_id,
+            "entity_id": binary_sensor_entries[device_class].id,
             "metadata": {"secondary": False},
         }
         for device_class in BinarySensorDeviceClass
@@ -101,7 +102,7 @@ async def test_get_conditions_hidden_auxiliary(
         config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
-    entity_registry.async_get_or_create(
+    entity_entry = entity_registry.async_get_or_create(
         DOMAIN,
         "test",
         "5678",
@@ -115,7 +116,7 @@ async def test_get_conditions_hidden_auxiliary(
             "domain": DOMAIN,
             "type": condition,
             "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
+            "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
         for condition in ["is_on", "is_off"]
@@ -138,15 +139,15 @@ async def test_get_conditions_no_state(
         config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
-    entity_ids = {}
+    binary_sensor_entries = {}
     for device_class in BinarySensorDeviceClass:
-        entity_ids[device_class] = entity_registry.async_get_or_create(
+        binary_sensor_entries[device_class] = entity_registry.async_get_or_create(
             DOMAIN,
             "test",
             f"5678_{device_class}",
             device_id=device_entry.id,
             original_device_class=device_class,
-        ).entity_id
+        )
 
     await hass.async_block_till_done()
 
@@ -156,7 +157,7 @@ async def test_get_conditions_no_state(
             "domain": DOMAIN,
             "type": condition["type"],
             "device_id": device_entry.id,
-            "entity_id": entity_ids[device_class],
+            "entity_id": binary_sensor_entries[device_class].id,
             "metadata": {"secondary": False},
         }
         for device_class in BinarySensorDeviceClass
@@ -198,8 +199,44 @@ async def test_get_condition_capabilities(
         assert capabilities == expected_capabilities
 
 
+async def test_get_condition_capabilities_legacy(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test we get the expected capabilities from a binary_sensor condition."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_registry.async_get_or_create(
+        DOMAIN, "test", "5678", device_id=device_entry.id
+    )
+    expected_capabilities = {
+        "extra_fields": [
+            {"name": "for", "optional": True, "type": "positive_time_period_dict"}
+        ]
+    }
+    conditions = await async_get_device_automations(
+        hass, DeviceAutomationType.CONDITION, device_entry.id
+    )
+    for condition in conditions:
+        condition["entity_id"] = entity_registry.async_get(
+            condition["entity_id"]
+        ).entity_id
+        capabilities = await async_get_device_automation_capabilities(
+            hass, DeviceAutomationType.CONDITION, condition
+        )
+        assert capabilities == expected_capabilities
+
+
 async def test_if_state(
-    hass: HomeAssistant, calls, enable_custom_integrations: None
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    calls,
+    enable_custom_integrations: None,
 ) -> None:
     """Test for turn_on and turn_off conditions."""
     platform = getattr(hass.components, f"test.{DOMAIN}")
@@ -208,7 +245,7 @@ async def test_if_state(
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
     await hass.async_block_till_done()
 
-    sensor1 = platform.ENTITIES["battery"]
+    entry = entity_registry.async_get(platform.ENTITIES["battery"].entity_id)
 
     assert await async_setup_component(
         hass,
@@ -222,7 +259,7 @@ async def test_if_state(
                             "condition": "device",
                             "domain": DOMAIN,
                             "device_id": "",
-                            "entity_id": sensor1.entity_id,
+                            "entity_id": entry.id,
                             "type": "is_bat_low",
                         }
                     ],
@@ -241,7 +278,7 @@ async def test_if_state(
                             "condition": "device",
                             "domain": DOMAIN,
                             "device_id": "",
-                            "entity_id": sensor1.entity_id,
+                            "entity_id": entry.id,
                             "type": "is_not_bat_low",
                         }
                     ],
@@ -257,7 +294,7 @@ async def test_if_state(
         },
     )
     await hass.async_block_till_done()
-    assert hass.states.get(sensor1.entity_id).state == STATE_ON
+    assert hass.states.get(entry.entity_id).state == STATE_ON
     assert len(calls) == 0
 
     hass.bus.async_fire("test_event1")
@@ -265,7 +302,7 @@ async def test_if_state(
     assert len(calls) == 1
     assert calls[0].data["some"] == "is_on event - test_event1"
 
-    hass.states.async_set(sensor1.entity_id, STATE_OFF)
+    hass.states.async_set(entry.entity_id, STATE_OFF)
     hass.bus.async_fire("test_event1")
     hass.bus.async_fire("test_event2")
     await hass.async_block_till_done()
@@ -273,8 +310,63 @@ async def test_if_state(
     assert calls[1].data["some"] == "is_off event - test_event2"
 
 
+async def test_if_state_legacy(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    calls,
+    enable_custom_integrations: None,
+) -> None:
+    """Test for turn_on and turn_off conditions."""
+    platform = getattr(hass.components, f"test.{DOMAIN}")
+
+    platform.init()
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
+
+    entry = entity_registry.async_get(platform.ENTITIES["battery"].entity_id)
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {"platform": "event", "event_type": "test_event1"},
+                    "condition": [
+                        {
+                            "condition": "device",
+                            "domain": DOMAIN,
+                            "device_id": "",
+                            "entity_id": entry.entity_id,
+                            "type": "is_bat_low",
+                        }
+                    ],
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": "is_on {{ trigger.%s }}"
+                            % "}} - {{ trigger.".join(("platform", "event.event_type"))
+                        },
+                    },
+                },
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get(entry.entity_id).state == STATE_ON
+    assert len(calls) == 0
+
+    hass.bus.async_fire("test_event1")
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    assert calls[0].data["some"] == "is_on event - test_event1"
+
+
 async def test_if_fires_on_for_condition(
-    hass: HomeAssistant, calls, enable_custom_integrations: None
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    calls,
+    enable_custom_integrations: None,
 ) -> None:
     """Test for firing if condition is on with delay."""
     point1 = dt_util.utcnow()
@@ -287,7 +379,7 @@ async def test_if_fires_on_for_condition(
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
     await hass.async_block_till_done()
 
-    sensor1 = platform.ENTITIES["battery"]
+    entry = entity_registry.async_get(platform.ENTITIES["battery"].entity_id)
 
     with freeze_time(point1) as time_freeze:
         assert await async_setup_component(
@@ -301,7 +393,7 @@ async def test_if_fires_on_for_condition(
                             "condition": "device",
                             "domain": DOMAIN,
                             "device_id": "",
-                            "entity_id": sensor1.entity_id,
+                            "entity_id": entry.id,
                             "type": "is_not_bat_low",
                             "for": {"seconds": 5},
                         },
@@ -319,7 +411,7 @@ async def test_if_fires_on_for_condition(
             },
         )
         await hass.async_block_till_done()
-        assert hass.states.get(sensor1.entity_id).state == STATE_ON
+        assert hass.states.get(entry.entity_id).state == STATE_ON
         assert len(calls) == 0
 
         hass.bus.async_fire("test_event1")
@@ -332,7 +424,7 @@ async def test_if_fires_on_for_condition(
         await hass.async_block_till_done()
         assert len(calls) == 0
 
-        hass.states.async_set(sensor1.entity_id, STATE_OFF)
+        hass.states.async_set(entry.entity_id, STATE_OFF)
         hass.bus.async_fire("test_event1")
         await hass.async_block_till_done()
         assert len(calls) == 0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use entity registry id in `binary_sensor` device conditions

#### Background:
When a device automation is configured by the user, the user picks a device without specifying an `entity_id`. If the user then changes the `entity_id` of that entity, the configured device automation no longer works.
By instead referencing the entity registry id of the entity, the device automation is still valid.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
