### PR TITLE
Add slots to the StateMachine class

### DIFF
--- a/homeassistant/components/recorder/core.py
+++ b/homeassistant/components/recorder/core.py
@@ -553,10 +553,10 @@ class Recorder(threading.Thread):
         If the number of entities has increased, increase the size of the LRU
         cache to avoid thrashing.
         """
-        new_size = self.hass.states.async_entity_ids_count() * 2
-        self.state_attributes_manager.adjust_lru_size(new_size)
-        self.states_meta_manager.adjust_lru_size(new_size)
-        self.statistics_meta_manager.adjust_lru_size(new_size)
+        if new_size := self.hass.states.async_entity_ids_count() * 2:
+            self.state_attributes_manager.adjust_lru_size(new_size)
+            self.states_meta_manager.adjust_lru_size(new_size)
+            self.statistics_meta_manager.adjust_lru_size(new_size)
 
     @callback
     def async_periodic_statistics(self) -> None:

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1410,6 +1410,8 @@ class State:
 class StateMachine:
     """Helper class that tracks the state of different entities."""
 
+    __slots__ = ("_states", "_reservations", "_bus", "_loop")
+
     def __init__(self, bus: EventBus, loop: asyncio.events.AbstractEventLoop) -> None:
         """Initialize state machine."""
         self._states: dict[str, State] = {}

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -56,6 +56,10 @@ from homeassistant.components.recorder.services import (
     SERVICE_PURGE,
     SERVICE_PURGE_ENTITIES,
 )
+from homeassistant.components.recorder.table_managers import (
+    state_attributes as state_attributes_table_manager,
+    states_meta as states_meta_table_manager,
+)
 from homeassistant.components.recorder.util import session_scope
 from homeassistant.const import (
     EVENT_COMPONENT_LOADED,
@@ -91,6 +95,15 @@ from tests.common import (
     mock_platform,
 )
 from tests.typing import RecorderInstanceGenerator
+
+
+@pytest.fixture
+def small_cache_size() -> None:
+    """Patch the default cache size to 8."""
+    with patch.object(state_attributes_table_manager, "CACHE_SIZE", 8), patch.object(
+        states_meta_table_manager, "CACHE_SIZE", 8
+    ):
+        yield
 
 
 def _default_recorder(hass):
@@ -2022,13 +2035,10 @@ def test_deduplication_event_data_inside_commit_interval(
         assert all(event.data_id == first_data_id for event in events)
 
 
-# Patch CACHE_SIZE since otherwise
-# the CI can fail because the test takes too long to run
-@patch(
-    "homeassistant.components.recorder.table_managers.state_attributes.CACHE_SIZE", 5
-)
 def test_deduplication_state_attributes_inside_commit_interval(
-    hass_recorder: Callable[..., HomeAssistant], caplog: pytest.LogCaptureFixture
+    small_cache_size: None,
+    hass_recorder: Callable[..., HomeAssistant],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test deduplication of state attributes inside the commit interval."""
     hass = hass_recorder()
@@ -2306,16 +2316,15 @@ async def test_excluding_attributes_by_integration(
 
 
 async def test_lru_increases_with_many_entities(
-    recorder_mock: Recorder, hass: HomeAssistant
+    small_cache_size: None, recorder_mock: Recorder, hass: HomeAssistant
 ) -> None:
     """Test that the recorder's internal LRU cache increases with many entities."""
-    # We do not actually want to record 4096 entities so we mock the entity count
-    mock_entity_count = 4096
-    with patch.object(
-        hass.states, "async_entity_ids_count", return_value=mock_entity_count
-    ):
-        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=10))
-        await async_wait_recording_done(hass)
+    mock_entity_count = 16
+    for idx in range(mock_entity_count):
+        hass.states.async_set(f"test.entity{idx}", "on")
+
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=10))
+    await async_wait_recording_done(hass)
 
     assert (
         recorder_mock.state_attributes_manager._id_map.get_size()

--- a/tests/helpers/test_restore_state.py
+++ b/tests/helpers/test_restore_state.py
@@ -232,17 +232,21 @@ async def test_hass_starting(hass: HomeAssistant) -> None:
     entity.hass = hass
     entity.entity_id = "input_boolean.b1"
 
+    all_states = hass.states.async_all()
+    assert len(all_states) == 0
+    hass.states.async_set("input_boolean.b1", "on")
+
     # Mock that only b1 is present this run
-    states = [State("input_boolean.b1", "on")]
     with patch(
         "homeassistant.helpers.restore_state.Store.async_save"
-    ) as mock_write_data, patch.object(hass.states, "async_all", return_value=states):
+    ) as mock_write_data:
         state = await entity.async_get_last_state()
         await hass.async_block_till_done()
 
     assert state is not None
     assert state.entity_id == "input_boolean.b1"
     assert state.state == "on"
+    hass.states.async_remove("input_boolean.b1")
 
     # Assert that no data was written yet, since hass is still starting.
     assert not mock_write_data.called
@@ -293,15 +297,20 @@ async def test_dump_data(hass: HomeAssistant) -> None:
         "input_boolean.b5": StoredState(State("input_boolean.b5", "off"), None, now),
     }
 
+    for state in states:
+        hass.states.async_set(state.entity_id, state.state, state.attributes)
+
     with patch(
         "homeassistant.helpers.restore_state.Store.async_save"
-    ) as mock_write_data, patch.object(hass.states, "async_all", return_value=states):
+    ) as mock_write_data:
         await data.async_dump_states()
 
     assert mock_write_data.called
     args = mock_write_data.mock_calls[0][1]
     written_states = args[0]
 
+    for state in states:
+        hass.states.async_remove(state.entity_id)
     # b0 should not be written, since it didn't extend RestoreEntity
     # b1 should be written, since it is present in the current run
     # b2 should not be written, since it is not registered with the helper
@@ -319,9 +328,12 @@ async def test_dump_data(hass: HomeAssistant) -> None:
     # Test that removed entities are not persisted
     await entity.async_remove()
 
+    for state in states:
+        hass.states.async_set(state.entity_id, state.state, state.attributes)
+
     with patch(
         "homeassistant.helpers.restore_state.Store.async_save"
-    ) as mock_write_data, patch.object(hass.states, "async_all", return_value=states):
+    ) as mock_write_data:
         await data.async_dump_states()
 
     assert mock_write_data.called
@@ -355,10 +367,13 @@ async def test_dump_error(hass: HomeAssistant) -> None:
 
     data = async_get(hass)
 
+    for state in states:
+        hass.states.async_set(state.entity_id, state.state, state.attributes)
+
     with patch(
         "homeassistant.helpers.restore_state.Store.async_save",
         side_effect=HomeAssistantError,
-    ) as mock_write_data, patch.object(hass.states, "async_all", return_value=states):
+    ) as mock_write_data:
         await data.async_dump_states()
 
     assert mock_write_data.called


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add slots to the StateMachine class

Fixes all tests to avoid patching the state machine.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
