### PR TITLE
Remove support for specific container images

### DIFF
--- a/homeassistant/components/version/__init__.py
+++ b/homeassistant/components/version/__init__.py
@@ -15,6 +15,7 @@ from .const import (
     CONF_CHANNEL,
     CONF_IMAGE,
     CONF_SOURCE,
+    DEFAULT_IMAGE,
     DOMAIN,
     PLATFORMS,
 )
@@ -26,12 +27,23 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up the version integration from a config entry."""
 
-    board = entry.data[CONF_BOARD]
+    source = entry.data[CONF_SOURCE]
 
-    if board not in BOARD_MAP:
+    if (board := entry.data[CONF_BOARD]) not in BOARD_MAP:
         _LOGGER.error(
             'Board "%s" is (no longer) valid. Please remove the integration "%s"',
             board,
+            entry.title,
+        )
+        return False
+
+    if (image := entry.data[CONF_IMAGE]) != DEFAULT_IMAGE and source in (
+        "container",
+        "docker",
+    ):
+        _LOGGER.error(
+            'Image "%s" is (no longer) valid. Please remove the integration "%s"',
+            image,
             entry.title,
         )
         return False
@@ -40,8 +52,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass=hass,
         api=HaVersion(
             session=async_get_clientsession(hass),
-            source=entry.data[CONF_SOURCE],
-            image=entry.data[CONF_IMAGE],
+            source=source,
+            image=image,
             board=BOARD_MAP[board],
             channel=entry.data[CONF_CHANNEL].lower(),
         ),

--- a/homeassistant/components/version/config_flow.py
+++ b/homeassistant/components/version/config_flow.py
@@ -26,7 +26,6 @@ from .const import (
     STEP_VERSION_SOURCE,
     VALID_BOARDS,
     VALID_CHANNELS,
-    VALID_CONTAINER_IMAGES,
     VALID_IMAGES,
     VERSION_SOURCE_LOCAL,
     VERSION_SOURCE_MAP,
@@ -101,14 +100,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                             vol.Required(CONF_BOARD, default=DEFAULT_BOARD): vol.In(
                                 VALID_BOARDS
                             ),
-                        }
-                    )
-                else:
-                    data_schema = data_schema.extend(
-                        {
-                            vol.Required(CONF_IMAGE, default=DEFAULT_IMAGE): vol.In(
-                                VALID_CONTAINER_IMAGES
-                            )
                         }
                     )
             else:

--- a/homeassistant/components/version/const.py
+++ b/homeassistant/components/version/const.py
@@ -114,10 +114,6 @@ VALID_IMAGES: Final = [
     "tinker",
 ]
 
-VALID_CONTAINER_IMAGES: Final[list[str]] = [
-    f"{image}{POSTFIX_CONTAINER_NAME}" if image != DEFAULT_IMAGE else image
-    for image in VALID_IMAGES
-]
 VALID_CHANNELS: Final[list[str]] = [
     str(channel.value).title() for channel in HaVersionChannel
 ]

--- a/tests/components/version/test_config_flow.py
+++ b/tests/components/version/test_config_flow.py
@@ -141,15 +141,15 @@ async def test_advanced_form_container(hass: HomeAssistant) -> None:
         return_value=True,
     ) as mock_setup_entry:
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], {CONF_IMAGE: "odroid-n2-homeassistant"}
+            result["flow_id"], {CONF_CHANNEL: "Beta"}
         )
         await hass.async_block_till_done()
 
     assert result["type"] == FlowResultType.CREATE_ENTRY
-    assert result["title"] == VERSION_SOURCE_DOCKER_HUB
+    assert result["title"] == f"{VERSION_SOURCE_DOCKER_HUB} Beta"
     assert result["data"] == {
         **DEFAULT_CONFIGURATION,
-        CONF_IMAGE: "odroid-n2-homeassistant",
+        CONF_CHANNEL: "beta",
         CONF_SOURCE: HaVersionSource.CONTAINER,
         CONF_VERSION_SOURCE: VERSION_SOURCE_DOCKER_HUB,
     }

--- a/tests/components/version/test_init.py
+++ b/tests/components/version/test_init.py
@@ -1,0 +1,79 @@
+"""The tests for version init."""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components.version.const import (
+    CONF_BOARD,
+    CONF_IMAGE,
+    DEFAULT_CONFIGURATION,
+)
+from homeassistant.const import CONF_SOURCE
+from homeassistant.core import HomeAssistant
+
+from .common import (
+    MOCK_VERSION,
+    MOCK_VERSION_CONFIG_ENTRY_DATA,
+    MOCK_VERSION_DATA,
+)
+
+from tests.common import MockConfigEntry
+
+
+async def test_unsupported_board(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test configuring with an unsupported board."""
+    mock_entry = MockConfigEntry(
+        **{
+            **MOCK_VERSION_CONFIG_ENTRY_DATA,
+            "data": {
+                **DEFAULT_CONFIGURATION,
+                CONF_BOARD: "not-supported",
+            },
+        }
+    )
+    mock_entry.add_to_hass(hass)
+
+    with patch(
+        "pyhaversion.HaVersion.get_version",
+        return_value=(MOCK_VERSION, MOCK_VERSION_DATA),
+    ):
+        assert not await hass.config_entries.async_setup(mock_entry.entry_id)
+        await hass.async_block_till_done()
+        assert (
+            'Board "not-supported" is (no longer) valid. Please remove the integration "Local installation"'
+            in caplog.text
+        )
+
+
+async def test_unsupported_container_image(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test configuring with an unsupported container image."""
+    mock_entry = MockConfigEntry(
+        **{
+            **MOCK_VERSION_CONFIG_ENTRY_DATA,
+            "data": {
+                **DEFAULT_CONFIGURATION,
+                CONF_IMAGE: "not-supported-homeassistant",
+                CONF_SOURCE: "container",
+            },
+        }
+    )
+    mock_entry.add_to_hass(hass)
+
+    with patch(
+        "pyhaversion.HaVersion.get_version",
+        return_value=(MOCK_VERSION, MOCK_VERSION_DATA),
+    ):
+        assert not await hass.config_entries.async_setup(mock_entry.entry_id)
+        await hass.async_block_till_done()
+        assert (
+            'Image "not-supported-homeassistant" is (no longer) valid. Please remove the integration "Local installation"'
+            in caplog.text
+        )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

Since images are no longer published to docker-hub, the version integration can no longer get version information about newer images.

If you have configured the version integration with the "Docker Hub" source and specified an image other than "Default", the integration will no longer work.

To fix this you need to remove your current integration for it and set it up again.

If you had this configured to a specific image because you used that image in your docker configuration, you should also change that to `homeassistant/home-assistant` or `ghcr.io/home-assistant/home-assistant` instead.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Remove support for specific docker images as those are no longer updated.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
