### PR TITLE
Warn when changing multipan channel if there are not 2 known users

### DIFF
--- a/homeassistant/components/homeassistant_hardware/silabs_multiprotocol_addon.py
+++ b/homeassistant/components/homeassistant_hardware/silabs_multiprotocol_addon.py
@@ -522,23 +522,8 @@ class OptionsFlowHandler(config_entries.OptionsFlow, ABC):
         """Reconfigure the addon."""
         multipan_manager = await get_addon_manager(self.hass)
         active_platforms = await multipan_manager.async_active_platforms()
-        if len(active_platforms) == 0:
-            return await self.async_step_notify_no_multipan_user()
-        if len(active_platforms) == 1:
+        if set(active_platforms) != {"otbr", "zha"}:
             return await self.async_step_notify_unknown_multipan_user()
-        return await self.async_step_change_channel()
-
-    async def async_step_notify_no_multipan_user(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
-        """Notify that there may be unknown multipan platforms."""
-        if user_input is None:
-            return self.async_show_form(
-                step_id="notify_no_multipan_user",
-                description_placeholders={
-                    "known_platforms": ", ".join(["otbr", "zha"])
-                },
-            )
         return await self.async_step_change_channel()
 
     async def async_step_notify_unknown_multipan_user(

--- a/homeassistant/components/homeassistant_hardware/silabs_multiprotocol_addon.py
+++ b/homeassistant/components/homeassistant_hardware/silabs_multiprotocol_addon.py
@@ -138,6 +138,17 @@ class MultiprotocolAddonManager(AddonManager):
 
         return tasks
 
+    async def async_active_platforms(self) -> list[str]:
+        """Return a list of platforms using the multipan radio."""
+        active_platforms: list[str] = []
+
+        for integration_domain, platform in self._platforms.items():
+            if not await platform.async_using_multipan(self._hass):
+                continue
+            active_platforms.append(integration_domain)
+
+        return active_platforms
+
     @callback
     def async_get_channel(self) -> int | None:
         """Get the channel."""
@@ -510,7 +521,44 @@ class OptionsFlowHandler(config_entries.OptionsFlow, ABC):
     ) -> FlowResult:
         """Reconfigure the addon."""
         multipan_manager = await get_addon_manager(self.hass)
+        active_platforms = await multipan_manager.async_active_platforms()
+        if len(active_platforms) == 0:
+            return await self.async_step_notify_no_multipan_user()
+        if len(active_platforms) == 1:
+            return await self.async_step_notify_unknown_multipan_user()
+        return await self.async_step_change_channel()
 
+    async def async_step_notify_no_multipan_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Notify that there may be unknown multipan platforms."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="notify_no_multipan_user",
+            )
+        return await self.async_step_change_channel()
+
+    async def async_step_notify_unknown_multipan_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Notify that there may be unknown multipan platforms."""
+        multipan_manager = await get_addon_manager(self.hass)
+        active_platforms = await multipan_manager.async_active_platforms()
+
+        if user_input is None:
+            return self.async_show_form(
+                step_id="notify_unknown_multipan_user",
+                description_placeholders={
+                    "active_platforms": ", ".join(active_platforms)
+                },
+            )
+        return await self.async_step_change_channel()
+
+    async def async_step_change_channel(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Change the channel."""
+        multipan_manager = await get_addon_manager(self.hass)
         if user_input is None:
             channels = [str(x) for x in range(11, 27)]
             suggested_channel = DEFAULT_CHANNEL
@@ -529,7 +577,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow, ABC):
                 }
             )
             return self.async_show_form(
-                step_id="reconfigure_addon", data_schema=data_schema
+                step_id="change_channel", data_schema=data_schema
             )
 
         # Change the shared channel

