### PR TITLE
Add set_config service to Fully Kiosk Browser integration

### DIFF
--- a/homeassistant/components/fully_kiosk/const.py
+++ b/homeassistant/components/fully_kiosk/const.py
@@ -25,6 +25,10 @@ MEDIA_SUPPORT_FULLYKIOSK = (
 
 SERVICE_LOAD_URL = "load_url"
 SERVICE_START_APPLICATION = "start_application"
+SERVICE_SET_CONFIG = "set_config"
 
 ATTR_URL = "url"
 ATTR_APPLICATION = "application"
+ATTR_CONFIG_TYPE = "config_type"
+ATTR_KEY = "key"
+ATTR_VALUE = "value"

--- a/homeassistant/components/fully_kiosk/const.py
+++ b/homeassistant/components/fully_kiosk/const.py
@@ -29,6 +29,5 @@ SERVICE_SET_CONFIG = "set_config"
 
 ATTR_URL = "url"
 ATTR_APPLICATION = "application"
-ATTR_CONFIG_TYPE = "config_type"
 ATTR_KEY = "key"
 ATTR_VALUE = "value"

--- a/homeassistant/components/fully_kiosk/services.py
+++ b/homeassistant/components/fully_kiosk/services.py
@@ -12,9 +12,13 @@ import homeassistant.helpers.device_registry as dr
 
 from .const import (
     ATTR_APPLICATION,
+    ATTR_CONFIG_TYPE,
+    ATTR_KEY,
     ATTR_URL,
+    ATTR_VALUE,
     DOMAIN,
     SERVICE_LOAD_URL,
+    SERVICE_SET_CONFIG,
     SERVICE_START_APPLICATION,
 )
 from .coordinator import FullyKioskDataUpdateCoordinator
@@ -62,6 +66,18 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         for coordinator in await collect_coordinators(call.data[ATTR_DEVICE_ID]):
             await coordinator.fully.startApplication(call.data[ATTR_APPLICATION])
 
+    async def async_set_config(call: ServiceCall) -> None:
+        """Set a Fully Kiosk Browser config value on the device."""
+        for coordinator in await collect_coordinators(call.data[ATTR_DEVICE_ID]):
+            if call.data[ATTR_CONFIG_TYPE] == "string":
+                await coordinator.fully.setConfigurationString(
+                    call.data[ATTR_KEY], call.data[ATTR_VALUE]
+                )
+            elif call.data[ATTR_CONFIG_TYPE] == "bool":
+                await coordinator.fully.setConfigurationBool(
+                    call.data[ATTR_KEY], call.data[ATTR_VALUE]
+                )
+
     # Register all the above services
     service_mapping = [
         (async_load_url, SERVICE_LOAD_URL, ATTR_URL),
@@ -81,3 +97,19 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                 )
             ),
         )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SET_CONFIG,
+        async_set_config,
+        schema=vol.Schema(
+            vol.All(
+                {
+                    vol.Required(ATTR_DEVICE_ID): cv.ensure_list,
+                    vol.Required(ATTR_CONFIG_TYPE): vol.In(["string", "bool"]),
+                    vol.Required(ATTR_KEY): cv.string,
+                    vol.Required(ATTR_VALUE): vol.Any(cv.string, cv.boolean),
+                }
+            )
+        ),
+    )

