### PR TITLE
Remove incompatible button entities for Mazda electric vehicles

### DIFF
--- a/homeassistant/components/mazda/button.py
+++ b/homeassistant/components/mazda/button.py
@@ -78,21 +78,25 @@ BUTTON_ENTITIES = [
         key="start_engine",
         name="Start engine",
         icon="mdi:engine",
+        is_supported=lambda data: not data["isElectric"],
     ),
     MazdaButtonEntityDescription(
         key="stop_engine",
         name="Stop engine",
         icon="mdi:engine-off",
+        is_supported=lambda data: not data["isElectric"],
     ),
     MazdaButtonEntityDescription(
         key="turn_on_hazard_lights",
         name="Turn on hazard lights",
         icon="mdi:hazard-lights",
+        is_supported=lambda data: not data["isElectric"],
     ),
     MazdaButtonEntityDescription(
         key="turn_off_hazard_lights",
         name="Turn off hazard lights",
         icon="mdi:hazard-lights",
+        is_supported=lambda data: not data["isElectric"],
     ),
     MazdaButtonEntityDescription(
         key="refresh_vehicle_status",

--- a/tests/components/mazda/test_button.py
+++ b/tests/components/mazda/test_button.py
@@ -65,40 +65,6 @@ async def test_button_setup_electric_vehicle(hass: HomeAssistant) -> None:
 
     entity_registry = er.async_get(hass)
 
-    entry = entity_registry.async_get("button.my_mazda3_start_engine")
-    assert entry
-    assert entry.unique_id == "JM000000000000000_start_engine"
-    state = hass.states.get("button.my_mazda3_start_engine")
-    assert state
-    assert state.attributes.get(ATTR_FRIENDLY_NAME) == "My Mazda3 Start engine"
-    assert state.attributes.get(ATTR_ICON) == "mdi:engine"
-
-    entry = entity_registry.async_get("button.my_mazda3_stop_engine")
-    assert entry
-    assert entry.unique_id == "JM000000000000000_stop_engine"
-    state = hass.states.get("button.my_mazda3_stop_engine")
-    assert state
-    assert state.attributes.get(ATTR_FRIENDLY_NAME) == "My Mazda3 Stop engine"
-    assert state.attributes.get(ATTR_ICON) == "mdi:engine-off"
-
-    entry = entity_registry.async_get("button.my_mazda3_turn_on_hazard_lights")
-    assert entry
-    assert entry.unique_id == "JM000000000000000_turn_on_hazard_lights"
-    state = hass.states.get("button.my_mazda3_turn_on_hazard_lights")
-    assert state
-    assert state.attributes.get(ATTR_FRIENDLY_NAME) == "My Mazda3 Turn on hazard lights"
-    assert state.attributes.get(ATTR_ICON) == "mdi:hazard-lights"
-
-    entry = entity_registry.async_get("button.my_mazda3_turn_off_hazard_lights")
-    assert entry
-    assert entry.unique_id == "JM000000000000000_turn_off_hazard_lights"
-    state = hass.states.get("button.my_mazda3_turn_off_hazard_lights")
-    assert state
-    assert (
-        state.attributes.get(ATTR_FRIENDLY_NAME) == "My Mazda3 Turn off hazard lights"
-    )
-    assert state.attributes.get(ATTR_ICON) == "mdi:hazard-lights"
-
     entry = entity_registry.async_get("button.my_mazda3_refresh_status")
     assert entry
     assert entry.unique_id == "JM000000000000000_refresh_vehicle_status"
@@ -109,20 +75,20 @@ async def test_button_setup_electric_vehicle(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    ("entity_id_suffix", "api_method_name"),
+    ("electric_vehicle", "entity_id_suffix", "api_method_name"),
     [
-        ("start_engine", "start_engine"),
-        ("stop_engine", "stop_engine"),
-        ("turn_on_hazard_lights", "turn_on_hazard_lights"),
-        ("turn_off_hazard_lights", "turn_off_hazard_lights"),
-        ("refresh_status", "refresh_vehicle_status"),
+        (False, "start_engine", "start_engine"),
+        (False, "stop_engine", "stop_engine"),
+        (False, "turn_on_hazard_lights", "turn_on_hazard_lights"),
+        (False, "turn_off_hazard_lights", "turn_off_hazard_lights"),
+        (True, "refresh_status", "refresh_vehicle_status"),
     ],
 )
 async def test_button_press(
-    hass: HomeAssistant, entity_id_suffix, api_method_name
+    hass: HomeAssistant, electric_vehicle, entity_id_suffix, api_method_name
 ) -> None:
     """Test pressing the button entities."""
-    client_mock = await init_integration(hass, electric_vehicle=True)
+    client_mock = await init_integration(hass, electric_vehicle=electric_vehicle)
 
     await hass.services.async_call(
         BUTTON_DOMAIN,

--- a/tests/components/mazda/test_button.py
+++ b/tests/components/mazda/test_button.py
@@ -75,6 +75,31 @@ async def test_button_setup_electric_vehicle(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
+    ("electric_vehicle", "entity_id_suffix"),
+    [
+        (True, "start_engine"),
+        (True, "stop_engine"),
+        (True, "turn_on_hazard_lights"),
+        (True, "turn_off_hazard_lights"),
+        (False, "refresh_status"),
+    ],
+)
+async def test_button_not_created(
+    hass: HomeAssistant, electric_vehicle, entity_id_suffix
+) -> None:
+    """Test that button entities are not created when they should not be."""
+    await init_integration(hass, electric_vehicle=electric_vehicle)
+
+    entity_registry = er.async_get(hass)
+
+    entity_id = f"button.my_mazda3_{entity_id_suffix}"
+    entry = entity_registry.async_get(entity_id)
+    assert entry is None
+    state = hass.states.get(entity_id)
+    assert state is None
+
+
+@pytest.mark.parametrize(
     ("electric_vehicle", "entity_id_suffix", "api_method_name"),
     [
         (False, "start_engine", "start_engine"),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In the Mazda integration, the Mazda API does not support start engine, stop engine, and hazard lights functionality for electric vehicles. Therefore this PR removes those entities for only those vehicles. I don't believe this is a breaking change since those entities were already non-functional, but let me know if I'm incorrect.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/93558
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
