### PR TITLE
Improve reading of MOTD and bump mcstatus to 11.0.0

### DIFF
--- a/homeassistant/components/minecraft_server/__init__.py
+++ b/homeassistant/components/minecraft_server/__init__.py
@@ -179,12 +179,7 @@ class MinecraftServer:
             self.players_online = status_response.players.online
             self.players_max = status_response.players.max
             self.latency_time = status_response.latency
-
-            # For some servers MOTD is not the key 'text' but rather the description directly.
-            try:
-                self.motd = (status_response.description).get("text")  # type: ignore[attr-defined]
-            except AttributeError:
-                self.motd = status_response.description
+            self.motd = status_response.motd.to_plain()
 
             self.players_list = []
             if status_response.players.sample is not None:

--- a/homeassistant/components/minecraft_server/__init__.py
+++ b/homeassistant/components/minecraft_server/__init__.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 import logging
 from typing import Any
 
-from mcstatus.server import MinecraftServer as MCStatus
+from mcstatus.server import JavaServer
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT, Platform
@@ -69,9 +69,6 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
 class MinecraftServer:
     """Representation of a Minecraft server."""
 
-    # Private constants
-    _MAX_RETRIES_STATUS = 3
-
     def __init__(
         self, hass: HomeAssistant, unique_id: str, config_data: Mapping[str, Any]
     ) -> None:
@@ -88,16 +85,16 @@ class MinecraftServer:
         self.srv_record_checked = False
 
         # 3rd party library instance
-        self._mc_status = MCStatus(self.host, self.port)
+        self._server = JavaServer(self.host, self.port)
 
         # Data provided by 3rd party library
-        self.version = None
-        self.protocol_version = None
-        self.latency_time = None
-        self.players_online = None
-        self.players_max = None
+        self.version: str | None = None
+        self.protocol_version: int | None = None
+        self.latency_time: float | None = None
+        self.players_online: int | None = None
+        self.players_max: int | None = None
         self.players_list: list[str] | None = None
-        self.motd = None
+        self.motd: str | None = None
 
         # Dispatcher signal name
         self.signal_name = f"{SIGNAL_NAME_PREFIX}_{self.unique_id}"
@@ -133,13 +130,11 @@ class MinecraftServer:
                 # with data extracted out of SRV record.
                 self.host = srv_record[CONF_HOST]
                 self.port = srv_record[CONF_PORT]
-                self._mc_status = MCStatus(self.host, self.port)
+                self._server = JavaServer(self.host, self.port)
 
         # Ping the server with a status request.
         try:
-            await self._hass.async_add_executor_job(
-                self._mc_status.status, self._MAX_RETRIES_STATUS
-            )
+            await self._server.async_status()
             self.online = True
         except OSError as error:
             _LOGGER.debug(
@@ -176,9 +171,7 @@ class MinecraftServer:
     async def _async_status_request(self) -> None:
         """Request server status and update properties."""
         try:
-            status_response = await self._hass.async_add_executor_job(
-                self._mc_status.status, self._MAX_RETRIES_STATUS
-            )
+            status_response = await self._server.async_status()
 
             # Got answer to request, update properties.
             self.version = status_response.version.name
@@ -186,7 +179,13 @@ class MinecraftServer:
             self.players_online = status_response.players.online
             self.players_max = status_response.players.max
             self.latency_time = status_response.latency
-            self.motd = (status_response.description).get("text")
+
+            # For some servers MOTD is not the key 'text' but rather the description directly.
+            try:
+                self.motd = (status_response.description).get("text")  # type: ignore[attr-defined]
+            except AttributeError:
+                self.motd = status_response.description
+
             self.players_list = []
             if status_response.players.sample is not None:
                 for player in status_response.players.sample:
@@ -244,7 +243,7 @@ class MinecraftServerEntity(Entity):
             manufacturer=MANUFACTURER,
             model=f"Minecraft Server ({self._server.version})",
             name=self._server.name,
-            sw_version=self._server.protocol_version,
+            sw_version=str(self._server.protocol_version),
         )
         self._attr_device_class = device_class
         self._extra_state_attributes = None

--- a/homeassistant/components/minecraft_server/config_flow.py
+++ b/homeassistant/components/minecraft_server/config_flow.py
@@ -8,6 +8,7 @@ import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT
+from homeassistant.data_entry_flow import FlowResult
 
 from . import MinecraftServer, helpers
 from .const import DEFAULT_HOST, DEFAULT_NAME, DEFAULT_PORT, DOMAIN
@@ -18,7 +19,7 @@ class MinecraftServerConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
-    async def async_step_user(self, user_input=None):
+    async def async_step_user(self, user_input=None) -> FlowResult:
         """Handle the initial step."""
         errors = {}
 
