### PR TITLE
Add slots to core EventBus

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -973,6 +973,8 @@ _FilterableJobType = tuple[
 class EventBus:
     """Allow the firing of and listening for events."""
 
+    __slots__ = ("_listeners", "_match_all_listeners", "_hass")
+
     def __init__(self, hass: HomeAssistant) -> None:
         """Initialize a new event bus."""
         self._listeners: dict[str, list[_FilterableJobType]] = {}

--- a/tests/components/ffmpeg/test_init.py
+++ b/tests/components/ffmpeg/test_init.py
@@ -8,7 +8,11 @@ from homeassistant.components.ffmpeg import (
     SERVICE_START,
     SERVICE_STOP,
 )
-from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    EVENT_HOMEASSISTANT_START,
+    EVENT_HOMEASSISTANT_STOP,
+)
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.setup import async_setup_component, setup_component
 
@@ -54,7 +58,7 @@ class MockFFmpegDev(ffmpeg.FFmpegBase):
 
         self.hass = hass
         self.entity_id = entity_id
-        self.ffmpeg = MagicMock
+        self.ffmpeg = MagicMock()
         self.called_stop = False
         self.called_start = False
         self.called_restart = False
@@ -104,12 +108,18 @@ async def test_setup_component_test_register(hass: HomeAssistant) -> None:
     with assert_setup_component(1):
         await async_setup_component(hass, ffmpeg.DOMAIN, {ffmpeg.DOMAIN: {}})
 
-    hass.bus.async_listen_once = MagicMock()
     ffmpeg_dev = MockFFmpegDev(hass)
+    ffmpeg_dev._async_stop_ffmpeg = AsyncMock()
+    ffmpeg_dev._async_start_ffmpeg = AsyncMock()
     await ffmpeg_dev.async_added_to_hass()
 
-    assert hass.bus.async_listen_once.called
-    assert hass.bus.async_listen_once.call_count == 2
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
+    assert len(ffmpeg_dev._async_start_ffmpeg.mock_calls) == 2
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
+    await hass.async_block_till_done()
+    assert len(ffmpeg_dev._async_stop_ffmpeg.mock_calls) == 2
 
 
 async def test_setup_component_test_register_no_startup(hass: HomeAssistant) -> None:
@@ -117,12 +127,18 @@ async def test_setup_component_test_register_no_startup(hass: HomeAssistant) -> 
     with assert_setup_component(1):
         await async_setup_component(hass, ffmpeg.DOMAIN, {ffmpeg.DOMAIN: {}})
 
-    hass.bus.async_listen_once = MagicMock()
     ffmpeg_dev = MockFFmpegDev(hass, False)
+    ffmpeg_dev._async_stop_ffmpeg = AsyncMock()
+    ffmpeg_dev._async_start_ffmpeg = AsyncMock()
     await ffmpeg_dev.async_added_to_hass()
 
-    assert hass.bus.async_listen_once.called
-    assert hass.bus.async_listen_once.call_count == 1
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
+    assert len(ffmpeg_dev._async_start_ffmpeg.mock_calls) == 1
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
+    await hass.async_block_till_done()
+    assert len(ffmpeg_dev._async_stop_ffmpeg.mock_calls) == 2
 
 
 async def test_setup_component_test_service_start(hass: HomeAssistant) -> None:

--- a/tests/components/google_pubsub/test_init.py
+++ b/tests/components/google_pubsub/test_init.py
@@ -8,7 +8,7 @@ import pytest
 
 import homeassistant.components.google_pubsub as google_pubsub
 from homeassistant.components.google_pubsub import DateTimeJSONEncoder as victim
-from homeassistant.core import HomeAssistant, split_entity_id
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 GOOGLE_PUBSUB_PATH = "homeassistant.components.google_pubsub"
@@ -107,19 +107,6 @@ async def test_full_config(hass: HomeAssistant, mock_client) -> None:
     assert mock_client.from_service_account_json.call_args[0][0] == os.path.join(
         hass.config.config_dir, "creds"
     )
