### PR TITLE
Add optional location based region to dwd_weather_warnings

### DIFF
--- a/homeassistant/components/dwd_weather_warnings/__init__.py
+++ b/homeassistant/components/dwd_weather_warnings/__init__.py
@@ -2,43 +2,16 @@
 
 from __future__ import annotations
 
-from dwdwfsapi import DwdWeatherWarningsAPI
-
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .const import (
-    CONF_REGION_DEVICE_TRACKER,
-    CONF_REGION_IDENTIFIER,
-    DOMAIN,
-    LOGGER,
-    PLATFORMS,
-)
+from .const import DOMAIN, PLATFORMS
 from .coordinator import DwdWeatherWarningsCoordinator
-from .exceptions import EntityNotFoundError
-from .util import get_position_data
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up a config entry."""
-    # Initialize the API and coordinator based on the specified data.
-    if (region_identifier := entry.data.get(CONF_REGION_IDENTIFIER)) is not None:
-        api = await hass.async_add_executor_job(
-            DwdWeatherWarningsAPI, region_identifier
-        )
-    else:
-        device_tracker = entry.data.get(CONF_REGION_DEVICE_TRACKER)
-
-        try:
-            position = get_position_data(hass, device_tracker)
-        except (EntityNotFoundError, AttributeError) as err:
-            # The provided device_tracker is not available or missing required attributes.
-            LOGGER.error(f"Failed to setup dwd_weather_warnings: {repr(err)}")
-            return False
-
-        api = await hass.async_add_executor_job(DwdWeatherWarningsAPI, position)
-
-    coordinator = DwdWeatherWarningsCoordinator(hass, api)
+    coordinator = DwdWeatherWarningsCoordinator(hass, entry)
     await coordinator.async_config_entry_first_refresh()
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator

--- a/homeassistant/components/dwd_weather_warnings/__init__.py
+++ b/homeassistant/components/dwd_weather_warnings/__init__.py
@@ -3,11 +3,9 @@
 from __future__ import annotations
 
 from dwdwfsapi import DwdWeatherWarningsAPI
-import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
 
 from .const import (
     CONF_REGION_DEVICE_TRACKER,
@@ -23,26 +21,13 @@ from .util import get_position_data
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up a config entry."""
-    region_identifier: str = entry.data.get(CONF_REGION_IDENTIFIER, None)
-    device_tracker: str = entry.data.get(CONF_REGION_DEVICE_TRACKER, None)
-
     # Initialize the API and coordinator based on the specified data.
-    if region_identifier is not None:
+    if (region_identifier := entry.data.get(CONF_REGION_IDENTIFIER)) is not None:
         api = await hass.async_add_executor_job(
             DwdWeatherWarningsAPI, region_identifier
         )
-    elif device_tracker is not None:
-        registry = er.async_get(hass)
-
-        try:
-            device_tracker = er.async_validate_entity_id(registry, device_tracker)
-        except vol.Invalid:
-            # The entity/UUID is invalid or not associated with an entity registry item.
-            LOGGER.error(
-                "Failed to setup dwd_weather_warnings for unknown entity %s",
-                device_tracker,
-            )
-            return False
+    else:
+        device_tracker = entry.data.get(CONF_REGION_DEVICE_TRACKER)
 
         try:
             position = get_position_data(hass, device_tracker)

--- a/homeassistant/components/dwd_weather_warnings/__init__.py
+++ b/homeassistant/components/dwd_weather_warnings/__init__.py
@@ -3,22 +3,43 @@
 from __future__ import annotations
 
 from dwdwfsapi import DwdWeatherWarningsAPI
+import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 
-from .const import CONF_REGION_IDENTIFIER, DOMAIN, PLATFORMS
+from .const import CONF_GPS_TRACKER, CONF_REGION_IDENTIFIER, DOMAIN, LOGGER, PLATFORMS
 from .coordinator import DwdWeatherWarningsCoordinator
+from .util import get_position_data
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up a config entry."""
-    region_identifier: str = entry.data[CONF_REGION_IDENTIFIER]
+    region_identifier: str = entry.data.get(CONF_REGION_IDENTIFIER, None)
+    gps_tracker: str = entry.data.get(CONF_GPS_TRACKER, None)
 
-    # Initialize the API and coordinator.
-    api = await hass.async_add_executor_job(DwdWeatherWarningsAPI, region_identifier)
+    # Initialize the API and coordinator based on the specified data.
+    if region_identifier is not None:
+        api = await hass.async_add_executor_job(
+            DwdWeatherWarningsAPI, region_identifier
+        )
+    elif gps_tracker is not None:
+        try:
+            registry = er.async_get(hass)
+            gps_tracker = er.async_validate_entity_id(registry, gps_tracker)
+        except vol.Invalid:
+            # The entity/UUID is invalid or not associated with an entity registry item.
+            LOGGER.error(
+                "Failed to setup dwd_weather_warnings for unknown entity %s",
+                gps_tracker,
+            )
+            return False
+
+        position = get_position_data(hass, gps_tracker)
+        api = await hass.async_add_executor_job(DwdWeatherWarningsAPI, position)
+
     coordinator = DwdWeatherWarningsCoordinator(hass, api)
-
     await coordinator.async_config_entry_first_refresh()
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator

--- a/homeassistant/components/dwd_weather_warnings/__init__.py
+++ b/homeassistant/components/dwd_weather_warnings/__init__.py
@@ -31,8 +31,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             DwdWeatherWarningsAPI, region_identifier
         )
     elif device_tracker is not None:
+        registry = er.async_get(hass)
+
         try:
-            registry = er.async_get(hass)
             device_tracker = er.async_validate_entity_id(registry, device_tracker)
         except vol.Invalid:
             # The entity/UUID is invalid or not associated with an entity registry item.

--- a/homeassistant/components/dwd_weather_warnings/__init__.py
+++ b/homeassistant/components/dwd_weather_warnings/__init__.py
@@ -9,7 +9,13 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from .const import CONF_GPS_TRACKER, CONF_REGION_IDENTIFIER, DOMAIN, LOGGER, PLATFORMS
+from .const import (
+    CONF_REGION_DEVICE_TRACKER,
+    CONF_REGION_IDENTIFIER,
+    DOMAIN,
+    LOGGER,
+    PLATFORMS,
+)
 from .coordinator import DwdWeatherWarningsCoordinator
 from .util import get_position_data
 
@@ -17,26 +23,26 @@ from .util import get_position_data
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up a config entry."""
     region_identifier: str = entry.data.get(CONF_REGION_IDENTIFIER, None)
-    gps_tracker: str = entry.data.get(CONF_GPS_TRACKER, None)
+    device_tracker: str = entry.data.get(CONF_REGION_DEVICE_TRACKER, None)
 
     # Initialize the API and coordinator based on the specified data.
     if region_identifier is not None:
         api = await hass.async_add_executor_job(
             DwdWeatherWarningsAPI, region_identifier
         )
-    elif gps_tracker is not None:
+    elif device_tracker is not None:
         try:
             registry = er.async_get(hass)
