### PR TITLE
Add more test coverage for ESPHome lights

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -310,7 +310,6 @@ omit =
     homeassistant/components/esphome/camera.py
     homeassistant/components/esphome/domain_data.py
     homeassistant/components/esphome/entry_data.py
-    homeassistant/components/esphome/light.py
     homeassistant/components/etherscan/sensor.py
     homeassistant/components/eufy/*
     homeassistant/components/eufylife_ble/__init__.py

--- a/homeassistant/components/esphome/light.py
+++ b/homeassistant/components/esphome/light.py
@@ -364,12 +364,6 @@ class EsphomeLight(EsphomeEntity[LightInfo, LightState], LightEntity):
 
     @property
     @esphome_state_property
-    def color_temp(self) -> int:
-        """Return the CT color value in mireds."""
-        return round(self._state.color_temperature)
-
-    @property
-    @esphome_state_property
     def color_temp_kelvin(self) -> int:
         """Return the CT color value in Kelvin."""
         return _mired_to_kelvin(self._state.color_temperature)

--- a/tests/components/esphome/test_light.py
+++ b/tests/components/esphome/test_light.py
@@ -1085,13 +1085,13 @@ async def test_light_rgbww_without_cold_warm_white_support(
                 | LightColorCapability.COLOR_TEMPERATURE
                 | LightColorCapability.ON_OFF
                 | LightColorCapability.BRIGHTNESS,
-                cold_white=0,
-                warm_white=0,
+                white=0,
                 rgb=(pytest.approx(0.32941176470588235), 1.0, 0.0),
                 brightness=pytest.approx(0.4980392156862745),
             )
         ]
     )
+
     mock_client.light_command.reset_mock()
 
     await hass.services.async_call(
@@ -1106,8 +1106,8 @@ async def test_light_rgbww_without_cold_warm_white_support(
                 key=1,
                 state=True,
                 color_brightness=pytest.approx(0.4235294117647059),
-                cold_white=1,
-                warm_white=1,
+                color_temperature=276.5,
+                white=1,
                 color_mode=LightColorCapability.RGB
                 | LightColorCapability.WHITE
                 | LightColorCapability.COLOR_TEMPERATURE
@@ -1131,8 +1131,8 @@ async def test_light_rgbww_without_cold_warm_white_support(
                 key=1,
                 state=True,
                 color_brightness=pytest.approx(0.4235294117647059),
-                cold_white=1,
-                warm_white=1,
+                white=1,
+                color_temperature=276.5,
                 color_mode=LightColorCapability.RGB
                 | LightColorCapability.WHITE
                 | LightColorCapability.COLOR_TEMPERATURE
@@ -1159,8 +1159,8 @@ async def test_light_rgbww_without_cold_warm_white_support(
                 key=1,
                 state=True,
                 color_brightness=1,
-                cold_white=1,
-                warm_white=1,
+                white=1,
+                color_temperature=276.5,
                 color_mode=LightColorCapability.RGB
                 | LightColorCapability.WHITE
                 | LightColorCapability.COLOR_TEMPERATURE
@@ -1184,8 +1184,8 @@ async def test_light_rgbww_without_cold_warm_white_support(
                 key=1,
                 state=True,
                 color_brightness=0,
-                cold_white=0,
-                warm_white=100,
+                white=100,
+                color_temperature=400.0,
                 color_mode=LightColorCapability.RGB
                 | LightColorCapability.WHITE
                 | LightColorCapability.COLOR_TEMPERATURE

--- a/tests/components/esphome/test_light.py
+++ b/tests/components/esphome/test_light.py
@@ -27,6 +27,7 @@ from homeassistant.components.light import (
     ATTR_RGBW_COLOR,
     ATTR_RGBWW_COLOR,
     ATTR_SUPPORTED_COLOR_MODES,
+    ATTR_TRANSITION,
     DOMAIN as LIGHT_DOMAIN,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
@@ -131,6 +132,17 @@ async def test_light_brightness(
                 brightness=pytest.approx(0.4980392156862745),
             )
         ]
+    )
+    mock_client.light_command.reset_mock()
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: "light.test_my_light", ATTR_TRANSITION: 2},
+        blocking=True,
+    )
+    mock_client.light_command.assert_has_calls(
+        [call(key=1, state=False, transition_length=2.0)]
     )
     mock_client.light_command.reset_mock()
 

--- a/tests/components/esphome/test_light.py
+++ b/tests/components/esphome/test_light.py
@@ -18,6 +18,7 @@ from homeassistant.components.light import (
     ATTR_COLOR_TEMP_KELVIN,
     ATTR_EFFECT,
     ATTR_EFFECT_LIST,
+    ATTR_FLASH,
     ATTR_HS_COLOR,
     ATTR_MAX_COLOR_TEMP_KELVIN,
     ATTR_MAX_MIREDS,
@@ -29,6 +30,8 @@ from homeassistant.components.light import (
     ATTR_SUPPORTED_COLOR_MODES,
     ATTR_TRANSITION,
     DOMAIN as LIGHT_DOMAIN,
+    FLASH_LONG,
+    FLASH_SHORT,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
     STATE_ON,
@@ -143,6 +146,53 @@ async def test_light_brightness(
     )
     mock_client.light_command.assert_has_calls(
         [call(key=1, state=False, transition_length=2.0)]
+    )
+    mock_client.light_command.reset_mock()
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: "light.test_my_light", ATTR_FLASH: FLASH_LONG},
+        blocking=True,
+    )
+    mock_client.light_command.assert_has_calls(
+        [call(key=1, state=False, flash_length=10.0)]
+    )
+    mock_client.light_command.reset_mock()
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: "light.test_my_light", ATTR_TRANSITION: 2},
+        blocking=True,
+    )
+    mock_client.light_command.assert_has_calls(
+        [
+            call(
+                key=1,
+                state=True,
+                transition_length=2.0,
+                color_mode=LightColorCapability.BRIGHTNESS,
+            )
+        ]
+    )
+    mock_client.light_command.reset_mock()
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: "light.test_my_light", ATTR_FLASH: FLASH_SHORT},
+        blocking=True,
+    )
+    mock_client.light_command.assert_has_calls(
+        [
+            call(
+                key=1,
+                state=True,
+                flash_length=2.0,
+                color_mode=LightColorCapability.BRIGHTNESS,
+            )
+        ]
     )
     mock_client.light_command.reset_mock()
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add more test coverage for ESPHome lights

- Remove dead code left over from mireds -> kelvin

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
