### PR TITLE
Fix bug in check_config when an integration is removed by its own validator

### DIFF
--- a/homeassistant/helpers/check_config.py
+++ b/homeassistant/helpers/check_config.py
@@ -183,13 +183,6 @@ async def async_check_ha_config_file(  # noqa: C901
                 config = config_schema(config)
                 if domain in config:
                     result[domain] = config[domain]
-                else:
-                    result.add_error(
-                        f"Config found for {domain} integration in "
-                        "configuration.yaml. YAML support for this "
-                        "integration has been removed. Please remove "
-                        "it from your configuration.yaml."
-                    )
             except vol.Invalid as ex:
                 _comp_error(ex, domain, config)
                 continue

--- a/homeassistant/helpers/check_config.py
+++ b/homeassistant/helpers/check_config.py
@@ -181,6 +181,7 @@ async def async_check_ha_config_file(  # noqa: C901
         if config_schema is not None:
             try:
                 config = config_schema(config)
+                # Don't fail if the validator removed the domain from the config
                 if domain in config:
                     result[domain] = config[domain]
             except vol.Invalid as ex:

--- a/homeassistant/helpers/check_config.py
+++ b/homeassistant/helpers/check_config.py
@@ -183,6 +183,13 @@ async def async_check_ha_config_file(  # noqa: C901
                 config = config_schema(config)
                 if domain in config:
                     result[domain] = config[domain]
+                else:
+                    result.add_error(
+                        f"Config found for {domain} integration in "
+                        "configuration.yaml. YAML support for this "
+                        "integration has been removed. Please remove "
+                        "it from your configuration.yaml."
+                    )
             except vol.Invalid as ex:
                 _comp_error(ex, domain, config)
                 continue

--- a/homeassistant/helpers/check_config.py
+++ b/homeassistant/helpers/check_config.py
@@ -181,7 +181,8 @@ async def async_check_ha_config_file(  # noqa: C901
         if config_schema is not None:
             try:
                 config = config_schema(config)
-                result[domain] = config[domain]
+                if domain in config:
+                    result[domain] = config[domain]
             except vol.Invalid as ex:
                 _comp_error(ex, domain, config)
                 continue

--- a/tests/helpers/test_check_config.py
+++ b/tests/helpers/test_check_config.py
@@ -264,6 +264,3 @@ async def test_removed_yaml_support(hass: HomeAssistant) -> None:
         log_ha_config(res)
 
         assert res.keys() == {"homeassistant"}
-        assert res.error_str.startswith(
-            "Config found for bla integration in configuration.yaml. YAML support for this integration has been removed. Please remove it from your configuration.yaml."
-        )

--- a/tests/helpers/test_check_config.py
+++ b/tests/helpers/test_check_config.py
@@ -8,9 +8,10 @@ from homeassistant.helpers.check_config import (
     CheckConfigError,
     async_check_ha_config_file,
 )
+import homeassistant.helpers.config_validation as cv
 from homeassistant.requirements import RequirementsNotFound
 
-from tests.common import mock_platform, patch_yaml_files
+from tests.common import MockModule, mock_integration, mock_platform, patch_yaml_files
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -246,3 +247,23 @@ bla:
         assert err.domain == "bla"
         assert err.message == "Unexpected error calling config validator: Broken"
         assert err.config == {"value": 1}
+
+
+async def test_removed_yaml_support(hass: HomeAssistant) -> None:
+    """Test config validation check with removed CONFIG_SCHEMA without raise if present."""
+    mock_integration(
+        hass,
+        MockModule(
+            domain="bla", config_schema=cv.removed("bla", raise_if_present=False)
+        ),
+        False,
+    )
+    files = {YAML_CONFIG_FILE: BASE_CONFIG + "bla:\n  platform: demo"}
+    with patch("os.path.isfile", return_value=True), patch_yaml_files(files):
+        res = await async_check_ha_config_file(hass)
+        log_ha_config(res)
+
+        assert res.keys() == {"homeassistant"}
+        assert res.error_str.startswith(
+            "Config found for bla integration in configuration.yaml. YAML support for this integration has been removed. Please remove it from your configuration.yaml."
+        )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As found out in #96061, the integrations `tradfri` and `webostv` were blocking restart without a clear error message. When checking the code, both had `cv.removed(DOMAIN, raise_if_present=False)`, meaning that the field should be removed, but it isn't a big deal so we don't raise an exception. 

Except, after `config = config_schema(config)`, the `tradfri` key is gone from the config because of the `cv.removed`. When accessed in the next line, it threw a KeyError.

This also solves the verify configuration feature in Developer tools from returning a 500 (and the frontend just says that it's still loading).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #96061
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
