### PR TITLE
Fix error for stt when async_get_engine is not implemented

### DIFF
--- a/homeassistant/components/demo/__init__.py
+++ b/homeassistant/components/demo/__init__.py
@@ -50,7 +50,6 @@ COMPONENTS_WITH_CONFIG_ENTRY_DEMO_PLATFORM = [
 
 COMPONENTS_WITH_DEMO_PLATFORM = [
     Platform.TTS,
-    Platform.STT,
     Platform.MAILBOX,
     Platform.NOTIFY,
     Platform.IMAGE_PROCESSING,

--- a/homeassistant/components/stt/legacy.py
+++ b/homeassistant/components/stt/legacy.py
@@ -65,12 +65,15 @@ def async_setup_legacy(
             return
 
         try:
-            provider = await platform.async_get_engine(hass, p_config, discovery_info)
+            if hasattr(platform, "async_get_engine"):
+                provider = await platform.async_get_engine(
+                    hass, p_config, discovery_info
+                )
 
-            provider.name = p_type
-            provider.hass = hass
+                provider.name = p_type
+                provider.hass = hass
 
-            providers[provider.name] = provider
+                providers[provider.name] = provider
         except Exception:  # pylint: disable=broad-except
             _LOGGER.exception("Error setting up platform: %s", p_type)
             return

--- a/homeassistant/components/stt/legacy.py
+++ b/homeassistant/components/stt/legacy.py
@@ -65,15 +65,12 @@ def async_setup_legacy(
             return
 
         try:
-            if hasattr(platform, "async_get_engine"):
-                provider = await platform.async_get_engine(
-                    hass, p_config, discovery_info
-                )
+            provider = await platform.async_get_engine(hass, p_config, discovery_info)
 
-                provider.name = p_type
-                provider.hass = hass
+            provider.name = p_type
+            provider.hass = hass
 
-                providers[provider.name] = provider
+            providers[provider.name] = provider
         except Exception:  # pylint: disable=broad-except
             _LOGGER.exception("Error setting up platform: %s", p_type)
             return


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix error for stt when async_get_engine is not implemented.

When the `demo` platform is set up. The following error is logged:

```log
2023-06-28 08:04:55.746 ERROR (MainThread) [homeassistant.components.stt.legacy] Error setting up platform: demo
Traceback (most recent call last):
  File "/workspaces/core/homeassistant/components/stt/legacy.py", line 68, in async_setup_platform
    provider = await platform.async_get_engine(hass, p_config, discovery_info)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'homeassistant.components.demo.stt' has no attribute 'async_get_engine'

```

This PR fixes this by checking removing the legacy `stt` platform from the `demo` integration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