--- a/homeassistant/components/fully_kiosk/services.py
+++ b/homeassistant/components/fully_kiosk/services.py
@@ -72,8 +72,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
             # check if call.data[ATTR_VALUE] is a bool
             if (
                 isinstance(call.data[ATTR_VALUE], bool)
-                or call.data[ATTR_VALUE].lower() == "true"
-                or call.data[ATTR_VALUE].lower() == "false"
+                or call.data[ATTR_VALUE].lower() in ("true", "false")
             ):
                 await coordinator.fully.setConfigurationBool(
                     call.data[ATTR_KEY], call.data[ATTR_VALUE]

--- a/homeassistant/components/fully_kiosk/services.py
+++ b/homeassistant/components/fully_kiosk/services.py
@@ -70,10 +70,9 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         for coordinator in await collect_coordinators(call.data[ATTR_DEVICE_ID]):
             # Fully API has different methods for setting string and bool values.
             # check if call.data[ATTR_VALUE] is a bool
-            if (
-                isinstance(call.data[ATTR_VALUE], bool)
-                or call.data[ATTR_VALUE].lower() in ("true", "false")
-            ):
+            if isinstance(call.data[ATTR_VALUE], bool) or call.data[
+                ATTR_VALUE
+            ].lower() in ("true", "false"):
                 await coordinator.fully.setConfigurationBool(
                     call.data[ATTR_KEY], call.data[ATTR_VALUE]
                 )

--- a/homeassistant/components/fully_kiosk/services.yaml
+++ b/homeassistant/components/fully_kiosk/services.yaml
@@ -34,13 +34,6 @@ set_config:
       required: true
       selector:
         text:
-    config_type:
-      name: Type
-      description: Type of configuration parameter (either 'string' or 'bool').
-      example: "string"
-      required: true
-      selector:
-        text:
 
 start_application:
   name: Start Application

--- a/homeassistant/components/fully_kiosk/services.yaml
+++ b/homeassistant/components/fully_kiosk/services.yaml
@@ -13,6 +13,35 @@ load_url:
       selector:
         text:
 
+set_config:
+  name: Set Configuration
+  description: Set a configuration parameter on Fully Kiosk Browser.
+  target:
+    device:
+      integration: fully_kiosk
+  fields:
+    key:
+      name: Key
+      description: Configuration parameter to set.
+      example: "motionSensitivity"
+      required: true
+      selector:
+        text:
+    value:
+      name: Value
+      description: Value for the configuration parameter.
+      example: "90"
+      required: true
+      selector:
+        text:
+    config_type:
+      name: Type
+      description: Type of configuration parameter (either 'string' or 'bool').
+      example: "string"
+      required: true
+      selector:
+        text:
+
 start_application:
   name: Start Application
   description: Start an application on the device running Fully Kiosk Browser.

--- a/tests/components/fully_kiosk/test_services.py
+++ b/tests/components/fully_kiosk/test_services.py
@@ -5,7 +5,6 @@ import pytest
 
 from homeassistant.components.fully_kiosk.const import (
     ATTR_APPLICATION,
-    ATTR_CONFIG_TYPE,
     ATTR_KEY,
     ATTR_URL,
     ATTR_VALUE,
@@ -63,28 +62,43 @@ async def test_services(
         SERVICE_SET_CONFIG,
         {
             ATTR_DEVICE_ID: [device_entry.id],
-            ATTR_CONFIG_TYPE: "string",
-            ATTR_KEY: "test_key",
-            ATTR_VALUE: "test_value",
+            ATTR_KEY: key,
+            ATTR_VALUE: value,
         },
         blocking=True,
     )
 
     mock_fully_kiosk.setConfigurationString.assert_called_once_with(key, value)
 
+    key = "test_key"
+    value = "true"
     await hass.services.async_call(
         DOMAIN,
         SERVICE_SET_CONFIG,
         {
             ATTR_DEVICE_ID: [device_entry.id],
-            ATTR_CONFIG_TYPE: "bool",
-            ATTR_KEY: "test_key",
-            ATTR_VALUE: "test_value",
+            ATTR_KEY: key,
+            ATTR_VALUE: value,
         },
         blocking=True,
     )
 
     mock_fully_kiosk.setConfigurationBool.assert_called_once_with(key, value)
+
+    key = "test_key"
+    value = True
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_CONFIG,
+        {
+            ATTR_DEVICE_ID: [device_entry.id],
+            ATTR_KEY: key,
+            ATTR_VALUE: value,
+        },
+        blocking=True,
+    )
+
+    mock_fully_kiosk.setConfigurationBool.assert_called_with(key, value)
 
 
 async def test_service_unloaded_entry(

--- a/tests/components/fully_kiosk/test_services.py
+++ b/tests/components/fully_kiosk/test_services.py
@@ -5,9 +5,13 @@ import pytest
 
 from homeassistant.components.fully_kiosk.const import (
     ATTR_APPLICATION,
+    ATTR_CONFIG_TYPE,
+    ATTR_KEY,
     ATTR_URL,
+    ATTR_VALUE,
     DOMAIN,
     SERVICE_LOAD_URL,
+    SERVICE_SET_CONFIG,
     SERVICE_START_APPLICATION,
 )
 from homeassistant.const import ATTR_DEVICE_ID
@@ -50,6 +54,37 @@ async def test_services(
     )
 
     mock_fully_kiosk.startApplication.assert_called_once_with(app)
+
+    key = "test_key"
+    value = "test_value"
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_CONFIG,
+        {
+            ATTR_DEVICE_ID: [device_entry.id],
+            ATTR_CONFIG_TYPE: "string",
+            ATTR_KEY: "test_key",
+            ATTR_VALUE: "test_value",
+        },
+        blocking=True,
+    )
+
+    mock_fully_kiosk.setConfigurationString.assert_called_once_with(key, value)
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_CONFIG,
+        {
+            ATTR_DEVICE_ID: [device_entry.id],
+            ATTR_CONFIG_TYPE: "bool",
+            ATTR_KEY: "test_key",
+            ATTR_VALUE: "test_value",
+        },
+        blocking=True,
+    )
+
+    mock_fully_kiosk.setConfigurationBool.assert_called_once_with(key, value)
 
 
 async def test_service_unloaded_entry(


### PR DESCRIPTION
## Proposed change
This PR adds a new `set_config` service to the Fully Kiosk Browser integration. This service allows you to change any of FKB's many configuration parameters through Home Assistant, and is the last piece of the Fully Kiosk Browser custom integration to migrate to the core integration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/27982

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
