### PR TITLE
Remove webhook deprecation notices

### DIFF
--- a/homeassistant/components/webhook/__init__.py
+++ b/homeassistant/components/webhook/__init__.py
@@ -43,7 +43,7 @@ def async_register(
     webhook_id: str,
     handler: Callable[[HomeAssistant, str, Request], Awaitable[Response | None]],
     *,
-    local_only: bool | None = False,
+    local_only: bool = False,
     allowed_methods: Iterable[str] | None = None,
 ) -> None:
     """Register a webhook."""
@@ -144,7 +144,7 @@ async def async_handle_webhook(
         )
         return Response(status=HTTPStatus.METHOD_NOT_ALLOWED)
 
-    if webhook["local_only"] in (True, None) and not isinstance(request, MockRequest):
+    if webhook["local_only"] and not isinstance(request, MockRequest):
         if TYPE_CHECKING:
             assert isinstance(request, Request)
             assert request.remote is not None
@@ -158,15 +158,6 @@ async def async_handle_webhook(
             _LOGGER.warning("Received remote request for local webhook %s", webhook_id)
             if webhook["local_only"]:
                 return Response(status=HTTPStatus.OK)
-            if not webhook.get("warned_about_deprecation"):
-                webhook["warned_about_deprecation"] = True
-                _LOGGER.warning(
-                    "Deprecation warning: "
-                    "Webhook '%s' does not provide a value for local_only. "
-                    "This webhook will be blocked after the 2023.7.0 release. "
-                    "Use `local_only: false` to keep this webhook operating as-is",
-                    webhook_id,
-                )
 
     try:
         response = await webhook["handler"](hass, webhook_id, request)

--- a/homeassistant/components/webhook/trigger.py
+++ b/homeassistant/components/webhook/trigger.py
@@ -10,11 +10,6 @@ import voluptuous as vol
 from homeassistant.const import CONF_PLATFORM, CONF_WEBHOOK_ID
 from homeassistant.core import CALLBACK_TYPE, HassJob, HomeAssistant, callback
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.issue_registry import (
-    IssueSeverity,
-    async_create_issue,
-    async_delete_issue,
-)
 from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
 from homeassistant.helpers.typing import ConfigType
 
@@ -85,31 +80,7 @@ async def async_attach_trigger(
 ) -> CALLBACK_TYPE:
     """Trigger based on incoming webhooks."""
     webhook_id: str = config[CONF_WEBHOOK_ID]
-    local_only = config.get(CONF_LOCAL_ONLY)
-    issue_id: str | None = None
-    if local_only is None:
-        issue_id = f"trigger_missing_local_only_{webhook_id}"
-        variables = trigger_info["variables"] or {}
-        automation_info = variables.get("this", {})
-        automation_id = automation_info.get("attributes", {}).get("id")
-        automation_entity_id = automation_info.get("entity_id")
-        automation_name = trigger_info.get("name") or automation_entity_id
-        async_create_issue(
-            hass,
-            DOMAIN,
-            issue_id,
-            breaks_in_ha_version="2023.7.0",
-            is_fixable=False,
-            severity=IssueSeverity.WARNING,
-            learn_more_url="https://www.home-assistant.io/docs/automation/trigger/#webhook-trigger",
-            translation_key="trigger_missing_local_only",
-            translation_placeholders={
-                "webhook_id": webhook_id,
-                "automation_name": automation_name,
-                "entity_id": automation_entity_id,
-                "edit": f"/config/automation/edit/{automation_id}",
-            },
-        )
+    local_only = config.get(CONF_LOCAL_ONLY, True)
     allowed_methods = config.get(CONF_ALLOWED_METHODS, DEFAULT_METHODS)
     job = HassJob(action)
 
@@ -135,8 +106,6 @@ async def async_attach_trigger(
     @callback
     def unregister():
         """Unregister webhook."""
-        if issue_id:
-            async_delete_issue(hass, DOMAIN, issue_id)
         triggers[webhook_id].remove(trigger_instance)
         if not triggers[webhook_id]:
             async_unregister(hass, webhook_id)

--- a/tests/components/webhook/test_trigger.py
+++ b/tests/components/webhook/test_trigger.py
@@ -137,7 +137,7 @@ async def test_webhook_allowed_methods_internet(
                     "platform": "webhook",
                     "webhook_id": "post_webhook",
                     "allowed_methods": "PUT",
-                    # Enable after 2023.4.0: "local_only": False,
+                    "local_only": False,
                 },
                 "action": {
                     "event": "test_success",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

Any webhook trigger that does not set `local_only` to `false` can only be activated by devices on the same network as Home Assistant.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Follow-up to #66494. Removing temporary deprecation log messages and issues from adding `local_only` option.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: #66494

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
