### PR TITLE
mqtt: allow relative URLs in configuration_url

### DIFF
--- a/homeassistant/components/mqtt/mixins.py
+++ b/homeassistant/components/mqtt/mixins.py
@@ -210,7 +210,7 @@ MQTT_ENTITY_DEVICE_INFO_SCHEMA = vol.All(
             vol.Optional(CONF_SW_VERSION): cv.string,
             vol.Optional(CONF_VIA_DEVICE): cv.string,
             vol.Optional(CONF_SUGGESTED_AREA): cv.string,
-            vol.Optional(CONF_CONFIGURATION_URL): cv.url,
+            vol.Optional(CONF_CONFIGURATION_URL): cv.absolute_or_relative_url,
         }
     ),
     validate_device_has_at_least_one_identifier,

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -729,7 +729,7 @@ def socket_timeout(value: Any | None) -> object:
 
 # pylint: disable=no-value-for-parameter
 def url(value: Any) -> str:
-    """Validate an URL."""
+    """Validate an http or https URL."""
     url_in = str(value)
 
     if urlparse(url_in).scheme in ["http", "https"]:
@@ -746,6 +746,18 @@ def url_no_path(value: Any) -> str:
         raise vol.Invalid("url it not allowed to have a path component")
 
     return url_in
+
+
+def absolute_or_relative_url(value: Any) -> str:
+    """Validate an absolute or relative http or https URL."""
+    if value and type(value) == str:
+        parsed_url = urlparse(value)
+        if parsed_url.scheme != "":
+            return url(value)
+        if parsed_url.path != "":
+            return value
+
+    raise vol.Invalid("invalid url")
 
 
 def x10_address(value: str) -> str:

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -790,6 +790,21 @@ def test_entity_device_info_schema() -> None:
             "configuration_url": "http://example.com",
         }
     )
+    # relative configuration_url
+    MQTT_ENTITY_DEVICE_INFO_SCHEMA(
+        {
+            "identifiers": ["helloworld", "hello"],
+            "connections": [
+                [dr.CONNECTION_NETWORK_MAC, "02:5b:26:a8:dc:12"],
+                [dr.CONNECTION_ZIGBEE, "zigbee_id"],
+            ],
+            "manufacturer": "Whatever",
+            "name": "Beer",
+            "model": "Glass",
+            "sw_version": "0.1-beta",
+            "configuration_url": "/api/hassio_ingress/XXXXXXXXXX",
+        }
+    )
     # no identifiers
     with pytest.raises(vol.Invalid):
         MQTT_ENTITY_DEVICE_INFO_SCHEMA(

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -145,6 +145,37 @@ def test_url_no_path() -> None:
         assert schema(value)
 
 
+def test_absolute_or_relative_url() -> None:
+    """Test absolute or relative URL."""
+    schema = vol.Schema(cv.absolute_or_relative_url)
+
+    for value in (
+        None,
+        "",
+        100,
+        "htp://ha.io",
+        "http://??,**",
+        "https://??,**",
+    ):
+        with pytest.raises(vol.MultipleInvalid):
+            schema(value)
+
+    for value in (
+        "http://localhost",
+        "https://localhost/test/index.html",
+        "http://home-assistant.io",
+        "http://home-assistant.io/test/",
+        "https://community.home-assistant.io/",
+    ):
+        assert schema(value)
+
+    for value in (
+        "/api/test/",
+        "subresource",
+    ):
+        assert schema(value)
+
+
 def test_platform_config() -> None:
     """Test platform config validation."""
     options = ({}, {"hello": "world"})


### PR DESCRIPTION
## Proposed change

I use zigbee2mqtt as hassio add-on; it's web interface in hence reachable over the ingress url like `/api/hassio_ingress/XXXXXXXXXX`; zigbee2mqtt can define the appropriate `configuration_url` using it's `frontend.url` configuration option, using the `bashio::addon.ingress_entr` returned value.

The result is that the "Visit" button will open a new tab into the device's own zigbee2mqtt page, which is handy. I was able to test this by patching the `.storage/core.device_registry` file: as expected the browser will auto-determine the full URL from the base URL it is using.

![image](https://github.com/home-assistant/core/assets/87642/2a1cdc1b-4858-48e6-821e-9bb82ae575b5)

However, currently the mqtt `configuration_url` only allows strictly absolute HTTP URLs, validated by [voluptuous' URL validator](https://github.com/alecthomas/voluptuous/blob/master/voluptuous/validators.py#L487), which basically checks that the URL starts with `http` or `https`, so when Z2M attempts to create relative `configuration_urls`, HA crashes.

This PR introduces a new validator `cv.absolute_or_relative_url` which keeps the previous behaviour if the URL has a scheme defined, but allows relative URLs.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is blocking https://github.com/zigbee2mqtt/hassio-zigbee2mqtt/pull/499

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.