### PR TITLE
Make script services always respond when asked

### DIFF
--- a/homeassistant/components/script/__init__.py
+++ b/homeassistant/components/script/__init__.py
@@ -608,7 +608,7 @@ class ScriptEntity(BaseScriptEntity, RestoreEntity):
             variables=service.data, context=service.context, wait=True
         )
         if service.return_response:
-            return response
+            return response or {}
         return None
 
     async def async_added_to_hass(self) -> None:

--- a/tests/components/script/test_init.py
+++ b/tests/components/script/test_init.py
@@ -26,7 +26,7 @@ from homeassistant.core import (
     callback,
     split_entity_id,
 )
-from homeassistant.exceptions import HomeAssistantError, ServiceNotFound
+from homeassistant.exceptions import ServiceNotFound
 from homeassistant.helpers import entity_registry as er, template
 from homeassistant.helpers.event import async_track_state_change
 from homeassistant.helpers.script import (
@@ -1645,10 +1645,12 @@ async def test_responses_error(hass: HomeAssistant) -> None:
         },
     )
 
-    with pytest.raises(HomeAssistantError):
-        assert await hass.services.async_call(
+    assert (
+        await hass.services.async_call(
             DOMAIN, "test", {"greeting": "world"}, blocking=True, return_response=True
         )
+        == {}
+    )
     # Validate we can also call it without return_response
     assert (
         await hass.services.async_call(

--- a/tests/components/script/test_init.py
+++ b/tests/components/script/test_init.py
@@ -1625,7 +1625,7 @@ async def test_responses(hass: HomeAssistant, response: Any) -> None:
     )
 
 
-async def test_responses_error(hass: HomeAssistant) -> None:
+async def test_responses_no_response(hass: HomeAssistant) -> None:
     """Test response variable not set."""
     mock_restore_cache(hass, ())
     assert await async_setup_component(
@@ -1645,6 +1645,7 @@ async def test_responses_error(hass: HomeAssistant) -> None:
         },
     )
 
+    # Validate we can call it with return_response
     assert (
         await hass.services.async_call(
             DOMAIN, "test", {"greeting": "world"}, blocking=True, return_response=True


### PR DESCRIPTION
## Proposed change
Script services are registered with `SupportsResponse.OPTIONAL` meaning:
`The service optionally returns response data when asked by the caller.`

This PR will make it always return a response when asked by the caller, also when the script itself doesn't return a response.

Previously we would throw because a service should respond a dict and the service responded None.

As follow up we could register script services for scripts that do not include a `stop` action with `response_variable` as `SupportsResponse.NONE`, but a script with a stop action could still return nothing on some paths, so this PR will still be needed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
