### PR TITLE
Handle missing or incorrect device name and unique id for ESPHome during manual add

### DIFF
--- a/homeassistant/components/esphome/config_flow.py
+++ b/homeassistant/components/esphome/config_flow.py
@@ -40,6 +40,8 @@ ERROR_INVALID_ENCRYPTION_KEY = "invalid_psk"
 ESPHOME_URL = "https://esphome.io/"
 _LOGGER = logging.getLogger(__name__)
 
+ZERO_NOISE_PSK = "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA="
+
 
 class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
     """Handle a esphome config flow."""
@@ -149,10 +151,17 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
     async def _async_try_fetch_device_info(self) -> FlowResult:
         error = await self.fetch_device_info()
 
-        if (
-            error == ERROR_REQUIRES_ENCRYPTION_KEY
-            and await self._retrieve_encryption_key_from_dashboard()
-        ):
+        if error == ERROR_REQUIRES_ENCRYPTION_KEY:
+            if not self._device_name and not self._noise_psk:
+                # If device name is not set we can send a zero noise psk
+                # to get the device name which will allow us to populate
+                # the device name and hopefully get the encryption key
+                # from the dashboard.
+                self._noise_psk = ZERO_NOISE_PSK
+                error = await self.fetch_device_info()
+                self._noise_psk = None
+
+            await self._retrieve_encryption_key_from_dashboard()
             error = await self.fetch_device_info()
             # If the fetched key is invalid, unset it again.
             if error == ERROR_INVALID_ENCRYPTION_KEY:
@@ -323,7 +332,10 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
             self._device_info = await cli.device_info()
         except RequiresEncryptionAPIError:
             return ERROR_REQUIRES_ENCRYPTION_KEY
-        except InvalidEncryptionKeyAPIError:
+        except InvalidEncryptionKeyAPIError as ex:
+            if ex.received_name:
+                self._device_name = ex.received_name
+                self._name = ex.received_name
             return ERROR_INVALID_ENCRYPTION_KEY
         except ResolveAPIError:
             return "resolve_error"
@@ -380,7 +392,6 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
             return False
 
         await dashboard.async_request_refresh()
-
         if not dashboard.last_update_success:
             return False
 

--- a/homeassistant/components/esphome/config_flow.py
+++ b/homeassistant/components/esphome/config_flow.py
@@ -161,8 +161,10 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
                 error = await self.fetch_device_info()
                 self._noise_psk = None
 
-            await self._retrieve_encryption_key_from_dashboard()
-            error = await self.fetch_device_info()
+            if self._device_name:
+                await self._retrieve_encryption_key_from_dashboard()
+                error = await self.fetch_device_info()
+
             # If the fetched key is invalid, unset it again.
             if error == ERROR_INVALID_ENCRYPTION_KEY:
                 self._noise_psk = None

--- a/homeassistant/components/esphome/config_flow.py
+++ b/homeassistant/components/esphome/config_flow.py
@@ -350,9 +350,8 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
 
         self._name = self._device_info.friendly_name or self._device_info.name
         self._device_name = self._device_info.name
