### PR TITLE
Bump Roborock to 0.29.2

### DIFF
--- a/homeassistant/components/roborock/device.py
+++ b/homeassistant/components/roborock/device.py
@@ -2,6 +2,8 @@
 
 from typing import Any
 
+from roborock.api import AttributeCache
+from roborock.command_cache import CacheableAttribute
 from roborock.containers import Status
 from roborock.exceptions import RoborockException
 from roborock.local_api import RoborockLocalClient
@@ -26,6 +28,15 @@ class RoborockEntity(Entity):
         self._attr_unique_id = unique_id
         self._attr_device_info = device_info
         self._api = api
+
+    @property
+    def api(self) -> RoborockLocalClient:
+        """Returns the api."""
+        return self._api
+
+    def get_cache(self, attribute: CacheableAttribute) -> AttributeCache:
+        """Get an item from the api cache."""
+        return self._api.cache.get(attribute)
 
     async def send(
         self, command: RoborockCommand, params: dict[str, Any] | list[Any] | None = None

--- a/homeassistant/components/roborock/manifest.json
+++ b/homeassistant/components/roborock/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/roborock",
   "iot_class": "local_polling",
   "loggers": ["roborock"],
-  "requirements": ["python-roborock==0.23.6"]
+  "requirements": ["python-roborock==0.29.2"]
 }

--- a/homeassistant/components/roborock/switch.py
+++ b/homeassistant/components/roborock/switch.py
@@ -1,23 +1,27 @@
 """Support for Roborock switch."""
+from __future__ import annotations
+
 import asyncio
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 import logging
 from typing import Any
 
-from roborock.exceptions import RoborockException
-from roborock.roborock_typing import RoborockCommand
+from roborock.api import AttributeCache
+from roborock.command_cache import CacheableAttribute
+from roborock.local_api import RoborockLocalClient
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util import slugify
 
 from .const import DOMAIN
 from .coordinator import RoborockDataUpdateCoordinator
-from .device import RoborockCoordinatedEntity, RoborockEntity
+from .device import RoborockEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -27,23 +31,11 @@ class RoborockSwitchDescriptionMixin:
     """Define an entity description mixin for switch entities."""
 
     # Gets the status of the switch
-    get_value: Callable[[RoborockEntity], Coroutine[Any, Any, dict]]
-    # Evaluate the result of get_value to determine a bool
-    evaluate_value: Callable[[dict], bool]
+    cache_key: CacheableAttribute
     # Sets the status of the switch
-    set_command: Callable[[RoborockEntity, bool], Coroutine[Any, Any, dict]]
-    # Check support of this feature
-    check_support: Callable[[RoborockDataUpdateCoordinator], Coroutine[Any, Any, dict]]
-
-
-@dataclass
-class RoborockCoordinatedSwitchDescriptionMixIn:
-    """Define an entity description mixin for switch entities."""
-
-    get_value: Callable[[RoborockCoordinatedEntity], bool]
-    set_command: Callable[[RoborockCoordinatedEntity, bool], Coroutine[Any, Any, dict]]
-    # Check support of this feature
-    check_support: Callable[[RoborockDataUpdateCoordinator], dict]
+    update_value: Callable[[AttributeCache, bool], Coroutine[Any, Any, dict]]
+    # Attribute from cache
+    attribute: str
 
 
 @dataclass
