### PR TITLE
Migrate cover services to support translations

### DIFF
--- a/homeassistant/components/cover/services.yaml
+++ b/homeassistant/components/cover/services.yaml
@@ -1,8 +1,6 @@
 # Describes the format for available cover services
 
 open_cover:
-  name: Open
-  description: Open all or specified cover.
   target:
     entity:
       domain: cover
@@ -10,8 +8,6 @@ open_cover:
         - cover.CoverEntityFeature.OPEN
 
 close_cover:
-  name: Close
-  description: Close all or specified cover.
   target:
     entity:
       domain: cover
@@ -19,8 +15,6 @@ close_cover:
         - cover.CoverEntityFeature.CLOSE
 
 toggle:
-  name: Toggle
-  description: Toggle a cover open/closed.
   target:
     entity:
       domain: cover
@@ -29,8 +23,6 @@ toggle:
           - cover.CoverEntityFeature.OPEN
 
 set_cover_position:
-  name: Set position
-  description: Move to specific position all or specified cover.
   target:
     entity:
       domain: cover
@@ -38,8 +30,6 @@ set_cover_position:
         - cover.CoverEntityFeature.SET_POSITION
   fields:
     position:
-      name: Position
-      description: Position of the cover
       required: true
       selector:
         number:
@@ -48,8 +38,6 @@ set_cover_position:
           unit_of_measurement: "%"
 
 stop_cover:
-  name: Stop
-  description: Stop all or specified cover.
   target:
     entity:
       domain: cover
@@ -57,8 +45,6 @@ stop_cover:
         - cover.CoverEntityFeature.STOP
 
 open_cover_tilt:
-  name: Open tilt
-  description: Open all or specified cover tilt.
   target:
     entity:
       domain: cover
@@ -66,8 +52,6 @@ open_cover_tilt:
         - cover.CoverEntityFeature.OPEN_TILT
 
 close_cover_tilt:
-  name: Close tilt
-  description: Close all or specified cover tilt.
   target:
     entity:
       domain: cover
@@ -75,8 +59,6 @@ close_cover_tilt:
         - cover.CoverEntityFeature.CLOSE_TILT
 
 toggle_cover_tilt:
-  name: Toggle tilt
-  description: Toggle a cover tilt open/closed.
   target:
     entity:
       domain: cover
@@ -85,8 +67,6 @@ toggle_cover_tilt:
           - cover.CoverEntityFeature.OPEN_TILT
 
 set_cover_tilt_position:
-  name: Set tilt position
-  description: Move to specific position all or specified cover tilt.
   target:
     entity:
       domain: cover
@@ -94,8 +74,6 @@ set_cover_tilt_position:
         - cover.CoverEntityFeature.SET_TILT_POSITION
   fields:
     tilt_position:
-      name: Tilt position
-      description: Tilt position of the cover.
       required: true
       selector:
         number:
@@ -104,8 +82,6 @@ set_cover_tilt_position:
           unit_of_measurement: "%"
 
 stop_cover_tilt:
-  name: Stop tilt
-  description: Stop all or specified cover.
   target:
     entity:
       domain: cover

--- a/homeassistant/components/cover/strings.json
+++ b/homeassistant/components/cover/strings.json
@@ -76,5 +76,59 @@
     "window": {
       "name": "Window"
     }
+  },
+  "services": {
+    "open_cover": {
+      "name": "Open",
+      "description": "Opens a cover."
+    },
+    "close_cover": {
+      "name": "Close",
+      "description": "Closes a cover."
+    },
+    "toggle": {
+      "name": "Toggle",
+      "description": "Toggle a cover open/closed."
+    },
+    "set_cover_position": {
+      "name": "Set position",
+      "description": "Moves a cover to a specific position.",
+      "fields": {
+        "position": {
+          "name": "Position",
+          "description": "Target position."
+        }
+      }
+    },
+    "stop_cover": {
+      "name": "Stop",
+      "description": "Stops cover movement."
+    },
+    "open_cover_tilt": {
+      "name": "Open tilt",
+      "description": "Tilts a cover open."
+    },
+    "close_cover_tilt": {
+      "name": "Close tilt",
+      "description": "Tilts a cover to close."
+    },
+    "toggle_cover_tilt": {
+      "name": "Toggle tilt",
+      "description": "Toggles a cover tilt open/closed."
+    },
+    "set_cover_tilt_position": {
+      "name": "Set tilt position",
+      "description": "Moves a cover tilt to a specific position.",
+      "fields": {
+        "tilt_position": {
+          "name": "Tilt position",
+          "description": "Target tilt positition."
+        }
+      }
+    },
+    "stop_cover_tilt": {
+      "name": "Stop tilt",
+      "description": "Stops a tilting cover movement."
+    }
   }
 }

--- a/homeassistant/components/cover/strings.json
+++ b/homeassistant/components/cover/strings.json
@@ -88,7 +88,7 @@
     },
     "toggle": {
       "name": "Toggle",
-      "description": "Toggle a cover open/closed."
+      "description": "Toggles a cover open/closed."
     },
     "set_cover_position": {
       "name": "Set position",
@@ -102,7 +102,7 @@
     },
     "stop_cover": {
       "name": "Stop",
-      "description": "Stops cover movement."
+      "description": "Stops the cover movement."
     },
     "open_cover_tilt": {
       "name": "Open tilt",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Migrates the cover entity component-provided services to support translated services.

More information (and depends on), see: #95984

ℹ️ The contents of this PR has been scripted and migrated from source automatically. Afterward, tweaked it for consistency and used references.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
