### PR TITLE
Avoid CI fail in command_line tests

### DIFF
--- a/tests/components/command_line/test_binary_sensor.py
+++ b/tests/components/command_line/test_binary_sensor.py
@@ -240,16 +240,18 @@ async def test_updating_to_often(
         )
         await hass.async_block_till_done()
 
-    assert len(called) == 1
+    assert called
     assert (
         "Updating Command Line Binary Sensor Test took longer than the scheduled update interval"
         not in caplog.text
     )
+    called.clear()
+    caplog.clear()
 
     async_fire_time_changed(hass, dt_util.now() + timedelta(seconds=1))
     await hass.async_block_till_done()
 
-    assert len(called) == 2
+    assert called
     assert (
         "Updating Command Line Binary Sensor Test took longer than the scheduled update interval"
         in caplog.text

--- a/tests/components/command_line/test_binary_sensor.py
+++ b/tests/components/command_line/test_binary_sensor.py
@@ -268,13 +268,11 @@ async def test_updating_manually(
     called = []
 
     class MockCommandBinarySensor(CommandBinarySensor):
-        """Mock entity that updates slow."""
+        """Mock entity that updates."""
 
         async def _async_update(self) -> None:
-            """Update slow."""
+            """Update."""
             called.append(1)
-            # Add waiting time
-            await asyncio.sleep(1)
 
     with patch(
         "homeassistant.components.command_line.binary_sensor.CommandBinarySensor",
@@ -299,7 +297,8 @@ async def test_updating_manually(
         )
         await hass.async_block_till_done()
 
-    assert len(called) == 1
+    assert called
+    called.clear
 
     await hass.services.async_call(
         HA_DOMAIN,
@@ -308,6 +307,4 @@ async def test_updating_manually(
         blocking=True,
     )
     await hass.async_block_till_done()
-    assert len(called) == 2
-
-    await asyncio.sleep(0.2)
+    assert called

--- a/tests/components/command_line/test_cover.py
+++ b/tests/components/command_line/test_cover.py
@@ -326,16 +326,18 @@ async def test_updating_to_often(
         )
         await hass.async_block_till_done()
 
-    assert len(called) == 0
+    assert not called
     assert (
         "Updating Command Line Cover Test took longer than the scheduled update interval"
         not in caplog.text
     )
+    called.clear()
+    caplog.clear()
 
     async_fire_time_changed(hass, dt_util.now() + timedelta(seconds=1))
     await hass.async_block_till_done()
 
-    assert len(called) == 1
+    assert called
     assert (
         "Updating Command Line Cover Test took longer than the scheduled update interval"
         in caplog.text

--- a/tests/components/command_line/test_cover.py
+++ b/tests/components/command_line/test_cover.py
@@ -354,13 +354,11 @@ async def test_updating_manually(
     called = []
 
     class MockCommandCover(CommandCover):
-        """Mock entity that updates slow."""
+        """Mock entity that updates."""
 
         async def _async_update(self) -> None:
-            """Update slow."""
+            """Update."""
             called.append(1)
-            # Add waiting time
-            await asyncio.sleep(1)
 
     with patch(
         "homeassistant.components.command_line.cover.CommandCover",
@@ -386,7 +384,8 @@ async def test_updating_manually(
 
     async_fire_time_changed(hass, dt_util.now() + timedelta(seconds=10))
     await hass.async_block_till_done()
-    assert len(called) == 1
+    assert called
+    called.clear()
 
     await hass.services.async_call(
         HA_DOMAIN,
@@ -395,6 +394,4 @@ async def test_updating_manually(
         blocking=True,
     )
     await hass.async_block_till_done()
-    assert len(called) == 2
-
-    await asyncio.sleep(0.2)
+    assert called

--- a/tests/components/command_line/test_sensor.py
+++ b/tests/components/command_line/test_sensor.py
@@ -603,13 +603,11 @@ async def test_updating_manually(
     called = []
 
     class MockCommandSensor(CommandSensor):
-        """Mock entity that updates slow."""
+        """Mock entity that updates."""
 
         async def _async_update(self) -> None:
             """Update slow."""
             called.append(1)
-            # Add waiting time
-            await asyncio.sleep(1)
 
     with patch(
         "homeassistant.components.command_line.sensor.CommandSensor",
@@ -632,7 +630,8 @@ async def test_updating_manually(
         )
         await hass.async_block_till_done()
 
-    assert len(called) == 1
+    assert called
+    called.clear()
 
     await hass.services.async_call(
         HA_DOMAIN,
@@ -641,6 +640,4 @@ async def test_updating_manually(
         blocking=True,
     )
     await hass.async_block_till_done()
-    assert len(called) == 2
-
-    await asyncio.sleep(0.2)
+    assert called

--- a/tests/components/command_line/test_sensor.py
+++ b/tests/components/command_line/test_sensor.py
@@ -575,16 +575,18 @@ async def test_updating_to_often(
         )
         await hass.async_block_till_done()
 
-    assert len(called) == 1
+    assert called
     assert (
         "Updating Command Line Sensor Test took longer than the scheduled update interval"
         not in caplog.text
     )
+    called.clear()
+    caplog.clear()
 
     async_fire_time_changed(hass, dt_util.now() + timedelta(seconds=1))
     await hass.async_block_till_done()
 
-    assert len(called) == 2
+    assert called
     assert (
         "Updating Command Line Sensor Test took longer than the scheduled update interval"
         in caplog.text

--- a/tests/components/command_line/test_switch.py
+++ b/tests/components/command_line/test_switch.py
@@ -684,16 +684,18 @@ async def test_updating_to_often(
         )
         await hass.async_block_till_done()
 
-    assert len(called) == 0
+    assert not called
     assert (
         "Updating Command Line Switch Test took longer than the scheduled update interval"
         not in caplog.text
     )
+    called.clear()
+    caplog.clear()
 
     async_fire_time_changed(hass, dt_util.now() + timedelta(seconds=1))
     await hass.async_block_till_done()
 
-    assert len(called) == 1
+    assert called
     assert (
         "Updating Command Line Switch Test took longer than the scheduled update interval"
         in caplog.text

--- a/tests/components/command_line/test_switch.py
+++ b/tests/components/command_line/test_switch.py
@@ -712,13 +712,11 @@ async def test_updating_manually(
     called = []
 
     class MockCommandSwitch(CommandSwitch):
-        """Mock entity that updates slow."""
+        """Mock entity that updates."""
 
         async def _async_update(self) -> None:
             """Update slow."""
             called.append(1)
-            # Add waiting time
-            await asyncio.sleep(1)
 
     with patch(
         "homeassistant.components.command_line.switch.CommandSwitch",
@@ -745,7 +743,8 @@ async def test_updating_manually(
 
     async_fire_time_changed(hass, dt_util.now() + timedelta(seconds=10))
     await hass.async_block_till_done()
-    assert len(called) == 1
+    assert called
+    called.clear()
 
     await hass.services.async_call(
         HA_DOMAIN,
@@ -754,6 +753,4 @@ async def test_updating_manually(
         blocking=True,
     )
     await hass.async_block_till_done()
-    assert len(called) == 2
-
-    await asyncio.sleep(0.2)
+    assert called


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Avoid a failure like:

```log
async def test_updating_to_often( 
hass: HomeAssistant, caplog: pytest.LogCaptureFixture 
) -> None: 
"""Test handling updating when command already running.""" 
called = [] 

class MockCommandBinarySensor(CommandBinarySensor): 
"""Mock entity that updates slow.""" 

async def _async_update(self) -> None: 
"""Update slow.""" 
called.append(1) 
# Add waiting time 
await asyncio.sleep(1) 

with patch( 
"homeassistant.components.command_line.binary_sensor.CommandBinarySensor", 
side_effect=MockCommandBinarySensor, 
): 
await setup.async_setup_component( 
hass, 
DOMAIN, 
{ 
"command_line": [ 
{ 
"binary_sensor": { 
"name": "Test", 
"command": "echo 1", 
"payload_on": "1", 
"payload_off": "0", 
"scan_interval": 0.1, 
} 
} 
] 
}, 
) 
await hass.async_block_till_done() 

assert len(called) == 1 
assert ( 
"Updating Command Line Binary Sensor Test took longer than the scheduled update interval" 
not in caplog.text 
) 

async_fire_time_changed(hass, dt_util.now() + timedelta(seconds=1)) 
await hass.async_block_till_done() 

> assert len(called) == 2 
E assert 3 == 2 
E + where 3 = len([1, 1, 1]) 

tests/components/command_line/test_binary_sensor.py:252: AssertionError
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
