### PR TITLE
Add Airzone Cloud Zone running binary sensor

### DIFF
--- a/homeassistant/components/airzone_cloud/binary_sensor.py
+++ b/homeassistant/components/airzone_cloud/binary_sensor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Final
 
-from aioairzone_cloud.const import AZD_PROBLEMS, AZD_WARNINGS, AZD_ZONES
+from aioairzone_cloud.const import AZD_ACTIVE, AZD_PROBLEMS, AZD_WARNINGS, AZD_ZONES
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -29,6 +29,10 @@ class AirzoneBinarySensorEntityDescription(BinarySensorEntityDescription):
 
 
 ZONE_BINARY_SENSOR_TYPES: Final[tuple[AirzoneBinarySensorEntityDescription, ...]] = (
+    AirzoneBinarySensorEntityDescription(
+        device_class=BinarySensorDeviceClass.RUNNING,
+        key=AZD_ACTIVE,
+    ),
     AirzoneBinarySensorEntityDescription(
         attributes={
             "warnings": AZD_WARNINGS,

--- a/tests/components/airzone_cloud/test_binary_sensor.py
+++ b/tests/components/airzone_cloud/test_binary_sensor.py
@@ -1,6 +1,6 @@
 """The binary sensor tests for the Airzone Cloud platform."""
 
-from homeassistant.const import STATE_OFF
+from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 
 from .util import async_init_integration
@@ -16,6 +16,12 @@ async def test_airzone_create_binary_sensors(hass: HomeAssistant) -> None:
     assert state.state == STATE_OFF
     assert state.attributes.get("warnings") is None
 
+    state = hass.states.get("binary_sensor.dormitorio_running")
+    assert state.state == STATE_OFF
+
     state = hass.states.get("binary_sensor.salon_problem")
     assert state.state == STATE_OFF
     assert state.attributes.get("warnings") is None
+
+    state = hass.states.get("binary_sensor.salon_running")
+    assert state.state == STATE_ON

--- a/tests/components/airzone_cloud/util.py
+++ b/tests/components/airzone_cloud/util.py
@@ -4,6 +4,7 @@ from typing import Any
 from unittest.mock import patch
 
 from aioairzone_cloud.const import (
+    API_ACTIVE,
     API_AZ_AIDOO,
     API_AZ_SYSTEM,
     API_AZ_ZONE,
@@ -177,6 +178,7 @@ def mock_get_device_status(device: Device) -> dict[str, Any]:
         }
     if device.get_id() == "zone2":
         return {
+            API_ACTIVE: False,
             API_HUMIDITY: 24,
             API_IS_CONNECTED: True,
             API_WS_CONNECTED: True,
@@ -187,6 +189,7 @@ def mock_get_device_status(device: Device) -> dict[str, Any]:
             API_WARNINGS: [],
         }
     return {
+        API_ACTIVE: True,
         API_HUMIDITY: 30,
         API_IS_CONNECTED: True,
         API_WS_CONNECTED: True,


### PR DESCRIPTION
## Proposed change
Add `running` binary sensor support to Airzone Cloud zones, which indicates whether the HVAC is on or off for each Airzone Zone.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
