### PR TITLE
Fix ZHA serialization issue with warning devices

### DIFF
--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -25,10 +25,10 @@
     "pyserial-asyncio==0.6",
     "zha-quirks==0.0.101",
     "zigpy-deconz==0.21.0",
-    "zigpy==0.56.1",
+    "zigpy==0.56.2",
     "zigpy-xbee==0.18.1",
     "zigpy-zigate==0.11.0",
-    "zigpy-znp==0.11.2"
+    "zigpy-znp==0.11.3"
   ],
   "usb": [
     {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2759,10 +2759,10 @@ zigpy-xbee==0.18.1
 zigpy-zigate==0.11.0
 
 # homeassistant.components.zha
-zigpy-znp==0.11.2
+zigpy-znp==0.11.3
 
 # homeassistant.components.zha
-zigpy==0.56.1
+zigpy==0.56.2
 
 # homeassistant.components.zoneminder
 zm-py==0.5.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2023,10 +2023,10 @@ zigpy-xbee==0.18.1
 zigpy-zigate==0.11.0
 
 # homeassistant.components.zha
-zigpy-znp==0.11.2
+zigpy-znp==0.11.3
 
 # homeassistant.components.zha
-zigpy==0.56.1
+zigpy==0.56.2
 
 # homeassistant.components.zwave_js
 zwave-js-server-python==0.49.0

--- a/tests/components/zha/test_siren.py
+++ b/tests/components/zha/test_siren.py
@@ -1,10 +1,11 @@
 """Test zha siren."""
 from datetime import timedelta
-from unittest.mock import patch
+from unittest.mock import ANY, call, patch
 
 import pytest
 from zigpy.const import SIG_EP_PROFILE
 import zigpy.profiles.zha as zha
+import zigpy.zcl
 import zigpy.zcl.clusters.general as general
 import zigpy.zcl.clusters.security as security
 import zigpy.zcl.foundation as zcl_f
@@ -85,48 +86,76 @@ async def test_siren(hass: HomeAssistant, siren) -> None:
 
     # turn on from HA
     with patch(
-        "zigpy.zcl.Cluster.request",
+        "zigpy.device.Device.request",
         return_value=mock_coro([0x00, zcl_f.Status.SUCCESS]),
+    ), patch(
+        "zigpy.zcl.Cluster.request",
+        side_effect=zigpy.zcl.Cluster.request,
+        autospec=True,
     ):
         # turn on via UI
         await hass.services.async_call(
             SIREN_DOMAIN, "turn_on", {"entity_id": entity_id}, blocking=True
         )
-        assert len(cluster.request.mock_calls) == 1
-        assert cluster.request.call_args[0][0] is False
-        assert cluster.request.call_args[0][1] == 0
-        assert cluster.request.call_args[0][3] == 50  # bitmask for default args
-        assert cluster.request.call_args[0][4] == 5  # duration in seconds
-        assert cluster.request.call_args[0][5] == 0
-        assert cluster.request.call_args[0][6] == 2
+        assert cluster.request.mock_calls == [
+            call(
+                cluster,
+                False,
+                0,
+                ANY,
+                50,  # bitmask for default args
+                5,  # duration in seconds
+                0,
+                2,
+                manufacturer=None,
+                expect_reply=True,
+                tsn=None,
+            )
+        ]
 
     # test that the state has changed to on
     assert hass.states.get(entity_id).state == STATE_ON
 
     # turn off from HA
     with patch(
-        "zigpy.zcl.Cluster.request",
+        "zigpy.device.Device.request",
         return_value=mock_coro([0x01, zcl_f.Status.SUCCESS]),
+    ), patch(
+        "zigpy.zcl.Cluster.request",
+        side_effect=zigpy.zcl.Cluster.request,
+        autospec=True,
     ):
         # turn off via UI
         await hass.services.async_call(
             SIREN_DOMAIN, "turn_off", {"entity_id": entity_id}, blocking=True
         )
-        assert len(cluster.request.mock_calls) == 1
-        assert cluster.request.call_args[0][0] is False
-        assert cluster.request.call_args[0][1] == 0
-        assert cluster.request.call_args[0][3] == 2  # bitmask for default args
-        assert cluster.request.call_args[0][4] == 5  # duration in seconds
-        assert cluster.request.call_args[0][5] == 0
-        assert cluster.request.call_args[0][6] == 2
+        assert cluster.request.mock_calls == [
+            call(
+                cluster,
+                False,
+                0,
+                ANY,
+                2,  # bitmask for default args
+                5,  # duration in seconds
+                0,
+                2,
+                manufacturer=None,
+                expect_reply=True,
+                tsn=None,
+            )
+        ]
 
     # test that the state has changed to off
     assert hass.states.get(entity_id).state == STATE_OFF
 
     # turn on from HA
     with patch(
-        "zigpy.zcl.Cluster.request",
+        "zigpy.device.Device.request",
         return_value=mock_coro([0x00, zcl_f.Status.SUCCESS]),
+    ), patch(
+        "zigpy.zcl.Cluster.request",
+        side_effect=zigpy.zcl.Cluster.request,
+        autospec=True,
     ):
         # turn on via UI
         await hass.services.async_call(
@@ -140,14 +169,21 @@ async def test_siren(hass: HomeAssistant, siren) -> None:
             },
             blocking=True,
         )
-        assert len(cluster.request.mock_calls) == 1
-        assert cluster.request.call_args[0][0] is False
-        assert cluster.request.call_args[0][1] == 0
-        assert cluster.request.call_args[0][3] == 97  # bitmask for passed args
-        assert cluster.request.call_args[0][4] == 10  # duration in seconds
-        assert cluster.request.call_args[0][5] == 0
-        assert cluster.request.call_args[0][6] == 2
-
+        assert cluster.request.mock_calls == [
+            call(
+                cluster,
+                False,
+                0,
+                ANY,
+                97,  # bitmask for passed args
+                10,  # duration in seconds
+                0,
+                2,
+                manufacturer=None,
+                expect_reply=True,
+                tsn=None,
+            )
+        ]
         # test that the state has changed to on
     assert hass.states.get(entity_id).state == STATE_ON
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump ZHA dependencies:

 - zigpy to [0.56.2](https://github.com/zigpy/zigpy/releases/tag/0.56.2)
 - zigpy-znp to [0.11.3](https://github.com/zigpy/zigpy-znp/releases/tag/v0.11.3)

This is a bugfix release for the issues linked below that fixes a serialization issue with warning devices (e.g. smoke alarms).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #96101, fixes #95978
- This PR is related to issue: https://github.com/home-assistant/core/issues/94503#issuecomment-1624193457
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