-        await self.async_set_unique_id(
-            self._device_info.mac_address, raise_on_progress=False
-        )
+        mac_address = format_mac(self._device_info.mac_address)
+        await self.async_set_unique_id(mac_address, raise_on_progress=False)
         if not self._reauth_entry:
             self._abort_if_unique_id_configured(
                 updates={CONF_HOST: self._host, CONF_PORT: self._port}

--- a/homeassistant/components/esphome/config_flow.py
+++ b/homeassistant/components/esphome/config_flow.py
@@ -161,8 +161,10 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
                 error = await self.fetch_device_info()
                 self._noise_psk = None
 
-            if self._device_name:
-                await self._retrieve_encryption_key_from_dashboard()
+            if (
+                self._device_name
+                and await self._retrieve_encryption_key_from_dashboard()
+            ):
                 error = await self.fetch_device_info()
 
             # If the fetched key is invalid, unset it again.
@@ -387,10 +389,10 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
 
         Return boolean if a key was retrieved.
         """
-        if self._device_name is None:
-            return False
-
-        if (dashboard := async_get_dashboard(self.hass)) is None:
+        if (
+            self._device_name is None
+            or (dashboard := async_get_dashboard(self.hass)) is None
+        ):
             return False
 
         await dashboard.async_request_refresh()

--- a/homeassistant/components/esphome/manifest.json
+++ b/homeassistant/components/esphome/manifest.json
@@ -15,7 +15,7 @@
   "iot_class": "local_push",
   "loggers": ["aioesphomeapi", "noiseprotocol"],
   "requirements": [
-    "aioesphomeapi==15.0.1",
+    "aioesphomeapi==15.1.0",
     "bluetooth-data-tools==1.3.0",
     "esphome-dashboard-api==1.2.3"
   ],

--- a/homeassistant/components/esphome/manifest.json
+++ b/homeassistant/components/esphome/manifest.json
@@ -15,7 +15,7 @@
   "iot_class": "local_push",
   "loggers": ["aioesphomeapi", "noiseprotocol"],
   "requirements": [
-    "aioesphomeapi==15.1.0",
+    "aioesphomeapi==15.1.1",
     "bluetooth-data-tools==1.3.0",
     "esphome-dashboard-api==1.2.3"
   ],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -234,7 +234,7 @@ aioecowitt==2023.5.0
 aioemonitor==1.0.5
 
 # homeassistant.components.esphome
-aioesphomeapi==15.0.1
+aioesphomeapi==15.1.0
 
 # homeassistant.components.flo
 aioflo==2021.11.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -234,7 +234,7 @@ aioecowitt==2023.5.0
 aioemonitor==1.0.5
 
 # homeassistant.components.esphome
-aioesphomeapi==15.1.0
+aioesphomeapi==15.1.1
 
 # homeassistant.components.flo
 aioflo==2021.11.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -212,7 +212,7 @@ aioecowitt==2023.5.0
 aioemonitor==1.0.5
 
 # homeassistant.components.esphome
-aioesphomeapi==15.1.0
+aioesphomeapi==15.1.1
 
 # homeassistant.components.flo
 aioflo==2021.11.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -212,7 +212,7 @@ aioecowitt==2023.5.0
 aioemonitor==1.0.5
 
 # homeassistant.components.esphome
-aioesphomeapi==15.0.1
+aioesphomeapi==15.1.0
 
 # homeassistant.components.flo
 aioflo==2021.11.0

--- a/tests/components/esphome/test_config_flow.py
+++ b/tests/components/esphome/test_config_flow.py
@@ -231,7 +231,6 @@ async def test_user_dashboard_has_wrong_key(
     mock_client.device_info.side_effect = [
         RequiresEncryptionAPIError,
         InvalidEncryptionKeyAPIError,
-        InvalidEncryptionKeyAPIError,
         DeviceInfo(
             uses_password=False,
             name="test",
@@ -609,9 +608,9 @@ async def test_user_requires_psk(
     assert result["step_id"] == "encryption_key"
     assert result["errors"] == {}
 
-    assert len(mock_client.connect.mock_calls) == 3
-    assert len(mock_client.device_info.mock_calls) == 3
-    assert len(mock_client.disconnect.mock_calls) == 3
+    assert len(mock_client.connect.mock_calls) == 2
+    assert len(mock_client.device_info.mock_calls) == 2
+    assert len(mock_client.disconnect.mock_calls) == 2
 
 
 async def test_encryption_key_valid_psk(

--- a/tests/components/esphome/test_config_flow.py
+++ b/tests/components/esphome/test_config_flow.py
@@ -333,7 +333,7 @@ async def test_user_dashboard_has_wrong_key(
         DeviceInfo(
             uses_password=False,
             name="test",
-            mac_address="11:22:33:44:55:aa",
+            mac_address="11:22:33:44:55:AA",
         ),
     ]
 
@@ -380,7 +380,7 @@ async def test_user_discovers_name_and_gets_key_from_dashboard(
         DeviceInfo(
             uses_password=False,
             name="test",
-            mac_address="11:22:33:44:55:aa",
+            mac_address="11:22:33:44:55:AA",
         ),
     ]
 
@@ -483,7 +483,7 @@ async def test_user_discovers_name_and_dashboard_is_unavailable(
         DeviceInfo(
             uses_password=False,
             name="test",
-            mac_address="11:22:33:44:55:aa",
+            mac_address="11:22:33:44:55:AA",
         ),
     ]
 
@@ -1201,7 +1201,7 @@ async def test_zeroconf_encryption_key_via_dashboard(
         DeviceInfo(
             uses_password=False,
             name="test8266",
-            mac_address="11:22:33:44:55:aa",
+            mac_address="11:22:33:44:55:AA",
         ),
     ]
 

--- a/tests/components/esphome/test_config_flow.py
+++ b/tests/components/esphome/test_config_flow.py
@@ -326,7 +326,6 @@ async def test_user_discovers_name_and_gets_key_from_dashboard_fails(
     mock_client.device_info.side_effect = [
         RequiresEncryptionAPIError,
         InvalidEncryptionKeyAPIError("Wrong key", "test"),
-        RequiresEncryptionAPIError,
         DeviceInfo(
             uses_password=False,
             name="test",
@@ -382,7 +381,6 @@ async def test_user_discovers_name_and_dashboard_is_unavailable(
     mock_client.device_info.side_effect = [
         RequiresEncryptionAPIError,
         InvalidEncryptionKeyAPIError("Wrong key", "test"),
-        RequiresEncryptionAPIError,
         DeviceInfo(
             uses_password=False,
             name="test",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
upstream changelog: https://github.com/esphome/aioesphomeapi/compare/v15.0.1...v15.1.1

If we did not have the device name during setup we could never get the key from the dashboard. The device will send us its name if we try encryption which allows us to find the right key from the dashboard.

When the unique id was configured manually it would be uppercase, but zeroconf would discovery it lower case which would mean you could set up the same device multiple times and things would break.

This should help get users unstuck (this is common when users are using the device across subnets / remote / no mdns ) when they change the key and cannot get the device back online after deleting and trying to set it up again manually because they have trouble finding the right key.

This also brings the config flow coverage to 100%

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
