### PR TITLE
Add image url support

### DIFF
--- a/homeassistant/components/image/__init__.py
+++ b/homeassistant/components/image/__init__.py
@@ -123,9 +123,9 @@ class ImageEntity(Entity):
     _attr_should_poll: bool = False  # No need to poll image entities
     _attr_state: None = None  # State is determined by last_updated
 
-    def __init__(self, hass: HomeAssistant) -> None:
+    def __init__(self, hass: HomeAssistant, verify_ssl: bool = False) -> None:
         """Initialize an image entity."""
-        self._client = get_async_client(hass)
+        self._client = get_async_client(hass, verify_ssl=verify_ssl)
         self.access_tokens: collections.deque = collections.deque([], 2)
         self.async_update_token()
 

--- a/homeassistant/components/image/__init__.py
+++ b/homeassistant/components/image/__init__.py
@@ -18,7 +18,7 @@ import httpx
 from homeassistant.components.http import KEY_AUTHENTICATED, HomeAssistantView
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
-from homeassistant.core import Event, HomeAssistant, async_get_hass, callback
+from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.config_validation import (  # noqa: F401
     PLATFORM_SCHEMA,
@@ -123,9 +123,9 @@ class ImageEntity(Entity):
     _attr_should_poll: bool = False  # No need to poll image entities
     _attr_state: None = None  # State is determined by last_updated
 
-    def __init__(self) -> None:
+    def __init__(self, hass: HomeAssistant) -> None:
         """Initialize an image entity."""
-        self._client = get_async_client(async_get_hass())
+        self._client = get_async_client(hass)
         self.access_tokens: collections.deque = collections.deque([], 2)
         self.async_update_token()
 

--- a/homeassistant/components/kitchen_sink/image.py
+++ b/homeassistant/components/kitchen_sink/image.py
@@ -21,6 +21,7 @@ async def async_setup_platform(
     async_add_entities(
         [
             DemoImage(
+                hass,
                 "kitchen_sink_image_001",
                 "QR Code",
                 "image/png",
@@ -44,13 +45,14 @@ class DemoImage(ImageEntity):
 
     def __init__(
         self,
+        hass: HomeAssistant,
         unique_id: str,
         name: str,
         content_type: str,
         image: str,
     ) -> None:
         """Initialize the image entity."""
-        super().__init__()
+        super().__init__(hass)
         self._attr_content_type = content_type
         self._attr_name = name
         self._attr_unique_id = unique_id

--- a/homeassistant/components/mqtt/image.py
+++ b/homeassistant/components/mqtt/image.py
@@ -97,7 +97,7 @@ class MqttImage(MqttEntity, ImageEntity):
     ) -> None:
         """Initialize the MQTT Image."""
         self._client = get_async_client(hass)
-        ImageEntity.__init__(self)
+        ImageEntity.__init__(self, hass)
         MqttEntity.__init__(self, hass, config, config_entry, discovery_data)
 
     @staticmethod

--- a/homeassistant/components/template/image.py
+++ b/homeassistant/components/template/image.py
@@ -89,9 +89,9 @@ class TemplateImage(ImageEntity):
     _url: str | None = None
     _verify_ssl: bool
 
-    def __init__(self, verify_ssl: bool) -> None:
+    def __init__(self, hass: HomeAssistant, verify_ssl: bool) -> None:
         """Initialize the image."""
-        super().__init__()
+        super().__init__(hass)
         self._verify_ssl = verify_ssl
 
     async def async_image(self) -> bytes | None:
@@ -137,7 +137,7 @@ class StateImageEntity(TemplateEntity, TemplateImage):
     ) -> None:
         """Initialize the image."""
         TemplateEntity.__init__(self, hass, config=config, unique_id=unique_id)
-        TemplateImage.__init__(self, config[CONF_VERIFY_SSL])
+        TemplateImage.__init__(self, hass, config[CONF_VERIFY_SSL])
         self._url_template = config[CONF_URL]
 
     @property
@@ -179,7 +179,7 @@ class TriggerImageEntity(TriggerEntity, TemplateImage):
     ) -> None:
         """Initialize the entity."""
         TriggerEntity.__init__(self, hass, coordinator, config)
-        TemplateImage.__init__(self, config[CONF_VERIFY_SSL])
+        TemplateImage.__init__(self, hass, config[CONF_VERIFY_SSL])
 
     @property
     def entity_picture(self) -> str | None:

--- a/tests/components/image/conftest.py
+++ b/tests/components/image/conftest.py
@@ -125,7 +125,7 @@ def config_flow_fixture(hass: HomeAssistant) -> Generator[None, None, None]:
 
 
 @pytest.fixture(name="mock_image_config_entry")
-async def mock_image_config_entry_fixture(hass: HomeAssistant, config_flow):
+async def mock_image_config_entry_fixture(hass: HomeAssistant, config_flow: None):
     """Initialize a mock image config_entry."""
 
     async def async_setup_entry_init(
@@ -152,7 +152,9 @@ async def mock_image_config_entry_fixture(hass: HomeAssistant, config_flow):
     )
 
     mock_platform(
-        hass, f"{TEST_DOMAIN}.{image.DOMAIN}", MockImageConfigEntry(MockImageEntity())
+        hass,
+        f"{TEST_DOMAIN}.{image.DOMAIN}",
+        MockImageConfigEntry(MockImageEntity(hass)),
     )
 
     config_entry = MockConfigEntry(domain=TEST_DOMAIN)
@@ -167,7 +169,7 @@ async def mock_image_config_entry_fixture(hass: HomeAssistant, config_flow):
 async def mock_image_platform_fixture(hass: HomeAssistant):
     """Initialize a mock image platform."""
     mock_integration(hass, MockModule(domain="test"))
-    mock_platform(hass, "test.image", MockImagePlatform([MockImageEntity()]))
+    mock_platform(hass, "test.image", MockImagePlatform([MockImageEntity(hass)]))
     assert await async_setup_component(
         hass, image.DOMAIN, {"image": {"platform": "test"}}
     )

--- a/tests/components/image/conftest.py
+++ b/tests/components/image/conftest.py
@@ -36,6 +36,20 @@ class MockImageEntity(image.ImageEntity):
         return b"Test"
 
 
+class MockURLImageEntity(image.ImageEntity):
+    """Mock image entity."""
+
+    _attr_name = "Test"
+
+    async def async_added_to_hass(self):
+        """Set the update time."""
+        self._attr_image_last_updated = dt_util.utcnow()
+
+    async def async_image_url(self) -> str:
+        """Return URL of image."""
+        return "https://example.com/myimage.jpg"
+
+
 class MockImageNoStateEntity(image.ImageEntity):
     """Mock image entity."""
 

--- a/tests/components/image/test_init.py
+++ b/tests/components/image/test_init.py
@@ -60,7 +60,7 @@ async def test_state_attr(
 ) -> None:
     """Test image state with entity picture from attr."""
     mock_integration(hass, MockModule(domain="test"))
-    entity = MockImageEntity()
+    entity = MockImageEntity(hass)
     entity._attr_entity_picture = "abcd"
     mock_platform(hass, "test.image", MockImagePlatform([entity]))
     assert await async_setup_component(
@@ -83,7 +83,7 @@ async def test_no_state(
 ) -> None:
     """Test image state."""
     mock_integration(hass, MockModule(domain="test"))
-    mock_platform(hass, "test.image", MockImagePlatform([MockImageNoStateEntity()]))
+    mock_platform(hass, "test.image", MockImagePlatform([MockImageNoStateEntity(hass)]))
     assert await async_setup_component(
         hass, image.DOMAIN, {"image": {"platform": "test"}}
     )
@@ -130,7 +130,7 @@ async def test_fetch_image_sync(
 ) -> None:
     """Test fetching an image with an authenticated client."""
     mock_integration(hass, MockModule(domain="test"))
-    mock_platform(hass, "test.image", MockImagePlatform([MockImageSyncEntity()]))
+    mock_platform(hass, "test.image", MockImagePlatform([MockImageSyncEntity(hass)]))
     assert await async_setup_component(
         hass, image.DOMAIN, {"image": {"platform": "test"}}
     )
@@ -183,7 +183,7 @@ async def test_fetch_image_url_success(
     )
 
     mock_integration(hass, MockModule(domain="test"))
-    mock_platform(hass, "test.image", MockImagePlatform([MockURLImageEntity()]))
+    mock_platform(hass, "test.image", MockImagePlatform([MockURLImageEntity(hass)]))
     assert await async_setup_component(
         hass, image.DOMAIN, {"image": {"platform": "test"}}
     )
@@ -215,7 +215,7 @@ async def test_fetch_image_url_exception(
     respx.get("https://example.com/myimage.jpg").mock(side_effect=side_effect)
 
     mock_integration(hass, MockModule(domain="test"))
-    mock_platform(hass, "test.image", MockImagePlatform([MockURLImageEntity()]))
+    mock_platform(hass, "test.image", MockImagePlatform([MockURLImageEntity(hass)]))
     assert await async_setup_component(
         hass, image.DOMAIN, {"image": {"platform": "test"}}
     )

--- a/tests/components/image/test_init.py
+++ b/tests/components/image/test_init.py
@@ -1,9 +1,12 @@
 """The tests for the image component."""
 from http import HTTPStatus
-from unittest.mock import patch
+import ssl
+from unittest.mock import MagicMock, patch
 
 from aiohttp import hdrs
+import httpx
 import pytest
+import respx
 
 from homeassistant.components import image
 from homeassistant.core import HomeAssistant
@@ -14,6 +17,7 @@ from .conftest import (
     MockImageNoStateEntity,
     MockImagePlatform,
     MockImageSyncEntity,
+    MockURLImageEntity,
 )
 
 from tests.common import MockModule, mock_integration, mock_platform
@@ -167,3 +171,57 @@ async def test_fetch_image_unauthenticated(
 
     resp = await client.get("/api/image_proxy/image.unknown")
     assert resp.status == HTTPStatus.NOT_FOUND
+
+
+@respx.mock
+async def test_fetch_image_url_success(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
+    """Test fetching an image with an authenticated client."""
+    respx.get("https://example.com/myimage.jpg").respond(
+        status_code=HTTPStatus.OK, content_type="image/png", content=b"Test"
+    )
+
+    mock_integration(hass, MockModule(domain="test"))
+    mock_platform(hass, "test.image", MockImagePlatform([MockURLImageEntity()]))
+    assert await async_setup_component(
+        hass, image.DOMAIN, {"image": {"platform": "test"}}
+    )
+    await hass.async_block_till_done()
+
+    client = await hass_client()
+
+    resp = await client.get("/api/image_proxy/image.test")
+    assert resp.status == HTTPStatus.OK
+    body = await resp.read()
+    assert body == b"Test"
+
+
+@respx.mock
+@pytest.mark.parametrize(
+    "side_effect",
+    [
+        httpx.RequestError("server offline", request=MagicMock()),
+        httpx.TimeoutException,
+        ssl.SSLError,
+    ],
+)
+async def test_fetch_image_url_exception(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    side_effect: Exception,
+) -> None:
+    """Test fetching an image with an authenticated client."""
+    respx.get("https://example.com/myimage.jpg").mock(side_effect=side_effect)
+
+    mock_integration(hass, MockModule(domain="test"))
+    mock_platform(hass, "test.image", MockImagePlatform([MockURLImageEntity()]))
+    assert await async_setup_component(
+        hass, image.DOMAIN, {"image": {"platform": "test"}}
+    )
+    await hass.async_block_till_done()
+
+    client = await hass_client()
+
+    resp = await client.get("/api/image_proxy/image.test")
+    assert resp.status == HTTPStatus.INTERNAL_SERVER_ERROR


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow to fetch an image by URL instead of returning the image bytes.

An integration needs to implement one of the methods below and return the URL of the image that is to be received and set ...

```python
    async def async_image_url(self) -> str | None:
        """Return URL of image."""
```

or ...

```python
    def image_url(self) -> str | None:
        """Return URL of image."""
        return None
```

To fetch an image for the frontend `async_image` will be called, by default this  then will check if `async_image_url` or `image_url` returns a URL. If `None` is returned it will call `image`. If an `""` as URL is returned `async_image` will return `None`.

Examples where added to the demo platform

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/1820

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
