### PR TITLE
Revert "Remove airplay filter now that apple tv supports airplay 2"

### DIFF
--- a/homeassistant/components/apple_tv/manifest.json
+++ b/homeassistant/components/apple_tv/manifest.json
@@ -16,7 +16,24 @@
     "_touch-able._tcp.local.",
     "_appletv-v2._tcp.local.",
     "_hscp._tcp.local.",
-    "_airplay._tcp.local.",
+    {
+      "type": "_airplay._tcp.local.",
+      "properties": {
+        "model": "appletv*"
+      }
+    },
+    {
+      "type": "_airplay._tcp.local.",
+      "properties": {
+        "model": "audioaccessory*"
+      }
+    },
+    {
+      "type": "_airplay._tcp.local.",
+      "properties": {
+        "am": "airport*"
+      }
+    },
     {
       "type": "_raop._tcp.local.",
       "properties": {

--- a/homeassistant/generated/zeroconf.py
+++ b/homeassistant/generated/zeroconf.py
@@ -251,6 +251,21 @@ ZEROCONF = {
     "_airplay._tcp.local.": [
         {
             "domain": "apple_tv",
+            "properties": {
+                "model": "appletv*",
+            },
+        },
+        {
+            "domain": "apple_tv",
+            "properties": {
+                "model": "audioaccessory*",
+            },
+        },
+        {
+            "domain": "apple_tv",
+            "properties": {
+                "am": "airport*",
+            },
         },
         {
             "domain": "samsungtv",


### PR DESCRIPTION
Reverts home-assistant/core#94693

This is being reverted to get it out of the scope for the 2023.7 release.

Some of the issues/reasoning: 
- All Apple Airplay supported are discovered, even if we have (arguably) better native integrations available (Like Sonos, or Sony Bravia TVs).
- macOS is being discovered (but not supported), this is being addressed in #95189, but not there yet.
- The Apple TV integration is stepping out of its TV boundaries. The discussion is: Should we do that? Or, should Apple TV only work with Apple TV devices and should we investigate the possibility of creating a specific AirPlay integration instead?

fixes #95759 