-            gps_tracker = er.async_validate_entity_id(registry, gps_tracker)
+            device_tracker = er.async_validate_entity_id(registry, device_tracker)
         except vol.Invalid:
             # The entity/UUID is invalid or not associated with an entity registry item.
             LOGGER.error(
                 "Failed to setup dwd_weather_warnings for unknown entity %s",
-                gps_tracker,
+                device_tracker,
             )
             return False
 
-        position = get_position_data(hass, gps_tracker)
+        position = get_position_data(hass, device_tracker)
         api = await hass.async_add_executor_job(DwdWeatherWarningsAPI, position)
 
     coordinator = DwdWeatherWarningsCoordinator(hass, api)

--- a/homeassistant/components/dwd_weather_warnings/config_flow.py
+++ b/homeassistant/components/dwd_weather_warnings/config_flow.py
@@ -9,8 +9,10 @@ import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.selector import EntitySelector, EntitySelectorConfig
 
-from .const import CONF_REGION_IDENTIFIER, DOMAIN
+from .const import CONF_GPS_TRACKER, CONF_REGION_IDENTIFIER, DOMAIN
+from .util import get_position_data
 
 
 class DwdWeatherWarningsConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -25,27 +27,58 @@ class DwdWeatherWarningsConfigFlow(ConfigFlow, domain=DOMAIN):
         errors: dict = {}
 
         if user_input is not None:
-            region_identifier = user_input[CONF_REGION_IDENTIFIER]
+            valid_options = (CONF_REGION_IDENTIFIER, CONF_GPS_TRACKER)
 
-            # Validate region identifier using the API
-            if not await self.hass.async_add_executor_job(
-                DwdWeatherWarningsAPI, region_identifier
-            ):
-                errors["base"] = "invalid_identifier"
+            # Check, if either CONF_REGION_IDENTIFIER or CONF_GPS_TRACKER has been set.
+            if all(k not in user_input for k in valid_options):
+                errors["base"] = "no_identifier"
+            elif all(k in user_input for k in valid_options):
+                errors["base"] = "ambiguous_identifier"
+            elif CONF_REGION_IDENTIFIER in user_input:
+                # Validate region identifier using the API
+                identifier = user_input[CONF_REGION_IDENTIFIER]
 
-            if not errors:
-                # Set the unique ID for this config entry.
-                await self.async_set_unique_id(region_identifier)
-                self._abort_if_unique_id_configured()
+                if not await self.hass.async_add_executor_job(
+                    DwdWeatherWarningsAPI, identifier
+                ):
+                    errors["base"] = "invalid_identifier"
 
-                return self.async_create_entry(title=region_identifier, data=user_input)
+                if not errors:
+                    # Set the unique ID for this config entry.
+                    await self.async_set_unique_id(identifier)
+                    self._abort_if_unique_id_configured()
+
+                    return self.async_create_entry(title=identifier, data=user_input)
+            elif CONF_GPS_TRACKER in user_input:
+                # Validate position using the API
+                device_tracker = user_input[CONF_GPS_TRACKER]
+                position = get_position_data(self.hass, device_tracker)
+
+                if not await self.hass.async_add_executor_job(
+                    DwdWeatherWarningsAPI, position
+                ):
+                    errors["base"] = "invalid_identifier"
+
+                # Position is valid here, because the API call was successful.
+                if not errors and position is not None:
+                    # Set the unique ID for this config entry.
+                    await self.async_set_unique_id(f"{position[0]}-{position[1]}")
+                    self._abort_if_unique_id_configured()
+
+                    return self.async_create_entry(
+                        title=device_tracker.removeprefix("device_tracker."),
+                        data=user_input,
+                    )
 
         return self.async_show_form(
             step_id="user",
             errors=errors,
             data_schema=vol.Schema(
                 {
-                    vol.Required(CONF_REGION_IDENTIFIER): cv.string,
+                    vol.Optional(CONF_REGION_IDENTIFIER): cv.string,
+                    vol.Optional(CONF_GPS_TRACKER): EntitySelector(
+                        EntitySelectorConfig(domain="device_tracker")
+                    ),
                 }
             ),
         )

--- a/homeassistant/components/dwd_weather_warnings/config_flow.py
+++ b/homeassistant/components/dwd_weather_warnings/config_flow.py
@@ -16,6 +16,8 @@ from .const import CONF_REGION_DEVICE_TRACKER, CONF_REGION_IDENTIFIER, DOMAIN
 from .exceptions import EntityNotFoundError
 from .util import get_position_data
 