@@ -117,7 +118,7 @@ class MinecraftServerConfigFlow(ConfigFlow, domain=DOMAIN):
         # form filled with user_input and eventually with errors otherwise).
         return self._show_config_form(user_input, errors)
 
-    def _show_config_form(self, user_input=None, errors=None):
+    def _show_config_form(self, user_input=None, errors=None) -> FlowResult:
         """Show the setup form to the user."""
         if user_input is None:
             user_input = {}

--- a/homeassistant/components/minecraft_server/manifest.json
+++ b/homeassistant/components/minecraft_server/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "loggers": ["dnspython", "mcstatus"],
   "quality_scale": "silver",
-  "requirements": ["aiodns==3.0.0", "getmac==0.8.2", "mcstatus==10.0.3"]
+  "requirements": ["aiodns==3.0.0", "getmac==0.8.2", "mcstatus==11.0.0-rc3"]
 }

--- a/homeassistant/components/minecraft_server/manifest.json
+++ b/homeassistant/components/minecraft_server/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "loggers": ["dnspython", "mcstatus"],
   "quality_scale": "silver",
-  "requirements": ["aiodns==3.0.0", "getmac==0.8.2", "mcstatus==11.0.0-rc3"]
+  "requirements": ["aiodns==3.0.0", "getmac==0.8.2", "mcstatus==11.0.0"]
 }

--- a/homeassistant/components/minecraft_server/manifest.json
+++ b/homeassistant/components/minecraft_server/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "loggers": ["dnspython", "mcstatus"],
   "quality_scale": "silver",
-  "requirements": ["aiodns==3.0.0", "getmac==0.9.4", "mcstatus==10.0.3"]
+  "requirements": ["aiodns==3.0.0", "getmac==0.8.2", "mcstatus==10.0.3"]
 }

--- a/homeassistant/components/minecraft_server/manifest.json
+++ b/homeassistant/components/minecraft_server/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "loggers": ["dnspython", "mcstatus"],
   "quality_scale": "silver",
