### PR TITLE
Fix ESPHome alarm_control_panel when state is missing

### DIFF
--- a/homeassistant/components/esphome/alarm_control_panel.py
+++ b/homeassistant/components/esphome/alarm_control_panel.py
@@ -33,6 +33,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .entity import (
     EsphomeEntity,
+    esphome_state_property,
     platform_async_setup_entry,
 )
 from .enum_mapper import EsphomeEnumMapper
@@ -111,6 +112,7 @@ class EsphomeAlarmControlPanel(
         self._attr_code_arm_required = bool(static_info.requires_code_to_arm)
 
     @property
+    @esphome_state_property
     def state(self) -> str | None:
         """Return the state of the device."""
         return _ESPHOME_ACP_STATE_TO_HASS_STATE.from_esphome(self._state.state)

--- a/tests/components/esphome/test_alarm_control_panel.py
+++ b/tests/components/esphome/test_alarm_control_panel.py
@@ -24,6 +24,7 @@ from homeassistant.components.esphome.alarm_control_panel import EspHomeACPFeatu
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     STATE_ALARM_ARMED_AWAY,
+    STATE_UNKNOWN,
 )
 from homeassistant.core import HomeAssistant
 
@@ -209,3 +210,38 @@ async def test_generic_alarm_control_panel_no_code(
         [call(1, AlarmControlPanelCommand.DISARM, None)]
     )
     mock_client.alarm_control_panel_command.reset_mock()
+
+
+async def test_generic_alarm_control_panel_missing_state(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_generic_device_entry,
+) -> None:
+    """Test a generic alarm_control_panel entity that is missing state."""
+    entity_info = [
+        AlarmControlPanelInfo(
+            object_id="myalarm_control_panel",
+            key=1,
+            name="my alarm_control_panel",
+            unique_id="my_alarm_control_panel",
+            supported_features=EspHomeACPFeatures.ARM_AWAY
+            | EspHomeACPFeatures.ARM_CUSTOM_BYPASS
+            | EspHomeACPFeatures.ARM_HOME
+            | EspHomeACPFeatures.ARM_NIGHT
+            | EspHomeACPFeatures.ARM_VACATION
+            | EspHomeACPFeatures.TRIGGER,
+            requires_code=False,
+            requires_code_to_arm=False,
+        )
+    ]
+    states = []
+    user_service = []
+    await mock_generic_device_entry(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        user_service=user_service,
+        states=states,
+    )
+    state = hass.states.get("alarm_control_panel.test_my_alarm_control_panel")
+    assert state is not None
+    assert state.state == STATE_UNKNOWN


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
fixes #95835

The `esphome_state_property` decorator was missing

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
