### PR TITLE
Migrate & fix logger services to support translations

### DIFF
--- a/homeassistant/components/logger/services.yaml
+++ b/homeassistant/components/logger/services.yaml
@@ -1,26 +1,14 @@
 set_default_level:
-  name: Set default level
-  description: Set the default log level for integrations.
   fields:
     level:
-      name: Level
-      description: Default severity level for all integrations.
       selector:
         select:
           options:
-            - label: "Debug"
-              value: "debug"
-            - label: "Info"
-              value: "info"
-            - label: "Warning"
-              value: "warning"
-            - label: "Error"
-              value: "error"
-            - label: "Fatal"
-              value: "fatal"
-            - label: "Critical"
-              value: "critical"
-
+            - "debug"
+            - "info"
+            - "warning"
+            - "error"
+            - "fatal"
+            - "critical"
+          translation_key: level
 set_level:
-  name: Set level
-  description: Set log level for integrations.

--- a/homeassistant/components/logger/strings.json
+++ b/homeassistant/components/logger/strings.json
@@ -1,0 +1,30 @@
+{
+  "services": {
+    "set_default_level": {
+      "name": "Set default level",
+      "description": "Sets the default log level for integrations.",
+      "fields": {
+        "level": {
+          "name": "Level",
+          "description": "Default severity level for all integrations."
+        }
+      }
+    },
+    "set_level": {
+      "name": "Set level",
+      "description": "Sets log level for one or more integrations."
+    }
+  },
+  "selector": {
+    "level": {
+      "options": {
+        "debug": "Debug",
+        "info": "Info",
+        "warning": "Warning",
+        "error": "Error",
+        "fatal": "Fatal",
+        "critical": "Critical"
+      }
+    }
+  }
+}

--- a/homeassistant/components/logger/strings.json
+++ b/homeassistant/components/logger/strings.json
@@ -12,7 +12,7 @@
     },
     "set_level": {
       "name": "Set level",
-      "description": "Sets log level for one or more integrations."
+      "description": "Sets the log level for one or more integrations."
     }
   },
   "selector": {

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -173,7 +173,7 @@ _SERVICE_SCHEMA = vol.Schema(
     extra=vol.ALLOW_EXTRA,
 )
 
-_SERVICES_SCHEMA = vol.Schema({cv.slug: _SERVICE_SCHEMA})
+_SERVICES_SCHEMA = vol.Schema({cv.slug: vol.Any(None, _SERVICE_SCHEMA)})
 
 
 class ServiceParams(TypedDict):

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -677,6 +677,9 @@ async def test_async_get_all_descriptions_failing_integration(
     with patch(
         "homeassistant.helpers.service.async_get_integrations",
         return_value={"logger": ImportError},
+    ), patch(
+        "homeassistant.helpers.service.translation.async_get_translations",
+        return_value={},
     ):
         descriptions = await service.async_get_all_descriptions(hass)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Migrates the logger-provided services to support translated services. And adjusts the tests accordingly.

The tests showed an error in the schema, which is fixed too in this PR (to provide a test case).

More information, see: #95984

ℹ️ The contents of this PR has been scripted and migrated from source automatically. Afterward, tweaked it for consistency and used references.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
