### PR TITLE
Revert "Change the device class name `volatile organic compounds parts` to `VOCs ratio`"

### DIFF
--- a/homeassistant/components/sensor/strings.json
+++ b/homeassistant/components/sensor/strings.json
@@ -247,7 +247,7 @@
       "name": "VOCs"
     },
     "volatile_organic_compounds_parts": {
-      "name": "VOCs ratio"
+      "name": "[%key:component::sensor::entity_component::volatile_organic_compounds::name%]"
     },
     "voltage": {
       "name": "Voltage"


### PR DESCRIPTION
Reverts home-assistant/core#95126

We intentionally gave the same name to `volatile_organic_compounds_parts` and `volatile_organic_compounds`
Let's try to solve the device class selector issue separately