### PR TITLE
Restore KNX telegram history

### DIFF
--- a/homeassistant/components/knx/__init__.py
+++ b/homeassistant/components/knx/__init__.py
@@ -74,7 +74,7 @@ from .const import (
 )
 from .device import KNXInterfaceDevice
 from .expose import KNXExposeSensor, KNXExposeTime, create_knx_exposure
-from .project import KNXProject
+from .project import STORAGE_KEY as PROJECT_STORAGE_KEY, KNXProject
 from .schema import (
     BinarySensorSchema,
     ButtonSchema,
@@ -96,7 +96,7 @@ from .schema import (
     ga_validator,
     sensor_type_validator,
 )
-from .telegrams import Telegrams
+from .telegrams import STORAGE_KEY as TELEGRAMS_STORAGE_KEY, Telegrams
 from .websocket import register_panel
 
 _LOGGER = logging.getLogger(__name__)
@@ -360,16 +360,21 @@ async def async_update_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
 async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Remove a config entry."""
 
-    def remove_keyring_files(file_path: Path) -> None:
-        """Remove keyring files."""
+    def remove_files(storage_dir: Path, knxkeys_filename: str | None) -> None:
+        """Remove KNX files."""
+        if knxkeys_filename is not None:
+            with contextlib.suppress(FileNotFoundError):
+                (storage_dir / knxkeys_filename).unlink()
         with contextlib.suppress(FileNotFoundError):
-            file_path.unlink()
+            (storage_dir / PROJECT_STORAGE_KEY).unlink()
+        with contextlib.suppress(FileNotFoundError):
+            (storage_dir / TELEGRAMS_STORAGE_KEY).unlink()
         with contextlib.suppress(FileNotFoundError, OSError):
-            file_path.parent.rmdir()
+            (storage_dir / DOMAIN).rmdir()
 
-    if (_knxkeys_file := entry.data.get(CONF_KNX_KNXKEY_FILENAME)) is not None:
-        file_path = Path(hass.config.path(STORAGE_DIR)) / _knxkeys_file
-        await hass.async_add_executor_job(remove_keyring_files, file_path)
+    storage_dir = Path(hass.config.path(STORAGE_DIR))
+    knxkeys_filename = entry.data.get(CONF_KNX_KNXKEY_FILENAME)
+    await hass.async_add_executor_job(remove_files, storage_dir, knxkeys_filename)
 
 
 class KNXModule:
@@ -420,11 +425,13 @@ class KNXModule:
     async def start(self) -> None:
         """Start XKNX object. Connect to tunneling or Routing device."""
         await self.project.load_project()
+        await self.telegrams.load_history()
         await self.xknx.start()
 
     async def stop(self, event: Event | None = None) -> None:
         """Stop XKNX object. Disconnect from tunneling or Routing device."""
         await self.xknx.stop()
+        await self.telegrams.save_history()
 
     def connection_config(self) -> ConnectionConfig:
         """Return the connection_config."""

--- a/homeassistant/components/knx/const.py
+++ b/homeassistant/components/knx/const.py
@@ -53,7 +53,7 @@ CONF_KNX_DEFAULT_RATE_LIMIT: Final = 0
 DEFAULT_ROUTING_IA: Final = "0.0.240"
 
 CONF_KNX_TELEGRAM_LOG_SIZE: Final = "telegram_log_size"
-TELEGRAM_LOG_DEFAULT: Final = 50
+TELEGRAM_LOG_DEFAULT: Final = 200
 TELEGRAM_LOG_MAX: Final = 5000  # ~2 MB or ~5 hours of reasonable bus load
 
 ##

--- a/tests/components/knx/test_config_flow.py
+++ b/tests/components/knx/test_config_flow.py
@@ -910,7 +910,7 @@ async def test_form_with_automatic_connection_handling(
         CONF_KNX_ROUTE_BACK: False,
         CONF_KNX_TUNNEL_ENDPOINT_IA: None,
         CONF_KNX_STATE_UPDATER: True,
-        CONF_KNX_TELEGRAM_LOG_SIZE: 50,
+        CONF_KNX_TELEGRAM_LOG_SIZE: 200,
     }
     knx_setup.assert_called_once()
 
@@ -1210,7 +1210,7 @@ async def test_options_flow_connection_type(
             CONF_KNX_SECURE_DEVICE_AUTHENTICATION: None,
             CONF_KNX_SECURE_USER_ID: None,
             CONF_KNX_SECURE_USER_PASSWORD: None,
-            CONF_KNX_TELEGRAM_LOG_SIZE: 50,
+            CONF_KNX_TELEGRAM_LOG_SIZE: 200,
         }
 
 

--- a/tests/components/knx/test_init.py
+++ b/tests/components/knx/test_init.py
@@ -280,7 +280,7 @@ async def test_async_remove_entry(
         "pathlib.Path.rmdir"
     ) as rmdir_mock:
         assert await hass.config_entries.async_remove(config_entry.entry_id)
-        unlink_mock.assert_called_once()
+        assert unlink_mock.call_count == 3
         rmdir_mock.assert_called_once()
     await hass.async_block_till_done()
 

--- a/tests/components/knx/test_telegrams.py
+++ b/tests/components/knx/test_telegrams.py
@@ -1,0 +1,97 @@
+"""KNX Telegrams Tests."""
+from copy import copy
+from datetime import datetime
+from typing import Any
+
+import pytest
+
+from homeassistant.components.knx import DOMAIN
+from homeassistant.components.knx.telegrams import TelegramDict
+from homeassistant.core import HomeAssistant
+
+from .conftest import KNXTestKit
+
+MOCK_TIMESTAMP = "2023-07-02T14:51:24.045162-07:00"
+MOCK_TELEGRAMS = [
+    {
+        "destination": "1/3/4",
+        "destination_name": "",
+        "direction": "Incoming",
+        "dpt_main": None,
+        "dpt_sub": None,
+        "dpt_name": None,
+        "payload": True,
+        "source": "1.2.3",
+        "source_name": "",
+        "telegramtype": "GroupValueWrite",
+        "timestamp": MOCK_TIMESTAMP,
+        "unit": None,
+        "value": None,
+    },
+    {
+        "destination": "2/2/2",
+        "destination_name": "",
+        "direction": "Outgoing",
+        "dpt_main": None,
+        "dpt_sub": None,
+        "dpt_name": None,
+        "payload": [1, 2, 3, 4],
+        "source": "0.0.0",
+        "source_name": "",
+        "telegramtype": "GroupValueWrite",
+        "timestamp": MOCK_TIMESTAMP,
+        "unit": None,
+        "value": None,
+    },
+]
+
+
+def assert_telegram_history(telegrams: list[TelegramDict]) -> bool:
+    """Assert that the mock telegrams are equal to the given telegrams. Omitting timestamp."""
+    assert len(telegrams) == len(MOCK_TELEGRAMS)
+    for index in range(len(telegrams)):
+        test_telegram = copy(telegrams[index])  # don't modify the original
+        comp_telegram = MOCK_TELEGRAMS[index]
+        assert datetime.fromisoformat(test_telegram["timestamp"])
+        if isinstance(test_telegram["payload"], tuple):
+            # JSON encodes tuples to lists
+            test_telegram["payload"] = list(test_telegram["payload"])
+        assert test_telegram | {"timestamp": MOCK_TIMESTAMP} == comp_telegram
+    return True
+
+
+async def test_store_telegam_history(
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+    hass_storage: dict[str, Any],
+):
+    """Test storing telegram history."""
+    await knx.setup_integration({})
+
+    await knx.receive_write("1/3/4", True)
+    await hass.services.async_call(
+        "knx", "send", {"address": "2/2/2", "payload": [1, 2, 3, 4]}, blocking=True
+    )
+    await knx.assert_write("2/2/2", (1, 2, 3, 4))
+
+    assert len(hass.data[DOMAIN].telegrams.recent_telegrams) == 2
+    with pytest.raises(KeyError):
+        hass_storage["knx/telegrams_history.json"]
+
+    await hass.config_entries.async_unload(knx.mock_config_entry.entry_id)
+    saved_telegrams = hass_storage["knx/telegrams_history.json"]["data"]
+    assert assert_telegram_history(saved_telegrams)
+
+
+async def test_load_telegam_history(
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+    hass_storage: dict[str, Any],
+):
+    """Test telegram history restoration."""
+    hass_storage["knx/telegrams_history.json"] = {"version": 1, "data": MOCK_TELEGRAMS}
+    await knx.setup_integration({})
+    loaded_telegrams = hass.data[DOMAIN].telegrams.recent_telegrams
+    assert assert_telegram_history(loaded_telegrams)
+    # TelegramDict "payload" is a tuple, this shall be restored when loading from JSON
+    assert isinstance(loaded_telegrams[1]["payload"], tuple)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Restore KNX telegram history after reloading the integration or restarting HA
- Clean up all files created from uploaders in Config/OptionsFlow or Panel when removing the ConfigEntry 
Previously the parsed project file would have been left
- Change `TelegramDict` "timestamp" field type from `datetime.datetime` to `str` 
It is used via WS only - in the GroupMonitor or in DeviceTriggers - and there it is converted to `str` anyway. And since it is easier to store as JSON, we can just use the string format right from the start instead of converting it multiple times.
- Increase default telegram history size from 50 to 200

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
