### PR TITLE
Speedup tests command_line integration

### DIFF
--- a/tests/components/command_line/test_switch.py
+++ b/tests/components/command_line/test_switch.py
@@ -717,8 +717,6 @@ async def test_updating_to_often(
         in caplog.text
     )
 
-    await asyncio.sleep(0.2)
-
 
 async def test_updating_manually(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture

--- a/tests/components/command_line/test_switch.py
+++ b/tests/components/command_line/test_switch.py
@@ -650,16 +650,19 @@ async def test_updating_to_often(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test handling updating when command already running."""
+
     called = []
+    wait_till_event = asyncio.Event()
+    wait_till_event.set()
 
     class MockCommandSwitch(CommandSwitch):
-        """Mock entity that updates slow."""
+        """Mock entity that updates."""
 
         async def _async_update(self) -> None:
-            """Update slow."""
+            """Update entity."""
             called.append(1)
-            # Add waiting time
-            await asyncio.sleep(1)
+            # Wait till event is set
+            await wait_till_event.wait()
 
     with patch(
         "homeassistant.components.command_line.switch.CommandSwitch",
@@ -676,7 +679,7 @@ async def test_updating_to_often(
                             "command_on": "echo 2",
                             "command_off": "echo 3",
                             "name": "Test",
-                            "scan_interval": 0.1,
+                            "scan_interval": 10,
                         }
                     }
                 ]
@@ -689,12 +692,25 @@ async def test_updating_to_often(
         "Updating Command Line Switch Test took longer than the scheduled update interval"
         not in caplog.text
     )
-    called.clear()
-    caplog.clear()
-
-    async_fire_time_changed(hass, dt_util.now() + timedelta(seconds=1))
+    async_fire_time_changed(hass, dt_util.now() + timedelta(seconds=11))
     await hass.async_block_till_done()
+    assert called
+    called.clear()
 
+    assert (
+        "Updating Command Line Switch Test took longer than the scheduled update interval"
+        not in caplog.text
+    )
+
+    # Simulate update takes too long
+    wait_till_event.clear()
+    async_fire_time_changed(hass, dt_util.now() + timedelta(seconds=10))
+    await asyncio.sleep(0)
+    async_fire_time_changed(hass, dt_util.now() + timedelta(seconds=10))
+    wait_till_event.set()
+
+    # Finish processing update
+    await hass.async_block_till_done()
     assert called
     assert (
         "Updating Command Line Switch Test took longer than the scheduled update interval"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Speed up tests:

```log
Before PR:
============================================================================ slowest 10 durations =============================================================================
2.21s call     tests/components/command_line/test_binary_sensor.py::test_updating_to_often
2.21s call     tests/components/command_line/test_sensor.py::test_updating_to_often
1.21s call     tests/components/command_line/test_cover.py::test_updating_to_often
1.21s call     tests/components/command_line/test_switch.py::test_updating_to_often
0.06s setup    tests/components/command_line/test_init.py::test_setup_config
0.06s setup    tests/components/command_line/test_binary_sensor.py::test_setup_platform_yaml
0.05s setup    tests/components/command_line/test_sensor.py::test_setup_platform_yaml
0.05s setup    tests/components/command_line/test_cover.py::test_no_covers_platform_yaml
0.05s setup    tests/components/command_line/test_switch.py::test_state_platform_yaml
0.05s setup    tests/components/command_line/test_notify.py::test_setup_platform_yaml

Results (8.09s):

After PR:

============================================================================ slowest 10 durations =============================================================================
0.08s setup    tests/components/command_line/test_binary_sensor.py::test_setup_platform_yaml
0.06s setup    tests/components/command_line/test_init.py::test_setup_config
0.05s setup    tests/components/command_line/test_switch.py::test_state_platform_yaml
0.05s setup    tests/components/command_line/test_cover.py::test_no_covers_platform_yaml
0.05s setup    tests/components/command_line/test_notify.py::test_setup_platform_yaml
0.05s setup    tests/components/command_line/test_sensor.py::test_setup_platform_yaml
0.02s setup    tests/components/command_line/test_init.py::test_reload_service
0.02s call     tests/components/command_line/test_cover.py::test_state_value
0.01s setup    tests/components/command_line/test_sensor.py::test_unique_id[get_config0]
0.01s setup    tests/components/command_line/test_binary_sensor.py::test_template[get_config0]

Results (1.38s):
```



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
