### PR TITLE
Airthings BLE: Improve supported devices

### DIFF
--- a/homeassistant/components/airthings_ble/manifest.json
+++ b/homeassistant/components/airthings_ble/manifest.json
@@ -3,7 +3,20 @@
   "name": "Airthings BLE",
   "bluetooth": [
     {
-      "manufacturer_id": 820
+      "manufacturer_id": 820,
+      "service_uuid": "b42e1f6e-ade7-11e4-89d3-123b93f75cba"
+    },
+    {
+      "manufacturer_id": 820,
+      "service_uuid": "b42e4a8e-ade7-11e4-89d3-123b93f75cba"
+    },
+    {
+      "manufacturer_id": 820,
+      "service_uuid": "b42e1c08-ade7-11e4-89d3-123b93f75cba"
+    },
+    {
+      "manufacturer_id": 820,
+      "service_uuid": "b42e3882-ade7-11e4-89d3-123b93f75cba"
     }
   ],
   "codeowners": ["@vincegio"],

--- a/homeassistant/generated/bluetooth.py
+++ b/homeassistant/generated/bluetooth.py
@@ -9,6 +9,22 @@ BLUETOOTH: list[dict[str, bool | str | int | list[int]]] = [
     {
         "domain": "airthings_ble",
         "manufacturer_id": 820,
+        "service_uuid": "b42e1f6e-ade7-11e4-89d3-123b93f75cba",
+    },
+    {
+        "domain": "airthings_ble",
+        "manufacturer_id": 820,
+        "service_uuid": "b42e4a8e-ade7-11e4-89d3-123b93f75cba",
+    },
+    {
+        "domain": "airthings_ble",
+        "manufacturer_id": 820,
+        "service_uuid": "b42e1c08-ade7-11e4-89d3-123b93f75cba",
+    },
+    {
+        "domain": "airthings_ble",
+        "manufacturer_id": 820,
+        "service_uuid": "b42e3882-ade7-11e4-89d3-123b93f75cba",
     },
     {
         "connectable": False,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Not sure if it counts as a breaking change or not. This PR will filter out devices that does not support BLE syncing, e.g. View Plus and Hub. If the user already have added these devices, this could break it for them, but the devices have never given them any data. With this PR it will show an error that the device could not be setup.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Filter out devices not supporting BLE syncing. Supported devices:
* Wave gen. 1
* Wave Radon (previously Wave 2)
* Wave Mini
* Wave Plus

Not supported:
* View series (WiFi syncing, user need to use the cloud integration)
  * View Plus
  * View Radon
  * View Pollution
* Hub (no sensors)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #81830
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/28071

### Explanation for the added service UUIDs:
Each device/generation have it's own service UUID we can use. We still keep the `820` manufacturer ID, but we can add the services to filter out the devices we don't need.

`b42e1f6e-ade7-11e4-89d3-123b93f75cba`: Wave gen. 1
`b42e4a8e-ade7-11e4-89d3-123b93f75cba`: Wave Radon (rebranded, previously `Wave2` / `Wave gen 2`)
`b42e1c08-ade7-11e4-89d3-123b93f75cba`: Wave Plus
`b42e3882-ade7-11e4-89d3-123b93f75cba`: Wave Mini

I don't have any documentation, but I work for Airthings and have verified this against a 20+ Airthings BLE setup. Tested on macOS (development environment).

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
