### PR TITLE
Move Hydrawise to a supported library

### DIFF
--- a/homeassistant/components/hydrawise/__init__.py
+++ b/homeassistant/components/hydrawise/__init__.py
@@ -1,7 +1,7 @@
 """Support for Hydrawise cloud."""
 
 
-from hydrawiser.core import Hydrawiser
+from pydrawise.legacy import LegacyHydrawise
 from requests.exceptions import ConnectTimeout, HTTPError
 import voluptuous as vol
 
@@ -34,7 +34,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     scan_interval = conf.get(CONF_SCAN_INTERVAL)
 
     try:
-        hydrawise = await hass.async_add_executor_job(Hydrawiser, access_token)
+        hydrawise = await hass.async_add_executor_job(LegacyHydrawise, access_token)
     except (ConnectTimeout, HTTPError) as ex:
         LOGGER.error("Unable to connect to Hydrawise cloud service: %s", str(ex))
         _show_failure_notification(hass, str(ex))

--- a/homeassistant/components/hydrawise/binary_sensor.py
+++ b/homeassistant/components/hydrawise/binary_sensor.py
@@ -1,7 +1,7 @@
 """Support for Hydrawise sprinkler binary sensors."""
 from __future__ import annotations
 
-from hydrawiser.core import Hydrawiser
+from pydrawise.legacy import LegacyHydrawise
 import voluptuous as vol
 
 from homeassistant.components.binary_sensor import (
@@ -55,7 +55,7 @@ def setup_platform(
 ) -> None:
     """Set up a sensor for a Hydrawise device."""
     coordinator: HydrawiseDataUpdateCoordinator = hass.data[DOMAIN]
-    hydrawise: Hydrawiser = coordinator.api
+    hydrawise: LegacyHydrawise = coordinator.api
     monitored_conditions = config[CONF_MONITORED_CONDITIONS]
 
     entities = []

--- a/homeassistant/components/hydrawise/coordinator.py
+++ b/homeassistant/components/hydrawise/coordinator.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 
-from hydrawiser.core import Hydrawiser
+from pydrawise.legacy import LegacyHydrawise
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -16,7 +16,7 @@ class HydrawiseDataUpdateCoordinator(DataUpdateCoordinator[None]):
     """The Hydrawise Data Update Coordinator."""
 
     def __init__(
-        self, hass: HomeAssistant, api: Hydrawiser, scan_interval: timedelta
+        self, hass: HomeAssistant, api: LegacyHydrawise, scan_interval: timedelta
     ) -> None:
         """Initialize HydrawiseDataUpdateCoordinator."""
         super().__init__(hass, LOGGER, name=DOMAIN, update_interval=scan_interval)

--- a/homeassistant/components/hydrawise/manifest.json
+++ b/homeassistant/components/hydrawise/manifest.json
@@ -4,6 +4,6 @@
   "codeowners": ["@dknowles2", "@ptcryan"],
   "documentation": "https://www.home-assistant.io/integrations/hydrawise",
   "iot_class": "cloud_polling",
-  "loggers": ["hydrawiser"],
-  "requirements": ["Hydrawiser==0.2"]
+  "loggers": ["pydrawise"],
+  "requirements": ["pydrawise==2023.7.0"]
 }

--- a/homeassistant/components/hydrawise/sensor.py
+++ b/homeassistant/components/hydrawise/sensor.py
@@ -1,7 +1,7 @@
 """Support for Hydrawise sprinkler sensors."""
 from __future__ import annotations
 
-from hydrawiser.core import Hydrawiser
+from pydrawise.legacy import LegacyHydrawise
 import voluptuous as vol
 
 from homeassistant.components.sensor import (
@@ -57,7 +57,7 @@ def setup_platform(
 ) -> None:
     """Set up a sensor for a Hydrawise device."""
     coordinator: HydrawiseDataUpdateCoordinator = hass.data[DOMAIN]
-    hydrawise: Hydrawiser = coordinator.api
+    hydrawise: LegacyHydrawise = coordinator.api
     monitored_conditions = config[CONF_MONITORED_CONDITIONS]
 
     entities = [

--- a/homeassistant/components/hydrawise/switch.py
+++ b/homeassistant/components/hydrawise/switch.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from hydrawiser.core import Hydrawiser
+from pydrawise.legacy import LegacyHydrawise
 import voluptuous as vol
 
 from homeassistant.components.switch import (
@@ -63,7 +63,7 @@ def setup_platform(
 ) -> None:
     """Set up a sensor for a Hydrawise device."""
     coordinator: HydrawiseDataUpdateCoordinator = hass.data[DOMAIN]
-    hydrawise: Hydrawiser = coordinator.api
+    hydrawise: LegacyHydrawise = coordinator.api
     monitored_conditions: list[str] = config[CONF_MONITORED_CONDITIONS]
     default_watering_timer: int = config[CONF_WATERING_TIME]
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -31,9 +31,6 @@ HAP-python==4.7.0
 # homeassistant.components.tasmota
 HATasmota==0.6.5
 
-# homeassistant.components.hydrawise
-Hydrawiser==0.2
-
 # homeassistant.components.mastodon
 Mastodon.py==1.5.1
 
@@ -1637,6 +1634,9 @@ pydiscovergy==1.2.1
 
 # homeassistant.components.doods
 pydoods==1.0.2
+
+# homeassistant.components.hydrawise
+pydrawise==2023.7.0
 
 # homeassistant.components.android_ip_webcam
 pydroid-ipcam==2.0.0


### PR DESCRIPTION
## Proposed change
This moves Hydrawise to a supported library. The `hydrawiser` library is unmaintained: it's had no commits since 2020 and PRs have been sitting open with no responses for over 18 months.

The new library is rewrite of the interface exposed by the `hydrawiser` library, along with code cleanups and bug fixes. It also supports an async version that interfaces with the newer Hydrawise GraphQL API (which we can move to later).

We've had a number of bugs filed recently about the Hydrawise integration and they are difficult to fix without access to the underlying library, so this should let us keep the integration healthy.

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #95557
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.


To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
