### PR TITLE
Fix timezones used in list events

### DIFF
--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -793,7 +793,9 @@ async def async_list_events_service(
         end = start + service_call.data[EVENT_DURATION]
     else:
         end = service_call.data[EVENT_END_DATETIME]
-    calendar_event_list = await calendar.async_get_events(calendar.hass, start, end)
+    calendar_event_list = await calendar.async_get_events(
+        calendar.hass, dt_util.as_local(start), dt_util.as_local(end)
+    )
     return {
         "events": [
             dataclasses.asdict(event, dict_factory=_list_events_dict_factory)

--- a/homeassistant/components/demo/calendar.py
+++ b/homeassistant/components/demo/calendar.py
@@ -67,14 +67,6 @@ class DemoCalendar(CalendarEntity):
         end_date: datetime.datetime,
     ) -> list[CalendarEvent]:
         """Return calendar events within a datetime range."""
-        if start_date.tzinfo is None:
-            start_date = start_date.replace(
-                tzinfo=dt_util.get_time_zone(hass.config.time_zone)
-            )
-        if end_date.tzinfo is None:
-            end_date = end_date.replace(
-                tzinfo=dt_util.get_time_zone(hass.config.time_zone)
-            )
         assert start_date < end_date
         if self._event.start_datetime_local >= end_date:
             return []

--- a/tests/components/calendar/test_init.py
+++ b/tests/components/calendar/test_init.py
@@ -388,7 +388,17 @@ async def test_create_event_service_invalid_params(
 
 
 @freeze_time("2023-06-22 10:30:00+00:00")
-async def test_list_events_service(hass: HomeAssistant, set_time_zone: None) -> None:
+@pytest.mark.parametrize(
+    ("start_time", "end_time"),
+    [
+        ("2023-06-22T04:30:00-06:00", "2023-06-22T06:30:00-06:00"),
+        ("2023-06-22T04:30:00", "2023-06-22T06:30:00"),
+        ("2023-06-22T10:30:00Z", "2023-06-22T12:30:00Z"),
+    ],
+)
+async def test_list_events_service(
+    hass: HomeAssistant, set_time_zone: None, start_time: str, end_time: str
+) -> None:
     """Test listing events from the service call using exlplicit start and end time.
 
     This test uses a fixed date/time so that it can deterministically test the
@@ -398,16 +408,13 @@ async def test_list_events_service(hass: HomeAssistant, set_time_zone: None) -> 
     await async_setup_component(hass, "calendar", {"calendar": {"platform": "demo"}})
     await hass.async_block_till_done()
 
-    start = dt_util.now()
-    end = start + timedelta(days=1)
-
     response = await hass.services.async_call(
         DOMAIN,
         SERVICE_LIST_EVENTS,
         {
             "entity_id": "calendar.calendar_1",
-            "start_date_time": start,
-            "end_date_time": end,
+            "start_date_time": start_time,
+            "end_date_time": end_time,
         },
         blocking=True,
         return_response=True,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Followup to #95778 that fixes a bug in the list events call, properly translating input timezones to the local timezone. `async_get_events` should always be called with the home assistant timezone.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
