### PR TITLE
Remove polling_interval_seconds option from wemo

### DIFF
--- a/homeassistant/components/wemo/strings.json
+++ b/homeassistant/components/wemo/strings.json
@@ -15,14 +15,12 @@
       "init": {
         "data": {
           "enable_subscription": "Subscribe to device local push updates",
-          "enable_long_press": "Register for device long-press events",
-          "polling_interval_seconds": "Seconds to wait between polling the device"
+          "enable_long_press": "Register for device long-press events"
         }
       }
     },
     "error": {
       "long_press_requires_subscription": "Local push update subscriptions must be enabled to use long-press events",
-      "polling_interval_to_small": "Polling more frequently than 10 seconds is not supported",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     }
   },

--- a/tests/components/wemo/test_config_flow.py
+++ b/tests/components/wemo/test_config_flow.py
@@ -61,9 +61,3 @@ async def test_invalid_options(hass: HomeAssistant) -> None:
     assert result["errors"] == {
         "enable_subscription": "long_press_requires_subscription"
     }
-
-    # polling_interval_seconds must be larger than 10.
-    result = await hass.config_entries.options.async_configure(
-        result["flow_id"], user_input={"polling_interval_seconds": 1}
-    )
-    assert result["errors"] == {"polling_interval_seconds": "polling_interval_to_small"}

--- a/tests/components/wemo/test_wemo_device.py
+++ b/tests/components/wemo/test_wemo_device.py
@@ -214,37 +214,6 @@ async def test_options_enable_long_press_false(hass, pywemo_device, wemo_entity)
     pywemo_device.remove_long_press_virtual_device.assert_called_once_with()
 
 
-async def test_options_polling_interval_seconds(hass, pywemo_device, wemo_entity):
-    """Test setting Options.polling_interval_seconds = 45."""
-    config_entry = hass.config_entries.async_get_entry(wemo_entity.config_entry_id)
-    assert hass.config_entries.async_update_entry(
-        config_entry,
-        options=asdict(
-            wemo_device.Options(
-                enable_subscription=False,
-                enable_long_press=False,
-                polling_interval_seconds=45,
-            )
-        ),
-    )
-    await hass.async_block_till_done()
-
-    # Move time forward to capture the new interval.
-    async_fire_time_changed(hass, utcnow() + timedelta(seconds=31))
-    await hass.async_block_till_done()
-    pywemo_device.get_state.reset_mock()
-
-    # Make sure no polling occurs before 45 seconds.
-    async_fire_time_changed(hass, utcnow() + timedelta(seconds=31))
-    await hass.async_block_till_done()
-    pywemo_device.get_state.assert_not_called()
-
-    # Polling occurred after the interval.
-    async_fire_time_changed(hass, utcnow() + timedelta(seconds=46))
-    await hass.async_block_till_done()
-    pywemo_device.get_state.assert_has_calls([call(True), call()])
-
-
 class TestInsight:
     """Tests specific to the WeMo Insight device."""
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove the `polling_interval_seconds` option added in #56972 based on [feedback](https://github.com/home-assistant/core/pull/56972#discussion_r1244747663) after that PR was merged. Users can disable automatic polling and set up their own polling interval if needed. 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: #56972
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/28001

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
