### PR TITLE
Migrate alarm control panel services to support translations

### DIFF
--- a/homeassistant/components/alarm_control_panel/services.yaml
+++ b/homeassistant/components/alarm_control_panel/services.yaml
@@ -1,22 +1,16 @@
 # Describes the format for available alarm control panel services
 
 alarm_disarm:
-  name: Disarm
-  description: Send the alarm the command for disarm.
   target:
     entity:
       domain: alarm_control_panel
   fields:
     code:
-      name: Code
-      description: An optional code to disarm the alarm control panel with.
       example: "1234"
       selector:
         text:
 
 alarm_arm_custom_bypass:
-  name: Arm with custom bypass
-  description: Send arm custom bypass command.
   target:
     entity:
       domain: alarm_control_panel
@@ -24,15 +18,11 @@ alarm_arm_custom_bypass:
         - alarm_control_panel.AlarmControlPanelEntityFeature.ARM_CUSTOM_BYPASS
   fields:
     code:
-      name: Code
-      description: An optional code to arm custom bypass the alarm control panel with.
       example: "1234"
       selector:
         text:
 
 alarm_arm_home:
-  name: Arm home
-  description: Send the alarm the command for arm home.
   target:
     entity:
       domain: alarm_control_panel
@@ -40,15 +30,11 @@ alarm_arm_home:
         - alarm_control_panel.AlarmControlPanelEntityFeature.ARM_HOME
   fields:
     code:
-      name: Code
-      description: An optional code to arm home the alarm control panel with.
       example: "1234"
       selector:
         text:
 
 alarm_arm_away:
-  name: Arm away
-  description: Send the alarm the command for arm away.
   target:
     entity:
       domain: alarm_control_panel
@@ -56,15 +42,11 @@ alarm_arm_away:
         - alarm_control_panel.AlarmControlPanelEntityFeature.ARM_AWAY
   fields:
     code:
-      name: Code
-      description: An optional code to arm away the alarm control panel with.
       example: "1234"
       selector:
         text:
 
 alarm_arm_night:
-  name: Arm night
-  description: Send the alarm the command for arm night.
   target:
     entity:
       domain: alarm_control_panel
@@ -72,15 +54,11 @@ alarm_arm_night:
         - alarm_control_panel.AlarmControlPanelEntityFeature.ARM_NIGHT
   fields:
     code:
-      name: Code
-      description: An optional code to arm night the alarm control panel with.
       example: "1234"
       selector:
         text:
 
 alarm_arm_vacation:
-  name: Arm vacation
-  description: Send the alarm the command for arm vacation.
   target:
     entity:
       domain: alarm_control_panel
@@ -88,15 +66,11 @@ alarm_arm_vacation:
         - alarm_control_panel.AlarmControlPanelEntityFeature.ARM_VACATION
   fields:
     code:
-      name: Code
-      description: An optional code to arm vacation the alarm control panel with.
       example: "1234"
       selector:
         text:
 
 alarm_trigger:
-  name: Trigger
-  description: Send the alarm the command for trigger.
   target:
     entity:
       domain: alarm_control_panel
@@ -104,8 +78,6 @@ alarm_trigger:
         - alarm_control_panel.AlarmControlPanelEntityFeature.TRIGGER
   fields:
     code:
-      name: Code
-      description: An optional code to trigger the alarm control panel with.
       example: "1234"
       selector:
         text:

--- a/homeassistant/components/alarm_control_panel/strings.json
+++ b/homeassistant/components/alarm_control_panel/strings.json
@@ -62,5 +62,77 @@
         }
       }
     }
+  },
+  "services": {
+    "alarm_disarm": {
+      "name": "Disarm",
+      "description": "Send the alarm the command for disarm.",
+      "fields": {
+        "code": {
+          "name": "Code",
+          "description": "An optional code to disarm the alarm control panel with."
+        }
+      }
+    },
+    "alarm_arm_custom_bypass": {
+      "name": "Arm with custom bypass",
+      "description": "Send arm custom bypass command.",
+      "fields": {
+        "code": {
+          "name": "Code",
+          "description": "An optional code to arm custom bypass the alarm control panel with."
+        }
+      }
+    },
+    "alarm_arm_home": {
+      "name": "Arm home",
+      "description": "Send the alarm the command for arm home.",
+      "fields": {
+        "code": {
+          "name": "Code",
+          "description": "An optional code to arm home the alarm control panel with."
+        }
+      }
+    },
+    "alarm_arm_away": {
+      "name": "Arm away",
+      "description": "Send the alarm the command for arm away.",
+      "fields": {
+        "code": {
+          "name": "Code",
+          "description": "An optional code to arm away the alarm control panel with."
+        }
+      }
+    },
+    "alarm_arm_night": {
+      "name": "Arm night",
+      "description": "Send the alarm the command for arm night.",
+      "fields": {
+        "code": {
+          "name": "Code",
+          "description": "An optional code to arm night the alarm control panel with."
+        }
+      }
+    },
+    "alarm_arm_vacation": {
+      "name": "Arm vacation",
+      "description": "Send the alarm the command for arm vacation.",
+      "fields": {
+        "code": {
+          "name": "Code",
+          "description": "An optional code to arm vacation the alarm control panel with."
+        }
+      }
+    },
+    "alarm_trigger": {
+      "name": "Trigger",
+      "description": "Send the alarm the command for trigger.",
+      "fields": {
+        "code": {
+          "name": "Code",
+          "description": "An optional code to trigger the alarm control panel with."
+        }
+      }
+    }
   }
 }

