### PR TITLE
Move device info validation to device registry

### DIFF
--- a/homeassistant/exceptions.py
+++ b/homeassistant/exceptions.py
@@ -191,21 +191,6 @@ class MaxLengthExceeded(HomeAssistantError):
         self.max_length = max_length
 
 
-class RequiredParameterMissing(HomeAssistantError):
-    """Raised when a required parameter is missing from a function call."""
-
-    def __init__(self, parameter_names: list[str]) -> None:
-        """Initialize error."""
-        super().__init__(
-            self,
-            (
-                "Call must include at least one of the following parameters: "
-                f"{', '.join(parameter_names)}"
-            ),
-        )
-        self.parameter_names = parameter_names
-
-
 class DependencyError(HomeAssistantError):
     """Raised when dependencies cannot be setup."""
 

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -5,7 +5,7 @@ from collections import UserDict
 from collections.abc import Coroutine, ValuesView
 import logging
 import time
-from typing import TYPE_CHECKING, Any, TypedDict, TypeVar, cast
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 from urllib.parse import urlparse
 
 import attr
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
 
     from . import entity_registry
+    from .entity import DeviceInfo
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -93,25 +94,6 @@ DEVICE_INFO_TYPES = {
 }
 
 DEVICE_INFO_KEYS = set.union(*(itm for itm in DEVICE_INFO_TYPES.values()))
-
-
-class DeviceInfo(TypedDict, total=False):
-    """Entity device information for device registry."""
-
-    configuration_url: str | None
-    connections: set[tuple[str, str]]
-    default_manufacturer: str
-    default_model: str
-    default_name: str
-    entry_type: DeviceEntryType | None
-    hw_version: str | None
-    identifiers: set[tuple[str, str]]
-    manufacturer: str | None
-    model: str | None
-    name: str | None
-    suggested_area: str | None
-    sw_version: str | None
-    via_device: tuple[str, str]
 
 
 class DeviceEntryType(StrEnum):

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -5,14 +5,15 @@ from collections import UserDict
 from collections.abc import Coroutine, ValuesView
 import logging
 import time
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, TypedDict, TypeVar, cast
+from urllib.parse import urlparse
 
 import attr
 
 from homeassistant.backports.enum import StrEnum
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import Event, HomeAssistant, callback
-from homeassistant.exceptions import HomeAssistantError, RequiredParameterMissing
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.util.json import format_unserializable_data
 import homeassistant.util.uuid as uuid_util
 
@@ -60,11 +61,123 @@ DISABLED_CONFIG_ENTRY = DeviceEntryDisabler.CONFIG_ENTRY.value
 DISABLED_INTEGRATION = DeviceEntryDisabler.INTEGRATION.value
 DISABLED_USER = DeviceEntryDisabler.USER.value
 
+DEVICE_INFO_TYPES = {
+    # Device info is categorized by finding the first device info type which has all
+    # the keys of the device info. The link device info type must be kept first
+    # to make it preferred over primary.
+    "link": {
+        "connections",
+        "identifiers",
+    },
+    "primary": {
+        "configuration_url",
+        "connections",
+        "entry_type",
+        "hw_version",
+        "identifiers",
+        "manufacturer",
+        "model",
+        "name",
+        "suggested_area",
+        "sw_version",
+        "via_device",
+    },
+    "secondary": {
+        "connections",
+        "default_manufacturer",
+        "default_model",
+        "default_name",
+        # Used by Fritz
+        "via_device",
+    },
+}
+
+DEVICE_INFO_KEYS = set.union(*(itm for itm in DEVICE_INFO_TYPES.values()))
+
+
+class DeviceInfo(TypedDict, total=False):
+    """Entity device information for device registry."""
+
+    configuration_url: str | None
+    connections: set[tuple[str, str]]
+    default_manufacturer: str
+    default_model: str
+    default_name: str
+    entry_type: DeviceEntryType | None
+    hw_version: str | None
+    identifiers: set[tuple[str, str]]
+    manufacturer: str | None
+    model: str | None
+    name: str | None
+    suggested_area: str | None
+    sw_version: str | None
+    via_device: tuple[str, str]
+
 
 class DeviceEntryType(StrEnum):
     """Device entry type."""
 
     SERVICE = "service"
+
+
+class DeviceInfoError(HomeAssistantError):
+    """Raised when device info is invalid."""
+
+    def __init__(self, domain: str, device_info: DeviceInfo, message: str) -> None:
+        """Initialize error."""
+        super().__init__(
+            f"Invalid device info {device_info} for '{domain}' config entry: {message}",
+        )
+        self.device_info = device_info
+        self.domain = domain
+
+
+def _validate_device_info(
+    config_entry: ConfigEntry,
+    device_info: DeviceInfo,
+) -> str:
+    """Process a device info."""
+    keys = set(device_info)
+
+    # If no keys or not enough info to match up, abort
+    if not device_info.get("connections") and not device_info.get("identifiers"):
+        raise DeviceInfoError(
+            config_entry.domain,
+            device_info,
+            "device info must include at least one of identifiers or connections",
+        )
+
+    device_info_type: str | None = None
+
+    # Find the first device info type which has all keys in the device info
+    for possible_type, allowed_keys in DEVICE_INFO_TYPES.items():
+        if keys <= allowed_keys:
+            device_info_type = possible_type
+            break
+
+    if device_info_type is None:
+        raise DeviceInfoError(
+            config_entry.domain,
+            device_info,
+            (
+                "device info needs to either describe a device, "
+                "link to existing device or provide extra information."
+            ),
+        )
+
+    if (config_url := device_info.get("configuration_url")) is not None:
+        if type(config_url) is not str or urlparse(config_url).scheme not in [
+            "http",
+            "https",
+            "homeassistant",
+        ]:
+            raise DeviceInfoError(
+                config_entry.domain,
+                device_info,
+                f"invalid configuration_url '{config_url}'",
+            )
+
+    return device_info_type
 
 
 @attr.s(slots=True, frozen=True)
@@ -338,7 +451,7 @@ class DeviceRegistry:
         *,
         config_entry_id: str,
         configuration_url: str | None | UndefinedType = UNDEFINED,
-        connections: set[tuple[str, str]] | None = None,
+        connections: set[tuple[str, str]] | None | UndefinedType = UNDEFINED,
         default_manufacturer: str | None | UndefinedType = UNDEFINED,
         default_model: str | None | UndefinedType = UNDEFINED,
         default_name: str | None | UndefinedType = UNDEFINED,
@@ -346,22 +459,36 @@ class DeviceRegistry:
         disabled_by: DeviceEntryDisabler | None | UndefinedType = UNDEFINED,
         entry_type: DeviceEntryType | None | UndefinedType = UNDEFINED,
         hw_version: str | None | UndefinedType = UNDEFINED,
-        identifiers: set[tuple[str, str]] | None = None,
+        identifiers: set[tuple[str, str]] | None | UndefinedType = UNDEFINED,
         manufacturer: str | None | UndefinedType = UNDEFINED,
         model: str | None | UndefinedType = UNDEFINED,
         name: str | None | UndefinedType = UNDEFINED,
         suggested_area: str | None | UndefinedType = UNDEFINED,
         sw_version: str | None | UndefinedType = UNDEFINED,
-        via_device: tuple[str, str] | None = None,
+        via_device: tuple[str, str] | None | UndefinedType = UNDEFINED,
     ) -> DeviceEntry:
         """Get device. Create if it doesn't exist."""
-        if not identifiers and not connections:
-            raise RequiredParameterMissing(["identifiers", "connections"])
 
-        if identifiers is None:
+        # Reconstruct a DeviceInfo dict from the arguments.
+        # When we upgrade to Python 3.12, we can change this method to instead
+        # accept kwargs typed as a DeviceInfo dict (PEP 692)
+        _device_info = cast(
+            DeviceInfo,
+            {
+                key: val
+                for key, val in locals().items()
+                if key in DEVICE_INFO_KEYS and val != UNDEFINED
+            },
+        )
+        config_entry = self.hass.config_entries.async_get_entry(config_entry_id)
+        if not config_entry:
+            raise HomeAssistantError(f"Unknown config entry '{config_entry_id}'")
+        device_info_type = _validate_device_info(config_entry, _device_info)
+
+        if identifiers is None or identifiers is UNDEFINED:
             identifiers = set()
 
-        if connections is None:
+        if connections is None or connections is UNDEFINED:
             connections = set()
         else:
             connections = _normalize_connections(connections)
@@ -378,6 +505,9 @@ class DeviceRegistry:
                     config_entry_id, connections, identifiers
                 )
             self.devices[device.id] = device
+            # If creating a new device, default to the config entry name
+            if device_info_type == "primary" and (not name or name is UNDEFINED):
+                name = config_entry.title
 
         if default_manufacturer is not UNDEFINED and device.manufacturer is None:
             manufacturer = default_manufacturer
@@ -388,7 +518,7 @@ class DeviceRegistry:
         if default_name is not UNDEFINED and device.name is None:
             name = default_name
 
-        if via_device is not None:
+        if via_device is not None and via_device is not UNDEFINED:
             via = self.async_get_device(identifiers={via_device})
             via_device_id: str | UndefinedType = via.id if via else UNDEFINED
         else:

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -454,16 +454,29 @@ class DeviceRegistry:
         # Reconstruct a DeviceInfo dict from the arguments.
         # When we upgrade to Python 3.12, we can change this method to instead
         # accept kwargs typed as a DeviceInfo dict (PEP 692)
-        _device_info = cast(
-            "DeviceInfo",
-            {
-                key: val
-                for key, val in locals().items()
-                if key in DEVICE_INFO_KEYS and val != UNDEFINED
-            },
-        )
+        device_info: DeviceInfo = {}
+        for key, val in (
+            ("configuration_url", configuration_url),
+            ("connections", connections),
+            ("default_manufacturer", default_manufacturer),
+            ("default_model", default_model),
+            ("default_name", default_name),
+            ("entry_type", entry_type),
+            ("hw_version", hw_version),
+            ("identifiers", identifiers),
+            ("manufacturer", manufacturer),
+            ("model", model),
+            ("name", name),
+            ("suggested_area", suggested_area),
+            ("sw_version", sw_version),
+            ("via_device", via_device),
+        ):
+            if val is UNDEFINED:
+                continue
+            device_info[key] = val  # type: ignore[literal-required]
+
         config_entry = self.hass.config_entries.async_get_entry(config_entry_id)