+EXCLUSIVE_OPTIONS = (CONF_REGION_IDENTIFIER, CONF_REGION_DEVICE_TRACKER)
+
 
 class DwdWeatherWarningsConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle the config flow for the dwd_weather_warnings integration."""
@@ -29,12 +31,10 @@ class DwdWeatherWarningsConfigFlow(ConfigFlow, domain=DOMAIN):
         errors: dict = {}
 
         if user_input is not None:
-            valid_options = (CONF_REGION_IDENTIFIER, CONF_REGION_DEVICE_TRACKER)
-
             # Check, if either CONF_REGION_IDENTIFIER or CONF_GPS_TRACKER has been set.
-            if all(k not in user_input for k in valid_options):
+            if all(k not in user_input for k in EXCLUSIVE_OPTIONS):
                 errors["base"] = "no_identifier"
-            elif all(k in user_input for k in valid_options):
+            elif all(k in user_input for k in EXCLUSIVE_OPTIONS):
                 errors["base"] = "ambiguous_identifier"
             elif CONF_REGION_IDENTIFIER in user_input:
                 # Validate region identifier using the API
@@ -51,7 +51,7 @@ class DwdWeatherWarningsConfigFlow(ConfigFlow, domain=DOMAIN):
                     self._abort_if_unique_id_configured()
 
                     return self.async_create_entry(title=identifier, data=user_input)
-            elif CONF_REGION_DEVICE_TRACKER in user_input:
+            else:  # CONF_REGION_DEVICE_TRACKER
                 device_tracker = user_input[CONF_REGION_DEVICE_TRACKER]
                 registry = er.async_get(self.hass)
                 entity_entry = registry.async_get(device_tracker)

--- a/homeassistant/components/dwd_weather_warnings/config_flow.py
+++ b/homeassistant/components/dwd_weather_warnings/config_flow.py
@@ -11,7 +11,7 @@ from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.selector import EntitySelector, EntitySelectorConfig
 
-from .const import CONF_GPS_TRACKER, CONF_REGION_IDENTIFIER, DOMAIN
+from .const import CONF_REGION_DEVICE_TRACKER, CONF_REGION_IDENTIFIER, DOMAIN
 from .util import get_position_data
 
 
@@ -27,7 +27,7 @@ class DwdWeatherWarningsConfigFlow(ConfigFlow, domain=DOMAIN):
         errors: dict = {}
 
         if user_input is not None:
-            valid_options = (CONF_REGION_IDENTIFIER, CONF_GPS_TRACKER)
+            valid_options = (CONF_REGION_IDENTIFIER, CONF_REGION_DEVICE_TRACKER)
 
             # Check, if either CONF_REGION_IDENTIFIER or CONF_GPS_TRACKER has been set.
             if all(k not in user_input for k in valid_options):
@@ -49,9 +49,9 @@ class DwdWeatherWarningsConfigFlow(ConfigFlow, domain=DOMAIN):
                     self._abort_if_unique_id_configured()
 
                     return self.async_create_entry(title=identifier, data=user_input)
-            elif CONF_GPS_TRACKER in user_input:
+            elif CONF_REGION_DEVICE_TRACKER in user_input:
                 # Validate position using the API
-                device_tracker = user_input[CONF_GPS_TRACKER]
+                device_tracker = user_input[CONF_REGION_DEVICE_TRACKER]
                 position = get_position_data(self.hass, device_tracker)
 
                 if not await self.hass.async_add_executor_job(
@@ -76,7 +76,7 @@ class DwdWeatherWarningsConfigFlow(ConfigFlow, domain=DOMAIN):
             data_schema=vol.Schema(
                 {
                     vol.Optional(CONF_REGION_IDENTIFIER): cv.string,
-                    vol.Optional(CONF_GPS_TRACKER): EntitySelector(
+                    vol.Optional(CONF_REGION_DEVICE_TRACKER): EntitySelector(
                         EntitySelectorConfig(domain="device_tracker")
                     ),
                 }

--- a/homeassistant/components/dwd_weather_warnings/const.py
+++ b/homeassistant/components/dwd_weather_warnings/const.py
@@ -14,6 +14,7 @@ DOMAIN: Final = "dwd_weather_warnings"
 
 CONF_REGION_NAME: Final = "region_name"
 CONF_REGION_IDENTIFIER: Final = "region_identifier"
+CONF_GPS_TRACKER: Final = "gps_tracker"
 
 ATTR_REGION_NAME: Final = "region_name"
 ATTR_REGION_ID: Final = "region_id"

--- a/homeassistant/components/dwd_weather_warnings/const.py
+++ b/homeassistant/components/dwd_weather_warnings/const.py
@@ -14,7 +14,7 @@ DOMAIN: Final = "dwd_weather_warnings"
 
 CONF_REGION_NAME: Final = "region_name"
 CONF_REGION_IDENTIFIER: Final = "region_identifier"
-CONF_GPS_TRACKER: Final = "gps_tracker"
+CONF_REGION_DEVICE_TRACKER: Final = "region_device_tracker"
 
 ATTR_REGION_NAME: Final = "region_name"
 ATTR_REGION_ID: Final = "region_id"

--- a/homeassistant/components/dwd_weather_warnings/coordinator.py
+++ b/homeassistant/components/dwd_weather_warnings/coordinator.py
@@ -23,6 +23,7 @@ class DwdWeatherWarningsCoordinator(DataUpdateCoordinator[None]):
     """Custom coordinator for the dwd_weather_warnings integration."""
 
     config_entry: ConfigEntry
+    _api: DwdWeatherWarningsAPI
 
     def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
         """Initialize the dwd_weather_warnings coordinator."""
@@ -30,7 +31,6 @@ class DwdWeatherWarningsCoordinator(DataUpdateCoordinator[None]):
             hass, LOGGER, name=DOMAIN, update_interval=DEFAULT_SCAN_INTERVAL
         )
 
-        self._api = DwdWeatherWarningsAPI(None)
         self._device_tracker = None
 
     async def async_config_entry_first_refresh(self) -> None:
@@ -58,7 +58,4 @@ class DwdWeatherWarningsCoordinator(DataUpdateCoordinator[None]):
                 DwdWeatherWarningsAPI, position
             )
         else:
-            if self._api is None:
-                raise UpdateFailed("API is not initialized")
-
             await self.hass.async_add_executor_job(self._api.update)

--- a/homeassistant/components/dwd_weather_warnings/coordinator.py
+++ b/homeassistant/components/dwd_weather_warnings/coordinator.py
@@ -7,7 +7,8 @@ from dwdwfsapi import DwdWeatherWarningsAPI
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import DEFAULT_SCAN_INTERVAL, DOMAIN, LOGGER
+from .const import CONF_GPS_TRACKER, DEFAULT_SCAN_INTERVAL, DOMAIN, LOGGER
+from .util import get_position_data
 
 
 class DwdWeatherWarningsCoordinator(DataUpdateCoordinator[None]):
@@ -23,4 +24,11 @@ class DwdWeatherWarningsCoordinator(DataUpdateCoordinator[None]):
 
     async def _async_update_data(self) -> None:
         """Get the latest data from the DWD Weather Warnings API."""
-        await self.hass.async_add_executor_job(self.api.update)
+        if self.config_entry is not None:
+            if gps_tracker := self.config_entry.data.get(CONF_GPS_TRACKER, None):
+                position = get_position_data(self.hass, gps_tracker)
+                self.api = await self.hass.async_add_executor_job(
+                    DwdWeatherWarningsAPI, position
+                )
+            else:
+                await self.hass.async_add_executor_job(self.api.update)

--- a/homeassistant/components/dwd_weather_warnings/coordinator.py
+++ b/homeassistant/components/dwd_weather_warnings/coordinator.py
@@ -8,7 +8,13 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import CONF_REGION_DEVICE_TRACKER, DEFAULT_SCAN_INTERVAL, DOMAIN, LOGGER
+from .const import (
+    CONF_REGION_DEVICE_TRACKER,
+    CONF_REGION_IDENTIFIER,
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+    LOGGER,
+)
 from .exceptions import EntityNotFoundError
 from .util import get_position_data
 
@@ -18,24 +24,34 @@ class DwdWeatherWarningsCoordinator(DataUpdateCoordinator[None]):
 
     config_entry: ConfigEntry
 
-    def __init__(self, hass: HomeAssistant, api: DwdWeatherWarningsAPI) -> None:
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
         """Initialize the dwd_weather_warnings coordinator."""
         super().__init__(
             hass, LOGGER, name=DOMAIN, update_interval=DEFAULT_SCAN_INTERVAL
         )
 
-        self.api = api
+        self._api = None
+        self._device_tracker = None
+
+        # Do necessary setup of API when using a region identifier.
+        if region_identifier := entry.data.get(CONF_REGION_IDENTIFIER):
+            self._api = DwdWeatherWarningsAPI(region_identifier)
+        else:
+            self._device_tracker = entry.data.get(CONF_REGION_DEVICE_TRACKER)
 
     async def _async_update_data(self) -> None:
         """Get the latest data from the DWD Weather Warnings API."""
-        if device_tracker := self.config_entry.data.get(CONF_REGION_DEVICE_TRACKER):
+        if self._device_tracker:
             try:
-                position = get_position_data(self.hass, device_tracker)
+                position = get_position_data(self.hass, self._device_tracker)
             except (EntityNotFoundError, AttributeError) as err:
                 raise UpdateFailed(f"Error fetching position: {repr(err)}") from err
 
-            self.api = await self.hass.async_add_executor_job(
+            self._api = await self.hass.async_add_executor_job(
                 DwdWeatherWarningsAPI, position
             )
         else:
-            await self.hass.async_add_executor_job(self.api.update)
+            if self._api is None:
+                raise UpdateFailed("API is not initialized")
+
+            await self.hass.async_add_executor_job(self._api.update)

--- a/homeassistant/components/dwd_weather_warnings/coordinator.py
+++ b/homeassistant/components/dwd_weather_warnings/coordinator.py
@@ -30,7 +30,7 @@ class DwdWeatherWarningsCoordinator(DataUpdateCoordinator[None]):
             hass, LOGGER, name=DOMAIN, update_interval=DEFAULT_SCAN_INTERVAL
         )
 
-        self._api = None
+        self._api = DwdWeatherWarningsAPI(None)
         self._device_tracker = None
 
         # Do necessary setup of API when using a region identifier.

--- a/homeassistant/components/dwd_weather_warnings/coordinator.py
+++ b/homeassistant/components/dwd_weather_warnings/coordinator.py
@@ -33,11 +33,18 @@ class DwdWeatherWarningsCoordinator(DataUpdateCoordinator[None]):
         self._api = DwdWeatherWarningsAPI(None)
         self._device_tracker = None
 
-        # Do necessary setup of API when using a region identifier.
-        if region_identifier := entry.data.get(CONF_REGION_IDENTIFIER):
-            self._api = DwdWeatherWarningsAPI(region_identifier)
+    async def async_config_entry_first_refresh(self) -> None:
+        """Perform first refresh."""
+        if region_identifier := self.config_entry.data.get(CONF_REGION_IDENTIFIER):
+            self._api = await self.hass.async_add_executor_job(
+                DwdWeatherWarningsAPI, region_identifier
+            )
         else:
-            self._device_tracker = entry.data.get(CONF_REGION_DEVICE_TRACKER)
+            self._device_tracker = self.config_entry.data.get(
+                CONF_REGION_DEVICE_TRACKER
+            )
+
+        await super().async_config_entry_first_refresh()
 
     async def _async_update_data(self) -> None:
         """Get the latest data from the DWD Weather Warnings API."""

--- a/homeassistant/components/dwd_weather_warnings/coordinator.py
+++ b/homeassistant/components/dwd_weather_warnings/coordinator.py
@@ -7,7 +7,7 @@ from dwdwfsapi import DwdWeatherWarningsAPI
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import CONF_GPS_TRACKER, DEFAULT_SCAN_INTERVAL, DOMAIN, LOGGER
+from .const import CONF_REGION_DEVICE_TRACKER, DEFAULT_SCAN_INTERVAL, DOMAIN, LOGGER
 from .util import get_position_data
 
 
@@ -25,7 +25,9 @@ class DwdWeatherWarningsCoordinator(DataUpdateCoordinator[None]):
     async def _async_update_data(self) -> None:
         """Get the latest data from the DWD Weather Warnings API."""
         if self.config_entry is not None:
-            if gps_tracker := self.config_entry.data.get(CONF_GPS_TRACKER, None):
+            if gps_tracker := self.config_entry.data.get(
+                CONF_REGION_DEVICE_TRACKER, None
+            ):
                 position = get_position_data(self.hass, gps_tracker)
                 self.api = await self.hass.async_add_executor_job(
                     DwdWeatherWarningsAPI, position

--- a/homeassistant/components/dwd_weather_warnings/coordinator.py
+++ b/homeassistant/components/dwd_weather_warnings/coordinator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dwdwfsapi import DwdWeatherWarningsAPI
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
@@ -13,6 +14,8 @@ from .util import get_position_data
 
 class DwdWeatherWarningsCoordinator(DataUpdateCoordinator[None]):
     """Custom coordinator for the dwd_weather_warnings integration."""
+
+    config_entry: ConfigEntry
 
     def __init__(self, hass: HomeAssistant, api: DwdWeatherWarningsAPI) -> None:
         """Initialize the dwd_weather_warnings coordinator."""
@@ -24,13 +27,10 @@ class DwdWeatherWarningsCoordinator(DataUpdateCoordinator[None]):
 
     async def _async_update_data(self) -> None:
         """Get the latest data from the DWD Weather Warnings API."""
-        if self.config_entry is not None:
-            if gps_tracker := self.config_entry.data.get(
-                CONF_REGION_DEVICE_TRACKER, None
-            ):
-                position = get_position_data(self.hass, gps_tracker)
-                self.api = await self.hass.async_add_executor_job(
-                    DwdWeatherWarningsAPI, position
-                )
-            else:
-                await self.hass.async_add_executor_job(self.api.update)
+        if device_tracker := self.config_entry.data.get(CONF_REGION_DEVICE_TRACKER):
+            position = get_position_data(self.hass, device_tracker)
+            self.api = await self.hass.async_add_executor_job(
+                DwdWeatherWarningsAPI, position
+            )
+        else:
+            await self.hass.async_add_executor_job(self.api.update)

--- a/homeassistant/components/dwd_weather_warnings/exceptions.py
+++ b/homeassistant/components/dwd_weather_warnings/exceptions.py
@@ -1,4 +1,5 @@
 """Exceptions for the dwd_weather_warnings integration."""
+
 from homeassistant.exceptions import HomeAssistantError
 
 

--- a/homeassistant/components/dwd_weather_warnings/exceptions.py
+++ b/homeassistant/components/dwd_weather_warnings/exceptions.py
@@ -1,0 +1,6 @@
+"""Exceptions for the dwd_weather_warnings integration."""
+from homeassistant.exceptions import HomeAssistantError
+
+
+class EntityNotFoundError(HomeAssistantError):
+    """When a referenced entity was not found."""

--- a/homeassistant/components/dwd_weather_warnings/sensor.py
+++ b/homeassistant/components/dwd_weather_warnings/sensor.py
@@ -95,29 +95,27 @@ class DwdWeatherWarningsSensor(
             entry_type=DeviceEntryType.SERVICE,
         )
 
-        self.api = coordinator._api
-
     @property
     def native_value(self) -> int | None:
         """Return the state of the sensor."""
         if self.entity_description.key == CURRENT_WARNING_SENSOR:
-            return self.api.current_warning_level
+            return self.coordinator.api.current_warning_level
 
-        return self.api.expected_warning_level
+        return self.coordinator.api.expected_warning_level
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes of the sensor."""
         data = {
-            ATTR_REGION_NAME: self.api.warncell_name,
-            ATTR_REGION_ID: self.api.warncell_id,
-            ATTR_LAST_UPDATE: self.api.last_update,
+            ATTR_REGION_NAME: self.coordinator.api.warncell_name,
+            ATTR_REGION_ID: self.coordinator.api.warncell_id,
+            ATTR_LAST_UPDATE: self.coordinator.api.last_update,
         }
 
         if self.entity_description.key == CURRENT_WARNING_SENSOR:
-            searched_warnings = self.api.current_warnings
+            searched_warnings = self.coordinator.api.current_warnings
         else:
-            searched_warnings = self.api.expected_warnings
+            searched_warnings = self.coordinator.api.expected_warnings
 
         data[ATTR_WARNING_COUNT] = len(searched_warnings)
 
@@ -144,4 +142,4 @@ class DwdWeatherWarningsSensor(
     @property
     def available(self) -> bool:
         """Could the device be accessed during the last update call."""
-        return self.api.data_valid
+        return self.coordinator.api.data_valid

--- a/homeassistant/components/dwd_weather_warnings/sensor.py
+++ b/homeassistant/components/dwd_weather_warnings/sensor.py
@@ -101,23 +101,23 @@ class DwdWeatherWarningsSensor(
     def native_value(self) -> int | None:
         """Return the state of the sensor."""
         if self.entity_description.key == CURRENT_WARNING_SENSOR:
-            return self.coordinator.api.current_warning_level
+            return self.api.current_warning_level
 
-        return self.coordinator.api.expected_warning_level
+        return self.api.expected_warning_level
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes of the sensor."""
         data = {
-            ATTR_REGION_NAME: self.coordinator.api.warncell_name,
-            ATTR_REGION_ID: self.coordinator.api.warncell_id,
-            ATTR_LAST_UPDATE: self.coordinator.api.last_update,
+            ATTR_REGION_NAME: self.api.warncell_name,
+            ATTR_REGION_ID: self.api.warncell_id,
+            ATTR_LAST_UPDATE: self.api.last_update,
         }
 
         if self.entity_description.key == CURRENT_WARNING_SENSOR:
-            searched_warnings = self.coordinator.api.current_warnings
+            searched_warnings = self.api.current_warnings
         else:
-            searched_warnings = self.coordinator.api.expected_warnings
+            searched_warnings = self.api.expected_warnings
 
         data[ATTR_WARNING_COUNT] = len(searched_warnings)
 
@@ -144,4 +144,4 @@ class DwdWeatherWarningsSensor(
     @property
     def available(self) -> bool:
         """Could the device be accessed during the last update call."""
-        return self.coordinator.api.data_valid
+        return self.api.data_valid

--- a/homeassistant/components/dwd_weather_warnings/sensor.py
+++ b/homeassistant/components/dwd_weather_warnings/sensor.py
@@ -11,6 +11,8 @@ Wetterwarnungen (Stufe 1)
 
 from __future__ import annotations
 
+from typing import Any
+
 from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -96,26 +98,26 @@ class DwdWeatherWarningsSensor(
         self.api = coordinator.api
 
     @property
-    def native_value(self):
+    def native_value(self) -> int | None:
         """Return the state of the sensor."""
         if self.entity_description.key == CURRENT_WARNING_SENSOR:
-            return self.api.current_warning_level
+            return self.coordinator.api.current_warning_level
 
-        return self.api.expected_warning_level
+        return self.coordinator.api.expected_warning_level
 
     @property
-    def extra_state_attributes(self):
+    def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes of the sensor."""
         data = {
-            ATTR_REGION_NAME: self.api.warncell_name,
-            ATTR_REGION_ID: self.api.warncell_id,
-            ATTR_LAST_UPDATE: self.api.last_update,
+            ATTR_REGION_NAME: self.coordinator.api.warncell_name,
+            ATTR_REGION_ID: self.coordinator.api.warncell_id,
+            ATTR_LAST_UPDATE: self.coordinator.api.last_update,
         }
 
         if self.entity_description.key == CURRENT_WARNING_SENSOR:
-            searched_warnings = self.api.current_warnings
+            searched_warnings = self.coordinator.api.current_warnings
         else:
-            searched_warnings = self.api.expected_warnings
+            searched_warnings = self.coordinator.api.expected_warnings
 
         data[ATTR_WARNING_COUNT] = len(searched_warnings)
 
@@ -142,4 +144,4 @@ class DwdWeatherWarningsSensor(
     @property
     def available(self) -> bool:
         """Could the device be accessed during the last update call."""
-        return self.api.data_valid
+        return self.coordinator.api.data_valid

--- a/homeassistant/components/dwd_weather_warnings/sensor.py
+++ b/homeassistant/components/dwd_weather_warnings/sensor.py
@@ -95,7 +95,7 @@ class DwdWeatherWarningsSensor(
             entry_type=DeviceEntryType.SERVICE,
         )
 
-        self.api = coordinator.api
+        self.api = coordinator._api
 
     @property
     def native_value(self) -> int | None:

--- a/homeassistant/components/dwd_weather_warnings/strings.json
+++ b/homeassistant/components/dwd_weather_warnings/strings.json
@@ -12,7 +12,9 @@
     "error": {
       "no_identifier": "Either the region identifier or device tracker is required.",
       "ambiguous_identifier": "The region identifier and device tracker can not be specified together.",
-      "invalid_identifier": "The specified region identifier / device tracker is invalid."
+      "invalid_identifier": "The specified region identifier / device tracker is invalid.",
+      "entity_not_found": "The specified device tracker entity was not found.",
+      "attribute_not_found": "The required `latitude` or `longitude` attribute was not found in the specified device tracker."
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",

--- a/homeassistant/components/dwd_weather_warnings/strings.json
+++ b/homeassistant/components/dwd_weather_warnings/strings.json
@@ -2,17 +2,20 @@
   "config": {
     "step": {
       "user": {
-        "description": "To identify the desired region, the warncell ID / name is required.",
+        "description": "To identify the desired region, either the warncell ID / name or device tracker is required. The provided device tracker has to contain the attributes 'latitude' and 'longitude'.",
         "data": {
-          "region_identifier": "Warncell ID or name"
+          "region_identifier": "Warncell ID or name",
+          "gps_tracker": "Device tracker entity"
         }
       }
     },
     "error": {
-      "invalid_identifier": "The specified region identifier is invalid."
+      "no_identifier": "Either the region identifier or device tracker is required.",
+      "ambiguous_identifier": "The region identifier and device tracker can not be specified together.",
+      "invalid_identifier": "The specified region identifier / device tracker is invalid."
     },
     "abort": {
-      "already_configured": "Warncell ID / name is already configured.",
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "invalid_identifier": "[%key:component::dwd_weather_warnings::config::error::invalid_identifier%]"
     }
   },

--- a/homeassistant/components/dwd_weather_warnings/strings.json
+++ b/homeassistant/components/dwd_weather_warnings/strings.json
@@ -5,7 +5,7 @@
         "description": "To identify the desired region, either the warncell ID / name or device tracker is required. The provided device tracker has to contain the attributes 'latitude' and 'longitude'.",
         "data": {
           "region_identifier": "Warncell ID or name",
-          "gps_tracker": "Device tracker entity"
+          "region_device_tracker": "Device tracker entity"
         }
       }
     },

--- a/homeassistant/components/dwd_weather_warnings/util.py
+++ b/homeassistant/components/dwd_weather_warnings/util.py
@@ -10,9 +10,12 @@ from .exceptions import EntityNotFoundError
 
 
 def get_position_data(
-    hass: HomeAssistant, registry_id: str
+    hass: HomeAssistant, registry_id: str | None
 ) -> tuple[float, float] | None:
     """Extract longitude and latitude from a device tracker."""
+    if registry_id is None:
+        raise EntityNotFoundError("Failed to process registry ID")
+
     registry = er.async_get(hass)
     registry_entry = registry.async_get(registry_id)
     if registry_entry is None:

--- a/homeassistant/components/dwd_weather_warnings/util.py
+++ b/homeassistant/components/dwd_weather_warnings/util.py
@@ -4,29 +4,35 @@ from __future__ import annotations
 
 from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 
 from .exceptions import EntityNotFoundError
 
 
 def get_position_data(
-    hass: HomeAssistant, device_tracker: str
+    hass: HomeAssistant, registry_id: str
 ) -> tuple[float, float] | None:
     """Extract longitude and latitude from a device tracker."""
-    entity = hass.states.get(device_tracker)
+    registry = er.async_get(hass)
+    registry_entry = registry.async_get(registry_id)
+    if registry_entry is None:
+        raise EntityNotFoundError(f"Failed to find registry entry {registry_id}")
+
+    entity = hass.states.get(registry_entry.entity_id)
     if entity is None:
-        raise EntityNotFoundError(f"Failed to find entity {device_tracker}")
+        raise EntityNotFoundError(f"Failed to find entity {registry_entry.entity_id}")
 
     latitude = entity.attributes.get(ATTR_LATITUDE)
     if not latitude:
         raise AttributeError(
-            f"Failed to find attribute '{ATTR_LATITUDE}' in {device_tracker}",
+            f"Failed to find attribute '{ATTR_LATITUDE}' in {registry_entry.entity_id}",
             ATTR_LATITUDE,
         )
 
     longitude = entity.attributes.get(ATTR_LONGITUDE)
     if not longitude:
         raise AttributeError(
-            f"Failed to find attribute '{ATTR_LONGITUDE}' in {device_tracker}",
+            f"Failed to find attribute '{ATTR_LONGITUDE}' in {registry_entry.entity_id}",
             ATTR_LONGITUDE,
         )
 

--- a/homeassistant/components/dwd_weather_warnings/util.py
+++ b/homeassistant/components/dwd_weather_warnings/util.py
@@ -1,0 +1,32 @@
+"""Util functions for the dwd_weather_warnings integration."""
+
+from __future__ import annotations
+
+from homeassistant.core import HomeAssistant
+
+from .const import LOGGER
+
+
+def get_position_data(
+    hass: HomeAssistant, device_tracker: str
+) -> tuple[float, float] | None:
+    """Extract longitude and latitude from a device tracker."""
+    entity = hass.states.get(device_tracker)
+    if entity is None:
+        return None
+
+    latitude = entity.attributes.get("latitude")
+    if not latitude:
+        LOGGER.warning(
+            "Failed to find attribute 'latitude' in device_tracker %s", entity
+        )
+        return None
+
+    longitude = entity.attributes.get("longitude")
+    if not longitude:
+        LOGGER.warning(
+            "Failed to find attribute 'longitude' in device_tracker %s", entity
+        )
+        return None
+
+    return (latitude, longitude)

--- a/homeassistant/components/dwd_weather_warnings/util.py
+++ b/homeassistant/components/dwd_weather_warnings/util.py
@@ -10,12 +10,9 @@ from .exceptions import EntityNotFoundError
 
 
 def get_position_data(
-    hass: HomeAssistant, registry_id: str | None
+    hass: HomeAssistant, registry_id: str
 ) -> tuple[float, float] | None:
     """Extract longitude and latitude from a device tracker."""
-    if registry_id is None:
-        raise EntityNotFoundError("Failed to process registry ID")
-
     registry = er.async_get(hass)
     registry_entry = registry.async_get(registry_id)
     if registry_entry is None:

--- a/homeassistant/components/dwd_weather_warnings/util.py
+++ b/homeassistant/components/dwd_weather_warnings/util.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE
 from homeassistant.core import HomeAssistant
 
-from .const import LOGGER
+from .exceptions import EntityNotFoundError
 
 
 def get_position_data(
@@ -13,20 +14,20 @@ def get_position_data(
     """Extract longitude and latitude from a device tracker."""
     entity = hass.states.get(device_tracker)
     if entity is None:
-        return None
+        raise EntityNotFoundError(f"Failed to find entity {device_tracker}")
 
-    latitude = entity.attributes.get("latitude")
+    latitude = entity.attributes.get(ATTR_LATITUDE)
     if not latitude:
-        LOGGER.warning(
-            "Failed to find attribute 'latitude' in device_tracker %s", entity
+        raise AttributeError(
+            f"Failed to find attribute '{ATTR_LATITUDE}' in {device_tracker}",
+            ATTR_LATITUDE,
         )
-        return None
 
-    longitude = entity.attributes.get("longitude")
+    longitude = entity.attributes.get(ATTR_LONGITUDE)
     if not longitude:
-        LOGGER.warning(
-            "Failed to find attribute 'longitude' in device_tracker %s", entity
+        raise AttributeError(
+            f"Failed to find attribute '{ATTR_LONGITUDE}' in {device_tracker}",
+            ATTR_LONGITUDE,
         )
-        return None
 
     return (latitude, longitude)

--- a/tests/components/dwd_weather_warnings/test_config_flow.py
+++ b/tests/components/dwd_weather_warnings/test_config_flow.py
@@ -6,21 +6,12 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant.components.dwd_weather_warnings.const import (
-    ADVANCE_WARNING_SENSOR,
-    CONF_GPS_TRACKER,
+    CONF_REGION_DEVICE_TRACKER,
     CONF_REGION_IDENTIFIER,
-    CONF_REGION_NAME,
-    CURRENT_WARNING_SENSOR,
     DOMAIN,
 )
 from homeassistant.config_entries import SOURCE_USER
-from homeassistant.const import (
-    ATTR_LATITUDE,
-    ATTR_LONGITUDE,
-    CONF_MONITORED_CONDITIONS,
-    CONF_NAME,
-    STATE_HOME,
-)
+from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE, STATE_HOME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
@@ -31,13 +22,7 @@ DEMO_CONFIG_ENTRY_REGION: Final = {
 }
 
 DEMO_CONFIG_ENTRY_GPS: Final = {
-    CONF_GPS_TRACKER: "device_tracker.test_gps",
-}
-
-DEMO_YAML_CONFIGURATION: Final = {
-    CONF_NAME: "Unit Test",
-    CONF_REGION_NAME: "807111000",
-    CONF_MONITORED_CONDITIONS: [CURRENT_WARNING_SENSOR, ADVANCE_WARNING_SENSOR],
+    CONF_REGION_DEVICE_TRACKER: "device_tracker.test_gps",
 }
 
 pytestmark = pytest.mark.usefixtures("mock_setup_entry")
@@ -104,7 +89,7 @@ async def test_create_entry_gps(hass: HomeAssistant) -> None:
 
     # Add location data for unique ID.
     hass.states.async_set(
-        DEMO_CONFIG_ENTRY_GPS[CONF_GPS_TRACKER],
+        DEMO_CONFIG_ENTRY_GPS[CONF_REGION_DEVICE_TRACKER],
         STATE_HOME,
         {ATTR_LATITUDE: "50.180454", ATTR_LONGITUDE: "7.610263"},
     )
@@ -122,7 +107,7 @@ async def test_create_entry_gps(hass: HomeAssistant) -> None:
     assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["title"] == "test_gps"
     assert result["data"] == {
-        CONF_GPS_TRACKER: "device_tracker.test_gps",
+        CONF_REGION_DEVICE_TRACKER: "device_tracker.test_gps",
     }
 
 

--- a/tests/components/dwd_weather_warnings/test_config_flow.py
+++ b/tests/components/dwd_weather_warnings/test_config_flow.py
@@ -7,20 +7,31 @@ import pytest
 
 from homeassistant.components.dwd_weather_warnings.const import (
     ADVANCE_WARNING_SENSOR,
+    CONF_GPS_TRACKER,
     CONF_REGION_IDENTIFIER,
     CONF_REGION_NAME,
     CURRENT_WARNING_SENSOR,
     DOMAIN,
 )
 from homeassistant.config_entries import SOURCE_USER
-from homeassistant.const import CONF_MONITORED_CONDITIONS, CONF_NAME
+from homeassistant.const import (
+    ATTR_LATITUDE,
+    ATTR_LONGITUDE,
+    CONF_MONITORED_CONDITIONS,
+    CONF_NAME,
+    STATE_HOME,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from tests.common import MockConfigEntry
 
-DEMO_CONFIG_ENTRY: Final = {
+DEMO_CONFIG_ENTRY_REGION: Final = {
     CONF_REGION_IDENTIFIER: "807111000",
+}
+
+DEMO_CONFIG_ENTRY_GPS: Final = {
+    CONF_GPS_TRACKER: "device_tracker.test_gps",
 }
 
 DEMO_YAML_CONFIGURATION: Final = {
@@ -32,8 +43,8 @@ DEMO_YAML_CONFIGURATION: Final = {
 pytestmark = pytest.mark.usefixtures("mock_setup_entry")
 
 
-async def test_create_entry(hass: HomeAssistant) -> None:
-    """Test that the full config flow works."""
+async def test_create_entry_region(hass: HomeAssistant) -> None:
+    """Test that the full config flow works for a region identifier."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
@@ -45,7 +56,7 @@ async def test_create_entry(hass: HomeAssistant) -> None:
         return_value=False,
     ):
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input=DEMO_CONFIG_ENTRY
+            result["flow_id"], user_input=DEMO_CONFIG_ENTRY_REGION
         )
 
     # Test for invalid region identifier.
@@ -58,7 +69,7 @@ async def test_create_entry(hass: HomeAssistant) -> None:
         return_value=True,
     ):
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input=DEMO_CONFIG_ENTRY
+            result["flow_id"], user_input=DEMO_CONFIG_ENTRY_REGION
         )
 
     # Test for successfully created entry.
@@ -70,12 +81,57 @@ async def test_create_entry(hass: HomeAssistant) -> None:
     }
 
 
+async def test_create_entry_gps(hass: HomeAssistant) -> None:
+    """Test that the full config flow works for a device tracker."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    await hass.async_block_till_done()
+    assert result["type"] == FlowResultType.FORM
+
+    with patch(
+        "homeassistant.components.dwd_weather_warnings.config_flow.DwdWeatherWarningsAPI",
+        return_value=False,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input=DEMO_CONFIG_ENTRY_GPS
+        )
+
+    # Test for invalid location data.
+    await hass.async_block_till_done()
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {"base": "invalid_identifier"}
+
+    # Add location data for unique ID.
+    hass.states.async_set(
+        DEMO_CONFIG_ENTRY_GPS[CONF_GPS_TRACKER],
+        STATE_HOME,
+        {ATTR_LATITUDE: "50.180454", ATTR_LONGITUDE: "7.610263"},
+    )
+
+    with patch(
+        "homeassistant.components.dwd_weather_warnings.config_flow.DwdWeatherWarningsAPI",
+        return_value=True,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input=DEMO_CONFIG_ENTRY_GPS
+        )
+
+    # Test for successfully created entry.
+    await hass.async_block_till_done()
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == "test_gps"
+    assert result["data"] == {
+        CONF_GPS_TRACKER: "device_tracker.test_gps",
+    }
+
+
 async def test_config_flow_already_configured(hass: HomeAssistant) -> None:
     """Test aborting, if the warncell ID / name is already configured during the config."""
     entry = MockConfigEntry(
         domain=DOMAIN,
-        data=DEMO_CONFIG_ENTRY.copy(),
-        unique_id=DEMO_CONFIG_ENTRY[CONF_REGION_IDENTIFIER],
+        data=DEMO_CONFIG_ENTRY_REGION.copy(),
+        unique_id=DEMO_CONFIG_ENTRY_REGION[CONF_REGION_IDENTIFIER],
     )
     entry.add_to_hass(hass)
 
@@ -92,9 +148,40 @@ async def test_config_flow_already_configured(hass: HomeAssistant) -> None:
         return_value=True,
     ):
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input=DEMO_CONFIG_ENTRY
+            result["flow_id"], user_input=DEMO_CONFIG_ENTRY_REGION
         )
 
     await hass.async_block_till_done()
     assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "already_configured"
+
+
+async def test_config_flow_with_errors(hass: HomeAssistant) -> None:
+    """Test error scenarios during the configuration."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    await hass.async_block_till_done()
+    assert result["type"] == FlowResultType.FORM
+
+    # Test error for empty input data.
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
+    )
+
+    await hass.async_block_till_done()
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {"base": "no_identifier"}
+
+    # Test error for setting both options during configuration.
+    demo_input = DEMO_CONFIG_ENTRY_REGION.copy()
+    demo_input.update(DEMO_CONFIG_ENTRY_GPS.copy())
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input=demo_input,
+    )
+
+    await hass.async_block_till_done()
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {"base": "ambiguous_identifier"}

--- a/tests/components/dwd_weather_warnings/test_init.py
+++ b/tests/components/dwd_weather_warnings/test_init.py
@@ -4,26 +4,39 @@ from typing import Final
 
 from homeassistant.components.dwd_weather_warnings.const import (
     ADVANCE_WARNING_SENSOR,
+    CONF_REGION_DEVICE_TRACKER,
     CONF_REGION_IDENTIFIER,
     CURRENT_WARNING_SENSOR,
     DOMAIN,
 )
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import CONF_MONITORED_CONDITIONS, CONF_NAME
+from homeassistant.const import (
+    ATTR_LATITUDE,
+    ATTR_LONGITUDE,
+    CONF_MONITORED_CONDITIONS,
+    CONF_NAME,
+    STATE_HOME,
+)
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
-DEMO_CONFIG_ENTRY: Final = {
+DEMO_IDENTIFIER_CONFIG_ENTRY: Final = {
     CONF_NAME: "Unit Test",
     CONF_REGION_IDENTIFIER: "807111000",
     CONF_MONITORED_CONDITIONS: [CURRENT_WARNING_SENSOR, ADVANCE_WARNING_SENSOR],
 }
 
+DEMO_TRACKER_CONFIG_ENTRY: Final = {
+    CONF_NAME: "Unit Test",
+    CONF_REGION_DEVICE_TRACKER: "device_tracker.test_gps",
+    CONF_MONITORED_CONDITIONS: [CURRENT_WARNING_SENSOR, ADVANCE_WARNING_SENSOR],
+}
+
 
 async def test_load_unload_entry(hass: HomeAssistant) -> None:
-    """Test loading and unloading the integration."""
-    entry = MockConfigEntry(domain=DOMAIN, data=DEMO_CONFIG_ENTRY)
+    """Test loading and unloading the integration with a region identifier based entry."""
+    entry = MockConfigEntry(domain=DOMAIN, data=DEMO_IDENTIFIER_CONFIG_ENTRY)
     entry.add_to_hass(hass)
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
@@ -36,3 +49,57 @@ async def test_load_unload_entry(hass: HomeAssistant) -> None:
 
     assert entry.state is ConfigEntryState.NOT_LOADED
     assert entry.entry_id not in hass.data[DOMAIN]
+
+
+async def test_load_device_tracker_entry(hass: HomeAssistant) -> None:
+    """Test loading the integration with a device tracker based entry."""
+    # Test for invalid entity id
+    INVALID_DATA = DEMO_TRACKER_CONFIG_ENTRY.copy()
+    INVALID_DATA[CONF_REGION_DEVICE_TRACKER] = "invalid_entity_id"
+    entry = MockConfigEntry(domain=DOMAIN, data=INVALID_DATA)
+    entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    assert entry.state == ConfigEntryState.SETUP_ERROR
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Test for missing device tracker entity
+    entry = MockConfigEntry(domain=DOMAIN, data=DEMO_TRACKER_CONFIG_ENTRY)
+    entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    assert entry.state == ConfigEntryState.SETUP_ERROR
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Test for missing attribute in device tracker
+    hass.states.async_set(
+        DEMO_TRACKER_CONFIG_ENTRY[CONF_REGION_DEVICE_TRACKER],
+        STATE_HOME,
+        {ATTR_LONGITUDE: "7.610263"},
+    )
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    assert entry.state == ConfigEntryState.SETUP_ERROR
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Test for fully valid device tracker
+    hass.states.async_set(
+        DEMO_TRACKER_CONFIG_ENTRY[CONF_REGION_DEVICE_TRACKER],
+        STATE_HOME,
+        {ATTR_LATITUDE: "50.180454", ATTR_LONGITUDE: "7.610263"},
+    )
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state == ConfigEntryState.LOADED
+    assert entry.entry_id in hass.data[DOMAIN]

--- a/tests/components/dwd_weather_warnings/test_init.py
+++ b/tests/components/dwd_weather_warnings/test_init.py
@@ -61,7 +61,7 @@ async def test_load_invalid_registry_entry(hass: HomeAssistant) -> None:
 
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
-    assert entry.state == ConfigEntryState.SETUP_ERROR
+    assert entry.state == ConfigEntryState.SETUP_RETRY
 
 
 async def test_load_missing_device_tracker(hass: HomeAssistant) -> None:
@@ -71,7 +71,7 @@ async def test_load_missing_device_tracker(hass: HomeAssistant) -> None:
 
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
-    assert entry.state == ConfigEntryState.SETUP_ERROR
+    assert entry.state == ConfigEntryState.SETUP_RETRY
 
 
 async def test_load_missing_required_attribute(hass: HomeAssistant) -> None:
@@ -87,7 +87,7 @@ async def test_load_missing_required_attribute(hass: HomeAssistant) -> None:
 
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
-    assert entry.state == ConfigEntryState.SETUP_ERROR
+    assert entry.state == ConfigEntryState.SETUP_RETRY
 
 
 async def test_load_valid_device_tracker(

--- a/tests/components/dwd_weather_warnings/test_init.py
+++ b/tests/components/dwd_weather_warnings/test_init.py
@@ -18,6 +18,7 @@ from homeassistant.const import (
     STATE_HOME,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 
 from tests.common import MockConfigEntry
 
@@ -51,11 +52,10 @@ async def test_load_unload_entry(hass: HomeAssistant) -> None:
     assert entry.entry_id not in hass.data[DOMAIN]
 
 
-async def test_load_device_tracker_entry(hass: HomeAssistant) -> None:
-    """Test loading the integration with a device tracker based entry."""
-    # Test for invalid entity id
+async def test_load_invalid_registry_entry(hass: HomeAssistant) -> None:
+    """Test loading the integration with an invalid registry entry ID."""
     INVALID_DATA = DEMO_TRACKER_CONFIG_ENTRY.copy()
-    INVALID_DATA[CONF_REGION_DEVICE_TRACKER] = "invalid_entity_id"
+    INVALID_DATA[CONF_REGION_DEVICE_TRACKER] = "invalid_registry_id"
     entry = MockConfigEntry(domain=DOMAIN, data=INVALID_DATA)
     entry.add_to_hass(hass)
 
@@ -63,10 +63,9 @@ async def test_load_device_tracker_entry(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
     assert entry.state == ConfigEntryState.SETUP_ERROR
 
-    assert await hass.config_entries.async_unload(entry.entry_id)
-    await hass.async_block_till_done()
 
-    # Test for missing device tracker entity
+async def test_load_missing_device_tracker(hass: HomeAssistant) -> None:
+    """Test loading the integration with a missing device tracker."""
     entry = MockConfigEntry(domain=DOMAIN, data=DEMO_TRACKER_CONFIG_ENTRY)
     entry.add_to_hass(hass)
 
@@ -74,10 +73,12 @@ async def test_load_device_tracker_entry(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
     assert entry.state == ConfigEntryState.SETUP_ERROR
 
-    assert await hass.config_entries.async_unload(entry.entry_id)
-    await hass.async_block_till_done()
 
-    # Test for missing attribute in device tracker
+async def test_load_missing_required_attribute(hass: HomeAssistant) -> None:
+    """Test loading the integration with a device tracker missing a required attribute."""
+    entry = MockConfigEntry(domain=DOMAIN, data=DEMO_TRACKER_CONFIG_ENTRY)
+    entry.add_to_hass(hass)
+
     hass.states.async_set(
         DEMO_TRACKER_CONFIG_ENTRY[CONF_REGION_DEVICE_TRACKER],
         STATE_HOME,
@@ -88,10 +89,21 @@ async def test_load_device_tracker_entry(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
     assert entry.state == ConfigEntryState.SETUP_ERROR
 
-    assert await hass.config_entries.async_unload(entry.entry_id)
-    await hass.async_block_till_done()
 
-    # Test for fully valid device tracker
+async def test_load_valid_device_tracker(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test loading the integration with a valid device tracker based entry."""
+    entry = MockConfigEntry(domain=DOMAIN, data=DEMO_TRACKER_CONFIG_ENTRY)
+    entry.add_to_hass(hass)
+    entity_registry.async_get_or_create(
+        "device_tracker",
+        entry.domain,
+        "uuid",
+        suggested_object_id="test_gps",
+        config_entry=entry,
+    )
+
     hass.states.async_set(
         DEMO_TRACKER_CONFIG_ENTRY[CONF_REGION_DEVICE_TRACKER],
         STATE_HOME,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds the optional feature to have a dynamic region by configuring it to use a device tracker that contains the current location. This allows the user to have weather warnings wherever they go instead of using fixed locations.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/28107

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
