### PR TITLE
Fix sending a (default) pincode to Matter Lock operations

### DIFF
--- a/homeassistant/components/matter/lock.py
+++ b/homeassistant/components/matter/lock.py
@@ -58,7 +58,7 @@ class MatterLock(MatterEntity, LockEntity):
         """Lock the lock with pin if needed."""
         code: str = kwargs.get(
             ATTR_CODE,
-            self._lock_option_default_code,  # pylint: disable=protected-access
+            self._lock_option_default_code,
         )
         code_bytes = code.encode() if code else None
         await self.send_device_command(
@@ -69,7 +69,7 @@ class MatterLock(MatterEntity, LockEntity):
         """Unlock the lock with pin if needed."""
         code: str = kwargs.get(
             ATTR_CODE,
-            self._lock_option_default_code,  # pylint: disable=protected-access
+            self._lock_option_default_code,
         )
         code_bytes = code.encode() if code else None
         await self.send_device_command(

--- a/homeassistant/components/matter/lock.py
+++ b/homeassistant/components/matter/lock.py
@@ -8,7 +8,7 @@ from chip.clusters import Objects as clusters
 
 from homeassistant.components.lock import LockEntity, LockEntityDescription
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import Platform
+from homeassistant.const import ATTR_CODE, Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -56,11 +56,25 @@ class MatterLock(MatterEntity, LockEntity):
 
     async def async_lock(self, **kwargs: Any) -> None:
         """Lock the lock with pin if needed."""
-        await self.send_device_command(command=clusters.DoorLock.Commands.LockDoor())
+        code: str = kwargs.get(
+            ATTR_CODE,
+            self._lock_option_default_code,  # pylint: disable=protected-access
+        )
+        code_bytes = code.encode() if code else None
+        await self.send_device_command(
+            command=clusters.DoorLock.Commands.LockDoor(code_bytes)
+        )
 
     async def async_unlock(self, **kwargs: Any) -> None:
         """Unlock the lock with pin if needed."""
-        await self.send_device_command(command=clusters.DoorLock.Commands.UnlockDoor())
+        code: str = kwargs.get(
+            ATTR_CODE,
+            self._lock_option_default_code,  # pylint: disable=protected-access
+        )
+        code_bytes = code.encode() if code else None
+        await self.send_device_command(
+            command=clusters.DoorLock.Commands.UnlockDoor(code_bytes)
+        )
 
     @callback
     def _update_from_device(self) -> None:


### PR DESCRIPTION
## Proposed change
Allow sending a pincode to matter lock/unlock operations.
The pincode can either be provided in the service call or as entity option.

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #94316
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
