### PR TITLE
Fix not including device_name in friendly name if it is None

### DIFF
--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -772,9 +772,10 @@ class Entity(ABC):
         ):
             return name
 
+        device_name = device_entry.name_by_user or device_entry.name
         if self.use_device_name:
-            return device_entry.name_by_user or device_entry.name
-        return f"{device_entry.name_by_user or device_entry.name} {name}"
+            return device_name
+        return f"{device_name} {name}" if device_name else name
 
     @callback
     def _async_write_ha_state(self) -> None:

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -20,7 +20,7 @@ from homeassistant.const import (
 from homeassistant.core import Context, HomeAssistant, HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity, entity_registry as er
 from homeassistant.helpers.entity_component import async_update_entity
-from homeassistant.helpers.typing import UNDEFINED
+from homeassistant.helpers.typing import UNDEFINED, UndefinedType
 
 from tests.common import (
     MockConfigEntry,
@@ -989,12 +989,20 @@ async def _test_friendly_name(
 
 
 @pytest.mark.parametrize(
-    ("has_entity_name", "entity_name", "expected_friendly_name", "warn_implicit_name"),
     (
-        (False, "Entity Blu", "Entity Blu", False),
-        (False, None, None, False),
-        (True, "Entity Blu", "Device Bla Entity Blu", False),
-        (True, None, "Device Bla", False),
+        "has_entity_name",
+        "entity_name",
+        "device_name",
+        "expected_friendly_name",
+        "warn_implicit_name",
+    ),
+    (
+        (False, "Entity Blu", "Device Bla", "Entity Blu", False),
+        (False, None, "Device Bla", None, False),
+        (True, "Entity Blu", "Device Bla", "Device Bla Entity Blu", False),
+        (True, None, "Device Bla", "Device Bla", False),
+        (True, "Entity Blu", UNDEFINED, "Entity Blu", False),
+        (True, "Entity Blu", None, "Entity Blu", False),
     ),
 )
 async def test_friendly_name_attr(
@@ -1002,6 +1010,7 @@ async def test_friendly_name_attr(
     caplog: pytest.LogCaptureFixture,
     has_entity_name: bool,
     entity_name: str | None,
+    device_name: str | None | UndefinedType,
     expected_friendly_name: str | None,
     warn_implicit_name: bool,
 ) -> None:
@@ -1012,7 +1021,7 @@ async def test_friendly_name_attr(
         device_info={
             "identifiers": {("hue", "1234")},
             "connections": {(dr.CONNECTION_NETWORK_MAC, "abcd")},
-            "name": "Device Bla",
+            "name": device_name,
         },
     )
     ent._attr_has_entity_name = has_entity_name

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -1002,7 +1002,7 @@ async def _test_friendly_name(
         (True, "Entity Blu", "Device Bla", "Device Bla Entity Blu", False),
         (True, None, "Device Bla", "Device Bla", False),
         (True, "Entity Blu", UNDEFINED, "Entity Blu", False),
-        (True, "Entity Blu", None, "Entity Blu", False),
+        (True, "Entity Blu", None, "Mock Title Entity Blu", False),
     ),
 )
 async def test_friendly_name_attr(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Not sure

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If both `device_entry.name_by_user` or `device_entry.name` are `None`, then it should not be used to build the friendly name.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
