### PR TITLE
Migrate vacuum services to support translations

### DIFF
--- a/homeassistant/components/vacuum/services.yaml
+++ b/homeassistant/components/vacuum/services.yaml
@@ -1,8 +1,6 @@
 # Describes the format for available vacuum services
 
 turn_on:
-  name: Turn on
-  description: Start a new cleaning task.
   target:
     entity:
       domain: vacuum
@@ -10,8 +8,6 @@ turn_on:
         - vacuum.VacuumEntityFeature.TURN_ON
 
 turn_off:
-  name: Turn off
-  description: Stop the current cleaning task and return to home.
   target:
     entity:
       domain: vacuum
@@ -19,8 +15,6 @@ turn_off:
         - vacuum.VacuumEntityFeature.TURN_OFF
 
 stop:
-  name: Stop
-  description: Stop the current cleaning task.
   target:
     entity:
       domain: vacuum
@@ -28,8 +22,6 @@ stop:
         - vacuum.VacuumEntityFeature.STOP
 
 locate:
-  name: Locate
-  description: Locate the vacuum cleaner robot.
   target:
     entity:
       domain: vacuum
@@ -37,8 +29,6 @@ locate:
         - vacuum.VacuumEntityFeature.LOCATE
 
 start_pause:
-  name: Start/Pause
-  description: Start, pause, or resume the cleaning task.
   target:
     entity:
       domain: vacuum
@@ -46,8 +36,6 @@ start_pause:
         - vacuum.VacuumEntityFeature.PAUSE
 
 start:
-  name: Start
-  description: Start or resume the cleaning task.
   target:
     entity:
       domain: vacuum
@@ -55,8 +43,6 @@ start:
         - vacuum.VacuumEntityFeature.START
 
 pause:
-  name: Pause
-  description: Pause the cleaning task.
   target:
     entity:
       domain: vacuum
@@ -64,8 +50,6 @@ pause:
         - vacuum.VacuumEntityFeature.PAUSE
 
 return_to_base:
-  name: Return to base
-  description: Tell the vacuum cleaner to return to its dock.
   target:
     entity:
       domain: vacuum
@@ -73,45 +57,31 @@ return_to_base:
         - vacuum.VacuumEntityFeature.RETURN_HOME
 
 clean_spot:
-  name: Clean spot
-  description: Tell the vacuum cleaner to do a spot clean-up.
   target:
     entity:
       domain: vacuum
 
 send_command:
-  name: Send command
-  description: Send a raw command to the vacuum cleaner.
   target:
     entity:
       domain: vacuum
   fields:
     command:
-      name: Command
-      description: Command to execute.
       required: true
       example: "set_dnd_timer"
       selector:
         text:
     params:
-      name: Parameters
-      description: Parameters for the command.
       example: '{ "key": "value" }'
       selector:
         object:
 
 set_fan_speed:
-  name: Set fan speed
-  description: Set the fan speed of the vacuum cleaner.
   target:
     entity:
       domain: vacuum
   fields:
     fan_speed:
-      name: Fan speed
-      description:
-        Platform dependent vacuum cleaner fan speed, with speed steps, like
-        'medium' or by percentage, between 0 and 100.
       required: true
       example: "low"
       selector:

--- a/homeassistant/components/vacuum/strings.json
+++ b/homeassistant/components/vacuum/strings.json
@@ -34,5 +34,67 @@
       "title": "The {platform} custom integration is using deprecated vacuum feature",
       "description": "The custom integration `{platform}` is extending the deprecated base class `VacuumEntity` instead of `StateVacuumEntity`.\n\nPlease report it to the author of the `{platform}` custom integration.\n\nOnce an updated version of `{platform}` is available, install it and restart Home Assistant to fix this issue."
     }
+  },
+  "services": {
+    "turn_on": {
+      "name": "Turn on",
+      "description": "Starts a new cleaning task."
+    },
+    "turn_off": {
+      "name": "Turn off",
+      "description": "Stops the current cleaning task and return to home."
+    },
+    "stop": {
+      "name": "Stop",
+      "description": "Stops the current cleaning task."
+    },
+    "locate": {
+      "name": "Locate",
+      "description": "Locates the vacuum cleaner robot."
+    },
+    "start_pause": {
+      "name": "Start/pause",
+      "description": "Starts, pauses, or resumes the cleaning task."
+    },
+    "start": {
+      "name": "Start",
+      "description": "Starts or resumes the cleaning task."
+    },
+    "pause": {
+      "name": "Pause",
+      "description": "Pauses the cleaning task."
+    },
+    "return_to_base": {
+      "name": "Return to base",
+      "description": "Tells the vacuum cleaner to return to its dock."
+    },
+    "clean_spot": {
+      "name": "Clean spot",
+      "description": "Tells the vacuum cleaner to do a spot clean-up."
+    },
+    "send_command": {
+      "name": "Send command",
+      "description": "Sends a raw command to the vacuum cleaner.",
+      "fields": {
+        "command": {
+          "name": "Command",
+          "description": "Command to execute."
+        },
+        "params": {
+          "name": "Parameters",
+          "description": "Parameters for the command."
+        }
+      }
+    },
+    "set_fan_speed": {
+      "name": "Set fan speed",
+      "description": "Sets the fan speed of the vacuum cleaner.",
+      "fields": {
+        "fan_speed": {
+          "name": "Fan speed",
+          "description": "Platform dependent vacuum cleaner fan speed, with speed steps, like 'medium' or by percentage, between 0 and 100."
+        }
+      }
+    }
   }
 }

--- a/homeassistant/components/vacuum/strings.json
+++ b/homeassistant/components/vacuum/strings.json
@@ -42,7 +42,7 @@
     },
     "turn_off": {
       "name": "Turn off",
-      "description": "Stops the current cleaning task and return to home."
+      "description": "Stops the current cleaning task and returns to its dock."
     },
     "stop": {
       "name": "Stop",
@@ -78,11 +78,11 @@
       "fields": {
         "command": {
           "name": "Command",
-          "description": "Command to execute."
+          "description": "Command to execute. The commands are integration-specific."
         },
         "params": {
           "name": "Parameters",
-          "description": "Parameters for the command."
+          "description": "Parameters for the command. The parameters are integration-specific."
         }
       }
     },
@@ -92,7 +92,7 @@
       "fields": {
         "fan_speed": {
           "name": "Fan speed",
-          "description": "Platform dependent vacuum cleaner fan speed, with speed steps, like 'medium' or by percentage, between 0 and 100."
+          "description": "Fan speed. The value depends on the integration. Some integrations have speed steps, like 'medium'. Some use a percentage, between 0 and 100."
         }
       }
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Migrates the vacuum-provided services to support translated services.

More information, see: #95984

ℹ️ The contents of this PR has been scripted and migrated from source automatically. Afterward, tweaked it for consistency and used references.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
