### PR TITLE
Use action response in intent_script speech template

### DIFF
--- a/tests/components/intent_script/test_init.py
+++ b/tests/components/intent_script/test_init.py
@@ -95,6 +95,38 @@ async def test_intent_script_wait_response(hass: HomeAssistant) -> None:
     assert response.card["simple"]["content"] == "Content for Paulus"
 
 
+async def test_intent_script_service_response(hass: HomeAssistant) -> None:
+    """Test intent scripts work."""
+    calls = async_mock_service(
+        hass, "test", "service", response={"some_key": "some value"}
+    )
+
+    await async_setup_component(
+        hass,
+        "intent_script",
+        {
+            "intent_script": {
+                "HelloWorldServiceResponse": {
+                    "action": [
+                        {"service": "test.service", "response_variable": "result"},
+                        {"stop": "", "response_variable": "result"},
+                    ],
+                    "speech": {
+                        "text": "The service returned {{ action_response.some_key }}"
+                    },
+                }
+            }
+        },
+    )
+
+    response = await intent.async_handle(hass, "test", "HelloWorldServiceResponse")
+
+    assert len(calls) == 1
+    assert calls[0].return_response
+
+    assert response.speech["plain"]["speech"] == "The service returned some value"
+
+
 async def test_intent_script_falsy_reprompt(hass: HomeAssistant) -> None:
     """Test intent scripts work."""
     calls = async_mock_service(hass, "test", "service")


### PR DESCRIPTION
## Proposed change

A small PR allowing to use service call responses (feature [added in 2023.7](https://www.home-assistant.io/blog/2023/07/05/release-20237/#services-can-now-respond)) when handling an intent with `intent_script`.

The change simply merges the data returned from the configured action with those coming from the intent itself, so that both are available inside the speech template. This allows to do neat things like this:

```yaml
conversation:
    EventCountToday:
      - "How many meetings do I have today?"

intent_script:
  EventCountToday:
    action:
      - service: calendar.list_events
        target:
          entity_id: calendar.my_calendar
        data_template:
          start_date_time: "{{ today_at('00:00') }}"
          duration: { "hours": 24 }
        response_variable: result                     # get service response
      - stop: ""
        response_variable: result                     # and return it
    speech:
      text: "{{ action_response.events | length }}"   # use the action's response
```

__Note__: the action response is alway a dictionary so I opted for the simple solution of merging it with the intent's slot data, so that `events` above is directly available. An alternative approach would be to introduce a `response_variable`, like in scripts, but it seemed too cumbersome to me. I could certainly do it this way if you thing it's better.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests



## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/28156

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
