### PR TITLE
Default device name to config entry title

### DIFF
--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -636,7 +636,10 @@ class EntityPlatform:
 
                 if (
                     # device info that is purely meant for linking doesn't need default name
-                    set(processed_dev_info) > {"identifiers", "connections"}
+                    any(
+                        key not in {"identifiers", "connections"}
+                        for key in (processed_dev_info)
+                    )
                     and "default_name" not in processed_dev_info
                     and not processed_dev_info.get("name")
                 ):

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -608,18 +608,13 @@ class EntityPlatform:
                     entity.add_to_platform_abort()
                     return
 
-            if self.config_entry is not None:
-                config_entry_id: str | None = self.config_entry.entry_id
-            else:
-                config_entry_id = None
-
             device_info = entity.device_info
             device_id = None
             device = None
 
-            if config_entry_id is not None and device_info is not None:
+            if self.config_entry and device_info is not None:
                 processed_dev_info: dict[str, str | None] = {
-                    "config_entry_id": config_entry_id
+                    "config_entry_id": self.config_entry.entry_id
                 }
                 for key in (
                     "connections",
@@ -640,6 +635,12 @@ class EntityPlatform:
                         processed_dev_info[key] = device_info[
                             key  # type: ignore[literal-required]
                         ]
+
+                if (
+                    "default_name" not in processed_dev_info
+                    and not processed_dev_info.get("name")
+                ):
+                    processed_dev_info["name"] = self.config_entry.title
 
                 if "configuration_url" in device_info:
                     if device_info["configuration_url"] is None:

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -613,9 +613,7 @@ class EntityPlatform:
             device = None
 
             if self.config_entry and device_info is not None:
-                processed_dev_info: dict[str, str | None] = {
-                    "config_entry_id": self.config_entry.entry_id
-                }
+                processed_dev_info: dict[str, str | None] = {}
                 for key in (
                     "connections",
                     "default_manufacturer",
@@ -637,7 +635,9 @@ class EntityPlatform:
                         ]
 
                 if (
-                    "default_name" not in processed_dev_info
+                    # device info that is purely meant for linking doesn't need default name
+                    set(processed_dev_info) > {"identifiers", "connections"}
+                    and "default_name" not in processed_dev_info
                     and not processed_dev_info.get("name")
                 ):
                     processed_dev_info["name"] = self.config_entry.title
@@ -661,7 +661,8 @@ class EntityPlatform:
 
                 try:
                     device = device_registry.async_get_or_create(
-                        **processed_dev_info  # type: ignore[arg-type]
+                        config_entry_id=self.config_entry.entry_id,
+                        **processed_dev_info,  # type: ignore[arg-type]
                     )
                     device_id = device.id
                 except RequiredParameterMissing:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If no device name is given, we default the name of the device to the config entry title. This is ignored if a default name is given. That way we always have a device name.

Replaces #95485

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
