### PR TITLE
Add integrations for Mitsubishi-Climaveneta i-MXW and i-Life2 fancoil series

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -203,6 +203,9 @@ build.json @home-assistant/supervisor
 /homeassistant/components/cisco_webex_teams/ @fbradyirl
 /homeassistant/components/climate/ @home-assistant/core
 /tests/components/climate/ @home-assistant/core
+/homeassistant/components/climaveneta_ilife/ @tadiern
+/homeassistant/components/climaveneta_imxw/ @tadiern
+/tests/components/climaveneta_imxw/ @tadiern
 /homeassistant/components/cloud/ @home-assistant/cloud
 /tests/components/cloud/ @home-assistant/cloud
 /homeassistant/components/cloudflare/ @ludeeus @ctalkington

--- a/homeassistant/components/climaveneta_ilife/__init__.py
+++ b/homeassistant/components/climaveneta_ilife/__init__.py
@@ -1,0 +1,1 @@
+"""The climaveneta_ilife integration."""

--- a/homeassistant/components/climaveneta_ilife/climate.py
+++ b/homeassistant/components/climaveneta_ilife/climate.py
@@ -1,0 +1,301 @@
+"""Support for the Mitsubishi-Climaveneta iLife2 fancoil series."""
+from __future__ import annotations
+
+from datetime import timedelta
+import logging
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.components.climate import (
+    FAN_AUTO,
+    FAN_HIGH,
+    FAN_LOW,
+    FAN_MEDIUM,
+    FAN_OFF,
+    PLATFORM_SCHEMA,
+    ClimateEntity,
+    ClimateEntityFeature,
+    HVACAction,
+    HVACMode,
+)
+from homeassistant.components.modbus import (
+    CALL_TYPE_REGISTER_HOLDING,
+    CALL_TYPE_WRITE_REGISTER,
+    CONF_HUB,
+    DEFAULT_HUB,
+    ModbusHub,
+    get_hub,
+)
+from homeassistant.const import (
+    ATTR_TEMPERATURE,
+    CONF_NAME,
+    CONF_SLAVE,
+    DEVICE_DEFAULT_NAME,
+    UnitOfTemperature,
+)
+from homeassistant.core import HomeAssistant
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Optional(CONF_HUB, default=DEFAULT_HUB): cv.string,
+        vol.Required(CONF_SLAVE): vol.All(int, vol.Range(min=0, max=255)),
+        vol.Optional(CONF_NAME, default=DEVICE_DEFAULT_NAME): cv.string,
+    }
+)
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+MODE_SUMMER = 0
+MODE_WINTER = 1
+
+MODE_OFF = 0
+MODE_ON = 1
+
+WATER_BYPASS = 0
+WATER_CIRCULATING = 1
+
+
+# registers
+TARGET_TEMPERATURE_REGISTER = 231
+ACTUAL_AIR_TEMPERATURE_REGISTER = 0
+ACTUAL_WATER_TEMPERATURE_REGISTER = 1
+STATE_READ_SETPOINT_REGISTER = 8
+STATE_READ_REGISTER = 104
+STATE_READ_FAN_SPEED = 15
+STATE_READ_PROGRAM_REGISTER = 201
+STATE_OUT_REGISTER = 9
+STATE_MAN_REGISTER = 233
+
+
+SCAN_INTERVAL = timedelta(seconds=30)
+
+
+async def async_setup_platform(
+    hass: HomeAssistant,
+    config: ConfigType,
+    async_add_entities: AddEntitiesCallback,
+    discovery_info: DiscoveryInfoType | None = None,
+) -> None:
+    """Set up the ClimavenetaILIFE Platform."""
+    modbus_slave = config.get(CONF_SLAVE)
+    name = config.get(CONF_NAME)
+    hub = get_hub(hass, config[CONF_HUB])
+    async_add_entities([ClimavenetaILIFE(hub, modbus_slave, name)], True)
+
+
+class ClimavenetaILIFE(ClimateEntity):
+    """Representation of a ClimavenetaILIFE fancoil unit."""
+
+    _attr_fan_modes = [FAN_AUTO, FAN_LOW, FAN_MEDIUM, FAN_HIGH]
+    _attr_hvac_mode = FAN_AUTO
+
+    _attr_hvac_mode = HVACMode.COOL
+    _attr_hvac_modes = [
+        HVACMode.HEAT,
+        HVACMode.COOL,
+        HVACMode.HEAT_COOL,
+        HVACMode.OFF,
+    ]
+
+    _attr_supported_features = (
+        ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.FAN_MODE
+    )
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
+
+    def __init__(
+        self, hub: ModbusHub, modbus_slave: int | None, name: str | None
+    ) -> None:
+        """Initialize the unit."""
+        self._hub = hub
+        self._attr_name = name
+        self._slave = modbus_slave
+        self._attr_fan_mode = None
+        self._filter_alarm: int | None = None
+        self._heat_recovery: int | None = None
+        self._heater_enabled: int | None = None
+        self._heating: int | None = None
+        self._cooling: int | None = None
+        self._alarm = False
+        self._min_temp = 15
+        self._max_temp = 30
+        self._attr_on_off = 0
+        self._attr_fan_only = 0
+        self._attr_ev_water = 0
+        self._attr_unique_id = f"{str(hub.name)}_{name}_{str(modbus_slave)}"
+
+    async def async_update(self) -> None:
+        """Update unit attributes."""
+
+        # setpoint and actuals
+        self._attr_target_temperature = await self._async_read_temp_from_register(
+            CALL_TYPE_REGISTER_HOLDING, STATE_READ_SETPOINT_REGISTER
+        )
+
+        self._attr_current_temperature = await self._async_read_temp_from_register(
+            CALL_TYPE_REGISTER_HOLDING, ACTUAL_AIR_TEMPERATURE_REGISTER
+        )
+
+        # state heating/cooling/fan only/off
+
+        man_register = await self._async_read_int16_from_register(
+            CALL_TYPE_REGISTER_HOLDING, STATE_MAN_REGISTER
+        )
+
+        program_register = await self._async_read_int16_from_register(
+            CALL_TYPE_REGISTER_HOLDING, STATE_READ_PROGRAM_REGISTER
+        )
+        if (program_register & (1 << 7)) == 0b10000000:
+            self._attr_on_off = 0  # standby
+        else:
+            self._attr_on_off = 1  # normal operation
+
+        if self._attr_on_off:
+            stat_register = await self._async_read_int16_from_register(
+                CALL_TYPE_REGISTER_HOLDING, STATE_READ_REGISTER
+            )
+            await self._async_read_int16_from_register(
+                CALL_TYPE_REGISTER_HOLDING, STATE_OUT_REGISTER
+            )
+
+            if man_register == 0:
+                self._attr_hvac_mode = HVACMode.HEAT_COOL
+            elif man_register == 3:
+                self._attr_hvac_mode = HVACMode.HEAT
+            elif man_register == 5:
+                self._attr_hvac_mode = HVACMode.COOL
+            else:
+                self._attr_hvac_mode = (
+                    HVACMode.OFF
+                )  # not a valid number, this register should always be 0, 3 or 5.
+
+            if (stat_register & (1 << 1) == 0) and (stat_register & (1 << 0) == 0):
+                self._attr_hvac_action = HVACAction.IDLE
+            elif stat_register & (1 << 1) == 0:
+                self._attr_hvac_action = HVACAction.COOLING
+            else:
+                self._attr_hvac_action = HVACAction.HEATING
+
+            # fan speed
+            if (program_register & 0b111) == 0b000:
+                self._attr_fan_mode = FAN_AUTO
+            elif (program_register & 0b111) == 0b001:
+                self._attr_fan_mode = FAN_LOW
+            elif (program_register & 0b111) == 0b010:
+                self._attr_fan_mode = FAN_MEDIUM
+            elif (program_register & 0b111) == 0b011:
+                self._attr_fan_mode = FAN_HIGH
+            else:
+                self._attr_fan_mode = FAN_OFF  # unknown state
+        else:
+            self._attr_hvac_mode = HVACMode.OFF
+            self._attr_hvac_action = HVACAction.OFF
+            self._attr_fan_mode = FAN_OFF
+
+    async def async_set_temperature(self, **kwargs: Any) -> None:
+        """Set new target temperature."""
+        if (target_temperature := kwargs.get(ATTR_TEMPERATURE)) is None:
+            _LOGGER.error("Received invalid temperature")
+            return
+
+        if await self._async_write_int16_to_register(
+            TARGET_TEMPERATURE_REGISTER, int(target_temperature * 10)
+        ):
+            self._attr_target_temperature = target_temperature
+        else:
+            _LOGGER.error(
+                "Modbus error setting target temperature to Climaveneta i-Life"
+            )
+
+    async def async_set_fan_mode(self, fan_mode: str) -> None:
+        """Set new fan mode."""
+        if fan_mode in (FAN_AUTO, FAN_LOW, FAN_MEDIUM, FAN_HIGH) and self.fan_modes:
+            fan_mode_index = self.fan_modes.index(fan_mode)
+
+            if self._attr_on_off == MODE_OFF:
+                fan_mode_index = fan_mode_index + (
+                    1 << 7
+                )  # keep it powered off (standby) if fan mode is set when off.
+
+            if self.fan_modes and await self._async_write_int16_to_register(
+                STATE_READ_PROGRAM_REGISTER, fan_mode_index
+            ):
+                self._attr_fan_mode = fan_mode
+            else:
+                _LOGGER.error("Modbus error setting fan mode to Climaveneta i-Life")
+
+    async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
+        """Set new target hvac mode."""
+        if hvac_mode == HVACMode.OFF:
+            if await self._async_write_int16_to_register(
+                STATE_READ_PROGRAM_REGISTER, 0b10000000
+            ):
+                self._attr_hvac_mode = hvac_mode
+            else:
+                _LOGGER.error(
+                    "Modbus error writing hvac mode OFF to Climaveneta i-Life"
+                )
+        else:
+            # if the device is off, then power it on and then set the mode
+            if self._attr_on_off == MODE_OFF:
+                await self._async_write_int16_to_register(
+                    STATE_READ_PROGRAM_REGISTER, 0
+                )
+            if hvac_mode == HVACMode.COOL:
+                winter_summer = 5  # summer
+            elif hvac_mode == HVACMode.HEAT_COOL:
+                winter_summer = 0  # auto
+            else:
+                winter_summer = 3  # winter
+            if self.hvac_modes and await self._async_write_int16_to_register(
+                STATE_MAN_REGISTER, winter_summer
+            ):
+                self._attr_hvac_mode = hvac_mode
+            else:
+                _LOGGER.error(
+                    "Modbus error setting hvac mode %s to Climaveneta i-Life", hvac_mode
+                )
+
+    # Based on _async_read_register in ModbusThermostat class
+    async def _async_read_int16_from_register(
+        self, register_type: str, register: int
+    ) -> int:
+        """Read register using the Modbus hub slave."""
+
+        # _LOGGER.error(
+        #     "Climaveneta iMWX read from slave %s, register %s",
+        #     str(self._slave),
+        #     str(register),
+        # )
+
+        result = await self._hub.async_pymodbus_call(
+            self._slave, register, 1, register_type
+        )
+        if result is None:
+            _LOGGER.error("Error reading value from Climaveneta i-Life modbus adapter")
+            return -1
+
+        return int(result.registers[0])
+
+    async def _async_read_temp_from_register(
+        self, register_type: str, register: int
+    ) -> float:
+        result = float(
+            await self._async_read_int16_from_register(register_type, register)
+        )
+        if not result:
+            return -1
+        return result / 10.0
+
+    async def _async_write_int16_to_register(self, register: int, value: int) -> bool:
+        result = await self._hub.async_pymodbus_call(
+            self._slave, register, value, CALL_TYPE_WRITE_REGISTER
+        )
+        if not result:
+            return False
+        return True