-  "requirements": ["aiodns==3.0.0", "getmac==0.8.2", "mcstatus==6.0.0"]
+  "requirements": ["aiodns==3.0.0", "getmac==0.9.4", "mcstatus==10.0.3"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -851,13 +851,11 @@ georss-qld-bushfire-alert-client==0.5
 
 # homeassistant.components.dlna_dmr
 # homeassistant.components.kef
+# homeassistant.components.minecraft_server
 # homeassistant.components.nmap_tracker
 # homeassistant.components.samsungtv
 # homeassistant.components.upnp
 getmac==0.8.2
-
-# homeassistant.components.minecraft_server
-getmac==0.9.4
 
 # homeassistant.components.gios
 gios==3.1.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -851,11 +851,13 @@ georss-qld-bushfire-alert-client==0.5
 
 # homeassistant.components.dlna_dmr
 # homeassistant.components.kef
-# homeassistant.components.minecraft_server
 # homeassistant.components.nmap_tracker
 # homeassistant.components.samsungtv
 # homeassistant.components.upnp
 getmac==0.8.2
+
+# homeassistant.components.minecraft_server
+getmac==0.9.4
 
 # homeassistant.components.gios
 gios==3.1.0
@@ -1175,7 +1177,7 @@ maxcube-api==0.4.3
 mbddns==0.1.2
 
 # homeassistant.components.minecraft_server
-mcstatus==6.0.0
+mcstatus==10.0.3
 
 # homeassistant.components.meater
 meater-python==0.0.8

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1175,7 +1175,7 @@ maxcube-api==0.4.3
 mbddns==0.1.2
 
 # homeassistant.components.minecraft_server
-mcstatus==10.0.3
+mcstatus==11.0.0-rc3
 
 # homeassistant.components.meater
 meater-python==0.0.8

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1175,7 +1175,7 @@ maxcube-api==0.4.3
 mbddns==0.1.2
 
 # homeassistant.components.minecraft_server
-mcstatus==11.0.0-rc3
+mcstatus==11.0.0
 
 # homeassistant.components.meater
 meater-python==0.0.8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -670,13 +670,11 @@ georss-qld-bushfire-alert-client==0.5
 
 # homeassistant.components.dlna_dmr
 # homeassistant.components.kef
+# homeassistant.components.minecraft_server
 # homeassistant.components.nmap_tracker
 # homeassistant.components.samsungtv
 # homeassistant.components.upnp
 getmac==0.8.2
-
-# homeassistant.components.minecraft_server
-getmac==0.9.4
 
 # homeassistant.components.gios
 gios==3.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -898,7 +898,7 @@ maxcube-api==0.4.3
 mbddns==0.1.2
 
 # homeassistant.components.minecraft_server
-mcstatus==10.0.3
+mcstatus==11.0.0-rc3
 
 # homeassistant.components.meater
 meater-python==0.0.8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -670,11 +670,13 @@ georss-qld-bushfire-alert-client==0.5
 
 # homeassistant.components.dlna_dmr
 # homeassistant.components.kef
-# homeassistant.components.minecraft_server
 # homeassistant.components.nmap_tracker
 # homeassistant.components.samsungtv
 # homeassistant.components.upnp
 getmac==0.8.2
+
+# homeassistant.components.minecraft_server
+getmac==0.9.4
 
 # homeassistant.components.gios
 gios==3.1.0
@@ -898,7 +900,7 @@ maxcube-api==0.4.3
 mbddns==0.1.2
 
 # homeassistant.components.minecraft_server
-mcstatus==6.0.0
+mcstatus==10.0.3
 
 # homeassistant.components.meater
 meater-python==0.0.8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -898,7 +898,7 @@ maxcube-api==0.4.3
 mbddns==0.1.2
 
 # homeassistant.components.minecraft_server
-mcstatus==11.0.0-rc3
+mcstatus==11.0.0
 
 # homeassistant.components.meater
 meater-python==0.0.8

--- a/tests/components/minecraft_server/test_config_flow.py
+++ b/tests/components/minecraft_server/test_config_flow.py
@@ -4,7 +4,7 @@ import asyncio
 from unittest.mock import patch
 
 import aiodns
-from mcstatus.server import PingResponse
+from mcstatus.status_response import JavaStatusResponse
 
 from homeassistant.components.minecraft_server.const import (
     DEFAULT_NAME,
@@ -31,7 +31,7 @@ class QueryMock:
         self.ttl = None
 
 
-STATUS_RESPONSE_RAW = {
+JAVA_STATUS_RESPONSE_RAW = {
     "description": {"text": "Dummy Description"},
     "version": {"name": "Dummy Version", "protocol": 123},
     "players": {
@@ -104,7 +104,9 @@ async def test_same_host(hass: HomeAssistant) -> None:
         side_effect=aiodns.error.DNSError,
     ), patch(
         "mcstatus.server.JavaServer.async_status",
-        return_value=PingResponse(STATUS_RESPONSE_RAW),
+        return_value=JavaStatusResponse(
+            None, None, None, None, JAVA_STATUS_RESPONSE_RAW, None
+        ),
     ):
         unique_id = "mc.dummyserver.com-25565"
         config_data = {
@@ -174,7 +176,9 @@ async def test_connection_succeeded_with_srv_record(hass: HomeAssistant) -> None
         return_value=SRV_RECORDS,
     ), patch(
         "mcstatus.server.JavaServer.async_status",
-        return_value=PingResponse(STATUS_RESPONSE_RAW),
+        return_value=JavaStatusResponse(
+            None, None, None, None, JAVA_STATUS_RESPONSE_RAW, None
+        ),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}, data=USER_INPUT_SRV
@@ -193,7 +197,9 @@ async def test_connection_succeeded_with_host(hass: HomeAssistant) -> None:
         side_effect=aiodns.error.DNSError,
     ), patch(
         "mcstatus.server.JavaServer.async_status",
-        return_value=PingResponse(STATUS_RESPONSE_RAW),
+        return_value=JavaStatusResponse(
+            None, None, None, None, JAVA_STATUS_RESPONSE_RAW, None
+        ),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}, data=USER_INPUT
@@ -212,7 +218,9 @@ async def test_connection_succeeded_with_ip4(hass: HomeAssistant) -> None:
         side_effect=aiodns.error.DNSError,
     ), patch(
         "mcstatus.server.JavaServer.async_status",
-        return_value=PingResponse(STATUS_RESPONSE_RAW),
+        return_value=JavaStatusResponse(
+            None, None, None, None, JAVA_STATUS_RESPONSE_RAW, None
+        ),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}, data=USER_INPUT_IPV4
@@ -231,7 +239,9 @@ async def test_connection_succeeded_with_ip6(hass: HomeAssistant) -> None:
         side_effect=aiodns.error.DNSError,
     ), patch(
         "mcstatus.server.JavaServer.async_status",
-        return_value=PingResponse(STATUS_RESPONSE_RAW),
+        return_value=JavaStatusResponse(
+            None, None, None, None, JAVA_STATUS_RESPONSE_RAW, None
+        ),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}, data=USER_INPUT_IPV6

--- a/tests/components/minecraft_server/test_config_flow.py
+++ b/tests/components/minecraft_server/test_config_flow.py
@@ -4,7 +4,7 @@ import asyncio
 from unittest.mock import patch
 
 import aiodns
-from mcstatus.pinger import PingResponse
+from mcstatus.server import PingResponse
 
 from homeassistant.components.minecraft_server.const import (
     DEFAULT_NAME,
@@ -22,7 +22,7 @@ from tests.common import MockConfigEntry
 class QueryMock:
     """Mock for result of aiodns.DNSResolver.query."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Set up query result mock."""
         self.host = "mc.dummyserver.com"
         self.port = 23456
@@ -103,7 +103,7 @@ async def test_same_host(hass: HomeAssistant) -> None:
         "aiodns.DNSResolver.query",
         side_effect=aiodns.error.DNSError,
     ), patch(
-        "mcstatus.server.MinecraftServer.status",
+        "mcstatus.server.JavaServer.async_status",
         return_value=PingResponse(STATUS_RESPONSE_RAW),
     ):
         unique_id = "mc.dummyserver.com-25565"
@@ -158,7 +158,7 @@ async def test_connection_failed(hass: HomeAssistant) -> None:
     with patch(
         "aiodns.DNSResolver.query",
         side_effect=aiodns.error.DNSError,
-    ), patch("mcstatus.server.MinecraftServer.status", side_effect=OSError):
+    ), patch("mcstatus.server.JavaServer.async_status", side_effect=OSError):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}, data=USER_INPUT
         )
