### PR TITLE
Bump ZHA dependencies

### DIFF
--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -20,15 +20,15 @@
     "zigpy_znp"
   ],
   "requirements": [
-    "bellows==0.35.5",
+    "bellows==0.35.6",
     "pyserial==3.5",
     "pyserial-asyncio==0.6",
     "zha-quirks==0.0.101",
     "zigpy-deconz==0.21.0",
-    "zigpy==0.56.0",
-    "zigpy-xbee==0.18.0",
+    "zigpy==0.56.1",
+    "zigpy-xbee==0.18.1",
     "zigpy-zigate==0.11.0",
-    "zigpy-znp==0.11.1"
+    "zigpy-znp==0.11.2"
   ],
   "usb": [
     {

--- a/homeassistant/components/zha/radio_manager.py
+++ b/homeassistant/components/zha/radio_manager.py
@@ -250,11 +250,12 @@ class ZhaRadioManager:
 
             assert self.current_settings is not None
 
+        metadata = self.current_settings.network_info.metadata["ezsp"]
+
         if (
             self.current_settings.node_info.ieee == self.chosen_backup.node_info.ieee
-            or not self.current_settings.network_info.metadata["ezsp"][
-                "can_write_custom_eui64"
-            ]
+            or metadata["can_rewrite_custom_eui64"]
+            or not metadata["can_burn_userdata_custom_eui64"]
         ):
             # No point in prompting the user if the backup doesn't have a new IEEE
             # address or if there is no way to overwrite the IEEE address a second time

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -497,7 +497,7 @@ beautifulsoup4==4.11.1
 # beewi-smartclim==0.0.10
 
 # homeassistant.components.zha
-bellows==0.35.5
+bellows==0.35.6
 
 # homeassistant.components.bmw_connected_drive
 bimmer-connected==0.13.7
@@ -2753,16 +2753,16 @@ ziggo-mediabox-xl==1.1.0
 zigpy-deconz==0.21.0
 
 # homeassistant.components.zha
-zigpy-xbee==0.18.0
+zigpy-xbee==0.18.1
 
 # homeassistant.components.zha
 zigpy-zigate==0.11.0
 
 # homeassistant.components.zha
-zigpy-znp==0.11.1
+zigpy-znp==0.11.2
 
 # homeassistant.components.zha
-zigpy==0.56.0
+zigpy==0.56.1
 
 # homeassistant.components.zoneminder
 zm-py==0.5.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -418,7 +418,7 @@ base36==0.1.1
 beautifulsoup4==4.11.1
 
 # homeassistant.components.zha
-bellows==0.35.5
+bellows==0.35.6
 
 # homeassistant.components.bmw_connected_drive
 bimmer-connected==0.13.7
@@ -2017,16 +2017,16 @@ zha-quirks==0.0.101
 zigpy-deconz==0.21.0
 
 # homeassistant.components.zha
-zigpy-xbee==0.18.0
+zigpy-xbee==0.18.1
 
 # homeassistant.components.zha
 zigpy-zigate==0.11.0
 
 # homeassistant.components.zha
-zigpy-znp==0.11.1
+zigpy-znp==0.11.2
 
 # homeassistant.components.zha
-zigpy==0.56.0
+zigpy==0.56.1
 
 # homeassistant.components.zwave_js
 zwave-js-server-python==0.49.0

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -74,6 +74,12 @@ def mock_app():
     mock_app = AsyncMock()
     mock_app.backups = create_autospec(BackupManager, instance=True)
     mock_app.backups.backups = []
+    mock_app.state.network_info.metadata = {
+        "ezsp": {
+            "can_burn_userdata_custom_eui64": True,
+            "can_rewrite_custom_eui64": False,
+        }
+    }
 
     with patch(
         "zigpy.application.ControllerApplication.new", AsyncMock(return_value=mock_app)
@@ -1517,6 +1523,7 @@ async def test_ezsp_restore_without_settings_change_ieee(
     mock_app.state.node_info = backup.node_info
     mock_app.state.network_info = copy.deepcopy(backup.network_info)
     mock_app.state.network_info.network_key.tx_counter += 10000
+    mock_app.state.network_info.metadata["ezsp"] = {}
 
     # Include the overwrite option, just in case someone uploads a backup with it
     backup.network_info.metadata["ezsp"] = {EZSP_OVERWRITE_EUI64: True}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump ZHA dependencies:

 - bellows to [0.35.6](https://github.com/zigpy/bellows/releases/tag/0.35.6)
 - zigpy to [0.56.1](https://github.com/zigpy/zigpy/releases/tag/0.56.1)
 - zigpy-xbee to [0.18.1](https://github.com/zigpy/zigpy-xbee/releases/tag/0.18.1)
 - zigpy-znp to [0.11.2](https://github.com/zigpy/zigpy-znp/releases/tag/v0.11.2)

This PR fixes a few small bugs:
 - topology scanning failing (broken in `dev`, not in any release so far)
 - energy scanning during startup breaking with the latest SkyConnect/Yellow Zigbee firmware
 - improved debug logging for command retries with Z-Stack coordinators

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #92375
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
