### PR TITLE
Migrate calendar services to support translations

### DIFF
--- a/homeassistant/components/calendar/services.yaml
+++ b/homeassistant/components/calendar/services.yaml
@@ -1,6 +1,4 @@
 create_event:
-  name: Create event
-  description: Add a new calendar event.
   target:
     entity:
       domain: calendar
@@ -8,73 +6,49 @@ create_event:
         - calendar.CalendarEntityFeature.CREATE_EVENT
   fields:
     summary:
-      name: Summary
-      description: Defines the short summary or subject for the event
       required: true
       example: "Department Party"
       selector:
         text:
     description:
-      name: Description
-      description: A more complete description of the event than that provided by the summary.
       example: "Meeting to provide technical review for 'Phoenix' design."
       selector:
         text:
     start_date_time:
-      name: Start time
-      description: The date and time the event should start.
       example: "2022-03-22 20:00:00"
       selector:
         datetime:
     end_date_time:
-      name: End time
-      description: The date and time the event should end.
       example: "2022-03-22 22:00:00"
       selector:
         datetime:
     start_date:
-      name: Start date
-      description: The date the all-day event should start.
       example: "2022-03-22"
       selector:
         date:
     end_date:
-      name: End date
-      description: The date the all-day event should end (exclusive).
       example: "2022-03-23"
       selector:
         date:
     in:
-      name: In
-      description: Days or weeks that you want to create the event in.
       example: '{"days": 2} or {"weeks": 2}'
     location:
-      name: Location
-      description: The location of the event.
       example: "Conference Room - F123, Bldg. 002"
       selector:
         text:
 list_events:
-  name: List event
-  description: List events on a calendar within a time range.
   target:
     entity:
       domain: calendar
   fields:
     start_date_time:
-      name: Start time
-      description: Return active events after this time (exclusive). When not set, defaults to now.
       example: "2022-03-22 20:00:00"
       selector:
         datetime:
     end_date_time:
-      name: End time
-      description: Return active events before this time (exclusive). Cannot be used with 'duration'.
       example: "2022-03-22 22:00:00"
       selector:
         datetime:
     duration:
-      name: Duration
-      description: Return active events from start_date_time until the specified duration.
       selector:
         duration:

--- a/homeassistant/components/calendar/strings.json
+++ b/homeassistant/components/calendar/strings.json
@@ -32,5 +32,63 @@
         }
       }
     }
+  },
+  "services": {
+    "create_event": {
+      "name": "Create event",
+      "description": "Add a new calendar event.",
+      "fields": {
+        "summary": {
+          "name": "Summary",
+          "description": "Defines the short summary or subject for the event."
+        },
+        "description": {
+          "name": "Description",
+          "description": "A more complete description of the event than that provided by the summary."
+        },
+        "start_date_time": {
+          "name": "Start time",
+          "description": "The date and time the event should start."
+        },
+        "end_date_time": {
+          "name": "End time",
+          "description": "The date and time the event should end."
+        },
+        "start_date": {
+          "name": "Start date",
+          "description": "The date the all-day event should start."
+        },
+        "end_date": {
+          "name": "End date",
+          "description": "The date the all-day event should end (exclusive)."
+        },
+        "in": {
+          "name": "In",
+          "description": "Days or weeks that you want to create the event in."
+        },
+        "location": {
+          "name": "Location",
+          "description": "The location of the event."
+        }
+      }
+    },
+    "list_events": {
+      "name": "List event",
+      "description": "List events on a calendar within a time range.",
+      "fields": {
+        "start_date_time": {
+          "name": "Start time",
+          "description": "Return active events after this time (exclusive). When not set, defaults to now."
+        },
+        "end_date_time": {
+          "name": "End time",
+          "description": "Return active events before this time (exclusive). Cannot be used with 'duration'."
+        },
+        "duration": {
+          "name": "Duration",
+          "description": "Return active events from start_date_time until the specified duration."
+        }
+      }
+    }
   }
 }

--- a/homeassistant/components/calendar/strings.json
+++ b/homeassistant/components/calendar/strings.json
@@ -36,7 +36,7 @@
   "services": {
     "create_event": {
       "name": "Create event",
-      "description": "Add a new calendar event.",
+      "description": "Adds a new calendar event.",
       "fields": {
         "summary": {
           "name": "Summary",
@@ -44,7 +44,7 @@
         },
         "description": {
           "name": "Description",
-          "description": "A more complete description of the event than that provided by the summary."
+          "description": "A more complete description of the event than the one provided by the summary."
         },
         "start_date_time": {
           "name": "Start time",
@@ -74,19 +74,19 @@
     },
     "list_events": {
       "name": "List event",
-      "description": "List events on a calendar within a time range.",
+      "description": "Lists events on a calendar within a time range.",
       "fields": {
         "start_date_time": {
           "name": "Start time",
-          "description": "Return active events after this time (exclusive). When not set, defaults to now."
+          "description": "Returns active events after this time (exclusive). When not set, defaults to now."
         },
         "end_date_time": {
           "name": "End time",
-          "description": "Return active events before this time (exclusive). Cannot be used with 'duration'."
+          "description": "Returns active events before this time (exclusive). Cannot be used with 'duration'."
         },
         "duration": {
           "name": "Duration",
-          "description": "Return active events from start_date_time until the specified duration."
+          "description": "Returns active events from start_date_time until the specified duration."
         }
       }
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Migrates the calendar entity component-provided services to support translated services.

More information (and depends on), see: #95984

ℹ️ The contents of this PR has been scripted and migrated from source automatically.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
