### PR TITLE
Some small fixes for the Matter light platform

### DIFF
--- a/homeassistant/components/matter/light.py
+++ b/homeassistant/components/matter/light.py
@@ -450,6 +450,11 @@ DISCOVERY_SCHEMAS = [
             device_types.Fan,
             device_types.GenericSwitch,
             device_types.OnOffPlugInUnit,
+            device_types.HeatingCoolingUnit,
+            device_types.Pump,
+            device_types.CastingVideoClient,
+            device_types.VideoRemoteControl,
+            device_types.Speaker,
         ),
     ),
 ]

--- a/homeassistant/components/matter/light.py
+++ b/homeassistant/components/matter/light.py
@@ -446,6 +446,10 @@ DISCOVERY_SCHEMAS = [
         ),
         # important: make sure to rule out all device types that are also based on the
         # onoff and levelcontrol clusters !
-        not_device_type=(device_types.Fan, device_types.GenericSwitch),
+        not_device_type=(
+            device_types.Fan,
+            device_types.GenericSwitch,
+            device_types.OnOffPlugInUnit,
+        ),
     ),
 ]

--- a/homeassistant/components/matter/light.py
+++ b/homeassistant/components/matter/light.py
@@ -377,4 +377,75 @@ DISCOVERY_SCHEMAS = [
             device_types.OnOffLight,
         ),
     ),
+    # Additional schema to match (HS Color) lights with incorrect/missing device type
+    MatterDiscoverySchema(
+        platform=Platform.LIGHT,
+        entity_description=LightEntityDescription(key="MatterHSColorLightFallback"),
+        entity_class=MatterLight,
+        required_attributes=(
+            clusters.OnOff.Attributes.OnOff,
+            clusters.LevelControl.Attributes.CurrentLevel,
+            clusters.ColorControl.Attributes.CurrentHue,
+            clusters.ColorControl.Attributes.CurrentSaturation,
+        ),
+        optional_attributes=(
+            clusters.ColorControl.Attributes.ColorTemperatureMireds,
+            clusters.ColorControl.Attributes.ColorMode,
+            clusters.ColorControl.Attributes.CurrentX,
+            clusters.ColorControl.Attributes.CurrentY,
+        ),
+    ),
+    # Additional schema to match (XY Color) lights with incorrect/missing device type
+    MatterDiscoverySchema(
+        platform=Platform.LIGHT,
+        entity_description=LightEntityDescription(key="MatterXYColorLightFallback"),
+        entity_class=MatterLight,
+        required_attributes=(
+            clusters.OnOff.Attributes.OnOff,
+            clusters.LevelControl.Attributes.CurrentLevel,
+            clusters.ColorControl.Attributes.CurrentX,
+            clusters.ColorControl.Attributes.CurrentY,
+        ),
+        optional_attributes=(
+            clusters.ColorControl.Attributes.ColorTemperatureMireds,
+            clusters.ColorControl.Attributes.ColorMode,
+            clusters.ColorControl.Attributes.CurrentHue,
+            clusters.ColorControl.Attributes.CurrentSaturation,
+        ),
+    ),
+    # Additional schema to match (color temperature) lights with incorrect/missing device type
+    MatterDiscoverySchema(
+        platform=Platform.LIGHT,
+        entity_description=LightEntityDescription(
+            key="MatterColorTemperatureLightFallback"
+        ),
+        entity_class=MatterLight,
+        required_attributes=(
+            clusters.OnOff.Attributes.OnOff,
+            clusters.LevelControl.Attributes.CurrentLevel,
+            clusters.ColorControl.Attributes.ColorTemperatureMireds,
+        ),
+        optional_attributes=(clusters.ColorControl.Attributes.ColorMode,),
+    ),
+    # Additional schema to match generic dimmable lights with incorrect/missing device type
+    MatterDiscoverySchema(
+        platform=Platform.LIGHT,
+        entity_description=LightEntityDescription(key="MatterDimmableLightFallback"),
+        entity_class=MatterLight,
+        required_attributes=(
+            clusters.OnOff.Attributes.OnOff,
+            clusters.LevelControl.Attributes.CurrentLevel,
+        ),
+        optional_attributes=(
+            clusters.ColorControl.Attributes.ColorMode,
+            clusters.ColorControl.Attributes.CurrentHue,
+            clusters.ColorControl.Attributes.CurrentSaturation,
+            clusters.ColorControl.Attributes.CurrentX,
+            clusters.ColorControl.Attributes.CurrentY,
+            clusters.ColorControl.Attributes.ColorTemperatureMireds,
+        ),
+        # important: make sure to rule out all device types that are also based on the
+        # onoff and levelcontrol clusters !
+        not_device_type=(device_types.Fan, device_types.GenericSwitch),
+    ),
 ]

--- a/homeassistant/components/matter/light.py
+++ b/homeassistant/components/matter/light.py
@@ -220,7 +220,7 @@ class MatterLight(MatterEntity, LightEntity):
         return round(
             renormalize(
                 level_control.currentLevel,
-                (level_control.minLevel, level_control.maxLevel),
+                (level_control.minLevel or 0, level_control.maxLevel or 255),
                 (0, 255),
             )
         )

--- a/homeassistant/components/matter/light.py
+++ b/homeassistant/components/matter/light.py
@@ -220,7 +220,7 @@ class MatterLight(MatterEntity, LightEntity):
         return round(
             renormalize(
                 level_control.currentLevel,
-                (level_control.minLevel or 0, level_control.maxLevel or 255),
+                (level_control.minLevel or 0, level_control.maxLevel or 254),
                 (0, 255),
             )
         )

--- a/homeassistant/components/matter/light.py
+++ b/homeassistant/components/matter/light.py
@@ -299,6 +299,8 @@ class MatterLight(MatterEntity, LightEntity):
             # colormode(s)
             if self._entity_info.endpoint.has_attribute(
                 None, clusters.ColorControl.Attributes.ColorMode
+            ) and self._entity_info.endpoint.has_attribute(
+                None, clusters.ColorControl.Attributes.ColorCapabilities
             ):
                 capabilities = self.get_matter_attribute_value(
                     clusters.ColorControl.Attributes.ColorCapabilities


### PR DESCRIPTION
## Proposed change

- add fallback discovery schema for devices with wrong or missing devicetype (e.g. tasmota devices)
- add guard when minlevel or maxlevel brightness is not reported by device (e.g. tapo switches)
- add guard when  ColorCapabilities attribute is missing on device


## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #95323 fixes #95171
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