--- a/homeassistant/components/alarm_control_panel/strings.json
+++ b/homeassistant/components/alarm_control_panel/strings.json
@@ -66,11 +66,11 @@
   "services": {
     "alarm_disarm": {
       "name": "Disarm",
-      "description": "Send the alarm the command for disarm.",
+      "description": "Disarms the alarm.",
       "fields": {
         "code": {
           "name": "Code",
-          "description": "An optional code to disarm the alarm control panel with."
+          "description": "Code to disarm the alarm."
         }
       }
     },
@@ -79,8 +79,8 @@
       "description": "Send arm custom bypass command.",
       "fields": {
         "code": {
-          "name": "Code",
-          "description": "An optional code to arm custom bypass the alarm control panel with."
+          "name": "[%key:component::alarm_control_panel::services::alarm_disarm::fields::code::name%]",
+          "description": "Code to arm the alarm."
         }
       }
     },
@@ -89,8 +89,8 @@
       "description": "Send the alarm the command for arm home.",
       "fields": {
         "code": {
-          "name": "Code",
-          "description": "An optional code to arm home the alarm control panel with."
+          "name": "[%key:component::alarm_control_panel::services::alarm_disarm::fields::code::name%]",
+          "description": "[%key:component::alarm_control_panel::services::alarm_arm_custom_bypass::fields::code::description%]"
         }
       }
     },
@@ -99,8 +99,8 @@
       "description": "Send the alarm the command for arm away.",
       "fields": {
         "code": {
-          "name": "Code",
-          "description": "An optional code to arm away the alarm control panel with."
+          "name": "[%key:component::alarm_control_panel::services::alarm_disarm::fields::code::name%]",
+          "description": "[%key:component::alarm_control_panel::services::alarm_arm_custom_bypass::fields::code::description%]"
         }
       }
     },
@@ -109,8 +109,8 @@
       "description": "Send the alarm the command for arm night.",
       "fields": {
         "code": {
-          "name": "Code",
-          "description": "An optional code to arm night the alarm control panel with."
+          "name": "[%key:component::alarm_control_panel::services::alarm_disarm::fields::code::name%]",
+          "description": "[%key:component::alarm_control_panel::services::alarm_arm_custom_bypass::fields::code::description%]"
         }
       }
     },
@@ -119,8 +119,8 @@
       "description": "Send the alarm the command for arm vacation.",
       "fields": {
         "code": {
-          "name": "Code",
-          "description": "An optional code to arm vacation the alarm control panel with."
+          "name": "[%key:component::alarm_control_panel::services::alarm_disarm::fields::code::name%]",
+          "description": "[%key:component::alarm_control_panel::services::alarm_arm_custom_bypass::fields::code::description%]"
         }
       }
     },
@@ -129,8 +129,8 @@
       "description": "Send the alarm the command for trigger.",
       "fields": {
         "code": {
-          "name": "Code",
-          "description": "An optional code to trigger the alarm control panel with."
+          "name": "[%key:component::alarm_control_panel::services::alarm_disarm::fields::code::name%]",
+          "description": "[%key:component::alarm_control_panel::services::alarm_arm_custom_bypass::fields::code::description%]"
         }
       }
     }

--- a/homeassistant/components/alarm_control_panel/strings.json
+++ b/homeassistant/components/alarm_control_panel/strings.json
@@ -76,7 +76,7 @@
     },
     "alarm_arm_custom_bypass": {
       "name": "Arm with custom bypass",
-      "description": "Send arm custom bypass command.",
+      "description": "Arms the alarm while allowing to bypass a custom area.",
       "fields": {
         "code": {
           "name": "[%key:component::alarm_control_panel::services::alarm_disarm::fields::code::name%]",
@@ -86,7 +86,7 @@
     },
     "alarm_arm_home": {
       "name": "Arm home",
-      "description": "Send the alarm the command for arm home.",
+      "description": "Sets the alarm to: _armed, but someone is home_.",
       "fields": {
         "code": {
           "name": "[%key:component::alarm_control_panel::services::alarm_disarm::fields::code::name%]",
@@ -96,7 +96,7 @@
     },
     "alarm_arm_away": {
       "name": "Arm away",
-      "description": "Send the alarm the command for arm away.",
+      "description": "Sets the alarm to: _armed, no one home_.",
       "fields": {
         "code": {
           "name": "[%key:component::alarm_control_panel::services::alarm_disarm::fields::code::name%]",
@@ -106,7 +106,7 @@
     },
     "alarm_arm_night": {
       "name": "Arm night",
-      "description": "Send the alarm the command for arm night.",
+      "description": "Sets the alarm to: _armed for the night_.",
       "fields": {
         "code": {
           "name": "[%key:component::alarm_control_panel::services::alarm_disarm::fields::code::name%]",
@@ -116,7 +116,7 @@
     },
     "alarm_arm_vacation": {
       "name": "Arm vacation",
-      "description": "Send the alarm the command for arm vacation.",
+      "description": "Sets the alarm to: _armed for vacation_.",
       "fields": {
         "code": {
           "name": "[%key:component::alarm_control_panel::services::alarm_disarm::fields::code::name%]",
@@ -126,7 +126,7 @@
     },
     "alarm_trigger": {
       "name": "Trigger",
-      "description": "Send the alarm the command for trigger.",
+      "description": "Enables an external alarm trigger.",
       "fields": {
         "code": {
           "name": "[%key:component::alarm_control_panel::services::alarm_disarm::fields::code::name%]",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Migrates the alarm control panel entity component-provided services to support translated services.

More information (and depends on), see: #95984

ℹ️ The contents of this PR has been scripted and migrated from source automatically.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
