### PR TITLE
Migrate from deprecated VacuumEntity to StateVacuumEntity in Ecovacs

### DIFF
--- a/homeassistant/components/ecovacs/vacuum.py
+++ b/homeassistant/components/ecovacs/vacuum.py
@@ -6,7 +6,16 @@ from typing import Any
 
 import sucks
 
-from homeassistant.components.vacuum import VacuumEntity, VacuumEntityFeature
+from homeassistant.components.vacuum import (
+    STATE_CLEANING,
+    STATE_DOCKED,
+    STATE_ERROR,
+    STATE_IDLE,
+    STATE_PAUSED,
+    STATE_RETURNING,
+    StateVacuumEntity,
+    VacuumEntityFeature,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.icon import icon_for_battery_level
@@ -34,7 +43,7 @@ def setup_platform(
     add_entities(vacuums, True)
 
 
-class EcovacsVacuum(VacuumEntity):
+class EcovacsVacuum(StateVacuumEntity):
     """Ecovacs Vacuums such as Deebot."""
 
     _attr_fan_speed_list = [sucks.FAN_SPEED_NORMAL, sucks.FAN_SPEED_HIGH]
@@ -47,7 +56,7 @@ class EcovacsVacuum(VacuumEntity):
         | VacuumEntityFeature.TURN_OFF
         | VacuumEntityFeature.TURN_ON
         | VacuumEntityFeature.LOCATE
-        | VacuumEntityFeature.STATUS
+        | VacuumEntityFeature.STATE
         | VacuumEntityFeature.SEND_COMMAND
         | VacuumEntityFeature.FAN_SPEED
     )
@@ -56,14 +65,18 @@ class EcovacsVacuum(VacuumEntity):
         """Initialize the Ecovacs Vacuum."""
         self.device = device
         self.device.connect_and_wait_until_ready()
-        if self.device.vacuum.get("nick") is not None:
-            self._attr_name = str(self.device.vacuum["nick"])
+        vacuum = self.device.vacuum
+
+        self.error = None
+        self._attr_unique_id = vacuum.get("did")
+
+        if vacuum.get("nick") is not None:
+            self._attr_name = str(vacuum["nick"])
         else:
             # In case there is no nickname defined, use the device id
-            self._attr_name = str(format(self.device.vacuum["did"]))
+            self._attr_name = str(format(vacuum["did"]))
 
-        self._error = None
-        _LOGGER.debug("Vacuum initialized: %s", self.name)
+        _LOGGER.debug("StateVacuum initialized: %s", self.name)
 
     async def async_added_to_hass(self) -> None:
         """Set up the event listeners now that hass is ready."""
@@ -79,9 +92,9 @@ class EcovacsVacuum(VacuumEntity):
         to change, that will come through as a separate on_status event
         """
         if error == "no_error":
-            self._error = None
+            self.error = None
         else:
-            self._error = error
+            self.error = error
 
         self.hass.bus.fire(
             "ecovacs_error", {"entity_id": self.entity_id, "error": error}
@@ -89,36 +102,24 @@ class EcovacsVacuum(VacuumEntity):
         self.schedule_update_ha_state()
 
     @property
-    def unique_id(self) -> str:
-        """Return an unique ID."""
-        return self.device.vacuum.get("did")
+    def state(self) -> str | None:
+        """Return the state of the vacuum cleaner."""
+        if self.error is not None:
+            return STATE_ERROR
 
-    @property
-    def is_on(self) -> bool:
-        """Return true if vacuum is currently cleaning."""
-        return self.device.is_cleaning
+        if self.device.is_cleaning:
+            return STATE_CLEANING
 
-    @property
-    def is_charging(self) -> bool:
-        """Return true if vacuum is currently charging."""
-        return self.device.is_charging
+        if self.device.is_charging:
+            return STATE_DOCKED
 
-    @property
-    def status(self) -> str | None:
-        """Return the status of the vacuum cleaner."""
-        return self.device.vacuum_status
+        if self.device.vacuum_status == sucks.CLEAN_MODE_STOP:
+            return STATE_PAUSED
 
-    def return_to_base(self, **kwargs: Any) -> None:
-        """Set the vacuum cleaner to return to the dock."""
+        if self.device.vacuum_status == sucks.CHARGE_MODE_RETURNING:
+            return STATE_RETURNING
 
-        self.device.run(sucks.Charge())
-
-    @property
-    def battery_icon(self) -> str:
-        """Return the battery icon for the vacuum cleaner."""
-        return icon_for_battery_level(
-            battery_level=self.battery_level, charging=self.is_charging
-        )
+        return STATE_IDLE
 
     @property
     def battery_level(self) -> int | None:
@@ -126,12 +127,36 @@ class EcovacsVacuum(VacuumEntity):
         if self.device.battery_status is not None:
             return self.device.battery_status * 100
 
-        return super().battery_level
+        return None
+
+    @property
+    def battery_icon(self) -> str:
+        """Return the battery icon for the vacuum cleaner."""
+        return icon_for_battery_level(
+            battery_level=self.battery_level, charging=self.device.is_charging
+        )
 
     @property
     def fan_speed(self) -> str | None:
         """Return the fan speed of the vacuum cleaner."""
         return self.device.fan_speed
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return the device-specific state attributes of this vacuum."""
+        data: dict[str, Any] = {}
+        data[ATTR_ERROR] = self.error
+
+        for key, val in self.device.components.items():
+            attr_name = ATTR_COMPONENT_PREFIX + key
+            data[attr_name] = int(val * 100)
+
+        return data
+
+    def return_to_base(self, **kwargs: Any) -> None:
+        """Set the vacuum cleaner to return to the dock."""
+
+        self.device.run(sucks.Charge())
 
     def turn_on(self, **kwargs: Any) -> None:
         """Turn the vacuum on and start cleaning."""
@@ -159,7 +184,7 @@ class EcovacsVacuum(VacuumEntity):
 
     def set_fan_speed(self, fan_speed: str, **kwargs: Any) -> None:
         """Set fan speed."""
-        if self.is_on:
+        if self.state == STATE_CLEANING:
             self.device.run(sucks.Clean(mode=self.device.clean_status, speed=fan_speed))
 
     def send_command(
@@ -170,15 +195,3 @@ class EcovacsVacuum(VacuumEntity):
     ) -> None:
         """Send a command to a vacuum cleaner."""
         self.device.run(sucks.VacBotCommand(command, params))
-
-    @property
-    def extra_state_attributes(self) -> dict[str, Any]:
-        """Return the device-specific state attributes of this vacuum."""
-        data: dict[str, Any] = {}
-        data[ATTR_ERROR] = self._error
-
-        for key, val in self.device.components.items():
-            attr_name = ATTR_COMPONENT_PREFIX + key
-            data[attr_name] = int(val * 100)
-
-        return data

--- a/homeassistant/components/ecovacs/vacuum.py
+++ b/homeassistant/components/ecovacs/vacuum.py
@@ -11,7 +11,6 @@ from homeassistant.components.vacuum import (
     STATE_DOCKED,
     STATE_ERROR,
     STATE_IDLE,
-    STATE_PAUSED,
     STATE_RETURNING,
     StateVacuumEntity,
     VacuumEntityFeature,
@@ -67,13 +66,8 @@ class EcovacsVacuum(StateVacuumEntity):
         vacuum = self.device.vacuum
 
         self.error = None
-        self._attr_unique_id = vacuum.get("did")
-
-        if vacuum.get("nick") is not None:
-            self._attr_name = str(vacuum["nick"])
-        else:
-            # In case there is no nickname defined, use the device id
-            self._attr_name = str(format(vacuum["did"]))
+        self._attr_unique_id = vacuum["did"]
+        self._attr_name = vacuum.get("nick", vacuum["did"])
 
         _LOGGER.debug("StateVacuum initialized: %s", self.name)
 
@@ -113,12 +107,12 @@ class EcovacsVacuum(StateVacuumEntity):
             return STATE_DOCKED
 
         if self.device.vacuum_status == sucks.CLEAN_MODE_STOP:
-            return STATE_PAUSED
+            return STATE_IDLE
 
         if self.device.vacuum_status == sucks.CHARGE_MODE_RETURNING:
             return STATE_RETURNING
 
-        return STATE_IDLE
+        return None
 
     @property
     def battery_level(self) -> int | None:

--- a/homeassistant/components/ecovacs/vacuum.py
+++ b/homeassistant/components/ecovacs/vacuum.py
@@ -53,8 +53,7 @@ class EcovacsVacuum(StateVacuumEntity):
         | VacuumEntityFeature.RETURN_HOME
         | VacuumEntityFeature.CLEAN_SPOT
         | VacuumEntityFeature.STOP
-        | VacuumEntityFeature.TURN_OFF
-        | VacuumEntityFeature.TURN_ON
+        | VacuumEntityFeature.START
         | VacuumEntityFeature.LOCATE
         | VacuumEntityFeature.STATE
         | VacuumEntityFeature.SEND_COMMAND
@@ -158,14 +157,10 @@ class EcovacsVacuum(StateVacuumEntity):
 
         self.device.run(sucks.Charge())
 
-    def turn_on(self, **kwargs: Any) -> None:
+    def start(self, **kwargs: Any) -> None:
         """Turn the vacuum on and start cleaning."""
 
         self.device.run(sucks.Clean())
-
-    def turn_off(self, **kwargs: Any) -> None:
-        """Turn the vacuum off stopping the cleaning and returning home."""
-        self.return_to_base()
 
     def stop(self, **kwargs: Any) -> None:
         """Stop the vacuum cleaner."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The Ecovacs integration has been migrated to the new StateVacuumEntity under the hood.
The states of the vacuum entity now reports not only on or off, instead `cleaning`, `paused`, `docked` (_implicit mean charging_), `returning` (_to base_), `idle` and `error`. Further the actions `turn_on` (_start cleaning_) and `turn_off` (_stop cleaning and return to base_) were superseded by three single actions `start`, `stop` and `return_to_base`

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
