### PR TITLE
Differentiate between device info types

### DIFF
--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -69,15 +69,16 @@ DEVICE_INFO_TYPES = (
     },
     # primary info
     {
+        "configuration_url",
         "connections",
-        "identifiers",
         "entry_type",
+        "hw_version",
+        "identifiers",
         "manufacturer",
         "model",
         "name",
         "suggested_area",
         "sw_version",
-        "hw_version",
         "via_device",
     },
     # secondary info
@@ -86,6 +87,8 @@ DEVICE_INFO_TYPES = (
         "default_manufacturer",
         "default_model",
         "default_name",
+        # Used by Fritz
+        "via_device",
     },
 )
 

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -668,7 +668,7 @@ class EntityPlatform:
                 keys = set(processed_dev_info)
                 if not any(keys <= allowed for allowed in DEVICE_INFO_TYPES):
                     raise HomeAssistantError(
-                        "Device info needs to be describe a device, link to existing device or provide extra information."
+                        "Device info needs to either describe a device, link to existing device or provide extra information."
                     )
 
                 if (

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -61,14 +61,8 @@ PLATFORM_NOT_READY_RETRIES = 10
 DATA_ENTITY_PLATFORM = "entity_platform"
 PLATFORM_NOT_READY_BASE_WAIT_TIME = 30  # seconds
 
-DEVICE_INFO_TYPES = (
-    # link info
-    {
-        "connections",
-        "identifiers",
-    },
-    # primary info
-    {
+DEVICE_INFO_TYPES = {
+    "primary": {
         "configuration_url",
         "connections",
         "entry_type",
@@ -81,8 +75,7 @@ DEVICE_INFO_TYPES = (
         "sw_version",
         "via_device",
     },
-    # secondary info
-    {
+    "secondary": {
         "connections",
         "default_manufacturer",
         "default_model",
@@ -90,7 +83,11 @@ DEVICE_INFO_TYPES = (
         # Used by Fritz
         "via_device",
     },
-)
+    "link": {
+        "connections",
+        "identifiers",
+    },
+}
 
 _LOGGER = getLogger(__name__)
 
@@ -666,7 +663,14 @@ class EntityPlatform:
                         ]
 
                 keys = set(processed_dev_info)
-                if not any(keys <= allowed for allowed in DEVICE_INFO_TYPES):
+                entity_type: str | None = None
+
+                for possible_type, allowed_keys in DEVICE_INFO_TYPES.items():
+                    if keys <= allowed_keys:
+                        entity_type = possible_type
+                        break
+
+                if entity_type is None:
                     raise HomeAssistantError(
                         "Device info needs to either describe a device, "
                         "link to existing device or provide extra information."

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -668,7 +668,8 @@ class EntityPlatform:
                 keys = set(processed_dev_info)
                 if not any(keys <= allowed for allowed in DEVICE_INFO_TYPES):
                     raise HomeAssistantError(
-                        "Device info needs to either describe a device, link to existing device or provide extra information."
+                        "Device info needs to either describe a device, "
+                        "link to existing device or provide extra information."
                     )
 
                 if (

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -61,6 +61,34 @@ PLATFORM_NOT_READY_RETRIES = 10
 DATA_ENTITY_PLATFORM = "entity_platform"
 PLATFORM_NOT_READY_BASE_WAIT_TIME = 30  # seconds
 
+DEVICE_INFO_TYPES = (
+    # link info
+    {
+        "connections",
+        "identifiers",
+    },
+    # primary info
+    {
+        "connections",
+        "identifiers",
+        "entry_type",
+        "manufacturer",
+        "model",
+        "name",
+        "suggested_area",
+        "sw_version",
+        "hw_version",
+        "via_device",
+    },
+    # secondary info
+    {
+        "connections",
+        "default_manufacturer",
+        "default_model",
+        "default_name",
+    },
+)
+
 _LOGGER = getLogger(__name__)
 
 
@@ -633,6 +661,12 @@ class EntityPlatform:
                         processed_dev_info[key] = device_info[
                             key  # type: ignore[literal-required]
                         ]
+
+                keys = set(processed_dev_info)
+                if not any(keys <= allowed for allowed in DEVICE_INFO_TYPES):
+                    raise HomeAssistantError(
+                        "Device info needs to be describe a device, link to existing device or provide extra information."
+                    )
 
                 if (
                     # device info that is purely meant for linking doesn't need default name

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -787,15 +787,15 @@ class EntityPlatform:
             )
             return None
 
-        if device_info.get("configuration_url") is not None:
-            if urlparse(device_info["configuration_url"]).scheme not in [
+        if (config_url := device_info.get("configuration_url")) is not None:
+            if type(config_url) is not str or urlparse(config_url).scheme not in [
                 "http",
                 "https",
                 "homeassistant",
             ]:
                 self.logger.error(
                     "Ignoring device info with invalid configuration_url '%s'",
-                    device_info["configuration_url"],
+                    config_url,
                 )
                 return None
 

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -60,7 +60,9 @@ DATA_ENTITY_PLATFORM = "entity_platform"
 PLATFORM_NOT_READY_BASE_WAIT_TIME = 30  # seconds
 
 DEVICE_INFO_TYPES = {
-    # Order is important or else link types are detected as primary
+    # Device info is categorized by finding the first device info type which has all
+    # the keys of the device info. The link device info type must be kept first
+    # to make it preferred over primary.
     "link": {
         "connections",
         "identifiers",
@@ -774,6 +776,7 @@ class EntityPlatform:
 
         device_info_type: str | None = None
 
+        # Find the first device info type which has all keys in the device info
         for possible_type, allowed_keys in DEVICE_INFO_TYPES.items():
             if keys <= allowed_keys:
                 device_info_type = possible_type

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -771,18 +771,6 @@ class EntityPlatform:
             )
             return None
 
-        if device_info.get("configuration_url") is not None:
-            if urlparse(device_info["configuration_url"]).scheme not in [
-                "http",
-                "https",
-                "homeassistant",
-            ]:
-                self.logger.error(
-                    "Ignoring device info with invalid configuration_url '%s'",
-                    device_info["configuration_url"],
-                )
-                return None
-
         device_info_type: str | None = None
 
         for possible_type, allowed_keys in DEVICE_INFO_TYPES.items():
@@ -798,14 +786,21 @@ class EntityPlatform:
             )
             return None
 
+        if device_info.get("configuration_url") is not None:
+            if urlparse(device_info["configuration_url"]).scheme not in [
+                "http",
+                "https",
+                "homeassistant",
+            ]:
+                self.logger.error(
+                    "Ignoring device info with invalid configuration_url '%s'",
+                    device_info["configuration_url"],
+                )
+                return None
+
         assert self.config_entry is not None
 
-        if (
-            # device info that is purely meant for linking doesn't need default name
-            device_info_type != "link"
-            and "default_name" not in device_info
-            and not device_info.get("name")
-        ):
+        if device_info_type == "primary" and not device_info.get("name"):
             device_info = {
                 **device_info,  # type: ignore[misc]
                 "name": self.config_entry.title,

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -762,6 +762,12 @@ class EntityPlatform:
         self, device_info: DeviceInfo
     ) -> dev_reg.DeviceEntry | None:
         """Process a device info."""
+        keys = set(device_info)
+
+        # If no keys or not enough info to match up, abort
+        if not keys or len(keys & {"connections", "identifiers"}) == 0:
+            return None
+
         if device_info.get("configuration_url") is not None:
             if urlparse(device_info["configuration_url"]).scheme not in [
                 "http",
@@ -773,12 +779,6 @@ class EntityPlatform:
                     device_info["configuration_url"],
                 )
                 return None
-
-        keys = set(device_info)
-
-        # If no keys or not enough info to match up, abort
-        if not keys or len(keys & {"connections", "identifiers"}) == 0:
-            return None
 
         device_info_type: str | None = None
 

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -60,6 +60,11 @@ DATA_ENTITY_PLATFORM = "entity_platform"
 PLATFORM_NOT_READY_BASE_WAIT_TIME = 30  # seconds
 
 DEVICE_INFO_TYPES = {
+    # Order is important or else link types are detected as primary
+    "link": {
+        "connections",
+        "identifiers",
+    },
     "primary": {
         "configuration_url",
         "connections",
@@ -80,10 +85,6 @@ DEVICE_INFO_TYPES = {
         "default_name",
         # Used by Fritz
         "via_device",
-    },
-    "link": {
-        "connections",
-        "identifiers",
     },
 }
 

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -804,7 +804,7 @@ class EntityPlatform:
         if device_info_type == "primary" and not device_info.get("name"):
             device_info = {
                 **device_info,  # type: ignore[misc]
-                "name": self.config_entry.title,
+                "name": self.config_entry.title or self.config_entry.domain,
             }
 
         return dev_reg.async_get(self.hass).async_get_or_create(

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -804,7 +804,7 @@ class EntityPlatform:
         if device_info_type == "primary" and not device_info.get("name"):
             device_info = {
                 **device_info,  # type: ignore[misc]
-                "name": self.config_entry.title or self.config_entry.domain,
+                "name": self.config_entry.title,
             }
 
         return dev_reg.async_get(self.hass).async_get_or_create(

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -29,7 +29,6 @@ from homeassistant.core import (
 from homeassistant.exceptions import (
     HomeAssistantError,
     PlatformNotReady,
-    RequiredParameterMissing,
 )
 from homeassistant.generated import languages
 from homeassistant.setup import async_start_setup
@@ -42,14 +41,13 @@ from . import (
     service,
     translation,
 )
-from .device_registry import DeviceRegistry
 from .entity_registry import EntityRegistry, RegistryEntryDisabler, RegistryEntryHider
 from .event import async_call_later, async_track_time_interval
 from .issue_registry import IssueSeverity, async_create_issue
 from .typing import UNDEFINED, ConfigType, DiscoveryInfoType
 
 if TYPE_CHECKING:
-    from .entity import Entity
+    from .entity import DeviceInfo, Entity
 
 
 SLOW_SETUP_WARNING = 10
@@ -513,12 +511,9 @@ class EntityPlatform:
 
         hass = self.hass
 
-        device_registry = dev_reg.async_get(hass)
         entity_registry = ent_reg.async_get(hass)
         tasks = [
-            self._async_add_entity(
-                entity, update_before_add, entity_registry, device_registry
-            )
+            self._async_add_entity(entity, update_before_add, entity_registry)
             for entity in new_entities
         ]
 
@@ -580,7 +575,6 @@ class EntityPlatform:
         entity: Entity,
         update_before_add: bool,
         entity_registry: EntityRegistry,
-        device_registry: DeviceRegistry,
     ) -> None:
         """Add an entity to the platform."""
         if entity is None:
@@ -637,81 +631,10 @@ class EntityPlatform:
                     return
 
             device_info = entity.device_info
-            device_id = None
-            device = None
+            device: dev_reg.DeviceEntry | None = None
 
             if self.config_entry and device_info is not None:
-                processed_dev_info: dict[str, str | None] = {}
-                for key in (
-                    "connections",
-                    "default_manufacturer",
-                    "default_model",
-                    "default_name",
-                    "entry_type",
-                    "identifiers",
-                    "manufacturer",
-                    "model",
-                    "name",
-                    "suggested_area",
-                    "sw_version",
-                    "hw_version",
-                    "via_device",
-                ):
-                    if key in device_info:
-                        processed_dev_info[key] = device_info[
-                            key  # type: ignore[literal-required]
-                        ]
-
-                keys = set(processed_dev_info)
-                entity_type: str | None = None
-
-                for possible_type, allowed_keys in DEVICE_INFO_TYPES.items():
-                    if keys <= allowed_keys:
-                        entity_type = possible_type
-                        break
-
-                if entity_type is None:
-                    raise HomeAssistantError(
-                        "Device info needs to either describe a device, "
-                        "link to existing device or provide extra information."
-                    )
-
-                if (
-                    # device info that is purely meant for linking doesn't need default name
-                    any(
-                        key not in {"identifiers", "connections"}
-                        for key in (processed_dev_info)
-                    )
-                    and "default_name" not in processed_dev_info
-                    and not processed_dev_info.get("name")
-                ):
-                    processed_dev_info["name"] = self.config_entry.title
-
-                if "configuration_url" in device_info:
-                    if device_info["configuration_url"] is None:
-                        processed_dev_info["configuration_url"] = None
-                    else:
-                        configuration_url = str(device_info["configuration_url"])
-                        if urlparse(configuration_url).scheme in [
-                            "http",
-                            "https",
-                            "homeassistant",
-                        ]:
-                            processed_dev_info["configuration_url"] = configuration_url
-                        else:
-                            _LOGGER.warning(
-                                "Ignoring invalid device configuration_url '%s'",
-                                configuration_url,
-                            )
-
-                try:
-                    device = device_registry.async_get_or_create(
-                        config_entry_id=self.config_entry.entry_id,
-                        **processed_dev_info,  # type: ignore[arg-type]
-                    )
-                    device_id = device.id
-                except RequiredParameterMissing:
-                    pass
+                device = self._async_process_device_info(device_info)
 
             # An entity may suggest the entity_id by setting entity_id itself
             suggested_entity_id: str | None = entity.entity_id
@@ -746,7 +669,7 @@ class EntityPlatform:
                 entity.unique_id,
                 capabilities=entity.capability_attributes,
                 config_entry=self.config_entry,
-                device_id=device_id,
+                device_id=device.id if device else None,
                 disabled_by=disabled_by,
                 entity_category=entity.entity_category,
                 get_initial_options=entity.get_initial_entity_options,
@@ -833,6 +756,83 @@ class EntityPlatform:
         entity.async_on_remove(remove_entity_cb)
 
         await entity.add_to_platform_finish()
+
+    @callback
+    def _async_process_device_info(
+        self, device_info: DeviceInfo
+    ) -> dev_reg.DeviceEntry | None:
+        """Process a device info."""
+        processed_dev_info: DeviceInfo = {}
+        for key in (
+            "connections",
+            "default_manufacturer",
+            "default_model",
+            "default_name",
+            "entry_type",
+            "hw_version",
+            "identifiers",
+            "manufacturer",
+            "model",
+            "name",
+            "suggested_area",
+            "sw_version",
+            "via_device",
+        ):
+            if key in device_info:
+                processed_dev_info[key] = device_info[key]  # type: ignore [literal-required]
+
+        if "configuration_url" in device_info:
+            if device_info["configuration_url"] is None:
+                processed_dev_info["configuration_url"] = None
+            else:
+                configuration_url = str(device_info["configuration_url"])
+                if urlparse(configuration_url).scheme in [
+                    "http",
+                    "https",
+                    "homeassistant",
+                ]:
+                    processed_dev_info["configuration_url"] = configuration_url
+                else:
+                    _LOGGER.warning(
+                        "Ignoring invalid device configuration_url '%s'",
+                        configuration_url,
+                    )
+
+        keys = set(processed_dev_info)
+
+        # If no keys or not enough info to match up, abort
+        if not keys or len(keys & {"connections", "identifiers"}) == 0:
+            return None
+
+        device_info_type: str | None = None
+
+        for possible_type, allowed_keys in DEVICE_INFO_TYPES.items():
+            if keys <= allowed_keys:
+                device_info_type = possible_type
+                break
+
+        if device_info_type is None:
+            self.logger.error(
+                "Device info for %s needs to either describe a device, "
+                "link to existing device or provide extra information.",
+                device_info,
+            )
+            return None
+
+        assert self.config_entry is not None
+
+        if (
+            # device info that is purely meant for linking doesn't need default name
+            device_info_type != "link"
+            and "default_name" not in processed_dev_info
+            and not processed_dev_info.get("name")
+        ):
+            processed_dev_info["name"] = self.config_entry.title
+
+        return dev_reg.async_get(self.hass).async_get_or_create(
+            config_entry_id=self.config_entry.entry_id,
+            **processed_dev_info,
+        )
 
     async def async_reset(self) -> None:
         """Remove all entities and reset data.

--- a/tests/components/fritzbox/conftest.py
+++ b/tests/components/fritzbox/conftest.py
@@ -10,4 +10,5 @@ def fritz_fixture() -> Mock:
     with patch("homeassistant.components.fritzbox.Fritzhome") as fritz, patch(
         "homeassistant.components.fritzbox.config_flow.Fritzhome"
     ):
+        fritz.return_value.get_prefixed_host.return_value = "http://1.2.3.4"
         yield fritz

--- a/tests/components/hyperion/__init__.py
+++ b/tests/components/hyperion/__init__.py
@@ -114,6 +114,7 @@ def create_mock_client() -> Mock:
     mock_client.instances = [
         {"friendly_name": "Test instance 1", "instance": 0, "running": True}
     ]
+    mock_client.remote_url = f"http://{TEST_HOST}:{TEST_PORT_UI}"
 
     return mock_client
 

--- a/tests/components/purpleair/conftest.py
+++ b/tests/components/purpleair/conftest.py
@@ -19,6 +19,7 @@ def api_fixture(get_sensors_response):
     """Define a fixture to return a mocked aiopurple API object."""
     return Mock(
         async_check_api_key=AsyncMock(),
+        get_map_url=Mock(return_value="http://example.com"),
         sensors=Mock(
             async_get_nearby_sensors=AsyncMock(
                 return_value=[

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -1846,12 +1846,13 @@ async def test_device_name_defaulting_config_entry(
 ) -> None:
     """Test setting the device name based on input info."""
     device_info = {
-        "identifiers": {("hue", "1234")},
-        "name": entity_device_name,
+        "connections": {(dr.CONNECTION_NETWORK_MAC, "1234")},
     }
 
     if entity_device_default_name:
         device_info["default_name"] = entity_device_default_name
+    else:
+        device_info["name"] = entity_device_name
 
     class DeviceNameEntity(Entity):
         _attr_unique_id = "qwer"
@@ -1874,6 +1875,6 @@ async def test_device_name_defaulting_config_entry(
     await hass.async_block_till_done()
 
     dev_reg = dr.async_get(hass)
-    device = dev_reg.async_get_device({("hue", "1234")})
+    device = dev_reg.async_get_device(set(), {(dr.CONNECTION_NETWORK_MAC, "1234")})
     assert device is not None
     assert device.name == expected_device_name

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -1779,16 +1779,23 @@ async def test_translated_device_class_name_influences_entity_id(
 
 
 @pytest.mark.parametrize(
-    ("entity_device_name", "entity_device_default_name", "expected_device_name"),
+    (
+        "config_entry_title",
+        "entity_device_name",
+        "entity_device_default_name",
+        "expected_device_name",
+    ),
     [
-        (None, None, "Mock Config Entry Title"),
-        ("", None, "Mock Config Entry Title"),
-        (None, "Hello", "Hello"),
-        ("Mock Device Name", None, "Mock Device Name"),
+        ("", None, None, "test"),
+        ("Mock Config Entry Title", None, None, "Mock Config Entry Title"),
+        ("Mock Config Entry Title", "", None, "Mock Config Entry Title"),
+        ("Mock Config Entry Title", None, "Hello", "Hello"),
+        ("Mock Config Entry Title", "Mock Device Name", None, "Mock Device Name"),
     ],
 )
 async def test_device_name_defaulting_config_entry(
     hass: HomeAssistant,
+    config_entry_title: str,
     entity_device_name: str,
     entity_device_default_name: str,
     expected_device_name: str,
@@ -1813,9 +1820,7 @@ async def test_device_name_defaulting_config_entry(
         return True
 
     platform = MockPlatform(async_setup_entry=async_setup_entry)
-    config_entry = MockConfigEntry(
-        title="Mock Config Entry Title", entry_id="super-mock-id"
-    )
+    config_entry = MockConfigEntry(title=config_entry_title, entry_id="super-mock-id")
     entity_platform = MockEntityPlatform(
         hass, platform_name=config_entry.domain, platform=platform
     )

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -1836,10 +1836,13 @@ async def test_device_name_defaulting_config_entry(
 @pytest.mark.parametrize(
     ("device_info"),
     [
+        # No identifiers
         {},
         {"name": "bla"},
         {"default_name": "bla"},
+        # Match multiple types
         {
+            "identifiers": {("hue", "1234")},
             "name": "bla",
             "default_name": "yo",
         },
@@ -1850,7 +1853,7 @@ async def test_device_name_defaulting_config_entry(
         },
     ],
 )
-async def test_device_type_checking(
+async def test_device_type_error_checking(
     hass: HomeAssistant,
     device_info: dict,
 ) -> None:

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -1786,7 +1786,6 @@ async def test_translated_device_class_name_influences_entity_id(
         "expected_device_name",
     ),
     [
-        ("", None, None, "test"),
         ("Mock Config Entry Title", None, None, "Mock Config Entry Title"),
         ("Mock Config Entry Title", "", None, "Mock Config Entry Title"),
         ("Mock Config Entry Title", None, "Hello", "Hello"),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Home Assistant is now differentiating between 3 different types of device info that can be included with an entity. It will reject device info values that include keys belonging to 2 different types.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is a first step to make `device_info` property on an entity more strict. Eventual goal will be to know which config entry is the primary entry making a device.

This first step is going to distinguish between 3 types of device info that we expect:
 - primary device info (name, etc)
 - linking to existing device (only connections/identifiers)
 - providing extra info (default_X values)

Requires:

- https://github.com/home-assistant/core/pull/95648
- https://github.com/home-assistant/core/pull/95647
- https://github.com/home-assistant/core/pull/95646
- https://github.com/home-assistant/core/pull/95645
- https://github.com/home-assistant/core/pull/95644
- https://github.com/home-assistant/core/pull/95683

Architecture discussion https://github.com/home-assistant/architecture/discussions/936

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
