### PR TITLE
Avoid http route linear search fallback when there are multiple paths

### DIFF
--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -582,32 +582,37 @@ class FastUrlDispatcher(UrlDispatcher):
     def __init__(self) -> None:
         """Initialize the dispatcher."""
         super().__init__()
-        self._resource_index: dict[str, AbstractResource] = {}
+        self._resource_index: dict[str, list[AbstractResource]] = {}
 
     def register_resource(self, resource: AbstractResource) -> None:
         """Register a resource."""
         super().register_resource(resource)
         canonical = resource.canonical
         if "{" in canonical:  # strip at the first { to allow for variables
-            canonical = canonical.split("{")[0]
-            canonical = canonical.rstrip("/")
-        self._resource_index[canonical] = resource
+            canonical = canonical.split("{")[0].rstrip("/")
+        # There may be multiple resources for a canonical path
+        # so we use a list to avoid falling back to a full linear search
+        self._resource_index.setdefault(canonical, []).append(resource)
 
     async def resolve(self, request: web.Request) -> UrlMappingMatchInfo:
         """Resolve a request."""
         url_parts = request.rel_url.raw_parts
         resource_index = self._resource_index
+
         # Walk the url parts looking for candidates
         for i in range(len(url_parts), 1, -1):
             url_part = "/" + "/".join(url_parts[1:i])
-            if (resource_candidate := resource_index.get(url_part)) is not None and (
-                match_dict := (await resource_candidate.resolve(request))[0]
-            ) is not None:
-                return match_dict
+            if (resource_candidates := resource_index.get(url_part)) is not None:
+                for candidate in resource_candidates:
+                    if (
+                        match_dict := (await candidate.resolve(request))[0]
+                    ) is not None:
+                        return match_dict
         # Next try the index view if we don't have a match
-        if (index_view_candidate := resource_index.get("/")) is not None and (
-            match_dict := (await index_view_candidate.resolve(request))[0]
-        ) is not None:
-            return match_dict
+        if (index_view_candidates := resource_index.get("/")) is not None:
+            for candidate in index_view_candidates:
+                if (match_dict := (await candidate.resolve(request))[0]) is not None:
+                    return match_dict
+
         # Finally, fallback to the linear search
         return await super().resolve(request)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
followup to #95721

I added some logging to my production installs for when the fast dispatcher fell back to the linear search in the super and found this after I had more widely deployed the fast dispatcher.

`hassio_ingress` registers multiple paths with the same canonical url (without the template vars). Since we would only see the latest one, the fast dispatcher would fallback to the linear search for ingress as designed (ie everything still worked as expected, it was just slower).

We now save both resources in the index so we only have to do two lookups to find it.

The improvement is quite visible for the ESPHome dashboard as my devices no longer show Offline and than switch to Online after a second.  The whole ESPHome dashboard/addon is a lot more responsive.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
