### PR TITLE
Limit fields returned for the list events service

### DIFF
--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -60,6 +60,7 @@ from .const import (
     EVENT_TIME_FIELDS,
     EVENT_TYPES,
     EVENT_UID,
+    LIST_EVENT_FIELDS,
     CalendarEntityFeature,
 )
 
@@ -413,6 +414,13 @@ def _api_event_dict_factory(obj: Iterable[tuple[str, Any]]) -> dict[str, Any]:
         else:
             result[name] = value
     return result
+
+
+def _list_events_dict_factory(
+    obj: Iterable[tuple[str, Any]]
+) -> dict[str, JsonValueType]:
+    """Convert CalendarEvent dataclass items to dictionary of attributes."""
+    return {name: value for name, value in obj if name in LIST_EVENT_FIELDS}
 
 
 def _get_datetime_local(
@@ -782,9 +790,7 @@ async def async_list_events_service(
     else:
         end = service_call.data[EVENT_END_DATETIME]
     calendar_event_list = await calendar.async_get_events(calendar.hass, start, end)
-    events: list[JsonValueType] = [
-        dataclasses.asdict(event) for event in calendar_event_list
-    ]
     return {
-        "events": events,
+        "events": dataclasses.asdict(event, dict_factory=_list_events_dict_factory)
+        for event in calendar_event_list
     }

--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -791,6 +791,8 @@ async def async_list_events_service(
         end = service_call.data[EVENT_END_DATETIME]
     calendar_event_list = await calendar.async_get_events(calendar.hass, start, end)
     return {
-        "events": dataclasses.asdict(event, dict_factory=_list_events_dict_factory)
-        for event in calendar_event_list
+        "events": [
+            dataclasses.asdict(event, dict_factory=_list_events_dict_factory)
+            for event in calendar_event_list
+        ]
     }

--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -420,7 +420,11 @@ def _list_events_dict_factory(
     obj: Iterable[tuple[str, Any]]
 ) -> dict[str, JsonValueType]:
     """Convert CalendarEvent dataclass items to dictionary of attributes."""
-    return {name: value for name, value in obj if name in LIST_EVENT_FIELDS}
+    return {
+        name: value
+        for name, value in obj
+        if name in LIST_EVENT_FIELDS and value is not None
+    }
 
 
 def _get_datetime_local(

--- a/homeassistant/components/calendar/const.py
+++ b/homeassistant/components/calendar/const.py
@@ -41,3 +41,12 @@ EVENT_TIME_FIELDS = {
 }
 EVENT_TYPES = "event_types"
 EVENT_DURATION = "duration"
+
+# Fields for the list events service
+LIST_EVENT_FIELDS = {
+    EVENT_START,
+    EVENT_END,
+    EVENT_SUMMARY,
+    EVENT_DESCRIPTION,
+    EVENT_LOCATION,
+}

--- a/homeassistant/components/calendar/const.py
+++ b/homeassistant/components/calendar/const.py
@@ -44,8 +44,8 @@ EVENT_DURATION = "duration"
 
 # Fields for the list events service
 LIST_EVENT_FIELDS = {
-    EVENT_START,
-    EVENT_END,
+    "start",
+    "end",
     EVENT_SUMMARY,
     EVENT_DESCRIPTION,
     EVENT_LOCATION,

--- a/tests/components/calendar/test_init.py
+++ b/tests/components/calendar/test_init.py
@@ -11,6 +11,7 @@ import voluptuous as vol
 
 from homeassistant.bootstrap import async_setup_component
 from homeassistant.components.calendar import DOMAIN, SERVICE_LIST_EVENTS
+from homeassistant.components.calendar.const import LIST_EVENT_FIELDS
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 import homeassistant.util.dt as dt_util
@@ -447,6 +448,9 @@ async def test_list_events_service_duration(
     assert "events" in response
     events = response["events"]
     assert [event["summary"] for event in events] == expected_events
+    for event in events:
+        for key in event:
+            assert key in LIST_EVENT_FIELDS
 
 
 async def test_list_events_positive_duration(hass: HomeAssistant) -> None:

--- a/tests/components/calendar/test_init.py
+++ b/tests/components/calendar/test_init.py
@@ -4,14 +4,13 @@ from __future__ import annotations
 from datetime import timedelta
 from http import HTTPStatus
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import pytest
 import voluptuous as vol
 
 from homeassistant.bootstrap import async_setup_component
 from homeassistant.components.calendar import DOMAIN, SERVICE_LIST_EVENTS
-from homeassistant.components.calendar.const import LIST_EVENT_FIELDS
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 import homeassistant.util.dt as dt_util
@@ -406,11 +405,17 @@ async def test_list_events_service(hass: HomeAssistant) -> None:
         blocking=True,
         return_response=True,
     )
-    assert response
-    assert "events" in response
-    events = response["events"]
-    assert len(events) == 1
-    assert events[0]["summary"] == "Future Event"
+    assert response == {
+        "events": [
+            {
+                "start": ANY,
+                "end": ANY,
+                "summary": "Future Event",
+                "description": "Future Description",
+                "location": "Future Location",
+            }
+        ]
+    }
 
 
 @pytest.mark.parametrize(
@@ -448,9 +453,6 @@ async def test_list_events_service_duration(
     assert "events" in response
     events = response["events"]
     assert [event["summary"] for event in events] == expected_events
-    for event in events:
-        for key in event:
-            assert key in LIST_EVENT_FIELDS
 
 
 async def test_list_events_positive_duration(hass: HomeAssistant) -> None:

--- a/tests/components/websocket_api/test_commands.py
+++ b/tests/components/websocket_api/test_commands.py
@@ -1769,9 +1769,6 @@ async def test_execute_script_complex_response(
                 "summary": "Future Event",
                 "description": "Future Description",
                 "location": "Future Location",
-                "uid": None,
-                "recurrence_id": None,
-                "rrule": None,
             }
         ]
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This limits the response to the set of fields documented at https://rc.home-assistant.io/integrations/calendar#service-calendarlist_events (removing rrule, recurrence id, and uid fields)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
