### PR TITLE
Update matter locks to support pin code validation

### DIFF
--- a/homeassistant/components/matter/lock.py
+++ b/homeassistant/components/matter/lock.py
@@ -34,6 +34,26 @@ class MatterLock(MatterEntity, LockEntity):
     features: int | None = None
 
     @property
+    def code_format(self) -> str | None:
+        """Regex for code format or None if no code is required."""
+        if self.get_matter_attribute_value(
+            clusters.DoorLock.Attributes.RequirePINforRemoteOperation
+        ):
+            min_pincode_length = int(
+                self.get_matter_attribute_value(
+                    clusters.DoorLock.Attributes.MinPINCodeLength
+                )
+            )
+            max_pincode_length = int(
+                self.get_matter_attribute_value(
+                    clusters.DoorLock.Attributes.MaxPINCodeLength
+                )
+            )
+            return f"^\\d{{{min_pincode_length},{max_pincode_length}}}$"
+
+        return None
+
+    @property
     def supports_door_position_sensor(self) -> bool:
         """Return True if the lock supports door position sensor."""
         if self.features is None:

--- a/tests/components/matter/test_door_lock.py
+++ b/tests/components/matter/test_door_lock.py
@@ -11,7 +11,7 @@ from homeassistant.components.lock import (
     STATE_UNLOCKED,
     STATE_UNLOCKING,
 )
-from homeassistant.const import STATE_UNKNOWN
+from homeassistant.const import ATTR_CODE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 
 from .common import (
@@ -104,3 +104,46 @@ async def test_lock(
     state = hass.states.get("lock.mock_door_lock")
     assert state
     assert state.state == STATE_UNKNOWN
+
+
+# This tests needs to be adjusted to remove lingering tasks
+@pytest.mark.parametrize("expected_lingering_tasks", [True])
+async def test_lock_requires_pin(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    door_lock: MatterNode,
+) -> None:
+    """Test door lock with PINCode."""
+
+    code = "1234567"
+
+    # set RequirePINforRemoteOperation
+    set_node_attribute(door_lock, 1, 257, 51, True)
+    # set door state to unlocked
+    set_node_attribute(door_lock, 1, 257, 0, 2)
+
+    with pytest.raises(ValueError):
+        # Lock door using invalid code format
+        await trigger_subscription_callback(hass, matter_client)
+        await hass.services.async_call(
+            "lock",
+            "lock",
+            {"entity_id": "lock.mock_door_lock", ATTR_CODE: "1234"},
+            blocking=True,
+        )
+
+    # Lock door using valid code
+    await trigger_subscription_callback(hass, matter_client)
+    await hass.services.async_call(
+        "lock",
+        "lock",
+        {"entity_id": "lock.mock_door_lock", ATTR_CODE: code},
+        blocking=True,
+    )
+    assert matter_client.send_device_command.call_count == 1
+    assert matter_client.send_device_command.call_args == call(
+        node_id=door_lock.node_id,
+        endpoint_id=1,
+        command=clusters.DoorLock.Commands.LockDoor(code.encode()),
+        timed_request_timeout_ms=1000,
+    )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add pincode validation to matter locks that require pincode for remote operation.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/94316
- Link to documentation pull request: 

This is a follow up of a previous bug report.
 Matter Locks was updated to send pin codes if provided (https://github.com/home-assistant/core/pull/95402), but without a code_format defined, the UI would ignore codes.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
