### PR TITLE
Migrate device_tracker services to support translations

### DIFF
--- a/homeassistant/components/device_tracker/services.yaml
+++ b/homeassistant/components/device_tracker/services.yaml
@@ -1,50 +1,34 @@
 # Describes the format for available device tracker services
 
 see:
-  name: See
-  description: Control tracked device.
   fields:
     mac:
-      name: MAC address
-      description: MAC address of device
       example: "FF:FF:FF:FF:FF:FF"
       selector:
         text:
     dev_id:
-      name: Device ID
-      description: Id of device (find id in known_devices.yaml).
       example: "phonedave"
       selector:
         text:
     host_name:
-      name: Host name
-      description: Hostname of device
       example: "Dave"
       selector:
         text:
     location_name:
-      name: Location name
-      description: Name of location where device is located (not_home is away).
       example: "home"
       selector:
         text:
     gps:
-      name: GPS coordinates
-      description: GPS coordinates where device is located, specified by latitude and longitude.
       example: "[51.509802, -0.086692]"
       selector:
         object:
     gps_accuracy:
-      name: GPS accuracy
-      description: Accuracy of GPS coordinates.
       selector:
         number:
           min: 1
           max: 100
           unit_of_measurement: "%"
     battery:
-      name: Battery level
-      description: Battery level of device.
       selector:
         number:
           min: 0

--- a/homeassistant/components/device_tracker/strings.json
+++ b/homeassistant/components/device_tracker/strings.json
@@ -45,7 +45,7 @@
   "services": {
     "see": {
       "name": "See",
-      "description": "Control tracked device.",
+      "description": "Records a seen tracked device.",
       "fields": {
         "mac": {
           "name": "MAC address",
@@ -53,14 +53,14 @@
         },
         "dev_id": {
           "name": "Device ID",
-          "description": "Id of device (find id in known_devices.yaml)."
+          "description": "ID of device (find the ID in `known_devices.yaml`)."
         },
         "host_name": {
-          "name": "Host name",
+          "name": "Hostname",
           "description": "Hostname of device."
         },
         "location_name": {
-          "name": "Location name",
+          "name": "Location",
           "description": "Name of location where device is located (not_home is away)."
         },
         "gps": {

--- a/homeassistant/components/device_tracker/strings.json
+++ b/homeassistant/components/device_tracker/strings.json
@@ -49,31 +49,31 @@
       "fields": {
         "mac": {
           "name": "MAC address",
-          "description": "MAC address of device."
+          "description": "MAC address of the device."
         },
         "dev_id": {
           "name": "Device ID",
-          "description": "ID of device (find the ID in `known_devices.yaml`)."
+          "description": "ID of the device (find the ID in `known_devices.yaml`)."
         },
         "host_name": {
           "name": "Hostname",
-          "description": "Hostname of device."
+          "description": "Hostname of the device."
         },
         "location_name": {
           "name": "Location",
-          "description": "Name of location where device is located (not_home is away)."
+          "description": "Name of the location where the device is located. The options are: `home`, `not_home`, or the name of the zone."
         },
         "gps": {
           "name": "GPS coordinates",
-          "description": "GPS coordinates where device is located, specified by latitude and longitude."
+          "description": "GPS coordinates where the device is located, specified by latitude and longitude (for example: [51.513845, -0.100539])."
         },
         "gps_accuracy": {
           "name": "GPS accuracy",
-          "description": "Accuracy of GPS coordinates."
+          "description": "Accuracy of the GPS coordinates."
         },
         "battery": {
           "name": "Battery level",
-          "description": "Battery level of device."
+          "description": "Battery level of the device."
         }
       }
     }

--- a/homeassistant/components/device_tracker/strings.json
+++ b/homeassistant/components/device_tracker/strings.json
@@ -41,5 +41,41 @@
         }
       }
     }
+  },
+  "services": {
+    "see": {
+      "name": "See",
+      "description": "Control tracked device.",
+      "fields": {
+        "mac": {
+          "name": "MAC address",
+          "description": "MAC address of device."
+        },
+        "dev_id": {
+          "name": "Device ID",
+          "description": "Id of device (find id in known_devices.yaml)."
+        },
+        "host_name": {
+          "name": "Host name",
+          "description": "Hostname of device."
+        },
+        "location_name": {
+          "name": "Location name",
+          "description": "Name of location where device is located (not_home is away)."
+        },
+        "gps": {
+          "name": "GPS coordinates",
+          "description": "GPS coordinates where device is located, specified by latitude and longitude."
+        },
+        "gps_accuracy": {
+          "name": "GPS accuracy",
+          "description": "Accuracy of GPS coordinates."
+        },
+        "battery": {
+          "name": "Battery level",
+          "description": "Battery level of device."
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Migrates the device_tracker entity component-provided services to support translated services.

More information (and depends on), see: #95984

ℹ️ The contents of this PR has been scripted and migrated from source automatically. Afterward, tweaked it for consistency and used references.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
