### PR TITLE
Fix songpal test_setup_failed test

### DIFF
--- a/tests/components/songpal/test_media_player.py
+++ b/tests/components/songpal/test_media_player.py
@@ -103,8 +103,8 @@ async def test_setup_failed(
         await hass.async_block_till_done()
     all_states = hass.states.async_all()
     assert len(all_states) == 0
-    warning_records = [x for x in caplog.records if x.levelno == logging.WARNING]
-    assert len(warning_records) == 2
+    assert "[name(http://0.0.0.0:10000/sony)] Unable to connect" in caplog.text
+    assert "Platform songpal not ready yet: Unable to do POST request" in caplog.text
     assert not any(x.levelno == logging.ERROR for x in caplog.records)
     caplog.clear()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve songpal test_setup_failed test. It now counts the number of warings in the test, but that can lead to false positives.

Fixes: `FAILED tests/components/songpal/test_media_player.py::test_setup_failed - assert 3 == 2`

Example logging when this gets wrong and logs 3 warings failing the test.

```log
----------------------------- Captured stderr call ----------------------------- 
WARNING:asyncio:Executing <Task pending name='Task-53151' coro=<test_setup_failed() running at /home/runner/work/core/core/tests/components/songpal/test_media_player.py:102> wait_for=<Task pending name='setup component songpal' coro=<_async_setup_component() running at /home/runner/work/core/core/homeassistant/setup.py:168> cb=[set.remove(), Task.task_wakeup()] created at /home/runner/work/core/core/homeassistant/core.py:552> cb=[_run_until_complete_cb() at /opt/hostedtoolcache/Python/3.10.12/x64/lib/python3.10/asyncio/base_events.py:184] created at /opt/hostedtoolcache/Python/3.10.12/x64/lib/python3.10/asyncio/tasks.py:636> took 0.107 seconds 
INFO:homeassistant.loader:Loaded songpal from homeassistant.components.songpal 
INFO:homeassistant.setup:Setting up songpal 
INFO:homeassistant.setup:Setup of domain songpal took 0.0 seconds 
INFO:homeassistant.loader:Loaded media_player from homeassistant.components.media_player 
INFO:homeassistant.loader:Loaded http from homeassistant.components.http 
DEBUG:homeassistant.setup:Dependency media_player will wait for dependencies ['http'] 
INFO:homeassistant.setup:Setting up http 
DEBUG:tests.common:Writing data to http.auth: {'version': 1, 'minor_version': 1, 'key': 'http.auth', 'data': {'content_user': '127eb3dc55ba41608a71a4c45cceccb2'}} 
DEBUG:homeassistant.components.network.network:Adapters: [{'name': 'eth0', 'index': 0, 'enabled': True, 'auto': True, 'default': True, 'ipv4': [{'address': '10.10.10.10', 'network_prefix': 24}], 'ipv6': []}] 
INFO:homeassistant.setup:Setup of domain http took 0.0 seconds 
DEBUG:homeassistant.core:Bus:Handling <Event component_loaded[L]: component=http> 
INFO:homeassistant.setup:Setting up media_player 
INFO:homeassistant.setup:Setup of domain media_player took 0.0 seconds 
DEBUG:homeassistant.core:Bus:Handling <Event component_loaded[L]: component=media_player> 
DEBUG:homeassistant.helpers.translation:Cache miss for en: media_player 
DEBUG:homeassistant.helpers.translation:Cache miss for en: songpal 
INFO:homeassistant.components.media_player:Setting up media_player.songpal 
WARNING:homeassistant.components.songpal.media_player:[name(http://0.0.0.0:10000/sony)] Unable to connect 
DEBUG:homeassistant.components.songpal.media_player:Unable to get methods from songpal: Unable to do POST request: : None 
WARNING:homeassistant.components.media_player:Platform songpal not ready yet: Unable to do POST request: : None; Retrying in background in 30 seconds 
DEBUG:homeassistant.core:Bus:Handling <Event component_loaded[L]: component=songpal>
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
