### PR TITLE
Improve integration startup in AVM Fritz!Tools

### DIFF
--- a/homeassistant/components/fritz/common.py
+++ b/homeassistant/components/fritz/common.py
@@ -129,13 +129,34 @@ class Interface(TypedDict):
     type: str
 
 
-class HostInfo(TypedDict):
-    """FRITZ!Box host info class."""
-
-    mac: str
-    name: str
-    ip: str
-    status: bool
+HostAttributes = TypedDict(
+    "HostAttributes",
+    {
+        "Index": int,
+        "IPAddress": str,
+        "MACAddress": str,
+        "Active": bool,
+        "HostName": str,
+        "InterfaceType": str,
+        "X_AVM-DE_Port": int,
+        "X_AVM-DE_Speed": int,
+        "X_AVM-DE_UpdateAvailable": bool,
+        "X_AVM-DE_UpdateSuccessful": str,
+        "X_AVM-DE_InfoURL": str | None,
+        "X_AVM-DE_MACAddressList": str | None,
+        "X_AVM-DE_Model": str | None,
+        "X_AVM-DE_URL": str | None,
+        "X_AVM-DE_Guest": bool,
+        "X_AVM-DE_RequestClient": str,
+        "X_AVM-DE_VPN": bool,
+        "X_AVM-DE_WANAccess": str,
+        "X_AVM-DE_Disallow": bool,
+        "X_AVM-DE_IsMeshable": str,
+        "X_AVM-DE_Priority": str,
+        "X_AVM-DE_FriendlyName": str,
+        "X_AVM-DE_FriendlyNameIsWriteable": str,
+    },
+)
 
 
 class UpdateCoordinatorDataType(TypedDict):