-        device_info_type = _validate_device_info(config_entry, _device_info)
+        device_info_type = _validate_device_info(config_entry, device_info)
 
         if identifiers is None or identifiers is UNDEFINED:
             identifiers = set()

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -455,7 +455,7 @@ class DeviceRegistry:
         # When we upgrade to Python 3.12, we can change this method to instead
         # accept kwargs typed as a DeviceInfo dict (PEP 692)
         _device_info = cast(
-            DeviceInfo,
+            "DeviceInfo",
             {
                 key: val
                 for key, val in locals().items()

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -12,7 +12,7 @@ import logging
 import math
 import sys
 from timeit import default_timer as timer
-from typing import TYPE_CHECKING, Any, Final, Literal, TypedDict, TypeVar, final
+from typing import TYPE_CHECKING, Any, Final, Literal, TypeVar, final
 
 import voluptuous as vol
 
@@ -40,7 +40,7 @@ from homeassistant.loader import bind_hass
 from homeassistant.util import dt as dt_util, ensure_unique_string, slugify
 
 from . import device_registry as dr, entity_registry as er
-from .device_registry import DeviceEntryType
+from .device_registry import DeviceInfo
 from .event import (
     async_track_device_registry_updated_event,
     async_track_entity_registry_updated_event,
@@ -172,25 +172,6 @@ def get_unit_of_measurement(hass: HomeAssistant, entity_id: str) -> str | None:
         raise HomeAssistantError(f"Unknown entity {entity_id}")
 
     return entry.unit_of_measurement
-
-
-class DeviceInfo(TypedDict, total=False):
-    """Entity device information for device registry."""
-
-    configuration_url: str | None
-    connections: set[tuple[str, str]]
-    default_manufacturer: str
-    default_model: str
-    default_name: str
-    entry_type: DeviceEntryType | None
-    identifiers: set[tuple[str, str]]
-    manufacturer: str | None
-    model: str | None
-    name: str | None
-    suggested_area: str | None
-    sw_version: str | None
-    hw_version: str | None
-    via_device: tuple[str, str]
 
 
 ENTITY_CATEGORIES_SCHEMA: Final = vol.Coerce(EntityCategory)

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -12,7 +12,7 @@ import logging
 import math
 import sys
 from timeit import default_timer as timer
-from typing import TYPE_CHECKING, Any, Final, Literal, TypeVar, final
+from typing import TYPE_CHECKING, Any, Final, Literal, TypedDict, TypeVar, final
 
 import voluptuous as vol
 
@@ -40,7 +40,7 @@ from homeassistant.loader import bind_hass
 from homeassistant.util import dt as dt_util, ensure_unique_string, slugify
 
 from . import device_registry as dr, entity_registry as er
-from .device_registry import DeviceInfo
+from .device_registry import DeviceEntryType
 from .event import (
     async_track_device_registry_updated_event,
     async_track_entity_registry_updated_event,
@@ -172,6 +172,25 @@ def get_unit_of_measurement(hass: HomeAssistant, entity_id: str) -> str | None:
         raise HomeAssistantError(f"Unknown entity {entity_id}")
 
     return entry.unit_of_measurement
+
+
+class DeviceInfo(TypedDict, total=False):
+    """Entity device information for device registry."""
+
+    configuration_url: str | None
+    connections: set[tuple[str, str]]
+    default_manufacturer: str
+    default_model: str
+    default_name: str
+    entry_type: DeviceEntryType | None
+    identifiers: set[tuple[str, str]]
+    manufacturer: str | None
+    model: str | None
+    name: str | None
+    suggested_area: str | None
+    sw_version: str | None
+    hw_version: str | None
+    via_device: tuple[str, str]
 
 
 ENTITY_CATEGORIES_SCHEMA: Final = vol.Coerce(EntityCategory)

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -7,7 +7,6 @@ from contextvars import ContextVar
 from datetime import datetime, timedelta
 from logging import Logger, getLogger
 from typing import TYPE_CHECKING, Any, Protocol
-from urllib.parse import urlparse
 
 import voluptuous as vol
 
@@ -48,7 +47,7 @@ from .issue_registry import IssueSeverity, async_create_issue
 from .typing import UNDEFINED, ConfigType, DiscoveryInfoType
 
 if TYPE_CHECKING:
-    from .entity import DeviceInfo, Entity
+    from .entity import Entity
 
 
 SLOW_SETUP_WARNING = 10
@@ -59,37 +58,6 @@ SLOW_ADD_MIN_TIMEOUT = 500
 PLATFORM_NOT_READY_RETRIES = 10
 DATA_ENTITY_PLATFORM = "entity_platform"
 PLATFORM_NOT_READY_BASE_WAIT_TIME = 30  # seconds
-
-DEVICE_INFO_TYPES = {
-    # Device info is categorized by finding the first device info type which has all
-    # the keys of the device info. The link device info type must be kept first
-    # to make it preferred over primary.
-    "link": {
-        "connections",
-        "identifiers",
-    },
-    "primary": {
-        "configuration_url",
-        "connections",
-        "entry_type",
-        "hw_version",
-        "identifiers",
-        "manufacturer",
-        "model",
-        "name",
-        "suggested_area",
-        "sw_version",
-        "via_device",
-    },
-    "secondary": {
-        "connections",
-        "default_manufacturer",
-        "default_model",
-        "default_name",
-        # Used by Fritz
-        "via_device",
-    },
-}
 
 _LOGGER = getLogger(__name__)
 
@@ -646,7 +614,14 @@ class EntityPlatform:
                     return
 
             if self.config_entry and (device_info := entity.device_info):
-                device = self._async_process_device_info(device_info)
+                try:
+                    device = dev_reg.async_get(self.hass).async_get_or_create(
+                        config_entry_id=self.config_entry.entry_id,
+                        **device_info,
+                    )
+                except dev_reg.DeviceInfoError as exc:
+                    _LOGGER.error(str(exc))
+                    device = None
             else:
                 device = None
 
@@ -772,62 +747,6 @@ class EntityPlatform:
         entity.async_on_remove(remove_entity_cb)
 
         await entity.add_to_platform_finish()
-
-    @callback
-    def _async_process_device_info(
-        self, device_info: DeviceInfo
-    ) -> dev_reg.DeviceEntry | None:
-        """Process a device info."""
-        keys = set(device_info)
-
-        # If no keys or not enough info to match up, abort
-        if len(keys & {"connections", "identifiers"}) == 0:
-            self.logger.error(
-                "Ignoring device info without identifiers or connections: %s",
-                device_info,
-            )
-            return None
-
-        device_info_type: str | None = None
-
-        # Find the first device info type which has all keys in the device info
-        for possible_type, allowed_keys in DEVICE_INFO_TYPES.items():
-            if keys <= allowed_keys:
-                device_info_type = possible_type
-                break
-
-        if device_info_type is None:
-            self.logger.error(
-                "Device info for %s needs to either describe a device, "
-                "link to existing device or provide extra information.",
-                device_info,
-            )
-            return None
-
-        if (config_url := device_info.get("configuration_url")) is not None:
-            if type(config_url) is not str or urlparse(config_url).scheme not in [
-                "http",
-                "https",
-                "homeassistant",
-            ]:
-                self.logger.error(
-                    "Ignoring device info with invalid configuration_url '%s'",
-                    config_url,
-                )
-                return None
-
-        assert self.config_entry is not None
-
-        if device_info_type == "primary" and not device_info.get("name"):
-            device_info = {
-                **device_info,  # type: ignore[misc]
-                "name": self.config_entry.title,
-            }
-
-        return dev_reg.async_get(self.hass).async_get_or_create(
-            config_entry_id=self.config_entry.entry_id,
-            **device_info,
-        )
 
     async def async_reset(self) -> None:
         """Remove all entities and reset data.

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -620,7 +620,7 @@ class EntityPlatform:
                         **device_info,
                     )
                 except dev_reg.DeviceInfoError as exc:
-                    _LOGGER.error(str(exc))
+                    self.logger.error("Ignoring invalid device info: %s", str(exc))
                     device = None
             else:
                 device = None

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -39,11 +39,8 @@ async def test_get_or_create_returns_same_entry(
     update_events,
 ) -> None:
     """Make sure we do not duplicate entries."""
-    config_entry = MockConfigEntry(entry_id="1234")
-    config_entry.add_to_hass(hass)
-
     entry = device_registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
+        config_entry_id="1234",
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("bridgeid", "0123")},
         sw_version="sw-version",
@@ -53,7 +50,7 @@ async def test_get_or_create_returns_same_entry(
         suggested_area="Game Room",
     )
     entry2 = device_registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
+        config_entry_id="1234",
         connections={(dr.CONNECTION_NETWORK_MAC, "11:22:33:66:77:88")},
         identifiers={("bridgeid", "0123")},
         manufacturer="manufacturer",
@@ -61,7 +58,7 @@ async def test_get_or_create_returns_same_entry(
         suggested_area="Game Room",
     )
     entry3 = device_registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
+        config_entry_id="1234",
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
 
@@ -99,22 +96,18 @@ async def test_get_or_create_returns_same_entry(
 
 
 async def test_requirement_for_identifier_or_connection(
-    hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Make sure we do require some descriptor of device."""
-    config_entry = MockConfigEntry(entry_id="1234")
-    config_entry.add_to_hass(hass)
-
     entry = device_registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
+        config_entry_id="1234",
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers=set(),
         manufacturer="manufacturer",
         model="model",
     )
     entry2 = device_registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
+        config_entry_id="1234",
         connections=set(),
         identifiers={("bridgeid", "0123")},
         manufacturer="manufacturer",
@@ -127,7 +120,7 @@ async def test_requirement_for_identifier_or_connection(
 
     with pytest.raises(HomeAssistantError):
         device_registry.async_get_or_create(
-            config_entry_id=config_entry.entry_id,
+            config_entry_id="1234",
             connections=set(),
             identifiers=set(),
             manufacturer="manufacturer",
@@ -135,31 +128,24 @@ async def test_requirement_for_identifier_or_connection(
         )
 
 
-async def test_multiple_config_entries(
-    hass: HomeAssistant, device_registry: dr.DeviceRegistry
-) -> None:
+async def test_multiple_config_entries(device_registry: dr.DeviceRegistry) -> None:
     """Make sure we do not get duplicate entries."""
-    config_entry1 = MockConfigEntry(entry_id="123")
-    config_entry1.add_to_hass(hass)
-    config_entry2 = MockConfigEntry(entry_id="456")
-    config_entry2.add_to_hass(hass)
-
     entry = device_registry.async_get_or_create(
-        config_entry_id=config_entry1.entry_id,
+        config_entry_id="123",
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("bridgeid", "0123")},
         manufacturer="manufacturer",
         model="model",
     )
     entry2 = device_registry.async_get_or_create(
-        config_entry_id=config_entry2.entry_id,
+        config_entry_id="456",
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("bridgeid", "0123")},
         manufacturer="manufacturer",
         model="model",
     )
     entry3 = device_registry.async_get_or_create(
-        config_entry_id=config_entry1.entry_id,
+        config_entry_id="123",
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("bridgeid", "0123")},
         manufacturer="manufacturer",
@@ -217,11 +203,8 @@ async def test_loading_from_storage(
     assert len(registry.devices) == 1
     assert len(registry.deleted_devices) == 1
 
-    config_entry = MockConfigEntry(entry_id="1234")
-    config_entry.add_to_hass(hass)
-
     entry = registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
+        config_entry_id="1234",
         connections={("Zigbee", "01.23.45.67.89")},
         identifiers={("serial", "12:34:56:AB:CD:EF")},
         manufacturer="manufacturer",
@@ -250,7 +233,7 @@ async def test_loading_from_storage(
 
     # Restore a device, id should be reused from the deleted device entry
     entry = registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
+        config_entry_id="1234",
         connections={("Zigbee", "23.45.67.89.01")},
         identifiers={("serial", "34:56:AB:CD:EF:12")},
         manufacturer="manufacturer",
@@ -263,7 +246,6 @@ async def test_loading_from_storage(
         identifiers={("serial", "34:56:AB:CD:EF:12")},
         manufacturer="manufacturer",
         model="model",
-        name="Mock Title",  # From config entry title
     )
     assert entry.id == "bcdefghijklmn"
     assert isinstance(entry.config_entries, set)
@@ -324,12 +306,9 @@ async def test_migration_1_1_to_1_3(
     await dr.async_load(hass)
     registry = dr.async_get(hass)
 
-    config_entry = MockConfigEntry(entry_id="1234")
-    config_entry.add_to_hass(hass)
-
     # Test data was loaded
     entry = registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
+        config_entry_id="1234",
         connections={("Zigbee", "01.23.45.67.89")},
         identifiers={("serial", "12:34:56:AB:CD:EF")},
     )
@@ -337,7 +316,7 @@ async def test_migration_1_1_to_1_3(
 
     # Update to trigger a store
     entry = registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
+        config_entry_id="1234",
         connections={("Zigbee", "01.23.45.67.89")},
         identifiers={("serial", "12:34:56:AB:CD:EF")},
         sw_version="new_version",
@@ -451,12 +430,9 @@ async def test_migration_1_2_to_1_3(
     await dr.async_load(hass)
     registry = dr.async_get(hass)
 
-    config_entry = MockConfigEntry(entry_id="1234")
-    config_entry.add_to_hass(hass)
-
     # Test data was loaded
     entry = registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
+        config_entry_id="1234",
         connections={("Zigbee", "01.23.45.67.89")},
         identifiers={("serial", "12:34:56:AB:CD:EF")},
     )
@@ -464,7 +440,7 @@ async def test_migration_1_2_to_1_3(
 
     # Update to trigger a store
     entry = registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
+        config_entry_id="1234",
         connections={("Zigbee", "01.23.45.67.89")},
         identifiers={("serial", "12:34:56:AB:CD:EF")},
         sw_version="new_version",
@@ -524,27 +500,22 @@ async def test_removing_config_entries(
     hass: HomeAssistant, device_registry: dr.DeviceRegistry, update_events
 ) -> None:
     """Make sure we do not get duplicate entries."""
-    config_entry1 = MockConfigEntry(entry_id="123")
-    config_entry1.add_to_hass(hass)
-    config_entry2 = MockConfigEntry(entry_id="456")
-    config_entry2.add_to_hass(hass)
-
     entry = device_registry.async_get_or_create(
-        config_entry_id=config_entry1.entry_id,
+        config_entry_id="123",
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("bridgeid", "0123")},
         manufacturer="manufacturer",
         model="model",
     )
     entry2 = device_registry.async_get_or_create(
-        config_entry_id=config_entry2.entry_id,
+        config_entry_id="456",
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("bridgeid", "0123")},
         manufacturer="manufacturer",
         model="model",
     )
     entry3 = device_registry.async_get_or_create(
-        config_entry_id=config_entry1.entry_id,
+        config_entry_id="123",
         connections={(dr.CONNECTION_NETWORK_MAC, "34:56:78:CD:EF:12")},
         identifiers={("bridgeid", "4567")},
         manufacturer="manufacturer",
@@ -589,27 +560,22 @@ async def test_deleted_device_removing_config_entries(
     hass: HomeAssistant, device_registry: dr.DeviceRegistry, update_events
 ) -> None:
     """Make sure we do not get duplicate entries."""
-    config_entry1 = MockConfigEntry(entry_id="123")
-    config_entry1.add_to_hass(hass)
-    config_entry2 = MockConfigEntry(entry_id="456")
-    config_entry2.add_to_hass(hass)
-
     entry = device_registry.async_get_or_create(
-        config_entry_id=config_entry1.entry_id,
+        config_entry_id="123",
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("bridgeid", "0123")},
         manufacturer="manufacturer",
         model="model",
     )
     entry2 = device_registry.async_get_or_create(
-        config_entry_id=config_entry2.entry_id,
+        config_entry_id="456",
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("bridgeid", "0123")},
         manufacturer="manufacturer",
         model="model",
     )
     entry3 = device_registry.async_get_or_create(
-        config_entry_id=config_entry1.entry_id,
+        config_entry_id="123",
         connections={(dr.CONNECTION_NETWORK_MAC, "34:56:78:CD:EF:12")},
         identifiers={("bridgeid", "4567")},
         manufacturer="manufacturer",
@@ -660,7 +626,7 @@ async def test_deleted_device_removing_config_entries(
 
     # Re-add, expect to keep the device id
     entry2 = device_registry.async_get_or_create(
-        config_entry_id=config_entry2.entry_id,
+        config_entry_id="456",
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("bridgeid", "0123")},
         manufacturer="manufacturer",
@@ -676,7 +642,7 @@ async def test_deleted_device_removing_config_entries(
 
     # Re-add, expect to get a new device id after the purge
     entry4 = device_registry.async_get_or_create(
-        config_entry_id=config_entry1.entry_id,
+        config_entry_id="123",
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("bridgeid", "0123")},
         manufacturer="manufacturer",
@@ -685,15 +651,10 @@ async def test_deleted_device_removing_config_entries(
     assert entry3.id != entry4.id
 
 
-async def test_removing_area_id(
-    hass: HomeAssistant, device_registry: dr.DeviceRegistry
-) -> None:
+async def test_removing_area_id(device_registry: dr.DeviceRegistry) -> None:
     """Make sure we can clear area id."""
-    config_entry = MockConfigEntry(entry_id="123")
-    config_entry.add_to_hass(hass)
-
     entry = device_registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
+        config_entry_id="123",
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("bridgeid", "0123")},
         manufacturer="manufacturer",
@@ -709,17 +670,10 @@ async def test_removing_area_id(
     assert entry_w_area != entry_wo_area
 
 
-async def test_specifying_via_device_create(
-    hass: HomeAssistant, device_registry: dr.DeviceRegistry
-) -> None:
+async def test_specifying_via_device_create(device_registry: dr.DeviceRegistry) -> None:
     """Test specifying a via_device and removal of the hub device."""
-    config_entry1 = MockConfigEntry(entry_id="123")
-    config_entry1.add_to_hass(hass)
-    config_entry2 = MockConfigEntry(entry_id="456")
-    config_entry2.add_to_hass(hass)
-
     via = device_registry.async_get_or_create(
-        config_entry_id=config_entry1.entry_id,
+        config_entry_id="123",
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("hue", "0123")},
         manufacturer="manufacturer",
@@ -727,7 +681,7 @@ async def test_specifying_via_device_create(
     )
 
     light = device_registry.async_get_or_create(
-        config_entry_id=config_entry2.entry_id,
+        config_entry_id="456",
         connections=set(),
         identifiers={("hue", "456")},
         manufacturer="manufacturer",
@@ -742,17 +696,10 @@ async def test_specifying_via_device_create(
     assert light.via_device_id is None
 
 
-async def test_specifying_via_device_update(
-    hass: HomeAssistant, device_registry: dr.DeviceRegistry
-) -> None:
+async def test_specifying_via_device_update(device_registry: dr.DeviceRegistry) -> None:
     """Test specifying a via_device and updating."""
-    config_entry1 = MockConfigEntry(entry_id="123")
-    config_entry1.add_to_hass(hass)
-    config_entry2 = MockConfigEntry(entry_id="456")
-    config_entry2.add_to_hass(hass)
-
     light = device_registry.async_get_or_create(
-        config_entry_id=config_entry2.entry_id,
+        config_entry_id="456",
         connections=set(),
         identifiers={("hue", "456")},
         manufacturer="manufacturer",
@@ -763,7 +710,7 @@ async def test_specifying_via_device_update(
     assert light.via_device_id is None
 
     via = device_registry.async_get_or_create(
-        config_entry_id=config_entry1.entry_id,
+        config_entry_id="123",
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("hue", "0123")},
         manufacturer="manufacturer",
@@ -771,7 +718,7 @@ async def test_specifying_via_device_update(
     )
 
     light = device_registry.async_get_or_create(
-        config_entry_id=config_entry2.entry_id,
+        config_entry_id="456",
         connections=set(),
         identifiers={("hue", "456")},
         manufacturer="manufacturer",
@@ -786,19 +733,8 @@ async def test_loading_saving_data(
     hass: HomeAssistant, device_registry: dr.DeviceRegistry
 ) -> None:
     """Test that we load/save data correctly."""
-    config_entry1 = MockConfigEntry(entry_id="123")
-    config_entry1.add_to_hass(hass)
-    config_entry2 = MockConfigEntry(entry_id="456")
-    config_entry2.add_to_hass(hass)
-    config_entry3 = MockConfigEntry(entry_id="789")
-    config_entry3.add_to_hass(hass)
-    config_entry4 = MockConfigEntry(entry_id="abc")
-    config_entry4.add_to_hass(hass)
-    config_entry5 = MockConfigEntry(entry_id="999")
-    config_entry5.add_to_hass(hass)
-
     orig_via = device_registry.async_get_or_create(
-        config_entry_id=config_entry1.entry_id,
+        config_entry_id="123",
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("hue", "0123")},
         manufacturer="manufacturer",
@@ -809,7 +745,7 @@ async def test_loading_saving_data(
     )
 
     orig_light = device_registry.async_get_or_create(
-        config_entry_id=config_entry2.entry_id,
+        config_entry_id="456",
         connections=set(),
         identifiers={("hue", "456")},
         manufacturer="manufacturer",
@@ -819,7 +755,7 @@ async def test_loading_saving_data(
     )
 
     orig_light2 = device_registry.async_get_or_create(
-        config_entry_id=config_entry2.entry_id,
+        config_entry_id="456",
         connections=set(),
         identifiers={("hue", "789")},
         manufacturer="manufacturer",
@@ -830,7 +766,7 @@ async def test_loading_saving_data(
     device_registry.async_remove_device(orig_light2.id)
 
     orig_light3 = device_registry.async_get_or_create(
-        config_entry_id=config_entry3.entry_id,
+        config_entry_id="789",
         connections={(dr.CONNECTION_NETWORK_MAC, "34:56:AB:CD:EF:12")},
         identifiers={("hue", "abc")},
         manufacturer="manufacturer",
@@ -838,7 +774,7 @@ async def test_loading_saving_data(
     )
 
     device_registry.async_get_or_create(
-        config_entry_id=config_entry4.entry_id,
+        config_entry_id="abc",
         connections={(dr.CONNECTION_NETWORK_MAC, "34:56:AB:CD:EF:12")},
         identifiers={("abc", "123")},
         manufacturer="manufacturer",
@@ -848,7 +784,7 @@ async def test_loading_saving_data(
     device_registry.async_remove_device(orig_light3.id)
 
     orig_light4 = device_registry.async_get_or_create(
-        config_entry_id=config_entry3.entry_id,
+        config_entry_id="789",
         connections={(dr.CONNECTION_NETWORK_MAC, "34:56:AB:CD:EF:12")},
         identifiers={("hue", "abc")},
         manufacturer="manufacturer",
@@ -859,7 +795,7 @@ async def test_loading_saving_data(
     assert orig_light4.id == orig_light3.id
 
     orig_kitchen_light = device_registry.async_get_or_create(
-        config_entry_id=config_entry5.entry_id,
+        config_entry_id="999",
         connections=set(),
         identifiers={("hue", "999")},
         manufacturer="manufacturer",
@@ -913,15 +849,10 @@ async def test_loading_saving_data(
     assert orig_kitchen_light_witout_suggested_area == new_kitchen_light
 
 
-async def test_no_unnecessary_changes(
-    hass: HomeAssistant, device_registry: dr.DeviceRegistry
-) -> None:
+async def test_no_unnecessary_changes(device_registry: dr.DeviceRegistry) -> None:
     """Make sure we do not consider devices changes."""
-    config_entry = MockConfigEntry(entry_id="1234")
-    config_entry.add_to_hass(hass)
-
     entry = device_registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
+        config_entry_id="1234",
         connections={("ethernet", "12:34:56:78:90:AB:CD:EF")},
         identifiers={("hue", "456"), ("bla", "123")},
     )
@@ -929,27 +860,22 @@ async def test_no_unnecessary_changes(
         "homeassistant.helpers.device_registry.DeviceRegistry.async_schedule_save"
     ) as mock_save:
         entry2 = device_registry.async_get_or_create(
-            config_entry_id=config_entry.entry_id, identifiers={("hue", "456")}
+            config_entry_id="1234", identifiers={("hue", "456")}
         )
 
     assert entry.id == entry2.id
     assert len(mock_save.mock_calls) == 0
 
 
-async def test_format_mac(
-    hass: HomeAssistant, device_registry: dr.DeviceRegistry
-) -> None:
+async def test_format_mac(device_registry: dr.DeviceRegistry) -> None:
     """Make sure we normalize mac addresses."""
-    config_entry = MockConfigEntry(entry_id="1234")
-    config_entry.add_to_hass(hass)
-
     entry = device_registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
+        config_entry_id="1234",
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
     for mac in ["123456ABCDEF", "123456abcdef", "12:34:56:ab:cd:ef", "1234.56ab.cdef"]:
         test_entry = device_registry.async_get_or_create(
-            config_entry_id=config_entry.entry_id,
+            config_entry_id="1234",
             connections={(dr.CONNECTION_NETWORK_MAC, mac)},
         )
         assert test_entry.id == entry.id, mac
@@ -967,7 +893,7 @@ async def test_format_mac(
         "123.456.abc.def",  # too many .
     ]:
         invalid_mac_entry = device_registry.async_get_or_create(
-            config_entry_id=config_entry.entry_id,
+            config_entry_id="1234",
             connections={(dr.CONNECTION_NETWORK_MAC, invalid)},
         )
         assert list(invalid_mac_entry.connections)[0][1] == invalid
@@ -977,11 +903,8 @@ async def test_update(
     hass: HomeAssistant, device_registry: dr.DeviceRegistry, update_events
 ) -> None:
     """Verify that we can update some attributes of a device."""
-    config_entry = MockConfigEntry(entry_id="1234")
-    config_entry.add_to_hass(hass)
-
     entry = device_registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
+        config_entry_id="1234",
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("hue", "456"), ("bla", "123")},
     )
@@ -1076,27 +999,22 @@ async def test_update_remove_config_entries(
     hass: HomeAssistant, device_registry: dr.DeviceRegistry, update_events
 ) -> None:
     """Make sure we do not get duplicate entries."""
-    config_entry1 = MockConfigEntry(entry_id="123")
-    config_entry1.add_to_hass(hass)
-    config_entry2 = MockConfigEntry(entry_id="456")
-    config_entry2.add_to_hass(hass)
-
     entry = device_registry.async_get_or_create(
-        config_entry_id=config_entry1.entry_id,
+        config_entry_id="123",
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("bridgeid", "0123")},
         manufacturer="manufacturer",
         model="model",
     )
     entry2 = device_registry.async_get_or_create(
-        config_entry_id=config_entry2.entry_id,
+        config_entry_id="456",
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("bridgeid", "0123")},
         manufacturer="manufacturer",
         model="model",
     )
     entry3 = device_registry.async_get_or_create(
-        config_entry_id=config_entry1.entry_id,
+        config_entry_id="123",
         connections={(dr.CONNECTION_NETWORK_MAC, "34:56:78:CD:EF:12")},
         identifiers={("bridgeid", "4567")},
         manufacturer="manufacturer",
@@ -1149,11 +1067,8 @@ async def test_update_suggested_area(
     update_events,
 ) -> None:
     """Verify that we can update the suggested area version of a device."""
-    config_entry = MockConfigEntry(entry_id="1234")
-    config_entry.add_to_hass(hass)
-
     entry = device_registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
+        config_entry_id="1234",
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("bla", "123")},
     )
@@ -1215,12 +1130,9 @@ async def test_cleanup_device_registry(
     d3 = device_registry.async_get_or_create(
         identifiers={("hue", "d3")}, config_entry_id=config_entry.entry_id
     )
-    non_existing_config_entry = MockConfigEntry(entry_id="non_existing")
-    non_existing_config_entry.add_to_hass(hass)
     device_registry.async_get_or_create(
         identifiers={("something", "d4")}, config_entry_id="non_existing"
     )
-    hass.config_entries._entries.pop(non_existing_config_entry.entry_id)
 
     ent_reg = er.async_get(hass)
     ent_reg.async_get_or_create("light", "hue", "e1", device_id=d1.id)
@@ -1322,11 +1234,8 @@ async def test_restore_device(
     hass: HomeAssistant, device_registry: dr.DeviceRegistry, update_events
 ) -> None:
     """Make sure device id is stable."""
-    config_entry = MockConfigEntry(entry_id="123")
-    config_entry.add_to_hass(hass)
-
     entry = device_registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
+        config_entry_id="123",
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("bridgeid", "0123")},
         manufacturer="manufacturer",
@@ -1342,14 +1251,14 @@ async def test_restore_device(
     assert len(device_registry.deleted_devices) == 1
 
     entry2 = device_registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
+        config_entry_id="123",
         connections={(dr.CONNECTION_NETWORK_MAC, "34:56:78:CD:EF:12")},
         identifiers={("bridgeid", "4567")},
         manufacturer="manufacturer",
         model="model",
     )
     entry3 = device_registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
+        config_entry_id="123",
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("bridgeid", "0123")},
         manufacturer="manufacturer",
@@ -1386,11 +1295,8 @@ async def test_restore_simple_device(
     hass: HomeAssistant, device_registry: dr.DeviceRegistry, update_events
 ) -> None:
     """Make sure device id is stable."""
-    config_entry = MockConfigEntry(entry_id="123")
-    config_entry.add_to_hass(hass)
-
     entry = device_registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
+        config_entry_id="123",
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("bridgeid", "0123")},
     )
@@ -1404,12 +1310,12 @@ async def test_restore_simple_device(
     assert len(device_registry.deleted_devices) == 1
 
     entry2 = device_registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
+        config_entry_id="123",
         connections={(dr.CONNECTION_NETWORK_MAC, "34:56:78:CD:EF:12")},
         identifiers={("bridgeid", "4567")},
     )
     entry3 = device_registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
+        config_entry_id="123",
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("bridgeid", "0123")},
     )
@@ -1440,13 +1346,8 @@ async def test_restore_shared_device(
     hass: HomeAssistant, device_registry: dr.DeviceRegistry, update_events
 ) -> None:
     """Make sure device id is stable for shared devices."""
-    config_entry1 = MockConfigEntry(entry_id="123")
-    config_entry1.add_to_hass(hass)
-    config_entry2 = MockConfigEntry(entry_id="234")
-    config_entry2.add_to_hass(hass)
-
     entry = device_registry.async_get_or_create(
-        config_entry_id=config_entry1.entry_id,
+        config_entry_id="123",
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("entry_123", "0123")},
         manufacturer="manufacturer",
@@ -1457,7 +1358,7 @@ async def test_restore_shared_device(
     assert len(device_registry.deleted_devices) == 0
 
     device_registry.async_get_or_create(
-        config_entry_id=config_entry2.entry_id,
+        config_entry_id="234",
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("entry_234", "2345")},
         manufacturer="manufacturer",
@@ -1473,7 +1374,7 @@ async def test_restore_shared_device(
     assert len(device_registry.deleted_devices) == 1
 
     entry2 = device_registry.async_get_or_create(
-        config_entry_id=config_entry1.entry_id,
+        config_entry_id="123",
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("entry_123", "0123")},
         manufacturer="manufacturer",
@@ -1491,7 +1392,7 @@ async def test_restore_shared_device(
     device_registry.async_remove_device(entry.id)
 
     entry3 = device_registry.async_get_or_create(
-        config_entry_id=config_entry2.entry_id,
+        config_entry_id="234",
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("entry_234", "2345")},
         manufacturer="manufacturer",
@@ -1507,7 +1408,7 @@ async def test_restore_shared_device(
     assert isinstance(entry3.identifiers, set)
 
     entry4 = device_registry.async_get_or_create(
-        config_entry_id=config_entry1.entry_id,
+        config_entry_id="123",
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("entry_123", "0123")},
         manufacturer="manufacturer",
@@ -1555,23 +1456,19 @@ async def test_restore_shared_device(
 
 
 async def test_get_or_create_empty_then_set_default_values(
-    hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test creating an entry, then setting default name, model, manufacturer."""
-    config_entry = MockConfigEntry(entry_id="1234")
-    config_entry.add_to_hass(hass)
-
     entry = device_registry.async_get_or_create(
+        config_entry_id="1234",
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
-        config_entry_id=config_entry.entry_id,
     )
     assert entry.name is None
     assert entry.model is None
     assert entry.manufacturer is None
 
     entry = device_registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
+        config_entry_id="1234",
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         default_name="default name 1",
         default_model="default model 1",
@@ -1582,7 +1479,7 @@ async def test_get_or_create_empty_then_set_default_values(
     assert entry.manufacturer == "default manufacturer 1"
 
     entry = device_registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
+        config_entry_id="1234",
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         default_name="default name 2",
         default_model="default model 2",
@@ -1594,23 +1491,19 @@ async def test_get_or_create_empty_then_set_default_values(
 
 
 async def test_get_or_create_empty_then_update(
-    hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test creating an entry, then setting name, model, manufacturer."""
-    config_entry = MockConfigEntry(entry_id="1234")
-    config_entry.add_to_hass(hass)
-
     entry = device_registry.async_get_or_create(
+        config_entry_id="1234",
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
-        config_entry_id=config_entry.entry_id,
     )
     assert entry.name is None
     assert entry.model is None
     assert entry.manufacturer is None
 
     entry = device_registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
+        config_entry_id="1234",
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         name="name 1",
         model="model 1",
@@ -1621,7 +1514,7 @@ async def test_get_or_create_empty_then_update(
     assert entry.manufacturer == "manufacturer 1"
 
     entry = device_registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
+        config_entry_id="1234",
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         default_name="default name 1",
         default_model="default model 1",
@@ -1633,15 +1526,11 @@ async def test_get_or_create_empty_then_update(
 
 
 async def test_get_or_create_sets_default_values(
-    hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test creating an entry, then setting default name, model, manufacturer."""
-    config_entry = MockConfigEntry(entry_id="1234")
-    config_entry.add_to_hass(hass)
-
     entry = device_registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
+        config_entry_id="1234",
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         default_name="default name 1",
         default_model="default model 1",
@@ -1652,7 +1541,7 @@ async def test_get_or_create_sets_default_values(
     assert entry.manufacturer == "default manufacturer 1"
 
     entry = device_registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
+        config_entry_id="1234",
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         default_name="default name 2",
         default_model="default model 2",
@@ -1664,18 +1553,13 @@ async def test_get_or_create_sets_default_values(
 
 
 async def test_verify_suggested_area_does_not_overwrite_area_id(
-    hass: HomeAssistant,
-    device_registry: dr.DeviceRegistry,
-    area_registry: ar.AreaRegistry,
+    device_registry: dr.DeviceRegistry, area_registry: ar.AreaRegistry
 ) -> None:
     """Make sure suggested area does not override a set area id."""
-    config_entry = MockConfigEntry(entry_id="1234")
-    config_entry.add_to_hass(hass)
-
     game_room_area = area_registry.async_create("Game Room")
 
     original_entry = device_registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
+        config_entry_id="1234",
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("bridgeid", "0123")},
         sw_version="sw-version",
@@ -1690,7 +1574,7 @@ async def test_verify_suggested_area_does_not_overwrite_area_id(
     assert entry.area_id == game_room_area.id
 
     entry2 = device_registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
+        config_entry_id="1234",
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("bridgeid", "0123")},
         sw_version="sw-version",

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -8,7 +8,7 @@ import pytest
 from homeassistant import config_entries
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
 from homeassistant.core import CoreState, HomeAssistant, callback
-from homeassistant.exceptions import RequiredParameterMissing
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import (
     area_registry as ar,
     device_registry as dr,
@@ -39,8 +39,11 @@ async def test_get_or_create_returns_same_entry(
     update_events,
 ) -> None:
     """Make sure we do not duplicate entries."""
+    config_entry = MockConfigEntry(entry_id="1234")
+    config_entry.add_to_hass(hass)
+
     entry = device_registry.async_get_or_create(
-        config_entry_id="1234",
+        config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("bridgeid", "0123")},
         sw_version="sw-version",
@@ -50,7 +53,7 @@ async def test_get_or_create_returns_same_entry(
         suggested_area="Game Room",
     )
     entry2 = device_registry.async_get_or_create(
-        config_entry_id="1234",
+        config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "11:22:33:66:77:88")},
         identifiers={("bridgeid", "0123")},
         manufacturer="manufacturer",
@@ -58,7 +61,7 @@ async def test_get_or_create_returns_same_entry(
         suggested_area="Game Room",
     )
     entry3 = device_registry.async_get_or_create(
-        config_entry_id="1234",
+        config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
 
@@ -96,18 +99,22 @@ async def test_get_or_create_returns_same_entry(
 
 
 async def test_requirement_for_identifier_or_connection(
+    hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Make sure we do require some descriptor of device."""
+    config_entry = MockConfigEntry(entry_id="1234")
+    config_entry.add_to_hass(hass)
+
     entry = device_registry.async_get_or_create(
-        config_entry_id="1234",
+        config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers=set(),
         manufacturer="manufacturer",
         model="model",
     )
     entry2 = device_registry.async_get_or_create(
-        config_entry_id="1234",
+        config_entry_id=config_entry.entry_id,
         connections=set(),
         identifiers={("bridgeid", "0123")},
         manufacturer="manufacturer",
@@ -118,36 +125,41 @@ async def test_requirement_for_identifier_or_connection(
     assert entry
     assert entry2
 
-    with pytest.raises(RequiredParameterMissing) as exc_info:
+    with pytest.raises(HomeAssistantError):
         device_registry.async_get_or_create(
-            config_entry_id="1234",
+            config_entry_id=config_entry.entry_id,
             connections=set(),
             identifiers=set(),
             manufacturer="manufacturer",
             model="model",
         )
 
-    assert exc_info.value.parameter_names == ["identifiers", "connections"]
 
-
-async def test_multiple_config_entries(device_registry: dr.DeviceRegistry) -> None:
+async def test_multiple_config_entries(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
     """Make sure we do not get duplicate entries."""
+    config_entry1 = MockConfigEntry(entry_id="123")
+    config_entry1.add_to_hass(hass)
+    config_entry2 = MockConfigEntry(entry_id="456")
+    config_entry2.add_to_hass(hass)
+
     entry = device_registry.async_get_or_create(
-        config_entry_id="123",
+        config_entry_id=config_entry1.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("bridgeid", "0123")},
         manufacturer="manufacturer",
         model="model",
     )
     entry2 = device_registry.async_get_or_create(
-        config_entry_id="456",
+        config_entry_id=config_entry2.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("bridgeid", "0123")},
         manufacturer="manufacturer",
         model="model",
     )
     entry3 = device_registry.async_get_or_create(
-        config_entry_id="123",
+        config_entry_id=config_entry1.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("bridgeid", "0123")},
         manufacturer="manufacturer",
@@ -205,8 +217,11 @@ async def test_loading_from_storage(
     assert len(registry.devices) == 1
     assert len(registry.deleted_devices) == 1
 
+    config_entry = MockConfigEntry(entry_id="1234")
+    config_entry.add_to_hass(hass)
+
     entry = registry.async_get_or_create(
-        config_entry_id="1234",
+        config_entry_id=config_entry.entry_id,
         connections={("Zigbee", "01.23.45.67.89")},
         identifiers={("serial", "12:34:56:AB:CD:EF")},
         manufacturer="manufacturer",
@@ -235,7 +250,7 @@ async def test_loading_from_storage(
 
     # Restore a device, id should be reused from the deleted device entry
     entry = registry.async_get_or_create(
-        config_entry_id="1234",
+        config_entry_id=config_entry.entry_id,
         connections={("Zigbee", "23.45.67.89.01")},
         identifiers={("serial", "34:56:AB:CD:EF:12")},
         manufacturer="manufacturer",
@@ -248,6 +263,7 @@ async def test_loading_from_storage(
         identifiers={("serial", "34:56:AB:CD:EF:12")},
         manufacturer="manufacturer",
         model="model",
+        name="Mock Title",  # From config entry title
     )
     assert entry.id == "bcdefghijklmn"
     assert isinstance(entry.config_entries, set)
@@ -308,9 +324,12 @@ async def test_migration_1_1_to_1_3(
     await dr.async_load(hass)
     registry = dr.async_get(hass)
 
+    config_entry = MockConfigEntry(entry_id="1234")
+    config_entry.add_to_hass(hass)
+
     # Test data was loaded
     entry = registry.async_get_or_create(
-        config_entry_id="1234",
+        config_entry_id=config_entry.entry_id,
         connections={("Zigbee", "01.23.45.67.89")},
         identifiers={("serial", "12:34:56:AB:CD:EF")},
     )
@@ -318,7 +337,7 @@ async def test_migration_1_1_to_1_3(
 
     # Update to trigger a store
     entry = registry.async_get_or_create(
-        config_entry_id="1234",
+        config_entry_id=config_entry.entry_id,
         connections={("Zigbee", "01.23.45.67.89")},
         identifiers={("serial", "12:34:56:AB:CD:EF")},
         sw_version="new_version",
@@ -432,9 +451,12 @@ async def test_migration_1_2_to_1_3(
     await dr.async_load(hass)
     registry = dr.async_get(hass)
 
+    config_entry = MockConfigEntry(entry_id="1234")
+    config_entry.add_to_hass(hass)
+
     # Test data was loaded
     entry = registry.async_get_or_create(
-        config_entry_id="1234",
+        config_entry_id=config_entry.entry_id,
         connections={("Zigbee", "01.23.45.67.89")},
         identifiers={("serial", "12:34:56:AB:CD:EF")},
     )
@@ -442,7 +464,7 @@ async def test_migration_1_2_to_1_3(
 
     # Update to trigger a store
     entry = registry.async_get_or_create(
-        config_entry_id="1234",
+        config_entry_id=config_entry.entry_id,
         connections={("Zigbee", "01.23.45.67.89")},
         identifiers={("serial", "12:34:56:AB:CD:EF")},
         sw_version="new_version",
@@ -502,22 +524,27 @@ async def test_removing_config_entries(
     hass: HomeAssistant, device_registry: dr.DeviceRegistry, update_events
 ) -> None:
     """Make sure we do not get duplicate entries."""
+    config_entry1 = MockConfigEntry(entry_id="123")
+    config_entry1.add_to_hass(hass)
+    config_entry2 = MockConfigEntry(entry_id="456")
+    config_entry2.add_to_hass(hass)
+
     entry = device_registry.async_get_or_create(
-        config_entry_id="123",
+        config_entry_id=config_entry1.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("bridgeid", "0123")},
         manufacturer="manufacturer",
         model="model",
     )
     entry2 = device_registry.async_get_or_create(
-        config_entry_id="456",
+        config_entry_id=config_entry2.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("bridgeid", "0123")},
         manufacturer="manufacturer",
         model="model",
     )
     entry3 = device_registry.async_get_or_create(
-        config_entry_id="123",
+        config_entry_id=config_entry1.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "34:56:78:CD:EF:12")},
         identifiers={("bridgeid", "4567")},
         manufacturer="manufacturer",
@@ -562,22 +589,27 @@ async def test_deleted_device_removing_config_entries(
     hass: HomeAssistant, device_registry: dr.DeviceRegistry, update_events
 ) -> None:
     """Make sure we do not get duplicate entries."""
+    config_entry1 = MockConfigEntry(entry_id="123")
+    config_entry1.add_to_hass(hass)
+    config_entry2 = MockConfigEntry(entry_id="456")
+    config_entry2.add_to_hass(hass)
+
     entry = device_registry.async_get_or_create(
-        config_entry_id="123",
+        config_entry_id=config_entry1.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("bridgeid", "0123")},
         manufacturer="manufacturer",
         model="model",
     )
     entry2 = device_registry.async_get_or_create(
-        config_entry_id="456",
+        config_entry_id=config_entry2.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("bridgeid", "0123")},
         manufacturer="manufacturer",
         model="model",
     )
     entry3 = device_registry.async_get_or_create(
-        config_entry_id="123",
+        config_entry_id=config_entry1.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "34:56:78:CD:EF:12")},
         identifiers={("bridgeid", "4567")},
         manufacturer="manufacturer",
@@ -628,7 +660,7 @@ async def test_deleted_device_removing_config_entries(
 
     # Re-add, expect to keep the device id
     entry2 = device_registry.async_get_or_create(
-        config_entry_id="456",
+        config_entry_id=config_entry2.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("bridgeid", "0123")},
         manufacturer="manufacturer",
@@ -644,7 +676,7 @@ async def test_deleted_device_removing_config_entries(
 
     # Re-add, expect to get a new device id after the purge
     entry4 = device_registry.async_get_or_create(
-        config_entry_id="123",
+        config_entry_id=config_entry1.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("bridgeid", "0123")},
         manufacturer="manufacturer",
@@ -653,10 +685,15 @@ async def test_deleted_device_removing_config_entries(
     assert entry3.id != entry4.id
 
 
-async def test_removing_area_id(device_registry: dr.DeviceRegistry) -> None:
+async def test_removing_area_id(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
     """Make sure we can clear area id."""
+    config_entry = MockConfigEntry(entry_id="123")
+    config_entry.add_to_hass(hass)
+
     entry = device_registry.async_get_or_create(
-        config_entry_id="123",
+        config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("bridgeid", "0123")},
         manufacturer="manufacturer",
@@ -672,10 +709,17 @@ async def test_removing_area_id(device_registry: dr.DeviceRegistry) -> None:
     assert entry_w_area != entry_wo_area
 
 
-async def test_specifying_via_device_create(device_registry: dr.DeviceRegistry) -> None:
+async def test_specifying_via_device_create(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
     """Test specifying a via_device and removal of the hub device."""
+    config_entry1 = MockConfigEntry(entry_id="123")
+    config_entry1.add_to_hass(hass)
+    config_entry2 = MockConfigEntry(entry_id="456")
+    config_entry2.add_to_hass(hass)
+
     via = device_registry.async_get_or_create(
-        config_entry_id="123",
+        config_entry_id=config_entry1.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("hue", "0123")},
         manufacturer="manufacturer",
@@ -683,7 +727,7 @@ async def test_specifying_via_device_create(device_registry: dr.DeviceRegistry) 
     )
 
     light = device_registry.async_get_or_create(
-        config_entry_id="456",
+        config_entry_id=config_entry2.entry_id,
         connections=set(),
         identifiers={("hue", "456")},
         manufacturer="manufacturer",
@@ -698,10 +742,17 @@ async def test_specifying_via_device_create(device_registry: dr.DeviceRegistry) 
     assert light.via_device_id is None
 
 
-async def test_specifying_via_device_update(device_registry: dr.DeviceRegistry) -> None:
+async def test_specifying_via_device_update(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
     """Test specifying a via_device and updating."""
+    config_entry1 = MockConfigEntry(entry_id="123")
+    config_entry1.add_to_hass(hass)
+    config_entry2 = MockConfigEntry(entry_id="456")
+    config_entry2.add_to_hass(hass)
+
     light = device_registry.async_get_or_create(
-        config_entry_id="456",
+        config_entry_id=config_entry2.entry_id,
         connections=set(),
         identifiers={("hue", "456")},
         manufacturer="manufacturer",
@@ -712,7 +763,7 @@ async def test_specifying_via_device_update(device_registry: dr.DeviceRegistry) 
     assert light.via_device_id is None
 
     via = device_registry.async_get_or_create(
-        config_entry_id="123",
+        config_entry_id=config_entry1.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("hue", "0123")},
         manufacturer="manufacturer",
@@ -720,7 +771,7 @@ async def test_specifying_via_device_update(device_registry: dr.DeviceRegistry) 
     )
 
     light = device_registry.async_get_or_create(
-        config_entry_id="456",
+        config_entry_id=config_entry2.entry_id,
         connections=set(),
         identifiers={("hue", "456")},
         manufacturer="manufacturer",
@@ -735,8 +786,19 @@ async def test_loading_saving_data(
     hass: HomeAssistant, device_registry: dr.DeviceRegistry
 ) -> None:
     """Test that we load/save data correctly."""
+    config_entry1 = MockConfigEntry(entry_id="123")
+    config_entry1.add_to_hass(hass)
+    config_entry2 = MockConfigEntry(entry_id="456")
+    config_entry2.add_to_hass(hass)
+    config_entry3 = MockConfigEntry(entry_id="789")
+    config_entry3.add_to_hass(hass)
+    config_entry4 = MockConfigEntry(entry_id="abc")
+    config_entry4.add_to_hass(hass)
+    config_entry5 = MockConfigEntry(entry_id="999")
+    config_entry5.add_to_hass(hass)
+
     orig_via = device_registry.async_get_or_create(
-        config_entry_id="123",
+        config_entry_id=config_entry1.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("hue", "0123")},
         manufacturer="manufacturer",
@@ -747,7 +809,7 @@ async def test_loading_saving_data(
     )
 
     orig_light = device_registry.async_get_or_create(
-        config_entry_id="456",
+        config_entry_id=config_entry2.entry_id,
         connections=set(),
         identifiers={("hue", "456")},
         manufacturer="manufacturer",
@@ -757,7 +819,7 @@ async def test_loading_saving_data(
     )
 
     orig_light2 = device_registry.async_get_or_create(
-        config_entry_id="456",
+        config_entry_id=config_entry2.entry_id,
         connections=set(),
         identifiers={("hue", "789")},
         manufacturer="manufacturer",
@@ -768,7 +830,7 @@ async def test_loading_saving_data(
     device_registry.async_remove_device(orig_light2.id)
 
     orig_light3 = device_registry.async_get_or_create(
-        config_entry_id="789",
+        config_entry_id=config_entry3.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "34:56:AB:CD:EF:12")},
         identifiers={("hue", "abc")},
         manufacturer="manufacturer",
@@ -776,7 +838,7 @@ async def test_loading_saving_data(
     )
 
     device_registry.async_get_or_create(
-        config_entry_id="abc",
+        config_entry_id=config_entry4.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "34:56:AB:CD:EF:12")},
         identifiers={("abc", "123")},
         manufacturer="manufacturer",
@@ -786,7 +848,7 @@ async def test_loading_saving_data(
     device_registry.async_remove_device(orig_light3.id)
 
     orig_light4 = device_registry.async_get_or_create(
-        config_entry_id="789",
+        config_entry_id=config_entry3.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "34:56:AB:CD:EF:12")},
         identifiers={("hue", "abc")},
         manufacturer="manufacturer",
@@ -797,7 +859,7 @@ async def test_loading_saving_data(
     assert orig_light4.id == orig_light3.id
 
     orig_kitchen_light = device_registry.async_get_or_create(
-        config_entry_id="999",
+        config_entry_id=config_entry5.entry_id,
         connections=set(),
         identifiers={("hue", "999")},
         manufacturer="manufacturer",
@@ -851,10 +913,15 @@ async def test_loading_saving_data(
     assert orig_kitchen_light_witout_suggested_area == new_kitchen_light
 
 
-async def test_no_unnecessary_changes(device_registry: dr.DeviceRegistry) -> None:
+async def test_no_unnecessary_changes(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
     """Make sure we do not consider devices changes."""
+    config_entry = MockConfigEntry(entry_id="1234")
+    config_entry.add_to_hass(hass)
+
     entry = device_registry.async_get_or_create(
-        config_entry_id="1234",
+        config_entry_id=config_entry.entry_id,
         connections={("ethernet", "12:34:56:78:90:AB:CD:EF")},
         identifiers={("hue", "456"), ("bla", "123")},
     )
@@ -862,22 +929,27 @@ async def test_no_unnecessary_changes(device_registry: dr.DeviceRegistry) -> Non
         "homeassistant.helpers.device_registry.DeviceRegistry.async_schedule_save"
     ) as mock_save:
         entry2 = device_registry.async_get_or_create(
-            config_entry_id="1234", identifiers={("hue", "456")}
+            config_entry_id=config_entry.entry_id, identifiers={("hue", "456")}
         )
 
     assert entry.id == entry2.id
     assert len(mock_save.mock_calls) == 0
 
 
-async def test_format_mac(device_registry: dr.DeviceRegistry) -> None:
+async def test_format_mac(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
     """Make sure we normalize mac addresses."""
+    config_entry = MockConfigEntry(entry_id="1234")
+    config_entry.add_to_hass(hass)
+
     entry = device_registry.async_get_or_create(
-        config_entry_id="1234",
+        config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
     for mac in ["123456ABCDEF", "123456abcdef", "12:34:56:ab:cd:ef", "1234.56ab.cdef"]:
         test_entry = device_registry.async_get_or_create(
-            config_entry_id="1234",
+            config_entry_id=config_entry.entry_id,
             connections={(dr.CONNECTION_NETWORK_MAC, mac)},
         )
         assert test_entry.id == entry.id, mac
@@ -895,7 +967,7 @@ async def test_format_mac(device_registry: dr.DeviceRegistry) -> None:
         "123.456.abc.def",  # too many .
     ]:
         invalid_mac_entry = device_registry.async_get_or_create(
-            config_entry_id="1234",
+            config_entry_id=config_entry.entry_id,
             connections={(dr.CONNECTION_NETWORK_MAC, invalid)},
         )
         assert list(invalid_mac_entry.connections)[0][1] == invalid
@@ -905,8 +977,11 @@ async def test_update(
     hass: HomeAssistant, device_registry: dr.DeviceRegistry, update_events
 ) -> None:
     """Verify that we can update some attributes of a device."""
+    config_entry = MockConfigEntry(entry_id="1234")
+    config_entry.add_to_hass(hass)
+
     entry = device_registry.async_get_or_create(
-        config_entry_id="1234",
+        config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("hue", "456"), ("bla", "123")},
     )
@@ -1001,22 +1076,27 @@ async def test_update_remove_config_entries(
     hass: HomeAssistant, device_registry: dr.DeviceRegistry, update_events
 ) -> None:
     """Make sure we do not get duplicate entries."""
+    config_entry1 = MockConfigEntry(entry_id="123")
+    config_entry1.add_to_hass(hass)
+    config_entry2 = MockConfigEntry(entry_id="456")
+    config_entry2.add_to_hass(hass)
+
     entry = device_registry.async_get_or_create(
-        config_entry_id="123",
+        config_entry_id=config_entry1.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("bridgeid", "0123")},
         manufacturer="manufacturer",
         model="model",
     )
     entry2 = device_registry.async_get_or_create(
-        config_entry_id="456",
+        config_entry_id=config_entry2.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("bridgeid", "0123")},
         manufacturer="manufacturer",
         model="model",
     )
     entry3 = device_registry.async_get_or_create(
-        config_entry_id="123",
+        config_entry_id=config_entry1.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "34:56:78:CD:EF:12")},
         identifiers={("bridgeid", "4567")},
         manufacturer="manufacturer",
@@ -1069,8 +1149,11 @@ async def test_update_suggested_area(
     update_events,
 ) -> None:
     """Verify that we can update the suggested area version of a device."""
+    config_entry = MockConfigEntry(entry_id="1234")
+    config_entry.add_to_hass(hass)
+
     entry = device_registry.async_get_or_create(
-        config_entry_id="1234",
+        config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("bla", "123")},
     )
@@ -1132,9 +1215,12 @@ async def test_cleanup_device_registry(
     d3 = device_registry.async_get_or_create(
         identifiers={("hue", "d3")}, config_entry_id=config_entry.entry_id
     )
+    non_existing_config_entry = MockConfigEntry(entry_id="non_existing")
+    non_existing_config_entry.add_to_hass(hass)
     device_registry.async_get_or_create(
         identifiers={("something", "d4")}, config_entry_id="non_existing"
     )
+    hass.config_entries._entries.pop(non_existing_config_entry.entry_id)
 
     ent_reg = er.async_get(hass)
     ent_reg.async_get_or_create("light", "hue", "e1", device_id=d1.id)
@@ -1236,8 +1322,11 @@ async def test_restore_device(
     hass: HomeAssistant, device_registry: dr.DeviceRegistry, update_events
 ) -> None:
     """Make sure device id is stable."""
+    config_entry = MockConfigEntry(entry_id="123")
+    config_entry.add_to_hass(hass)
+
     entry = device_registry.async_get_or_create(
-        config_entry_id="123",
+        config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("bridgeid", "0123")},
         manufacturer="manufacturer",
@@ -1253,14 +1342,14 @@ async def test_restore_device(
     assert len(device_registry.deleted_devices) == 1
 
     entry2 = device_registry.async_get_or_create(
-        config_entry_id="123",
+        config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "34:56:78:CD:EF:12")},
         identifiers={("bridgeid", "4567")},
         manufacturer="manufacturer",
         model="model",
     )
     entry3 = device_registry.async_get_or_create(
-        config_entry_id="123",
+        config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("bridgeid", "0123")},
         manufacturer="manufacturer",
@@ -1297,8 +1386,11 @@ async def test_restore_simple_device(
     hass: HomeAssistant, device_registry: dr.DeviceRegistry, update_events
 ) -> None:
     """Make sure device id is stable."""
+    config_entry = MockConfigEntry(entry_id="123")
+    config_entry.add_to_hass(hass)
+
     entry = device_registry.async_get_or_create(
-        config_entry_id="123",
+        config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("bridgeid", "0123")},
     )
@@ -1312,12 +1404,12 @@ async def test_restore_simple_device(
     assert len(device_registry.deleted_devices) == 1
 
     entry2 = device_registry.async_get_or_create(
-        config_entry_id="123",
+        config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "34:56:78:CD:EF:12")},
         identifiers={("bridgeid", "4567")},
     )
     entry3 = device_registry.async_get_or_create(
-        config_entry_id="123",
+        config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("bridgeid", "0123")},
     )
@@ -1348,8 +1440,13 @@ async def test_restore_shared_device(
     hass: HomeAssistant, device_registry: dr.DeviceRegistry, update_events
 ) -> None:
     """Make sure device id is stable for shared devices."""
+    config_entry1 = MockConfigEntry(entry_id="123")
+    config_entry1.add_to_hass(hass)
+    config_entry2 = MockConfigEntry(entry_id="234")
+    config_entry2.add_to_hass(hass)
+
     entry = device_registry.async_get_or_create(
-        config_entry_id="123",
+        config_entry_id=config_entry1.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("entry_123", "0123")},
         manufacturer="manufacturer",
@@ -1360,7 +1457,7 @@ async def test_restore_shared_device(
     assert len(device_registry.deleted_devices) == 0
 
     device_registry.async_get_or_create(
-        config_entry_id="234",
+        config_entry_id=config_entry2.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("entry_234", "2345")},
         manufacturer="manufacturer",
@@ -1376,7 +1473,7 @@ async def test_restore_shared_device(
     assert len(device_registry.deleted_devices) == 1
 
     entry2 = device_registry.async_get_or_create(
-        config_entry_id="123",
+        config_entry_id=config_entry1.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("entry_123", "0123")},
         manufacturer="manufacturer",
@@ -1394,7 +1491,7 @@ async def test_restore_shared_device(
     device_registry.async_remove_device(entry.id)
 
     entry3 = device_registry.async_get_or_create(
-        config_entry_id="234",
+        config_entry_id=config_entry2.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("entry_234", "2345")},
         manufacturer="manufacturer",
@@ -1410,7 +1507,7 @@ async def test_restore_shared_device(
     assert isinstance(entry3.identifiers, set)
 
     entry4 = device_registry.async_get_or_create(
-        config_entry_id="123",
+        config_entry_id=config_entry1.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("entry_123", "0123")},
         manufacturer="manufacturer",
@@ -1458,19 +1555,24 @@ async def test_restore_shared_device(
 
 
 async def test_get_or_create_empty_then_set_default_values(
+    hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test creating an entry, then setting default name, model, manufacturer."""
+    config_entry = MockConfigEntry(entry_id="1234")
+    config_entry.add_to_hass(hass)
+
     entry = device_registry.async_get_or_create(
-        identifiers={("bridgeid", "0123")}, config_entry_id="1234"
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+        config_entry_id=config_entry.entry_id,
     )
     assert entry.name is None
     assert entry.model is None
     assert entry.manufacturer is None
 
     entry = device_registry.async_get_or_create(
-        config_entry_id="1234",
-        identifiers={("bridgeid", "0123")},
+        config_entry_id=config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         default_name="default name 1",
         default_model="default model 1",
         default_manufacturer="default manufacturer 1",
@@ -1480,8 +1582,8 @@ async def test_get_or_create_empty_then_set_default_values(
     assert entry.manufacturer == "default manufacturer 1"
 
     entry = device_registry.async_get_or_create(
-        config_entry_id="1234",
-        identifiers={("bridgeid", "0123")},
+        config_entry_id=config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         default_name="default name 2",
         default_model="default model 2",
         default_manufacturer="default manufacturer 2",
@@ -1492,19 +1594,24 @@ async def test_get_or_create_empty_then_set_default_values(
 
 
 async def test_get_or_create_empty_then_update(
+    hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test creating an entry, then setting name, model, manufacturer."""
+    config_entry = MockConfigEntry(entry_id="1234")
+    config_entry.add_to_hass(hass)
+
     entry = device_registry.async_get_or_create(
-        identifiers={("bridgeid", "0123")}, config_entry_id="1234"
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+        config_entry_id=config_entry.entry_id,
     )
     assert entry.name is None
     assert entry.model is None
     assert entry.manufacturer is None
 
     entry = device_registry.async_get_or_create(
-        config_entry_id="1234",
-        identifiers={("bridgeid", "0123")},
+        config_entry_id=config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         name="name 1",
         model="model 1",
         manufacturer="manufacturer 1",
@@ -1514,8 +1621,8 @@ async def test_get_or_create_empty_then_update(
     assert entry.manufacturer == "manufacturer 1"
 
     entry = device_registry.async_get_or_create(
-        config_entry_id="1234",
-        identifiers={("bridgeid", "0123")},
+        config_entry_id=config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         default_name="default name 1",
         default_model="default model 1",
         default_manufacturer="default manufacturer 1",
@@ -1526,12 +1633,16 @@ async def test_get_or_create_empty_then_update(
 
 
 async def test_get_or_create_sets_default_values(
+    hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test creating an entry, then setting default name, model, manufacturer."""
+    config_entry = MockConfigEntry(entry_id="1234")
+    config_entry.add_to_hass(hass)
+
     entry = device_registry.async_get_or_create(
-        config_entry_id="1234",
-        identifiers={("bridgeid", "0123")},
+        config_entry_id=config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         default_name="default name 1",
         default_model="default model 1",
         default_manufacturer="default manufacturer 1",
@@ -1541,8 +1652,8 @@ async def test_get_or_create_sets_default_values(
     assert entry.manufacturer == "default manufacturer 1"
 
     entry = device_registry.async_get_or_create(
-        config_entry_id="1234",
-        identifiers={("bridgeid", "0123")},
+        config_entry_id=config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         default_name="default name 2",
         default_model="default model 2",
         default_manufacturer="default manufacturer 2",
@@ -1553,13 +1664,18 @@ async def test_get_or_create_sets_default_values(
 
 
 async def test_verify_suggested_area_does_not_overwrite_area_id(
-    device_registry: dr.DeviceRegistry, area_registry: ar.AreaRegistry
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    area_registry: ar.AreaRegistry,
 ) -> None:
     """Make sure suggested area does not override a set area id."""
+    config_entry = MockConfigEntry(entry_id="1234")
+    config_entry.add_to_hass(hass)
+
     game_room_area = area_registry.async_create("Game Room")
 
     original_entry = device_registry.async_get_or_create(
-        config_entry_id="1234",
+        config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("bridgeid", "0123")},
         sw_version="sw-version",
@@ -1574,7 +1690,7 @@ async def test_verify_suggested_area_does_not_overwrite_area_id(
     assert entry.area_id == game_room_area.id
 
     entry2 = device_registry.async_get_or_create(
-        config_entry_id="1234",
+        config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={("bridgeid", "0123")},
         sw_version="sw-version",

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -972,6 +972,7 @@ async def _test_friendly_name(
 
     platform = MockPlatform(async_setup_entry=async_setup_entry)
     config_entry = MockConfigEntry(entry_id="super-mock-id")
+    config_entry.add_to_hass(hass)
     entity_platform = MockEntityPlatform(
         hass, platform_name=config_entry.domain, platform=platform
     )

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -1061,9 +1061,11 @@ async def test_entity_registry_updates_invalid_entity_id(hass: HomeAssistant) ->
 
 async def test_device_info_called(hass: HomeAssistant) -> None:
     """Test device info is forwarded correctly."""
+    config_entry = MockConfigEntry(entry_id="123")
+    config_entry.add_to_hass(hass)
     registry = dr.async_get(hass)
     via = registry.async_get_or_create(
-        config_entry_id="123",
+        config_entry_id=config_entry.entry_id,
         connections=set(),
         identifiers={("hue", "via-id")},
         manufacturer="manufacturer",
@@ -1099,6 +1101,7 @@ async def test_device_info_called(hass: HomeAssistant) -> None:
 
     platform = MockPlatform(async_setup_entry=async_setup_entry)
     config_entry = MockConfigEntry(entry_id="super-mock-id")
+    config_entry.add_to_hass(hass)
     entity_platform = MockEntityPlatform(
         hass, platform_name=config_entry.domain, platform=platform
     )
@@ -1125,9 +1128,11 @@ async def test_device_info_called(hass: HomeAssistant) -> None:
 
 async def test_device_info_not_overrides(hass: HomeAssistant) -> None:
     """Test device info is forwarded correctly."""
+    config_entry = MockConfigEntry(entry_id="bla")
+    config_entry.add_to_hass(hass)
     registry = dr.async_get(hass)
     device = registry.async_get_or_create(
-        config_entry_id="bla",
+        config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "abcd")},
         manufacturer="test-manufacturer",
         model="test-model",
@@ -1155,6 +1160,7 @@ async def test_device_info_not_overrides(hass: HomeAssistant) -> None:
 
     platform = MockPlatform(async_setup_entry=async_setup_entry)
     config_entry = MockConfigEntry(entry_id="super-mock-id")
+    config_entry.add_to_hass(hass)
     entity_platform = MockEntityPlatform(
         hass, platform_name=config_entry.domain, platform=platform
     )
@@ -1175,9 +1181,11 @@ async def test_device_info_homeassistant_url(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test device info with homeassistant URL."""
+    config_entry = MockConfigEntry(entry_id="123")
+    config_entry.add_to_hass(hass)
     registry = dr.async_get(hass)
     registry.async_get_or_create(
-        config_entry_id="123",
+        config_entry_id=config_entry.entry_id,
         connections=set(),
         identifiers={("mqtt", "via-id")},
         manufacturer="manufacturer",
@@ -1202,6 +1210,7 @@ async def test_device_info_homeassistant_url(
 
     platform = MockPlatform(async_setup_entry=async_setup_entry)
     config_entry = MockConfigEntry(entry_id="super-mock-id")
+    config_entry.add_to_hass(hass)
     entity_platform = MockEntityPlatform(
         hass, platform_name=config_entry.domain, platform=platform
     )
@@ -1221,9 +1230,11 @@ async def test_device_info_change_to_no_url(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test device info changes to no URL."""
+    config_entry = MockConfigEntry(entry_id="123")
+    config_entry.add_to_hass(hass)
     registry = dr.async_get(hass)
     registry.async_get_or_create(
-        config_entry_id="123",
+        config_entry_id=config_entry.entry_id,
         connections=set(),
         identifiers={("mqtt", "via-id")},
         manufacturer="manufacturer",
@@ -1249,6 +1260,7 @@ async def test_device_info_change_to_no_url(
 
     platform = MockPlatform(async_setup_entry=async_setup_entry)
     config_entry = MockConfigEntry(entry_id="super-mock-id")
+    config_entry.add_to_hass(hass)
     entity_platform = MockEntityPlatform(
         hass, platform_name=config_entry.domain, platform=platform
     )
@@ -1304,6 +1316,7 @@ async def test_entity_disabled_by_device(hass: HomeAssistant) -> None:
 
     platform = MockPlatform(async_setup_entry=async_setup_entry)
     config_entry = MockConfigEntry(entry_id="super-mock-id", domain=DOMAIN)
+    config_entry.add_to_hass(hass)
     entity_platform = MockEntityPlatform(
         hass, platform_name=config_entry.domain, platform=platform
     )
@@ -1621,6 +1634,7 @@ async def test_entity_name_influences_entity_id(
 
     platform = MockPlatform(async_setup_entry=async_setup_entry)
     config_entry = MockConfigEntry(entry_id="super-mock-id")
+    config_entry.add_to_hass(hass)
     entity_platform = MockEntityPlatform(
         hass, platform_name=config_entry.domain, platform=platform
     )
@@ -1690,6 +1704,7 @@ async def test_translated_entity_name_influences_entity_id(
 
     platform = MockPlatform(async_setup_entry=async_setup_entry)
     config_entry = MockConfigEntry(entry_id="super-mock-id")
+    config_entry.add_to_hass(hass)
     entity_platform = MockEntityPlatform(
         hass, platform_name=config_entry.domain, platform=platform
     )
@@ -1773,6 +1788,7 @@ async def test_translated_device_class_name_influences_entity_id(
 
     platform = MockPlatform(async_setup_entry=async_setup_entry)
     config_entry = MockConfigEntry(entry_id="super-mock-id")
+    config_entry.add_to_hass(hass)
     entity_platform = MockEntityPlatform(
         hass, platform_name=config_entry.domain, platform=platform
     )
@@ -1830,6 +1846,7 @@ async def test_device_name_defaulting_config_entry(
 
     platform = MockPlatform(async_setup_entry=async_setup_entry)
     config_entry = MockConfigEntry(title=config_entry_title, entry_id="super-mock-id")
+    config_entry.add_to_hass(hass)
     entity_platform = MockEntityPlatform(
         hass, platform_name=config_entry.domain, platform=platform
     )
@@ -1882,6 +1899,7 @@ async def test_device_type_error_checking(
     config_entry = MockConfigEntry(
         title="Mock Config Entry Title", entry_id="super-mock-id"
     )
+    config_entry.add_to_hass(hass)
     entity_platform = MockEntityPlatform(
         hass, platform_name=config_entry.domain, platform=platform
     )

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -1061,11 +1061,9 @@ async def test_entity_registry_updates_invalid_entity_id(hass: HomeAssistant) ->
 
 async def test_device_info_called(hass: HomeAssistant) -> None:
     """Test device info is forwarded correctly."""
-    config_entry = MockConfigEntry(entry_id="123")
-    config_entry.add_to_hass(hass)
     registry = dr.async_get(hass)
     via = registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
+        config_entry_id="123",
         connections=set(),
         identifiers={("hue", "via-id")},
         manufacturer="manufacturer",
@@ -1101,7 +1099,6 @@ async def test_device_info_called(hass: HomeAssistant) -> None:
 
     platform = MockPlatform(async_setup_entry=async_setup_entry)
     config_entry = MockConfigEntry(entry_id="super-mock-id")
-    config_entry.add_to_hass(hass)
     entity_platform = MockEntityPlatform(
         hass, platform_name=config_entry.domain, platform=platform
     )
@@ -1128,11 +1125,9 @@ async def test_device_info_called(hass: HomeAssistant) -> None:
 
 async def test_device_info_not_overrides(hass: HomeAssistant) -> None:
     """Test device info is forwarded correctly."""
-    config_entry = MockConfigEntry(entry_id="bla")
-    config_entry.add_to_hass(hass)
     registry = dr.async_get(hass)
     device = registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
+        config_entry_id="bla",
         connections={(dr.CONNECTION_NETWORK_MAC, "abcd")},
         manufacturer="test-manufacturer",
         model="test-model",
@@ -1160,7 +1155,6 @@ async def test_device_info_not_overrides(hass: HomeAssistant) -> None:
 
     platform = MockPlatform(async_setup_entry=async_setup_entry)
     config_entry = MockConfigEntry(entry_id="super-mock-id")
-    config_entry.add_to_hass(hass)
     entity_platform = MockEntityPlatform(
         hass, platform_name=config_entry.domain, platform=platform
     )
@@ -1181,11 +1175,9 @@ async def test_device_info_homeassistant_url(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test device info with homeassistant URL."""
-    config_entry = MockConfigEntry(entry_id="123")
-    config_entry.add_to_hass(hass)
     registry = dr.async_get(hass)
     registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
+        config_entry_id="123",
         connections=set(),
         identifiers={("mqtt", "via-id")},
         manufacturer="manufacturer",
@@ -1210,7 +1202,6 @@ async def test_device_info_homeassistant_url(
 
     platform = MockPlatform(async_setup_entry=async_setup_entry)
     config_entry = MockConfigEntry(entry_id="super-mock-id")
-    config_entry.add_to_hass(hass)
     entity_platform = MockEntityPlatform(
         hass, platform_name=config_entry.domain, platform=platform
     )
@@ -1230,11 +1221,9 @@ async def test_device_info_change_to_no_url(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test device info changes to no URL."""
-    config_entry = MockConfigEntry(entry_id="123")
-    config_entry.add_to_hass(hass)
     registry = dr.async_get(hass)
     registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
+        config_entry_id="123",
         connections=set(),
         identifiers={("mqtt", "via-id")},
         manufacturer="manufacturer",
@@ -1260,7 +1249,6 @@ async def test_device_info_change_to_no_url(
 
     platform = MockPlatform(async_setup_entry=async_setup_entry)
     config_entry = MockConfigEntry(entry_id="super-mock-id")
-    config_entry.add_to_hass(hass)
     entity_platform = MockEntityPlatform(
         hass, platform_name=config_entry.domain, platform=platform
     )
@@ -1316,7 +1304,6 @@ async def test_entity_disabled_by_device(hass: HomeAssistant) -> None:
 
     platform = MockPlatform(async_setup_entry=async_setup_entry)
     config_entry = MockConfigEntry(entry_id="super-mock-id", domain=DOMAIN)
-    config_entry.add_to_hass(hass)
     entity_platform = MockEntityPlatform(
         hass, platform_name=config_entry.domain, platform=platform
     )
@@ -1634,7 +1621,6 @@ async def test_entity_name_influences_entity_id(
 
     platform = MockPlatform(async_setup_entry=async_setup_entry)
     config_entry = MockConfigEntry(entry_id="super-mock-id")
-    config_entry.add_to_hass(hass)
     entity_platform = MockEntityPlatform(
         hass, platform_name=config_entry.domain, platform=platform
     )
@@ -1704,7 +1690,6 @@ async def test_translated_entity_name_influences_entity_id(
 
     platform = MockPlatform(async_setup_entry=async_setup_entry)
     config_entry = MockConfigEntry(entry_id="super-mock-id")
-    config_entry.add_to_hass(hass)
     entity_platform = MockEntityPlatform(
         hass, platform_name=config_entry.domain, platform=platform
     )
@@ -1788,7 +1773,6 @@ async def test_translated_device_class_name_influences_entity_id(
 
     platform = MockPlatform(async_setup_entry=async_setup_entry)
     config_entry = MockConfigEntry(entry_id="super-mock-id")
-    config_entry.add_to_hass(hass)
     entity_platform = MockEntityPlatform(
         hass, platform_name=config_entry.domain, platform=platform
     )
@@ -1899,7 +1883,6 @@ async def test_device_type_error_checking(
     config_entry = MockConfigEntry(
         title="Mock Config Entry Title", entry_id="super-mock-id"
     )
-    config_entry.add_to_hass(hass)
     entity_platform = MockEntityPlatform(
         hass, platform_name=config_entry.domain, platform=platform
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Move device info validation introduced in https://github.com/home-assistant/core/pull/95641 from entity platform to device registry

Rationale:
Devices are not only created by entity platform, by moving the validation all calls creating devices will be validated

Needs:
- https://github.com/home-assistant/core/pull/96480
- https://github.com/home-assistant/core/pull/96481
- https://github.com/home-assistant/core/pull/96482
- https://github.com/home-assistant/core/pull/96483

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