--- a/homeassistant/components/homeassistant_hardware/silabs_multiprotocol_addon.py
+++ b/homeassistant/components/homeassistant_hardware/silabs_multiprotocol_addon.py
@@ -530,16 +530,9 @@ class OptionsFlowHandler(config_entries.OptionsFlow, ABC):
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Notify that there may be unknown multipan platforms."""
-        multipan_manager = await get_addon_manager(self.hass)
-        active_platforms = await multipan_manager.async_active_platforms()
-
         if user_input is None:
             return self.async_show_form(
                 step_id="notify_unknown_multipan_user",
-                description_placeholders={
-                    "active_platforms": ", ".join(active_platforms),
-                    "known_platforms": ", ".join(["otbr", "zha"]),
-                },
             )
         return await self.async_step_change_channel()
 

--- a/homeassistant/components/homeassistant_hardware/silabs_multiprotocol_addon.py
+++ b/homeassistant/components/homeassistant_hardware/silabs_multiprotocol_addon.py
@@ -535,6 +535,9 @@ class OptionsFlowHandler(config_entries.OptionsFlow, ABC):
         if user_input is None:
             return self.async_show_form(
                 step_id="notify_no_multipan_user",
+                description_placeholders={
+                    "known_platforms": ", ".join(["otbr", "zha"])
+                },
             )
         return await self.async_step_change_channel()
 
@@ -549,7 +552,8 @@ class OptionsFlowHandler(config_entries.OptionsFlow, ABC):
             return self.async_show_form(
                 step_id="notify_unknown_multipan_user",
                 description_placeholders={
-                    "active_platforms": ", ".join(active_platforms)
+                    "active_platforms": ", ".join(active_platforms),
+                    "known_platforms": ", ".join(["otbr", "zha"]),
                 },
             )
         return await self.async_step_change_channel()

--- a/homeassistant/components/homeassistant_hardware/strings.json
+++ b/homeassistant/components/homeassistant_hardware/strings.json
@@ -18,6 +18,12 @@
             "uninstall_addon": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::uninstall_addon::title%]"
           }
         },
+        "change_channel": {
+          "title": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::reconfigure_addon::title%]",
+          "data": {
+            "channel": "Channel"
+          }
+        },
         "install_addon": {
           "title": "The Silicon Labs Multiprotocol add-on installation has started"
         },
@@ -25,11 +31,16 @@
           "title": "Channel change initiated",
           "description": "A Zigbee and Thread channel change has been initiated and will finish in {delay_minutes} minutes."
         },
+        "notify_no_multipan_user": {
+          "title": "Manual configuration may be needed",
+          "description": "Home Assistant found nothing using the IEEE 802.15.4 radio. If you have configured a service to use the radio yourself, for example Zigbee2MQTT, you will have to reconfigure the channel in that service after completing this guide."
+        },
+        "notify_unknown_multipan_user": {
+          "title": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::notify_no_multipan_user::title%]",
+          "description": "Home Assistant found '{active_platforms} using the IEEE 802.15.4 radio. If you have configured a service to use the radio yourself, for example Zigbee2MQTT, you will have to reconfigure the channel in that service after completing this guide."
+        },
         "reconfigure_addon": {
-          "title": "Reconfigure IEEE 802.15.4 radio multiprotocol support",
-          "data": {
-            "channel": "Channel"
-          }
+          "title": "Reconfigure IEEE 802.15.4 radio multiprotocol support"
         },
         "show_revert_guide": {
           "title": "Multiprotocol support is enabled for this device",

--- a/homeassistant/components/homeassistant_hardware/strings.json
+++ b/homeassistant/components/homeassistant_hardware/strings.json
@@ -33,11 +33,11 @@
         },
         "notify_no_multipan_user": {
           "title": "Manual configuration may be needed",
-          "description": "Home Assistant found nothing using the IEEE 802.15.4 radio. If you have configured a service to use the radio yourself, for example Zigbee2MQTT, you will have to reconfigure the channel in that service after completing this guide."
+          "description": "Home Assistant found no integrations using the IEEE 802.15.4 radio. If you have configured an integration other than {known_platforms} to use the radio yourself, for example Zigbee2MQTT, you will have to reconfigure the channel in that integration after completing this guide."
         },
         "notify_unknown_multipan_user": {
           "title": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::notify_no_multipan_user::title%]",
-          "description": "Home Assistant found '{active_platforms} using the IEEE 802.15.4 radio. If you have configured a service to use the radio yourself, for example Zigbee2MQTT, you will have to reconfigure the channel in that service after completing this guide."
+          "description": "Home Assistant found integrations {active_platforms} using the IEEE 802.15.4 radio, expected to find all of {known_platforms}. If you have configured an integration to use the radio yourself, for example Zigbee2MQTT, you will have to reconfigure the channel in that integration after completing this guide."
         },
         "reconfigure_addon": {
           "title": "Reconfigure IEEE 802.15.4 radio multiprotocol support"

--- a/homeassistant/components/homeassistant_hardware/strings.json
+++ b/homeassistant/components/homeassistant_hardware/strings.json
@@ -31,13 +31,9 @@
           "title": "Channel change initiated",
           "description": "A Zigbee and Thread channel change has been initiated and will finish in {delay_minutes} minutes."
         },
-        "notify_no_multipan_user": {
-          "title": "Manual configuration may be needed",
-          "description": "Home Assistant found no integrations using the IEEE 802.15.4 radio. If you have configured an integration other than {known_platforms} to use the radio yourself, for example Zigbee2MQTT, you will have to reconfigure the channel in that integration after completing this guide."
-        },
         "notify_unknown_multipan_user": {
-          "title": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::notify_no_multipan_user::title%]",
-          "description": "Home Assistant found integration {active_platforms} using the IEEE 802.15.4 radio, expected to find all of {known_platforms}. If you have configured an integration to use the radio yourself, for example Zigbee2MQTT, you will have to reconfigure the channel in that integration after completing this guide."
+          "title": "Manual configuration may be needed",
+          "description": "Home Assistant can automatically change the channels for otbr and zha. If you have configured another integration to use the radio, for example Zigbee2MQTT, you will have to reconfigure the channel in that integration after completing this guide."
         },
         "reconfigure_addon": {
           "title": "Reconfigure IEEE 802.15.4 radio multiprotocol support"

--- a/homeassistant/components/homeassistant_hardware/strings.json
+++ b/homeassistant/components/homeassistant_hardware/strings.json
@@ -37,7 +37,7 @@
         },
         "notify_unknown_multipan_user": {
           "title": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::notify_no_multipan_user::title%]",
-          "description": "Home Assistant found integrations {active_platforms} using the IEEE 802.15.4 radio, expected to find all of {known_platforms}. If you have configured an integration to use the radio yourself, for example Zigbee2MQTT, you will have to reconfigure the channel in that integration after completing this guide."
+          "description": "Home Assistant found integration {active_platforms} using the IEEE 802.15.4 radio, expected to find all of {known_platforms}. If you have configured an integration to use the radio yourself, for example Zigbee2MQTT, you will have to reconfigure the channel in that integration after completing this guide."
         },
         "reconfigure_addon": {
           "title": "Reconfigure IEEE 802.15.4 radio multiprotocol support"

--- a/homeassistant/components/homeassistant_sky_connect/strings.json
+++ b/homeassistant/components/homeassistant_sky_connect/strings.json
@@ -17,6 +17,12 @@
           "uninstall_addon": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::addon_menu::menu_options::uninstall_addon%]"
         }
       },
+      "change_channel": {
+        "title": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::change_channel::title%]",
+        "data": {
+          "channel": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::change_channel::data::channel%]"
+        }
+      },
       "install_addon": {
         "title": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::install_addon::title%]"
       },
@@ -24,11 +30,16 @@
         "title": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::notify_channel_change::title%]",
         "description": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::notify_channel_change::description%]"
       },
+      "notify_no_multipan_user": {
+        "title": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::notify_no_multipan_user::title%]",
+        "description": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::notify_no_multipan_user::description%]"
+      },
+      "notify_unknown_multipan_user": {
+        "title": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::notify_unknown_multipan_user::title%]",
+        "description": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::notify_unknown_multipan_user::description%]"
+      },
       "reconfigure_addon": {
-        "title": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::reconfigure_addon::title%]",
-        "data": {
-          "channel": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::reconfigure_addon::data::channel%]"
-        }
+        "title": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::reconfigure_addon::title%]"
       },
       "show_revert_guide": {
         "title": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::show_revert_guide::title%]",

--- a/homeassistant/components/homeassistant_sky_connect/strings.json
+++ b/homeassistant/components/homeassistant_sky_connect/strings.json
@@ -30,10 +30,6 @@
         "title": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::notify_channel_change::title%]",
         "description": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::notify_channel_change::description%]"
       },
-      "notify_no_multipan_user": {
-        "title": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::notify_no_multipan_user::title%]",
-        "description": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::notify_no_multipan_user::description%]"
-      },
       "notify_unknown_multipan_user": {
         "title": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::notify_unknown_multipan_user::title%]",
         "description": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::notify_unknown_multipan_user::description%]"

--- a/homeassistant/components/homeassistant_yellow/strings.json
+++ b/homeassistant/components/homeassistant_yellow/strings.json
@@ -44,10 +44,6 @@
           "multipan_settings": "Configure IEEE 802.15.4 radio multiprotocol support"
         }
       },
-      "notify_no_multipan_user": {
-        "title": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::notify_no_multipan_user::title%]",
-        "description": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::notify_no_multipan_user::description%]"
-      },
       "notify_unknown_multipan_user": {
         "title": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::notify_unknown_multipan_user::title%]",
         "description": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::notify_unknown_multipan_user::description%]"

--- a/homeassistant/components/homeassistant_yellow/strings.json
+++ b/homeassistant/components/homeassistant_yellow/strings.json
@@ -17,6 +17,12 @@
           "uninstall_addon": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::addon_menu::menu_options::uninstall_addon%]"
         }
       },
+      "change_channel": {
+        "title": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::change_channel::title%]",
+        "data": {
+          "channel": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::change_channel::data::channel%]"
+        }
+      },
       "hardware_settings": {
         "title": "Configure hardware settings",
         "data": {
@@ -38,6 +44,14 @@
           "multipan_settings": "Configure IEEE 802.15.4 radio multiprotocol support"
         }
       },
+      "notify_no_multipan_user": {
+        "title": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::notify_no_multipan_user::title%]",
+        "description": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::notify_no_multipan_user::description%]"
+      },
+      "notify_unknown_multipan_user": {
+        "title": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::notify_unknown_multipan_user::title%]",
+        "description": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::notify_unknown_multipan_user::description%]"
+      },
       "reboot_menu": {
         "title": "Reboot required",
         "description": "The settings have changed, but the new settings will not take effect until the system is rebooted",
@@ -47,10 +61,7 @@
         }
       },
       "reconfigure_addon": {
-        "title": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::reconfigure_addon::title%]",
-        "data": {
-          "channel": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::reconfigure_addon::data::channel%]"
-        }
+        "title": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::reconfigure_addon::title%]"
       },
       "show_revert_guide": {
         "title": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::show_revert_guide::title%]",

--- a/tests/components/homeassistant_hardware/test_silabs_multiprotocol_addon.py
+++ b/tests/components/homeassistant_hardware/test_silabs_multiprotocol_addon.py
@@ -506,6 +506,7 @@ async def test_option_flow_addon_installed_same_device_reconfigure_no_user(
     )
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "notify_no_multipan_user"
+    assert result["description_placeholders"] == {"known_platforms": "otbr, zha"}
 
     result = await hass.config_entries.options.async_configure(result["flow_id"], {})
     assert result["type"] == FlowResultType.FORM
@@ -567,7 +568,10 @@ async def test_option_flow_addon_installed_same_device_reconfigure_single_user(
     )
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "notify_unknown_multipan_user"
-    assert result["description_placeholders"] == {"active_platforms": "test"}
+    assert result["description_placeholders"] == {
+        "active_platforms": "test",
+        "known_platforms": "otbr, zha",
+    }
 
     result = await hass.config_entries.options.async_configure(result["flow_id"], {})
     assert result["type"] == FlowResultType.FORM

--- a/tests/components/homeassistant_hardware/test_silabs_multiprotocol_addon.py
+++ b/tests/components/homeassistant_hardware/test_silabs_multiprotocol_addon.py
@@ -138,17 +138,6 @@ def mock_multiprotocol_platform(
     return platform
 
 
-@pytest.fixture
-def mock_multiprotocol_platform_2(
-    hass: HomeAssistant,
-) -> Generator[FakeConfigFlow, None, None]:
-    """Fixture for a test silabs multiprotocol platform."""
-    hass.config.components.add(TEST_DOMAIN_2)
-    platform = MockMultiprotocolPlatform()
-    mock_platform(hass, f"{TEST_DOMAIN_2}.silabs_multiprotocol", platform)
-    return platform
-
-
 def get_suggested(schema, key):
     """Get suggested value for key in voluptuous schema."""
     for k in schema:
@@ -468,68 +457,7 @@ async def test_option_flow_addon_installed_other_device(
 @pytest.mark.parametrize(
     ("configured_channel", "suggested_channel"), [(None, "15"), (11, "11")]
 )
-async def test_option_flow_addon_installed_same_device_reconfigure_no_user(
-    hass: HomeAssistant,
-    addon_info,
-    addon_store_info,
-    addon_installed,
-    configured_channel: int | None,
-    suggested_channel: int,
-) -> None:
-    """Test reconfiguring the multi pan addon."""
-    mock_integration(hass, MockModule("hassio"))
-    addon_info.return_value["options"]["device"] = "/dev/ttyTEST123"
-
-    multipan_manager = await silabs_multiprotocol_addon.get_addon_manager(hass)
-    multipan_manager._channel = configured_channel
-
-    # Setup the config entry
-    config_entry = MockConfigEntry(
-        data={},
-        domain=TEST_DOMAIN,
-        options={},
-        title="Test HW",
-    )
-    config_entry.add_to_hass(hass)
-
-    with patch(
-        "homeassistant.components.homeassistant_hardware.silabs_multiprotocol_addon.is_hassio",
-        side_effect=Mock(return_value=True),
-    ):
-        result = await hass.config_entries.options.async_init(config_entry.entry_id)
-        assert result["type"] == FlowResultType.MENU
-        assert result["step_id"] == "addon_menu"
-
-    result = await hass.config_entries.options.async_configure(
-        result["flow_id"],
-        {"next_step_id": "reconfigure_addon"},
-    )
-    assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == "notify_no_multipan_user"
-    assert result["description_placeholders"] == {"known_platforms": "otbr, zha"}
-
-    result = await hass.config_entries.options.async_configure(result["flow_id"], {})
-    assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == "change_channel"
-    assert get_suggested(result["data_schema"].schema, "channel") == suggested_channel
-
-    result = await hass.config_entries.options.async_configure(
-        result["flow_id"], {"channel": "14"}
-    )
-    assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == "notify_channel_change"
-    assert result["description_placeholders"] == {"delay_minutes": "5"}
-
-    result = await hass.config_entries.options.async_configure(result["flow_id"], {})
-    assert result["type"] == FlowResultType.CREATE_ENTRY
-
-    assert multipan_manager._channel == 14
-
-
-@pytest.mark.parametrize(
-    ("configured_channel", "suggested_channel"), [(None, "15"), (11, "11")]
-)
-async def test_option_flow_addon_installed_same_device_reconfigure_single_user(
+async def test_option_flow_addon_installed_same_device_reconfigure_unexpected_users(
     hass: HomeAssistant,
     addon_info,
     addon_store_info,
@@ -595,13 +523,11 @@ async def test_option_flow_addon_installed_same_device_reconfigure_single_user(
 @pytest.mark.parametrize(
     ("configured_channel", "suggested_channel"), [(None, "15"), (11, "11")]
 )
-async def test_option_flow_addon_installed_same_device_reconfigure_two_users(
+async def test_option_flow_addon_installed_same_device_reconfigure_expected_users(
     hass: HomeAssistant,
     addon_info,
     addon_store_info,
     addon_installed,
-    mock_multiprotocol_platform: MockMultiprotocolPlatform,
-    mock_multiprotocol_platform_2: MockMultiprotocolPlatform,
     configured_channel: int | None,
     suggested_channel: int,
 ) -> None:
@@ -621,13 +547,19 @@ async def test_option_flow_addon_installed_same_device_reconfigure_two_users(
     )
     config_entry.add_to_hass(hass)
 
-    config_entry_2 = MockConfigEntry(
-        data={},
-        domain=TEST_DOMAIN_2,
-        options={},
-        title="Test HW",
-    )
-    config_entry_2.add_to_hass(hass)
+    mock_multiprotocol_platforms = {}
+    for domain in ["otbr", "zha"]:
+        mock_multiprotocol_platform = MockMultiprotocolPlatform()
+        mock_multiprotocol_platforms[domain] = mock_multiprotocol_platform
+        mock_multiprotocol_platform.channel = configured_channel
+        mock_multiprotocol_platform.using_multipan = True
+
+        hass.config.components.add(domain)
+        mock_platform(
+            hass, f"{domain}.silabs_multiprotocol", mock_multiprotocol_platform
+        )
+        hass.bus.async_fire(EVENT_COMPONENT_LOADED, {ATTR_COMPONENT: domain})
+    await hass.async_block_till_done()
 
     with patch(
         "homeassistant.components.homeassistant_hardware.silabs_multiprotocol_addon.is_hassio",
@@ -655,8 +587,8 @@ async def test_option_flow_addon_installed_same_device_reconfigure_two_users(
     result = await hass.config_entries.options.async_configure(result["flow_id"], {})
     assert result["type"] == FlowResultType.CREATE_ENTRY
 
-    assert mock_multiprotocol_platform.change_channel_calls == [(14, 300)]
-    assert mock_multiprotocol_platform_2.change_channel_calls == [(14, 300)]
+    for domain in ["otbr", "zha"]:
+        assert mock_multiprotocol_platforms[domain].change_channel_calls == [(14, 300)]
     assert multipan_manager._channel == 14
 
 
@@ -1190,6 +1122,6 @@ async def test_active_plaforms(
             hass, f"{domain}.silabs_multiprotocol", mock_multiprotocol_platform
         )
         hass.bus.async_fire(EVENT_COMPONENT_LOADED, {ATTR_COMPONENT: domain})
-        await hass.async_block_till_done()
 
+    await hass.async_block_till_done()
     assert await multipan_manager.async_active_platforms() == active_platforms

--- a/tests/components/homeassistant_hardware/test_silabs_multiprotocol_addon.py
+++ b/tests/components/homeassistant_hardware/test_silabs_multiprotocol_addon.py
@@ -496,10 +496,6 @@ async def test_option_flow_addon_installed_same_device_reconfigure_unexpected_us
     )
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "notify_unknown_multipan_user"
-    assert result["description_placeholders"] == {
-        "active_platforms": "test",
-        "known_platforms": "otbr, zha",
-    }
 
     result = await hass.config_entries.options.async_configure(result["flow_id"], {})
     assert result["type"] == FlowResultType.FORM


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Notify user that manual configuartion may be needed when changing multipan channel if there are not 2 known users (otbr + zha)

The purpose is to notify a user who may be using otbr together with a zigbee integration other than ZHA, for example zigbee2mqtt

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
