### PR TITLE
Rename CO2Signal to Electricity Maps

### DIFF
--- a/homeassistant/components/co2signal/const.py
+++ b/homeassistant/components/co2signal/const.py
@@ -3,4 +3,4 @@
 
 DOMAIN = "co2signal"
 CONF_COUNTRY_CODE = "country_code"
-ATTRIBUTION = "Data provided by CO2signal"
+ATTRIBUTION = "Data provided by Electricity Maps"

--- a/homeassistant/components/co2signal/manifest.json
+++ b/homeassistant/components/co2signal/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "co2signal",
-  "name": "CO2 Signal",
+  "name": "Electricity Maps",
   "codeowners": [],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/co2signal",

--- a/homeassistant/components/co2signal/manifest.json
+++ b/homeassistant/components/co2signal/manifest.json
@@ -3,7 +3,7 @@
   "name": "Electricity Maps",
   "codeowners": [],
   "config_flow": true,
-  "documentation": "https://www.home-assistant.io/integrations/co2signal",
+  "documentation": "https://www.home-assistant.io/integrations/electricity_maps",
   "iot_class": "cloud_polling",
   "loggers": ["CO2Signal"],
   "requirements": ["CO2Signal==0.4.2"]

--- a/homeassistant/components/co2signal/sensor.py
+++ b/homeassistant/components/co2signal/sensor.py
@@ -75,11 +75,11 @@ class CO2Sensor(CoordinatorEntity[CO2SignalCoordinator], SensorEntity):
             "country_code": coordinator.data["countryCode"],
         }
         self._attr_device_info = DeviceInfo(
-            configuration_url="https://www.electricitymap.org/",
+            configuration_url="https://www.electricitymaps.com/",
             entry_type=DeviceEntryType.SERVICE,
             identifiers={(DOMAIN, coordinator.entry_id)},
-            manufacturer="Tmrow.com",
-            name="CO2 signal",
+            manufacturer="Electricity Maps",
+            name="Electricity Maps",
         )
         self._attr_unique_id = (
             f"{coordinator.entry_id}_{description.unique_id or description.key}"

--- a/homeassistant/components/co2signal/strings.json
+++ b/homeassistant/components/co2signal/strings.json
@@ -6,7 +6,7 @@
           "location": "Get data for",
           "api_key": "[%key:common::config_flow::data::access_token%]"
         },
-        "description": "Visit https://co2signal.com/ to request a token."
+        "description": "Visit https://electricitymaps.com/free-tier to request a token."
       },
       "coordinates": {
         "data": {

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -846,7 +846,7 @@
       "iot_class": "local_polling"
     },
     "co2signal": {
-      "name": "CO2 Signal",
+      "name": "Electricity Maps",
       "integration_type": "hub",
       "config_flow": true,
       "iot_class": "cloud_polling"


### PR DESCRIPTION
## Breaking change

Electricity Maps are rebranding CO2 Signal to include it under the Electricity Maps name. There are no changes for users besides the name.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

We at Electricity Maps are rebranding CO2 Signal to include it under the Electricity Maps name.

The only user-impacting change is that new users of the integration will have to go to a new website ([api-portal.electricitymaps.com](https://api-portal.electricitymaps.com/catalog/prd_8e3ood60rcv8f51h)) to get their api key. The existing API keys and URLs will continue working.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

_none of these are appropriate, but bugfix seems to be the closest_

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

The [PR to documentation](https://github.com/home-assistant/home-assistant.io/pull/28116) that renames the integration should be merged first! Alternatively we can keep the link to https://www.home-assistant.io/integrations/co2signal and rename the path in a follow-up PR? Let me know what is preferred.

- This PR fixes or closes issue: 
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/28116
- Link to related brand pull request: https://github.com/home-assistant/brands/pull/4521

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
