### PR TITLE
Get MyStrom device state before checking support

### DIFF
--- a/homeassistant/components/mystrom/__init__.py
+++ b/homeassistant/components/mystrom/__init__.py
@@ -83,12 +83,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     device_type = hass.data[DOMAIN][entry.entry_id].info["type"]
+    platforms = []
     if device_type in [101, 106, 107]:
-        platforms = PLATFORMS_SWITCH
+        platforms.extend(PLATFORMS_SWITCH)
     elif device_type in [102, 105]:
-        platforms = PLATFORMS_BULB
-    else:
-        platforms = []
+        platforms.extend(PLATFORMS_BULB)
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, platforms):
         hass.data[DOMAIN].pop(entry.entry_id)
 

--- a/tests/components/mystrom/__init__.py
+++ b/tests/components/mystrom/__init__.py
@@ -1,5 +1,5 @@
 """Tests for the myStrom integration."""
-from typing import Any
+from typing import Any, Optional
 
 
 def get_default_device_response(device_type: int) -> dict[str, Any]:
@@ -17,3 +17,156 @@ def get_default_device_response(device_type: int) -> dict[str, Any]:
         "connected": True,
         "signal": 94,
     }
+
+
+def get_default_bulb_state() -> dict[str, Any]:
+    """Get default bulb state."""
+    return {
+        "type": "rgblamp",
+        "battery": False,
+        "reachable": True,
+        "meshroot": True,
+        "on": False,
+        "color": "46;18;100",
+        "mode": "hsv",
+        "ramp": 10,
+        "power": 0.45,
+        "fw_version": "2.58.0",
+    }
+
+
+def get_default_switch_state() -> dict[str, Any]:
+    """Get default switch state."""
+    return {
+        "power": 1.69,
+        "Ws": 0.81,
+        "relay": True,
+        "temperature": 24.87,
+        "version": "2.59.32",
+        "mac": "6001940376EB",
+        "ssid": "personal",
+        "ip": "192.168.0.23",
+        "mask": "255.255.255.0",
+        "gw": "192.168.0.1",
+        "dns": "192.168.0.1",
+        "static": False,
+        "connected": True,
+        "signal": 94,
+    }
+
+
+class MyStromDeviceMock:
+    """Base device mock."""
+
+    def __init__(self, state: dict[str, Any]) -> None:
+        """Initialize device mock."""
+        self._requested_state = False
+        self._state = state
+
+    async def get_state(self) -> None:
+        """Set if state is requested."""
+        self._requested_state = True
+
+
+class MyStromBulbMock(MyStromDeviceMock):
+    """MyStrom Bulb mock."""
+
+    def __init__(self, mac: str, state: dict[str, Any]) -> None:
+        """Initialize bulb mock."""
+        super().__init__(state)
+        self.mac = mac
+
+    @property
+    def firmware(self) -> Optional[str]:
+        """Return current firmware."""
+        if not self._requested_state:
+            return None
+        return self._state["fw_version"]
+
+    @property
+    def consumption(self) -> Optional[float]:
+        """Return current firmware."""
+        if not self._requested_state:
+            return None
+        return self._state["power"]
+
+    @property
+    def color(self) -> Optional[str]:
+        """Return current color settings."""
+        if not self._requested_state:
+            return None
+        return self._state["color"]
+
+    @property
+    def mode(self) -> Optional[str]:
+        """Return current mode."""
+        if not self._requested_state:
+            return None
+        return self._state["mode"]
+
+    @property
+    def transition_time(self) -> Optional[int]:
+        """Return current transition time (ramp)."""
+        if not self._requested_state:
+            return None
+        return self._state["ramp"]
+
+    @property
+    def bulb_type(self) -> Optional[str]:
+        """Return the type of the bulb."""
+        if not self._requested_state:
+            return None
+        return self._state["type"]
+
+    @property
+    def state(self) -> Optional[bool]:
+        """Return the current state of the bulb."""
+        if not self._requested_state:
+            return None
+        return self._state["on"]
+
+
+class MyStromSwitchMock(MyStromDeviceMock):
+    """MyStrom Switch mock."""
+
+    @property
+    def relay(self) -> Optional[bool]:
+        """Return the relay state."""
+        if not self._requested_state:
+            return None
+        return self._state["on"]
+
+    @property
+    def consumption(self) -> Optional[float]:
+        """Return the current power consumption in mWh."""
+        if not self._requested_state:
+            return None
+        return self._state["power"]
+
+    @property
+    def consumedWs(self) -> Optional[float]:
+        """The average of energy consumed per second since last report call."""
+        if not self._requested_state:
+            return None
+        return self._state["Ws"]
+
+    @property
+    def firmware(self) -> Optional[str]:
+        """Return the current firmware."""
+        if not self._requested_state:
+            return None
+        return self._state["version"]
+
+    @property
+    def mac(self) -> Optional[str]:
+        """Return the MAC address."""
+        if not self._requested_state:
+            return None
+        return self._state["mac"]
+
+    @property
+    def temperature(self) -> Optional[float]:
+        """Return the current temperature in celsius."""
+        if not self._requested_state:
+            return None
+        return self._state["temperature"]

--- a/tests/components/mystrom/__init__.py
+++ b/tests/components/mystrom/__init__.py
@@ -1,1 +1,19 @@
 """Tests for the myStrom integration."""
+from typing import Any
+
+
+def get_default_device_response(device_type: int) -> dict[str, Any]:
+    """Return default device response."""
+    return {
+        "version": "2.59.32",
+        "mac": "6001940376EB",
+        "type": device_type,
+        "ssid": "personal",
+        "ip": "192.168.0.23",
+        "mask": "255.255.255.0",
+        "gw": "192.168.0.1",
+        "dns": "192.168.0.1",
+        "static": False,
+        "connected": True,
+        "signal": 94,
+    }

