### PR TITLE
Add toggle switch to Daikin HVAC units

### DIFF
--- a/homeassistant/components/daikin/switch.py
+++ b/homeassistant/components/daikin/switch.py
@@ -161,4 +161,4 @@ class DaikinToggleSwitch(SwitchEntity):
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the zone off."""
-        await self._api.device.set({DAIKIN_ATTR_MODE: ATTR_STATE_OFF})
+        await self._api.device.set({DAIKIN_ATTR_MODE: "off"})

--- a/homeassistant/components/daikin/switch.py
+++ b/homeassistant/components/daikin/switch.py
@@ -6,12 +6,10 @@ from typing import Any
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import DOMAIN as DAIKIN_DOMAIN, DaikinApi
-from .const import ATTR_STATE_OFF
 
 ZONE_ICON = "mdi:home-circle"
 STREAMER_ICON = "mdi:air-filter"

--- a/homeassistant/components/daikin/switch.py
+++ b/homeassistant/components/daikin/switch.py
@@ -143,11 +143,6 @@ class DaikinToggleSwitch(SwitchEntity):
         """Return the state of the sensor."""
         return "off" not in self._api.device.represent(DAIKIN_ATTR_MODE)
 
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return a device description for device registry."""
-        return self._api.device_info
-
     async def async_update(self) -> None:
         """Retrieve latest state."""
         await self._api.async_update()

--- a/homeassistant/components/daikin/switch.py
+++ b/homeassistant/components/daikin/switch.py
@@ -139,11 +139,6 @@ class DaikinToggleSwitch(SwitchEntity):
         self._attr_unique_id = f"{self._api.device.mac}-toggle"
 
     @property
-    def unique_id(self) -> str:
-        """Return a unique ID."""
-        return f"{self._api.device.mac}-toggle"
-
-    @property
     def is_on(self) -> bool:
         """Return the state of the sensor."""
         return "off" not in self._api.device.represent(DAIKIN_ATTR_MODE)

--- a/homeassistant/components/daikin/switch.py
+++ b/homeassistant/components/daikin/switch.py
@@ -10,7 +10,6 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import DOMAIN as DAIKIN_DOMAIN, DaikinApi
-
 from .const import ATTR_STATE_OFF
 
 ZONE_ICON = "mdi:home-circle"
@@ -39,7 +38,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up Daikin climate based on config_entry."""
     daikin_api: DaikinApi = hass.data[DAIKIN_DOMAIN][entry.entry_id]
-    switches: list[DaikinZoneSwitch | DaikinStreamerSwitch] = []
+    switches: list[DaikinZoneSwitch | DaikinStreamerSwitch | DaikinToggleSwitch] = []
     if zones := daikin_api.device.zones:
         switches.extend(
             [
@@ -144,9 +143,7 @@ class DaikinToggleSwitch(SwitchEntity):
     @property
     def is_on(self) -> bool:
         """Return the state of the sensor."""
-        return (
-            ATTR_STATE_OFF not in self._api.device.represent(DAIKIN_ATTR_MODE)
-        )
+        return ATTR_STATE_OFF not in self._api.device.represent(DAIKIN_ATTR_MODE)
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -163,4 +160,4 @@ class DaikinToggleSwitch(SwitchEntity):
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the zone off."""
-        await self._api.device.set({DAIKIN_ATTR_MODE:ATTR_STATE_OFF})
+        await self._api.device.set({DAIKIN_ATTR_MODE: ATTR_STATE_OFF})

--- a/homeassistant/components/daikin/switch.py
+++ b/homeassistant/components/daikin/switch.py
@@ -146,7 +146,7 @@ class DaikinToggleSwitch(SwitchEntity):
     @property
     def is_on(self) -> bool:
         """Return the state of the sensor."""
-        return ATTR_STATE_OFF not in self._api.device.represent(DAIKIN_ATTR_MODE)
+        return "off" not in self._api.device.represent(DAIKIN_ATTR_MODE)
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/homeassistant/components/daikin/switch.py
+++ b/homeassistant/components/daikin/switch.py
@@ -6,6 +6,7 @@ from typing import Any
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 

--- a/homeassistant/components/daikin/switch.py
+++ b/homeassistant/components/daikin/switch.py
@@ -132,9 +132,11 @@ class DaikinToggleSwitch(SwitchEntity):
     _attr_icon = TOGGLE_ICON
     _attr_has_entity_name = True
 
-    def __init__(self, daikin_api: DaikinApi) -> None:
+    def __init__(self, api: DaikinApi) -> None:
         """Initialize switch."""
-        self._api = daikin_api
+        self._api = api
+        self._attr_device_info = api.device_info
+        self._attr_unique_id = f"{self._api.device.mac}-toggle"
 
     @property
     def unique_id(self) -> str:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds a switch entity to each device allowing it to be easily switched on and off. This is especially helpful when using Mini-split units.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/28097

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