--- a/homeassistant/components/climaveneta_ilife/climate.py
+++ b/homeassistant/components/climaveneta_ilife/climate.py
@@ -267,12 +267,6 @@ class ClimavenetaILIFE(ClimateEntity):
     ) -> int:
         """Read register using the Modbus hub slave."""
 
-        # _LOGGER.error(
-        #     "Climaveneta iMWX read from slave %s, register %s",
-        #     str(self._slave),
-        #     str(register),
-        # )
-
         result = await self._hub.async_pymodbus_call(
             self._slave, register, 1, register_type
         )

--- a/homeassistant/components/climaveneta_ilife/const.py
+++ b/homeassistant/components/climaveneta_ilife/const.py
@@ -1,0 +1,6 @@
+"""Constants for the climaveneta_ilife integration."""
+
+DOMAIN = "climaveneta_ilife"
+
+
+TIMEOUT = 60

--- a/homeassistant/components/climaveneta_ilife/manifest.json
+++ b/homeassistant/components/climaveneta_ilife/manifest.json
@@ -1,0 +1,9 @@
+{
+  "domain": "climaveneta_ilife",
+  "name": "climaveneta_ilife",
+  "codeowners": ["@tadiern"],
+  "dependencies": ["modbus"],
+  "documentation": "https://www.home-assistant.io/integrations/climaveneta_ilife",
+  "homekit": {},
+  "iot_class": "local_polling"
+}

