### PR TITLE
Simplify ESPHome bluetooth disconnected during operation wrapper

### DIFF
--- a/homeassistant/components/esphome/bluetooth/client.py
+++ b/homeassistant/components/esphome/bluetooth/client.py
@@ -67,7 +67,7 @@ def verify_connected(func: _WrapFuncType) -> _WrapFuncType:
             self._disconnected_futures  # pylint: disable=protected-access
         )
         disconnected_future = loop.create_future()
-        disconnected_futures.append(disconnected_future)
+        disconnected_futures.add(disconnected_future)
 
         task = asyncio.current_task(loop)
 
@@ -86,6 +86,7 @@ def verify_connected(func: _WrapFuncType) -> _WrapFuncType:
                 "Disconnected during operation"
             ) from ex
         finally:
+            disconnected_futures.remove(disconnected_future)
             disconnected_future.remove_done_callback(_on_disconnected)
 
     return cast(_WrapFuncType, _async_wrap_bluetooth_connected_operation)
@@ -155,7 +156,7 @@ class ESPHomeClient(BaseBleakClient):
             int, tuple[Callable[[], Coroutine[Any, Any, None]], Callable[[], None]]
         ] = {}
         self._loop = asyncio.get_running_loop()
-        self._disconnected_futures: list[asyncio.Future[None]] = []
+        self._disconnected_futures: set[asyncio.Future[None]] = set()
         device_info = self.entry_data.device_info
         assert device_info is not None
         self._device_info = device_info

--- a/homeassistant/components/esphome/bluetooth/client.py
+++ b/homeassistant/components/esphome/bluetooth/client.py
@@ -62,29 +62,25 @@ def verify_connected(func: _WrapFuncType) -> _WrapFuncType:
     async def _async_wrap_bluetooth_connected_operation(
         self: ESPHomeClient, *args: Any, **kwargs: Any
     ) -> Any:
-        disconnected_event = (
-            self._disconnected_event  # pylint: disable=protected-access
+        disconnected_future = (
+            self._loop.create_future()  # pylint: disable=protected-access
         )
-        if not disconnected_event:
-            raise BleakError("Not connected")
-        action_task = asyncio.create_task(func(self, *args, **kwargs))
-        disconnect_task = asyncio.create_task(disconnected_event.wait())
-        await asyncio.wait(
-            (action_task, disconnect_task),
-            return_when=asyncio.FIRST_COMPLETED,
+        self._disconnected_futures.append(  # pylint: disable=protected-access
+            disconnected_future
         )
-        if disconnect_task.done():
-            action_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await action_task
-
+        task = asyncio.current_task()
+        disconnected_future.add_done_callback(
+            lambda _: task.cancel() if not task.done() else None  # type: ignore[union-attr]
+        )
+        try:
+            return await func(self, *args, **kwargs)
+        except asyncio.CancelledError as ex:
             raise BleakError(
                 f"{self._source_name}: "  # pylint: disable=protected-access
                 f"{self._ble_device.name} - "  # pylint: disable=protected-access
                 f" {self._ble_device.address}: "  # pylint: disable=protected-access
                 "Disconnected during operation"
-            )
-        return action_task.result()
+            ) from ex
 
     return cast(_WrapFuncType, _async_wrap_bluetooth_connected_operation)
 
@@ -152,7 +148,8 @@ class ESPHomeClient(BaseBleakClient):
         self._notify_cancels: dict[
             int, tuple[Callable[[], Coroutine[Any, Any, None]], Callable[[], None]]
         ] = {}
-        self._disconnected_event: asyncio.Event | None = None
+        self._loop = asyncio.get_running_loop()
+        self._disconnected_futures: list[asyncio.Future[None]] = []
         device_info = self.entry_data.device_info
         assert device_info is not None
         self._device_info = device_info
@@ -192,9 +189,10 @@ class ESPHomeClient(BaseBleakClient):
         for _, notify_abort in self._notify_cancels.values():
             notify_abort()
         self._notify_cancels.clear()
-        if self._disconnected_event:
-            self._disconnected_event.set()
-            self._disconnected_event = None
+        for future in self._disconnected_futures:
+            if not future.done():
+                future.set_result(None)
+        self._disconnected_futures.clear()
         self._unsubscribe_connection_state()
 
     def _async_ble_device_disconnected(self) -> None:
@@ -359,7 +357,6 @@ class ESPHomeClient(BaseBleakClient):
             await self.disconnect()
             raise
 
-        self._disconnected_event = asyncio.Event()
         return True
 
     @api_error_as_bleak_error

--- a/homeassistant/components/esphome/bluetooth/client.py
+++ b/homeassistant/components/esphome/bluetooth/client.py
@@ -86,7 +86,7 @@ def verify_connected(func: _WrapFuncType) -> _WrapFuncType:
                 "Disconnected during operation"
             ) from ex
         finally:
-            disconnected_futures.remove(disconnected_future)
+            disconnected_futures.discard(disconnected_future)
             disconnected_future.remove_done_callback(_on_disconnected)
 
     return cast(_WrapFuncType, _async_wrap_bluetooth_connected_operation)


### PR DESCRIPTION
Side note: I'm working to decouple the esphome Bluetooth client into an external package (it's a slow process) and add more coverage to the esphome integration.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Avoids creating tasks by using a similar underlying pattern as `async_timeout` which reduces (hopefully eliminates) the chance of race conditions  where we don't provide a useful error when a device disconnects out from under us since we don't have 3 tasks to contend with (disconnect watcher, the bluetooth operation, and the current task).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