@@ -173,7 +173,7 @@ async def test_connection_succeeded_with_srv_record(hass: HomeAssistant) -> None
         "aiodns.DNSResolver.query",
         return_value=SRV_RECORDS,
     ), patch(
-        "mcstatus.server.MinecraftServer.status",
+        "mcstatus.server.JavaServer.async_status",
         return_value=PingResponse(STATUS_RESPONSE_RAW),
     ):
         result = await hass.config_entries.flow.async_init(
@@ -192,7 +192,7 @@ async def test_connection_succeeded_with_host(hass: HomeAssistant) -> None:
         "aiodns.DNSResolver.query",
         side_effect=aiodns.error.DNSError,
     ), patch(
-        "mcstatus.server.MinecraftServer.status",
+        "mcstatus.server.JavaServer.async_status",
         return_value=PingResponse(STATUS_RESPONSE_RAW),
     ):
         result = await hass.config_entries.flow.async_init(
@@ -211,7 +211,7 @@ async def test_connection_succeeded_with_ip4(hass: HomeAssistant) -> None:
         "aiodns.DNSResolver.query",
         side_effect=aiodns.error.DNSError,
     ), patch(
-        "mcstatus.server.MinecraftServer.status",
+        "mcstatus.server.JavaServer.async_status",
         return_value=PingResponse(STATUS_RESPONSE_RAW),
     ):
         result = await hass.config_entries.flow.async_init(
@@ -230,7 +230,7 @@ async def test_connection_succeeded_with_ip6(hass: HomeAssistant) -> None:
         "aiodns.DNSResolver.query",
         side_effect=aiodns.error.DNSError,
     ), patch(
-        "mcstatus.server.MinecraftServer.status",
+        "mcstatus.server.JavaServer.async_status",
         return_value=PingResponse(STATUS_RESPONSE_RAW),
     ):
         result = await hass.config_entries.flow.async_init(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
1) Bump mcstatus to version 11.0.0 (as a preparation for future support of Minecraft Bedrock servers) .
Changelog: https://github.com/py-mine/mcstatus/releases/tag/v11.0.0
Diff: https://github.com/py-mine/mcstatus/compare/v6.0.0...v11.0.0
2) Switch to new async APIs of mcstatus.
3) Improve reading of MOTD (message of the day, world message) sensor by using the new MOTD parser. Some servers require the MOTD to be read differently (refer to linked issues). mcstatus v11.0.0 introduced a new MOTD parser, which should fix this issue (at least with my server it does). A nice side effect is, that the new parser returns the MOTD as plain text. This gets rid of the special characters used to style the MOTD in the Minecraft clients.

Notes:
- `_MAX_RETRIES_STATUS = 3` was removed as this is now the default within the API.
- I tested the changes with my local server as well as with some publicly available ones.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
The dependency upgrade of mcstatus required small changes in the code as well as in the unit tests.
This PR requires no documentation update.

- This PR fixes or closes issue: fixes #75060, fixes #74061 and fixes #70100
- This PR is related to issue: n/a
- Link to documentation pull request: n /a

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