@@ -353,11 +374,11 @@ class FritzBoxTools(
         """Event specific per FRITZ!Box entry to signal updates in devices."""
         return f"{DOMAIN}-device-update-{self._unique_id}"
 
-    async def _async_update_hosts_info(self) -> list[HostInfo]:
+    async def _async_update_hosts_info(self) -> list[HostAttributes]:
         """Retrieve latest hosts information from the FRITZ!Box."""
         try:
             return await self.hass.async_add_executor_job(
-                self.fritz_hosts.get_hosts_info
+                self.fritz_hosts.get_hosts_attributes
             )
         except Exception as ex:  # pylint: disable=[broad-except]
             if not self.hass.is_stopping:
@@ -462,15 +483,15 @@ class FritzBoxTools(
         new_device = False
         hosts = {}
         for host in await self._async_update_hosts_info():
-            if not host.get("mac"):
+            if not host.get("MACAddress"):
                 continue
 
-            hosts[host["mac"]] = Device(
-                name=host["name"],
-                connected=host["status"],
+            hosts[host["MACAddress"]] = Device(
+                name=host["HostName"],
+                connected=host["Active"],
                 connected_to="",
                 connection_type="",
-                ip_address=host["ip"],
+                ip_address=host["IPAddress"],
                 ssid=None,
                 wan_access=None,
             )
@@ -583,7 +604,7 @@ class FritzBoxTools(
     ) -> None:
         """Trigger device trackers cleanup."""
         device_hosts_list = await self.hass.async_add_executor_job(
-            self.fritz_hosts.get_hosts_info
+            self.fritz_hosts.get_hosts_attributes
         )
         entity_reg: er.EntityRegistry = er.async_get(self.hass)
 
@@ -600,8 +621,8 @@ class FritzBoxTools(
         device_hosts_macs = set()
         device_hosts_names = set()
         for device in device_hosts_list:
-            device_hosts_macs.add(device["mac"])
-            device_hosts_names.add(device["name"])
+            device_hosts_macs.add(device["MACAddress"])
+            device_hosts_names.add(device["HostName"])
 
         for entry in ha_entity_reg_list:
             if entry.original_name is None:

--- a/tests/components/fritz/conftest.py
+++ b/tests/components/fritz/conftest.py
@@ -6,7 +6,12 @@ from fritzconnection.core.processor import Service
 from fritzconnection.lib.fritzhosts import FritzHosts
 import pytest
 
-from .const import MOCK_FB_SERVICES, MOCK_MESH_DATA, MOCK_MODELNAME
+from .const import (
+    MOCK_FB_SERVICES,
+    MOCK_HOST_ATTRIBUTES_DATA,
+    MOCK_MESH_DATA,
+    MOCK_MODELNAME,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -74,6 +79,10 @@ class FritzHostMock(FritzHosts):
     def get_mesh_topology(self, raw=False):
         """Retrurn mocked mesh data."""
         return MOCK_MESH_DATA
+
+    def get_hosts_attributes(self):
+        """Retrurn mocked host attributes data."""
+        return MOCK_HOST_ATTRIBUTES_DATA
 
 
 @pytest.fixture(name="fc_data")

--- a/tests/components/fritz/const.py
+++ b/tests/components/fritz/const.py
@@ -52,27 +52,8 @@ MOCK_FB_SERVICES: dict[str, dict] = {
         },
     },
     "Hosts1": {
-        "GetGenericHostEntry": [
-            {
-                "NewIPAddress": MOCK_IPS["fritz.box"],
-                "NewAddressSource": "Static",
-                "NewLeaseTimeRemaining": 0,
-                "NewMACAddress": MOCK_MESH_MASTER_MAC,
-                "NewInterfaceType": "",
-                "NewActive": True,
-                "NewHostName": "fritz.box",
-            },
-            {
-                "NewIPAddress": MOCK_IPS["printer"],
-                "NewAddressSource": "DHCP",
-                "NewLeaseTimeRemaining": 0,
-                "NewMACAddress": "AA:BB:CC:00:11:22",
-                "NewInterfaceType": "Ethernet",
-                "NewActive": True,
-                "NewHostName": "printer",
-            },
-        ],
         "X_AVM-DE_GetMeshListPath": {},
+        "X_AVM-DE_GetHostListPath": {},
     },
     "LANEthernetInterfaceConfig1": {
         "GetStatistics": {
@@ -783,6 +764,58 @@ MOCK_MESH_DATA = {
     ],
 }
 
+MOCK_HOST_ATTRIBUTES_DATA = [
+    {
+        "Index": 1,
+        "IPAddress": MOCK_IPS["printer"],
+        "MACAddress": "AA:BB:CC:00:11:22",
+        "Active": True,
+        "HostName": "printer",
+        "InterfaceType": "Ethernet",
+        "X_AVM-DE_Port": 1,
+        "X_AVM-DE_Speed": 1000,
+        "X_AVM-DE_UpdateAvailable": False,
+        "X_AVM-DE_UpdateSuccessful": "unknown",
+        "X_AVM-DE_InfoURL": None,
+        "X_AVM-DE_MACAddressList": None,
+        "X_AVM-DE_Model": None,
+        "X_AVM-DE_URL": f"http://{MOCK_IPS['printer']}",
+        "X_AVM-DE_Guest": False,
+        "X_AVM-DE_RequestClient": "0",
+        "X_AVM-DE_VPN": False,
+        "X_AVM-DE_WANAccess": "granted",
+        "X_AVM-DE_Disallow": False,
+        "X_AVM-DE_IsMeshable": "0",
+        "X_AVM-DE_Priority": "0",
+        "X_AVM-DE_FriendlyName": "printer",
+        "X_AVM-DE_FriendlyNameIsWriteable": "1",
+    },
+    {
+        "Index": 2,
+        "IPAddress": MOCK_IPS["fritz.box"],
+        "MACAddress": MOCK_MESH_MASTER_MAC,
+        "Active": True,
+        "HostName": "fritz.box",
+        "InterfaceType": None,
+        "X_AVM-DE_Port": 0,
+        "X_AVM-DE_Speed": 0,
+        "X_AVM-DE_UpdateAvailable": False,
+        "X_AVM-DE_UpdateSuccessful": "unknown",
+        "X_AVM-DE_InfoURL": None,
+        "X_AVM-DE_MACAddressList": f"{MOCK_MESH_MASTER_MAC},{MOCK_MESH_MASTER_WIFI1_MAC}",
+        "X_AVM-DE_Model": None,
+        "X_AVM-DE_URL": f"http://{MOCK_IPS['fritz.box']}",
+        "X_AVM-DE_Guest": False,
+        "X_AVM-DE_RequestClient": "0",
+        "X_AVM-DE_VPN": False,
+        "X_AVM-DE_WANAccess": "granted",
+        "X_AVM-DE_Disallow": False,
+        "X_AVM-DE_IsMeshable": "1",
+        "X_AVM-DE_Priority": "0",
+        "X_AVM-DE_FriendlyName": "fritz.box",
+        "X_AVM-DE_FriendlyNameIsWriteable": "0",
+    },
+]
 
 MOCK_USER_DATA = MOCK_CONFIG[DOMAIN][CONF_DEVICES][0]
 MOCK_DEVICE_INFO = {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This makes use of the new [`FritzHost.get_hosts_attributes()`](https://github.com/kbr/fritzconnection/blob/fa214c5cf65a28a77f1c579a27bdf757e5455006/fritzconnection/lib/fritzhosts.py#L193) which uses the [`X_AVM-DE_GetHostListPath`](https://avm.de/fileadmin/user_upload/Global/Service/Schnittstellen/hostsSCPD.pdf) api to get all hosts attribute at once, instead of one api call per device. Example of startup time and data update time reduction with 35 device

| prior this PR | now |
| --- | --- |
| ![image](https://github.com/home-assistant/core/assets/35783820/1038c642-2fef-4e5c-abff-aa59cc6450ac) | ![image](https://github.com/home-assistant/core/assets/35783820/2c82e44d-ac0d-41bc-af2e-2b3181e7a671) |
| `Finished fetching fritz-192.168.1.1-coordinator data in 7.908 seconds (success: True)` | `Finished fetching fritz-192.168.1.1-coordinator data in 3.326 seconds (success: True)` |


- needs #96265

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #93448
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