--- a/homeassistant/components/climaveneta_ilife/strings.json
+++ b/homeassistant/components/climaveneta_ilife/strings.json
@@ -1,0 +1,21 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "username": "[%key:common::config_flow::data::username%]",
+          "password": "[%key:common::config_flow::data::password%]"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    }
+  }
+}

--- a/homeassistant/components/climaveneta_imxw/__init__.py
+++ b/homeassistant/components/climaveneta_imxw/__init__.py
@@ -1,0 +1,1 @@
+"""The climaveneta_imxw integration."""

--- a/homeassistant/components/climaveneta_imxw/climate.py
+++ b/homeassistant/components/climaveneta_imxw/climate.py
@@ -235,8 +235,6 @@ class ClimavenetaIMXW(ClimateEntity):
                     else:
                         self._attr_fan_mode = FAN_AUTO  # should never arrive here...
 
-        # print something for debugging
-
         self._t1_alarm = await self._async_read_int16_from_register(
             CALL_TYPE_REGISTER_HOLDING, 0x1028
         )
@@ -249,33 +247,9 @@ class ClimavenetaIMXW(ClimateEntity):
             CALL_TYPE_REGISTER_HOLDING, 0x102B
         )
 
-        #        _LOGGER.error(
-        #            "Climaveneta iMXW %s. Winter: %d. ActualT: %f SetpointT_winter: %f SetpointT_summer: %f",
-        #            self._attr_name,
-        #            self._summer_winter,
-        #            self._attr_current_temperature,
-        #            self._attr_winter_temperature,
-        #            self._attr_summer_temperature,
-        #        )
-        # _LOGGER.error(
-        #    "OnOff: %d. EV_Water: %d",
-        #    self._attr_on_off,
-        #    self._attr_ev_water,
-        # )
-
-        #        t2_temp = await self._async_read_temp_from_register(
-        #            CALL_TYPE_REGISTER_HOLDING, 0x1003
-        #        )
         self._exchanger_temperature = await self._async_read_temp_from_register(
             CALL_TYPE_REGISTER_HOLDING, 0x1004
         )
