### PR TITLE
KNX Cover: Use absolute tilt position if available

### DIFF
--- a/homeassistant/components/knx/cover.py
+++ b/homeassistant/components/knx/cover.py
@@ -163,11 +163,17 @@ class KNXCover(KnxEntity, CoverEntity):
 
     async def async_open_cover_tilt(self, **kwargs: Any) -> None:
         """Open the cover tilt."""
-        await self._device.set_short_up()
+        if self._device.angle.writable:
+            await self._device.set_angle(0)
+        else:
+            await self._device.set_short_up()
 
     async def async_close_cover_tilt(self, **kwargs: Any) -> None:
         """Close the cover tilt."""
-        await self._device.set_short_down()
+        if self._device.angle.writable:
+            await self._device.set_angle(100)
+        else:
+            await self._device.set_short_down()
 
     async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
         """Stop the cover tilt."""

--- a/tests/components/knx/test_cover.py
+++ b/tests/components/knx/test_cover.py
@@ -19,8 +19,6 @@ async def test_cover_basic(hass: HomeAssistant, knx: KNXTestKit) -> None:
                 CoverSchema.CONF_MOVE_SHORT_ADDRESS: "1/0/1",
                 CoverSchema.CONF_POSITION_STATE_ADDRESS: "1/0/2",
                 CoverSchema.CONF_POSITION_ADDRESS: "1/0/3",
-                CoverSchema.CONF_ANGLE_STATE_ADDRESS: "1/0/4",
-                CoverSchema.CONF_ANGLE_ADDRESS: "1/0/5",
             }
         }
     )
@@ -28,10 +26,8 @@ async def test_cover_basic(hass: HomeAssistant, knx: KNXTestKit) -> None:
 
     # read position state address and angle state address
     await knx.assert_read("1/0/2")
-    await knx.assert_read("1/0/4")
     # StateUpdater initialize state
     await knx.receive_response("1/0/2", (0x0F,))
-    await knx.receive_response("1/0/4", (0x30,))
     events.clear()
 
     # open cover
@@ -82,6 +78,32 @@ async def test_cover_basic(hass: HomeAssistant, knx: KNXTestKit) -> None:
     assert len(events) == 1
     events.pop()
 
+
+async def test_cover_tilt_absolute(hass: HomeAssistant, knx: KNXTestKit) -> None:
+    """Test KNX cover tilt."""
+    await knx.setup_integration(
+        {
+            CoverSchema.PLATFORM: {
+                CONF_NAME: "test",
+                CoverSchema.CONF_MOVE_LONG_ADDRESS: "1/0/0",
+                CoverSchema.CONF_MOVE_SHORT_ADDRESS: "1/0/1",
+                CoverSchema.CONF_POSITION_STATE_ADDRESS: "1/0/2",
+                CoverSchema.CONF_POSITION_ADDRESS: "1/0/3",
+                CoverSchema.CONF_ANGLE_STATE_ADDRESS: "1/0/4",
+                CoverSchema.CONF_ANGLE_ADDRESS: "1/0/5",
+            }
+        }
+    )
+    events = async_capture_events(hass, "state_changed")
+
+    # read position state address and angle state address
+    await knx.assert_read("1/0/2")
+    await knx.assert_read("1/0/4")
+    # StateUpdater initialize state
+    await knx.receive_response("1/0/2", (0x0F,))
+    await knx.receive_response("1/0/4", (0x30,))
+    events.clear()
+
     # set cover tilt position
     await hass.services.async_call(
         "cover",
@@ -102,7 +124,7 @@ async def test_cover_basic(hass: HomeAssistant, knx: KNXTestKit) -> None:
     await hass.services.async_call(
         "cover", "close_cover_tilt", target={"entity_id": "cover.test"}, blocking=True
     )
-    await knx.assert_write("1/0/1", True)
+    await knx.assert_write("1/0/5", (0xFF,))
 
     assert len(events) == 1
     events.pop()
@@ -111,4 +133,29 @@ async def test_cover_basic(hass: HomeAssistant, knx: KNXTestKit) -> None:
     await hass.services.async_call(
         "cover", "open_cover_tilt", target={"entity_id": "cover.test"}, blocking=True
     )
-    await knx.assert_write("1/0/1", False)
+    await knx.assert_write("1/0/5", (0x00,))
+
+
+async def test_cover_tilt_move_short(hass: HomeAssistant, knx: KNXTestKit) -> None:
+    """Test KNX cover tilt."""
+    await knx.setup_integration(
+        {
+            CoverSchema.PLATFORM: {
+                CONF_NAME: "test",
+                CoverSchema.CONF_MOVE_LONG_ADDRESS: "1/0/0",
+                CoverSchema.CONF_MOVE_SHORT_ADDRESS: "1/0/1",
+            }
+        }
+    )
+
+    # close cover tilt
+    await hass.services.async_call(
+        "cover", "close_cover_tilt", target={"entity_id": "cover.test"}, blocking=True
+    )
+    await knx.assert_write("1/0/1", 1)
+
+    # open cover tilt
+    await hass.services.async_call(
+        "cover", "open_cover_tilt", target={"entity_id": "cover.test"}, blocking=True
+    )
+    await knx.assert_write("1/0/1", 0)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use absolute tilt position if available for `open_cover_tilt` and `close_cover_tilt` instead of `move_short` group address.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #96129
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
