### PR TITLE
Allow integrations to register custom config panels

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -222,6 +222,9 @@ class Panel:
     # If the panel should only be visible to admins
     require_admin = False
 
+    # If the panel is a configuration panel for a integration
+    config_panel_domain: str | None = None
+
     def __init__(
         self,
         component_name: str,
@@ -230,6 +233,7 @@ class Panel:
         frontend_url_path: str | None,
         config: dict[str, Any] | None,
         require_admin: bool,
+        config_panel_domain: str | None,
     ) -> None:
         """Initialize a built-in panel."""
         self.component_name = component_name
@@ -238,6 +242,7 @@ class Panel:
         self.frontend_url_path = frontend_url_path or component_name
         self.config = config
         self.require_admin = require_admin
+        self.config_panel_domain = config_panel_domain
 
     @callback
     def to_response(self) -> PanelRespons:
@@ -249,6 +254,7 @@ class Panel:
             "config": self.config,
             "url_path": self.frontend_url_path,
             "require_admin": self.require_admin,
+            "config_panel_domain": self.config_panel_domain,
         }
 
 
@@ -264,6 +270,7 @@ def async_register_built_in_panel(
     require_admin: bool = False,
     *,
     update: bool = False,
+    config_panel_domain: str | None = None,
 ) -> None:
     """Register a built-in panel."""
     panel = Panel(
@@ -273,6 +280,7 @@ def async_register_built_in_panel(
         frontend_url_path,
         config,
         require_admin,
+        config_panel_domain,
     )
 
     panels = hass.data.setdefault(DATA_PANELS, {})
@@ -720,3 +728,4 @@ class PanelRespons(TypedDict):
     config: dict[str, Any] | None
     url_path: str | None
     require_admin: bool
+    config_panel_domain: str | None

--- a/homeassistant/components/panel_custom/__init__.py
+++ b/homeassistant/components/panel_custom/__init__.py
@@ -92,6 +92,8 @@ async def async_register_panel(
     config: ConfigType | None = None,
     # If your panel should only be shown to admin users
     require_admin: bool = False,
+    # If your panel is used to configure an integration, needs the domain of the integration
+    config_panel_domain: str | None = None,
 ) -> None:
     """Register a new custom panel."""
     if js_url is None and module_url is None:
@@ -127,6 +129,7 @@ async def async_register_panel(
         frontend_url_path=frontend_url_path,
         config=config,
         require_admin=require_admin,
+        config_panel_domain=config_panel_domain,
     )
 
 

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -265,6 +265,7 @@ async def test_setup_api_panel(
         "title": None,
         "url_path": "hassio",
         "require_admin": True,
+        "config_panel_domain": None,
         "config": {
             "_panel_custom": {
                 "embed_iframe": True,

--- a/tests/components/panel_iframe/test_init.py
+++ b/tests/components/panel_iframe/test_init.py
@@ -54,6 +54,7 @@ async def test_correct_config(hass: HomeAssistant) -> None:
     assert panels.get("router").to_response() == {
         "component_name": "iframe",
         "config": {"url": "http://192.168.1.1"},
+        "config_panel_domain": None,
         "icon": "mdi:network-wireless",
         "title": "Router",
         "url_path": "router",
@@ -63,6 +64,7 @@ async def test_correct_config(hass: HomeAssistant) -> None:
     assert panels.get("weather").to_response() == {
         "component_name": "iframe",
         "config": {"url": "https://www.wunderground.com/us/ca/san-diego"},
+        "config_panel_domain": None,
         "icon": "mdi:weather",
         "title": "Weather",
         "url_path": "weather",
@@ -72,6 +74,7 @@ async def test_correct_config(hass: HomeAssistant) -> None:
     assert panels.get("api").to_response() == {
         "component_name": "iframe",
         "config": {"url": "/api"},
+        "config_panel_domain": None,
         "icon": "mdi:weather",
         "title": "Api",
         "url_path": "api",
@@ -81,6 +84,7 @@ async def test_correct_config(hass: HomeAssistant) -> None:
     assert panels.get("ftp").to_response() == {
         "component_name": "iframe",
         "config": {"url": "ftp://some/ftp"},
+        "config_panel_domain": None,
         "icon": "mdi:weather",
         "title": "FTP",
         "url_path": "ftp",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR allows for integrations to register configuration panels for their integrations. This can be useful for e.g., KNX, Dynalite, insteon, etc.; These currently all register a sidebar panel, as that is the only place they can currently put such things.

TODO:
- [x] Needs frontend PR

/CC @bramkragten 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