-
-
-def make_event(entity_id):
-    """Make a mock event for test."""
-    domain = split_entity_id(entity_id)[0]
-    state = mock.MagicMock(
-        state="not blank",
-        domain=domain,
-        entity_id=entity_id,
-        object_id="entity",
-        attributes={},
-    )
-    return mock.MagicMock(data={"new_state": state}, time_fired=12345)
 
 
 async def _setup(hass, filter_config):

--- a/tests/components/influxdb/test_init.py
+++ b/tests/components/influxdb/test_init.py
@@ -534,13 +534,6 @@ async def test_event_listener_states(
     await _setup(hass, mock_client, config_ext, get_write_api)
 
     for state_state in (1, "unknown", "", "unavailable"):
-        state = MagicMock(
-            state=state_state,
-            domain="fake",
-            entity_id="fake.entity_id",
-            object_id="entity_id",
-            attributes={},
-        )
         body = [
             {
                 "measurement": "fake.entity_id",
@@ -549,7 +542,7 @@ async def test_event_listener_states(
                 "fields": {"value": 1},
             }
         ]
-        hass.states.async_set(state.entity_id, state.state, state.attributes)
+        hass.states.async_set("fake.entity_id", state_state)
         await hass.async_block_till_done()
         hass.data[influxdb.DOMAIN].block_till_done()
 

--- a/tests/components/influxdb/test_init.py
+++ b/tests/components/influxdb/test_init.py
@@ -1407,14 +1407,6 @@ async def test_event_listener_backlog_full(
     """Test the event listener drops old events when backlog gets full."""
     await _setup(hass, mock_client, config_ext, get_write_api)
 
-    state = MagicMock(
-        state=1,
-        domain="fake",
-        entity_id="entity.id",
-        object_id="entity",
-        attributes={},
-    )
-
     monotonic_time = 0
 
     def fast_monotonic():
@@ -1424,7 +1416,7 @@ async def test_event_listener_backlog_full(
         return monotonic_time
 
     with patch("homeassistant.components.influxdb.time.monotonic", new=fast_monotonic):
-        hass.states.async_set(state.entity_id, state.state, state.attributes)
+        hass.states.async_set("entity.id", 1)
         await hass.async_block_till_done()
         hass.data[influxdb.DOMAIN].block_till_done()
 
@@ -1454,15 +1446,6 @@ async def test_event_listener_attribute_name_conflict(
 ) -> None:
     """Test the event listener when an attribute conflicts with another field."""
     await _setup(hass, mock_client, config_ext, get_write_api)
-
-    attrs = {"value": "value_str"}
-    state = MagicMock(
-        state=1,
-        domain="fake",
-        entity_id="fake.something",
-        object_id="something",
-        attributes=attrs,
-    )
     body = [
         {
             "measurement": "fake.something",
@@ -1471,7 +1454,7 @@ async def test_event_listener_attribute_name_conflict(
             "fields": {"value": 1, "value__str": "value_str"},
         }
     ]
-    hass.states.async_set(state.entity_id, state.state, state.attributes)
+    hass.states.async_set("fake.something", 1, {"value": "value_str"})
     await hass.async_block_till_done()
     hass.data[influxdb.DOMAIN].block_till_done()
 

--- a/tests/components/influxdb/test_init.py
+++ b/tests/components/influxdb/test_init.py
@@ -559,13 +559,6 @@ async def execute_filter_test(hass: HomeAssistant, tests, write_api, get_mock_ca
     """Execute all tests for a given filtering test."""
     for test in tests:
         domain, entity_id = split_entity_id(test.id)
-        state = MagicMock(
-            state=1,
-            domain=domain,
-            entity_id=test.id,
-            object_id=entity_id,
-            attributes={},
-        )
         body = [
             {
                 "measurement": test.id,
@@ -574,7 +567,7 @@ async def execute_filter_test(hass: HomeAssistant, tests, write_api, get_mock_ca
                 "fields": {"value": 1},
             }
         ]
-        hass.states.async_set(test.id, state.state, state.attributes)
+        hass.states.async_set(test.id, 1)
         await hass.async_block_till_done()
         hass.data[influxdb.DOMAIN].block_till_done()
 
@@ -1574,16 +1567,9 @@ async def test_invalid_inputs_error(
 
     write_api = get_write_api(mock_client)
     write_api.side_effect = test_exception
-    state = MagicMock(
-        state=1,
-        domain="fake",
-        entity_id="fake.something",
-        object_id="something",
-        attributes={},
-    )
 
     with patch(f"{INFLUX_PATH}.time.sleep") as sleep:
-        hass.states.async_set(state.entity_id, state.state, state.attributes)
+        hass.states.async_set("fake.something", 1)
         await hass.async_block_till_done()
         hass.data[influxdb.DOMAIN].block_till_done()
 
@@ -1673,16 +1659,6 @@ async def test_precision(
     await _setup(hass, mock_client, config, get_write_api)
 
     value = "1.9"
-    attrs = {
-        "unit_of_measurement": "foobars",
-    }
-    state = MagicMock(
-        state=value,
-        domain="fake",
-        entity_id="fake.entity_id",
-        object_id="entity",
-        attributes=attrs,
-    )
     body = [
         {
             "measurement": "foobars",
@@ -1691,7 +1667,13 @@ async def test_precision(
             "fields": {"value": float(value)},
         }
     ]
-    hass.states.async_set(state.entity_id, state.state, state.attributes)
+    hass.states.async_set(
+        "fake.entity_id",
+        value,
+        {
+            "unit_of_measurement": "foobars",
+        },
+    )
     await hass.async_block_till_done()
     hass.data[influxdb.DOMAIN].block_till_done()
 

--- a/tests/components/influxdb/test_init.py
+++ b/tests/components/influxdb/test_init.py
@@ -449,13 +449,6 @@ async def test_event_listener_no_units(
             attrs = {"unit_of_measurement": unit}
         else:
             attrs = {}
-        state = MagicMock(
-            state=1,
-            domain="fake",
-            entity_id="fake.entity_id",
-            object_id="entity_id",
-            attributes=attrs,
-        )
         body = [
             {
                 "measurement": "fake.entity_id",
@@ -464,7 +457,7 @@ async def test_event_listener_no_units(
                 "fields": {"value": 1},
             }
         ]
-        hass.states.async_set(state.entity_id, state.state, state.attributes)
+        hass.states.async_set("fake.entity_id", 1, attrs)
         await hass.async_block_till_done()
         hass.data[influxdb.DOMAIN].block_till_done()
 
@@ -499,13 +492,6 @@ async def test_event_listener_inf(
     await _setup(hass, mock_client, config_ext, get_write_api)
 
     attrs = {"bignumstring": "9" * 999, "nonumstring": "nan"}
-    state = MagicMock(
-        state=8,
-        domain="fake",
-        entity_id="fake.entity_id",
-        object_id="entity_id",
-        attributes=attrs,
-    )
     body = [
         {
             "measurement": "fake.entity_id",
@@ -514,7 +500,7 @@ async def test_event_listener_inf(
             "fields": {"value": 8},
         }
     ]
-    hass.states.async_set(state.entity_id, state.state, state.attributes)
+    hass.states.async_set("fake.entity_id", 8, attrs)
     await hass.async_block_till_done()
     hass.data[influxdb.DOMAIN].block_till_done()
 

--- a/tests/components/influxdb/test_init.py
+++ b/tests/components/influxdb/test_init.py
@@ -392,7 +392,6 @@ async def test_event_listener(
             object_id="entity_id",
             attributes=attrs,
         )
-        MagicMock(data={"new_state": state}, time_fired=12345)
         body = [
             {
                 "measurement": "foobars",
@@ -464,7 +463,6 @@ async def test_event_listener_no_units(
             object_id="entity_id",
             attributes=attrs,
         )
-        MagicMock(data={"new_state": state}, time_fired=12345)
         body = [
             {
                 "measurement": "fake.entity_id",
@@ -515,7 +513,6 @@ async def test_event_listener_inf(
         object_id="entity_id",
         attributes=attrs,
     )
-    MagicMock(data={"new_state": state}, time_fired=12345)
     body = [
         {
             "measurement": "fake.entity_id",
@@ -565,7 +562,6 @@ async def test_event_listener_states(
             object_id="entity_id",
             attributes={},
         )
-        MagicMock(data={"new_state": state}, time_fired=12345)
         body = [
             {
                 "measurement": "fake.entity_id",
@@ -598,7 +594,6 @@ async def execute_filter_test(hass: HomeAssistant, tests, write_api, get_mock_ca
             object_id=entity_id,
             attributes={},
         )
-        MagicMock(data={"new_state": state}, time_fired=12345)
         body = [
             {
                 "measurement": test.id,
@@ -960,7 +955,6 @@ async def test_event_listener_invalid_type(
             object_id="entity_id",
             attributes=attrs,
         )
-        MagicMock(data={"new_state": state}, time_fired=12345)
         body = [
             {
                 "measurement": "foobars",
@@ -1021,7 +1015,6 @@ async def test_event_listener_default_measurement(
         object_id="ok",
         attributes={},
     )
-    MagicMock(data={"new_state": state}, time_fired=12345)
     body = [
         {
             "measurement": "state",
@@ -1073,7 +1066,6 @@ async def test_event_listener_unit_of_measurement_field(
         object_id="entity_id",
         attributes=attrs,
     )
-    MagicMock(data={"new_state": state}, time_fired=12345)
     body = [
         {
             "measurement": "state",
@@ -1125,7 +1117,6 @@ async def test_event_listener_tags_attributes(
         object_id="something",
         attributes=attrs,
     )
-    MagicMock(data={"new_state": state}, time_fired=12345)
     body = [
         {
             "measurement": "fake.something",
@@ -1195,7 +1186,6 @@ async def test_event_listener_component_override_measurement(
             object_id=comp["id"],
             attributes={},
         )
-        MagicMock(data={"new_state": state}, time_fired=12345)
         body = [
             {
                 "measurement": comp["res"],
@@ -1269,7 +1259,6 @@ async def test_event_listener_component_measurement_attr(
             object_id=comp["id"],
             attributes=comp["attrs"],
         )
-        MagicMock(data={"new_state": state}, time_fired=12345)
         body = [
             {
                 "measurement": comp["res"],
@@ -1356,7 +1345,6 @@ async def test_event_listener_ignore_attributes(
                 "domain_ignore": 1,
             },
         )
-        MagicMock(data={"new_state": state}, time_fired=12345)
         fields = {"value": 1}
         fields.update(comp["attrs"])
         body = [
@@ -1413,7 +1401,6 @@ async def test_event_listener_ignore_attributes_overlapping_entities(
         object_id="fake",
         attributes={"ignore": 1},
     )
-    MagicMock(data={"new_state": state}, time_fired=12345)
     body = [
         {
             "measurement": "units",
@@ -1465,7 +1452,6 @@ async def test_event_listener_scheduled_write(
         object_id="entity_id",
         attributes={},
     )
-    MagicMock(data={"new_state": state}, time_fired=12345)
     write_api = get_write_api(mock_client)
     write_api.side_effect = OSError("foo")
 
@@ -1518,7 +1504,6 @@ async def test_event_listener_backlog_full(
         object_id="entity",
         attributes={},
     )
-    MagicMock(data={"new_state": state}, time_fired=12345)
 
     monotonic_time = 0
 
@@ -1568,7 +1553,6 @@ async def test_event_listener_attribute_name_conflict(
         object_id="something",
         attributes=attrs,
     )
-    MagicMock(data={"new_state": state}, time_fired=12345)
     body = [
         {
             "measurement": "fake.something",
@@ -1704,7 +1688,6 @@ async def test_invalid_inputs_error(
         object_id="something",
         attributes={},
     )
-    MagicMock(data={"new_state": state}, time_fired=12345)
 
     with patch(f"{INFLUX_PATH}.time.sleep") as sleep:
         hass.states.async_set(state.entity_id, state.state, state.attributes)
@@ -1807,7 +1790,6 @@ async def test_precision(
         object_id="entity",
         attributes=attrs,
     )
-    MagicMock(data={"new_state": state}, time_fired=12345)
     body = [
         {
             "measurement": "foobars",

--- a/tests/components/influxdb/test_init.py
+++ b/tests/components/influxdb/test_init.py
@@ -385,13 +385,6 @@ async def test_event_listener(
             "updated_at": datetime.datetime(2017, 1, 1, 0, 0),
             "multi_periods": "0.120.240.2023873",
         }
-        state = MagicMock(
-            state=in_,
-            domain="fake",
-            entity_id="fake.entity_id",
-            object_id="entity_id",
-            attributes=attrs,
-        )
         body = [
             {
                 "measurement": "foobars",
@@ -417,7 +410,7 @@ async def test_event_listener(
         if out[1] is not None:
             body[0]["fields"]["value"] = out[1]
 
-        hass.states.async_set(state.entity_id, state.state, state.attributes)
+        hass.states.async_set("fake.entity_id", in_, attrs)
         await hass.async_block_till_done()
         hass.data[influxdb.DOMAIN].block_till_done()
 
@@ -1007,14 +1000,6 @@ async def test_event_listener_default_measurement(
     config = {"default_measurement": "state"}
     config.update(config_ext)
     await _setup(hass, mock_client, config, get_write_api)
-
-    state = MagicMock(
-        state=1,
-        domain="fake",
-        entity_id="fake.ok",
-        object_id="ok",
-        attributes={},
-    )
     body = [
         {
             "measurement": "state",
@@ -1023,7 +1008,7 @@ async def test_event_listener_default_measurement(
             "fields": {"value": 1},
         }
     ]
-    hass.states.async_set(state.entity_id, state.state, state.attributes)
+    hass.states.async_set("fake.ok", 1)
     await hass.async_block_till_done()
     hass.data[influxdb.DOMAIN].block_till_done()
 
@@ -1059,13 +1044,6 @@ async def test_event_listener_unit_of_measurement_field(
     await _setup(hass, mock_client, config, get_write_api)
 
     attrs = {"unit_of_measurement": "foobars"}
-    state = MagicMock(
-        state="foo",
-        domain="fake",
-        entity_id="fake.entity_id",
-        object_id="entity_id",
-        attributes=attrs,
-    )
     body = [
         {
             "measurement": "state",
@@ -1074,7 +1052,7 @@ async def test_event_listener_unit_of_measurement_field(
             "fields": {"state": "foo", "unit_of_measurement_str": "foobars"},
         }
     ]
-    hass.states.async_set(state.entity_id, state.state, state.attributes)
+    hass.states.async_set("fake.entity_id", "foo", attrs)
     await hass.async_block_till_done()
     hass.data[influxdb.DOMAIN].block_till_done()
 
@@ -1110,13 +1088,6 @@ async def test_event_listener_tags_attributes(
     await _setup(hass, mock_client, config, get_write_api)
 
     attrs = {"friendly_fake": "tag_str", "field_fake": "field_str"}
-    state = MagicMock(
-        state=1,
-        domain="fake",
-        entity_id="fake.something",
-        object_id="something",
-        attributes=attrs,
-    )
     body = [
         {
             "measurement": "fake.something",
@@ -1129,7 +1100,7 @@ async def test_event_listener_tags_attributes(
             "fields": {"value": 1, "field_fake_str": "field_str"},
         }
     ]
-    hass.states.async_set(state.entity_id, state.state, state.attributes)
+    hass.states.async_set("fake.something", 1, attrs)
     await hass.async_block_till_done()
     hass.data[influxdb.DOMAIN].block_till_done()
 
@@ -1179,13 +1150,6 @@ async def test_event_listener_component_override_measurement(
         {"domain": "other", "id": "just_fake", "res": "other.just_fake"},
     ]
     for comp in test_components:
-        state = MagicMock(
-            state=1,
-            domain=comp["domain"],
-            entity_id=f"{comp['domain']}.{comp['id']}",
-            object_id=comp["id"],
-            attributes={},
-        )
         body = [
             {
                 "measurement": comp["res"],
@@ -1194,7 +1158,7 @@ async def test_event_listener_component_override_measurement(
                 "fields": {"value": 1},
             }
         ]
-        hass.states.async_set(state.entity_id, state.state, state.attributes)
+        hass.states.async_set(f"{comp['domain']}.{comp['id']}", 1)
         await hass.async_block_till_done()
         hass.data[influxdb.DOMAIN].block_till_done()
 

--- a/tests/components/logentries/test_init.py
+++ b/tests/components/logentries/test_init.py
@@ -1,10 +1,10 @@
 """The tests for the Logentries component."""
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import ANY, call, patch
 
 import pytest
 
 import homeassistant.components.logentries as logentries
-from homeassistant.const import EVENT_STATE_CHANGED, STATE_OFF, STATE_ON
+from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -12,19 +12,23 @@ from homeassistant.setup import async_setup_component
 async def test_setup_config_full(hass: HomeAssistant) -> None:
     """Test setup with all data."""
     config = {"logentries": {"token": "secret"}}
-    hass.bus.listen = MagicMock()
     assert await async_setup_component(hass, logentries.DOMAIN, config)
-    assert hass.bus.listen.called
-    assert hass.bus.listen.call_args_list[0][0][0] == EVENT_STATE_CHANGED
+
+    with patch("homeassistant.components.logentries.requests.post") as mock_post:
+        hass.states.async_set("fake.entity", STATE_ON)
+        await hass.async_block_till_done()
+        assert len(mock_post.mock_calls) == 1
 
 
 async def test_setup_config_defaults(hass: HomeAssistant) -> None:
     """Test setup with defaults."""
     config = {"logentries": {"token": "token"}}
-    hass.bus.listen = MagicMock()
     assert await async_setup_component(hass, logentries.DOMAIN, config)
-    assert hass.bus.listen.called
-    assert hass.bus.listen.call_args_list[0][0][0] == EVENT_STATE_CHANGED
+
+    with patch("homeassistant.components.logentries.requests.post") as mock_post:
+        hass.states.async_set("fake.entity", STATE_ON)
+        await hass.async_block_till_done()
+        assert len(mock_post.mock_calls) == 1
 
 
 @pytest.fixture
@@ -47,28 +51,24 @@ async def test_event_listener(hass: HomeAssistant, mock_dump, mock_requests) -> 
     mock_post = mock_requests.post
     mock_requests.exceptions.RequestException = Exception
     config = {"logentries": {"token": "token"}}
-    hass.bus.listen = MagicMock()
     assert await async_setup_component(hass, logentries.DOMAIN, config)
-    handler_method = hass.bus.listen.call_args_list[0][0][1]
 
     valid = {"1": 1, "1.0": 1.0, STATE_ON: 1, STATE_OFF: 0, "foo": "foo"}
     for in_, out in valid.items():
-        state = MagicMock(state=in_, domain="fake", object_id="entity", attributes={})
-        event = MagicMock(data={"new_state": state}, time_fired=12345)
-        body = [
-            {
-                "domain": "fake",
-                "entity_id": "entity",
-                "attributes": {},
-                "time": "12345",
-                "value": out,
-            }
-        ]
         payload = {
             "host": "https://webhook.logentries.com/noformat/logs/token",
-            "event": body,
+            "event": [
+                {
+                    "domain": "fake",
+                    "entity_id": "entity",
+                    "attributes": {},
+                    "time": ANY,
+                    "value": out,
+                }
+            ],
         }
-        handler_method(event)
+        hass.states.async_set("fake.entity", in_)
+        await hass.async_block_till_done()
         assert mock_post.call_count == 1
         assert mock_post.call_args == call(payload["host"], data=payload, timeout=10)
         mock_post.reset_mock()

--- a/tests/components/prometheus/test_init.py
+++ b/tests/components/prometheus/test_init.py
@@ -58,7 +58,7 @@ from homeassistant.const import (
     UnitOfEnergy,
     UnitOfTemperature,
 )
-from homeassistant.core import HomeAssistant, split_entity_id
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
@@ -1596,19 +1596,6 @@ async def test_full_config(hass: HomeAssistant, mock_client) -> None:
     }
     assert await async_setup_component(hass, prometheus.DOMAIN, config)
     await hass.async_block_till_done()
-
-
-def make_event(entity_id):
-    """Make a mock event for test."""
-    domain = split_entity_id(entity_id)[0]
-    state = mock.MagicMock(
-        state="not blank",
-        domain=domain,
-        entity_id=entity_id,
-        object_id="entity",
-        attributes={},
-    )
-    return mock.MagicMock(data={"new_state": state}, time_fired=12345)
 
 
 async def _setup(hass, filter_config):

--- a/tests/components/prometheus/test_init.py
+++ b/tests/components/prometheus/test_init.py
@@ -44,7 +44,6 @@ from homeassistant.const import (
     CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
     CONTENT_TYPE_TEXT_PLAIN,
     DEGREE,
-    EVENT_STATE_CHANGED,
     PERCENTAGE,
     STATE_CLOSED,
     STATE_CLOSING,
@@ -1568,23 +1567,13 @@ def mock_client_fixture():
         yield counter_client
 
 
-@pytest.fixture
-def mock_bus(hass):
-    """Mock the event bus listener."""
-    hass.bus.listen = mock.MagicMock()
-
-
-@pytest.mark.usefixtures("mock_bus")
 async def test_minimal_config(hass: HomeAssistant, mock_client) -> None:
     """Test the minimal config and defaults of component."""
     config = {prometheus.DOMAIN: {}}
     assert await async_setup_component(hass, prometheus.DOMAIN, config)
     await hass.async_block_till_done()
-    assert hass.bus.listen.called
-    assert hass.bus.listen.call_args_list[0][0][0] == EVENT_STATE_CHANGED
 
 
-@pytest.mark.usefixtures("mock_bus")
 async def test_full_config(hass: HomeAssistant, mock_client) -> None:
     """Test the full config of component."""
     config = {
@@ -1607,8 +1596,6 @@ async def test_full_config(hass: HomeAssistant, mock_client) -> None:
     }
     assert await async_setup_component(hass, prometheus.DOMAIN, config)
     await hass.async_block_till_done()
-    assert hass.bus.listen.called
-    assert hass.bus.listen.call_args_list[0][0][0] == EVENT_STATE_CHANGED
 
 
 def make_event(entity_id):
@@ -1629,13 +1616,11 @@ async def _setup(hass, filter_config):
     config = {prometheus.DOMAIN: {"filter": filter_config}}
     assert await async_setup_component(hass, prometheus.DOMAIN, config)
     await hass.async_block_till_done()
-    return hass.bus.listen.call_args_list[0][0][1]
 
 
-@pytest.mark.usefixtures("mock_bus")
 async def test_allowlist(hass: HomeAssistant, mock_client) -> None:
     """Test an allowlist only config."""
-    handler_method = await _setup(
+    await _setup(
         hass,
         {
             "include_domains": ["fake"],
@@ -1654,18 +1639,17 @@ async def test_allowlist(hass: HomeAssistant, mock_client) -> None:
     ]
 
     for test in tests:
-        event = make_event(test.id)
-        handler_method(event)
+        hass.states.async_set(test.id, "not blank")
+        await hass.async_block_till_done()
 
         was_called = mock_client.labels.call_count == 1
         assert test.should_pass == was_called
         mock_client.labels.reset_mock()
 
 
-@pytest.mark.usefixtures("mock_bus")
 async def test_denylist(hass: HomeAssistant, mock_client) -> None:
     """Test a denylist only config."""
-    handler_method = await _setup(
+    await _setup(
         hass,
         {
             "exclude_domains": ["fake"],
@@ -1684,18 +1668,17 @@ async def test_denylist(hass: HomeAssistant, mock_client) -> None:
     ]
 
     for test in tests:
-        event = make_event(test.id)
-        handler_method(event)
+        hass.states.async_set(test.id, "not blank")
+        await hass.async_block_till_done()
 
         was_called = mock_client.labels.call_count == 1
         assert test.should_pass == was_called
         mock_client.labels.reset_mock()
 
 
-@pytest.mark.usefixtures("mock_bus")
 async def test_filtered_denylist(hass: HomeAssistant, mock_client) -> None:
     """Test a denylist config with a filtering allowlist."""
-    handler_method = await _setup(
+    await _setup(
         hass,
         {
             "include_entities": ["fake.included", "test.excluded_test"],
@@ -1715,8 +1698,8 @@ async def test_filtered_denylist(hass: HomeAssistant, mock_client) -> None:
     ]
 
     for test in tests:
-        event = make_event(test.id)
-        handler_method(event)
+        hass.states.async_set(test.id, "not blank")
+        await hass.async_block_till_done()
 
         was_called = mock_client.labels.call_count == 1
         assert test.should_pass == was_called


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use slots in the EventBus

Fix all the tests that were patching the EventBus (and firing state change events with invalid entity ids)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
