### PR TITLE
Deprecate mqtt vacuum with legacy schema

### DIFF
--- a/homeassistant/components/mqtt/strings.json
+++ b/homeassistant/components/mqtt/strings.json
@@ -6,7 +6,7 @@
     },
     "deprecation_mqtt_legacy_vacuum_discovery": {
       "title": "MQTT vacuum entities with legacy schema added through MQTT discovery",
-      "description": "MQTT vacuum entities that use the legacy schema are deprecated, please adjust your devices to use the correct schema."
+      "description": "MQTT vacuum entities that use the legacy schema are deprecated, please adjust your devices to use the correct schema and restart Home Assistant to fix this issue."
     }
   },
   "config": {

--- a/homeassistant/components/mqtt/strings.json
+++ b/homeassistant/components/mqtt/strings.json
@@ -1,4 +1,14 @@
 {
+  "issues": {
+    "deprecation_mqtt_legacy_vacuum_yaml": {
+      "title": "MQTT vacuum entities with legacy schema found in your configuration.yaml",
+      "description": "MQTT vacuum entities that use the legacy schema are deprecated, please adjust your configuration.yaml and restart Home Assistant to fix this issue."
+    },
+    "deprecation_mqtt_legacy_vacuum_discovery": {
+      "title": "MQTT vacuum entities with legacy schema added through MQTT discovery",
+      "description": "MQTT vacuum entities that use the legacy schema are deprecated, please adjust your devices to use the correct schema."
+    }
+  },
   "config": {
     "step": {
       "broker": {

--- a/homeassistant/components/mqtt/vacuum/__init__.py
+++ b/homeassistant/components/mqtt/vacuum/__init__.py
@@ -1,7 +1,7 @@
 """Support for MQTT vacuums."""
 
 # The legacy schema for MQTT vacuum was deprecated with HA Core 2023.7.0
-# and is will be removed with HA Core 2024.2.0
+# and will be removed with HA Core 2024.2.0
 
 from __future__ import annotations
 
@@ -37,7 +37,7 @@ MQTT_VACUUM_DOCS_URL = "https://www.home-assistant.io/integrations/vacuum.mqtt/"
 
 
 # The legacy schema for MQTT vacuum was deprecated with HA Core 2023.7.0
-# and is will be removed with HA Core 2024.2.0
+# and will be removed with HA Core 2024.2.0
 def warn_for_deprecation_legacy_schema(
     hass: HomeAssistant, config: ConfigType, discovery_data: DiscoveryInfoType | None
 ) -> None:
@@ -68,7 +68,7 @@ def validate_mqtt_vacuum_discovery(config_value: ConfigType) -> ConfigType:
     """Validate MQTT vacuum schema."""
 
     # The legacy schema for MQTT vacuum was deprecated with HA Core 2023.7.0
-    # and is will be removed with HA Core 2024.2.0
+    # and will be removed with HA Core 2024.2.0
 
     schemas = {LEGACY: DISCOVERY_SCHEMA_LEGACY, STATE: DISCOVERY_SCHEMA_STATE}
     config: ConfigType = schemas[config_value[CONF_SCHEMA]](config_value)
@@ -79,7 +79,7 @@ def validate_mqtt_vacuum_modern(config_value: ConfigType) -> ConfigType:
     """Validate MQTT vacuum modern schema."""
 
     # The legacy schema for MQTT vacuum was deprecated with HA Core 2023.7.0
-    # and is will be removed with HA Core 2024.2.0
+    # and will be removed with HA Core 2024.2.0
 
     schemas = {
         LEGACY: PLATFORM_SCHEMA_LEGACY_MODERN,
@@ -120,7 +120,7 @@ async def _async_setup_entity(
     """Set up the MQTT vacuum."""
 
     # The legacy schema for MQTT vacuum was deprecated with HA Core 2023.7.0
-    # and is will be removed with HA Core 2024.2.0
+    # and will be removed with HA Core 2024.2.0
     warn_for_deprecation_legacy_schema(hass, config, discovery_data)
     setup_entity = {
         LEGACY: async_setup_entity_legacy,

--- a/homeassistant/components/mqtt/vacuum/__init__.py
+++ b/homeassistant/components/mqtt/vacuum/__init__.py
@@ -66,6 +66,10 @@ def warn_for_deprecation_legacy_schema(
 
 def validate_mqtt_vacuum_discovery(config_value: ConfigType) -> ConfigType:
     """Validate MQTT vacuum schema."""
+
+    # The legacy schema for MQTT vacuum was deprecated with HA Core 2023.7.0
+    # and is will be removed with HA Core 2024.2.0
+
     schemas = {LEGACY: DISCOVERY_SCHEMA_LEGACY, STATE: DISCOVERY_SCHEMA_STATE}
     config: ConfigType = schemas[config_value[CONF_SCHEMA]](config_value)
     return config

--- a/homeassistant/components/mqtt/vacuum/__init__.py
+++ b/homeassistant/components/mqtt/vacuum/__init__.py
@@ -1,7 +1,12 @@
 """Support for MQTT vacuums."""
+
+# The legacy schema for MQTT vacuum was deprecated with HA Core 2023.7.0
+# and is will be removed with HA Core 2024.2.0
+
 from __future__ import annotations
 
 import functools
+import logging
 
 import voluptuous as vol
 
@@ -9,8 +14,10 @@ from homeassistant.components import vacuum
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
+from ..const import DOMAIN
 from ..mixins import async_setup_entry_helper
 from .schema import CONF_SCHEMA, LEGACY, MQTT_VACUUM_SCHEMA, STATE
 from .schema_legacy import (
@@ -24,6 +31,38 @@ from .schema_state import (
     async_setup_entity_state,
 )
 
+_LOGGER = logging.getLogger(__name__)
+
+MQTT_VACUUM_DOCS_URL = "https://www.home-assistant.io/integrations/vacuum.mqtt/"
+
+
+# The legacy schema for MQTT vacuum was deprecated with HA Core 2023.7.0
+# and is will be removed with HA Core 2024.2.0
+def warn_for_deprecation_legacy_schema(
+    hass: HomeAssistant, config: ConfigType, discovery_data: DiscoveryInfoType | None
+) -> None:
+    """Warn for deprecation of legacy schema."""
+    if config[CONF_SCHEMA] == STATE:
+        return
+
+    key_suffix = "yaml" if discovery_data is None else "discovery"
+    translation_key = f"deprecation_mqtt_legacy_vacuum_{key_suffix}"
+    async_create_issue(
+        hass,
+        DOMAIN,
+        translation_key,
+        breaks_in_ha_version="2024.2.0",
+        is_fixable=False,
+        is_persistent=True,
+        translation_key=translation_key,
+        learn_more_url=MQTT_VACUUM_DOCS_URL,
+        severity=IssueSeverity.WARNING,
+    )
+    _LOGGER.warning(
+        "Deprecated `legacy` schema detected for MQTT vacuum, expected `state` schema, config found: %s",
+        config,
+    )
+
 
 def validate_mqtt_vacuum_discovery(config_value: ConfigType) -> ConfigType:
     """Validate MQTT vacuum schema."""
@@ -34,6 +73,10 @@ def validate_mqtt_vacuum_discovery(config_value: ConfigType) -> ConfigType:
 
 def validate_mqtt_vacuum_modern(config_value: ConfigType) -> ConfigType:
     """Validate MQTT vacuum modern schema."""
+
+    # The legacy schema for MQTT vacuum was deprecated with HA Core 2023.7.0
+    # and is will be removed with HA Core 2024.2.0
+
     schemas = {
         LEGACY: PLATFORM_SCHEMA_LEGACY_MODERN,
         STATE: PLATFORM_SCHEMA_STATE_MODERN,
@@ -71,6 +114,10 @@ async def _async_setup_entity(
     discovery_data: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up the MQTT vacuum."""
+
+    # The legacy schema for MQTT vacuum was deprecated with HA Core 2023.7.0
+    # and is will be removed with HA Core 2024.2.0
+    warn_for_deprecation_legacy_schema(hass, config, discovery_data)
     setup_entity = {
         LEGACY: async_setup_entity_legacy,
         STATE: async_setup_entity_state,

--- a/homeassistant/components/mqtt/vacuum/__init__.py
+++ b/homeassistant/components/mqtt/vacuum/__init__.py
@@ -53,7 +53,6 @@ def warn_for_deprecation_legacy_schema(
         translation_key,
         breaks_in_ha_version="2024.2.0",
         is_fixable=False,
-        is_persistent=True,
         translation_key=translation_key,
         learn_more_url=MQTT_VACUUM_DOCS_URL,
         severity=IssueSeverity.WARNING,

--- a/homeassistant/components/mqtt/vacuum/__init__.py
+++ b/homeassistant/components/mqtt/vacuum/__init__.py
@@ -1,6 +1,6 @@
 """Support for MQTT vacuums."""
 
-# The legacy schema for MQTT vacuum was deprecated with HA Core 2023.7.0
+# The legacy schema for MQTT vacuum was deprecated with HA Core 2023.8.0
 # and will be removed with HA Core 2024.2.0
 
 from __future__ import annotations
@@ -36,7 +36,7 @@ _LOGGER = logging.getLogger(__name__)
 MQTT_VACUUM_DOCS_URL = "https://www.home-assistant.io/integrations/vacuum.mqtt/"
 
 
-# The legacy schema for MQTT vacuum was deprecated with HA Core 2023.7.0
+# The legacy schema for MQTT vacuum was deprecated with HA Core 2023.8.0
 # and will be removed with HA Core 2024.2.0
 def warn_for_deprecation_legacy_schema(
     hass: HomeAssistant, config: ConfigType, discovery_data: DiscoveryInfoType | None
@@ -66,7 +66,7 @@ def warn_for_deprecation_legacy_schema(
 def validate_mqtt_vacuum_discovery(config_value: ConfigType) -> ConfigType:
     """Validate MQTT vacuum schema."""
 
-    # The legacy schema for MQTT vacuum was deprecated with HA Core 2023.7.0
+    # The legacy schema for MQTT vacuum was deprecated with HA Core 2023.8.0
     # and will be removed with HA Core 2024.2.0
 
     schemas = {LEGACY: DISCOVERY_SCHEMA_LEGACY, STATE: DISCOVERY_SCHEMA_STATE}
@@ -77,7 +77,7 @@ def validate_mqtt_vacuum_discovery(config_value: ConfigType) -> ConfigType:
 def validate_mqtt_vacuum_modern(config_value: ConfigType) -> ConfigType:
     """Validate MQTT vacuum modern schema."""
 
-    # The legacy schema for MQTT vacuum was deprecated with HA Core 2023.7.0
+    # The legacy schema for MQTT vacuum was deprecated with HA Core 2023.8.0
     # and will be removed with HA Core 2024.2.0
 
     schemas = {
@@ -118,7 +118,7 @@ async def _async_setup_entity(
 ) -> None:
     """Set up the MQTT vacuum."""
 
-    # The legacy schema for MQTT vacuum was deprecated with HA Core 2023.7.0
+    # The legacy schema for MQTT vacuum was deprecated with HA Core 2023.8.0
     # and will be removed with HA Core 2024.2.0
     warn_for_deprecation_legacy_schema(hass, config, discovery_data)
     setup_entity = {

--- a/homeassistant/components/mqtt/vacuum/schema_legacy.py
+++ b/homeassistant/components/mqtt/vacuum/schema_legacy.py
@@ -1,4 +1,9 @@
-"""Support for Legacy MQTT vacuum."""
+"""Support for Legacy MQTT vacuum.
+
+The legacy schema for MQTT vacuum was deprecated with HA Core 2023.7.0
+and is will be removed with HA Core 2024.2.0
+"""
+
 from __future__ import annotations
 
 from collections.abc import Callable

--- a/homeassistant/components/mqtt/vacuum/schema_legacy.py
+++ b/homeassistant/components/mqtt/vacuum/schema_legacy.py
@@ -1,6 +1,6 @@
 """Support for Legacy MQTT vacuum.
 
-The legacy schema for MQTT vacuum was deprecated with HA Core 2023.7.0
+The legacy schema for MQTT vacuum was deprecated with HA Core 2023.8.0
 and is will be removed with HA Core 2024.2.0
 """
 

--- a/tests/components/mqtt/test_legacy_vacuum.py
+++ b/tests/components/mqtt/test_legacy_vacuum.py
@@ -1,4 +1,8 @@
 """The tests for the Legacy Mqtt vacuum platform."""
+
+# The legacy schema for MQTT vacuum was deprecated with HA Core 2023.8.0
+# and will be removed with HA Core 2024.2.0
+
 from copy import deepcopy
 import json
 from typing import Any


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Deprecate mqtt vacuum with legacy schema.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
