### PR TITLE
Use default MyStrom devicetype if not present

### DIFF
--- a/homeassistant/components/mystrom/__init__.py
+++ b/homeassistant/components/mystrom/__init__.py
@@ -32,6 +32,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _LOGGER.error("No route to myStrom plug: %s", host)
         raise ConfigEntryNotReady() from err
 
+    if "type" not in info:
+        info["type"] = 101
+
     device_type = info["type"]
     if device_type in [101, 106, 107]:
         device = MyStromSwitch(host)

--- a/homeassistant/components/mystrom/__init__.py
+++ b/homeassistant/components/mystrom/__init__.py
@@ -50,8 +50,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _LOGGER.error("No route to myStrom plug: %s", host)
         raise ConfigEntryNotReady() from err
 
-    if "type" not in info:
-        info["type"] = 101
+    info.setdefault("type", 101)
 
     device_type = info["type"]
     if device_type in [101, 106, 107]:

--- a/tests/components/mystrom/__init__.py
+++ b/tests/components/mystrom/__init__.py
@@ -2,12 +2,11 @@
 from typing import Any, Optional
 
 
-def get_default_device_response(device_type: int) -> dict[str, Any]:
+def get_default_device_response(device_type: int | None) -> dict[str, Any]:
     """Return default device response."""
-    return {
+    response = {
         "version": "2.59.32",
         "mac": "6001940376EB",
-        "type": device_type,
         "ssid": "personal",
         "ip": "192.168.0.23",
         "mask": "255.255.255.0",
@@ -17,6 +16,9 @@ def get_default_device_response(device_type: int) -> dict[str, Any]:
         "connected": True,
         "signal": 94,
     }
+    if device_type is not None:
+        response["type"] = device_type
+    return response
 
 
 def get_default_bulb_state() -> dict[str, Any]:

--- a/tests/components/mystrom/__init__.py
+++ b/tests/components/mystrom/__init__.py
@@ -16,8 +16,7 @@ def get_default_device_response(device_type: int | None) -> dict[str, Any]:
         "connected": True,
         "signal": 94,
     }
-    if device_type is not None:
-        response["type"] = device_type
+    response.setdefault("type", device_type)
     return response
 
 

--- a/tests/components/mystrom/__init__.py
+++ b/tests/components/mystrom/__init__.py
@@ -16,7 +16,8 @@ def get_default_device_response(device_type: int | None) -> dict[str, Any]:
         "connected": True,
         "signal": 94,
     }
-    response.setdefault("type", device_type)
+    if device_type is not None:
+        response["type"] = device_type
     return response
 
 

--- a/tests/components/mystrom/test_init.py
+++ b/tests/components/mystrom/test_init.py
@@ -44,7 +44,7 @@ async def test_init_switch_and_unload(
     hass: HomeAssistant, config_entry: MockConfigEntry
 ) -> None:
     """Test the initialization of a myStrom switch."""
-    await init_integration(hass, config_entry, 101)
+    await init_integration(hass, config_entry, 106)
     state = hass.states.get("switch.mystrom_device")
     assert state is not None
     assert config_entry.state is ConfigEntryState.LOADED
@@ -58,7 +58,7 @@ async def test_init_switch_and_unload(
 @pytest.mark.parametrize(
     ("device_type", "platform", "entry_state", "entity_state_none"),
     [
-        (101, "switch", ConfigEntryState.LOADED, False),
+        (None, "switch", ConfigEntryState.LOADED, False),
         (102, "light", ConfigEntryState.LOADED, False),
         (103, "button", ConfigEntryState.SETUP_ERROR, True),
         (104, "button", ConfigEntryState.SETUP_ERROR, True),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Every device except the oldest MyStrom switch returns a type. Before the config flow, the type was not needed. Now it's used to differentiate between a switch and a bulb. To allow the first generation of switches to work again, we set the type to that switch if it's not present.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #95929
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
