### PR TITLE
Add Nut commands to diagnostics data

### DIFF
--- a/homeassistant/components/nut/diagnostics.py
+++ b/homeassistant/components/nut/diagnostics.py
@@ -12,7 +12,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from . import PyNUTData
-from .const import DOMAIN, PYNUT_DATA, PYNUT_UNIQUE_ID
+from .const import DOMAIN, PYNUT_DATA, PYNUT_UNIQUE_ID, USER_AVAILABLE_COMMANDS
 
 TO_REDACT = {CONF_PASSWORD, CONF_USERNAME}
 
@@ -26,7 +26,12 @@ async def async_get_config_entry_diagnostics(
 
     # Get information from Nut library
     nut_data: PyNUTData = hass_data[PYNUT_DATA]
-    data["nut_data"] = {"ups_list": nut_data.ups_list, "status": nut_data.status}
+    nut_cmd: set[str] = hass_data[USER_AVAILABLE_COMMANDS]
+    data["nut_data"] = {
+        "ups_list": nut_data.ups_list,
+        "status": nut_data.status,
+        "commands": nut_cmd,
+    }
 
     # Gather information how this Nut device is represented in Home Assistant
     device_registry = dr.async_get(hass)

--- a/tests/components/nut/test_diagnostics.py
+++ b/tests/components/nut/test_diagnostics.py
@@ -1,0 +1,43 @@
+"""Tests for the diagnostics data provided by the Nut integration."""
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.components.nut.diagnostics import TO_REDACT
+from homeassistant.core import HomeAssistant
+
+from .util import async_init_integration
+
+from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
+
+
+async def test_diagnostics(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+) -> None:
+    """Test diagnostics."""
+    list_commands: set[str] = ["beeper.enable"]
+    list_commands_return_value = {
+        supported_command: supported_command for supported_command in list_commands
+    }
+
+    mock_config_entry = await async_init_integration(
+        hass,
+        username="someuser",
+        password="somepassword",
+        list_vars={"ups.status": "OL"},
+        list_ups={"ups1": "UPS 1"},
+        list_commands_return_value=list_commands_return_value,
+    )
+
+    entry_dict = async_redact_data(mock_config_entry.as_dict(), TO_REDACT)
+    nut_data_dict = {
+        "ups_list": {"ups1": "UPS 1"},
+        "status": {"ups.status": "OL"},
+        "commands": list_commands,
+    }
+
+    result = await get_diagnostics_for_config_entry(
+        hass, hass_client, mock_config_entry
+    )
+    assert result["entry"] == entry_dict
+    assert result["nut_data"] == nut_data_dict


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This will show available NUT commands in diagnostics data

Here output example:

```
{
  "home_assistant": {
    "installation_type": "Unsupported Third Party Container",
    "version": "2023.8.0.dev0",
    "dev": true,
    "hassio": false,
    "virtualenv": false,
    "python_version": "3.11.4",
    "docker": true,
    "arch": "x86_64",
    "timezone": "Europe/Rome",
    "os_name": "Linux",
    "os_version": "5.15.90.1-microsoft-standard-WSL2",
    "run_as_root": false
  },
  "custom_components": {},
  "integration_manifest": {
    "domain": "nut",
    "name": "Network UPS Tools (NUT)",
    "codeowners": [
      "@bdraco",
      "@ollo69",
      "@pestevez"
    ],
    "config_flow": true,
    "documentation": "https://www.home-assistant.io/integrations/nut",
    "integration_type": "device",
    "iot_class": "local_polling",
    "loggers": [
      "pynut2"
    ],
    "requirements": [
      "pynut2==2.1.2"
    ],
    "zeroconf": [
      "_nut._tcp.local."
    ],
    "is_built_in": true
  },
  "data": {
    "entry": {
      "entry_id": "538deba8d47cbfbb95ee0b554f8e453e",
      "version": 1,
      "domain": "nut",
      "title": "192.168.10.27:3493",
      "data": {
        "host": "192.168.10.27",
        "port": 3493,
        "username": "**REDACTED**",
        "password": "**REDACTED**"
      },
      "options": {},
      "pref_disable_new_entities": false,
      "pref_disable_polling": false,
      "source": "user",
      "unique_id": null,
      "disabled_by": null
    },
    "nut_data": {
      "ups_list": {
        "eraplus800": "Technoware Era Plus 800"
      },
      "status": {
        "battery.charge": "100",
        "battery.voltage": "13.90",
        "battery.voltage.high": "13.00",
        "battery.voltage.low": "10.40",
        "battery.voltage.nominal": "12.0",
        "device.type": "ups",
        "driver.name": "blazer_usb",
        "driver.parameter.langid_fix": "0x409",
        "driver.parameter.pollinterval": "2",
        "driver.parameter.port": "auto",
        "driver.parameter.synchronous": "no",
        "driver.version": "2.7.4",
        "driver.version.internal": "0.12",
        "input.current.nominal": "5.0",
        "input.frequency": "49.8",
        "input.frequency.nominal": "50",
        "input.voltage": "244.0",
        "input.voltage.fault": "244.0",
        "input.voltage.nominal": "230",
        "output.voltage": "234.5",
        "ups.beeper.status": "enabled",
        "ups.delay.shutdown": "30",
        "ups.delay.start": "180",
        "ups.load": "16",
        "ups.productid": "5161",
        "ups.status": "OL",
        "ups.type": "offline / line interactive",
        "ups.vendorid": "0665"
      },
      "commands": [
        "test.battery.start",
        "test.battery.start.quick",
        "test.battery.stop",
        "shutdown.stayoff",
        "shutdown.stop",
        "beeper.toggle",
        "test.battery.start.deep",
        "load.on",
        "shutdown.return",
        "load.off"
      ]
    },
    "device": {
      "area_id": null,
      "config_entries": [
        "538deba8d47cbfbb95ee0b554f8e453e"
      ],
      "configuration_url": null,
      "connections": [],
      "disabled_by": null,
      "entry_type": null,
      "hw_version": null,
      "id": "61fc842e8f2957664877099a613ec773",
      "identifiers": [
        [
          "nut",
          "538deba8d47cbfbb95ee0b554f8e453e"
        ]
      ],
      "manufacturer": "0665",
      "model": "5161",
      "name_by_user": null,
      "name": "Eraplus800",
      "suggested_area": null,
      "sw_version": null,
      "via_device_id": null,
      "is_new": false,
      "_json_repr": "{\"area_id\":null,\"configuration_url\":null,\"config_entries\":[\"538deba8d47cbfbb95ee0b554f8e453e\"],\"connections\":[],\"disabled_by\":null,\"entry_type\":null,\"hw_version\":null,\"id\":\"61fc842e8f2957664877099a613ec773\",\"identifiers\":[[\"nut\",\"538deba8d47cbfbb95ee0b554f8e453e\"]],\"manufacturer\":\"0665\",\"model\":\"5161\",\"name_by_user\":null,\"name\":\"Eraplus800\",\"sw_version\":null,\"via_device_id\":null}",
      "entities": {
        "sensor.eraplus800_load": {
          "unique_id": "538deba8d47cbfbb95ee0b554f8e453e_ups.load",
          "platform": "nut",
          "aliases": [],
          "area_id": null,
          "capabilities": {
            "state_class": "measurement"
          },
          "config_entry_id": "538deba8d47cbfbb95ee0b554f8e453e",
          "device_class": null,
          "device_id": "61fc842e8f2957664877099a613ec773",
          "domain": "sensor",
          "disabled_by": null,
          "entity_category": null,
          "hidden_by": null,
          "icon": null,
          "id": "154af93af20d46686564a2c67a462bdc",
          "has_entity_name": true,
          "name": null,
          "options": {
            "conversation": {
              "should_expose": false
            }
          },
          "original_device_class": null,
          "original_icon": "mdi:gauge",
          "original_name": "Load",
          "supported_features": 0,
          "translation_key": "ups_load",
          "unit_of_measurement": "%",
          "_partial_repr": "{\"area_id\":null,\"config_entry_id\":\"538deba8d47cbfbb95ee0b554f8e453e\",\"device_id\":\"61fc842e8f2957664877099a613ec773\",\"disabled_by\":null,\"entity_category\":null,\"entity_id\":\"sensor.eraplus800_load\",\"has_entity_name\":true,\"hidden_by\":null,\"icon\":null,\"id\":\"154af93af20d46686564a2c67a462bdc\",\"name\":null,\"options\":{\"conversation\":{\"should_expose\":false}},\"original_name\":\"Load\",\"platform\":\"nut\",\"translation_key\":\"ups_load\",\"unique_id\":\"538deba8d47cbfbb95ee0b554f8e453e_ups.load\"}",
          "_display_repr": "{\"ei\":\"sensor.eraplus800_load\",\"pl\":\"nut\",\"di\":\"61fc842e8f2957664877099a613ec773\",\"tk\":\"ups_load\",\"en\":\"Load\"}",
          "state": {
            "state": "16",
            "attributes": {
              "state_class": "measurement",
              "unit_of_measurement": "%",
              "icon": "mdi:gauge",
              "friendly_name": "Eraplus800 Load"
            },
            "last_changed": "2023-07-10T20:19:38.830720+00:00",
            "last_updated": "2023-07-10T20:19:38.830720+00:00"
          }
        },
        "sensor.eraplus800_load_restart_delay": {
          "unique_id": "538deba8d47cbfbb95ee0b554f8e453e_ups.delay.start",
          "platform": "nut",
          "aliases": [],
          "area_id": null,
          "capabilities": null,
          "config_entry_id": "538deba8d47cbfbb95ee0b554f8e453e",
          "device_class": null,
          "device_id": "61fc842e8f2957664877099a613ec773",
          "domain": "sensor",
          "disabled_by": "integration",
          "entity_category": "diagnostic",
          "hidden_by": null,
          "icon": null,
          "id": "c8c6a97953c3f593a7132e48d3fe275d",
          "has_entity_name": true,
          "name": null,
          "options": {},
          "original_device_class": "duration",
          "original_icon": null,
          "original_name": "Load restart delay",
          "supported_features": 0,
          "translation_key": "ups_delay_start",
          "unit_of_measurement": "s",
          "_partial_repr": "{\"area_id\":null,\"config_entry_id\":\"538deba8d47cbfbb95ee0b554f8e453e\",\"device_id\":\"61fc842e8f2957664877099a613ec773\",\"disabled_by\":\"integration\",\"entity_category\":\"diagnostic\",\"entity_id\":\"sensor.eraplus800_load_restart_delay\",\"has_entity_name\":true,\"hidden_by\":null,\"icon\":null,\"id\":\"c8c6a97953c3f593a7132e48d3fe275d\",\"name\":null,\"options\":{},\"original_name\":\"Load restart delay\",\"platform\":\"nut\",\"translation_key\":\"ups_delay_start\",\"unique_id\":\"538deba8d47cbfbb95ee0b554f8e453e_ups.delay.start\"}",
          "_display_repr": {
            "__type": "<enum 'UndefinedType'>",
            "repr": "<UndefinedType._singleton: 0>"
          },
          "state": null
        },
        "sensor.eraplus800_ups_shutdown_delay": {
          "unique_id": "538deba8d47cbfbb95ee0b554f8e453e_ups.delay.shutdown",
          "platform": "nut",
          "aliases": [],
          "area_id": null,
          "capabilities": null,
          "config_entry_id": "538deba8d47cbfbb95ee0b554f8e453e",
          "device_class": null,
          "device_id": "61fc842e8f2957664877099a613ec773",
          "domain": "sensor",
          "disabled_by": "integration",
          "entity_category": "diagnostic",
          "hidden_by": null,
          "icon": null,
          "id": "e74f80e99977d8bcc03d0275031f2bd4",
          "has_entity_name": true,
          "name": null,
          "options": {},
          "original_device_class": "duration",
          "original_icon": null,
          "original_name": "UPS shutdown delay",
          "supported_features": 0,
          "translation_key": "ups_delay_shutdown",
          "unit_of_measurement": "s",
          "_partial_repr": "{\"area_id\":null,\"config_entry_id\":\"538deba8d47cbfbb95ee0b554f8e453e\",\"device_id\":\"61fc842e8f2957664877099a613ec773\",\"disabled_by\":\"integration\",\"entity_category\":\"diagnostic\",\"entity_id\":\"sensor.eraplus800_ups_shutdown_delay\",\"has_entity_name\":true,\"hidden_by\":null,\"icon\":null,\"id\":\"e74f80e99977d8bcc03d0275031f2bd4\",\"name\":null,\"options\":{},\"original_name\":\"UPS shutdown delay\",\"platform\":\"nut\",\"translation_key\":\"ups_delay_shutdown\",\"unique_id\":\"538deba8d47cbfbb95ee0b554f8e453e_ups.delay.shutdown\"}",
          "_display_repr": {
            "__type": "<enum 'UndefinedType'>",
            "repr": "<UndefinedType._singleton: 0>"
          },
          "state": null
        },
        "sensor.eraplus800_beeper_status": {
          "unique_id": "538deba8d47cbfbb95ee0b554f8e453e_ups.beeper.status",
          "platform": "nut",
          "aliases": [],
          "area_id": null,
          "capabilities": null,
          "config_entry_id": "538deba8d47cbfbb95ee0b554f8e453e",
          "device_class": null,
          "device_id": "61fc842e8f2957664877099a613ec773",
          "domain": "sensor",
          "disabled_by": "integration",
          "entity_category": "diagnostic",
          "hidden_by": null,
          "icon": null,
          "id": "3d45fc4fc7f268a1203d1351812c93d7",
          "has_entity_name": true,
          "name": null,
          "options": {},
          "original_device_class": null,
          "original_icon": "mdi:information-outline",
          "original_name": "Beeper status",
          "supported_features": 0,
          "translation_key": "ups_beeper_status",
          "unit_of_measurement": null,
          "_partial_repr": "{\"area_id\":null,\"config_entry_id\":\"538deba8d47cbfbb95ee0b554f8e453e\",\"device_id\":\"61fc842e8f2957664877099a613ec773\",\"disabled_by\":\"integration\",\"entity_category\":\"diagnostic\",\"entity_id\":\"sensor.eraplus800_beeper_status\",\"has_entity_name\":true,\"hidden_by\":null,\"icon\":null,\"id\":\"3d45fc4fc7f268a1203d1351812c93d7\",\"name\":null,\"options\":{},\"original_name\":\"Beeper status\",\"platform\":\"nut\",\"translation_key\":\"ups_beeper_status\",\"unique_id\":\"538deba8d47cbfbb95ee0b554f8e453e_ups.beeper.status\"}",
          "_display_repr": {
            "__type": "<enum 'UndefinedType'>",
            "repr": "<UndefinedType._singleton: 0>"
          },
          "state": null
        },
        "sensor.eraplus800_ups_type": {
          "unique_id": "538deba8d47cbfbb95ee0b554f8e453e_ups.type",
          "platform": "nut",
          "aliases": [],
          "area_id": null,
          "capabilities": null,
          "config_entry_id": "538deba8d47cbfbb95ee0b554f8e453e",
          "device_class": null,
          "device_id": "61fc842e8f2957664877099a613ec773",
          "domain": "sensor",
          "disabled_by": "integration",
          "entity_category": "diagnostic",
          "hidden_by": null,
          "icon": null,
          "id": "973a594139d91892aceaedb65402445a",
          "has_entity_name": true,
          "name": null,
          "options": {},
          "original_device_class": null,
          "original_icon": "mdi:information-outline",
          "original_name": "UPS type",
          "supported_features": 0,
          "translation_key": "ups_type",
          "unit_of_measurement": null,
          "_partial_repr": "{\"area_id\":null,\"config_entry_id\":\"538deba8d47cbfbb95ee0b554f8e453e\",\"device_id\":\"61fc842e8f2957664877099a613ec773\",\"disabled_by\":\"integration\",\"entity_category\":\"diagnostic\",\"entity_id\":\"sensor.eraplus800_ups_type\",\"has_entity_name\":true,\"hidden_by\":null,\"icon\":null,\"id\":\"973a594139d91892aceaedb65402445a\",\"name\":null,\"options\":{},\"original_name\":\"UPS type\",\"platform\":\"nut\",\"translation_key\":\"ups_type\",\"unique_id\":\"538deba8d47cbfbb95ee0b554f8e453e_ups.type\"}",
          "_display_repr": {
            "__type": "<enum 'UndefinedType'>",
            "repr": "<UndefinedType._singleton: 0>"
          },
          "state": null
        },
        "sensor.eraplus800_battery_charge": {
          "unique_id": "538deba8d47cbfbb95ee0b554f8e453e_battery.charge",
          "platform": "nut",
          "aliases": [],
          "area_id": null,
          "capabilities": {
            "state_class": "measurement"
          },
          "config_entry_id": "538deba8d47cbfbb95ee0b554f8e453e",
          "device_class": null,
          "device_id": "61fc842e8f2957664877099a613ec773",
          "domain": "sensor",
          "disabled_by": null,
          "entity_category": null,
          "hidden_by": null,
          "icon": null,
          "id": "20f673230f8af69222f64eb5ea4993df",
          "has_entity_name": true,
          "name": null,
          "options": {
            "conversation": {
              "should_expose": false
            }
          },
          "original_device_class": "battery",
          "original_icon": null,
          "original_name": "Battery charge",
          "supported_features": 0,
          "translation_key": "battery_charge",
          "unit_of_measurement": "%",
          "_partial_repr": "{\"area_id\":null,\"config_entry_id\":\"538deba8d47cbfbb95ee0b554f8e453e\",\"device_id\":\"61fc842e8f2957664877099a613ec773\",\"disabled_by\":null,\"entity_category\":null,\"entity_id\":\"sensor.eraplus800_battery_charge\",\"has_entity_name\":true,\"hidden_by\":null,\"icon\":null,\"id\":\"20f673230f8af69222f64eb5ea4993df\",\"name\":null,\"options\":{\"conversation\":{\"should_expose\":false}},\"original_name\":\"Battery charge\",\"platform\":\"nut\",\"translation_key\":\"battery_charge\",\"unique_id\":\"538deba8d47cbfbb95ee0b554f8e453e_battery.charge\"}",
          "_display_repr": "{\"ei\":\"sensor.eraplus800_battery_charge\",\"pl\":\"nut\",\"di\":\"61fc842e8f2957664877099a613ec773\",\"tk\":\"battery_charge\",\"en\":\"Battery charge\"}",
          "state": {
            "state": "100",
            "attributes": {
              "state_class": "measurement",
              "unit_of_measurement": "%",
              "device_class": "battery",
              "friendly_name": "Eraplus800 Battery charge"
            },
            "last_changed": "2023-07-10T20:19:38.832355+00:00",
            "last_updated": "2023-07-10T20:19:38.832355+00:00"
          }
        },
        "sensor.eraplus800_battery_voltage": {
          "unique_id": "538deba8d47cbfbb95ee0b554f8e453e_battery.voltage",
          "platform": "nut",
          "aliases": [],
          "area_id": null,
          "capabilities": {
            "state_class": "measurement"
          },
          "config_entry_id": "538deba8d47cbfbb95ee0b554f8e453e",
          "device_class": null,
          "device_id": "61fc842e8f2957664877099a613ec773",
          "domain": "sensor",
          "disabled_by": "integration",
          "entity_category": "diagnostic",
          "hidden_by": null,
          "icon": null,
          "id": "a83511b7eab76b9dc9c4872752f0e87c",
          "has_entity_name": true,
          "name": null,
          "options": {},
          "original_device_class": "voltage",
          "original_icon": null,
          "original_name": "Battery voltage",
          "supported_features": 0,
          "translation_key": "battery_voltage",
          "unit_of_measurement": "V",
          "_partial_repr": "{\"area_id\":null,\"config_entry_id\":\"538deba8d47cbfbb95ee0b554f8e453e\",\"device_id\":\"61fc842e8f2957664877099a613ec773\",\"disabled_by\":\"integration\",\"entity_category\":\"diagnostic\",\"entity_id\":\"sensor.eraplus800_battery_voltage\",\"has_entity_name\":true,\"hidden_by\":null,\"icon\":null,\"id\":\"a83511b7eab76b9dc9c4872752f0e87c\",\"name\":null,\"options\":{},\"original_name\":\"Battery voltage\",\"platform\":\"nut\",\"translation_key\":\"battery_voltage\",\"unique_id\":\"538deba8d47cbfbb95ee0b554f8e453e_battery.voltage\"}",
          "_display_repr": {
            "__type": "<enum 'UndefinedType'>",
            "repr": "<UndefinedType._singleton: 0>"
          },
          "state": null
        },
        "sensor.eraplus800_nominal_battery_voltage": {
          "unique_id": "538deba8d47cbfbb95ee0b554f8e453e_battery.voltage.nominal",
          "platform": "nut",
          "aliases": [],
          "area_id": null,
          "capabilities": null,
          "config_entry_id": "538deba8d47cbfbb95ee0b554f8e453e",
          "device_class": null,
          "device_id": "61fc842e8f2957664877099a613ec773",
          "domain": "sensor",
          "disabled_by": "integration",
          "entity_category": "diagnostic",
          "hidden_by": null,
          "icon": null,
          "id": "7c64a73761a55ca3a98ee8dcc1ffc61a",
          "has_entity_name": true,
          "name": null,
          "options": {},
          "original_device_class": "voltage",
          "original_icon": null,
          "original_name": "Nominal battery voltage",
          "supported_features": 0,
          "translation_key": "battery_voltage_nominal",
          "unit_of_measurement": "V",
          "_partial_repr": "{\"area_id\":null,\"config_entry_id\":\"538deba8d47cbfbb95ee0b554f8e453e\",\"device_id\":\"61fc842e8f2957664877099a613ec773\",\"disabled_by\":\"integration\",\"entity_category\":\"diagnostic\",\"entity_id\":\"sensor.eraplus800_nominal_battery_voltage\",\"has_entity_name\":true,\"hidden_by\":null,\"icon\":null,\"id\":\"7c64a73761a55ca3a98ee8dcc1ffc61a\",\"name\":null,\"options\":{},\"original_name\":\"Nominal battery voltage\",\"platform\":\"nut\",\"translation_key\":\"battery_voltage_nominal\",\"unique_id\":\"538deba8d47cbfbb95ee0b554f8e453e_battery.voltage.nominal\"}",
          "_display_repr": {
            "__type": "<enum 'UndefinedType'>",
            "repr": "<UndefinedType._singleton: 0>"
          },
          "state": null
        },
        "sensor.eraplus800_low_battery_voltage": {
          "unique_id": "538deba8d47cbfbb95ee0b554f8e453e_battery.voltage.low",
          "platform": "nut",
          "aliases": [],
          "area_id": null,
          "capabilities": null,
          "config_entry_id": "538deba8d47cbfbb95ee0b554f8e453e",
          "device_class": null,
          "device_id": "61fc842e8f2957664877099a613ec773",
          "domain": "sensor",
          "disabled_by": "integration",
          "entity_category": "diagnostic",
          "hidden_by": null,
          "icon": null,
          "id": "705fe31dd006bbe1fd36b63aeb897e46",
          "has_entity_name": true,
          "name": null,
          "options": {},
          "original_device_class": "voltage",
          "original_icon": null,
          "original_name": "Low battery voltage",
          "supported_features": 0,
          "translation_key": "battery_voltage_low",
          "unit_of_measurement": "V",
          "_partial_repr": "{\"area_id\":null,\"config_entry_id\":\"538deba8d47cbfbb95ee0b554f8e453e\",\"device_id\":\"61fc842e8f2957664877099a613ec773\",\"disabled_by\":\"integration\",\"entity_category\":\"diagnostic\",\"entity_id\":\"sensor.eraplus800_low_battery_voltage\",\"has_entity_name\":true,\"hidden_by\":null,\"icon\":null,\"id\":\"705fe31dd006bbe1fd36b63aeb897e46\",\"name\":null,\"options\":{},\"original_name\":\"Low battery voltage\",\"platform\":\"nut\",\"translation_key\":\"battery_voltage_low\",\"unique_id\":\"538deba8d47cbfbb95ee0b554f8e453e_battery.voltage.low\"}",
          "_display_repr": {
            "__type": "<enum 'UndefinedType'>",
            "repr": "<UndefinedType._singleton: 0>"
          },
          "state": null
        },
        "sensor.eraplus800_high_battery_voltage": {
          "unique_id": "538deba8d47cbfbb95ee0b554f8e453e_battery.voltage.high",
          "platform": "nut",
          "aliases": [],
          "area_id": null,
          "capabilities": null,
          "config_entry_id": "538deba8d47cbfbb95ee0b554f8e453e",
          "device_class": null,
          "device_id": "61fc842e8f2957664877099a613ec773",
          "domain": "sensor",
          "disabled_by": "integration",
          "entity_category": "diagnostic",
          "hidden_by": null,
          "icon": null,
          "id": "8b09aae8abce4378c6887bc1b733c248",
          "has_entity_name": true,
          "name": null,
          "options": {},
          "original_device_class": "voltage",
          "original_icon": null,
          "original_name": "High battery voltage",
          "supported_features": 0,
          "translation_key": "battery_voltage_high",
          "unit_of_measurement": "V",
          "_partial_repr": "{\"area_id\":null,\"config_entry_id\":\"538deba8d47cbfbb95ee0b554f8e453e\",\"device_id\":\"61fc842e8f2957664877099a613ec773\",\"disabled_by\":\"integration\",\"entity_category\":\"diagnostic\",\"entity_id\":\"sensor.eraplus800_high_battery_voltage\",\"has_entity_name\":true,\"hidden_by\":null,\"icon\":null,\"id\":\"8b09aae8abce4378c6887bc1b733c248\",\"name\":null,\"options\":{},\"original_name\":\"High battery voltage\",\"platform\":\"nut\",\"translation_key\":\"battery_voltage_high\",\"unique_id\":\"538deba8d47cbfbb95ee0b554f8e453e_battery.voltage.high\"}",
          "_display_repr": {
            "__type": "<enum 'UndefinedType'>",
            "repr": "<UndefinedType._singleton: 0>"
          },
          "state": null
        },
        "sensor.eraplus800_input_voltage": {
          "unique_id": "538deba8d47cbfbb95ee0b554f8e453e_input.voltage",
          "platform": "nut",
          "aliases": [],
          "area_id": null,
          "capabilities": {
            "state_class": "measurement"
          },
          "config_entry_id": "538deba8d47cbfbb95ee0b554f8e453e",
          "device_class": null,
          "device_id": "61fc842e8f2957664877099a613ec773",
          "domain": "sensor",
          "disabled_by": null,
          "entity_category": null,
          "hidden_by": null,
          "icon": null,
          "id": "1c6a479d951e4fd563c76356b92e221f",
          "has_entity_name": true,
          "name": null,
          "options": {
            "conversation": {
              "should_expose": false
            }
          },
          "original_device_class": "voltage",
          "original_icon": null,
          "original_name": "Input voltage",
          "supported_features": 0,
          "translation_key": "input_voltage",
          "unit_of_measurement": "V",
          "_partial_repr": "{\"area_id\":null,\"config_entry_id\":\"538deba8d47cbfbb95ee0b554f8e453e\",\"device_id\":\"61fc842e8f2957664877099a613ec773\",\"disabled_by\":null,\"entity_category\":null,\"entity_id\":\"sensor.eraplus800_input_voltage\",\"has_entity_name\":true,\"hidden_by\":null,\"icon\":null,\"id\":\"1c6a479d951e4fd563c76356b92e221f\",\"name\":null,\"options\":{\"conversation\":{\"should_expose\":false}},\"original_name\":\"Input voltage\",\"platform\":\"nut\",\"translation_key\":\"input_voltage\",\"unique_id\":\"538deba8d47cbfbb95ee0b554f8e453e_input.voltage\"}",
          "_display_repr": "{\"ei\":\"sensor.eraplus800_input_voltage\",\"pl\":\"nut\",\"di\":\"61fc842e8f2957664877099a613ec773\",\"tk\":\"input_voltage\",\"en\":\"Input voltage\"}",
          "state": {
            "state": "244.0",
            "attributes": {
              "state_class": "measurement",
              "unit_of_measurement": "V",
              "device_class": "voltage",
              "friendly_name": "Eraplus800 Input voltage"
            },
            "last_changed": "2023-07-10T20:19:38.833806+00:00",
            "last_updated": "2023-07-10T20:19:38.833806+00:00"
          }
        },
        "sensor.eraplus800_nominal_input_voltage": {
          "unique_id": "538deba8d47cbfbb95ee0b554f8e453e_input.voltage.nominal",
          "platform": "nut",
          "aliases": [],
          "area_id": null,
          "capabilities": null,
          "config_entry_id": "538deba8d47cbfbb95ee0b554f8e453e",
          "device_class": null,
          "device_id": "61fc842e8f2957664877099a613ec773",
          "domain": "sensor",
          "disabled_by": "integration",
          "entity_category": "diagnostic",
          "hidden_by": null,
          "icon": null,
          "id": "7c7816027d22df1b8e9ce16d3de7cef0",
          "has_entity_name": true,
          "name": null,
          "options": {},
          "original_device_class": "voltage",
          "original_icon": null,
          "original_name": "Nominal input voltage",
          "supported_features": 0,
          "translation_key": "input_voltage_nominal",
          "unit_of_measurement": "V",
          "_partial_repr": "{\"area_id\":null,\"config_entry_id\":\"538deba8d47cbfbb95ee0b554f8e453e\",\"device_id\":\"61fc842e8f2957664877099a613ec773\",\"disabled_by\":\"integration\",\"entity_category\":\"diagnostic\",\"entity_id\":\"sensor.eraplus800_nominal_input_voltage\",\"has_entity_name\":true,\"hidden_by\":null,\"icon\":null,\"id\":\"7c7816027d22df1b8e9ce16d3de7cef0\",\"name\":null,\"options\":{},\"original_name\":\"Nominal input voltage\",\"platform\":\"nut\",\"translation_key\":\"input_voltage_nominal\",\"unique_id\":\"538deba8d47cbfbb95ee0b554f8e453e_input.voltage.nominal\"}",
          "_display_repr": {
            "__type": "<enum 'UndefinedType'>",
            "repr": "<UndefinedType._singleton: 0>"
          },
          "state": null
        },
        "sensor.eraplus800_input_line_frequency": {
          "unique_id": "538deba8d47cbfbb95ee0b554f8e453e_input.frequency",
          "platform": "nut",
          "aliases": [],
          "area_id": null,
          "capabilities": {
            "state_class": "measurement"
          },
          "config_entry_id": "538deba8d47cbfbb95ee0b554f8e453e",
          "device_class": null,
          "device_id": "61fc842e8f2957664877099a613ec773",
          "domain": "sensor",
          "disabled_by": "integration",
          "entity_category": "diagnostic",
          "hidden_by": null,
          "icon": null,
          "id": "fabe68bf8bf258215b6e2dff545d32be",
          "has_entity_name": true,
          "name": null,
          "options": {},
          "original_device_class": "frequency",
          "original_icon": null,
          "original_name": "Input line frequency",
          "supported_features": 0,
          "translation_key": "input_frequency",
          "unit_of_measurement": "Hz",
          "_partial_repr": "{\"area_id\":null,\"config_entry_id\":\"538deba8d47cbfbb95ee0b554f8e453e\",\"device_id\":\"61fc842e8f2957664877099a613ec773\",\"disabled_by\":\"integration\",\"entity_category\":\"diagnostic\",\"entity_id\":\"sensor.eraplus800_input_line_frequency\",\"has_entity_name\":true,\"hidden_by\":null,\"icon\":null,\"id\":\"fabe68bf8bf258215b6e2dff545d32be\",\"name\":null,\"options\":{},\"original_name\":\"Input line frequency\",\"platform\":\"nut\",\"translation_key\":\"input_frequency\",\"unique_id\":\"538deba8d47cbfbb95ee0b554f8e453e_input.frequency\"}",
          "_display_repr": {
            "__type": "<enum 'UndefinedType'>",
            "repr": "<UndefinedType._singleton: 0>"
          },
          "state": null
        },
        "sensor.eraplus800_nominal_input_line_frequency": {
          "unique_id": "538deba8d47cbfbb95ee0b554f8e453e_input.frequency.nominal",
          "platform": "nut",
          "aliases": [],
          "area_id": null,
          "capabilities": null,
          "config_entry_id": "538deba8d47cbfbb95ee0b554f8e453e",
          "device_class": null,
          "device_id": "61fc842e8f2957664877099a613ec773",
          "domain": "sensor",
          "disabled_by": "integration",
          "entity_category": "diagnostic",
          "hidden_by": null,
          "icon": null,
          "id": "d2e3858130680324e7f1c63b6a34727d",
          "has_entity_name": true,
          "name": null,
          "options": {},
          "original_device_class": "frequency",
          "original_icon": null,
          "original_name": "Nominal input line frequency",
          "supported_features": 0,
          "translation_key": "input_frequency_nominal",
          "unit_of_measurement": "Hz",
          "_partial_repr": "{\"area_id\":null,\"config_entry_id\":\"538deba8d47cbfbb95ee0b554f8e453e\",\"device_id\":\"61fc842e8f2957664877099a613ec773\",\"disabled_by\":\"integration\",\"entity_category\":\"diagnostic\",\"entity_id\":\"sensor.eraplus800_nominal_input_line_frequency\",\"has_entity_name\":true,\"hidden_by\":null,\"icon\":null,\"id\":\"d2e3858130680324e7f1c63b6a34727d\",\"name\":null,\"options\":{},\"original_name\":\"Nominal input line frequency\",\"platform\":\"nut\",\"translation_key\":\"input_frequency_nominal\",\"unique_id\":\"538deba8d47cbfbb95ee0b554f8e453e_input.frequency.nominal\"}",
          "_display_repr": {
            "__type": "<enum 'UndefinedType'>",
            "repr": "<UndefinedType._singleton: 0>"
          },
          "state": null
        },
        "sensor.eraplus800_output_voltage": {
          "unique_id": "538deba8d47cbfbb95ee0b554f8e453e_output.voltage",
          "platform": "nut",
          "aliases": [],
          "area_id": null,
          "capabilities": {
            "state_class": "measurement"
          },
          "config_entry_id": "538deba8d47cbfbb95ee0b554f8e453e",
          "device_class": null,
          "device_id": "61fc842e8f2957664877099a613ec773",
          "domain": "sensor",
          "disabled_by": null,
          "entity_category": null,
          "hidden_by": null,
          "icon": null,
          "id": "cf93d121dd629a886aed7d4010f0418b",
          "has_entity_name": true,
          "name": null,
          "options": {
            "conversation": {
              "should_expose": false
            }
          },
          "original_device_class": "voltage",
          "original_icon": null,
          "original_name": "Output voltage",
          "supported_features": 0,
          "translation_key": "output_voltage",
          "unit_of_measurement": "V",
          "_partial_repr": "{\"area_id\":null,\"config_entry_id\":\"538deba8d47cbfbb95ee0b554f8e453e\",\"device_id\":\"61fc842e8f2957664877099a613ec773\",\"disabled_by\":null,\"entity_category\":null,\"entity_id\":\"sensor.eraplus800_output_voltage\",\"has_entity_name\":true,\"hidden_by\":null,\"icon\":null,\"id\":\"cf93d121dd629a886aed7d4010f0418b\",\"name\":null,\"options\":{\"conversation\":{\"should_expose\":false}},\"original_name\":\"Output voltage\",\"platform\":\"nut\",\"translation_key\":\"output_voltage\",\"unique_id\":\"538deba8d47cbfbb95ee0b554f8e453e_output.voltage\"}",
          "_display_repr": "{\"ei\":\"sensor.eraplus800_output_voltage\",\"pl\":\"nut\",\"di\":\"61fc842e8f2957664877099a613ec773\",\"tk\":\"output_voltage\",\"en\":\"Output voltage\"}",
          "state": {
            "state": "234.5",
            "attributes": {
              "state_class": "measurement",
              "unit_of_measurement": "V",
              "device_class": "voltage",
              "friendly_name": "Eraplus800 Output voltage"
            },
            "last_changed": "2023-07-10T20:19:38.835939+00:00",
            "last_updated": "2023-07-10T20:19:38.835939+00:00"
          }
        },
        "sensor.eraplus800_status": {
          "unique_id": "538deba8d47cbfbb95ee0b554f8e453e_ups.status.display",
          "platform": "nut",
          "aliases": [],
          "area_id": null,
          "capabilities": null,
          "config_entry_id": "538deba8d47cbfbb95ee0b554f8e453e",
          "device_class": null,
          "device_id": "61fc842e8f2957664877099a613ec773",
          "domain": "sensor",
          "disabled_by": null,
          "entity_category": null,
          "hidden_by": null,
          "icon": null,
          "id": "d5a83940d0bf21399dee72c70f8a6e9e",
          "has_entity_name": true,
          "name": null,
          "options": {
            "conversation": {
              "should_expose": false
            }
          },
          "original_device_class": null,
          "original_icon": "mdi:information-outline",
          "original_name": "Status",
          "supported_features": 0,
          "translation_key": "ups_status_display",
          "unit_of_measurement": null,
          "_partial_repr": "{\"area_id\":null,\"config_entry_id\":\"538deba8d47cbfbb95ee0b554f8e453e\",\"device_id\":\"61fc842e8f2957664877099a613ec773\",\"disabled_by\":null,\"entity_category\":null,\"entity_id\":\"sensor.eraplus800_status\",\"has_entity_name\":true,\"hidden_by\":null,\"icon\":null,\"id\":\"d5a83940d0bf21399dee72c70f8a6e9e\",\"name\":null,\"options\":{\"conversation\":{\"should_expose\":false}},\"original_name\":\"Status\",\"platform\":\"nut\",\"translation_key\":\"ups_status_display\",\"unique_id\":\"538deba8d47cbfbb95ee0b554f8e453e_ups.status.display\"}",
          "_display_repr": "{\"ei\":\"sensor.eraplus800_status\",\"pl\":\"nut\",\"di\":\"61fc842e8f2957664877099a613ec773\",\"tk\":\"ups_status_display\",\"en\":\"Status\"}",
          "state": {
            "state": "Online",
            "attributes": {
              "icon": "mdi:information-outline",
              "friendly_name": "Eraplus800 Status"
            },
            "last_changed": "2023-07-10T20:19:38.836364+00:00",
            "last_updated": "2023-07-10T20:19:38.836364+00:00"
          }
        },
        "sensor.eraplus800_status_data": {
          "unique_id": "538deba8d47cbfbb95ee0b554f8e453e_ups.status",
          "platform": "nut",
          "aliases": [],
          "area_id": null,
          "capabilities": null,
          "config_entry_id": "538deba8d47cbfbb95ee0b554f8e453e",
          "device_class": null,
          "device_id": "61fc842e8f2957664877099a613ec773",
          "domain": "sensor",
          "disabled_by": null,
          "entity_category": null,
          "hidden_by": null,
          "icon": null,
          "id": "c7446367513bb1d255e0a46d812345c2",
          "has_entity_name": true,
          "name": null,
          "options": {
            "conversation": {
              "should_expose": false
            }
          },
          "original_device_class": null,
          "original_icon": "mdi:information-outline",
          "original_name": "Status data",
          "supported_features": 0,
          "translation_key": "ups_status",
          "unit_of_measurement": null,
          "_partial_repr": {
            "__type": "<enum 'UndefinedType'>",
            "repr": "<UndefinedType._singleton: 0>"
          },
          "_display_repr": {
            "__type": "<enum 'UndefinedType'>",
            "repr": "<UndefinedType._singleton: 0>"
          },
          "state": {
            "state": "OL",
            "attributes": {
              "icon": "mdi:information-outline",
              "friendly_name": "Eraplus800 Status data"
            },
            "last_changed": "2023-07-10T20:19:38.944503+00:00",
            "last_updated": "2023-07-10T20:19:38.944503+00:00"
          }
        }
      }
    }
  }
}
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #96238
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
