### PR TITLE
Adjust services supported by litterrobot vacuum

### DIFF
--- a/homeassistant/components/litterrobot/strings.json
+++ b/homeassistant/components/litterrobot/strings.json
@@ -28,11 +28,11 @@
   "issues": {
     "service_deprecation_turn_off": {
       "title": "Litter-Robot vaccum support for vacuum.turn_off is being removed",
-      "description": "Litter-Robot vaccum support for the vacuum.turn_off service is deprecated and will be removed in Home Assistant 2024.2; Please adjust any automation or script that uses the service to instead call vacuum.stop."
+      "description": "Litter-Robot vaccum support for the vacuum.turn_off service is deprecated and will be removed in Home Assistant 2024.2; Please adjust any automation or script that uses the service to instead call vacuum.stop and select submit below to mark this issue as resolved."
     },
     "service_deprecation_turn_on": {
       "title": "Litter-Robot vaccum support for vacuum.turn_on is being removed",
-      "description": "Litter-Robot vaccum support for the vacuum.turn_on service is deprecated and will be removed in Home Assistant 2024.2; Please adjust any automation or script that uses the service to instead call vacuum.start."
+      "description": "Litter-Robot vaccum support for the vacuum.turn_on service is deprecated and will be removed in Home Assistant 2024.2; Please adjust any automation or script that uses the service to instead call vacuum.start and select submit below to mark this issue as resolved."
     }
   },
   "entity": {

--- a/homeassistant/components/litterrobot/strings.json
+++ b/homeassistant/components/litterrobot/strings.json
@@ -25,6 +25,16 @@
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     }
   },
