### PR TITLE
Add generic HomeAssistant class

### DIFF
--- a/homeassistant/components/elgato/__init__.py
+++ b/homeassistant/components/elgato/__init__.py
@@ -2,6 +2,7 @@
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import HassType
 
 from .const import DOMAIN
 from .coordinator import ElgatoDataUpdateCoordinator
@@ -9,7 +10,9 @@ from .coordinator import ElgatoDataUpdateCoordinator
 PLATFORMS = [Platform.BUTTON, Platform.LIGHT, Platform.SENSOR, Platform.SWITCH]
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(
+    hass: HassType[ElgatoDataUpdateCoordinator], entry: ConfigEntry
+) -> bool:
     """Set up Elgato Light from a config entry."""
     coordinator = ElgatoDataUpdateCoordinator(hass, entry)
     await coordinator.async_config_entry_first_refresh()

--- a/homeassistant/components/elgato/button.py
+++ b/homeassistant/components/elgato/button.py
@@ -14,9 +14,9 @@ from homeassistant.components.button import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
-from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import HassType
 
 from .const import DOMAIN
 from .coordinator import ElgatoDataUpdateCoordinator
@@ -54,12 +54,12 @@ BUTTONS = [
 
 
 async def async_setup_entry(
-    hass: HomeAssistant,
+    hass: HassType[ElgatoDataUpdateCoordinator],
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Elgato button based on a config entry."""
-    coordinator: ElgatoDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = hass.data[DOMAIN][entry.entry_id]
     async_add_entities(
         ElgatoButtonEntity(
             coordinator=coordinator,

--- a/homeassistant/components/elgato/diagnostics.py
+++ b/homeassistant/components/elgato/diagnostics.py
@@ -4,17 +4,17 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import HassType
 
 from .const import DOMAIN
 from .coordinator import ElgatoDataUpdateCoordinator
 
 
 async def async_get_config_entry_diagnostics(
-    hass: HomeAssistant, entry: ConfigEntry
+    hass: HassType[ElgatoDataUpdateCoordinator], entry: ConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    coordinator: ElgatoDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = hass.data[DOMAIN][entry.entry_id]
     return {
         "info": coordinator.data.info.dict(),
         "state": coordinator.data.state.dict(),

--- a/homeassistant/components/elgato/light.py
+++ b/homeassistant/components/elgato/light.py
@@ -13,12 +13,12 @@ from homeassistant.components.light import (
     LightEntity,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import (
     AddEntitiesCallback,
     async_get_current_platform,
 )
+from homeassistant.helpers.typing import HassType
 
 from .const import DOMAIN, SERVICE_IDENTIFY
 from .coordinator import ElgatoDataUpdateCoordinator
@@ -28,12 +28,12 @@ PARALLEL_UPDATES = 1
 
 
 async def async_setup_entry(
-    hass: HomeAssistant,
+    hass: HassType[ElgatoDataUpdateCoordinator],
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Elgato Light based on a config entry."""
-    coordinator: ElgatoDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = hass.data[DOMAIN][entry.entry_id]
     async_add_entities([ElgatoLight(coordinator)])
 
     platform = async_get_current_platform()

--- a/homeassistant/components/elgato/sensor.py
+++ b/homeassistant/components/elgato/sensor.py
@@ -18,8 +18,8 @@ from homeassistant.const import (
     UnitOfElectricPotential,
     UnitOfPower,
 )
-from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import HassType
 
 from .const import DOMAIN
 from .coordinator import ElgatoData, ElgatoDataUpdateCoordinator
@@ -108,12 +108,12 @@ SENSORS = [
 
 
 async def async_setup_entry(
-    hass: HomeAssistant,
+    hass: HassType[ElgatoDataUpdateCoordinator],
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Elgato sensor based on a config entry."""
-    coordinator: ElgatoDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = hass.data[DOMAIN][entry.entry_id]
 
     async_add_entities(
         ElgatoSensorEntity(

--- a/homeassistant/components/elgato/switch.py
+++ b/homeassistant/components/elgato/switch.py
@@ -10,9 +10,9 @@ from elgato import Elgato, ElgatoError
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
-from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import HassType
 
 from .const import DOMAIN
 from .coordinator import ElgatoData, ElgatoDataUpdateCoordinator
@@ -61,12 +61,12 @@ SWITCHES = [
 
 
 async def async_setup_entry(
-    hass: HomeAssistant,
+    hass: HassType[ElgatoDataUpdateCoordinator],
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Elgato switches based on a config entry."""
-    coordinator: ElgatoDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = hass.data[DOMAIN][entry.entry_id]
 
     async_add_entities(
         ElgatoSwitchEntity(

--- a/homeassistant/helpers/typing.py
+++ b/homeassistant/helpers/typing.py
@@ -1,9 +1,11 @@
 """Typing Helpers for Home Assistant."""
 from collections.abc import Mapping
 from enum import Enum
-from typing import Any
+from typing import Any, Generic, TypeVar
 
 import homeassistant.core
+
+_DataT = TypeVar("_DataT")
 
 GPSType = tuple[float, float]
 ConfigType = dict[str, Any]
@@ -34,3 +36,9 @@ UNDEFINED = UndefinedType._singleton  # pylint: disable=protected-access
 # In due time they will be removed.
 HomeAssistantType = homeassistant.core.HomeAssistant
 ServiceCallType = homeassistant.core.ServiceCall
+
+
+class HassType(homeassistant.core.HomeAssistant, Generic[_DataT]):
+    """Generic HomeAssistant class to better type data."""
+
+    data: dict[str, dict[str, _DataT]]


### PR DESCRIPTION
## Proposed change
Currently, one common issue is the typing of `hass.data`. Since it's only defined as `dict[str, Any]`, integrations need to add individual type assignments or casts each time.

This change would add a generic `HomeAssistant` class called `HassType` which would help with that. For now, this is a separate class, however once TypeVar defaults are fully supported by mypy, this can be changed to a simple TypeAlias. Unfortunately, it's not yet practical to make `HomeAssistant.data` itself generic. With the `disallow_any_generics` setting for core files, we'd need to add a generic type (e.g. `dict[str, Any]`) to **all** `HomeAssistant` types in these files.

I believe this could help improve the typing of integrations. Is it something we what to do?

_If so, I'll update our pylint plugin to allow `HassType` as well._


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
