### PR TITLE
Migrate bracketed IP addresses in ZHA config entry

### DIFF
--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -41,9 +41,7 @@ from .core.const import (
 )
 from .core.discovery import GROUP_PROBE
 
-BRACKETED_IP_ADDRESS_REGEX = re.compile(
-    r"^socket://\[(?P<host>\d+\.\d+\.\d+\.\d+)\]:(?P<port>\d+)$"
-)
+BRACKETED_IP_ADDRESS_REGEX = re.compile(r"^(socket|tcp)://\[\d+\.\d+\.\d+\.\d+\]:\d+$")
 
 DEVICE_CONFIG_SCHEMA_ENTRY = vol.Schema({vol.Optional(CONF_TYPE): cv.string})
 ZHA_CONFIG_SCHEMA = {

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -41,8 +41,6 @@ from .core.const import (
 )
 from .core.discovery import GROUP_PROBE
 
-BRACKETED_IP_ADDRESS_REGEX = re.compile(r"^(socket|tcp)://\[\d+\.\d+\.\d+\.\d+\]:\d+$")
-
 DEVICE_CONFIG_SCHEMA_ENTRY = vol.Schema({vol.Optional(CONF_TYPE): cv.string})
 ZHA_CONFIG_SCHEMA = {
     vol.Optional(CONF_BAUDRATE): cv.positive_int,
@@ -99,7 +97,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     path = config_entry.data[CONF_DEVICE][CONF_DEVICE_PATH]
     data = copy.deepcopy(dict(config_entry.data))
 
-    if BRACKETED_IP_ADDRESS_REGEX.match(path):
+    if re.match(r"^(socket|tcp)://\[\d+\.\d+\.\d+\.\d+\]:\d+$", path):
         data[CONF_DEVICE][CONF_DEVICE_PATH] = path.replace("[", "").replace("]", "")
         hass.config_entries.async_update_entry(config_entry, data=data)
 

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -86,6 +86,19 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
+def _clean_serial_port_path(path: str) -> str:
+    """Clean the serial port path, applying corrections where necessary."""
+
+    if path.startswith("socket://"):
+        path = path.strip()
+
+    # Removes extraneous brackets from IP addresses (they don't parse in CPython 3.11.4)
+    if re.match(r"^socket://\[\d+\.\d+\.\d+\.\d+\]:\d+$", path):
+        path = path.replace("[", "").replace("]", "")
+
+    return path
+
+
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Set up ZHA.
 
@@ -95,10 +108,12 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     # Remove brackets around IP addresses, this no longer works in CPython 3.11.4
     # This will be removed in 2023.11.0
     path = config_entry.data[CONF_DEVICE][CONF_DEVICE_PATH]
+    cleaned_path = _clean_serial_port_path(path)
     data = copy.deepcopy(dict(config_entry.data))
 
-    if re.match(r"^(socket|tcp)://\[\d+\.\d+\.\d+\.\d+\]:\d+$", path):
-        data[CONF_DEVICE][CONF_DEVICE_PATH] = path.replace("[", "").replace("]", "")
+    if path != cleaned_path:
+        _LOGGER.debug("Cleaned serial port path %r -> %r", path, cleaned_path)
+        data[CONF_DEVICE][CONF_DEVICE_PATH] = cleaned_path
         hass.config_entries.async_update_entry(config_entry, data=data)
 
     zha_data = hass.data.setdefault(DATA_ZHA, {})

--- a/tests/components/zha/test_init.py
+++ b/tests/components/zha/test_init.py
@@ -114,20 +114,27 @@ async def test_config_depreciation(hass: HomeAssistant, zha_config) -> None:
 @pytest.mark.parametrize(
     ("path", "cleaned_path"),
     [
+        # No corrections
         ("/dev/path1", "/dev/path1"),
         ("/dev/path1[asd]", "/dev/path1[asd]"),
+        ("/dev/path1 ", "/dev/path1 "),
         ("socket://1.2.3.4:5678", "socket://1.2.3.4:5678"),
+        # Brackets around URI
         ("socket://[1.2.3.4]:5678", "socket://1.2.3.4:5678"),
+        # Spaces
+        ("socket://dev/path1 ", "socket://dev/path1"),
+        # Both
+        ("socket://[1.2.3.4]:5678 ", "socket://1.2.3.4:5678"),
     ],
 )
 @patch("homeassistant.components.zha.setup_quirks", Mock(return_value=True))
 @patch(
     "homeassistant.components.zha.websocket_api.async_load_api", Mock(return_value=True)
 )
-async def test_setup_with_v3_brackets_in_uri(
+async def test_setup_with_v3_cleaning_uri(
     hass: HomeAssistant, path: str, cleaned_path: str
 ) -> None:
-    """Test migration of config entry from v3 with brackets around the IP address."""
+    """Test migration of config entry from v3, applying corrections to the port path."""
     config_entry_v3 = MockConfigEntry(
         domain=DOMAIN,
         data={

--- a/tests/components/zha/test_init.py
+++ b/tests/components/zha/test_init.py
@@ -115,18 +115,19 @@ async def test_config_depreciation(hass: HomeAssistant, zha_config) -> None:
     ("path", "cleaned_path"),
     [
         ("/dev/path1", "/dev/path1"),
-        ("/dev/path1 ", "/dev/path1 "),
-        ("socket://dev/path1 ", "socket://dev/path1"),
+        ("/dev/path1[asd]", "/dev/path1[asd]"),
+        ("socket://1.2.3.4:5678", "socket://1.2.3.4:5678"),
+        ("socket://[1.2.3.4]:5678", "socket://1.2.3.4:5678"),
     ],
 )
 @patch("homeassistant.components.zha.setup_quirks", Mock(return_value=True))
 @patch(
     "homeassistant.components.zha.websocket_api.async_load_api", Mock(return_value=True)
 )
-async def test_setup_with_v3_spaces_in_uri(
+async def test_setup_with_v3_brackets_in_uri(
     hass: HomeAssistant, path: str, cleaned_path: str
 ) -> None:
-    """Test migration of config entry from v3 with spaces after `socket://` URI."""
+    """Test migration of config entry from v3 with brackets around the IP address."""
     config_entry_v3 = MockConfigEntry(
         domain=DOMAIN,
         data={


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
CPython 3.11.4 exposed a URI parsing bug in previous versions (https://github.com/python/cpython/issues/103848) that allowed for bracketed IP addresses like `socket://[1.2.3.4]:5678` to erroneously be parsed correctly. This PR automatically fixes these URIs (and also removes stale migration code scheduled to be removed in 2023.7.0).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #94733
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