+  "issues": {
+    "service_deprecation_turn_off": {
+      "title": "Litter-Robot vaccum support for vacuum.turn_off is being removed",
+      "description": "Litter-Robot vaccum support for the vacuum.turn_off service is deprecated and will be removed in Home Assistant 2024.2; Please adjust any automation or script that uses the service to instead call vacuum.stop."
+    },
+    "service_deprecation_turn_on": {
+      "title": "Litter-Robot vaccum support for vacuum.turn_on is being removed",
+      "description": "Litter-Robot vaccum support for the vacuum.turn_on service is deprecated and will be removed in Home Assistant 2024.2; Please adjust any automation or script that uses the service to instead call vacuum.start."
+    }
+  },
   "entity": {
     "binary_sensor": {
       "sleeping": {

--- a/homeassistant/components/litterrobot/strings.json
+++ b/homeassistant/components/litterrobot/strings.json
@@ -28,11 +28,25 @@
   "issues": {
     "service_deprecation_turn_off": {
       "title": "Litter-Robot vaccum support for vacuum.turn_off is being removed",
-      "description": "Litter-Robot vaccum support for the vacuum.turn_off service is deprecated and will be removed in Home Assistant 2024.2; Please adjust any automation or script that uses the service to instead call vacuum.stop and select submit below to mark this issue as resolved."
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "[%key:component::litterrobot::issues::service_deprecation_turn_off::title%]",
+            "description": "Litter-Robot vaccum support for the vacuum.turn_off service is deprecated and will be removed in Home Assistant 2024.2; Please adjust any automation or script that uses the service to instead call vacuum.stop and select submit below to mark this issue as resolved."
+          }
+        }
+      }
     },
     "service_deprecation_turn_on": {
       "title": "Litter-Robot vaccum support for vacuum.turn_on is being removed",
-      "description": "Litter-Robot vaccum support for the vacuum.turn_on service is deprecated and will be removed in Home Assistant 2024.2; Please adjust any automation or script that uses the service to instead call vacuum.start and select submit below to mark this issue as resolved."
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "[%key:component::litterrobot::issues::service_deprecation_turn_off::title%]",
+            "description": "Litter-Robot vaccum support for the vacuum.turn_on service is deprecated and will be removed in Home Assistant 2024.2; Please adjust any automation or script that uses the service to instead call vacuum.start and select submit below to mark this issue as resolved."
+          }
+        }
+      }
     }
   },
   "entity": {

--- a/homeassistant/components/litterrobot/strings.json
+++ b/homeassistant/components/litterrobot/strings.json
@@ -27,23 +27,23 @@
   },
   "issues": {
     "service_deprecation_turn_off": {
-      "title": "Litter-Robot vaccum support for vacuum.turn_off is being removed",
+      "title": "Litter-Robot vaccum support for {old_service} is being removed",
       "fix_flow": {
         "step": {
           "confirm": {
             "title": "[%key:component::litterrobot::issues::service_deprecation_turn_off::title%]",
-            "description": "Litter-Robot vaccum support for the vacuum.turn_off service is deprecated and will be removed in Home Assistant 2024.2; Please adjust any automation or script that uses the service to instead call vacuum.stop and select submit below to mark this issue as resolved."
+            "description": "Litter-Robot vaccum support for the {old_service} service is deprecated and will be removed in Home Assistant 2024.2; Please adjust any automation or script that uses the service to instead call {new_service} and select submit below to mark this issue as resolved."
           }
         }
       }
     },
     "service_deprecation_turn_on": {
-      "title": "Litter-Robot vaccum support for vacuum.turn_on is being removed",
+      "title": "[%key:component::litterrobot::issues::service_deprecation_turn_off::title%]",
       "fix_flow": {
         "step": {
           "confirm": {
             "title": "[%key:component::litterrobot::issues::service_deprecation_turn_off::title%]",
-            "description": "Litter-Robot vaccum support for the vacuum.turn_on service is deprecated and will be removed in Home Assistant 2024.2; Please adjust any automation or script that uses the service to instead call vacuum.start and select submit below to mark this issue as resolved."
+            "description": "[%key:component::litterrobot::issues::service_deprecation_turn_off::fix_flow::step::confirm::description%]"
           }
         }
       }

--- a/homeassistant/components/litterrobot/vacuum.py
+++ b/homeassistant/components/litterrobot/vacuum.py
@@ -77,7 +77,6 @@ class LitterRobotCleaner(LitterRobotEntity[LitterRobot], StateVacuumEntity):
     _attr_supported_features = (
         VacuumEntityFeature.START
         | VacuumEntityFeature.STATE
-        | VacuumEntityFeature.STATUS
         | VacuumEntityFeature.TURN_OFF
         | VacuumEntityFeature.TURN_ON
     )

--- a/homeassistant/components/litterrobot/vacuum.py
+++ b/homeassistant/components/litterrobot/vacuum.py
@@ -85,8 +85,6 @@ class LitterRobotCleaner(LitterRobotEntity[LitterRobot], StateVacuumEntity):
         | VacuumEntityFeature.TURN_OFF
         | VacuumEntityFeature.TURN_ON
     )
-    _turn_off_call_reported: bool = False
-    _turn_on_call_reported: bool = False
 
     @property
     def state(self) -> str:
@@ -103,15 +101,13 @@ class LitterRobotCleaner(LitterRobotEntity[LitterRobot], StateVacuumEntity):
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the cleaner on, starting a clean cycle."""
         await self.robot.set_power_status(True)
-        if self._turn_on_call_reported:
-            return
-        self._turn_on_call_reported = True
         ir.async_create_issue(
             self.hass,
             DOMAIN,
             "service_deprecation_turn_on",
             breaks_in_ha_version="2024.2.0",
-            is_fixable=False,
+            is_fixable=True,
+            is_persistent=True,
             severity=ir.IssueSeverity.WARNING,
             translation_key="service_deprecation_turn_on",
         )
@@ -119,15 +115,13 @@ class LitterRobotCleaner(LitterRobotEntity[LitterRobot], StateVacuumEntity):
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the unit off, stopping any cleaning in progress as is."""
         await self.robot.set_power_status(False)
-        if self._turn_off_call_reported:
-            return
-        self._turn_off_call_reported = True
         ir.async_create_issue(
             self.hass,
             DOMAIN,
             "service_deprecation_turn_off",
             breaks_in_ha_version="2024.2.0",
-            is_fixable=False,
+            is_fixable=True,
+            is_persistent=True,
             severity=ir.IssueSeverity.WARNING,
             translation_key="service_deprecation_turn_off",
         )

--- a/homeassistant/components/litterrobot/vacuum.py
+++ b/homeassistant/components/litterrobot/vacuum.py
@@ -77,6 +77,7 @@ class LitterRobotCleaner(LitterRobotEntity[LitterRobot], StateVacuumEntity):
     _attr_supported_features = (
         VacuumEntityFeature.START
         | VacuumEntityFeature.STATE
+        | VacuumEntityFeature.STOP
         | VacuumEntityFeature.TURN_OFF
         | VacuumEntityFeature.TURN_ON
     )
@@ -104,6 +105,10 @@ class LitterRobotCleaner(LitterRobotEntity[LitterRobot], StateVacuumEntity):
     async def async_start(self) -> None:
         """Start a clean cycle."""
         await self.robot.start_cleaning()
+
+    async def async_stop(self, **kwargs: Any) -> None:
+        """Stop the vacuum cleaner."""
+        await self.robot.set_power_status(False)
 
     async def async_set_sleep_mode(
         self, enabled: bool, start_time: str | None = None

--- a/homeassistant/components/litterrobot/vacuum.py
+++ b/homeassistant/components/litterrobot/vacuum.py
@@ -128,6 +128,7 @@ class LitterRobotCleaner(LitterRobotEntity[LitterRobot], StateVacuumEntity):
 
     async def async_start(self) -> None:
         """Start a clean cycle."""
+        await self.robot.set_power_status(True)
         await self.robot.start_cleaning()
 
     async def async_stop(self, **kwargs: Any) -> None:

--- a/homeassistant/components/litterrobot/vacuum.py
+++ b/homeassistant/components/litterrobot/vacuum.py
@@ -110,6 +110,10 @@ class LitterRobotCleaner(LitterRobotEntity[LitterRobot], StateVacuumEntity):
             is_persistent=True,
             severity=ir.IssueSeverity.WARNING,
             translation_key="service_deprecation_turn_on",
+            translation_placeholders={
+                "old_service": "vacuum.turn_on",
+                "new_service": "vacuum.start",
+            },
         )
 
     async def async_turn_off(self, **kwargs: Any) -> None:
@@ -124,6 +128,10 @@ class LitterRobotCleaner(LitterRobotEntity[LitterRobot], StateVacuumEntity):
             is_persistent=True,
             severity=ir.IssueSeverity.WARNING,
             translation_key="service_deprecation_turn_off",
+            translation_placeholders={
+                "old_service": "vacuum.turn_off",
+                "new_service": "vacuum.stop",
+            },
         )
 
     async def async_start(self) -> None:

--- a/tests/components/litterrobot/test_vacuum.py
+++ b/tests/components/litterrobot/test_vacuum.py
@@ -174,7 +174,7 @@ async def test_issues(
     await hass.services.async_call(
         COMPONENT_SERVICE_DOMAIN.get(service, PLATFORM_DOMAIN),
         service,
-        {},
+        {ATTR_ENTITY_ID: VACUUM_ENTITY_ID},
         blocking=True,
     )
 

--- a/tests/components/litterrobot/test_vacuum.py
+++ b/tests/components/litterrobot/test_vacuum.py
@@ -12,6 +12,7 @@ from homeassistant.components.vacuum import (
     ATTR_STATUS,
     DOMAIN as PLATFORM_DOMAIN,
     SERVICE_START,
+    SERVICE_STOP,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
     STATE_DOCKED,
@@ -98,6 +99,7 @@ async def test_vacuum_with_error(
     ("service", "command", "extra"),
     [
         (SERVICE_START, "start_cleaning", None),
+        (SERVICE_STOP, "set_power_status", None),
         (SERVICE_TURN_OFF, "set_power_status", None),
         (SERVICE_TURN_ON, "set_power_status", None),
         (


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for `vacuum.stop` and deprecate the implementation of services `vacuum.turn_on` and `vacuum.turn_off` in `litterrobot` vacuum

### Background:
Services `vacuum.turn_on` and `vacuum.turn_off` are supported by the deprecated base class `VacuumEntity`, not by the base class `StateVacuumEntity` which is implemented by `litterrobot`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
