### PR TITLE
Use entity registry id in cover device actions

### DIFF
--- a/homeassistant/components/device_automation/helpers.py
+++ b/homeassistant/components/device_automation/helpers.py
@@ -28,6 +28,7 @@ STATIC_VALIDATOR = {
 ENTITY_PLATFORMS = {
     Platform.ALARM_CONTROL_PANEL.value,
     Platform.BUTTON.value,
+    Platform.COVER.value,
     Platform.FAN.value,
     Platform.HUMIDIFIER.value,
     Platform.LIGHT.value,

--- a/tests/components/cover/test_device_action.py
+++ b/tests/components/cover/test_device_action.py
@@ -61,7 +61,7 @@ async def test_get_actions(
         config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
-    entity_registry.async_get_or_create(
+    entity_entry = entity_registry.async_get_or_create(
         DOMAIN,
         "test",
         "5678",
@@ -70,7 +70,7 @@ async def test_get_actions(
     )
     if set_state:
         hass.states.async_set(
-            f"{DOMAIN}.test_5678", "attributes", {"supported_features": features_state}
+            entity_entry.entity_id, "attributes", {"supported_features": features_state}
         )
     await hass.async_block_till_done()
 
@@ -80,7 +80,7 @@ async def test_get_actions(
             "domain": DOMAIN,
             "type": action,
             "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
+            "entity_id": entity_entry.id,
             "metadata": {"secondary": False},
         }
         for action in expected_action_types
@@ -114,7 +114,7 @@ async def test_get_actions_hidden_auxiliary(
         config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
-    entity_registry.async_get_or_create(
+    entity_entry = entity_registry.async_get_or_create(
         DOMAIN,
         "test",
         "5678",
@@ -129,7 +129,7 @@ async def test_get_actions_hidden_auxiliary(
             "domain": DOMAIN,
             "type": action,
             "device_id": device_entry.id,
-            "entity_id": f"{DOMAIN}.test_5678",
+            "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
         for action in ["close"]
@@ -184,6 +184,57 @@ async def test_get_action_capabilities(
     action_types = {action["type"] for action in actions}
     assert action_types == {"open", "close", "stop", "open_tilt", "close_tilt"}
     for action in actions:
+        capabilities = await async_get_device_automation_capabilities(
+            hass, DeviceAutomationType.ACTION, action
+        )
+        assert capabilities == {"extra_fields": []}
+
+
+async def test_get_action_capabilities_legacy(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    enable_custom_integrations: None,
+) -> None:
+    """Test we get the expected capabilities from a cover action."""
+    platform = getattr(hass.components, f"test.{DOMAIN}")
+    platform.init(empty=True)
+    platform.ENTITIES.append(
+        platform.MockCover(
+            name="Set position cover",
+            is_on=True,
+            unique_id="unique_set_pos_cover",
+            current_cover_position=50,
+            supported_features=CoverEntityFeature.OPEN
+            | CoverEntityFeature.CLOSE
+            | CoverEntityFeature.STOP
+            | CoverEntityFeature.OPEN_TILT
+            | CoverEntityFeature.CLOSE_TILT
+            | CoverEntityFeature.STOP_TILT,
+        ),
+    )
+    ent = platform.ENTITIES[0]
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
+
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_registry.async_get_or_create(
+        DOMAIN, "test", ent.unique_id, device_id=device_entry.id
+    )
+
+    actions = await async_get_device_automations(
+        hass, DeviceAutomationType.ACTION, device_entry.id
+    )
+    assert len(actions) == 5  # open, close, open_tilt, close_tilt
+    action_types = {action["type"] for action in actions}
+    assert action_types == {"open", "close", "stop", "open_tilt", "close_tilt"}
+    for action in actions:
+        action["entity_id"] = entity_registry.async_get(action["entity_id"]).entity_id
         capabilities = await async_get_device_automation_capabilities(
             hass, DeviceAutomationType.ACTION, action
         )
@@ -298,11 +349,13 @@ async def test_get_action_capabilities_set_tilt_pos(
             assert capabilities == {"extra_fields": []}
 
 
-async def test_action(hass: HomeAssistant, enable_custom_integrations: None) -> None:
+async def test_action(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    enable_custom_integrations: None,
+) -> None:
     """Test for cover actions."""
-    platform = getattr(hass.components, f"test.{DOMAIN}")
-    platform.init()
-    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    entry = entity_registry.async_get_or_create(DOMAIN, "test", "5678")
 
     assert await async_setup_component(
         hass,
@@ -314,7 +367,7 @@ async def test_action(hass: HomeAssistant, enable_custom_integrations: None) -> 
                     "action": {
                         "domain": DOMAIN,
                         "device_id": "abcdefgh",
-                        "entity_id": "cover.entity",
+                        "entity_id": entry.id,
                         "type": "open",
                     },
                 },
@@ -323,7 +376,7 @@ async def test_action(hass: HomeAssistant, enable_custom_integrations: None) -> 
                     "action": {
                         "domain": DOMAIN,
                         "device_id": "abcdefgh",
-                        "entity_id": "cover.entity",
+                        "entity_id": entry.id,
                         "type": "close",
                     },
                 },
@@ -332,7 +385,7 @@ async def test_action(hass: HomeAssistant, enable_custom_integrations: None) -> 
                     "action": {
                         "domain": DOMAIN,
                         "device_id": "abcdefgh",
-                        "entity_id": "cover.entity",
+                        "entity_id": entry.id,
                         "type": "stop",
                     },
                 },
@@ -363,14 +416,24 @@ async def test_action(hass: HomeAssistant, enable_custom_integrations: None) -> 
     assert len(close_calls) == 1
     assert len(stop_calls) == 1
 
+    assert open_calls[0].domain == DOMAIN
+    assert open_calls[0].service == "open_cover"
+    assert open_calls[0].data == {"entity_id": entry.entity_id}
+    assert close_calls[0].domain == DOMAIN
+    assert close_calls[0].service == "close_cover"
+    assert close_calls[0].data == {"entity_id": entry.entity_id}
+    assert stop_calls[0].domain == DOMAIN
+    assert stop_calls[0].service == "stop_cover"
+    assert stop_calls[0].data == {"entity_id": entry.entity_id}
 
-async def test_action_tilt(
-    hass: HomeAssistant, enable_custom_integrations: None
+
+async def test_action_legacy(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    enable_custom_integrations: None,
 ) -> None:
-    """Test for cover tilt actions."""
-    platform = getattr(hass.components, f"test.{DOMAIN}")
-    platform.init()
-    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    """Test for cover actions."""
+    entry = entity_registry.async_get_or_create(DOMAIN, "test", "5678")
 
     assert await async_setup_component(
         hass,
@@ -382,7 +445,45 @@ async def test_action_tilt(
                     "action": {
                         "domain": DOMAIN,
                         "device_id": "abcdefgh",
-                        "entity_id": "cover.entity",
+                        "entity_id": entry.id,
+                        "type": "open",
+                    },
+                },
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+
+    open_calls = async_mock_service(hass, "cover", "open_cover")
+
+    hass.bus.async_fire("test_event_open")
+    await hass.async_block_till_done()
+    assert len(open_calls) == 1
+
+    assert open_calls[0].domain == DOMAIN
+    assert open_calls[0].service == "open_cover"
+    assert open_calls[0].data == {"entity_id": entry.entity_id}
+
+
+async def test_action_tilt(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    enable_custom_integrations: None,
+) -> None:
+    """Test for cover tilt actions."""
+    entry = entity_registry.async_get_or_create(DOMAIN, "test", "5678")
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {"platform": "event", "event_type": "test_event_open"},
+                    "action": {
+                        "domain": DOMAIN,
+                        "device_id": "abcdefgh",
+                        "entity_id": entry.id,
                         "type": "open_tilt",
                     },
                 },
@@ -391,7 +492,7 @@ async def test_action_tilt(
                     "action": {
                         "domain": DOMAIN,
                         "device_id": "abcdefgh",
-                        "entity_id": "cover.entity",
+                        "entity_id": entry.id,
                         "type": "close_tilt",
                     },
                 },
@@ -418,14 +519,21 @@ async def test_action_tilt(
     assert len(open_calls) == 1
     assert len(close_calls) == 1
 
+    assert open_calls[0].domain == DOMAIN
+    assert open_calls[0].service == "open_cover_tilt"
+    assert open_calls[0].data == {"entity_id": entry.entity_id}
+    assert close_calls[0].domain == DOMAIN
+    assert close_calls[0].service == "close_cover_tilt"
+    assert close_calls[0].data == {"entity_id": entry.entity_id}
+
 
 async def test_action_set_position(
-    hass: HomeAssistant, enable_custom_integrations: None
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    enable_custom_integrations: None,
 ) -> None:
     """Test for cover set position actions."""
-    platform = getattr(hass.components, f"test.{DOMAIN}")
-    platform.init()
-    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    entry = entity_registry.async_get_or_create(DOMAIN, "test", "5678")
 
     assert await async_setup_component(
         hass,
@@ -440,7 +548,7 @@ async def test_action_set_position(
                     "action": {
                         "domain": DOMAIN,
                         "device_id": "abcdefgh",
-                        "entity_id": "cover.entity",
+                        "entity_id": entry.id,
                         "type": "set_position",
                         "position": 25,
                     },
@@ -453,7 +561,7 @@ async def test_action_set_position(
                     "action": {
                         "domain": DOMAIN,
                         "device_id": "abcdefgh",
-                        "entity_id": "cover.entity",
+                        "entity_id": entry.id,
                         "type": "set_tilt_position",
                         "position": 75,
                     },
@@ -469,11 +577,16 @@ async def test_action_set_position(
     hass.bus.async_fire("test_event_set_pos")
     await hass.async_block_till_done()
     assert len(cover_pos_calls) == 1
-    assert cover_pos_calls[0].data["position"] == 25
     assert len(tilt_pos_calls) == 0
 
     hass.bus.async_fire("test_event_set_tilt_pos")
     await hass.async_block_till_done()
     assert len(cover_pos_calls) == 1
     assert len(tilt_pos_calls) == 1
-    assert tilt_pos_calls[0].data["tilt_position"] == 75
+
+    assert cover_pos_calls[0].domain == DOMAIN
+    assert cover_pos_calls[0].service == "set_cover_position"
+    assert cover_pos_calls[0].data == {"entity_id": entry.entity_id, "position": 25}
+    assert tilt_pos_calls[0].domain == DOMAIN
+    assert tilt_pos_calls[0].service == "set_cover_tilt_position"
+    assert tilt_pos_calls[0].data == {"entity_id": entry.entity_id, "tilt_position": 75}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use entity registry id in `cover` device actions

#### Background:
When a device automation is configured by the user, the user picks a device without specifying an `entity_id`. If the user then changes the `entity_id` of that entity, the configured device automation no longer works.
By instead referencing the entity registry id of the entity, the device automation is still valid.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