@@ -53,59 +45,42 @@ class RoborockSwitchDescription(
     """Class to describe an Roborock switch entity."""
 
 
-@dataclass
-class RoborockCoordinatedSwitchDescription(
-    SwitchEntityDescription, RoborockCoordinatedSwitchDescriptionMixIn
-):
-    """Class to describe an Roborock switch entity that needs a coordinator."""
-
-
 SWITCH_DESCRIPTIONS: list[RoborockSwitchDescription] = [
     RoborockSwitchDescription(
-        set_command=lambda entity, value: entity.send(
-            RoborockCommand.SET_CHILD_LOCK_STATUS, {"lock_status": 1 if value else 0}
+        cache_key=CacheableAttribute.child_lock_status,
+        update_value=lambda cache, value: cache.update_value(
+            {"lock_status": 1 if value else 0}
         ),
-        get_value=lambda data: data.send(RoborockCommand.GET_CHILD_LOCK_STATUS),
-        check_support=lambda data: data.api.send_command(
-            RoborockCommand.GET_CHILD_LOCK_STATUS
-        ),
-        evaluate_value=lambda data: data["lock_status"] == 1,
+        attribute="lock_status",
         key="child_lock",
         translation_key="child_lock",
         icon="mdi:account-lock",
         entity_category=EntityCategory.CONFIG,
     ),
     RoborockSwitchDescription(
-        set_command=lambda entity, value: entity.send(
-            RoborockCommand.SET_FLOW_LED_STATUS, {"status": 1 if value else 0}
+        cache_key=CacheableAttribute.flow_led_status,
+        update_value=lambda cache, value: cache.update_value(
+            {"status": 1 if value else 0}
         ),
-        get_value=lambda data: data.send(RoborockCommand.GET_FLOW_LED_STATUS),
-        check_support=lambda data: data.api.send_command(
-            RoborockCommand.GET_FLOW_LED_STATUS
-        ),
-        evaluate_value=lambda data: data["status"] == 1,
+        attribute="status",
         key="status_indicator",
         translation_key="status_indicator",
         icon="mdi:alarm-light-outline",
         entity_category=EntityCategory.CONFIG,
     ),
-]
-
-COORDINATED_SWITCH_DESCRIPTION = [
-    RoborockCoordinatedSwitchDescription(
-        set_command=lambda entity, value: entity.send(
-            RoborockCommand.SET_DND_TIMER,
+    RoborockSwitchDescription(
+        cache_key=CacheableAttribute.dnd_timer,
+        update_value=lambda cache, value: cache.update_value(
             [
-                entity.coordinator.roborock_device_info.props.dnd_timer.start_hour,
-                entity.coordinator.roborock_device_info.props.dnd_timer.start_minute,
-                entity.coordinator.roborock_device_info.props.dnd_timer.end_hour,
-                entity.coordinator.roborock_device_info.props.dnd_timer.end_minute,
-            ],
+                cache.value.get("start_hour"),
+                cache.value.get("start_minute"),
+                cache.value.get("end_hour"),
+                cache.value.get("end_minute"),
+            ]
         )
         if value
-        else entity.send(RoborockCommand.CLOSE_DND_TIMER),
-        check_support=lambda data: data.roborock_device_info.props.dnd_timer,
-        get_value=lambda data: data.coordinator.roborock_device_info.props.dnd_timer.enabled,
+        else cache.close_value(),
+        attribute="enabled",
         key="dnd_switch",
         translation_key="dnd_switch",
         icon="mdi:bell-cancel",
@@ -120,114 +95,74 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Roborock switch platform."""
-
     coordinators: dict[str, RoborockDataUpdateCoordinator] = hass.data[DOMAIN][
         config_entry.entry_id
     ]
     possible_entities: list[
-        tuple[str, RoborockDataUpdateCoordinator, RoborockSwitchDescription]
+        tuple[RoborockDataUpdateCoordinator, RoborockSwitchDescription]
     ] = [
-        (device_id, coordinator, description)
-        for device_id, coordinator in coordinators.items()
+        (coordinator, description)
+        for coordinator in coordinators.values()
         for description in SWITCH_DESCRIPTIONS
     ]
     # We need to check if this function is supported by the device.
     results = await asyncio.gather(
         *(
-            description.check_support(coordinator)
-            for _, coordinator, description in possible_entities
+            coordinator.api.cache.get(description.cache_key).async_value()
+            for coordinator, description in possible_entities
         ),
         return_exceptions=True,
     )
-    valid_entities: list[RoborockNonCoordinatedSwitchEntity] = []
-    for posible_entity, result in zip(possible_entities, results):
-        if isinstance(result, Exception):
-            if not isinstance(result, RoborockException):
-                raise result
+    valid_entities: list[RoborockSwitch] = []
+    for (coordinator, description), result in zip(possible_entities, results):
+        if result is None or isinstance(result, Exception):
             _LOGGER.debug("Not adding entity because of %s", result)
         else:
             valid_entities.append(
-                RoborockNonCoordinatedSwitchEntity(
-                    f"{posible_entity[2].key}_{slugify(posible_entity[0])}",
-                    posible_entity[1],
-                    posible_entity[2],
-                    result,
+                RoborockSwitch(
+                    f"{description.key}_{slugify(coordinator.roborock_device_info.device.duid)}",
+                    coordinator.device_info,
+                    description,
+                    coordinator.api,
                 )
             )
-    async_add_entities(
-        valid_entities,
-        True,
-    )
-    async_add_entities(
-        (
-            RoborockCoordinatedSwitchEntity(
-                f"{description.key}_{slugify(device_id)}",
-                coordinator,
-                description,
-            )
-            for device_id, coordinator in coordinators.items()
-            for description in COORDINATED_SWITCH_DESCRIPTION
-            if description.check_support(coordinator) is not None
-        )
-    )
+    async_add_entities(valid_entities)
 
 
-class RoborockNonCoordinatedSwitchEntity(RoborockEntity, SwitchEntity):
-    """A class to let you turn functionality on Roborock devices on and off that does not need a coordinator."""
+class RoborockSwitch(RoborockEntity, SwitchEntity):
+    """A class to let you turn functionality on Roborock devices on and off that does need a coordinator."""
 
     entity_description: RoborockSwitchDescription
 
     def __init__(
         self,
         unique_id: str,
-        coordinator: RoborockDataUpdateCoordinator,
-        entity_description: RoborockSwitchDescription,
-        initial_value: bool,
+        device_info: DeviceInfo,
+        description: RoborockSwitchDescription,
+        api: RoborockLocalClient,
     ) -> None:
-        """Create a switch entity."""
-        self.entity_description = entity_description
-        super().__init__(unique_id, coordinator.device_info, coordinator.api)
-        self._attr_is_on = initial_value
+        """Initialize the entity."""
+        super().__init__(unique_id, device_info, api)
+        self.entity_description = description
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the switch."""
-        await self.entity_description.set_command(self, False)
-
-    async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn on the switch."""
-        await self.entity_description.set_command(self, True)
-
-    async def async_update(self) -> None:
-        """Update switch."""
-        self._attr_is_on = self.entity_description.evaluate_value(
-            await self.entity_description.get_value(self)
+        await self.entity_description.update_value(
+            self.get_cache(self.entity_description.cache_key), False
         )
 
-
-class RoborockCoordinatedSwitchEntity(RoborockCoordinatedEntity, SwitchEntity):
-    """A class to let you turn functionality on Roborock devices on and off that does need a coordinator."""
-
-    entity_description: RoborockCoordinatedSwitchDescription
-
-    def __init__(
-        self,
-        unique_id: str,
-        coordinator: RoborockDataUpdateCoordinator,
-        entity_description: RoborockCoordinatedSwitchDescription,
-    ) -> None:
-        """Create a switch entity."""
-        self.entity_description = entity_description
-        super().__init__(unique_id, coordinator)
-
-    async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn off the switch."""
-        await self.entity_description.set_command(self, False)
-
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the switch."""
-        await self.entity_description.set_command(self, True)
+        await self.entity_description.update_value(
+            self.get_cache(self.entity_description.cache_key), True
+        )
 
     @property
     def is_on(self) -> bool | None:
-        """Use the coordinator to determine if the switch is on."""
-        return self.entity_description.get_value(self)
+        """Return True if entity is on."""
+        return (
+            self.get_cache(self.entity_description.cache_key).value.get(
+                self.entity_description.attribute
+            )
+            == 1
+        )

--- a/homeassistant/components/roborock/vacuum.py
+++ b/homeassistant/components/roborock/vacuum.py
@@ -83,6 +83,7 @@ class RoborockVacuum(RoborockCoordinatedEntity, StateVacuumEntity):
         | VacuumEntityFeature.START
     )
     _attr_translation_key = DOMAIN
+    _attr_name = None
 
     def __init__(
         self,

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2137,7 +2137,7 @@ python-qbittorrent==0.4.3
 python-ripple-api==0.0.3
 
 # homeassistant.components.roborock
-python-roborock==0.23.6
+python-roborock==0.29.2
 
 # homeassistant.components.smarttub
 python-smarttub==0.0.33

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1563,7 +1563,7 @@ python-picnic-api==1.1.0
 python-qbittorrent==0.4.3
 
 # homeassistant.components.roborock
-python-roborock==0.23.6
+python-roborock==0.29.2
 
 # homeassistant.components.smarttub
 python-smarttub==0.0.33

--- a/tests/components/roborock/conftest.py
+++ b/tests/components/roborock/conftest.py
@@ -20,11 +20,17 @@ from tests.common import MockConfigEntry
 @pytest.fixture(name="bypass_api_fixture")
 def bypass_api_fixture() -> None:
     """Skip calls to the API."""
-    with patch("homeassistant.components.roborock.RoborockMqttClient.connect"), patch(
-        "homeassistant.components.roborock.RoborockMqttClient.send_command"
+    with patch(
+        "homeassistant.components.roborock.RoborockMqttClient.async_connect"
+    ), patch(
+        "homeassistant.components.roborock.RoborockMqttClient._send_command"
     ), patch(
         "homeassistant.components.roborock.coordinator.RoborockLocalClient.get_prop",
         return_value=PROP,
+    ), patch(
+        "roborock.api.AttributeCache.async_value"
+    ), patch(
+        "roborock.api.AttributeCache.value"
     ):
         yield
 

--- a/tests/components/roborock/mock_data.py
+++ b/tests/components/roborock/mock_data.py
@@ -367,7 +367,12 @@ STATUS = S7Status.from_dict(
         "unsave_map_flag": 0,
     }
 )
-PROP = DeviceProp(STATUS, DND_TIMER, CLEAN_SUMMARY, CONSUMABLE, CLEAN_RECORD)
+PROP = DeviceProp(
+    status=STATUS,
+    clean_summary=CLEAN_SUMMARY,
+    consumable=CONSUMABLE,
+    last_clean_record=CLEAN_RECORD,
+)
 
 NETWORK_INFO = NetworkInfo(
     ip="123.232.12.1", ssid="wifi", mac="ac:cc:cc:cc:cc", bssid="bssid", rssi=90

--- a/tests/components/roborock/snapshots/test_diagnostics.ambr
+++ b/tests/components/roborock/snapshots/test_diagnostics.ambr
@@ -221,21 +221,6 @@
               'sideBrushWorkTime': 74382,
               'strainerWorkTimes': 65,
             }),
-            'dndTimer': dict({
-              'enabled': 1,
-              'endHour': 7,
-              'endMinute': 0,
-              'endTime': dict({
-                '__type': "<class 'datetime.time'>",
-                'isoformat': '07:00:00',
-              }),
-              'startHour': 22,
-              'startMinute': 0,
-              'startTime': dict({
-                '__type': "<class 'datetime.time'>",
-                'isoformat': '22:00:00',
-              }),
-            }),
             'lastCleanRecord': dict({
               'area': 20965000,
               'avoidCount': 19,

--- a/tests/components/roborock/test_select.py
+++ b/tests/components/roborock/test_select.py
@@ -26,6 +26,8 @@ async def test_update_success(
     value: str,
 ) -> None:
     """Test allowed changing values for select entities."""
+    # Ensure that the entity exist, as these test can pass even if there is no entity.
+    assert hass.states.get(entity_id) is not None
     with patch(
         "homeassistant.components.roborock.coordinator.RoborockLocalClient.send_message"
     ) as mock_send_message:

--- a/tests/components/roborock/test_switch.py
+++ b/tests/components/roborock/test_switch.py
@@ -2,11 +2,9 @@
 from unittest.mock import patch
 
 import pytest
-from roborock.exceptions import RoborockException
 
 from homeassistant.components.switch import SERVICE_TURN_OFF, SERVICE_TURN_ON
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
 
 from tests.common import MockConfigEntry
 
@@ -26,6 +24,8 @@ async def test_update_success(
     entity_id: str,
 ) -> None:
     """Test turning switch entities on and off."""
+    # Ensure that the entity exist, as these test can pass even if there is no entity.
+    assert hass.states.get(entity_id) is not None
     with patch(
         "homeassistant.components.roborock.coordinator.RoborockLocalClient.send_message"
     ) as mock_send_message:
@@ -48,22 +48,3 @@ async def test_update_success(
             target={"entity_id": entity_id},
         )
     assert mock_send_message.assert_called_once
-
-
-async def test_update_failure(
-    hass: HomeAssistant,
-    bypass_api_fixture,
-    setup_entry: MockConfigEntry,
-) -> None:
-    """Test that changing a value will raise a homeassistanterror when it fails."""
-    with patch(
-        "homeassistant.components.roborock.coordinator.RoborockLocalClient.send_message",
-        side_effect=RoborockException(),
-    ), pytest.raises(HomeAssistantError):
-        await hass.services.async_call(
-            "switch",
-            SERVICE_TURN_ON,
-            service_data=None,
-            blocking=True,
-            target={"entity_id": "switch.roborock_s7_maxv_child_lock"},
-        )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
We spent a lot of time on the backend repository, adding caching, some listeners to better get some data, and fixing some bugs (also spent an unfortunate amount of releases trying to get semantic release to work properly)
https://github.com/humbertogontijo/python-roborock/compare/v0.23.6...v0.29.2

More can be done to the component here in regards to optimization, but for now, I wanted to keep this as small as possible.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
