### PR TITLE
Remove unsupported vacuum service handlers

### DIFF
--- a/homeassistant/components/vacuum/__init__.py
+++ b/homeassistant/components/vacuum/__init__.py
@@ -429,22 +429,6 @@ class VacuumEntity(_BaseVacuum, ToggleEntity):
         """
         await self.hass.async_add_executor_job(partial(self.start_pause, **kwargs))
 
-    @final
-    async def async_pause(self) -> None:
-        """Pause the cleaning task.
-
-        Not supported by VacuumEntity.
-        """
-        raise NotImplementedError()
-
-    @final
-    async def async_start(self) -> None:
-        """Start or resume the cleaning task.
-
-        Not supported by VacuumEntity.
-        """
-        raise NotImplementedError()
-
 
 @dataclass
 class StateVacuumEntityDescription(EntityDescription):
@@ -492,35 +476,3 @@ class StateVacuumEntity(_BaseVacuum):
         This method must be run in the event loop.
         """
         await self.hass.async_add_executor_job(self.pause)
-
-    @final
-    async def async_start_pause(self, **kwargs: Any) -> None:
-        """Start, pause or resume the cleaning task.
-
-        Not supported by StateVacuumEntity.
-        """
-        raise NotImplementedError()
-
-    @final
-    async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn the vacuum on and start cleaning.
-
-        Not supported by StateVacuumEntity.
-        """
-        raise NotImplementedError()
-
-    @final
-    async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn the vacuum off stopping the cleaning and returning home.
-
-        Not supported by StateVacuumEntity.
-        """
-        raise NotImplementedError()
-
-    @final
-    async def async_toggle(self, **kwargs: Any) -> None:
-        """Toggle the vacuum cleaner on or off.
-
-        Not supported by StateVacuumEntity.
-        """
-        raise NotImplementedError()

--- a/homeassistant/components/vacuum/__init__.py
+++ b/homeassistant/components/vacuum/__init__.py
@@ -429,11 +429,21 @@ class VacuumEntity(_BaseVacuum, ToggleEntity):
         """
         await self.hass.async_add_executor_job(partial(self.start_pause, **kwargs))
 
+    @final
     async def async_pause(self) -> None:
-        """Not supported."""
+        """Pause the cleaning task.
 
+        Not supported by VacuumEntity.
+        """
+        raise NotImplementedError()
+
+    @final
     async def async_start(self) -> None:
-        """Not supported."""
+        """Start or resume the cleaning task.
+
+        Not supported by VacuumEntity.
+        """
+        raise NotImplementedError()
 
 
 @dataclass
@@ -483,11 +493,34 @@ class StateVacuumEntity(_BaseVacuum):
         """
         await self.hass.async_add_executor_job(self.pause)
 
+    @final
+    async def async_start_pause(self, **kwargs: Any) -> None:
+        """Start, pause or resume the cleaning task.
+
+        Not supported by StateVacuumEntity.
+        """
+        raise NotImplementedError()
+
+    @final
     async def async_turn_on(self, **kwargs: Any) -> None:
-        """Not supported."""
+        """Turn the vacuum on and start cleaning.
 
+        Not supported by StateVacuumEntity.
+        """
+        raise NotImplementedError()
+
+    @final
     async def async_turn_off(self, **kwargs: Any) -> None:
-        """Not supported."""
+        """Turn the vacuum off stopping the cleaning and returning home.
 
+        Not supported by StateVacuumEntity.
+        """
+        raise NotImplementedError()
+
+    @final
     async def async_toggle(self, **kwargs: Any) -> None:
-        """Not supported."""
+        """Toggle the vacuum cleaner on or off.
+
+        Not supported by StateVacuumEntity.
+        """
+        raise NotImplementedError()

--- a/tests/components/demo/test_vacuum.py
+++ b/tests/components/demo/test_vacuum.py
@@ -241,8 +241,8 @@ async def test_unsupported_methods(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
     assert vacuum.is_on(hass, ENTITY_VACUUM_COMPLETE)
 
-    await common.async_pause(hass, ENTITY_VACUUM_COMPLETE)
-    assert vacuum.is_on(hass, ENTITY_VACUUM_COMPLETE)
+    with pytest.raises(AttributeError):
+        await common.async_pause(hass, ENTITY_VACUUM_COMPLETE)
 
     hass.states.async_set(ENTITY_VACUUM_COMPLETE, STATE_OFF)
     await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove unsupported vacuum service handlers

Background:
The original `vaccuum` base entity `VacuumEntity` was deprecated and replaced with the `StateVacuumEntity` in August 2018.
The two entities model a vacuum cleaner differently, including a different set of supported features and a different set of services.

To make it easier to write tests, both base classes included stubbed out service handlers for services only supported by the other base class. This proved confusing, and several integrations ended up implementing the wrong set of services.

Related PRs which deprecates the wrong services, and adds the correct ones:
- https://github.com/home-assistant/core/pull/95788
- https://github.com/home-assistant/core/pull/95789
- https://github.com/home-assistant/core/pull/95790

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
