### PR TITLE
Fix ESPHome camera not accepting the same exact image bytes

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -307,7 +307,6 @@ omit =
     homeassistant/components/escea/discovery.py
     homeassistant/components/esphome/__init__.py
     homeassistant/components/esphome/bluetooth/*
-    homeassistant/components/esphome/camera.py
     homeassistant/components/esphome/domain_data.py
     homeassistant/components/esphome/entry_data.py
     homeassistant/components/etherscan/sensor.py

--- a/homeassistant/components/esphome/entry_data.py
+++ b/homeassistant/components/esphome/entry_data.py
@@ -14,6 +14,7 @@ from aioesphomeapi import (
     APIVersion,
     BinarySensorInfo,
     CameraInfo,
+    CameraState,
     ClimateInfo,
     CoverInfo,
     DeviceInfo,
@@ -339,8 +340,9 @@ class RuntimeEntryData:
         if (
             current_state == state
             and subscription_key not in stale_state
+            and state_type is not CameraState
             and not (
-                type(state) is SensorState  # pylint: disable=unidiomatic-typecheck
+                state_type is SensorState  # pylint: disable=unidiomatic-typecheck
                 and (platform_info := self.info.get(SensorInfo))
                 and (entity_info := platform_info.get(state.key))
                 and (cast(SensorInfo, entity_info)).force_update

--- a/tests/components/esphome/test_camera.py
+++ b/tests/components/esphome/test_camera.py
@@ -1,0 +1,316 @@
+"""Test ESPHome cameras."""
+from collections.abc import Awaitable, Callable
+
+from aioesphomeapi import (
+    APIClient,
+    CameraInfo,
+    CameraState,
+    EntityInfo,
+    EntityState,
+    UserService,
+)
+
+from homeassistant.components.camera import (
+    STATE_IDLE,
+)
+from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
+
+from .conftest import MockESPHomeDevice
+
+from tests.typing import ClientSessionGenerator
+
+SMALLEST_VALID_JPEG = (
+    "ffd8ffe000104a46494600010101004800480000ffdb00430003020202020203020202030303030406040404040408060"
+    "6050609080a0a090809090a0c0f0c0a0b0e0b09090d110d0e0f101011100a0c12131210130f101010ffc9000b08000100"
+    "0101011100ffcc000600101005ffda0008010100003f00d2cf20ffd9"
+)
+SMALLEST_VALID_JPEG_BYTES = bytes.fromhex(SMALLEST_VALID_JPEG)
+
+
+async def test_camera_single_image(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: Callable[
+        [APIClient, list[EntityInfo], list[UserService], list[EntityState]],
+        Awaitable[MockESPHomeDevice],
+    ],
+    hass_client: ClientSessionGenerator,
+) -> None:
+    """Test a generic camera single image request."""
+    entity_info = [
+        CameraInfo(
+            object_id="mycamera",
+            key=1,
+            name="my camera",
+            unique_id="my_camera",
+        )
+    ]
+    states = []
+    user_service = []
+    mock_device = await mock_esphome_device(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        user_service=user_service,
+        states=states,
+    )
+    state = hass.states.get("camera.test_my_camera")
+    assert state is not None
+    assert state.state == STATE_IDLE
+
+    async def _mock_camera_image():
+        mock_device.set_state(CameraState(key=1, data=SMALLEST_VALID_JPEG_BYTES))
+
+    mock_client.request_single_image = _mock_camera_image
+
+    client = await hass_client()
+    resp = await client.get("/api/camera_proxy/camera.test_my_camera")
+    await hass.async_block_till_done()
+    state = hass.states.get("camera.test_my_camera")
+    assert state is not None
+    assert state.state == STATE_IDLE
+
+    assert resp.status == 200
+    assert resp.content_type == "image/jpeg"
+    assert resp.content_length == len(SMALLEST_VALID_JPEG_BYTES)
+    assert await resp.read() == SMALLEST_VALID_JPEG_BYTES
+
+
+async def test_camera_single_image_unavailable_before_requested(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: Callable[
+        [APIClient, list[EntityInfo], list[UserService], list[EntityState]],
+        Awaitable[MockESPHomeDevice],
+    ],
+    hass_client: ClientSessionGenerator,
+) -> None:
+    """Test a generic camera that goes unavailable before the request."""
+    entity_info = [
+        CameraInfo(
+            object_id="mycamera",
+            key=1,
+            name="my camera",
+            unique_id="my_camera",
+        )
+    ]
+    states = []
+    user_service = []
+    mock_device = await mock_esphome_device(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        user_service=user_service,
+        states=states,
+    )
+    state = hass.states.get("camera.test_my_camera")
+    assert state is not None
+    assert state.state == STATE_IDLE
+    await mock_device.mock_disconnect(False)
+
+    client = await hass_client()
+    resp = await client.get("/api/camera_proxy/camera.test_my_camera")
+    await hass.async_block_till_done()
+    state = hass.states.get("camera.test_my_camera")
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+
+    assert resp.status == 500
+
+
+async def test_camera_single_image_unavailable_during_request(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: Callable[
+        [APIClient, list[EntityInfo], list[UserService], list[EntityState]],
+        Awaitable[MockESPHomeDevice],
+    ],
+    hass_client: ClientSessionGenerator,
+) -> None:
+    """Test a generic camera that goes unavailable before the request."""
+    entity_info = [
+        CameraInfo(
+            object_id="mycamera",
+            key=1,
+            name="my camera",
+            unique_id="my_camera",
+        )
+    ]
+    states = []
+    user_service = []
+    mock_device = await mock_esphome_device(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        user_service=user_service,
+        states=states,
+    )
+    state = hass.states.get("camera.test_my_camera")
+    assert state is not None
+    assert state.state == STATE_IDLE
+
+    async def _mock_camera_image():
+        await mock_device.mock_disconnect(False)
+        # Currently there is a bug where the camera will block
+        # forever if we don't send a response
+        mock_device.set_state(CameraState(key=1, data=SMALLEST_VALID_JPEG_BYTES))
+
+    mock_client.request_single_image = _mock_camera_image
+
+    client = await hass_client()
+    resp = await client.get("/api/camera_proxy/camera.test_my_camera")
+    await hass.async_block_till_done()
+    state = hass.states.get("camera.test_my_camera")
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+
+    assert resp.status == 500
+
+
+async def test_camera_stream(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: Callable[
+        [APIClient, list[EntityInfo], list[UserService], list[EntityState]],
+        Awaitable[MockESPHomeDevice],
+    ],
+    hass_client: ClientSessionGenerator,
+) -> None:
+    """Test a generic camera stream."""
+    entity_info = [
+        CameraInfo(
+            object_id="mycamera",
+            key=1,
+            name="my camera",
+            unique_id="my_camera",
+        )
+    ]
+    states = []
+    user_service = []
+    mock_device = await mock_esphome_device(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        user_service=user_service,
+        states=states,
+    )
+    state = hass.states.get("camera.test_my_camera")
+    assert state is not None
+    assert state.state == STATE_IDLE
+    remaining_responses = 3
+
+    async def _mock_camera_image():
+        nonlocal remaining_responses
+        if remaining_responses == 0:
+            return
+        remaining_responses -= 1
+        mock_device.set_state(CameraState(key=1, data=SMALLEST_VALID_JPEG_BYTES))
+
+    mock_client.request_image_stream = _mock_camera_image
+    mock_client.request_single_image = _mock_camera_image
+
+    client = await hass_client()
+    resp = await client.get("/api/camera_proxy_stream/camera.test_my_camera")
+    await hass.async_block_till_done()
+    state = hass.states.get("camera.test_my_camera")
+    assert state is not None
+    assert state.state == STATE_IDLE
+
+    assert resp.status == 200
+    assert resp.content_type == "multipart/x-mixed-replace"
+    assert resp.content_length is None
+    raw_stream = b""
+    async for data in resp.content.iter_any():
+        raw_stream += data
+        if len(raw_stream) > 300:
+            break
+
+    assert b"image/jpeg" in raw_stream
+
+
+async def test_camera_stream_unavailable(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: Callable[
+        [APIClient, list[EntityInfo], list[UserService], list[EntityState]],
+        Awaitable[MockESPHomeDevice],
+    ],
+    hass_client: ClientSessionGenerator,
+) -> None:
+    """Test a generic camera stream when the device is disconnected."""
+    entity_info = [
+        CameraInfo(
+            object_id="mycamera",
+            key=1,
+            name="my camera",
+            unique_id="my_camera",
+        )
+    ]
+    states = []
+    user_service = []
+    mock_device = await mock_esphome_device(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        user_service=user_service,
+        states=states,
+    )
+    state = hass.states.get("camera.test_my_camera")
+    assert state is not None
+    assert state.state == STATE_IDLE
+
+    await mock_device.mock_disconnect(False)
+
+    client = await hass_client()
+    await client.get("/api/camera_proxy_stream/camera.test_my_camera")
+    await hass.async_block_till_done()
+    state = hass.states.get("camera.test_my_camera")
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+
+
+async def test_camera_stream_with_disconnection(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: Callable[
+        [APIClient, list[EntityInfo], list[UserService], list[EntityState]],
+        Awaitable[MockESPHomeDevice],
+    ],
+    hass_client: ClientSessionGenerator,
+) -> None:
+    """Test a generic camera stream that goes unavailable during the request."""
+    entity_info = [
+        CameraInfo(
+            object_id="mycamera",
+            key=1,
+            name="my camera",
+            unique_id="my_camera",
+        )
+    ]
+    states = []
+    user_service = []
+    mock_device = await mock_esphome_device(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        user_service=user_service,
+        states=states,
+    )
+    state = hass.states.get("camera.test_my_camera")
+    assert state is not None
+    assert state.state == STATE_IDLE
+    remaining_responses = 3
+
+    async def _mock_camera_image():
+        nonlocal remaining_responses
+        if remaining_responses == 0:
+            return
+        if remaining_responses == 2:
+            await mock_device.mock_disconnect(False)
+        remaining_responses -= 1
+        mock_device.set_state(CameraState(key=1, data=SMALLEST_VALID_JPEG_BYTES))
+
+    mock_client.request_image_stream = _mock_camera_image
+    mock_client.request_single_image = _mock_camera_image
+
+    client = await hass_client()
+    await client.get("/api/camera_proxy_stream/camera.test_my_camera")
+    await hass.async_block_till_done()
+    state = hass.states.get("camera.test_my_camera")
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix ESPHome camera not accepting the same exact image bytes. We always want the camera image to be sent to the stream even if its the exact same bytes so the fetch unblocks.

This is unlikely to be a problem in production so I did not tag it for a patch/beta

Adds 100% coverage for the camera platform

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
