### PR TITLE
Add tests for ESPHome cover platform

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -310,7 +310,6 @@ omit =
     homeassistant/components/esphome/bluetooth/*
     homeassistant/components/esphome/button.py
     homeassistant/components/esphome/camera.py
-    homeassistant/components/esphome/cover.py
     homeassistant/components/esphome/domain_data.py
     homeassistant/components/esphome/entry_data.py
     homeassistant/components/esphome/light.py

--- a/tests/components/esphome/test_cover.py
+++ b/tests/components/esphome/test_cover.py
@@ -1,0 +1,208 @@
+"""Test ESPHome covers."""
+
+from collections.abc import Awaitable, Callable
+from unittest.mock import call
+
+from aioesphomeapi import (
+    APIClient,
+    CoverInfo,
+    CoverOperation,
+    CoverState,
+    EntityInfo,
+    EntityState,
+    UserService,
+)
+
+from homeassistant.components.cover import (
+    ATTR_CURRENT_POSITION,
+    ATTR_CURRENT_TILT_POSITION,
+    ATTR_POSITION,
+    ATTR_TILT_POSITION,
+    DOMAIN as COVER_DOMAIN,
+    SERVICE_CLOSE_COVER,
+    SERVICE_CLOSE_COVER_TILT,
+    SERVICE_OPEN_COVER,
+    SERVICE_OPEN_COVER_TILT,
+    SERVICE_SET_COVER_POSITION,
+    SERVICE_SET_COVER_TILT_POSITION,
+    SERVICE_STOP_COVER,
+    STATE_CLOSED,
+    STATE_CLOSING,
+    STATE_OPEN,
+    STATE_OPENING,
+)
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
+
+from .conftest import MockESPHomeDevice
+
+
+async def test_cover_entity(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: Callable[
+        [APIClient, list[EntityInfo], list[UserService], list[EntityState]],
+        Awaitable[MockESPHomeDevice],
+    ],
+) -> None:
+    """Test a generic cover entity."""
+    entity_info = [
+        CoverInfo(
+            object_id="mycover",
+            key=1,
+            name="my cover",
+            unique_id="my_cover",
+            supports_position=True,
+            supports_tilt=True,
+            supports_stop=True,
+        )
+    ]
+    states = [
+        CoverState(
+            key=1,
+            position=0.5,
+            tilt=0.5,
+            current_operation=CoverOperation.IS_OPENING,
+        )
+    ]
+    user_service = []
+    mock_device = await mock_esphome_device(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        user_service=user_service,
+        states=states,
+    )
+    state = hass.states.get("cover.test_my_cover")
+    assert state is not None
+    assert state.state == STATE_OPENING
+    assert state.attributes[ATTR_CURRENT_POSITION] == 50
+    assert state.attributes[ATTR_CURRENT_TILT_POSITION] == 50
+
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_CLOSE_COVER,
+        {ATTR_ENTITY_ID: "cover.test_my_cover"},
+        blocking=True,
+    )
+    mock_client.cover_command.assert_has_calls([call(key=1, position=0.0)])
+    mock_client.cover_command.reset_mock()
+
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_OPEN_COVER,
+        {ATTR_ENTITY_ID: "cover.test_my_cover"},
+        blocking=True,
+    )
+    mock_client.cover_command.assert_has_calls([call(key=1, position=1.0)])
+    mock_client.cover_command.reset_mock()
+
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_SET_COVER_POSITION,
+        {ATTR_ENTITY_ID: "cover.test_my_cover", ATTR_POSITION: 50},
+        blocking=True,
+    )
+    mock_client.cover_command.assert_has_calls([call(key=1, position=0.5)])
+    mock_client.cover_command.reset_mock()
+
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_STOP_COVER,
+        {ATTR_ENTITY_ID: "cover.test_my_cover"},
+        blocking=True,
+    )
+    mock_client.cover_command.assert_has_calls([call(key=1, stop=True)])
+    mock_client.cover_command.reset_mock()
+
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_OPEN_COVER_TILT,
+        {ATTR_ENTITY_ID: "cover.test_my_cover"},
+        blocking=True,
+    )
+    mock_client.cover_command.assert_has_calls([call(key=1, tilt=1.0)])
+    mock_client.cover_command.reset_mock()
+
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_CLOSE_COVER_TILT,
+        {ATTR_ENTITY_ID: "cover.test_my_cover"},
+        blocking=True,
+    )
+    mock_client.cover_command.assert_has_calls([call(key=1, tilt=0.0)])
+    mock_client.cover_command.reset_mock()
+
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_SET_COVER_TILT_POSITION,
+        {ATTR_ENTITY_ID: "cover.test_my_cover", ATTR_TILT_POSITION: 50},
+        blocking=True,
+    )
+    mock_client.cover_command.assert_has_calls([call(key=1, tilt=0.5)])
+    mock_client.cover_command.reset_mock()
+
+    mock_device.set_state(
+        CoverState(key=1, position=0.0, current_operation=CoverOperation.IDLE)
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("cover.test_my_cover")
+    assert state is not None
+    assert state.state == STATE_CLOSED
+
+    mock_device.set_state(
+        CoverState(key=1, position=0.5, current_operation=CoverOperation.IS_CLOSING)
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("cover.test_my_cover")
+    assert state is not None
+    assert state.state == STATE_CLOSING
+
+    mock_device.set_state(
+        CoverState(key=1, position=1.0, current_operation=CoverOperation.IDLE)
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("cover.test_my_cover")
+    assert state is not None
+    assert state.state == STATE_OPEN
+
+
+async def test_cover_entity_without_position(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: Callable[
+        [APIClient, list[EntityInfo], list[UserService], list[EntityState]],
+        Awaitable[MockESPHomeDevice],
+    ],
+) -> None:
+    """Test a generic cover entity without position, tilt, or stop."""
+    entity_info = [
+        CoverInfo(
+            object_id="mycover",
+            key=1,
+            name="my cover",
+            unique_id="my_cover",
+            supports_position=False,
+            supports_tilt=False,
+            supports_stop=False,
+        )
+    ]
+    states = [
+        CoverState(
+            key=1,
+            position=0.5,
+            tilt=0.5,
+            current_operation=CoverOperation.IS_OPENING,
+        )
+    ]
+    user_service = []
+    await mock_esphome_device(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        user_service=user_service,
+        states=states,
+    )
+    state = hass.states.get("cover.test_my_cover")
+    assert state is not None
+    assert state.state == STATE_OPENING
+    assert ATTR_CURRENT_TILT_POSITION not in state.attributes
+    assert ATTR_CURRENT_POSITION not in state.attributes


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add tests for ESPHome cover platform

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
