### PR TITLE
Migrate siren services to support translations

### DIFF
--- a/homeassistant/components/siren/services.yaml
+++ b/homeassistant/components/siren/services.yaml
@@ -1,8 +1,6 @@
 # Describes the format for available siren services
 
 turn_on:
-  name: Turn on
-  description: Turn siren on.
   target:
     entity:
       domain: siren
@@ -10,7 +8,6 @@ turn_on:
         - siren.SirenEntityFeature.TURN_ON
   fields:
     tone:
-      description: The tone to emit when turning the siren on. When `available_tones` property is a map, either the key or the value can be used. Must be supported by the integration.
       example: fire
       filter:
         supported_features:
@@ -19,7 +16,6 @@ turn_on:
       selector:
         text:
     volume_level:
-      description: The volume level of the noise to emit when turning the siren on. Must be supported by the integration.
       example: 0.5
       filter:
         supported_features:
@@ -31,7 +27,6 @@ turn_on:
           max: 1
           step: 0.05
     duration:
-      description: The duration in seconds of the noise to emit when turning the siren on. Must be supported by the integration.
       example: 15
       filter:
         supported_features:
@@ -41,8 +36,6 @@ turn_on:
         text:
 
 turn_off:
-  name: Turn off
-  description: Turn siren off.
   target:
     entity:
       domain: siren
@@ -50,8 +43,6 @@ turn_off:
         - siren.SirenEntityFeature.TURN_OFF
 
 toggle:
-  name: Toggle
-  description: Toggles a siren.
   target:
     entity:
       domain: siren

--- a/homeassistant/components/siren/strings.json
+++ b/homeassistant/components/siren/strings.json
@@ -21,15 +21,15 @@
       "fields": {
         "tone": {
           "name": "Tone",
-          "description": "The tone to emit when turning the siren on. When `available_tones` property is a map, either the key or the value can be used. Must be supported by the integration."
+          "description": "The tone to emit. When `available_tones` property is a map, either the key or the value can be used. Must be supported by the integration."
         },
         "volume_level": {
           "name": "Volume",
-          "description": "The volume level of the noise to emit when turning the siren on. Must be supported by the integration."
+          "description": "The volume. 0 is inaudible, 1 is the maximum volume. Must be supported by the integration."
         },
         "duration": {
           "name": "Duration",
-          "description": "The duration in seconds of the noise to emit when turning the siren on. Must be supported by the integration."
+          "description": "Number of seconds the sound is played. Must be supported by the integration."
         }
       }
     },

--- a/homeassistant/components/siren/strings.json
+++ b/homeassistant/components/siren/strings.json
@@ -13,5 +13,33 @@
         }
       }
     }
+  },
+  "services": {
+    "turn_on": {
+      "name": "Turn on",
+      "description": "Turns the siren on.",
+      "fields": {
+        "tone": {
+          "name": "Tone",
+          "description": "The tone to emit when turning the siren on. When `available_tones` property is a map, either the key or the value can be used. Must be supported by the integration."
+        },
+        "volume_level": {
+          "name": "Volume",
+          "description": "The volume level of the noise to emit when turning the siren on. Must be supported by the integration."
+        },
+        "duration": {
+          "name": "Duration",
+          "description": "The duration in seconds of the noise to emit when turning the siren on. Must be supported by the integration."
+        }
+      }
+    },
+    "turn_off": {
+      "name": "Turn off",
+      "description": "Turns the siren off."
+    },
+    "toggle": {
+      "name": "Toggle",
+      "description": "Toggles the siren on/off."
+    }
   }
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Migrates the siren-provided services to support translated services.

More information, see: #95984

ℹ️ The contents of this PR has been scripted and migrated from source automatically. Afterward, tweaked it for consistency and used references.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