-
-        # _LOGGER.error(
-        #   "Name: %s T1: %d. T3: %d",
-        #    self._attr_name,
-        #    self._attr_current_temperature,
-        #    self._exchanger_temperature,
-        # )
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
@@ -339,12 +313,6 @@ class ClimavenetaIMXW(ClimateEntity):
         self, register_type: str, register: int
     ) -> int:
         """Read register using the Modbus hub slave."""
-
-        # _LOGGER.error(
-        #     "Climaveneta iMWX read from slave %s, register %s",
-        #     str(self._slave),
-        #     str(register),
-        # )
 
         result = await self._hub.async_pymodbus_call(
             self._slave, register, 1, register_type

--- a/homeassistant/components/climaveneta_imxw/climate.py
+++ b/homeassistant/components/climaveneta_imxw/climate.py
@@ -1,0 +1,374 @@
+"""Support for the Mitsubishi-Climaveneta iMXW fancoil series."""
+from __future__ import annotations
+
+from datetime import timedelta
+import logging
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.components.climate import (
+    FAN_AUTO,
+    FAN_HIGH,
+    FAN_LOW,
+    FAN_MEDIUM,
+    PLATFORM_SCHEMA,
+    SWING_OFF,
+    ClimateEntity,
+    ClimateEntityFeature,
+    HVACAction,
+    HVACMode,
+)
+from homeassistant.components.modbus import (
+    CALL_TYPE_REGISTER_HOLDING,
+    CALL_TYPE_WRITE_REGISTER,
+    CONF_HUB,
+    DEFAULT_HUB,
+    ModbusHub,
+    get_hub,
+)
+from homeassistant.const import (
+    ATTR_TEMPERATURE,
+    CONF_NAME,
+    CONF_SLAVE,
+    DEVICE_DEFAULT_NAME,
+    UnitOfTemperature,
+)
+from homeassistant.core import HomeAssistant
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Optional(CONF_HUB, default=DEFAULT_HUB): cv.string,
+        vol.Required(CONF_SLAVE): vol.All(int, vol.Range(min=0, max=255)),
+        vol.Optional(CONF_NAME, default=DEVICE_DEFAULT_NAME): cv.string,
+    }
+)
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+MODE_SUMMER = 0
+MODE_WINTER = 1
+
+MODE_OFF = 0
+MODE_ON = 1
+
+WATER_BYPASS = 0
+WATER_CIRCULATING = 1
+
+
+# registers
+TARGET_TEMPERATURE_SUMMER_REGISTER = 0x102D
+TARGET_TEMPERATURE_WINTER_REGISTER = 0x102E
+
+STATE_READ_ON_OFF_REGISTER = 0x100F
+STATE_READ_FAN_ONLY_REGISTER = 0x1010
+STATE_READ_SEASON_REGISTER = 0x1013
+STATE_READ_FAN_AUTO_REGISTER = 0x1017
+STATE_READ_FAN_STOP_REGISTER = 0x1018
+STATE_READ_FAN_MIN_SPEED_REGISTER = 0x1019
+STATE_READ_FAN_MED_SPEED_REGISTER = 0x101A
+STATE_READ_FAN_MAX_SPEED_REGISTER = 0x101B
+STATE_READ_EV_WATER_REGISTER = 0x101C
+
+ACTUAL_AIR_TEMPERATURE_REGISTER = 0x1002
+ACTUAL_WATER_TEMPERATURE_REGISTER = 0x1003
+
+STATE_WRITE_ON_OFF_REGISTER = 0x105C
+STATE_WRITE_MODE_REGISTER = 0x105D
+STATE_WRITE_FAN_SPEED_REGISTER = 0x105E
+
+
+SCAN_INTERVAL = timedelta(seconds=30)
+
+
+async def async_setup_platform(
+    hass: HomeAssistant,
+    config: ConfigType,
+    async_add_entities: AddEntitiesCallback,
+    discovery_info: DiscoveryInfoType | None = None,
+) -> None:
+    """Set up the ClimavenetaIMXW Platform."""
+    modbus_slave = config.get(CONF_SLAVE)
+    name = config.get(CONF_NAME)
+    hub = get_hub(hass, config[CONF_HUB])
+    async_add_entities([ClimavenetaIMXW(hub, modbus_slave, name)], True)
+
+
+class ClimavenetaIMXW(ClimateEntity):
+    """Representation of a ClimavenetaIMXW fancoil unit."""
+
+    _attr_fan_modes = [FAN_AUTO, FAN_LOW, FAN_MEDIUM, FAN_HIGH]
+    _attr_hvac_mode = FAN_AUTO
+
+    _attr_hvac_mode = HVACMode.COOL
+    _attr_hvac_modes = [
+        HVACMode.COOL,
+        HVACMode.HEAT,
+        HVACMode.FAN_ONLY,
+        HVACMode.HEAT_COOL,
+        HVACMode.OFF,
+    ]
+
+    _attr_swing_modes = [SWING_OFF]
+    _attr_swing_mode = SWING_OFF
+
+    _attr_supported_features = (
+        ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.FAN_MODE
+    )
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
+
+    def __init__(
+        self, hub: ModbusHub, modbus_slave: int | None, name: str | None
+    ) -> None:
+        """Initialize the unit."""
+        self._hub = hub
+        self._attr_name = name
+        self._slave = modbus_slave
+        self._attr_fan_mode = None
+        self._filter_alarm: int | None = None
+        self._heat_recovery: int | None = None
+        self._heater_enabled: int | None = None
+        self._heating: int | None = None
+        self._cooling: int | None = None
+        self._alarm = False
+        self._summer_winter = 0
+        self._target_temperature_winter: int | None = None
+        self._attr_winter_temperature = 0.0
+        self._attr_summer_temperature = 0.0
+        self._exchanger_temperature = 0.0
+        self._t1_alarm = 0
+        self._t3_alarm = 0
+        self._water_drain = 0
+        self._min_temp = 15
+        self._max_temp = 30
+        self._attr_on_off = 0
+        self._attr_fan_only = 0
+        self._attr_ev_water = 0
+        self._attr_unique_id = f"{str(hub.name)}_{name}_{str(modbus_slave)}"
+
+    async def async_update(self) -> None:
+        """Update unit attributes."""
+
+        # setpoint and actuals
+        self._summer_winter = await self._async_read_int16_from_register(
+            CALL_TYPE_REGISTER_HOLDING, STATE_READ_SEASON_REGISTER
+        )
+
+        if self._summer_winter == MODE_WINTER:  # winter
+            self._attr_winter_temperature = await self._async_read_temp_from_register(
+                CALL_TYPE_REGISTER_HOLDING, TARGET_TEMPERATURE_WINTER_REGISTER
+            )
+            self._attr_target_temperature = self._attr_winter_temperature
+        else:  # summer
+            self._attr_summer_temperature = await self._async_read_temp_from_register(
+                CALL_TYPE_REGISTER_HOLDING, TARGET_TEMPERATURE_SUMMER_REGISTER
+            )
+            self._attr_target_temperature = self._attr_summer_temperature
+
+        self._attr_current_temperature = await self._async_read_temp_from_register(
+            CALL_TYPE_REGISTER_HOLDING, ACTUAL_AIR_TEMPERATURE_REGISTER
+        )
+
+        # state heating/cooling/fan only/off
+        self._attr_on_off = await self._async_read_int16_from_register(
+            CALL_TYPE_REGISTER_HOLDING, STATE_READ_ON_OFF_REGISTER
+        )
+        if self._attr_on_off:
+            self._attr_fan_only = await self._async_read_int16_from_register(
+                CALL_TYPE_REGISTER_HOLDING, STATE_READ_FAN_ONLY_REGISTER
+            )
+            self._attr_ev_water = await self._async_read_int16_from_register(
+                CALL_TYPE_REGISTER_HOLDING, STATE_READ_EV_WATER_REGISTER
+            )
+            if self._attr_fan_only == MODE_ON:
+                self._attr_hvac_mode = HVACMode.FAN_ONLY
+                self._attr_hvac_action = HVACAction.FAN
+            else:
+                if self._summer_winter == MODE_SUMMER:
+                    self._attr_hvac_mode = HVACMode.COOL
+                    if self._attr_ev_water == WATER_CIRCULATING:
+                        self._attr_hvac_action = HVACAction.COOLING
+                    else:
+                        self._attr_hvac_action = HVACAction.IDLE
+
+                else:
+                    self._attr_hvac_mode = HVACMode.HEAT
+                    if self._attr_ev_water == WATER_CIRCULATING:
+                        self._attr_hvac_action = HVACAction.HEATING
+                    else:
+                        self._attr_hvac_action = HVACAction.IDLE
+        else:
+            self._attr_hvac_mode = HVACMode.OFF
+            self._attr_hvac_action = HVACAction.OFF
+
+        # fan speed
+
+        fan_auto = await self._async_read_int16_from_register(
+            CALL_TYPE_REGISTER_HOLDING, STATE_READ_FAN_AUTO_REGISTER
+        )
+        if fan_auto == MODE_ON:
+            self._attr_fan_mode = FAN_AUTO
+        else:
+            fan_min = await self._async_read_int16_from_register(
+                CALL_TYPE_REGISTER_HOLDING, STATE_READ_FAN_MIN_SPEED_REGISTER
+            )
+            if fan_min == MODE_ON:
+                self._attr_fan_mode = FAN_LOW
+            else:
+                fan_med = await self._async_read_int16_from_register(
+                    CALL_TYPE_REGISTER_HOLDING, STATE_READ_FAN_MED_SPEED_REGISTER
+                )
+                if fan_med == MODE_ON:
+                    self._attr_fan_mode = FAN_MEDIUM
+                else:
+                    fan_max = await self._async_read_int16_from_register(
+                        CALL_TYPE_REGISTER_HOLDING,
+                        STATE_READ_FAN_MAX_SPEED_REGISTER,
+                    )
+                    if fan_max == MODE_ON:
+                        self._attr_fan_mode = FAN_HIGH
+                    else:
+                        self._attr_fan_mode = FAN_AUTO  # should never arrive here...
+
+        # print something for debugging
+
+        self._t1_alarm = await self._async_read_int16_from_register(
+            CALL_TYPE_REGISTER_HOLDING, 0x1028
+        )
+
+        self._t3_alarm = await self._async_read_int16_from_register(
+            CALL_TYPE_REGISTER_HOLDING, 0x102A
+        )
+
+        self._water_drain = await self._async_read_int16_from_register(
+            CALL_TYPE_REGISTER_HOLDING, 0x102B
+        )
+
+        #        _LOGGER.error(
+        #            "Climaveneta iMXW %s. Winter: %d. ActualT: %f SetpointT_winter: %f SetpointT_summer: %f",
+        #            self._attr_name,
+        #            self._summer_winter,
+        #            self._attr_current_temperature,
+        #            self._attr_winter_temperature,
+        #            self._attr_summer_temperature,
+        #        )
+        # _LOGGER.error(
+        #    "OnOff: %d. EV_Water: %d",
+        #    self._attr_on_off,
+        #    self._attr_ev_water,
+        # )
+
+        #        t2_temp = await self._async_read_temp_from_register(
+        #            CALL_TYPE_REGISTER_HOLDING, 0x1003
+        #        )
+        self._exchanger_temperature = await self._async_read_temp_from_register(
+            CALL_TYPE_REGISTER_HOLDING, 0x1004
+        )
+
+        # _LOGGER.error(
+        #   "Name: %s T1: %d. T3: %d",
+        #    self._attr_name,
+        #    self._attr_current_temperature,
+        #    self._exchanger_temperature,
+        # )
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return device specific state attributes."""
+        return {
+            "t1_alarm": self._t1_alarm,
+            "t3_alarm": self._t3_alarm,
+            "water_drain_alarm": self._water_drain,
+            "heat_exchanger_temperature": self._exchanger_temperature,
+        }
+
+    async def async_set_temperature(self, **kwargs: Any) -> None:
+        """Set new target temperature."""
+        if (target_temperature := kwargs.get(ATTR_TEMPERATURE)) is None:
+            _LOGGER.error("Received invalid temperature")
+            return
+
+        if self._summer_winter == MODE_SUMMER:
+            register = TARGET_TEMPERATURE_SUMMER_REGISTER
+        else:
+            register = TARGET_TEMPERATURE_WINTER_REGISTER
+
+        if await self._async_write_int16_to_register(
+            register, int(target_temperature * 10)
+        ):
+            self._attr_target_temperature = target_temperature
+        else:
+            _LOGGER.error("Modbus error setting target temperature to Climaveneta iMXW")
+
+    async def async_set_fan_mode(self, fan_mode: str) -> None:
+        """Set new fan mode."""
+        if fan_mode in (FAN_AUTO, FAN_LOW, FAN_MEDIUM, FAN_HIGH):
+            if self.fan_modes and await self._async_write_int16_to_register(
+                STATE_WRITE_FAN_SPEED_REGISTER, self.fan_modes.index(fan_mode)
+            ):
+                self._attr_fan_mode = fan_mode
+            else:
+                _LOGGER.error("Modbus error setting fan mode to Climaveneta iMXW")
+
+    async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
+        """Set new target hvac mode."""
+        if hvac_mode == HVACMode.OFF:
+            await self._async_write_int16_to_register(
+                STATE_WRITE_ON_OFF_REGISTER, MODE_OFF
+            )
+        else:
+            # if the device is off, then power it on and then set the mode
+            if self._attr_on_off == MODE_OFF:
+                await self._async_write_int16_to_register(
+                    STATE_WRITE_ON_OFF_REGISTER, MODE_ON
+                )
+            if self.hvac_modes and await self._async_write_int16_to_register(
+                STATE_WRITE_MODE_REGISTER, self.hvac_modes.index(hvac_mode)
+            ):
+                self._attr_hvac_mode = hvac_mode
+            else:
+                _LOGGER.error("Modbus error setting fan mode to Climaveneta iMXW")
+
+    # Based on _async_read_register in ModbusThermostat class
+    async def _async_read_int16_from_register(
+        self, register_type: str, register: int
+    ) -> int:
+        """Read register using the Modbus hub slave."""
+
+        # _LOGGER.error(
+        #     "Climaveneta iMWX read from slave %s, register %s",
+        #     str(self._slave),
+        #     str(register),
+        # )
+
+        result = await self._hub.async_pymodbus_call(
+            self._slave, register, 1, register_type
+        )
+        if result is None:
+            _LOGGER.error("Error reading value from Climaveneta iMXW modbus adapter")
+            return -1
+
+        return int(result.registers[0])
+
+    async def _async_read_temp_from_register(
+        self, register_type: str, register: int
+    ) -> float:
+        result = float(
+            await self._async_read_int16_from_register(register_type, register)
+        )
+        if not result:
+            return -1
+        return result / 10.0
+
+    async def _async_write_int16_to_register(self, register: int, value: int) -> bool:
+        result = await self._hub.async_pymodbus_call(
+            self._slave, register, value, CALL_TYPE_WRITE_REGISTER
+        )
+        if not result:
+            return False
+        return True

--- a/homeassistant/components/climaveneta_imxw/const.py
+++ b/homeassistant/components/climaveneta_imxw/const.py
@@ -1,0 +1,6 @@
+"""Constants for the climaveneta_imxw integration."""
+
+DOMAIN = "climaveneta_imxw"
+
+
+TIMEOUT = 60

--- a/homeassistant/components/climaveneta_imxw/manifest.json
+++ b/homeassistant/components/climaveneta_imxw/manifest.json
@@ -1,0 +1,9 @@
+{
+  "domain": "climaveneta_imxw",
+  "name": "climaveneta_imxw",
+  "codeowners": ["@tadiern"],
+  "dependencies": ["modbus"],
+  "documentation": "https://www.home-assistant.io/integrations/climaveneta_imxw",
+  "homekit": {},
+  "iot_class": "local_polling"
+}

--- a/homeassistant/components/climaveneta_imxw/strings.json
+++ b/homeassistant/components/climaveneta_imxw/strings.json
@@ -1,0 +1,21 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "username": "[%key:common::config_flow::data::username%]",
+          "password": "[%key:common::config_flow::data::password%]"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    }
+  }
+}

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -833,6 +833,18 @@
         }
       }
     },
+    "climaveneta_ilife": {
+      "name": "climaveneta_ilife",
+      "integration_type": "hub",
+      "config_flow": false,
+      "iot_class": "local_polling"
+    },
+    "climaveneta_imxw": {
+      "name": "climaveneta_imxw",
+      "integration_type": "hub",
+      "config_flow": false,
+      "iot_class": "local_polling"
+    },
     "cloudflare": {
       "name": "Cloudflare",
       "integration_type": "hub",

--- a/tests/components/climaveneta_imxw/__init__.py
+++ b/tests/components/climaveneta_imxw/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the climaveneta_imxw integration."""

