### PR TITLE
Add targeted entities to sentence debug API

### DIFF
--- a/homeassistant/components/conversation/__init__.py
+++ b/homeassistant/components/conversation/__init__.py
@@ -8,6 +8,7 @@ import logging
 import re
 from typing import Any, Literal
 
+from hassil.recognize import RecognizeResult
 import voluptuous as vol
 
 from homeassistant import core
@@ -353,6 +354,10 @@ async def websocket_hass_agent_debug(
                         }
                         for entity_key, entity in result.entities.items()
                     },
+                    "targets": {
+                        state.entity_id: {"matched": is_matched}
+                        for state, is_matched in _get_debug_targets(hass, result)
+                    },
                 }
                 if result is not None
                 else None
@@ -360,6 +365,50 @@ async def websocket_hass_agent_debug(
             ]
         },
     )
+
+
+@bind_hass
+def _get_debug_targets(
+    hass: HomeAssistant,
+    result: RecognizeResult,
+) -> Iterable[tuple[core.State, bool]]:
+    """Yield state/is_matched pairs for a hassil recognition."""
+    entities = result.entities
+
+    name: str | None = None
+    area_name: str | None = None
+    domains: set[str] | None = None
+    device_classes: set[str] | None = None
+    state_names: set[str] | None = None
+
+    if "name" in entities:
+        name = str(entities["name"].value)
+
+    if "area" in entities:
+        area_name = str(entities["area"].value)
+
+    if "domain" in entities:
+        domains = set(cv.ensure_list(entities["domain"].value))
+
+    if "device_class" in entities:
+        device_classes = set(cv.ensure_list(entities["device_class"].value))
+
+    if "state" in entities:
+        # HassGetState only
+        state_names = set(cv.ensure_list(entities["state"].value))
+
+    states = intent.async_match_states(
+        hass,
+        name=name,
+        area_name=area_name,
+        domains=domains,
+        device_classes=device_classes,
+    )
+
+    for state in states:
+        # For queries, a target is "matched" based on its state
+        is_matched = (state_names is None) or (state.state in state_names)
+        yield state, is_matched
 
 
 class ConversationProcessView(http.HomeAssistantView):

--- a/homeassistant/components/conversation/__init__.py
+++ b/homeassistant/components/conversation/__init__.py
@@ -367,7 +367,6 @@ async def websocket_hass_agent_debug(
     )
 
 
-@bind_hass
 def _get_debug_targets(
     hass: HomeAssistant,
     result: RecognizeResult,

--- a/tests/components/conversation/snapshots/test_init.ambr
+++ b/tests/components/conversation/snapshots/test_init.ambr
@@ -405,6 +405,55 @@
           }),
         }),
       }),
+      dict({
+        'entities': dict({
+          'area': dict({
+            'name': 'area',
+            'text': 'kitchen',
+            'value': 'kitchen',
+          }),
+          'domain': dict({
+            'name': 'domain',
+            'text': '',
+            'value': 'light',
+          }),
+        }),
+        'intent': dict({
+          'name': 'HassTurnOn',
+        }),
+        'targets': dict({
+          'light.kitchen': dict({
+            'matched': True,
+          }),
+        }),
+      }),
+      dict({
+        'entities': dict({
+          'area': dict({
+            'name': 'area',
+            'text': 'kitchen',
+            'value': 'kitchen',
+          }),
+          'domain': dict({
+            'name': 'domain',
+            'text': 'lights',
+            'value': 'light',
+          }),
+          'state': dict({
+            'name': 'state',
+            'text': 'on',
+            'value': 'on',
+          }),
+        }),
+        'intent': dict({
+          'name': 'HassGetState',
+        }),
+        'targets': dict({
+          'light.kitchen': dict({
+            'matched': False,
+          }),
+        }),
+      }),
       None,
     ]),
   })

--- a/tests/components/conversation/snapshots/test_init.ambr
+++ b/tests/components/conversation/snapshots/test_init.ambr
@@ -382,6 +382,11 @@
         'intent': dict({
           'name': 'HassTurnOn',
         }),
+        'targets': dict({
+          'light.kitchen': dict({
+            'matched': True,
+          }),
+        }),
       }),
       dict({
         'entities': dict({
@@ -393,6 +398,11 @@
         }),
         'intent': dict({
           'name': 'HassTurnOff',
+        }),
+        'targets': dict({
+          'light.kitchen': dict({
+            'matched': True,
+          }),
         }),
       }),
       None,

--- a/tests/components/conversation/test_init.py
+++ b/tests/components/conversation/test_init.py
@@ -1652,16 +1652,22 @@ async def test_ws_hass_agent_debug(
     hass: HomeAssistant,
     init_components,
     hass_ws_client: WebSocketGenerator,
+    area_registry: ar.AreaRegistry,
     entity_registry: er.EntityRegistry,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test homeassistant agent debug websocket command."""
     client = await hass_ws_client(hass)
 
+    kitchen_area = area_registry.async_create("kitchen")
     entity_registry.async_get_or_create(
         "light", "demo", "1234", suggested_object_id="kitchen"
     )
-    entity_registry.async_update_entity("light.kitchen", aliases={"my cool light"})
+    entity_registry.async_update_entity(
+        "light.kitchen",
+        aliases={"my cool light"},
+        area_id=kitchen_area.id,
+    )
     hass.states.async_set("light.kitchen", "off")
 
     on_calls = async_mock_service(hass, LIGHT_DOMAIN, "turn_on")
@@ -1673,6 +1679,8 @@ async def test_ws_hass_agent_debug(
             "sentences": [
                 "turn on my cool light",
                 "turn my cool light off",
+                "turn on all lights in the kitchen",
+                "how many lights are on in the kitchen?",
                 "this will not match anything",  # null in results
             ],
         }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a "targets" field to the results from the sentence debug API. This contains the ids of the HA entities that would be targeted with a command or query.

Each targeted entity has a `matched` flag to indicate whether or not it would match a query (`HassGetState`). For example, asking "how many lights are on in the office?" will target **all** lights in the office but only *match* those whose state in "on". 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
