### PR TITLE
Revert "Remove unsupported services from tuya vacuum"

### DIFF
--- a/homeassistant/components/tuya/vacuum.py
+++ b/homeassistant/components/tuya/vacuum.py
@@ -150,6 +150,14 @@ class TuyaVacuumEntity(TuyaEntity, StateVacuumEntity):
             return None
         return TUYA_STATUS_TO_HA.get(status)
 
+    def turn_on(self, **kwargs: Any) -> None:
+        """Turn the device on."""
+        self._send_command([{"code": DPCode.POWER, "value": True}])
+
+    def turn_off(self, **kwargs: Any) -> None:
+        """Turn the device off."""
+        self._send_command([{"code": DPCode.POWER, "value": False}])
+
     def start(self, **kwargs: Any) -> None:
         """Start the device."""
         self._send_command([{"code": DPCode.POWER_GO, "value": True}])


### PR DESCRIPTION
Reverts home-assistant/core#95790

After some discussion with @MartinHjelmare on Discord, it seems like a better idea to deprecate the services in the same way as done here: <https://github.com/home-assistant/core/pull/95788>