### PR TITLE
Enable retries on rainbird devices by loading model and version

### DIFF
--- a/homeassistant/components/rainbird/coordinator.py
+++ b/homeassistant/components/rainbird/coordinator.py
@@ -9,6 +9,7 @@ from typing import TypeVar
 
 import async_timeout
 from pyrainbird.async_client import AsyncRainbirdController, RainbirdApiException
+from pyrainbird.data import ModelAndVersion
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
@@ -42,6 +43,7 @@ class RainbirdUpdateCoordinator(DataUpdateCoordinator[RainbirdDeviceState]):
         name: str,
         controller: AsyncRainbirdController,
         serial_number: str,
+        model_info: ModelAndVersion,
     ) -> None:
         """Initialize ZoneStateUpdateCoordinator."""
         super().__init__(
@@ -54,6 +56,7 @@ class RainbirdUpdateCoordinator(DataUpdateCoordinator[RainbirdDeviceState]):
         self._controller = controller
         self._serial_number = serial_number
         self._zones: set[int] | None = None
+        self._model_info = model_info
 
     @property
     def controller(self) -> AsyncRainbirdController:
@@ -72,6 +75,8 @@ class RainbirdUpdateCoordinator(DataUpdateCoordinator[RainbirdDeviceState]):
             name=f"{MANUFACTURER} Controller",
             identifiers={(DOMAIN, self._serial_number)},
             manufacturer=MANUFACTURER,
+            model=self._model_info.model_name,
+            sw_version=f"{self._model_info.major}.{self._model_info.minor}",
         )
 
     async def _async_update_data(self) -> RainbirdDeviceState:

--- a/tests/components/rainbird/conftest.py
+++ b/tests/components/rainbird/conftest.py
@@ -35,6 +35,8 @@ SERIAL_NUMBER = 0x12635436566
 
 # Get serial number Command 0x85. Serial is 0x12635436566
 SERIAL_RESPONSE = "850000012635436566"
+# Model and version command 0x82
+MODEL_AND_VERSION_RESPONSE = "820006090C"
 # Get available stations command 0x83
 AVAILABLE_STATIONS_RESPONSE = "83017F000000"  # Mask for 7 zones
 EMPTY_STATIONS_RESPONSE = "830000000000"
@@ -183,7 +185,13 @@ def mock_api_responses(
 
     These are returned in the order they are requested by the update coordinator.
     """
-    return [stations_response, zone_state_response, rain_response, rain_delay_response]
+    return [
+        MODEL_AND_VERSION_RESPONSE,
+        stations_response,
+        zone_state_response,
+        rain_response,
+        rain_delay_response,
+    ]
 
 
 @pytest.fixture(name="responses")

--- a/tests/components/rainbird/test_number.py
+++ b/tests/components/rainbird/test_number.py
@@ -70,6 +70,8 @@ async def test_set_value(
     device = device_registry.async_get_device({(DOMAIN, SERIAL_NUMBER)})
     assert device
     assert device.name == "Rain Bird Controller"
+    assert device.model == "ST8x-WiFi"
+    assert device.sw_version == "9.12"
 
     aioclient_mock.mock_calls.clear()
     responses.append(mock_response(ACK_ECHO))


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Update rainbird to load device model and version, and include in device info. The real motivation is to load the device information so that it can properly detect ME3 devices and enable retries (added in https://github.com/allenporter/pyrainbird/pull/207) since it is known to respond with "device is busy" errors spuriously.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: #92857
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
