### PR TITLE
Migrate ring to entity name

### DIFF
--- a/homeassistant/components/ring/binary_sensor.py
+++ b/homeassistant/components/ring/binary_sensor.py
@@ -35,13 +35,12 @@ class RingBinarySensorEntityDescription(
 BINARY_SENSOR_TYPES: tuple[RingBinarySensorEntityDescription, ...] = (
     RingBinarySensorEntityDescription(
         key="ding",
-        name="Ding",
+        translation_key="ding",
         category=["doorbots", "authorized_doorbots"],
         device_class=BinarySensorDeviceClass.OCCUPANCY,
     ),
     RingBinarySensorEntityDescription(
         key="motion",
-        name="Motion",
         category=["doorbots", "authorized_doorbots", "stickup_cams"],
         device_class=BinarySensorDeviceClass.MOTION,
     ),
@@ -85,7 +84,6 @@ class RingBinarySensor(RingEntityMixin, BinarySensorEntity):
         super().__init__(config_entry_id, device)
         self.entity_description = description
         self._ring = ring
-        self._attr_name = f"{device.name} {description.name}"
         self._attr_unique_id = f"{device.id}-{description.key}"
         self._update_alert()
 

--- a/homeassistant/components/ring/camera.py
+++ b/homeassistant/components/ring/camera.py
@@ -48,11 +48,12 @@ async def async_setup_entry(
 class RingCam(RingEntityMixin, Camera):
     """An implementation of a Ring Door Bell camera."""
 
+    _attr_name = None
+
     def __init__(self, config_entry_id, ffmpeg_manager, device):
         """Initialize a Ring Door Bell camera."""
         super().__init__(config_entry_id, device)
 
-        self._name = self._device.name
         self._ffmpeg_manager = ffmpeg_manager
         self._last_event = None
         self._last_video_id = None
@@ -89,11 +90,6 @@ class RingCam(RingEntityMixin, Camera):
             self._image = None
             self._expires_at = dt_util.utcnow()
             self.async_write_ha_state()
-
-    @property
-    def name(self):
-        """Return the name of this camera."""
-        return self._name
 
     @property
     def unique_id(self):

--- a/homeassistant/components/ring/entity.py
+++ b/homeassistant/components/ring/entity.py
@@ -10,6 +10,7 @@ class RingEntityMixin(Entity):
 
     _attr_attribution = ATTRIBUTION
     _attr_should_poll = False
+    _attr_has_entity_name = True
 
     def __init__(self, config_entry_id, device):
         """Initialize a sensor for Ring device."""

--- a/homeassistant/components/ring/light.py
+++ b/homeassistant/components/ring/light.py
@@ -50,6 +50,7 @@ class RingLight(RingEntityMixin, LightEntity):
 
     _attr_color_mode = ColorMode.ONOFF
     _attr_supported_color_modes = {ColorMode.ONOFF}
+    _attr_translation_key = "light"
 
     def __init__(self, config_entry_id, device):
         """Initialize the light."""
@@ -66,11 +67,6 @@ class RingLight(RingEntityMixin, LightEntity):
 
         self._light_on = self._device.lights == ON_STATE
         self.async_write_ha_state()
-
-    @property
-    def name(self):
-        """Name of the light."""
-        return f"{self._device.name} light"
 
     @property
     def unique_id(self):

--- a/homeassistant/components/ring/sensor.py
+++ b/homeassistant/components/ring/sensor.py
@@ -13,7 +13,6 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import PERCENTAGE, SIGNAL_STRENGTH_DECIBELS_MILLIWATT
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.icon import icon_for_battery_level
 
 from . import DOMAIN
 from .entity import RingEntityMixin
@@ -53,8 +52,6 @@ class RingSensor(RingEntityMixin, SensorEntity):
         """Initialize a sensor for Ring device."""
         super().__init__(config_entry_id, device)
         self.entity_description = description
-        self._extra = None
-        self._attr_name = f"{device.name} {description.name}"
         self._attr_unique_id = f"{device.id}-{description.key}"
 
     @property
@@ -66,18 +63,6 @@ class RingSensor(RingEntityMixin, SensorEntity):
 
         if sensor_type == "battery":
             return self._device.battery_life
-
-    @property
-    def icon(self):
-        """Icon to use in the frontend, if any."""
-        if (
-            self.entity_description.key == "battery"
-            and self._device.battery_life is not None
-        ):
-            return icon_for_battery_level(
-                battery_level=self._device.battery_life, charging=False
-            )
-        return self.entity_description.icon
 
 
 class HealthDataRingSensor(RingSensor):
@@ -204,7 +189,6 @@ class RingSensorEntityDescription(SensorEntityDescription, RingRequiredKeysMixin
 SENSOR_TYPES: tuple[RingSensorEntityDescription, ...] = (
     RingSensorEntityDescription(
         key="battery",
-        name="Battery",
         category=["doorbots", "authorized_doorbots", "stickup_cams"],
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.BATTERY,
@@ -212,7 +196,7 @@ SENSOR_TYPES: tuple[RingSensorEntityDescription, ...] = (
     ),
     RingSensorEntityDescription(
         key="last_activity",
-        name="Last Activity",
+        translation_key="last_activity",
         category=["doorbots", "authorized_doorbots", "stickup_cams"],
         icon="mdi:history",
         device_class=SensorDeviceClass.TIMESTAMP,
@@ -220,7 +204,7 @@ SENSOR_TYPES: tuple[RingSensorEntityDescription, ...] = (
     ),
     RingSensorEntityDescription(
         key="last_ding",
-        name="Last Ding",
+        translation_key="last_ding",
         category=["doorbots", "authorized_doorbots"],
         icon="mdi:history",
         kind="ding",
@@ -229,7 +213,7 @@ SENSOR_TYPES: tuple[RingSensorEntityDescription, ...] = (
     ),
     RingSensorEntityDescription(
         key="last_motion",
-        name="Last Motion",
+        translation_key="last_motion",
         category=["doorbots", "authorized_doorbots", "stickup_cams"],
         icon="mdi:history",
         kind="motion",
@@ -238,21 +222,21 @@ SENSOR_TYPES: tuple[RingSensorEntityDescription, ...] = (
     ),
     RingSensorEntityDescription(
         key="volume",
-        name="Volume",
+        translation_key="volume",
         category=["chimes", "doorbots", "authorized_doorbots", "stickup_cams"],
         icon="mdi:bell-ring",
         cls=RingSensor,
     ),
     RingSensorEntityDescription(
         key="wifi_signal_category",
-        name="WiFi Signal Category",
+        translation_key="wifi_signal_category",
         category=["chimes", "doorbots", "authorized_doorbots", "stickup_cams"],
         icon="mdi:wifi",
         cls=HealthDataRingSensor,
     ),
     RingSensorEntityDescription(
         key="wifi_signal_strength",
-        name="WiFi Signal Strength",
+        translation_key="wifi_signal_strength",
         category=["chimes", "doorbots", "authorized_doorbots", "stickup_cams"],
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
         icon="mdi:wifi",

--- a/homeassistant/components/ring/siren.py
+++ b/homeassistant/components/ring/siren.py
@@ -33,16 +33,15 @@ async def async_setup_entry(
 class RingChimeSiren(RingEntityMixin, SirenEntity):
     """Creates a siren to play the test chimes of a Chime device."""
 
+    _attr_available_tones = CHIME_TEST_SOUND_KINDS
+    _attr_supported_features = SirenEntityFeature.TURN_ON | SirenEntityFeature.TONES
+    _attr_translation_key = "siren"
+
     def __init__(self, config_entry: ConfigEntry, device) -> None:
         """Initialize a Ring Chime siren."""
         super().__init__(config_entry.entry_id, device)
         # Entity class attributes
-        self._attr_name = f"{self._device.name} Siren"
         self._attr_unique_id = f"{self._device.id}-siren"
-        self._attr_available_tones = CHIME_TEST_SOUND_KINDS
-        self._attr_supported_features = (
-            SirenEntityFeature.TURN_ON | SirenEntityFeature.TONES
-        )
 
     def turn_on(self, **kwargs: Any) -> None:
         """Play the test sound on a Ring Chime device."""

--- a/homeassistant/components/ring/strings.json
+++ b/homeassistant/components/ring/strings.json
@@ -22,5 +22,47 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     }
+  },
+  "entity": {
+    "binary_sensor": {
+      "ding": {
+        "name": "Ding"
+      }
+    },
+    "light": {
+      "light": {
+        "name": "[%key:component::light::title%]"
+      }
+    },
+    "siren": {
+      "siren": {
+        "name": "[%key:component::siren::title%]"
+      }
+    },
+    "sensor": {
+      "last_activity": {
+        "name": "Last activity"
+      },
+      "last_ding": {
+        "name": "Last ding"
+      },
+      "last_motion": {
+        "name": "Last motion"
+      },
+      "volume": {
+        "name": "Volume"
+      },
+      "wifi_signal_category": {
+        "name": "Wi-Fi signal category"
+      },
+      "wifi_signal_strength": {
+        "name": "Wi-Fi signal strength"
+      }
+    },
+    "switch": {
+      "siren": {
+        "name": "[%key:component::siren::title%]"
+      }
+    }
   }
 }

--- a/homeassistant/components/ring/switch.py
+++ b/homeassistant/components/ring/switch.py
@@ -53,11 +53,6 @@ class BaseRingSwitch(RingEntityMixin, SwitchEntity):
         self._unique_id = f"{self._device.id}-{self._device_type}"
 
     @property
-    def name(self):
-        """Name of the device."""
-        return f"{self._device.name} {self._device_type}"
-
-    @property
     def unique_id(self):
         """Return a unique ID."""
         return self._unique_id
@@ -65,6 +60,8 @@ class BaseRingSwitch(RingEntityMixin, SwitchEntity):
 
 class SirenSwitch(BaseRingSwitch):
     """Creates a switch to turn the ring cameras siren on and off."""
+
+    _attr_translation_key = "siren"
 
     def __init__(self, config_entry_id, device):
         """Initialize the switch for a device with a siren."""

--- a/tests/components/ring/test_light.py
+++ b/tests/components/ring/test_light.py
@@ -32,7 +32,7 @@ async def test_light_off_reports_correctly(
 
     state = hass.states.get("light.front_light")
     assert state.state == "off"
-    assert state.attributes.get("friendly_name") == "Front light"
+    assert state.attributes.get("friendly_name") == "Front Light"
 
 
 async def test_light_on_reports_correctly(
@@ -43,7 +43,7 @@ async def test_light_on_reports_correctly(
 
     state = hass.states.get("light.internal_light")
     assert state.state == "on"
-    assert state.attributes.get("friendly_name") == "Internal light"
+    assert state.attributes.get("friendly_name") == "Internal Light"
 
 
 async def test_light_can_be_turned_on(

--- a/tests/components/ring/test_switch.py
+++ b/tests/components/ring/test_switch.py
@@ -32,7 +32,7 @@ async def test_siren_off_reports_correctly(
 
     state = hass.states.get("switch.front_siren")
     assert state.state == "off"
-    assert state.attributes.get("friendly_name") == "Front siren"
+    assert state.attributes.get("friendly_name") == "Front Siren"
 
 
 async def test_siren_on_reports_correctly(
@@ -43,7 +43,7 @@ async def test_siren_on_reports_correctly(
 
     state = hass.states.get("switch.internal_siren")
     assert state.state == "on"
-    assert state.attributes.get("friendly_name") == "Internal siren"
+    assert state.attributes.get("friendly_name") == "Internal Siren"
     assert state.attributes.get("icon") == "mdi:alarm-bell"
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR migrates Ring to the `has_entity_name = True` way of naming entities.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