--- a/tests/components/climaveneta_imxw/conftest.py
+++ b/tests/components/climaveneta_imxw/conftest.py
@@ -1,0 +1,14 @@
+"""Common fixtures for the climaveneta_imxw tests."""
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+    """Override async_setup_entry."""
+    with patch(
+        "homeassistant.components.climaveneta_imxw.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
+        yield mock_setup_entry

--- a/tests/components/climaveneta_imxw/test_config_flow.py
+++ b/tests/components/climaveneta_imxw/test_config_flow.py
@@ -1,0 +1,93 @@
+"""Test the climaveneta_imxw config flow."""
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from homeassistant import config_entries
+from homeassistant.components.climaveneta_imxw.config_flow import (
+    CannotConnect,
+    InvalidAuth,
+)
+from homeassistant.components.climaveneta_imxw.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+pytestmark = pytest.mark.usefixtures("mock_setup_entry")
+
+
+async def test_form(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> None:
+    """Test we get the form."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] is None
+
+    with patch(
+        "homeassistant.components.climaveneta_imxw.config_flow.PlaceholderHub.authenticate",
+        return_value=True,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "1.1.1.1",
+                "username": "test-username",
+                "password": "test-password",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["title"] == "Name of the device"
+    assert result2["data"] == {
+        "host": "1.1.1.1",
+        "username": "test-username",
+        "password": "test-password",
+    }
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_invalid_auth(hass: HomeAssistant) -> None:
+    """Test we handle invalid auth."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.climaveneta_imxw.config_flow.PlaceholderHub.authenticate",
+        side_effect=InvalidAuth,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "1.1.1.1",
+                "username": "test-username",
+                "password": "test-password",
+            },
+        )
+
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["errors"] == {"base": "invalid_auth"}
+
+
+async def test_form_cannot_connect(hass: HomeAssistant) -> None:
+    """Test we handle cannot connect error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.climaveneta_imxw.config_flow.PlaceholderHub.authenticate",
+        side_effect=CannotConnect,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "1.1.1.1",
+                "username": "test-username",
+                "password": "test-password",
+            },
+        )
+
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["errors"] == {"base": "cannot_connect"}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Added new integration to support Mitsubishi-Climaveneta i-MXW 10-40 fancoil series and i-Life2 fancoil series.
These fancoils are OEM from Sabiana Carisma Fly and Innova Airleaf fancoils. I believe these are also sold under other brands. 
The two series of fancoils have a slightly different protocol and currently I haven't implemented an auto-discovery of the two series. Nevertheless, the two series are part of the same Mitsubishi-Climaveneta offering (customers have no way to know in advance they come from two different manufacturers) and I thought they should be part of the same PR even though they are actually two distinct integrations.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

These two integrations are based on Flexit integration and implements the Modbus RTU protocol over RS-485 bus. 

To add the integration, manually modify the configuration.yaml:

```
modbus:
  - name: usb_modbus
    type: serial
    baudrate: 9600
    bytesize: 8
    method: rtu
    parity: N
    port: /dev/ttyAMA0
    stopbits: 1

climate:
  - platform: climaveneta_imxw
    hub: "usb_modbus"
    name: "dining room"
    slave: 20
  - platform: climaveneta_ilife
    hub: "usb_modbus"
    name: "kitchen"
    slave: 22
```
  

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
