### PR TITLE
Add feature to turn off using IMAP-Push on an IMAP server

### DIFF
--- a/homeassistant/components/imap/__init__.py
+++ b/homeassistant/components/imap/__init__.py
@@ -14,7 +14,7 @@ from homeassistant.exceptions import (
     ConfigEntryNotReady,
 )
 
-from .const import CONF_ENFORCE_POLLING, DOMAIN
+from .const import CONF_ENABLE_PUSH, DOMAIN
 from .coordinator import (
     ImapPollingDataUpdateCoordinator,
     ImapPushDataUpdateCoordinator,
@@ -39,8 +39,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     coordinator_class: type[
         ImapPushDataUpdateCoordinator | ImapPollingDataUpdateCoordinator
     ]
-    enforce_polling: bool = entry.data.get(CONF_ENFORCE_POLLING, False)
-    if not enforce_polling and imap_client.has_capability("IDLE"):
+    enable_push: bool = entry.data.get(CONF_ENABLE_PUSH, True)
+    if enable_push and imap_client.has_capability("IDLE"):
         coordinator_class = ImapPushDataUpdateCoordinator
     else:
         coordinator_class = ImapPollingDataUpdateCoordinator

--- a/homeassistant/components/imap/__init__.py
+++ b/homeassistant/components/imap/__init__.py
@@ -14,7 +14,7 @@ from homeassistant.exceptions import (
     ConfigEntryNotReady,
 )
 
-from .const import DOMAIN
+from .const import CONF_ENFORCE_POLLING, DOMAIN
 from .coordinator import (
     ImapPollingDataUpdateCoordinator,
     ImapPushDataUpdateCoordinator,
@@ -39,7 +39,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     coordinator_class: type[
         ImapPushDataUpdateCoordinator | ImapPollingDataUpdateCoordinator
     ]
-    if imap_client.has_capability("IDLE"):
+    enforce_polling: bool = entry.data.get(CONF_ENFORCE_POLLING, False)
+    if not enforce_polling and imap_client.has_capability("IDLE"):
         coordinator_class = ImapPushDataUpdateCoordinator
     else:
         coordinator_class = ImapPollingDataUpdateCoordinator

--- a/homeassistant/components/imap/config_flow.py
+++ b/homeassistant/components/imap/config_flow.py
@@ -33,6 +33,7 @@ from homeassistant.util.ssl import SSLCipherList
 from .const import (
     CONF_CHARSET,
     CONF_CUSTOM_EVENT_DATA_TEMPLATE,
+    CONF_ENFORCE_POLLING,
     CONF_FOLDER,
     CONF_MAX_MESSAGE_SIZE,
     CONF_SEARCH,
@@ -87,6 +88,7 @@ OPTIONS_SCHEMA_ADVANCED = {
         cv.positive_int,
         vol.Range(min=DEFAULT_MAX_MESSAGE_SIZE, max=MAX_MESSAGE_SIZE_LIMIT),
     ),
+    vol.Optional(CONF_ENFORCE_POLLING, default=False): BOOLEAN_SELECTOR,
 }
 
 

--- a/homeassistant/components/imap/config_flow.py
+++ b/homeassistant/components/imap/config_flow.py
@@ -88,7 +88,7 @@ OPTIONS_SCHEMA_ADVANCED = {
         cv.positive_int,
         vol.Range(min=DEFAULT_MAX_MESSAGE_SIZE, max=MAX_MESSAGE_SIZE_LIMIT),
     ),
-    vol.Optional(CONF_ENABLE_PUSH, default=False): BOOLEAN_SELECTOR,
+    vol.Optional(CONF_ENABLE_PUSH, default=True): BOOLEAN_SELECTOR,
 }
 
 

--- a/homeassistant/components/imap/config_flow.py
+++ b/homeassistant/components/imap/config_flow.py
@@ -33,7 +33,7 @@ from homeassistant.util.ssl import SSLCipherList
 from .const import (
     CONF_CHARSET,
     CONF_CUSTOM_EVENT_DATA_TEMPLATE,
-    CONF_ENFORCE_POLLING,
+    CONF_ENABLE_PUSH,
     CONF_FOLDER,
     CONF_MAX_MESSAGE_SIZE,
     CONF_SEARCH,
@@ -88,7 +88,7 @@ OPTIONS_SCHEMA_ADVANCED = {
         cv.positive_int,
         vol.Range(min=DEFAULT_MAX_MESSAGE_SIZE, max=MAX_MESSAGE_SIZE_LIMIT),
     ),
-    vol.Optional(CONF_ENFORCE_POLLING, default=False): BOOLEAN_SELECTOR,
+    vol.Optional(CONF_ENABLE_PUSH, default=False): BOOLEAN_SELECTOR,
 }
 
 

--- a/homeassistant/components/imap/const.py
+++ b/homeassistant/components/imap/const.py
@@ -11,7 +11,7 @@ CONF_CHARSET: Final = "charset"
 CONF_MAX_MESSAGE_SIZE = "max_message_size"
 CONF_CUSTOM_EVENT_DATA_TEMPLATE: Final = "custom_event_data_template"
 CONF_SSL_CIPHER_LIST: Final = "ssl_cipher_list"
-CONF_ENFORCE_POLLING: Final = "enforce_polling"
+CONF_ENABLE_PUSH: Final = "enable_push"
 
 DEFAULT_PORT: Final = 993
 

--- a/homeassistant/components/imap/const.py
+++ b/homeassistant/components/imap/const.py
@@ -11,6 +11,7 @@ CONF_CHARSET: Final = "charset"
 CONF_MAX_MESSAGE_SIZE = "max_message_size"
 CONF_CUSTOM_EVENT_DATA_TEMPLATE: Final = "custom_event_data_template"
 CONF_SSL_CIPHER_LIST: Final = "ssl_cipher_list"
+CONF_ENFORCE_POLLING: Final = "enforce_polling"
 
 DEFAULT_PORT: Final = 993
 

--- a/homeassistant/components/imap/strings.json
+++ b/homeassistant/components/imap/strings.json
@@ -43,7 +43,7 @@
           "search": "[%key:component::imap::config::step::user::data::search%]",
           "custom_event_data_template": "Template to create custom event data",
           "max_message_size": "Max message size (2048 < size < 30000)",
-          "enforce_polling": "Enforce polling even if the server supports Push-IMAP"
+          "enable_push": "Enable Push-IMAP if the server supports it. Turn off if Push-IMAP updates are unreliable"
         }
       }
     },

