### PR TITLE
RFC: hassio: Retry supervisor API when not ready (work-around race-condition between supervisor and core)

### DIFF
--- a/homeassistant/components/hassio/handler.py
+++ b/homeassistant/components/hassio/handler.py
@@ -46,10 +46,14 @@ def api_data(funct):
 
     async def _wrapper(*argv, **kwargs):
         """Wrap function."""
-        data = await funct(*argv, **kwargs)
-        if data["result"] == "ok":
-            return data["data"]
-        raise HassioAPIError(data["message"])
+        while True:
+            data = await funct(*argv, **kwargs)
+            if data["result"] == "ok":
+                return data["data"]
+            if data["message"] == "System is not ready with state: setup":
+                await asyncio.sleep(1)
+                continue
+            raise HassioAPIError(data["message"])
 
     return _wrapper
 


### PR DESCRIPTION
## Proposed change
This is an RFC for a change to address a race condition between supervisor and core especially on fast machines. As described in #95887 after rebooting HAOS / HA supervised core and supervisor may be coming up in parallel and supervisor API may not be ready in time to reply to core API requests ` HassioAPIError('System is not ready with state: setup')` and this situation is not dealt with in core adequately, occasionally causing the first startup of core after a reboot to fail and requiring a manual restart of core.

I have first tried to address this on supervisor side, but my PR was closed without useful feedback as to how to address the situation instead: https://github.com/home-assistant/supervisor/pull/4428

I'm well aware that the proposed change is probably not clean so more or less looking for feedback and trying to get the attention of someone with more insight.



## Type of change
- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #95887 
- Forum thread: https://community.home-assistant.io/t/error-returned-from-supervisor-system-is-not-ready-with-state-setup/413084

## Checklist
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
