### PR TITLE
Display current version in common format in AVM Fritz!Tools

### DIFF
--- a/homeassistant/components/fritz/common.py
+++ b/homeassistant/components/fritz/common.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from functools import partial
 import logging
+import re
 from types import MappingProxyType
 from typing import Any, TypedDict, cast
 
@@ -259,7 +260,12 @@ class FritzBoxTools(
             self._unique_id = info.serial_number
 
         self._model = info.model_name
-        self._current_firmware = info.software_version
+        if (
+            version_normalized := re.search(r"^\d+\.[0]?(.*)", info.software_version)
+        ) is not None:
+            self._current_firmware = version_normalized.group(1)
+        else:
+            self._current_firmware = info.software_version
 
         (
             self._update_available,

--- a/tests/components/fritz/const.py
+++ b/tests/components/fritz/const.py
@@ -29,7 +29,7 @@ MOCK_HOST = "fake_host"
 MOCK_IPS = {"fritz.box": "192.168.178.1", "printer": "192.168.178.2"}
 MOCK_MODELNAME = "FRITZ!Box 7530 AX"
 MOCK_FIRMWARE = "256.07.29"
-MOCK_FIRMWARE_AVAILABLE = "256.07.50"
+MOCK_FIRMWARE_AVAILABLE = "7.50"
 MOCK_FIRMWARE_RELEASE_URL = (
     "http://download.avm.de/fritzbox/fritzbox-7530-ax/deutschland/fritz.os/info_de.txt"
 )

--- a/tests/components/fritz/test_diagnostics.py
+++ b/tests/components/fritz/test_diagnostics.py
@@ -50,7 +50,7 @@ async def test_entry_diagnostics(
                 for _, device in avm_wrapper.devices.items()
             ],
             "connection_type": "WANPPPConnection",
-            "current_firmware": "256.07.29",
+            "current_firmware": "7.29",
             "discovered_services": [
                 "DeviceInfo1",
                 "Hosts1",

--- a/tests/components/fritz/test_update.py
+++ b/tests/components/fritz/test_update.py
@@ -9,7 +9,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .const import (
-    MOCK_FIRMWARE,
     MOCK_FIRMWARE_AVAILABLE,
     MOCK_FIRMWARE_RELEASE_URL,
     MOCK_USER_DATA,
@@ -60,7 +59,7 @@ async def test_update_available(
         update = hass.states.get("update.mock_title_fritz_os")
         assert update is not None
         assert update.state == "on"
-        assert update.attributes.get("installed_version") == MOCK_FIRMWARE
+        assert update.attributes.get("installed_version") == "7.29"
         assert update.attributes.get("latest_version") == MOCK_FIRMWARE_AVAILABLE
         assert update.attributes.get("release_url") == MOCK_FIRMWARE_RELEASE_URL
 
@@ -83,8 +82,8 @@ async def test_no_update_available(
     update = hass.states.get("update.mock_title_fritz_os")
     assert update is not None
     assert update.state == "off"
-    assert update.attributes.get("installed_version") == MOCK_FIRMWARE
-    assert update.attributes.get("latest_version") == MOCK_FIRMWARE
+    assert update.attributes.get("installed_version") == "7.29"
+    assert update.attributes.get("latest_version") == "7.29"
 
 
 async def test_available_update_can_be_installed(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The current version is returned like `<HW-Version>.<major>.<minor>` (_eq. `154.07.39`_) but only shown as `<major>.<minor>`  (_eq. `7.39`_) in all places of the device WebUI. Further in case a new version is available, it is only provided in format `<major>.<minor>` (_eq. `7.50`_). This leads to a failing update entity, because `154.07.39` will always be considered to be the higher version compared to `7.50` by the update entity.

This PR will remove the `<HW-Version>` and a trailing zero from `<major>`, to make the current and new available versions comparable.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #95988
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
