### PR TITLE
Avoid probing ESPHome devices when we do not have the encryption key

### DIFF
--- a/homeassistant/components/esphome/config_flow.py
+++ b/homeassistant/components/esphome/config_flow.py
@@ -54,6 +54,7 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
         self._host: str | None = None
         self._port: int | None = None
         self._password: str | None = None
+        self._noise_required: bool | None = None
         self._noise_psk: str | None = None
         self._device_info: DeviceInfo | None = None
         self._reauth_entry: ConfigEntry | None = None
@@ -150,33 +151,40 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
         self.context["title_placeholders"] = {"name": self._name}
 
     async def _async_try_fetch_device_info(self) -> FlowResult:
-        error = await self.fetch_device_info()
+        """Try to fetch device info and return any errors."""
+        response: str | None
+        if self._noise_required:
+            # If we already know we need encryption, don't try to fetch device info
+            # without encryption.
+            response = ERROR_REQUIRES_ENCRYPTION_KEY
+        else:
+            response = await self.fetch_device_info()
 
-        if error == ERROR_REQUIRES_ENCRYPTION_KEY:
+        if response == ERROR_REQUIRES_ENCRYPTION_KEY:
             if not self._device_name and not self._noise_psk:
                 # If device name is not set we can send a zero noise psk
                 # to get the device name which will allow us to populate
                 # the device name and hopefully get the encryption key
                 # from the dashboard.
                 self._noise_psk = ZERO_NOISE_PSK
-                error = await self.fetch_device_info()
+                response = await self.fetch_device_info()
                 self._noise_psk = None
 
             if (
                 self._device_name
                 and await self._retrieve_encryption_key_from_dashboard()
             ):
-                error = await self.fetch_device_info()
+                response = await self.fetch_device_info()
 
             # If the fetched key is invalid, unset it again.
-            if error == ERROR_INVALID_ENCRYPTION_KEY:
+            if response == ERROR_INVALID_ENCRYPTION_KEY:
                 self._noise_psk = None
-                error = ERROR_REQUIRES_ENCRYPTION_KEY
+                response = ERROR_REQUIRES_ENCRYPTION_KEY
 
-        if error == ERROR_REQUIRES_ENCRYPTION_KEY:
+        if response == ERROR_REQUIRES_ENCRYPTION_KEY:
             return await self.async_step_encryption_key()
-        if error is not None:
-            return await self._async_step_user_base(error=error)
+        if response is not None:
+            return await self._async_step_user_base(error=response)
         return await self._async_authenticate_or_add()
 
     async def _async_authenticate_or_add(self) -> FlowResult:
@@ -219,6 +227,7 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
         self._device_name = device_name
         self._host = discovery_info.host
         self._port = discovery_info.port
+        self._noise_required = bool(discovery_info.properties.get("api_encryption"))
 
         # Check if already configured
         await self.async_set_unique_id(mac_address)

--- a/homeassistant/components/esphome/config_flow.py
+++ b/homeassistant/components/esphome/config_flow.py
@@ -158,6 +158,11 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
             # without encryption.
             response = ERROR_REQUIRES_ENCRYPTION_KEY
         else:
+            # After 2024.08, stop trying to fetch device info without encryption
+            # so we can avoid probe requests to check for password. At this point
+            # most devices should announce encryption support and password is
+            # deprecated and can be discovered by trying to connect only after they
+            # interact with the flow since it is expected to be a rare case.
             response = await self.fetch_device_info()
 
         if response == ERROR_REQUIRES_ENCRYPTION_KEY:

--- a/tests/components/esphome/test_config_flow.py
+++ b/tests/components/esphome/test_config_flow.py
@@ -1233,6 +1233,72 @@ async def test_zeroconf_encryption_key_via_dashboard(
     assert mock_client.noise_psk == VALID_NOISE_PSK
 
 
+async def test_zeroconf_encryption_key_via_dashboard_with_api_encryption_prop(
+    hass: HomeAssistant,
+    mock_client,
+    mock_zeroconf: None,
+    mock_dashboard,
+    mock_setup_entry: None,
+) -> None:
+    """Test encryption key retrieved from dashboard with api_encryption property set."""
+    service_info = zeroconf.ZeroconfServiceInfo(
+        host="192.168.43.183",
+        addresses=["192.168.43.183"],
+        hostname="test8266.local.",
+        name="mock_name",
+        port=6053,
+        properties={
+            "mac": "1122334455aa",
+            "api_encryption": "any",
+        },
+        type="mock_type",
+    )
+    flow = await hass.config_entries.flow.async_init(
+        "esphome", context={"source": config_entries.SOURCE_ZEROCONF}, data=service_info
+    )
+
+    assert flow["type"] == FlowResultType.FORM
+    assert flow["step_id"] == "discovery_confirm"
+
+    mock_dashboard["configured"].append(
+        {
+            "name": "test8266",
+            "configuration": "test8266.yaml",
+        }
+    )
+
+    await dashboard.async_get_dashboard(hass).async_refresh()
+
+    mock_client.device_info.side_effect = [
+        DeviceInfo(
+            uses_password=False,
+            name="test8266",
+            mac_address="11:22:33:44:55:AA",
+        ),
+    ]
+
+    with patch(
+        "homeassistant.components.esphome.dashboard.ESPHomeDashboardAPI.get_encryption_key",
+        return_value=VALID_NOISE_PSK,
+    ) as mock_get_encryption_key:
+        result = await hass.config_entries.flow.async_configure(
+            flow["flow_id"], user_input={}
+        )
+
+    assert len(mock_get_encryption_key.mock_calls) == 1
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == "test8266"
+    assert result["data"][CONF_HOST] == "192.168.43.183"
+    assert result["data"][CONF_PORT] == 6053
+    assert result["data"][CONF_NOISE_PSK] == VALID_NOISE_PSK
+
+    assert result["result"]
+    assert result["result"].unique_id == "11:22:33:44:55:aa"
+
+    assert mock_client.noise_psk == VALID_NOISE_PSK
+
+
 async def test_zeroconf_no_encryption_key_via_dashboard(
     hass: HomeAssistant,
     mock_client,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
makes use of the new `api_encryption` property in https://github.com/esphome/esphome/pull/5034

In the future (2024.8) we can stop probing devices on the network (when discovered) since we will have enough info to know if they need encryption or not.   The probing from a 2nd or 3rd HA instance can push the tcp buffer space over the edge and result in disconnects so its ideal to avoid it for devices that are resource constrained.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