--- a/tests/components/mystrom/test_init.py
+++ b/tests/components/mystrom/test_init.py
@@ -142,7 +142,7 @@ async def test_init_cannot_connect_because_of_get_state(
     """Test error handling for failing get_state."""
     with patch(
         "pymystrom.get_device_info",
-        side_effect=AsyncMock(return_value={"type": 101, "mac": DEVICE_MAC}),
+        side_effect=AsyncMock(return_value=get_default_device_response(101)),
     ), patch(
         "pymystrom.switch.MyStromSwitch.get_state", side_effect=MyStromConnectionError()
     ), patch(
@@ -151,4 +151,4 @@ async def test_init_cannot_connect_because_of_get_state(
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    assert config_entry.state == ConfigEntryState.SETUP_ERROR
+    assert config_entry.state == ConfigEntryState.SETUP_RETRY

--- a/tests/components/mystrom/test_init.py
+++ b/tests/components/mystrom/test_init.py
@@ -2,12 +2,19 @@
 from unittest.mock import AsyncMock, PropertyMock, patch
 
 from pymystrom.exceptions import MyStromConnectionError
+import pytest
 
 from homeassistant.components.mystrom.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
-from . import get_default_device_response
+from . import (
+    MyStromBulbMock,
+    MyStromSwitchMock,
+    get_default_bulb_state,
+    get_default_device_response,
+    get_default_switch_state,
+)
 from .conftest import DEVICE_MAC
 
 from tests.common import MockConfigEntry
@@ -17,29 +24,20 @@ async def init_integration(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
     device_type: int,
-    bulb_type: str = "strip",
 ) -> None:
     """Inititialize integration for testing."""
     with patch(
         "pymystrom.get_device_info",
         side_effect=AsyncMock(return_value=get_default_device_response(device_type)),
-    ), patch("pymystrom.switch.MyStromSwitch.get_state", return_value={}), patch(
-        "pymystrom.bulb.MyStromBulb.get_state", return_value={}
     ), patch(
-        "pymystrom.bulb.MyStromBulb.bulb_type", bulb_type
+        "homeassistant.components.mystrom._get_mystrom_bulb",
+        return_value=MyStromBulbMock("6001940376EB", get_default_bulb_state()),
     ), patch(
-        "pymystrom.switch.MyStromSwitch.mac",
-        new_callable=PropertyMock,
-        return_value=DEVICE_MAC,
-    ), patch(
-        "pymystrom.bulb.MyStromBulb.mac",
-        new_callable=PropertyMock,
-        return_value=DEVICE_MAC,
+        "homeassistant.components.mystrom._get_mystrom_switch",
+        return_value=MyStromSwitchMock(get_default_switch_state()),
     ):
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
-
-    assert config_entry.state == ConfigEntryState.LOADED
 
 
 async def test_init_switch_and_unload(
@@ -57,12 +55,35 @@ async def test_init_switch_and_unload(
     assert not hass.data.get(DOMAIN)
 
 
-async def test_init_bulb(hass: HomeAssistant, config_entry: MockConfigEntry) -> None:
+@pytest.mark.parametrize(
+    ("device_type", "platform", "entry_state", "entity_state_none"),
+    [
+        (101, "switch", ConfigEntryState.LOADED, False),
+        (102, "light", ConfigEntryState.LOADED, False),
+        (103, "button", ConfigEntryState.SETUP_ERROR, True),
+        (104, "button", ConfigEntryState.SETUP_ERROR, True),
+        (105, "light", ConfigEntryState.LOADED, False),
+        (106, "switch", ConfigEntryState.LOADED, False),
+        (107, "switch", ConfigEntryState.LOADED, False),
+        (110, "sensor", ConfigEntryState.SETUP_ERROR, True),
+        (113, "switch", ConfigEntryState.SETUP_ERROR, True),
+        (118, "button", ConfigEntryState.SETUP_ERROR, True),
+        (120, "switch", ConfigEntryState.SETUP_ERROR, True),
+    ],
+)
+async def test_init_bulb(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    device_type: int,
+    platform: str,
+    entry_state: ConfigEntryState,
+    entity_state_none: bool,
+) -> None:
     """Test the initialization of a myStrom bulb."""
-    await init_integration(hass, config_entry, 102)
-    state = hass.states.get("light.mystrom_device")
-    assert state is not None
-    assert config_entry.state is ConfigEntryState.LOADED
+    await init_integration(hass, config_entry, device_type)
+    state = hass.states.get(f"{platform}.mystrom_device")
+    assert (state is None) == entity_state_none
+    assert config_entry.state is entry_state
 
 
 async def test_init_of_unknown_bulb(

--- a/tests/components/mystrom/test_init.py
+++ b/tests/components/mystrom/test_init.py
@@ -7,6 +7,7 @@ from homeassistant.components.mystrom.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
+from . import get_default_device_response
 from .conftest import DEVICE_MAC
 
 from tests.common import MockConfigEntry
@@ -21,7 +22,7 @@ async def init_integration(
     """Inititialize integration for testing."""
     with patch(
         "pymystrom.get_device_info",
-        side_effect=AsyncMock(return_value={"type": device_type, "mac": DEVICE_MAC}),
+        side_effect=AsyncMock(return_value=get_default_device_response(device_type)),
     ), patch("pymystrom.switch.MyStromSwitch.get_state", return_value={}), patch(
         "pymystrom.bulb.MyStromBulb.get_state", return_value={}
     ), patch(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I checked the code in the library (wasn't updated since the config flow), and `device.bulb_type` is not set, until `device.get_state()` is called. Which was done in this code, but only after we check for compatibility.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #95995
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