--- a/homeassistant/components/imap/strings.json
+++ b/homeassistant/components/imap/strings.json
@@ -42,7 +42,8 @@
           "folder": "[%key:component::imap::config::step::user::data::folder%]",
           "search": "[%key:component::imap::config::step::user::data::search%]",
           "custom_event_data_template": "Template to create custom event data",
-          "max_message_size": "Max message size (2048 < size < 30000)"
+          "max_message_size": "Max message size (2048 < size < 30000)",
+          "enforce_polling": "Enforce polling even if the server supports Push-IMAP"
         }
       }
     },

--- a/tests/components/imap/test_config_flow.py
+++ b/tests/components/imap/test_config_flow.py
@@ -412,6 +412,8 @@ async def test_key_options_in_options_form(hass: HomeAssistant) -> None:
             {"custom_event_data_template": "{{ invalid_syntax"},
             data_entry_flow.FlowResultType.FORM,
         ),
+        ({"enforce_polling": False}, data_entry_flow.FlowResultType.CREATE_ENTRY),
+        ({"enforce_polling": True}, data_entry_flow.FlowResultType.CREATE_ENTRY),
     ],
     ids=[
         "valid_message_size",
@@ -419,6 +421,8 @@ async def test_key_options_in_options_form(hass: HomeAssistant) -> None:
         "invalid_message_size_high",
         "valid_template",
         "invalid_template",
+        "enforce_polling_false",
+        "enforce_polling_true",
     ],
 )
 async def test_advanced_options_form(
@@ -459,7 +463,7 @@ async def test_advanced_options_form(
             else:
                 # Check if entry was updated
                 for key, value in new_config.items():
-                    assert str(entry.data[key]) == value
+                    assert str(entry.data[key]) == str(value)
     except vol.MultipleInvalid:
         # Check if form was expected with these options
         assert assert_result == data_entry_flow.FlowResultType.FORM

--- a/tests/components/imap/test_config_flow.py
+++ b/tests/components/imap/test_config_flow.py
@@ -401,9 +401,9 @@ async def test_key_options_in_options_form(hass: HomeAssistant) -> None:
 @pytest.mark.parametrize(
     ("advanced_options", "assert_result"),
     [
-        ({"max_message_size": "8192"}, data_entry_flow.FlowResultType.CREATE_ENTRY),
-        ({"max_message_size": "1024"}, data_entry_flow.FlowResultType.FORM),
-        ({"max_message_size": "65536"}, data_entry_flow.FlowResultType.FORM),
+        ({"max_message_size": 8192}, data_entry_flow.FlowResultType.CREATE_ENTRY),
+        ({"max_message_size": 1024}, data_entry_flow.FlowResultType.FORM),
+        ({"max_message_size": 65536}, data_entry_flow.FlowResultType.FORM),
         (
             {"custom_event_data_template": "{{ subject }}"},
             data_entry_flow.FlowResultType.CREATE_ENTRY,
@@ -463,7 +463,7 @@ async def test_advanced_options_form(
             else:
                 # Check if entry was updated
                 for key, value in new_config.items():
-                    assert str(entry.data[key]) == str(value)
+                    assert entry.data[key] == value
     except vol.MultipleInvalid:
         # Check if form was expected with these options
         assert assert_result == data_entry_flow.FlowResultType.FORM

--- a/tests/components/imap/test_config_flow.py
+++ b/tests/components/imap/test_config_flow.py
@@ -412,8 +412,8 @@ async def test_key_options_in_options_form(hass: HomeAssistant) -> None:
             {"custom_event_data_template": "{{ invalid_syntax"},
             data_entry_flow.FlowResultType.FORM,
         ),
-        ({"enforce_polling": False}, data_entry_flow.FlowResultType.CREATE_ENTRY),
-        ({"enforce_polling": True}, data_entry_flow.FlowResultType.CREATE_ENTRY),
+        ({"enable_push": True}, data_entry_flow.FlowResultType.CREATE_ENTRY),
+        ({"enable_push": False}, data_entry_flow.FlowResultType.CREATE_ENTRY),
     ],
     ids=[
         "valid_message_size",
@@ -421,8 +421,8 @@ async def test_key_options_in_options_form(hass: HomeAssistant) -> None:
         "invalid_message_size_high",
         "valid_template",
         "invalid_template",
-        "enforce_polling_false",
-        "enforce_polling_true",
+        "enable_push_true",
+        "enable_push_false",
     ],
 )
 async def test_advanced_options_form(

--- a/tests/components/imap/test_init.py
+++ b/tests/components/imap/test_init.py
@@ -36,7 +36,7 @@ from tests.common import MockConfigEntry, async_capture_events, async_fire_time_
 
 
 @pytest.mark.parametrize(
-    ("cipher_list", "verify_ssl", "enforce_polling"),
+    ("cipher_list", "verify_ssl", "enable_push"),
     [
         (None, None, None),
         ("python_default", True, None),
@@ -55,7 +55,7 @@ async def test_entry_startup_and_unload(
     mock_imap_protocol: MagicMock,
     cipher_list: str | None,
     verify_ssl: bool | None,
-    enforce_polling: bool | None,
+    enable_push: bool | None,
 ) -> None:
     """Test imap entry startup and unload with push and polling coordinator and alternate ciphers."""
     config = MOCK_CONFIG.copy()
@@ -63,8 +63,8 @@ async def test_entry_startup_and_unload(
         config["ssl_cipher_list"] = cipher_list
     if verify_ssl is not None:
         config["verify_ssl"] = verify_ssl
-    if enforce_polling is not None:
-        config["enforce_polling"] = enforce_polling
+    if enable_push is not None:
+        config["enable_push"] = enable_push
 
     config_entry = MockConfigEntry(domain=DOMAIN, data=config)
     config_entry.add_to_hass(hass)
@@ -632,25 +632,25 @@ async def test_custom_template(
     [(TEST_SEARCH_RESPONSE, TEST_FETCH_RESPONSE_TEXT_PLAIN)],
 )
 @pytest.mark.parametrize(
-    ("imap_has_capability", "enforce_polling", "should_poll"),
+    ("imap_has_capability", "enable_push", "should_poll"),
     [
-        (True, True, True),
-        (False, True, True),
-        (True, False, False),
+        (True, False, True),
         (False, False, True),
+        (True, True, False),
+        (False, True, True),
     ],
     ids=["enforce_poll", "poll", "auto_push", "auto_poll"],
 )
 async def test_enforce_polling(
     hass: HomeAssistant,
     mock_imap_protocol: MagicMock,
-    enforce_polling: bool,
+    enable_push: bool,
     should_poll: True,
 ) -> None:
     """Test enforce polling."""
     event_called = async_capture_events(hass, "imap_content")
     config = MOCK_CONFIG.copy()
-    config["enforce_polling"] = enforce_polling
+    config["enable_push"] = enable_push
 
     config_entry = MockConfigEntry(domain=DOMAIN, data=config)
     config_entry.add_to_hass(hass)

--- a/tests/components/imap/test_init.py
+++ b/tests/components/imap/test_init.py
@@ -2,7 +2,7 @@
 import asyncio
 from datetime import datetime, timedelta, timezone
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 from aioimaplib import AUTH, NONAUTH, SELECTED, AioImapException, Response
 import pytest
@@ -625,3 +625,58 @@ async def test_custom_template(
     assert data["text"]
     assert data["custom"] == result
     assert error in caplog.text if error is not None else True
+
+
+@pytest.mark.parametrize(
+    ("imap_search", "imap_fetch"),
+    [(TEST_SEARCH_RESPONSE, TEST_FETCH_RESPONSE_TEXT_PLAIN)],
+)
+@pytest.mark.parametrize(
+    ("imap_has_capability", "enforce_polling", "should_poll"),
+    [
+        (True, True, True),
+        (False, True, True),
+        (True, False, False),
+        (False, False, True),
+    ],
+    ids=["enforce_poll", "poll", "auto_push", "auto_poll"],
+)
+async def test_enforce_polling(
+    hass: HomeAssistant,
+    mock_imap_protocol: MagicMock,
+    enforce_polling: bool,
+    should_poll: True,
+) -> None:
+    """Test enforce polling."""
+    event_called = async_capture_events(hass, "imap_content")
+    config = MOCK_CONFIG.copy()
+    config["enforce_polling"] = enforce_polling
+
+    config_entry = MockConfigEntry(domain=DOMAIN, data=config)
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    # Make sure we have had one update (when polling)
+    async_fire_time_changed(hass, utcnow() + timedelta(seconds=5))
+    await hass.async_block_till_done()
+    state = hass.states.get("sensor.imap_email_email_com")
+    # we should have received one message
+    assert state is not None
+    assert state.state == "1"
+    assert state.attributes["state_class"] == SensorStateClass.MEASUREMENT
+
+    # we should have received one event
+    assert len(event_called) == 1
+    data: dict[str, Any] = event_called[0].data
+    assert data["server"] == "imap.server.com"
+    assert data["username"] == "email@email.com"
+    assert data["search"] == "UnSeen UnDeleted"
+    assert data["folder"] == "INBOX"
+    assert data["sender"] == "john.doe@example.com"
+    assert data["subject"] == "Test subject"
+    assert data["text"]
+
+    if should_poll:
+        mock_imap_protocol.wait_server_push.assert_not_called()
+    else:
+        mock_imap_protocol.assert_has_calls([call.wait_server_push])

--- a/tests/components/imap/test_init.py
+++ b/tests/components/imap/test_init.py
@@ -36,13 +36,17 @@ from tests.common import MockConfigEntry, async_capture_events, async_fire_time_
 
 
 @pytest.mark.parametrize(
-    ("cipher_list", "verify_ssl"),
+    ("cipher_list", "verify_ssl", "enforce_polling"),
     [
-        (None, None),
-        ("python_default", True),
-        ("python_default", False),
-        ("modern", True),
-        ("intermediate", True),
+        (None, None, None),
+        ("python_default", True, None),
+        ("python_default", False, None),
+        ("modern", True, None),
+        ("intermediate", True, None),
+        (None, None, False),
+        (None, None, True),
+        ("python_default", True, False),
+        ("python_default", False, True),
     ],
 )
 @pytest.mark.parametrize("imap_has_capability", [True, False], ids=["push", "poll"])
@@ -51,6 +55,7 @@ async def test_entry_startup_and_unload(
     mock_imap_protocol: MagicMock,
     cipher_list: str | None,
     verify_ssl: bool | None,
+    enforce_polling: bool | None,
 ) -> None:
     """Test imap entry startup and unload with push and polling coordinator and alternate ciphers."""
     config = MOCK_CONFIG.copy()
@@ -58,6 +63,8 @@ async def test_entry_startup_and_unload(
         config["ssl_cipher_list"] = cipher_list
     if verify_ssl is not None:
         config["verify_ssl"] = verify_ssl
+    if enforce_polling is not None:
+        config["enforce_polling"] = enforce_polling
 
     config_entry = MockConfigEntry(domain=DOMAIN, data=config)
     config_entry.add_to_hass(hass)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In some cases IMAP push can be unstable and polling is a better option, even when IMAP Push is supported. Especially when server connections are easily disrupted. This PR adds an advanced option that allows users to turn of IMAP-Push to allow polling instead of using pushed imap updates.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #96427
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/28189

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
