### PR TITLE
Disconnect VoIP on RTCP bye message

### DIFF
--- a/homeassistant/components/voip/manifest.json
+++ b/homeassistant/components/voip/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://www.home-assistant.io/integrations/voip",
   "iot_class": "local_push",
   "quality_scale": "internal",
-  "requirements": ["voip-utils==0.0.7"]
+  "requirements": ["voip-utils==0.1.0"]
 }

--- a/homeassistant/components/voip/voip.py
+++ b/homeassistant/components/voip/voip.py
@@ -55,7 +55,7 @@ def make_protocol(
     hass: HomeAssistant,
     devices: VoIPDevices,
     call_info: CallInfo,
-    rtcp_state: RtcpState,
+    rtcp_state: RtcpState | None = None,
 ) -> VoipDatagramProtocol:
     """Plays a pre-recorded message if pipeline is misconfigured."""
     voip_device = devices.async_get_or_create(call_info)
@@ -150,7 +150,6 @@ class PipelineRtpDatagramProtocol(RtpDatagramProtocol):
         voip_device: VoIPDevice,
         context: Context,
         opus_payload_type: int,
-        rtcp_state: RtcpState,
         pipeline_timeout: float = 30.0,
         audio_timeout: float = 2.0,
         buffered_chunks_before_speech: int = 100,
@@ -160,14 +159,15 @@ class PipelineRtpDatagramProtocol(RtpDatagramProtocol):
         tone_delay: float = 0.2,
         tts_extra_timeout: float = 1.0,
         silence_seconds: float = 1.0,
+        rtcp_state: RtcpState | None = None,
     ) -> None:
         """Set up pipeline RTP server."""
         super().__init__(
-            rtcp_state=rtcp_state,
             rate=RATE,
             width=WIDTH,
             channels=CHANNELS,
             opus_payload_type=opus_payload_type,
+            rtcp_state=rtcp_state,
         )
 
         self.hass = hass
@@ -466,17 +466,17 @@ class PreRecordMessageProtocol(RtpDatagramProtocol):
         hass: HomeAssistant,
         file_name: str,
         opus_payload_type: int,
-        rtcp_state: RtcpState,
         message_delay: float = 1.0,
         loop_delay: float = 2.0,
+        rtcp_state: RtcpState | None = None,
     ) -> None:
         """Set up RTP server."""
         super().__init__(
-            rtcp_state=rtcp_state,
             rate=RATE,
             width=WIDTH,
             channels=CHANNELS,
             opus_payload_type=opus_payload_type,
+            rtcp_state=rtcp_state,
         )
         self.hass = hass
         self.file_name = file_name

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2614,7 +2614,7 @@ venstarcolortouch==0.19
 vilfo-api-client==0.4.1
 
 # homeassistant.components.voip
-voip-utils==0.0.7
+voip-utils==0.1.0
 
 # homeassistant.components.volkszaehler
 volkszaehler==0.4.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1914,7 +1914,7 @@ venstarcolortouch==0.19
 vilfo-api-client==0.4.1
 
 # homeassistant.components.voip
-voip-utils==0.0.7
+voip-utils==0.1.0
 
 # homeassistant.components.volvooncall
 volvooncall==0.10.3


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for stopping a VoIP call properly when a [bye message](https://www.freesoft.org/CIE/RFC/1889/32.htm) is received over RTCP from the caller. This requires opening two UDP ports per VoIP connection, one for RTP (audio) and the next port up for RTCP (control).

Specifically, this PR:

1. Bumps `voip-utils` package to version `0.1.0`: https://github.com/home-assistant-libs/voip-utils/compare/v0.0.7...v0.1.0 to support RTCP
2. Threads `RtcpState` through datagram protocols to listen for the "bye" message and disconnect immediately

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
