### PR TITLE
Don't require passing identifiers to DeviceRegistry.async_get_device

### DIFF
--- a/homeassistant/components/airly/__init__.py
+++ b/homeassistant/components/airly/__init__.py
@@ -90,7 +90,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             str(longitude),
         ),
     ):
-        device_entry = device_registry.async_get_device({old_ids})  # type: ignore[arg-type]
+        device_entry = device_registry.async_get_device(identifiers={old_ids})  # type: ignore[arg-type]
         if device_entry and entry.entry_id in device_entry.config_entries:
             new_ids = (DOMAIN, f"{latitude}-{longitude}")
             device_registry.async_update_device(

--- a/homeassistant/components/bosch_shc/entity.py
+++ b/homeassistant/components/bosch_shc/entity.py
@@ -15,9 +15,7 @@ async def async_remove_devices(
 ) -> None:
     """Get item that is removed from session."""
     dev_registry = get_dev_reg(hass)
-    device = dev_registry.async_get_device(
-        identifiers={(DOMAIN, entity.device_id)}, connections=set()
-    )
+    device = dev_registry.async_get_device(identifiers={(DOMAIN, entity.device_id)})
     if device is not None:
         dev_registry.async_update_device(device.id, remove_config_entry_id=entry_id)
 

--- a/homeassistant/components/broadlink/device.py
+++ b/homeassistant/components/broadlink/device.py
@@ -80,7 +80,9 @@ class BroadlinkDevice:
         """
         device_registry = dr.async_get(hass)
         assert entry.unique_id
-        device_entry = device_registry.async_get_device({(DOMAIN, entry.unique_id)})
+        device_entry = device_registry.async_get_device(
+            identifiers={(DOMAIN, entry.unique_id)}
+        )
         assert device_entry
         device_registry.async_update_device(device_entry.id, name=entry.title)
         await hass.config_entries.async_reload(entry.entry_id)

--- a/homeassistant/components/deconz/services.py
+++ b/homeassistant/components/deconz/services.py
@@ -168,14 +168,13 @@ async def async_remove_orphaned_entries_service(gateway: DeconzGateway) -> None:
     if gateway.api.config.mac:
         gateway_host = device_registry.async_get_device(
             connections={(CONNECTION_NETWORK_MAC, gateway.api.config.mac)},
-            identifiers=set(),
         )
         if gateway_host and gateway_host.id in devices_to_be_removed:
             devices_to_be_removed.remove(gateway_host.id)
 
     # Don't remove the Gateway service entry
     gateway_service = device_registry.async_get_device(
-        identifiers={(DOMAIN, gateway.api.config.bridge_id)}, connections=set()
+        identifiers={(DOMAIN, gateway.api.config.bridge_id)}
     )
     if gateway_service and gateway_service.id in devices_to_be_removed:
         devices_to_be_removed.remove(gateway_service.id)

--- a/homeassistant/components/device_tracker/config_entry.py
+++ b/homeassistant/components/device_tracker/config_entry.py
@@ -365,7 +365,7 @@ class ScannerEntity(BaseTrackerEntity):
         assert self.mac_address is not None
 
         return dr.async_get(self.hass).async_get_device(
-            set(), {(dr.CONNECTION_NETWORK_MAC, self.mac_address)}
+            connections={(dr.CONNECTION_NETWORK_MAC, self.mac_address)}
         )
 
     async def async_internal_added_to_hass(self) -> None:

--- a/homeassistant/components/dhcp/__init__.py
+++ b/homeassistant/components/dhcp/__init__.py
@@ -196,7 +196,7 @@ class WatcherBase(ABC):
 
         dev_reg: DeviceRegistry = async_get(self.hass)
         if device := dev_reg.async_get_device(
-            identifiers=set(), connections={(CONNECTION_NETWORK_MAC, uppercase_mac)}
+            connections={(CONNECTION_NETWORK_MAC, uppercase_mac)}
         ):
             for entry_id in device.config_entries:
                 if entry := self.hass.config_entries.async_get_entry(entry_id):

--- a/homeassistant/components/gios/__init__.py
+++ b/homeassistant/components/gios/__init__.py
@@ -37,7 +37,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # We used to use int in device_entry identifiers, convert this to str.
     device_registry = dr.async_get(hass)
     old_ids = (DOMAIN, station_id)
-    device_entry = device_registry.async_get_device({old_ids})  # type: ignore[arg-type]
+    device_entry = device_registry.async_get_device(identifiers={old_ids})  # type: ignore[arg-type]
     if device_entry and entry.entry_id in device_entry.config_entries:
         new_ids = (DOMAIN, str(station_id))
         device_registry.async_update_device(device_entry.id, new_identifiers={new_ids})

--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -758,7 +758,7 @@ def async_remove_addons_from_dev_reg(
 ) -> None:
     """Remove addons from the device registry."""
     for addon_slug in addons:
-        if dev := dev_reg.async_get_device({(DOMAIN, addon_slug)}):
+        if dev := dev_reg.async_get_device(identifiers={(DOMAIN, addon_slug)}):
             dev_reg.async_remove_device(dev.id)
 
 
@@ -855,7 +855,7 @@ class HassioDataUpdateCoordinator(DataUpdateCoordinator):
             async_remove_addons_from_dev_reg(self.dev_reg, stale_addons)
 
         if not self.is_hass_os and (
-            dev := self.dev_reg.async_get_device({(DOMAIN, "OS")})
+            dev := self.dev_reg.async_get_device(identifiers={(DOMAIN, "OS")})
         ):
             # Remove the OS device if it exists and the installation is not hassos
             self.dev_reg.async_remove_device(dev.id)

--- a/homeassistant/components/heos/__init__.py
+++ b/homeassistant/components/heos/__init__.py
@@ -220,7 +220,9 @@ class ControllerManager:
         # mapped_ids contains the mapped IDs (new:old)
         for new_id, old_id in mapped_ids.items():
             # update device registry
-            entry = self._device_registry.async_get_device({(DOMAIN, old_id)})
+            entry = self._device_registry.async_get_device(
+                identifiers={(DOMAIN, old_id)}
+            )
             new_identifiers = {(DOMAIN, new_id)}
             if entry:
                 self._device_registry.async_update_device(

--- a/homeassistant/components/home_plus_control/__init__.py
+++ b/homeassistant/components/home_plus_control/__init__.py
@@ -128,7 +128,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         entity_uids_to_remove = uids - set(module_data)
         for uid in entity_uids_to_remove:
             uids.remove(uid)
-            device = device_registry.async_get_device({(DOMAIN, uid)})
+            device = device_registry.async_get_device(identifiers={(DOMAIN, uid)})
             device_registry.async_remove_device(device.id)
 
         # Send out signal for new entity addition to Home Assistant

--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -203,7 +203,7 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         """Determine if the device is a homekit bridge or accessory."""
         dev_reg = dr.async_get(self.hass)
         device = dev_reg.async_get_device(
-            identifiers=set(), connections={(dr.CONNECTION_NETWORK_MAC, hkid)}
+            connections={(dr.CONNECTION_NETWORK_MAC, hkid)}
         )
 
         if device is None:

--- a/homeassistant/components/hue/v2/device.py
+++ b/homeassistant/components/hue/v2/device.py
@@ -58,7 +58,7 @@ async def async_setup_devices(bridge: "HueBridge"):
     @callback
     def remove_device(hue_device_id: str) -> None:
         """Remove device from registry."""
-        if device := dev_reg.async_get_device({(DOMAIN, hue_device_id)}):
+        if device := dev_reg.async_get_device(identifiers={(DOMAIN, hue_device_id)}):
             # note: removal of any underlying entities is handled by core
             dev_reg.async_remove_device(device.id)
 

--- a/homeassistant/components/hue/v2/entity.py
+++ b/homeassistant/components/hue/v2/entity.py
@@ -147,7 +147,9 @@ class HueBaseEntity(Entity):
             # regular devices are removed automatically by the logic in device.py.
             if resource.type in (ResourceTypes.ROOM, ResourceTypes.ZONE):
                 dev_reg = async_get_device_registry(self.hass)
-                if device := dev_reg.async_get_device({(DOMAIN, resource.id)}):
+                if device := dev_reg.async_get_device(
+                    identifiers={(DOMAIN, resource.id)}
+                ):
                     dev_reg.async_remove_device(device.id)
             # cleanup entities that are not strictly device-bound and have the bridge as parent
             if self.device is None:

--- a/homeassistant/components/hue/v2/hue_event.py
+++ b/homeassistant/components/hue/v2/hue_event.py
@@ -44,7 +44,7 @@ async def async_setup_hue_events(bridge: "HueBridge"):
             return
 
         hue_device = btn_controller.get_device(hue_resource.id)
-        device = dev_reg.async_get_device({(DOMAIN, hue_device.id)})
+        device = dev_reg.async_get_device(identifiers={(DOMAIN, hue_device.id)})
 
         # Fire event
         data = {
@@ -70,7 +70,7 @@ async def async_setup_hue_events(bridge: "HueBridge"):
         LOGGER.debug("Received relative_rotary event: %s", hue_resource)
 
         hue_device = btn_controller.get_device(hue_resource.id)
-        device = dev_reg.async_get_device({(DOMAIN, hue_device.id)})
+        device = dev_reg.async_get_device(identifiers={(DOMAIN, hue_device.id)})
 
         # Fire event
         data = {

--- a/homeassistant/components/ibeacon/coordinator.py
+++ b/homeassistant/components/ibeacon/coordinator.py
@@ -200,7 +200,9 @@ class IBeaconCoordinator:
     def _async_purge_untrackable_entities(self, unique_ids: set[str]) -> None:
         """Remove entities that are no longer trackable."""
         for unique_id in unique_ids:
-            if device := self._dev_reg.async_get_device({(DOMAIN, unique_id)}):
+            if device := self._dev_reg.async_get_device(
+                identifiers={(DOMAIN, unique_id)}
+            ):
                 self._dev_reg.async_remove_device(device.id)
             self._last_ibeacon_advertisement_by_unique_id.pop(unique_id, None)
 

--- a/homeassistant/components/insteon/api/device.py
+++ b/homeassistant/components/insteon/api/device.py
@@ -43,9 +43,7 @@ def get_insteon_device_from_ha_device(ha_device):
 
 async def async_device_name(dev_registry, address):
     """Get the Insteon device name from a device registry id."""
-    ha_device = dev_registry.async_get_device(
-        identifiers={(DOMAIN, str(address))}, connections=set()
-    )
+    ha_device = dev_registry.async_get_device(identifiers={(DOMAIN, str(address))})
     if not ha_device:
         if device := devices[address]:
             return f"{device.description} ({device.model})"

--- a/homeassistant/components/kodi/media_player.py
+++ b/homeassistant/components/kodi/media_player.py
@@ -422,7 +422,7 @@ class KodiEntity(MediaPlayerEntity):
         version = (await self._kodi.get_application_properties(["version"]))["version"]
         sw_version = f"{version['major']}.{version['minor']}"
         dev_reg = dr.async_get(self.hass)
-        device = dev_reg.async_get_device({(DOMAIN, self.unique_id)})
+        device = dev_reg.async_get_device(identifiers={(DOMAIN, self.unique_id)})
         dev_reg.async_update_device(device.id, sw_version=sw_version)
         self._device_id = device.id
 

--- a/homeassistant/components/lcn/__init__.py
+++ b/homeassistant/components/lcn/__init__.py
@@ -180,7 +180,7 @@ def async_host_input_received(
         logical_address.is_group,
     )
     identifiers = {(DOMAIN, generate_unique_id(config_entry.entry_id, address))}
-    device = device_registry.async_get_device(identifiers, set())
+    device = device_registry.async_get_device(identifiers=identifiers)
     if device is None:
         return
 

--- a/homeassistant/components/lcn/helpers.py
+++ b/homeassistant/components/lcn/helpers.py
@@ -291,7 +291,7 @@ def purge_device_registry(
 
     # Find device that references the host.
     references_host = set()
-    host_device = device_registry.async_get_device({(DOMAIN, entry_id)})
+    host_device = device_registry.async_get_device(identifiers={(DOMAIN, entry_id)})
     if host_device is not None:
         references_host.add(host_device.id)
 
@@ -299,7 +299,9 @@ def purge_device_registry(
     references_entry_data = set()
     for device_data in imported_entry_data[CONF_DEVICES]:
         device_unique_id = generate_unique_id(entry_id, device_data[CONF_ADDRESS])
-        device = device_registry.async_get_device({(DOMAIN, device_unique_id)})
+        device = device_registry.async_get_device(
+            identifiers={(DOMAIN, device_unique_id)}
+        )
         if device is not None:
             references_entry_data.add(device.id)
 

--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -142,7 +142,7 @@ async def _async_migrate_unique_ids(
             return None
         sensor_id = unique_id.split("_")[1]
         new_unique_id = f"occupancygroup_{bridge_unique_id}_{sensor_id}"
-        if dev_entry := dev_reg.async_get_device({(DOMAIN, unique_id)}):
+        if dev_entry := dev_reg.async_get_device(identifiers={(DOMAIN, unique_id)}):
             dev_reg.async_update_device(
                 dev_entry.id, new_identifiers={(DOMAIN, new_unique_id)}
             )

--- a/homeassistant/components/matter/adapter.py
+++ b/homeassistant/components/matter/adapter.py
@@ -80,7 +80,7 @@ class MatterAdapter:
                 node.endpoints[data["endpoint_id"]],
             )
             identifier = (DOMAIN, f"{ID_TYPE_DEVICE_ID}_{node_device_id}")
-            if device := device_registry.async_get_device({identifier}):
+            if device := device_registry.async_get_device(identifiers={identifier}):
                 device_registry.async_remove_device(device.id)
 
         def node_removed_callback(event: EventType, node_id: int) -> None:

--- a/homeassistant/components/nest/__init__.py
+++ b/homeassistant/components/nest/__init__.py
@@ -152,7 +152,9 @@ class SignalUpdateCallback:
             return
         _LOGGER.debug("Event Update %s", events.keys())
         device_registry = dr.async_get(self._hass)
-        device_entry = device_registry.async_get_device({(DOMAIN, device_id)})
+        device_entry = device_registry.async_get_device(
+            identifiers={(DOMAIN, device_id)}
+        )
         if not device_entry:
             return
         for api_event_type, image_event in events.items():

--- a/homeassistant/components/nest/device_info.py
+++ b/homeassistant/components/nest/device_info.py
@@ -100,6 +100,8 @@ def async_nest_devices_by_device_id(hass: HomeAssistant) -> Mapping[str, Device]
     device_registry = dr.async_get(hass)
     devices = {}
     for nest_device_id, device in async_nest_devices(hass).items():
-        if device_entry := device_registry.async_get_device({(DOMAIN, nest_device_id)}):
+        if device_entry := device_registry.async_get_device(
+            identifiers={(DOMAIN, nest_device_id)}
+        ):
             devices[device_entry.id] = device
     return devices

--- a/homeassistant/components/nest/media_source.py
+++ b/homeassistant/components/nest/media_source.py
@@ -244,7 +244,7 @@ class NestEventMediaStore(EventMediaStore):
         devices = {}
         for device in device_manager.devices.values():
             if device_entry := device_registry.async_get_device(
-                {(DOMAIN, device.name)}
+                identifiers={(DOMAIN, device.name)}
             ):
                 devices[device.name] = device_entry.id
         return devices

--- a/homeassistant/components/netatmo/netatmo_entity_base.py
+++ b/homeassistant/components/netatmo/netatmo_entity_base.py
@@ -70,7 +70,7 @@ class NetatmoBase(Entity):
                 await self.data_handler.unsubscribe(signal_name, None)
 
         registry = dr.async_get(self.hass)
-        if device := registry.async_get_device({(DOMAIN, self._id)}):
+        if device := registry.async_get_device(identifiers={(DOMAIN, self._id)}):
             self.hass.data[DOMAIN][DATA_DEVICE_IDS][self._id] = device.id
 
         self.async_update_callback()

--- a/homeassistant/components/notion/__init__.py
+++ b/homeassistant/components/notion/__init__.py
@@ -339,9 +339,13 @@ class NotionEntity(CoordinatorEntity[DataUpdateCoordinator[NotionData]]):
         self._bridge_id = sensor.bridge.id
 
         device_registry = dr.async_get(self.hass)
-        this_device = device_registry.async_get_device({(DOMAIN, sensor.hardware_id)})
+        this_device = device_registry.async_get_device(
+            identifiers={(DOMAIN, sensor.hardware_id)}
+        )
         bridge = self.coordinator.data.bridges[self._bridge_id]
-        bridge_device = device_registry.async_get_device({(DOMAIN, bridge.hardware_id)})
+        bridge_device = device_registry.async_get_device(
+            identifiers={(DOMAIN, bridge.hardware_id)}
+        )
 
         if not bridge_device or not this_device:
             return

--- a/homeassistant/components/onvif/config_flow.py
+++ b/homeassistant/components/onvif/config_flow.py
@@ -171,7 +171,7 @@ class OnvifFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         registry = dr.async_get(self.hass)
         if not (
             device := registry.async_get_device(
-                identifiers=set(), connections={(dr.CONNECTION_NETWORK_MAC, mac)}
+                connections={(dr.CONNECTION_NETWORK_MAC, mac)}
             )
         ):
             return self.async_abort(reason="no_devices_found")

--- a/homeassistant/components/overkiz/coordinator.py
+++ b/homeassistant/components/overkiz/coordinator.py
@@ -178,7 +178,9 @@ async def on_device_removed(
     base_device_url = event.device_url.split("#")[0]
     registry = dr.async_get(coordinator.hass)
 
-    if registered_device := registry.async_get_device({(DOMAIN, base_device_url)}):
+    if registered_device := registry.async_get_device(
+        identifiers={(DOMAIN, base_device_url)}
+    ):
         registry.async_remove_device(registered_device.id)
 
     if event.device_url:

--- a/homeassistant/components/sabnzbd/__init__.py
+++ b/homeassistant/components/sabnzbd/__init__.py
@@ -127,7 +127,7 @@ def async_get_entry_id_for_service_call(hass: HomeAssistant, call: ServiceCall) 
 def update_device_identifiers(hass: HomeAssistant, entry: ConfigEntry):
     """Update device identifiers to new identifiers."""
     device_registry = async_get(hass)
-    device_entry = device_registry.async_get_device({(DOMAIN, DOMAIN)})
+    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, DOMAIN)})
     if device_entry and entry.entry_id in device_entry.config_entries:
         new_identifiers = {(DOMAIN, entry.entry_id)}
         _LOGGER.debug(

--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -143,7 +143,6 @@ async def _async_setup_block_entry(hass: HomeAssistant, entry: ConfigEntry) -> b
     device_entry = None
     if entry.unique_id is not None:
         device_entry = dev_reg.async_get_device(
-            identifiers=set(),
             connections={(CONNECTION_NETWORK_MAC, format_mac(entry.unique_id))},
         )
     # https://github.com/home-assistant/core/pull/48076
@@ -227,7 +226,6 @@ async def _async_setup_rpc_entry(hass: HomeAssistant, entry: ConfigEntry) -> boo
     device_entry = None
     if entry.unique_id is not None:
         device_entry = dev_reg.async_get_device(
-            identifiers=set(),
             connections={(CONNECTION_NETWORK_MAC, format_mac(entry.unique_id))},
         )
     # https://github.com/home-assistant/core/pull/48076

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -268,7 +268,7 @@ def _async_register_base_station(
 
     # Check for an old system ID format and remove it:
     if old_base_station := device_registry.async_get_device(
-        {(DOMAIN, system.system_id)}  # type: ignore[arg-type]
+        identifiers={(DOMAIN, system.system_id)}  # type: ignore[arg-type]
     ):
         # Update the new base station with any properties the user might have configured
         # on the old base station:

--- a/homeassistant/components/tasmota/__init__.py
+++ b/homeassistant/components/tasmota/__init__.py
@@ -119,7 +119,9 @@ async def _remove_device(
     device_registry: DeviceRegistry,
 ) -> None:
     """Remove a discovered Tasmota device."""
-    device = device_registry.async_get_device(set(), {(CONNECTION_NETWORK_MAC, mac)})
+    device = device_registry.async_get_device(
+        connections={(CONNECTION_NETWORK_MAC, mac)}
+    )
 
     if device is None or config_entry.entry_id not in device.config_entries:
         return

--- a/homeassistant/components/tasmota/device_trigger.py
+++ b/homeassistant/components/tasmota/device_trigger.py
@@ -223,8 +223,7 @@ async def async_setup_trigger(
 
     device_registry = dr.async_get(hass)
     device = device_registry.async_get_device(
-        set(),
-        {(CONNECTION_NETWORK_MAC, tasmota_trigger.cfg.mac)},
+        connections={(CONNECTION_NETWORK_MAC, tasmota_trigger.cfg.mac)},
     )
 
     if device is None:

--- a/homeassistant/components/tasmota/discovery.py
+++ b/homeassistant/components/tasmota/discovery.py
@@ -302,7 +302,7 @@ async def async_start(  # noqa: C901
         device_registry = dr.async_get(hass)
         entity_registry = er.async_get(hass)
         device = device_registry.async_get_device(
-            set(), {(dr.CONNECTION_NETWORK_MAC, mac)}
+            connections={(dr.CONNECTION_NETWORK_MAC, mac)}
         )
 
         if device is None:

--- a/homeassistant/components/tibber/sensor.py
+++ b/homeassistant/components/tibber/sensor.py
@@ -289,7 +289,9 @@ async def async_setup_entry(
             )
 
         # migrate to new device ids
-        device_entry = device_registry.async_get_device({(TIBBER_DOMAIN, old_id)})
+        device_entry = device_registry.async_get_device(
+            identifiers={(TIBBER_DOMAIN, old_id)}
+        )
         if device_entry and entry.entry_id in device_entry.config_entries:
             device_registry.async_update_device(
                 device_entry.id, new_identifiers={(TIBBER_DOMAIN, home.home_id)}

--- a/homeassistant/components/unifiprotect/data.py
+++ b/homeassistant/components/unifiprotect/data.py
@@ -178,7 +178,7 @@ class ProtectData:
     def _async_remove_device(self, device: ProtectAdoptableDeviceModel) -> None:
         registry = dr.async_get(self._hass)
         device_entry = registry.async_get_device(
-            identifiers=set(), connections={(dr.CONNECTION_NETWORK_MAC, device.mac)}
+            connections={(dr.CONNECTION_NETWORK_MAC, device.mac)}
         )
         if device_entry:
             _LOGGER.debug("Device removed: %s", device.id)

--- a/homeassistant/components/uptimerobot/__init__.py
+++ b/homeassistant/components/uptimerobot/__init__.py
@@ -100,7 +100,7 @@ class UptimeRobotDataUpdateCoordinator(DataUpdateCoordinator[list[UptimeRobotMon
         if stale_monitors := current_monitors - new_monitors:
             for monitor_id in stale_monitors:
                 if device := self._device_registry.async_get_device(
-                    {(DOMAIN, monitor_id)}
+                    identifiers={(DOMAIN, monitor_id)}
                 ):
                     self._device_registry.async_remove_device(device.id)
 

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -254,7 +254,7 @@ class DriverEvents:
             self.dev_reg, self.config_entry.entry_id
         )
         known_devices = [
-            self.dev_reg.async_get_device({get_device_id(driver, node)})
+            self.dev_reg.async_get_device(identifiers={get_device_id(driver, node)})
             for node in controller.nodes.values()
         ]
 
@@ -401,7 +401,7 @@ class ControllerEvents:
         replaced: bool = event.get("replaced", False)
         # grab device in device registry attached to this node
         dev_id = get_device_id(self.driver_events.driver, node)
-        device = self.dev_reg.async_get_device({dev_id})
+        device = self.dev_reg.async_get_device(identifiers={dev_id})
         # We assert because we know the device exists
         assert device
         if replaced:
@@ -424,7 +424,7 @@ class ControllerEvents:
         driver = self.driver_events.driver
         device_id = get_device_id(driver, node)
         device_id_ext = get_device_id_ext(driver, node)
-        device = self.dev_reg.async_get_device({device_id})
+        device = self.dev_reg.async_get_device(identifiers={device_id})
         via_device_id = None
         controller = driver.controller
         # Get the controller node device ID if this node is not the controller
@@ -610,7 +610,7 @@ class NodeEvents:
         )
         if (
             not value.node.ready
-            or not (device := self.dev_reg.async_get_device({device_id}))
+            or not (device := self.dev_reg.async_get_device(identifiers={device_id}))
             or value.value_id in self.controller_events.discovered_value_ids[device.id]
         ):
             return
@@ -632,7 +632,7 @@ class NodeEvents:
         """Relay stateless value notification events from Z-Wave nodes to hass."""
         driver = self.controller_events.driver_events.driver
         device = self.dev_reg.async_get_device(
-            {get_device_id(driver, notification.node)}
+            identifiers={get_device_id(driver, notification.node)}
         )
         # We assert because we know the device exists
         assert device
@@ -671,7 +671,7 @@ class NodeEvents:
             "notification"
         ]
         device = self.dev_reg.async_get_device(
-            {get_device_id(driver, notification.node)}
+            identifiers={get_device_id(driver, notification.node)}
         )
         # We assert because we know the device exists
         assert device
@@ -741,7 +741,9 @@ class NodeEvents:
         driver = self.controller_events.driver_events.driver
         disc_info = value_updates_disc_info[value.value_id]
 
-        device = self.dev_reg.async_get_device({get_device_id(driver, value.node)})
+        device = self.dev_reg.async_get_device(
+            identifiers={get_device_id(driver, value.node)}
+        )
         # We assert because we know the device exists
         assert device
 

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -2347,7 +2347,7 @@ def _get_node_statistics_dict(
         """Convert a node to a device id."""
         driver = node.client.driver
         assert driver
-        device = dev_reg.async_get_device({get_device_id(driver, node)})
+        device = dev_reg.async_get_device(identifiers={get_device_id(driver, node)})
         assert device
         return device.id
 

--- a/homeassistant/components/zwave_js/triggers/event.py
+++ b/homeassistant/components/zwave_js/triggers/event.py
@@ -232,7 +232,7 @@ async def async_attach_trigger(
             assert driver is not None  # The node comes from the driver.
             drivers.add(driver)
             device_identifier = get_device_id(driver, node)
-            device = dev_reg.async_get_device({device_identifier})
+            device = dev_reg.async_get_device(identifiers={device_identifier})
             assert device
             # We need to store the device for the callback
             unsubs.append(

--- a/homeassistant/components/zwave_js/triggers/value_updated.py
+++ b/homeassistant/components/zwave_js/triggers/value_updated.py
@@ -179,7 +179,7 @@ async def async_attach_trigger(
             assert driver is not None  # The node comes from the driver.
             drivers.add(driver)
             device_identifier = get_device_id(driver, node)
-            device = dev_reg.async_get_device({device_identifier})
+            device = dev_reg.async_get_device(identifiers={device_identifier})
             assert device
             value_id = get_value_id_str(
                 node, command_class, property_, endpoint, property_key

--- a/homeassistant/components/zwave_me/__init__.py
+++ b/homeassistant/components/zwave_me/__init__.py
@@ -96,7 +96,7 @@ class ZWaveMeController:
         """Remove old-format devices in the registry."""
         for device_id in self.device_ids:
             device = registry.async_get_device(
-                {(DOMAIN, f"{self.config.unique_id}-{device_id}")}
+                identifiers={(DOMAIN, f"{self.config.unique_id}-{device_id}")}
             )
             if device is not None:
                 registry.async_remove_device(device.id)

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -272,8 +272,8 @@ class DeviceRegistryItems(UserDict[str, _EntryTypeT]):
 
     def get_entry(
         self,
-        connections: set[tuple[str, str]] | None,
         identifiers: set[tuple[str, str]] | None,
+        connections: set[tuple[str, str]] | None,
     ) -> _EntryTypeT | None:
         """Get entry from identifiers or connections."""
         if identifiers:
@@ -318,20 +318,19 @@ class DeviceRegistry:
     @callback
     def async_get_device(
         self,
-        *,
-        connections: set[tuple[str, str]] | None = None,
         identifiers: set[tuple[str, str]] | None = None,
+        connections: set[tuple[str, str]] | None = None,
     ) -> DeviceEntry | None:
         """Check if device is registered."""
-        return self.devices.get_entry(connections, identifiers)
+        return self.devices.get_entry(identifiers, connections)
 
     def _async_get_deleted_device(
         self,
-        connections: set[tuple[str, str]],
         identifiers: set[tuple[str, str]],
+        connections: set[tuple[str, str]],
     ) -> DeletedDeviceEntry | None:
         """Check if device is deleted."""
-        return self.deleted_devices.get_entry(connections, identifiers)
+        return self.deleted_devices.get_entry(identifiers, connections)
 
     @callback
     def async_get_or_create(
@@ -370,7 +369,7 @@ class DeviceRegistry:
         device = self.async_get_device(identifiers=identifiers, connections=connections)
 
         if device is None:
-            deleted_device = self._async_get_deleted_device(connections, identifiers)
+            deleted_device = self._async_get_deleted_device(identifiers, connections)
             if deleted_device is None:
                 device = DeviceEntry(is_new=True)
             else:

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -272,13 +272,14 @@ class DeviceRegistryItems(UserDict[str, _EntryTypeT]):
 
     def get_entry(
         self,
-        identifiers: set[tuple[str, str]],
         connections: set[tuple[str, str]] | None,
+        identifiers: set[tuple[str, str]] | None,
     ) -> _EntryTypeT | None:
         """Get entry from identifiers or connections."""
-        for identifier in identifiers:
-            if identifier in self._identifiers:
-                return self._identifiers[identifier]
+        if identifiers:
+            for identifier in identifiers:
+                if identifier in self._identifiers:
+                    return self._identifiers[identifier]
         if not connections:
             return None
         for connection in _normalize_connections(connections):
@@ -317,19 +318,20 @@ class DeviceRegistry:
     @callback
     def async_get_device(
         self,
-        identifiers: set[tuple[str, str]],
+        *,
         connections: set[tuple[str, str]] | None = None,
+        identifiers: set[tuple[str, str]] | None = None,
     ) -> DeviceEntry | None:
         """Check if device is registered."""
-        return self.devices.get_entry(identifiers, connections)
+        return self.devices.get_entry(connections, identifiers)
 
     def _async_get_deleted_device(
         self,
+        connections: set[tuple[str, str]],
         identifiers: set[tuple[str, str]],
-        connections: set[tuple[str, str]] | None,
     ) -> DeletedDeviceEntry | None:
         """Check if device is deleted."""
-        return self.deleted_devices.get_entry(identifiers, connections)
+        return self.deleted_devices.get_entry(connections, identifiers)
 
     @callback
     def async_get_or_create(
@@ -365,10 +367,10 @@ class DeviceRegistry:
         else:
             connections = _normalize_connections(connections)
 
-        device = self.async_get_device(identifiers, connections)
+        device = self.async_get_device(identifiers=identifiers, connections=connections)
 
         if device is None:
-            deleted_device = self._async_get_deleted_device(identifiers, connections)
+            deleted_device = self._async_get_deleted_device(connections, identifiers)
             if deleted_device is None:
                 device = DeviceEntry(is_new=True)
             else:
@@ -388,7 +390,7 @@ class DeviceRegistry:
             name = default_name
 
         if via_device is not None:
-            via = self.async_get_device({via_device})
+            via = self.async_get_device(identifiers={via_device})
             via_device_id: str | UndefinedType = via.id if via else UNDEFINED
         else:
             via_device_id = UNDEFINED

--- a/tests/components/assist_pipeline/test_select.py
+++ b/tests/components/assist_pipeline/test_select.py
@@ -102,7 +102,7 @@ async def test_select_entity_registering_device(
 ) -> None:
     """Test entity registering as an assist device."""
     dev_reg = dr.async_get(hass)
-    device = dev_reg.async_get_device({("test", "test")})
+    device = dev_reg.async_get_device(identifiers={("test", "test")})
     assert device is not None
 
     # Test device is registered

--- a/tests/components/broadlink/test_device.py
+++ b/tests/components/broadlink/test_device.py
@@ -260,7 +260,7 @@ async def test_device_setup_registry(
     assert len(device_registry.devices) == 1
 
     device_entry = device_registry.async_get_device(
-        {(DOMAIN, mock_setup.entry.unique_id)}
+        identifiers={(DOMAIN, mock_setup.entry.unique_id)}
     )
     assert device_entry.identifiers == {(DOMAIN, device.mac)}
     assert device_entry.name == device.name
@@ -349,7 +349,7 @@ async def test_device_update_listener(
         await hass.async_block_till_done()
 
     device_entry = device_registry.async_get_device(
-        {(DOMAIN, mock_setup.entry.unique_id)}
+        identifiers={(DOMAIN, mock_setup.entry.unique_id)}
     )
     assert device_entry.name == "New Name"
     for entry in er.async_entries_for_device(entity_registry, device_entry.id):

--- a/tests/components/broadlink/test_remote.py
+++ b/tests/components/broadlink/test_remote.py
@@ -33,7 +33,7 @@ async def test_remote_setup_works(
         mock_setup = await device.setup_entry(hass)
 
         device_entry = device_registry.async_get_device(
-            {(DOMAIN, mock_setup.entry.unique_id)}
+            identifiers={(DOMAIN, mock_setup.entry.unique_id)}
         )
         entries = er.async_entries_for_device(entity_registry, device_entry.id)
         remotes = [entry for entry in entries if entry.domain == Platform.REMOTE]
@@ -58,7 +58,7 @@ async def test_remote_send_command(
         mock_setup = await device.setup_entry(hass)
 
         device_entry = device_registry.async_get_device(
-            {(DOMAIN, mock_setup.entry.unique_id)}
+            identifiers={(DOMAIN, mock_setup.entry.unique_id)}
         )
         entries = er.async_entries_for_device(entity_registry, device_entry.id)
         remotes = [entry for entry in entries if entry.domain == Platform.REMOTE]
@@ -87,7 +87,7 @@ async def test_remote_turn_off_turn_on(
         mock_setup = await device.setup_entry(hass)
 
         device_entry = device_registry.async_get_device(
-            {(DOMAIN, mock_setup.entry.unique_id)}
+            identifiers={(DOMAIN, mock_setup.entry.unique_id)}
         )
         entries = er.async_entries_for_device(entity_registry, device_entry.id)
         remotes = [entry for entry in entries if entry.domain == Platform.REMOTE]

--- a/tests/components/broadlink/test_sensors.py
+++ b/tests/components/broadlink/test_sensors.py
@@ -34,7 +34,7 @@ async def test_a1_sensor_setup(
 
     assert mock_api.check_sensors_raw.call_count == 1
     device_entry = device_registry.async_get_device(
-        {(DOMAIN, mock_setup.entry.unique_id)}
+        identifiers={(DOMAIN, mock_setup.entry.unique_id)}
     )
     entries = er.async_entries_for_device(entity_registry, device_entry.id)
     sensors = [entry for entry in entries if entry.domain == Platform.SENSOR]
@@ -75,7 +75,7 @@ async def test_a1_sensor_update(
     mock_setup = await device.setup_entry(hass, mock_api=mock_api)
 
     device_entry = device_registry.async_get_device(
-        {(DOMAIN, mock_setup.entry.unique_id)}
+        identifiers={(DOMAIN, mock_setup.entry.unique_id)}
     )
     entries = er.async_entries_for_device(entity_registry, device_entry.id)
     sensors = [entry for entry in entries if entry.domain == Platform.SENSOR]
@@ -121,7 +121,7 @@ async def test_rm_pro_sensor_setup(
 
     assert mock_api.check_sensors.call_count == 1
     device_entry = device_registry.async_get_device(
-        {(DOMAIN, mock_setup.entry.unique_id)}
+        identifiers={(DOMAIN, mock_setup.entry.unique_id)}
     )
     entries = er.async_entries_for_device(entity_registry, device_entry.id)
     sensors = [entry for entry in entries if entry.domain == Platform.SENSOR]
@@ -150,7 +150,7 @@ async def test_rm_pro_sensor_update(
     mock_setup = await device.setup_entry(hass, mock_api=mock_api)
 
     device_entry = device_registry.async_get_device(
-        {(DOMAIN, mock_setup.entry.unique_id)}
+        identifiers={(DOMAIN, mock_setup.entry.unique_id)}
     )
     entries = er.async_entries_for_device(entity_registry, device_entry.id)
     sensors = [entry for entry in entries if entry.domain == Platform.SENSOR]
@@ -186,7 +186,7 @@ async def test_rm_pro_filter_crazy_temperature(
     mock_setup = await device.setup_entry(hass, mock_api=mock_api)
 
     device_entry = device_registry.async_get_device(
-        {(DOMAIN, mock_setup.entry.unique_id)}
+        identifiers={(DOMAIN, mock_setup.entry.unique_id)}
     )
     entries = er.async_entries_for_device(entity_registry, device_entry.id)
     sensors = [entry for entry in entries if entry.domain == Platform.SENSOR]
@@ -220,7 +220,7 @@ async def test_rm_mini3_no_sensor(
 
     assert mock_api.check_sensors.call_count <= 1
     device_entry = device_registry.async_get_device(
-        {(DOMAIN, mock_setup.entry.unique_id)}
+        identifiers={(DOMAIN, mock_setup.entry.unique_id)}
     )
     entries = er.async_entries_for_device(entity_registry, device_entry.id)
     sensors = [entry for entry in entries if entry.domain == Platform.SENSOR]
@@ -241,7 +241,7 @@ async def test_rm4_pro_hts2_sensor_setup(
 
     assert mock_api.check_sensors.call_count == 1
     device_entry = device_registry.async_get_device(
-        {(DOMAIN, mock_setup.entry.unique_id)}
+        identifiers={(DOMAIN, mock_setup.entry.unique_id)}
     )
     entries = er.async_entries_for_device(entity_registry, device_entry.id)
     sensors = [entry for entry in entries if entry.domain == Platform.SENSOR]
@@ -273,7 +273,7 @@ async def test_rm4_pro_hts2_sensor_update(
     mock_setup = await device.setup_entry(hass, mock_api=mock_api)
 
     device_entry = device_registry.async_get_device(
-        {(DOMAIN, mock_setup.entry.unique_id)}
+        identifiers={(DOMAIN, mock_setup.entry.unique_id)}
     )
     entries = er.async_entries_for_device(entity_registry, device_entry.id)
     sensors = [entry for entry in entries if entry.domain == Platform.SENSOR]
@@ -310,7 +310,7 @@ async def test_rm4_pro_no_sensor(
 
     assert mock_api.check_sensors.call_count <= 1
     device_entry = device_registry.async_get_device(
-        {(DOMAIN, mock_setup.entry.unique_id)}
+        identifiers={(DOMAIN, mock_setup.entry.unique_id)}
     )
     entries = er.async_entries_for_device(entity_registry, device_entry.id)
     sensors = {entry for entry in entries if entry.domain == Platform.SENSOR}
@@ -341,7 +341,7 @@ async def test_scb1e_sensor_setup(
 
     assert mock_api.get_state.call_count == 1
     device_entry = device_registry.async_get_device(
-        {(DOMAIN, mock_setup.entry.unique_id)}
+        identifiers={(DOMAIN, mock_setup.entry.unique_id)}
     )
     entries = er.async_entries_for_device(entity_registry, device_entry.id)
     sensors = [entry for entry in entries if entry.domain == Platform.SENSOR]
@@ -392,7 +392,7 @@ async def test_scb1e_sensor_update(
     mock_setup = await device.setup_entry(hass, mock_api=mock_api)
 
     device_entry = device_registry.async_get_device(
-        {(DOMAIN, mock_setup.entry.unique_id)}
+        identifiers={(DOMAIN, mock_setup.entry.unique_id)}
     )
     entries = er.async_entries_for_device(entity_registry, device_entry.id)
     sensors = [entry for entry in entries if entry.domain == Platform.SENSOR]

--- a/tests/components/broadlink/test_switch.py
+++ b/tests/components/broadlink/test_switch.py
@@ -22,7 +22,7 @@ async def test_switch_setup_works(
     mock_setup = await device.setup_entry(hass)
 
     device_entry = device_registry.async_get_device(
-        {(DOMAIN, mock_setup.entry.unique_id)}
+        identifiers={(DOMAIN, mock_setup.entry.unique_id)}
     )
     entries = er.async_entries_for_device(entity_registry, device_entry.id)
     switches = [entry for entry in entries if entry.domain == Platform.SWITCH]
@@ -46,7 +46,7 @@ async def test_switch_turn_off_turn_on(
     mock_setup = await device.setup_entry(hass)
 
     device_entry = device_registry.async_get_device(
-        {(DOMAIN, mock_setup.entry.unique_id)}
+        identifiers={(DOMAIN, mock_setup.entry.unique_id)}
     )
     entries = er.async_entries_for_device(entity_registry, device_entry.id)
     switches = [entry for entry in entries if entry.domain == Platform.SWITCH]
@@ -82,7 +82,7 @@ async def test_slots_switch_setup_works(
     mock_setup = await device.setup_entry(hass)
 
     device_entry = device_registry.async_get_device(
-        {(DOMAIN, mock_setup.entry.unique_id)}
+        identifiers={(DOMAIN, mock_setup.entry.unique_id)}
     )
     entries = er.async_entries_for_device(entity_registry, device_entry.id)
     switches = [entry for entry in entries if entry.domain == Platform.SWITCH]
@@ -107,7 +107,7 @@ async def test_slots_switch_turn_off_turn_on(
     mock_setup = await device.setup_entry(hass)
 
     device_entry = device_registry.async_get_device(
-        {(DOMAIN, mock_setup.entry.unique_id)}
+        identifiers={(DOMAIN, mock_setup.entry.unique_id)}
     )
     entries = er.async_entries_for_device(entity_registry, device_entry.id)
     switches = [entry for entry in entries if entry.domain == Platform.SWITCH]

--- a/tests/components/bthome/test_device_trigger.py
+++ b/tests/components/bthome/test_device_trigger.py
@@ -112,7 +112,7 @@ async def test_get_triggers_button(hass: HomeAssistant) -> None:
     assert len(events) == 1
 
     dev_reg = async_get_dev_reg(hass)
-    device = dev_reg.async_get_device({get_device_id(mac)})
+    device = dev_reg.async_get_device(identifiers={get_device_id(mac)})
     assert device
     expected_trigger = {
         CONF_PLATFORM: "device",
@@ -148,7 +148,7 @@ async def test_get_triggers_dimmer(hass: HomeAssistant) -> None:
     assert len(events) == 1
 
     dev_reg = async_get_dev_reg(hass)
-    device = dev_reg.async_get_device({get_device_id(mac)})
+    device = dev_reg.async_get_device(identifiers={get_device_id(mac)})
     assert device
     expected_trigger = {
         CONF_PLATFORM: "device",
@@ -243,7 +243,7 @@ async def test_if_fires_on_motion_detected(hass: HomeAssistant, calls) -> None:
     await hass.async_block_till_done()
 
     dev_reg = async_get_dev_reg(hass)
-    device = dev_reg.async_get_device({get_device_id(mac)})
+    device = dev_reg.async_get_device(identifiers={get_device_id(mac)})
     device_id = device.id
 
     assert await async_setup_component(

--- a/tests/components/canary/test_sensor.py
+++ b/tests/components/canary/test_sensor.py
@@ -88,7 +88,7 @@ async def test_sensors_pro(
         assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == data[2]
         assert state.state == data[1]
 
-    device = device_registry.async_get_device({(DOMAIN, "20")})
+    device = device_registry.async_get_device(identifiers={(DOMAIN, "20")})
     assert device
     assert device.manufacturer == MANUFACTURER
     assert device.name == "Dining Room"
@@ -208,7 +208,7 @@ async def test_sensors_flex(
         assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == data[2]
         assert state.state == data[1]
 
-    device = device_registry.async_get_device({(DOMAIN, "20")})
+    device = device_registry.async_get_device(identifiers={(DOMAIN, "20")})
     assert device
     assert device.manufacturer == MANUFACTURER
     assert device.name == "Dining Room"

--- a/tests/components/daikin/test_init.py
+++ b/tests/components/daikin/test_init.py
@@ -67,7 +67,7 @@ async def test_unique_id_migrate(hass: HomeAssistant, mock_daikin) -> None:
 
     assert config_entry.unique_id == HOST
 
-    assert device_registry.async_get_device({}, {(KEY_MAC, HOST)}).name is None
+    assert device_registry.async_get_device(connections={(KEY_MAC, HOST)}).name is None
 
     entity = entity_registry.async_get("climate.daikin_127_0_0_1")
     assert entity.unique_id == HOST
@@ -86,7 +86,8 @@ async def test_unique_id_migrate(hass: HomeAssistant, mock_daikin) -> None:
     assert config_entry.unique_id == MAC
 
     assert (
-        device_registry.async_get_device({}, {(KEY_MAC, MAC)}).name == "DaikinAP00000"
+        device_registry.async_get_device(connections={(KEY_MAC, MAC)}).name
+        == "DaikinAP00000"
     )
 
     entity = entity_registry.async_get("climate.daikin_127_0_0_1")

--- a/tests/components/dlink/test_init.py
+++ b/tests/components/dlink/test_init.py
@@ -66,7 +66,7 @@ async def test_device_info(
 
     entry = hass.config_entries.async_entries(DOMAIN)[0]
     device_registry = dr.async_get(hass)
-    device = device_registry.async_get_device({(DOMAIN, entry.entry_id)})
+    device = device_registry.async_get_device(identifiers={(DOMAIN, entry.entry_id)})
 
     assert device.connections == {("mac", "aa:bb:cc:dd:ee:ff")}
     assert device.identifiers == {(DOMAIN, entry.entry_id)}

--- a/tests/components/dremel_3d_printer/test_init.py
+++ b/tests/components/dremel_3d_printer/test_init.py
@@ -80,7 +80,9 @@ async def test_device_info(
     await hass.config_entries.async_setup(config_entry.entry_id)
     assert await async_setup_component(hass, DOMAIN, {})
     device_registry = dr.async_get(hass)
-    device = device_registry.async_get_device({(DOMAIN, config_entry.unique_id)})
+    device = device_registry.async_get_device(
+        identifiers={(DOMAIN, config_entry.unique_id)}
+    )
 
     assert device.manufacturer == "Dremel"
     assert device.model == "3D45"

--- a/tests/components/efergy/test_init.py
+++ b/tests/components/efergy/test_init.py
@@ -53,7 +53,7 @@ async def test_device_info(
     entry = await setup_platform(hass, aioclient_mock, SENSOR_DOMAIN)
     device_registry = dr.async_get(hass)
 
-    device = device_registry.async_get_device({(DOMAIN, entry.entry_id)})
+    device = device_registry.async_get_device(identifiers={(DOMAIN, entry.entry_id)})
 
     assert device.configuration_url == "https://engage.efergy.com/user/login"
     assert device.connections == {("mac", "ff:ff:ff:ff:ff:ff")}

--- a/tests/components/flux_led/test_light.py
+++ b/tests/components/flux_led/test_light.py
@@ -182,7 +182,7 @@ async def test_light_device_registry(
 
     device_registry = dr.async_get(hass)
     device = device_registry.async_get_device(
-        identifiers={}, connections={(dr.CONNECTION_NETWORK_MAC, MAC_ADDRESS)}
+        connections={(dr.CONNECTION_NETWORK_MAC, MAC_ADDRESS)}
     )
     assert device.sw_version == str(sw_version)
     assert device.model == model

--- a/tests/components/freedompro/test_binary_sensor.py
+++ b/tests/components/freedompro/test_binary_sensor.py
@@ -56,7 +56,7 @@ async def test_binary_sensor_get_state(
     registry = er.async_get(hass)
     registry_device = dr.async_get(hass)
 
-    device = registry_device.async_get_device({("freedompro", uid)})
+    device = registry_device.async_get_device(identifiers={("freedompro", uid)})
     assert device is not None
     assert device.identifiers == {("freedompro", uid)}
     assert device.manufacturer == "Freedompro"

--- a/tests/components/freedompro/test_climate.py
+++ b/tests/components/freedompro/test_climate.py
@@ -33,7 +33,7 @@ async def test_climate_get_state(hass: HomeAssistant, init_integration) -> None:
     entity_registry = er.async_get(hass)
     device_registry = dr.async_get(hass)
 
-    device = device_registry.async_get_device({("freedompro", uid)})
+    device = device_registry.async_get_device(identifiers={("freedompro", uid)})
     assert device is not None
     assert device.identifiers == {("freedompro", uid)}
     assert device.manufacturer == "Freedompro"

--- a/tests/components/freedompro/test_cover.py
+++ b/tests/components/freedompro/test_cover.py
@@ -47,7 +47,7 @@ async def test_cover_get_state(
     registry = er.async_get(hass)
     registry_device = dr.async_get(hass)
 
-    device = registry_device.async_get_device({("freedompro", uid)})
+    device = registry_device.async_get_device(identifiers={("freedompro", uid)})
     assert device is not None
     assert device.identifiers == {("freedompro", uid)}
     assert device.manufacturer == "Freedompro"

--- a/tests/components/freedompro/test_fan.py
+++ b/tests/components/freedompro/test_fan.py
@@ -27,7 +27,7 @@ async def test_fan_get_state(hass: HomeAssistant, init_integration) -> None:
     registry = er.async_get(hass)
     registry_device = dr.async_get(hass)
 
-    device = registry_device.async_get_device({("freedompro", uid)})
+    device = registry_device.async_get_device(identifiers={("freedompro", uid)})
     assert device is not None
     assert device.identifiers == {("freedompro", uid)}
     assert device.manufacturer == "Freedompro"

--- a/tests/components/freedompro/test_lock.py
+++ b/tests/components/freedompro/test_lock.py
@@ -26,7 +26,7 @@ async def test_lock_get_state(hass: HomeAssistant, init_integration) -> None:
     registry = er.async_get(hass)
     registry_device = dr.async_get(hass)
 
-    device = registry_device.async_get_device({("freedompro", uid)})
+    device = registry_device.async_get_device(identifiers={("freedompro", uid)})
     assert device is not None
     assert device.identifiers == {("freedompro", uid)}
     assert device.manufacturer == "Freedompro"

--- a/tests/components/fully_kiosk/test_diagnostics.py
+++ b/tests/components/fully_kiosk/test_diagnostics.py
@@ -24,7 +24,7 @@ async def test_diagnostics(
     """Test Fully Kiosk diagnostics."""
 
     device_registry = dr.async_get(hass)
-    device = device_registry.async_get_device({(DOMAIN, "abcdef-123456")})
+    device = device_registry.async_get_device(identifiers={(DOMAIN, "abcdef-123456")})
 
     diagnostics = await get_diagnostics_for_device(
         hass, hass_client, init_integration, device

--- a/tests/components/goalzero/test_init.py
+++ b/tests/components/goalzero/test_init.py
@@ -72,7 +72,7 @@ async def test_device_info(
     entry = await async_init_integration(hass, aioclient_mock)
     device_registry = dr.async_get(hass)
 
-    device = device_registry.async_get_device({(DOMAIN, entry.entry_id)})
+    device = device_registry.async_get_device(identifiers={(DOMAIN, entry.entry_id)})
 
     assert device.connections == {("mac", "12:34:56:78:90:12")}
     assert device.identifiers == {(DOMAIN, entry.entry_id)}

--- a/tests/components/gogogate2/test_cover.py
+++ b/tests/components/gogogate2/test_cover.py
@@ -334,7 +334,7 @@ async def test_device_info_ismartgate(
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device({(DOMAIN, "xyz")})
+    device = device_registry.async_get_device(identifiers={(DOMAIN, "xyz")})
     assert device
     assert device.manufacturer == MANUFACTURER
     assert device.name == "mycontroller"
@@ -369,7 +369,7 @@ async def test_device_info_gogogate2(
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device({(DOMAIN, "xyz")})
+    device = device_registry.async_get_device(identifiers={(DOMAIN, "xyz")})
     assert device
     assert device.manufacturer == MANUFACTURER
     assert device.name == "mycontroller"

--- a/tests/components/google_mail/test_init.py
+++ b/tests/components/google_mail/test_init.py
@@ -123,7 +123,7 @@ async def test_device_info(
     device_registry = dr.async_get(hass)
 
     entry = hass.config_entries.async_entries(DOMAIN)[0]
-    device = device_registry.async_get_device({(DOMAIN, entry.entry_id)})
+    device = device_registry.async_get_device(identifiers={(DOMAIN, entry.entry_id)})
 
     assert device.entry_type is dr.DeviceEntryType.SERVICE
     assert device.identifiers == {(DOMAIN, entry.entry_id)}

--- a/tests/components/heos/test_media_player.py
+++ b/tests/components/heos/test_media_player.py
@@ -263,7 +263,7 @@ async def test_updates_from_players_changed_new_ids(
     event = asyncio.Event()
 
     # Assert device registry matches current id
-    assert device_registry.async_get_device({(DOMAIN, 1)})
+    assert device_registry.async_get_device(identifiers={(DOMAIN, 1)})
     # Assert entity registry matches current id
     assert (
         entity_registry.async_get_entity_id(MEDIA_PLAYER_DOMAIN, DOMAIN, "1")
@@ -284,7 +284,7 @@ async def test_updates_from_players_changed_new_ids(
 
     # Assert device registry identifiers were updated
     assert len(device_registry.devices) == 2
-    assert device_registry.async_get_device({(DOMAIN, 101)})
+    assert device_registry.async_get_device(identifiers={(DOMAIN, 101)})
     # Assert entity registry unique id was updated
     assert len(entity_registry.entities) == 2
     assert (

--- a/tests/components/home_plus_control/test_switch.py
+++ b/tests/components/home_plus_control/test_switch.py
@@ -55,7 +55,7 @@ def one_entity_state(hass, device_uid):
     entity_reg = er.async_get(hass)
     device_reg = dr.async_get(hass)
 
-    device_id = device_reg.async_get_device({(DOMAIN, device_uid)}).id
+    device_id = device_reg.async_get_device(identifiers={(DOMAIN, device_uid)}).id
     entity_entries = er.async_entries_for_device(entity_reg, device_id)
 
     assert len(entity_entries) == 1

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -744,7 +744,7 @@ async def test_homekit_start(
     assert device_registry.async_get(bridge_with_wrong_mac.id) is None
 
     device = device_registry.async_get_device(
-        {(DOMAIN, entry.entry_id, BRIDGE_SERIAL_NUMBER)}
+        identifiers={(DOMAIN, entry.entry_id, BRIDGE_SERIAL_NUMBER)}
     )
     assert device
     formatted_mac = dr.format_mac(homekit.driver.state.mac)
@@ -760,7 +760,7 @@ async def test_homekit_start(
         await homekit.async_start()
 
     device = device_registry.async_get_device(
-        {(DOMAIN, entry.entry_id, BRIDGE_SERIAL_NUMBER)}
+        identifiers={(DOMAIN, entry.entry_id, BRIDGE_SERIAL_NUMBER)}
     )
     assert device
     formatted_mac = dr.format_mac(homekit.driver.state.mac)
@@ -953,7 +953,7 @@ async def test_homekit_unpair(
 
         formatted_mac = dr.format_mac(state.mac)
         hk_bridge_dev = device_registry.async_get_device(
-            {}, {(dr.CONNECTION_NETWORK_MAC, formatted_mac)}
+            connections={(dr.CONNECTION_NETWORK_MAC, formatted_mac)}
         )
 
         await hass.services.async_call(

--- a/tests/components/homekit_controller/common.py
+++ b/tests/components/homekit_controller/common.py
@@ -325,9 +325,7 @@ async def assert_devices_and_entities_created(
         #   we have detected broken serial numbers (and serial number is not used as an identifier).
 
         device = device_registry.async_get_device(
-            {
-                (IDENTIFIER_ACCESSORY_ID, expected.unique_id),
-            }
+            identifiers={(IDENTIFIER_ACCESSORY_ID, expected.unique_id)}
         )
 
         logger.debug("Comparing device %r to %r", device, expected)

--- a/tests/components/hue/test_device_trigger_v1.py
+++ b/tests/components/hue/test_device_trigger_v1.py
@@ -29,7 +29,7 @@ async def test_get_triggers(
 
     # Get triggers for specific tap switch
     hue_tap_device = device_reg.async_get_device(
-        {(hue.DOMAIN, "00:00:00:00:00:44:23:08")}
+        identifiers={(hue.DOMAIN, "00:00:00:00:00:44:23:08")}
     )
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, hue_tap_device.id
@@ -50,7 +50,7 @@ async def test_get_triggers(
 
     # Get triggers for specific dimmer switch
     hue_dimmer_device = device_reg.async_get_device(
-        {(hue.DOMAIN, "00:17:88:01:10:3e:3a:dc")}
+        identifiers={(hue.DOMAIN, "00:17:88:01:10:3e:3a:dc")}
     )
     hue_bat_sensor = entity_registry.async_get(
         "sensor.hue_dimmer_switch_1_battery_level"
@@ -95,7 +95,7 @@ async def test_if_fires_on_state_change(
 
     # Set an automation with a specific tap switch trigger
     hue_tap_device = device_reg.async_get_device(
-        {(hue.DOMAIN, "00:00:00:00:00:44:23:08")}
+        identifiers={(hue.DOMAIN, "00:00:00:00:00:44:23:08")}
     )
     assert await async_setup_component(
         hass,

--- a/tests/components/hue/test_device_trigger_v2.py
+++ b/tests/components/hue/test_device_trigger_v2.py
@@ -60,7 +60,7 @@ async def test_get_triggers(
 
     # Get triggers for `Wall switch with 2 controls`
     hue_wall_switch_device = device_reg.async_get_device(
-        {(hue.DOMAIN, "3ff06175-29e8-44a8-8fe7-af591b0025da")}
+        identifiers={(hue.DOMAIN, "3ff06175-29e8-44a8-8fe7-af591b0025da")}
     )
     hue_bat_sensor = entity_registry.async_get(
         "sensor.wall_switch_with_2_controls_battery"

--- a/tests/components/hue/test_sensor_v1.py
+++ b/tests/components/hue/test_sensor_v1.py
@@ -460,7 +460,7 @@ async def test_hue_events(hass: HomeAssistant, mock_bridge_v1, device_reg) -> No
     assert len(events) == 0
 
     hue_tap_device = device_reg.async_get_device(
-        {(hue.DOMAIN, "00:00:00:00:00:44:23:08")}
+        identifiers={(hue.DOMAIN, "00:00:00:00:00:44:23:08")}
     )
 
     mock_bridge_v1.api.sensors["7"].last_event = {"type": "button"}
@@ -492,7 +492,7 @@ async def test_hue_events(hass: HomeAssistant, mock_bridge_v1, device_reg) -> No
     }
 
     hue_dimmer_device = device_reg.async_get_device(
-        {(hue.DOMAIN, "00:17:88:01:10:3e:3a:dc")}
+        identifiers={(hue.DOMAIN, "00:17:88:01:10:3e:3a:dc")}
     )
 
     new_sensor_response = dict(new_sensor_response)
@@ -595,7 +595,7 @@ async def test_hue_events(hass: HomeAssistant, mock_bridge_v1, device_reg) -> No
     await hass.async_block_till_done()
 
     hue_aurora_device = device_reg.async_get_device(
-        {(hue.DOMAIN, "ff:ff:00:0f:e7:fd:bc:b7")}
+        identifiers={(hue.DOMAIN, "ff:ff:00:0f:e7:fd:bc:b7")}
     )
 
     assert len(mock_bridge_v1.mock_requests) == 6

--- a/tests/components/hyperion/test_camera.py
+++ b/tests/components/hyperion/test_camera.py
@@ -192,7 +192,7 @@ async def test_device_info(hass: HomeAssistant) -> None:
     device_id = get_hyperion_device_id(TEST_SYSINFO_ID, TEST_INSTANCE)
     device_registry = dr.async_get(hass)
 
-    device = device_registry.async_get_device({(DOMAIN, device_id)})
+    device = device_registry.async_get_device(identifiers={(DOMAIN, device_id)})
     assert device
     assert device.config_entries == {TEST_CONFIG_ENTRY_ID}
     assert device.identifiers == {(DOMAIN, device_id)}

--- a/tests/components/hyperion/test_light.py
+++ b/tests/components/hyperion/test_light.py
@@ -775,7 +775,7 @@ async def test_device_info(hass: HomeAssistant) -> None:
     device_id = get_hyperion_device_id(TEST_SYSINFO_ID, TEST_INSTANCE)
     device_registry = dr.async_get(hass)
 
-    device = device_registry.async_get_device({(DOMAIN, device_id)})
+    device = device_registry.async_get_device(identifiers={(DOMAIN, device_id)})
     assert device
     assert device.config_entries == {TEST_CONFIG_ENTRY_ID}
     assert device.identifiers == {(DOMAIN, device_id)}

--- a/tests/components/hyperion/test_switch.py
+++ b/tests/components/hyperion/test_switch.py
@@ -164,7 +164,7 @@ async def test_device_info(hass: HomeAssistant) -> None:
     device_identifer = get_hyperion_device_id(TEST_SYSINFO_ID, TEST_INSTANCE)
     device_registry = dr.async_get(hass)
 
-    device = device_registry.async_get_device({(DOMAIN, device_identifer)})
+    device = device_registry.async_get_device(identifiers={(DOMAIN, device_identifer)})
     assert device
     assert device.config_entries == {TEST_CONFIG_ENTRY_ID}
     assert device.identifiers == {(DOMAIN, device_identifer)}

--- a/tests/components/ibeacon/test_init.py
+++ b/tests/components/ibeacon/test_init.py
@@ -49,13 +49,12 @@ async def test_device_remove_devices(
     device_registry = dr.async_get(hass)
 
     device_entry = device_registry.async_get_device(
-        {
+        identifiers={
             (
                 DOMAIN,
                 "426c7565-4368-6172-6d42-6561636f6e73_3838_4949_61DE521B-F0BF-9F44-64D4-75BBE1738105",
             )
         },
-        {},
     )
     assert (
         await remove_device(await hass_ws_client(hass), device_entry.id, entry.entry_id)

--- a/tests/components/lcn/conftest.py
+++ b/tests/components/lcn/conftest.py
@@ -128,6 +128,6 @@ def get_device(hass, entry, address):
     """Get LCN device for specified address."""
     device_registry = dr.async_get(hass)
     identifiers = {(DOMAIN, generate_unique_id(entry.entry_id, address))}
-    device = device_registry.async_get_device(identifiers)
+    device = device_registry.async_get_device(identifiers=identifiers)
     assert device
     return device

--- a/tests/components/lcn/test_device_trigger.py
+++ b/tests/components/lcn/test_device_trigger.py
@@ -55,10 +55,12 @@ async def test_get_triggers_non_module_device(
     not_included_types = ("transmitter", "transponder", "fingerprint", "send_keys")
 
     device_registry = dr.async_get(hass)
-    host_device = device_registry.async_get_device({(DOMAIN, entry.entry_id)})
+    host_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, entry.entry_id)}
+    )
     group_device = get_device(hass, entry, (0, 5, True))
     resource_device = device_registry.async_get_device(
-        {(DOMAIN, f"{entry.entry_id}-m000007-output1")}
+        identifiers={(DOMAIN, f"{entry.entry_id}-m000007-output1")}
     )
 
     for device in (host_device, group_device, resource_device):

--- a/tests/components/lidarr/test_init.py
+++ b/tests/components/lidarr/test_init.py
@@ -52,7 +52,7 @@ async def test_device_info(
     entry = hass.config_entries.async_entries(DOMAIN)[0]
     device_registry = dr.async_get(hass)
     await hass.async_block_till_done()
-    device = device_registry.async_get_device({(DOMAIN, entry.entry_id)})
+    device = device_registry.async_get_device(identifiers={(DOMAIN, entry.entry_id)})
 
     assert device.configuration_url == "http://127.0.0.1:8668"
     assert device.identifiers == {(DOMAIN, entry.entry_id)}

--- a/tests/components/lifx/test_light.py
+++ b/tests/components/lifx/test_light.py
@@ -100,7 +100,7 @@ async def test_light_unique_id(hass: HomeAssistant) -> None:
 
     device_registry = dr.async_get(hass)
     device = device_registry.async_get_device(
-        identifiers=set(), connections={(dr.CONNECTION_NETWORK_MAC, SERIAL)}
+        connections={(dr.CONNECTION_NETWORK_MAC, SERIAL)}
     )
     assert device.identifiers == {(DOMAIN, SERIAL)}
 
@@ -123,7 +123,6 @@ async def test_light_unique_id_new_firmware(hass: HomeAssistant) -> None:
     assert entity_registry.async_get(entity_id).unique_id == SERIAL
     device_registry = dr.async_get(hass)
     device = device_registry.async_get_device(
-        identifiers=set(),
         connections={(dr.CONNECTION_NETWORK_MAC, MAC_ADDRESS)},
     )
     assert device.identifiers == {(DOMAIN, SERIAL)}

--- a/tests/components/matter/test_adapter.py
+++ b/tests/components/matter/test_adapter.py
@@ -41,7 +41,9 @@ async def test_device_registry_single_node_device(
 
     dev_reg = dr.async_get(hass)
     entry = dev_reg.async_get_device(
-        {(DOMAIN, "deviceid_00000000000004D2-0000000000000001-MatterNodeDevice")}
+        identifiers={
+            (DOMAIN, "deviceid_00000000000004D2-0000000000000001-MatterNodeDevice")
+        }
     )
     assert entry is not None
 
@@ -70,7 +72,9 @@ async def test_device_registry_single_node_device_alt(
 
     dev_reg = dr.async_get(hass)
     entry = dev_reg.async_get_device(
-        {(DOMAIN, "deviceid_00000000000004D2-0000000000000001-MatterNodeDevice")}
+        identifiers={
+            (DOMAIN, "deviceid_00000000000004D2-0000000000000001-MatterNodeDevice")
+        }
     )
     assert entry is not None
 
@@ -96,7 +100,7 @@ async def test_device_registry_bridge(
     dev_reg = dr.async_get(hass)
 
     # Validate bridge
-    bridge_entry = dev_reg.async_get_device({(DOMAIN, "mock-hub-id")})
+    bridge_entry = dev_reg.async_get_device(identifiers={(DOMAIN, "mock-hub-id")})
     assert bridge_entry is not None
 
     assert bridge_entry.name == "My Mock Bridge"
@@ -106,7 +110,9 @@ async def test_device_registry_bridge(
     assert bridge_entry.sw_version == "123.4.5"
 
     # Device 1
-    device1_entry = dev_reg.async_get_device({(DOMAIN, "mock-id-kitchen-ceiling")})
+    device1_entry = dev_reg.async_get_device(
+        identifiers={(DOMAIN, "mock-id-kitchen-ceiling")}
+    )
     assert device1_entry is not None
 
     assert device1_entry.via_device_id == bridge_entry.id
@@ -117,7 +123,9 @@ async def test_device_registry_bridge(
     assert device1_entry.sw_version == "67.8.9"
 
     # Device 2
-    device2_entry = dev_reg.async_get_device({(DOMAIN, "mock-id-living-room-ceiling")})
+    device2_entry = dev_reg.async_get_device(
+        identifiers={(DOMAIN, "mock-id-living-room-ceiling")}
+    )
     assert device2_entry is not None
 
     assert device2_entry.via_device_id == bridge_entry.id

--- a/tests/components/mobile_app/test_webhook.py
+++ b/tests/components/mobile_app/test_webhook.py
@@ -857,7 +857,9 @@ async def test_webhook_handle_scan_tag(
     hass: HomeAssistant, create_registrations, webhook_client
 ) -> None:
     """Test that we can scan tags."""
-    device = dr.async_get(hass).async_get_device({(DOMAIN, "mock-device-id")})
+    device = dr.async_get(hass).async_get_device(
+        identifiers={(DOMAIN, "mock-device-id")}
+    )
     assert device is not None
 
     events = async_capture_events(hass, EVENT_TAG_SCANNED)

--- a/tests/components/motioneye/test_camera.py
+++ b/tests/components/motioneye/test_camera.py
@@ -159,15 +159,17 @@ async def test_setup_camera_new_data_camera_removed(hass: HomeAssistant) -> None
 
     await hass.async_block_till_done()
     assert hass.states.get(TEST_CAMERA_ENTITY_ID)
-    assert device_registry.async_get_device({TEST_CAMERA_DEVICE_IDENTIFIER})
+    assert device_registry.async_get_device(identifiers={TEST_CAMERA_DEVICE_IDENTIFIER})
 
     client.async_get_cameras = AsyncMock(return_value={KEY_CAMERAS: []})
     async_fire_time_changed(hass, dt_util.utcnow() + DEFAULT_SCAN_INTERVAL)
     await hass.async_block_till_done()
     await hass.async_block_till_done()
     assert not hass.states.get(TEST_CAMERA_ENTITY_ID)
-    assert not device_registry.async_get_device({TEST_CAMERA_DEVICE_IDENTIFIER})
-    assert not device_registry.async_get_device({(DOMAIN, old_device_id)})
+    assert not device_registry.async_get_device(
+        identifiers={TEST_CAMERA_DEVICE_IDENTIFIER}
+    )
+    assert not device_registry.async_get_device(identifiers={(DOMAIN, old_device_id)})
     assert not entity_registry.async_get_entity_id(
         DOMAIN, "camera", old_entity_unique_id
     )
@@ -320,7 +322,7 @@ async def test_device_info(hass: HomeAssistant) -> None:
     device_identifier = get_motioneye_device_identifier(entry.entry_id, TEST_CAMERA_ID)
     device_registry = dr.async_get(hass)
 
-    device = device_registry.async_get_device({device_identifier})
+    device = device_registry.async_get_device(identifiers={device_identifier})
     assert device
     assert device.config_entries == {TEST_CONFIG_ENTRY_ID}
     assert device.identifiers == {device_identifier}

--- a/tests/components/motioneye/test_sensor.py
+++ b/tests/components/motioneye/test_sensor.py
@@ -88,7 +88,7 @@ async def test_sensor_device_info(hass: HomeAssistant) -> None:
     )
 
     device_registry = dr.async_get(hass)
-    device = device_registry.async_get_device({device_identifer})
+    device = device_registry.async_get_device(identifiers={device_identifer})
     assert device
 
     entity_registry = er.async_get(hass)

--- a/tests/components/motioneye/test_switch.py
+++ b/tests/components/motioneye/test_switch.py
@@ -193,7 +193,7 @@ async def test_switch_device_info(hass: HomeAssistant) -> None:
     )
     device_registry = dr.async_get(hass)
 
-    device = device_registry.async_get_device({device_identifer})
+    device = device_registry.async_get_device(identifiers={device_identifer})
     assert device
 
     entity_registry = er.async_get(hass)

--- a/tests/components/mqtt/test_common.py
+++ b/tests/components/mqtt/test_common.py
@@ -1036,7 +1036,7 @@ async def help_test_entity_device_info_with_connection(
     await hass.async_block_till_done()
 
     device = registry.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, "02:5b:26:a8:dc:12")}
+        connections={(dr.CONNECTION_NETWORK_MAC, "02:5b:26:a8:dc:12")}
     )
     assert device is not None
     assert device.connections == {(dr.CONNECTION_NETWORK_MAC, "02:5b:26:a8:dc:12")}

--- a/tests/components/mqtt/test_common.py
+++ b/tests/components/mqtt/test_common.py
@@ -1001,7 +1001,7 @@ async def help_test_entity_device_info_with_identifier(
     async_fire_mqtt_message(hass, f"homeassistant/{domain}/bla/config", data)
     await hass.async_block_till_done()
 
-    device = registry.async_get_device({("mqtt", "helloworld")})
+    device = registry.async_get_device(identifiers={("mqtt", "helloworld")})
     assert device is not None
     assert device.identifiers == {("mqtt", "helloworld")}
     assert device.manufacturer == "Whatever"
@@ -1069,14 +1069,14 @@ async def help_test_entity_device_info_remove(
     async_fire_mqtt_message(hass, f"homeassistant/{domain}/bla/config", data)
     await hass.async_block_till_done()
 
-    device = dev_registry.async_get_device({("mqtt", "helloworld")})
+    device = dev_registry.async_get_device(identifiers={("mqtt", "helloworld")})
     assert device is not None
     assert ent_registry.async_get_entity_id(domain, mqtt.DOMAIN, "veryunique")
 
     async_fire_mqtt_message(hass, f"homeassistant/{domain}/bla/config", "")
     await hass.async_block_till_done()
 
-    device = dev_registry.async_get_device({("mqtt", "helloworld")})
+    device = dev_registry.async_get_device(identifiers={("mqtt", "helloworld")})
     assert device is None
     assert not ent_registry.async_get_entity_id(domain, mqtt.DOMAIN, "veryunique")
 
@@ -1103,7 +1103,7 @@ async def help_test_entity_device_info_update(
     async_fire_mqtt_message(hass, f"homeassistant/{domain}/bla/config", data)
     await hass.async_block_till_done()
 
-    device = registry.async_get_device({("mqtt", "helloworld")})
+    device = registry.async_get_device(identifiers={("mqtt", "helloworld")})
     assert device is not None
     assert device.name == "Beer"
 
@@ -1112,7 +1112,7 @@ async def help_test_entity_device_info_update(
     async_fire_mqtt_message(hass, f"homeassistant/{domain}/bla/config", data)
     await hass.async_block_till_done()
 
-    device = registry.async_get_device({("mqtt", "helloworld")})
+    device = registry.async_get_device(identifiers={("mqtt", "helloworld")})
     assert device is not None
     assert device.name == "Milk"
 
@@ -1232,7 +1232,7 @@ async def help_test_entity_debug_info(
     async_fire_mqtt_message(hass, f"homeassistant/{domain}/bla/config", data)
     await hass.async_block_till_done()
 
-    device = registry.async_get_device({("mqtt", "helloworld")})
+    device = registry.async_get_device(identifiers={("mqtt", "helloworld")})
     assert device is not None
 
     debug_info_data = debug_info.info_for_device(hass, device.id)
@@ -1272,7 +1272,7 @@ async def help_test_entity_debug_info_max_messages(
     async_fire_mqtt_message(hass, f"homeassistant/{domain}/bla/config", data)
     await hass.async_block_till_done()
 
-    device = registry.async_get_device({("mqtt", "helloworld")})
+    device = registry.async_get_device(identifiers={("mqtt", "helloworld")})
     assert device is not None
 
     debug_info_data = debug_info.info_for_device(hass, device.id)
@@ -1352,7 +1352,7 @@ async def help_test_entity_debug_info_message(
     async_fire_mqtt_message(hass, f"homeassistant/{domain}/bla/config", data)
     await hass.async_block_till_done()
 
-    device = registry.async_get_device({("mqtt", "helloworld")})
+    device = registry.async_get_device(identifiers={("mqtt", "helloworld")})
     assert device is not None
 
     debug_info_data = debug_info.info_for_device(hass, device.id)
@@ -1443,7 +1443,7 @@ async def help_test_entity_debug_info_remove(
     async_fire_mqtt_message(hass, f"homeassistant/{domain}/bla/config", data)
     await hass.async_block_till_done()
 
-    device = registry.async_get_device({("mqtt", "helloworld")})
+    device = registry.async_get_device(identifiers={("mqtt", "helloworld")})
     assert device is not None
 
     debug_info_data = debug_info.info_for_device(hass, device.id)
@@ -1493,7 +1493,7 @@ async def help_test_entity_debug_info_update_entity_id(
     async_fire_mqtt_message(hass, f"homeassistant/{domain}/bla/config", data)
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device({("mqtt", "helloworld")})
+    device = device_registry.async_get_device(identifiers={("mqtt", "helloworld")})
     assert device is not None
 
     debug_info_data = debug_info.info_for_device(hass, device.id)
@@ -1555,7 +1555,7 @@ async def help_test_entity_disabled_by_default(
     await hass.async_block_till_done()
     entity_id = ent_registry.async_get_entity_id(domain, mqtt.DOMAIN, "veryunique1")
     assert entity_id is not None and hass.states.get(entity_id) is None
-    assert dev_registry.async_get_device({("mqtt", "helloworld")})
+    assert dev_registry.async_get_device(identifiers={("mqtt", "helloworld")})
 
     # Discover an enabled entity, tied to the same device
     config["enabled_by_default"] = True
@@ -1571,7 +1571,7 @@ async def help_test_entity_disabled_by_default(
     await hass.async_block_till_done()
     assert not ent_registry.async_get_entity_id(domain, mqtt.DOMAIN, "veryunique1")
     assert not ent_registry.async_get_entity_id(domain, mqtt.DOMAIN, "veryunique2")
-    assert not dev_registry.async_get_device({("mqtt", "helloworld")})
+    assert not dev_registry.async_get_device(identifiers={("mqtt", "helloworld")})
 
 
 async def help_test_entity_category(

--- a/tests/components/mqtt/test_device_tracker.py
+++ b/tests/components/mqtt/test_device_tracker.py
@@ -249,7 +249,7 @@ async def test_cleanup_device_tracker(
     await hass.async_block_till_done()
 
     # Verify device and registry entries are created
-    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device(identifiers={("mqtt", "0AFFD2")})
     assert device_entry is not None
     entity_entry = entity_registry.async_get("device_tracker.mqtt_unique")
     assert entity_entry is not None
@@ -273,7 +273,7 @@ async def test_cleanup_device_tracker(
     await hass.async_block_till_done()
 
     # Verify device and registry entries are cleared
-    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device(identifiers={("mqtt", "0AFFD2")})
     assert device_entry is None
     entity_entry = entity_registry.async_get("device_tracker.mqtt_unique")
     assert entity_entry is None

--- a/tests/components/mqtt/test_device_trigger.py
+++ b/tests/components/mqtt/test_device_trigger.py
@@ -64,7 +64,7 @@ async def test_get_triggers(
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla/config", data1)
     await hass.async_block_till_done()
 
-    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device(identifiers={("mqtt", "0AFFD2")})
     expected_triggers = [
         {
             "platform": "device",
@@ -98,7 +98,7 @@ async def test_get_unknown_triggers(
     async_fire_mqtt_message(hass, "homeassistant/sensor/bla/config", data1)
     await hass.async_block_till_done()
 
-    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device(identifiers={("mqtt", "0AFFD2")})
 
     assert await async_setup_component(
         hass,
@@ -145,7 +145,7 @@ async def test_get_non_existing_triggers(
     async_fire_mqtt_message(hass, "homeassistant/sensor/bla/config", data1)
     await hass.async_block_till_done()
 
-    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device(identifiers={("mqtt", "0AFFD2")})
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_entry.id
     )
@@ -171,7 +171,7 @@ async def test_discover_bad_triggers(
     )
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla/config", data0)
     await hass.async_block_till_done()
-    assert device_registry.async_get_device({("mqtt", "0AFFD2")}) is None
+    assert device_registry.async_get_device(identifiers={("mqtt", "0AFFD2")}) is None
 
     # Test sending correct data
     data1 = (
@@ -185,7 +185,7 @@ async def test_discover_bad_triggers(
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla/config", data1)
     await hass.async_block_till_done()
 
-    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device(identifiers={("mqtt", "0AFFD2")})
     expected_triggers = [
         {
             "platform": "device",
@@ -235,7 +235,7 @@ async def test_update_remove_triggers(
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla/config", data1)
     await hass.async_block_till_done()
 
-    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device(identifiers={("mqtt", "0AFFD2")})
     expected_triggers1 = [
         {
             "platform": "device",
@@ -268,7 +268,7 @@ async def test_update_remove_triggers(
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla/config", "")
     await hass.async_block_till_done()
 
-    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device(identifiers={("mqtt", "0AFFD2")})
     assert device_entry is None
 
 
@@ -299,7 +299,7 @@ async def test_if_fires_on_mqtt_message(
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla1/config", data1)
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla2/config", data2)
     await hass.async_block_till_done()
-    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device(identifiers={("mqtt", "0AFFD2")})
 
     assert await async_setup_component(
         hass,
@@ -380,7 +380,7 @@ async def test_if_fires_on_mqtt_message_template(
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla1/config", data1)
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla2/config", data2)
     await hass.async_block_till_done()
-    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device(identifiers={("mqtt", "0AFFD2")})
 
     assert await async_setup_component(
         hass,
@@ -463,7 +463,7 @@ async def test_if_fires_on_mqtt_message_late_discover(
     )
     async_fire_mqtt_message(hass, "homeassistant/sensor/bla0/config", data0)
     await hass.async_block_till_done()
-    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device(identifiers={("mqtt", "0AFFD2")})
 
     assert await async_setup_component(
         hass,
@@ -543,7 +543,7 @@ async def test_if_fires_on_mqtt_message_after_update(
     )
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla1/config", data1)
     await hass.async_block_till_done()
-    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device(identifiers={("mqtt", "0AFFD2")})
 
     assert await async_setup_component(
         hass,
@@ -615,7 +615,7 @@ async def test_no_resubscribe_same_topic(
     )
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla1/config", data1)
     await hass.async_block_till_done()
-    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device(identifiers={("mqtt", "0AFFD2")})
 
     assert await async_setup_component(
         hass,
@@ -663,7 +663,7 @@ async def test_not_fires_on_mqtt_message_after_remove_by_mqtt(
     )
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla1/config", data1)
     await hass.async_block_till_done()
-    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device(identifiers={("mqtt", "0AFFD2")})
 
     assert await async_setup_component(
         hass,
@@ -735,7 +735,7 @@ async def test_not_fires_on_mqtt_message_after_remove_from_registry(
     )
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla1/config", data1)
     await hass.async_block_till_done()
-    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device(identifiers={("mqtt", "0AFFD2")})
 
     assert await async_setup_component(
         hass,
@@ -801,7 +801,7 @@ async def test_attach_remove(
     )
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla1/config", data1)
     await hass.async_block_till_done()
-    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device(identifiers={("mqtt", "0AFFD2")})
 
     calls = []
 
@@ -864,7 +864,7 @@ async def test_attach_remove_late(
     )
     async_fire_mqtt_message(hass, "homeassistant/sensor/bla0/config", data0)
     await hass.async_block_till_done()
-    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device(identifiers={("mqtt", "0AFFD2")})
 
     calls = []
 
@@ -930,7 +930,7 @@ async def test_attach_remove_late2(
     )
     async_fire_mqtt_message(hass, "homeassistant/sensor/bla0/config", data0)
     await hass.async_block_till_done()
-    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device(identifiers={("mqtt", "0AFFD2")})
 
     calls = []
 
@@ -1036,7 +1036,7 @@ async def test_entity_device_info_with_identifier(
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla/config", data)
     await hass.async_block_till_done()
 
-    device = registry.async_get_device({("mqtt", "helloworld")})
+    device = registry.async_get_device(identifiers={("mqtt", "helloworld")})
     assert device is not None
     assert device.identifiers == {("mqtt", "helloworld")}
     assert device.manufacturer == "Whatever"
@@ -1072,7 +1072,7 @@ async def test_entity_device_info_update(
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla/config", data)
     await hass.async_block_till_done()
 
-    device = registry.async_get_device({("mqtt", "helloworld")})
+    device = registry.async_get_device(identifiers={("mqtt", "helloworld")})
     assert device is not None
     assert device.name == "Beer"
 
@@ -1081,7 +1081,7 @@ async def test_entity_device_info_update(
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla/config", data)
     await hass.async_block_till_done()
 
-    device = registry.async_get_device({("mqtt", "helloworld")})
+    device = registry.async_get_device(identifiers={("mqtt", "helloworld")})
     assert device is not None
     assert device.name == "Milk"
 
@@ -1110,7 +1110,9 @@ async def test_cleanup_trigger(
     await hass.async_block_till_done()
 
     # Verify device registry entry is created
-    device_entry = device_registry.async_get_device({("mqtt", "helloworld")})
+    device_entry = device_registry.async_get_device(
+        identifiers={("mqtt", "helloworld")}
+    )
     assert device_entry is not None
 
     triggers = await async_get_device_automations(
@@ -1134,7 +1136,9 @@ async def test_cleanup_trigger(
     await hass.async_block_till_done()
 
     # Verify device registry entry is cleared
-    device_entry = device_registry.async_get_device({("mqtt", "helloworld")})
+    device_entry = device_registry.async_get_device(
+        identifiers={("mqtt", "helloworld")}
+    )
     assert device_entry is None
 
     # Verify retained discovery topic has been cleared
@@ -1163,7 +1167,9 @@ async def test_cleanup_device(
     await hass.async_block_till_done()
 
     # Verify device registry entry is created
-    device_entry = device_registry.async_get_device({("mqtt", "helloworld")})
+    device_entry = device_registry.async_get_device(
+        identifiers={("mqtt", "helloworld")}
+    )
     assert device_entry is not None
 
     triggers = await async_get_device_automations(
@@ -1175,7 +1181,9 @@ async def test_cleanup_device(
     await hass.async_block_till_done()
 
     # Verify device registry entry is cleared
-    device_entry = device_registry.async_get_device({("mqtt", "helloworld")})
+    device_entry = device_registry.async_get_device(
+        identifiers={("mqtt", "helloworld")}
+    )
     assert device_entry is None
 
 
@@ -1210,7 +1218,9 @@ async def test_cleanup_device_several_triggers(
     await hass.async_block_till_done()
 
     # Verify device registry entry is created
-    device_entry = device_registry.async_get_device({("mqtt", "helloworld")})
+    device_entry = device_registry.async_get_device(
+        identifiers={("mqtt", "helloworld")}
+    )
     assert device_entry is not None
 
     triggers = await async_get_device_automations(
@@ -1224,7 +1234,9 @@ async def test_cleanup_device_several_triggers(
     await hass.async_block_till_done()
 
     # Verify device registry entry is not cleared
-    device_entry = device_registry.async_get_device({("mqtt", "helloworld")})
+    device_entry = device_registry.async_get_device(
+        identifiers={("mqtt", "helloworld")}
+    )
     assert device_entry is not None
 
     triggers = await async_get_device_automations(
@@ -1237,7 +1249,9 @@ async def test_cleanup_device_several_triggers(
     await hass.async_block_till_done()
 
     # Verify device registry entry is cleared
-    device_entry = device_registry.async_get_device({("mqtt", "helloworld")})
+    device_entry = device_registry.async_get_device(
+        identifiers={("mqtt", "helloworld")}
+    )
     assert device_entry is None
 
 
@@ -1274,7 +1288,9 @@ async def test_cleanup_device_with_entity1(
     await hass.async_block_till_done()
 
     # Verify device registry entry is created
-    device_entry = device_registry.async_get_device({("mqtt", "helloworld")})
+    device_entry = device_registry.async_get_device(
+        identifiers={("mqtt", "helloworld")}
+    )
     assert device_entry is not None
 
     triggers = await async_get_device_automations(
@@ -1286,7 +1302,9 @@ async def test_cleanup_device_with_entity1(
     await hass.async_block_till_done()
 
     # Verify device registry entry is not cleared
-    device_entry = device_registry.async_get_device({("mqtt", "helloworld")})
+    device_entry = device_registry.async_get_device(
+        identifiers={("mqtt", "helloworld")}
+    )
     assert device_entry is not None
 
     triggers = await async_get_device_automations(
@@ -1298,7 +1316,9 @@ async def test_cleanup_device_with_entity1(
     await hass.async_block_till_done()
 
     # Verify device registry entry is cleared
-    device_entry = device_registry.async_get_device({("mqtt", "helloworld")})
+    device_entry = device_registry.async_get_device(
+        identifiers={("mqtt", "helloworld")}
+    )
     assert device_entry is None
 
 
@@ -1335,7 +1355,9 @@ async def test_cleanup_device_with_entity2(
     await hass.async_block_till_done()
 
     # Verify device registry entry is created
-    device_entry = device_registry.async_get_device({("mqtt", "helloworld")})
+    device_entry = device_registry.async_get_device(
+        identifiers={("mqtt", "helloworld")}
+    )
     assert device_entry is not None
 
     triggers = await async_get_device_automations(
@@ -1347,7 +1369,9 @@ async def test_cleanup_device_with_entity2(
     await hass.async_block_till_done()
 
     # Verify device registry entry is not cleared
-    device_entry = device_registry.async_get_device({("mqtt", "helloworld")})
+    device_entry = device_registry.async_get_device(
+        identifiers={("mqtt", "helloworld")}
+    )
     assert device_entry is not None
 
     triggers = await async_get_device_automations(
@@ -1359,7 +1383,9 @@ async def test_cleanup_device_with_entity2(
     await hass.async_block_till_done()
 
     # Verify device registry entry is cleared
-    device_entry = device_registry.async_get_device({("mqtt", "helloworld")})
+    device_entry = device_registry.async_get_device(
+        identifiers={("mqtt", "helloworld")}
+    )
     assert device_entry is None
 
 
@@ -1457,7 +1483,7 @@ async def test_unload_entry(
     )
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla1/config", data1)
     await hass.async_block_till_done()
-    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device(identifiers={("mqtt", "0AFFD2")})
 
     assert await async_setup_component(
         hass,

--- a/tests/components/mqtt/test_device_trigger.py
+++ b/tests/components/mqtt/test_device_trigger.py
@@ -999,7 +999,7 @@ async def test_entity_device_info_with_connection(
     await hass.async_block_till_done()
 
     device = registry.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, "02:5b:26:a8:dc:12")}
+        connections={(dr.CONNECTION_NETWORK_MAC, "02:5b:26:a8:dc:12")}
     )
     assert device is not None
     assert device.connections == {(dr.CONNECTION_NETWORK_MAC, "02:5b:26:a8:dc:12")}
@@ -1430,7 +1430,7 @@ async def test_trigger_debug_info(
     await hass.async_block_till_done()
 
     device = registry.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, "02:5b:26:a8:dc:12")}
+        connections={(dr.CONNECTION_NETWORK_MAC, "02:5b:26:a8:dc:12")}
     )
     assert device is not None
 

--- a/tests/components/mqtt/test_diagnostics.py
+++ b/tests/components/mqtt/test_diagnostics.py
@@ -75,7 +75,7 @@ async def test_entry_diagnostics(
     )
     await hass.async_block_till_done()
 
-    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device(identifiers={("mqtt", "0AFFD2")})
 
     expected_debug_info = {
         "entities": [
@@ -190,7 +190,7 @@ async def test_redact_diagnostics(
     async_fire_mqtt_message(hass, "attributes-topic", location_data)
     await hass.async_block_till_done()
 
-    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device(identifiers={("mqtt", "0AFFD2")})
 
     expected_debug_info = {
         "entities": [

--- a/tests/components/mqtt/test_discovery.py
+++ b/tests/components/mqtt/test_discovery.py
@@ -727,7 +727,7 @@ async def test_cleanup_device(
     await hass.async_block_till_done()
 
     # Verify device and registry entries are created
-    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device(identifiers={("mqtt", "0AFFD2")})
     assert device_entry is not None
     entity_entry = entity_registry.async_get("sensor.mqtt_sensor")
     assert entity_entry is not None
@@ -751,7 +751,7 @@ async def test_cleanup_device(
     await hass.async_block_till_done()
 
     # Verify device and registry entries are cleared
-    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device(identifiers={("mqtt", "0AFFD2")})
     assert device_entry is None
     entity_entry = entity_registry.async_get("sensor.mqtt_sensor")
     assert entity_entry is None
@@ -786,7 +786,7 @@ async def test_cleanup_device_mqtt(
     await hass.async_block_till_done()
 
     # Verify device and registry entries are created
-    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device(identifiers={("mqtt", "0AFFD2")})
     assert device_entry is not None
     entity_entry = entity_registry.async_get("sensor.mqtt_sensor")
     assert entity_entry is not None
@@ -799,7 +799,7 @@ async def test_cleanup_device_mqtt(
     await hass.async_block_till_done()
 
     # Verify device and registry entries are cleared
-    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device(identifiers={("mqtt", "0AFFD2")})
     assert device_entry is None
     entity_entry = entity_registry.async_get("sensor.mqtt_sensor")
     assert entity_entry is None

--- a/tests/components/mqtt/test_discovery.py
+++ b/tests/components/mqtt/test_discovery.py
@@ -866,7 +866,7 @@ async def test_cleanup_device_multiple_config_entries(
 
     # Verify device and registry entries are created
     device_entry = device_registry.async_get_device(
-        set(), {("mac", "12:34:56:AB:CD:EF")}
+        connections={("mac", "12:34:56:AB:CD:EF")}
     )
     assert device_entry is not None
     assert device_entry.config_entries == {
@@ -897,7 +897,7 @@ async def test_cleanup_device_multiple_config_entries(
 
     # Verify device is still there but entity is cleared
     device_entry = device_registry.async_get_device(
-        set(), {("mac", "12:34:56:AB:CD:EF")}
+        connections={("mac", "12:34:56:AB:CD:EF")}
     )
     assert device_entry is not None
     entity_entry = entity_registry.async_get("sensor.mqtt_sensor")
@@ -966,7 +966,7 @@ async def test_cleanup_device_multiple_config_entries_mqtt(
 
     # Verify device and registry entries are created
     device_entry = device_registry.async_get_device(
-        set(), {("mac", "12:34:56:AB:CD:EF")}
+        connections={("mac", "12:34:56:AB:CD:EF")}
     )
     assert device_entry is not None
     assert device_entry.config_entries == {
@@ -989,7 +989,7 @@ async def test_cleanup_device_multiple_config_entries_mqtt(
 
     # Verify device is still there but entity is cleared
     device_entry = device_registry.async_get_device(
-        set(), {("mac", "12:34:56:AB:CD:EF")}
+        connections={("mac", "12:34:56:AB:CD:EF")}
     )
     assert device_entry is not None
     entity_entry = entity_registry.async_get("sensor.mqtt_sensor")
@@ -1518,7 +1518,7 @@ async def test_clear_config_topic_disabled_entity(
 
     # Verify device is created
     device_entry = device_registry.async_get_device(
-        set(), {("mac", "12:34:56:AB:CD:EF")}
+        connections={("mac", "12:34:56:AB:CD:EF")}
     )
     assert device_entry is not None
 
@@ -1584,7 +1584,7 @@ async def test_clean_up_registry_monitoring(
 
     # Verify device is created
     device_entry = device_registry.async_get_device(
-        set(), {("mac", "12:34:56:AB:CD:EF")}
+        connections={("mac", "12:34:56:AB:CD:EF")}
     )
     assert device_entry is not None
 

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -2604,7 +2604,7 @@ async def test_default_entry_setting_are_applied(
     async_fire_mqtt_message(hass, "homeassistant/sensor/bla/config", data)
     await hass.async_block_till_done()
 
-    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device(identifiers={("mqtt", "0AFFD2")})
     assert device_entry is not None
 
 
@@ -2757,7 +2757,7 @@ async def test_mqtt_ws_remove_discovered_device(
     await hass.async_block_till_done()
 
     # Verify device entry is created
-    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device(identifiers={("mqtt", "0AFFD2")})
     assert device_entry is not None
 
     client = await hass_ws_client(hass)
@@ -2774,7 +2774,7 @@ async def test_mqtt_ws_remove_discovered_device(
     assert response["success"]
 
     # Verify device entry is cleared
-    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device(identifiers={("mqtt", "0AFFD2")})
     assert device_entry is None
 
 
@@ -2809,7 +2809,7 @@ async def test_mqtt_ws_get_device_debug_info(
     await hass.async_block_till_done()
 
     # Verify device entry is created
-    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device(identifiers={("mqtt", "0AFFD2")})
     assert device_entry is not None
 
     client = await hass_ws_client(hass)
@@ -2864,7 +2864,7 @@ async def test_mqtt_ws_get_device_debug_info_binary(
     await hass.async_block_till_done()
 
     # Verify device entry is created
-    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device(identifiers={("mqtt", "0AFFD2")})
     assert device_entry is not None
 
     small_png = (
@@ -2971,7 +2971,7 @@ async def test_debug_info_multiple_devices(
     for dev in devices:
         domain = dev["domain"]
         id = dev["config"]["device"]["identifiers"][0]
-        device = registry.async_get_device({("mqtt", id)})
+        device = registry.async_get_device(identifiers={("mqtt", id)})
         assert device is not None
 
         debug_info_data = debug_info.info_for_device(hass, device.id)
@@ -3052,7 +3052,7 @@ async def test_debug_info_multiple_entities_triggers(
         await hass.async_block_till_done()
 
     device_id = config[0]["config"]["device"]["identifiers"][0]
-    device = registry.async_get_device({("mqtt", device_id)})
+    device = registry.async_get_device(identifiers={("mqtt", device_id)})
     assert device is not None
     debug_info_data = debug_info.info_for_device(hass, device.id)
     assert len(debug_info_data["entities"]) == 2
@@ -3132,7 +3132,7 @@ async def test_debug_info_wildcard(
     async_fire_mqtt_message(hass, "homeassistant/sensor/bla/config", data)
     await hass.async_block_till_done()
 
-    device = registry.async_get_device({("mqtt", "helloworld")})
+    device = registry.async_get_device(identifiers={("mqtt", "helloworld")})
     assert device is not None
 
     debug_info_data = debug_info.info_for_device(hass, device.id)
@@ -3180,7 +3180,7 @@ async def test_debug_info_filter_same(
     async_fire_mqtt_message(hass, "homeassistant/sensor/bla/config", data)
     await hass.async_block_till_done()
 
-    device = registry.async_get_device({("mqtt", "helloworld")})
+    device = registry.async_get_device(identifiers={("mqtt", "helloworld")})
     assert device is not None
 
     debug_info_data = debug_info.info_for_device(hass, device.id)
@@ -3241,7 +3241,7 @@ async def test_debug_info_same_topic(
     async_fire_mqtt_message(hass, "homeassistant/sensor/bla/config", data)
     await hass.async_block_till_done()
 
-    device = registry.async_get_device({("mqtt", "helloworld")})
+    device = registry.async_get_device(identifiers={("mqtt", "helloworld")})
     assert device is not None
 
     debug_info_data = debug_info.info_for_device(hass, device.id)
@@ -3294,7 +3294,7 @@ async def test_debug_info_qos_retain(
     async_fire_mqtt_message(hass, "homeassistant/sensor/bla/config", data)
     await hass.async_block_till_done()
 
-    device = registry.async_get_device({("mqtt", "helloworld")})
+    device = registry.async_get_device(identifiers={("mqtt", "helloworld")})
     assert device is not None
 
     debug_info_data = debug_info.info_for_device(hass, device.id)

--- a/tests/components/mqtt/test_sensor.py
+++ b/tests/components/mqtt/test_sensor.py
@@ -1142,7 +1142,7 @@ async def test_entity_device_info_with_hub(
     async_fire_mqtt_message(hass, "homeassistant/sensor/bla/config", data)
     await hass.async_block_till_done()
 
-    device = registry.async_get_device({("mqtt", "helloworld")})
+    device = registry.async_get_device(identifiers={("mqtt", "helloworld")})
     assert device is not None
     assert device.via_device_id == hub.id
 

--- a/tests/components/mqtt/test_tag.py
+++ b/tests/components/mqtt/test_tag.py
@@ -75,13 +75,13 @@ async def test_discover_bad_tag(
     data0 = '{ "device":{"identifiers":["0AFFD2"]}, "topics": "foobar/tag_scanned" }'
     async_fire_mqtt_message(hass, "homeassistant/tag/bla/config", data0)
     await hass.async_block_till_done()
-    assert device_registry.async_get_device({("mqtt", "0AFFD2")}) is None
+    assert device_registry.async_get_device(identifiers={("mqtt", "0AFFD2")}) is None
 
     # Test sending correct data
     async_fire_mqtt_message(hass, "homeassistant/tag/bla/config", json.dumps(config1))
     await hass.async_block_till_done()
 
-    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device(identifiers={("mqtt", "0AFFD2")})
     # Fake tag scan.
     async_fire_mqtt_message(hass, "foobar/tag_scanned", DEFAULT_TAG_SCAN)
     await hass.async_block_till_done()
@@ -100,7 +100,7 @@ async def test_if_fires_on_mqtt_message_with_device(
 
     async_fire_mqtt_message(hass, "homeassistant/tag/bla1/config", json.dumps(config))
     await hass.async_block_till_done()
-    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device(identifiers={("mqtt", "0AFFD2")})
 
     # Fake tag scan.
     async_fire_mqtt_message(hass, "foobar/tag_scanned", DEFAULT_TAG_SCAN)
@@ -138,7 +138,7 @@ async def test_if_fires_on_mqtt_message_with_template(
 
     async_fire_mqtt_message(hass, "homeassistant/tag/bla1/config", json.dumps(config))
     await hass.async_block_till_done()
-    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device(identifiers={("mqtt", "0AFFD2")})
 
     # Fake tag scan.
     async_fire_mqtt_message(hass, "foobar/tag_scanned", DEFAULT_TAG_SCAN_JSON)
@@ -180,7 +180,7 @@ async def test_if_fires_on_mqtt_message_after_update_with_device(
 
     async_fire_mqtt_message(hass, "homeassistant/tag/bla1/config", json.dumps(config1))
     await hass.async_block_till_done()
-    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device(identifiers={("mqtt", "0AFFD2")})
 
     # Fake tag scan.
     async_fire_mqtt_message(hass, "foobar/tag_scanned", DEFAULT_TAG_SCAN)
@@ -275,7 +275,7 @@ async def test_if_fires_on_mqtt_message_after_update_with_template(
 
     async_fire_mqtt_message(hass, "homeassistant/tag/bla1/config", json.dumps(config1))
     await hass.async_block_till_done()
-    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device(identifiers={("mqtt", "0AFFD2")})
 
     # Fake tag scan.
     async_fire_mqtt_message(hass, "foobar/tag_scanned", DEFAULT_TAG_SCAN_JSON)
@@ -320,7 +320,7 @@ async def test_no_resubscribe_same_topic(
 
     async_fire_mqtt_message(hass, "homeassistant/tag/bla1/config", json.dumps(config))
     await hass.async_block_till_done()
-    assert device_registry.async_get_device({("mqtt", "0AFFD2")})
+    assert device_registry.async_get_device(identifiers={("mqtt", "0AFFD2")})
 
     call_count = mqtt_mock.async_subscribe.call_count
     async_fire_mqtt_message(hass, "homeassistant/tag/bla1/config", json.dumps(config))
@@ -340,7 +340,7 @@ async def test_not_fires_on_mqtt_message_after_remove_by_mqtt_with_device(
 
     async_fire_mqtt_message(hass, "homeassistant/tag/bla1/config", json.dumps(config))
     await hass.async_block_till_done()
-    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device(identifiers={("mqtt", "0AFFD2")})
 
     # Fake tag scan.
     async_fire_mqtt_message(hass, "foobar/tag_scanned", DEFAULT_TAG_SCAN)
@@ -417,7 +417,7 @@ async def test_not_fires_on_mqtt_message_after_remove_from_registry(
 
     async_fire_mqtt_message(hass, "homeassistant/tag/bla1/config", json.dumps(config))
     await hass.async_block_till_done()
-    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device(identifiers={("mqtt", "0AFFD2")})
 
     # Fake tag scan.
     async_fire_mqtt_message(hass, "foobar/tag_scanned", DEFAULT_TAG_SCAN)
@@ -501,7 +501,7 @@ async def test_entity_device_info_with_identifier(
     async_fire_mqtt_message(hass, "homeassistant/tag/bla/config", data)
     await hass.async_block_till_done()
 
-    device = registry.async_get_device({("mqtt", "helloworld")})
+    device = registry.async_get_device(identifiers={("mqtt", "helloworld")})
     assert device is not None
     assert device.identifiers == {("mqtt", "helloworld")}
     assert device.manufacturer == "Whatever"
@@ -534,7 +534,7 @@ async def test_entity_device_info_update(
     async_fire_mqtt_message(hass, "homeassistant/tag/bla/config", data)
     await hass.async_block_till_done()
 
-    device = registry.async_get_device({("mqtt", "helloworld")})
+    device = registry.async_get_device(identifiers={("mqtt", "helloworld")})
     assert device is not None
     assert device.name == "Beer"
 
@@ -543,7 +543,7 @@ async def test_entity_device_info_update(
     async_fire_mqtt_message(hass, "homeassistant/tag/bla/config", data)
     await hass.async_block_till_done()
 
-    device = registry.async_get_device({("mqtt", "helloworld")})
+    device = registry.async_get_device(identifiers={("mqtt", "helloworld")})
     assert device is not None
     assert device.name == "Milk"
 
@@ -588,20 +588,24 @@ async def test_cleanup_tag(
     await hass.async_block_till_done()
 
     # Verify device registry entries are created
-    device_entry1 = device_registry.async_get_device({("mqtt", "helloworld")})
+    device_entry1 = device_registry.async_get_device(
+        identifiers={("mqtt", "helloworld")}
+    )
     assert device_entry1 is not None
     assert device_entry1.config_entries == {config_entry.entry_id, mqtt_entry.entry_id}
-    device_entry2 = device_registry.async_get_device({("mqtt", "hejhopp")})
+    device_entry2 = device_registry.async_get_device(identifiers={("mqtt", "hejhopp")})
     assert device_entry2 is not None
 
     # Remove other config entry from the device
     device_registry.async_update_device(
         device_entry1.id, remove_config_entry_id=config_entry.entry_id
     )
-    device_entry1 = device_registry.async_get_device({("mqtt", "helloworld")})
+    device_entry1 = device_registry.async_get_device(
+        identifiers={("mqtt", "helloworld")}
+    )
     assert device_entry1 is not None
     assert device_entry1.config_entries == {mqtt_entry.entry_id}
-    device_entry2 = device_registry.async_get_device({("mqtt", "hejhopp")})
+    device_entry2 = device_registry.async_get_device(identifiers={("mqtt", "hejhopp")})
     assert device_entry2 is not None
     mqtt_mock.async_publish.assert_not_called()
 
@@ -621,9 +625,11 @@ async def test_cleanup_tag(
     await hass.async_block_till_done()
 
     # Verify device registry entry is cleared
-    device_entry1 = device_registry.async_get_device({("mqtt", "helloworld")})
+    device_entry1 = device_registry.async_get_device(
+        identifiers={("mqtt", "helloworld")}
+    )
     assert device_entry1 is None
-    device_entry2 = device_registry.async_get_device({("mqtt", "hejhopp")})
+    device_entry2 = device_registry.async_get_device(identifiers={("mqtt", "hejhopp")})
     assert device_entry2 is not None
 
     # Verify retained discovery topic has been cleared
@@ -649,14 +655,18 @@ async def test_cleanup_device(
     await hass.async_block_till_done()
 
     # Verify device registry entry is created
-    device_entry = device_registry.async_get_device({("mqtt", "helloworld")})
+    device_entry = device_registry.async_get_device(
+        identifiers={("mqtt", "helloworld")}
+    )
     assert device_entry is not None
 
     async_fire_mqtt_message(hass, "homeassistant/tag/bla/config", "")
     await hass.async_block_till_done()
 
     # Verify device registry entry is cleared
-    device_entry = device_registry.async_get_device({("mqtt", "helloworld")})
+    device_entry = device_registry.async_get_device(
+        identifiers={("mqtt", "helloworld")}
+    )
     assert device_entry is None
 
 
@@ -684,14 +694,18 @@ async def test_cleanup_device_several_tags(
     await hass.async_block_till_done()
 
     # Verify device registry entry is created
-    device_entry = device_registry.async_get_device({("mqtt", "helloworld")})
+    device_entry = device_registry.async_get_device(
+        identifiers={("mqtt", "helloworld")}
+    )
     assert device_entry is not None
 
     async_fire_mqtt_message(hass, "homeassistant/tag/bla1/config", "")
     await hass.async_block_till_done()
 
     # Verify device registry entry is not cleared
-    device_entry = device_registry.async_get_device({("mqtt", "helloworld")})
+    device_entry = device_registry.async_get_device(
+        identifiers={("mqtt", "helloworld")}
+    )
     assert device_entry is not None
 
     # Fake tag scan.
@@ -704,7 +718,9 @@ async def test_cleanup_device_several_tags(
     await hass.async_block_till_done()
 
     # Verify device registry entry is cleared
-    device_entry = device_registry.async_get_device({("mqtt", "helloworld")})
+    device_entry = device_registry.async_get_device(
+        identifiers={("mqtt", "helloworld")}
+    )
     assert device_entry is None
 
 
@@ -749,7 +765,9 @@ async def test_cleanup_device_with_entity_and_trigger_1(
     await hass.async_block_till_done()
 
     # Verify device registry entry is created
-    device_entry = device_registry.async_get_device({("mqtt", "helloworld")})
+    device_entry = device_registry.async_get_device(
+        identifiers={("mqtt", "helloworld")}
+    )
     assert device_entry is not None
 
     triggers = await async_get_device_automations(
@@ -761,7 +779,9 @@ async def test_cleanup_device_with_entity_and_trigger_1(
     await hass.async_block_till_done()
 
     # Verify device registry entry is not cleared
-    device_entry = device_registry.async_get_device({("mqtt", "helloworld")})
+    device_entry = device_registry.async_get_device(
+        identifiers={("mqtt", "helloworld")}
+    )
     assert device_entry is not None
 
     async_fire_mqtt_message(hass, "homeassistant/device_automation/bla2/config", "")
@@ -771,7 +791,9 @@ async def test_cleanup_device_with_entity_and_trigger_1(
     await hass.async_block_till_done()
 
     # Verify device registry entry is cleared
-    device_entry = device_registry.async_get_device({("mqtt", "helloworld")})
+    device_entry = device_registry.async_get_device(
+        identifiers={("mqtt", "helloworld")}
+    )
     assert device_entry is None
 
 
@@ -816,7 +838,9 @@ async def test_cleanup_device_with_entity2(
     await hass.async_block_till_done()
 
     # Verify device registry entry is created
-    device_entry = device_registry.async_get_device({("mqtt", "helloworld")})
+    device_entry = device_registry.async_get_device(
+        identifiers={("mqtt", "helloworld")}
+    )
     assert device_entry is not None
 
     triggers = await async_get_device_automations(
@@ -831,14 +855,18 @@ async def test_cleanup_device_with_entity2(
     await hass.async_block_till_done()
 
     # Verify device registry entry is not cleared
-    device_entry = device_registry.async_get_device({("mqtt", "helloworld")})
+    device_entry = device_registry.async_get_device(
+        identifiers={("mqtt", "helloworld")}
+    )
     assert device_entry is not None
 
     async_fire_mqtt_message(hass, "homeassistant/tag/bla1/config", "")
     await hass.async_block_till_done()
 
     # Verify device registry entry is cleared
-    device_entry = device_registry.async_get_device({("mqtt", "helloworld")})
+    device_entry = device_registry.async_get_device(
+        identifiers={("mqtt", "helloworld")}
+    )
     assert device_entry is None
 
 
@@ -899,7 +927,7 @@ async def test_unload_entry(
 
     async_fire_mqtt_message(hass, "homeassistant/tag/bla1/config", json.dumps(config))
     await hass.async_block_till_done()
-    device_entry = device_registry.async_get_device({("mqtt", "0AFFD2")})
+    device_entry = device_registry.async_get_device(identifiers={("mqtt", "0AFFD2")})
 
     # Fake tag scan, should be processed
     async_fire_mqtt_message(hass, "foobar/tag_scanned", DEFAULT_TAG_SCAN)

--- a/tests/components/mqtt/test_tag.py
+++ b/tests/components/mqtt/test_tag.py
@@ -467,7 +467,7 @@ async def test_entity_device_info_with_connection(
     await hass.async_block_till_done()
 
     device = registry.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, "02:5b:26:a8:dc:12")}
+        connections={(dr.CONNECTION_NETWORK_MAC, "02:5b:26:a8:dc:12")}
     )
     assert device is not None
     assert device.connections == {(dr.CONNECTION_NETWORK_MAC, "02:5b:26:a8:dc:12")}

--- a/tests/components/nest/test_device_trigger.py
+++ b/tests/components/nest/test_device_trigger.py
@@ -103,7 +103,7 @@ async def test_get_triggers(
     await setup_platform()
 
     device_registry = dr.async_get(hass)
-    device_entry = device_registry.async_get_device({("nest", DEVICE_ID)})
+    device_entry = device_registry.async_get_device(identifiers={("nest", DEVICE_ID)})
 
     expected_triggers = [
         {
@@ -198,7 +198,7 @@ async def test_triggers_for_invalid_device_id(
     await setup_platform()
 
     device_registry = dr.async_get(hass)
-    device_entry = device_registry.async_get_device({("nest", DEVICE_ID)})
+    device_entry = device_registry.async_get_device(identifiers={("nest", DEVICE_ID)})
     assert device_entry is not None
 
     # Create an additional device that does not exist.  Fetching supported
@@ -324,7 +324,7 @@ async def test_subscriber_automation(
     await setup_platform()
 
     device_registry = dr.async_get(hass)
-    device_entry = device_registry.async_get_device({("nest", DEVICE_ID)})
+    device_entry = device_registry.async_get_device(identifiers={("nest", DEVICE_ID)})
 
     assert await setup_automation(hass, device_entry.id, "camera_motion")
 

--- a/tests/components/nest/test_diagnostics.py
+++ b/tests/components/nest/test_diagnostics.py
@@ -117,7 +117,7 @@ async def test_device_diagnostics(
     assert config_entry.state is ConfigEntryState.LOADED
 
     device_registry = dr.async_get(hass)
-    device = device_registry.async_get_device({(DOMAIN, NEST_DEVICE_ID)})
+    device = device_registry.async_get_device(identifiers={(DOMAIN, NEST_DEVICE_ID)})
     assert device is not None
 
     assert (

--- a/tests/components/nest/test_media_source.py
+++ b/tests/components/nest/test_media_source.py
@@ -256,7 +256,7 @@ async def test_supported_device(hass: HomeAssistant, setup_platform) -> None:
     assert camera is not None
 
     device_registry = dr.async_get(hass)
-    device = device_registry.async_get_device({(DOMAIN, DEVICE_ID)})
+    device = device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
     assert device
     assert device.name == DEVICE_NAME
 
@@ -318,7 +318,7 @@ async def test_camera_event(
     assert camera is not None
 
     device_registry = dr.async_get(hass)
-    device = device_registry.async_get_device({(DOMAIN, DEVICE_ID)})
+    device = device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
     assert device
     assert device.name == DEVICE_NAME
 
@@ -448,7 +448,7 @@ async def test_event_order(
     assert camera is not None
 
     device_registry = dr.async_get(hass)
-    device = device_registry.async_get_device({(DOMAIN, DEVICE_ID)})
+    device = device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
     assert device
     assert device.name == DEVICE_NAME
 
@@ -493,7 +493,7 @@ async def test_multiple_image_events_in_session(
     assert camera is not None
 
     device_registry = dr.async_get(hass)
-    device = device_registry.async_get_device({(DOMAIN, DEVICE_ID)})
+    device = device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
     assert device
     assert device.name == DEVICE_NAME
 
@@ -607,7 +607,7 @@ async def test_multiple_clip_preview_events_in_session(
     assert camera is not None
 
     device_registry = dr.async_get(hass)
-    device = device_registry.async_get_device({(DOMAIN, DEVICE_ID)})
+    device = device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
     assert device
     assert device.name == DEVICE_NAME
 
@@ -695,7 +695,7 @@ async def test_browse_invalid_device_id(
     await setup_platform()
 
     device_registry = dr.async_get(hass)
-    device = device_registry.async_get_device({(DOMAIN, DEVICE_ID)})
+    device = device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
     assert device
     assert device.name == DEVICE_NAME
 
@@ -716,7 +716,7 @@ async def test_browse_invalid_event_id(
     await setup_platform()
 
     device_registry = dr.async_get(hass)
-    device = device_registry.async_get_device({(DOMAIN, DEVICE_ID)})
+    device = device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
     assert device
     assert device.name == DEVICE_NAME
 
@@ -739,7 +739,7 @@ async def test_resolve_missing_event_id(
     await setup_platform()
 
     device_registry = dr.async_get(hass)
-    device = device_registry.async_get_device({(DOMAIN, DEVICE_ID)})
+    device = device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
     assert device
     assert device.name == DEVICE_NAME
 
@@ -771,7 +771,7 @@ async def test_resolve_invalid_event_id(
     await setup_platform()
 
     device_registry = dr.async_get(hass)
-    device = device_registry.async_get_device({(DOMAIN, DEVICE_ID)})
+    device = device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
     assert device
     assert device.name == DEVICE_NAME
 
@@ -819,7 +819,7 @@ async def test_camera_event_clip_preview(
     assert camera is not None
 
     device_registry = dr.async_get(hass)
-    device = device_registry.async_get_device({(DOMAIN, DEVICE_ID)})
+    device = device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
     assert device
     assert device.name == DEVICE_NAME
 
@@ -916,7 +916,7 @@ async def test_event_media_render_invalid_event_id(
     """Test event media API called with an invalid device id."""
     await setup_platform()
     device_registry = dr.async_get(hass)
-    device = device_registry.async_get_device({(DOMAIN, DEVICE_ID)})
+    device = device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
     assert device
     assert device.name == DEVICE_NAME
 
@@ -958,7 +958,7 @@ async def test_event_media_failure(
     assert camera is not None
 
     device_registry = dr.async_get(hass)
-    device = device_registry.async_get_device({(DOMAIN, DEVICE_ID)})
+    device = device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
     assert device
     assert device.name == DEVICE_NAME
 
@@ -998,7 +998,7 @@ async def test_media_permission_unauthorized(
     assert camera is not None
 
     device_registry = dr.async_get(hass)
-    device = device_registry.async_get_device({(DOMAIN, DEVICE_ID)})
+    device = device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
     assert device
     assert device.name == DEVICE_NAME
 
@@ -1034,9 +1034,9 @@ async def test_multiple_devices(
     await setup_platform()
 
     device_registry = dr.async_get(hass)
-    device1 = device_registry.async_get_device({(DOMAIN, DEVICE_ID)})
+    device1 = device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
     assert device1
-    device2 = device_registry.async_get_device({(DOMAIN, device_id2)})
+    device2 = device_registry.async_get_device(identifiers={(DOMAIN, device_id2)})
     assert device2
 
     # Very no events have been received yet
@@ -1121,7 +1121,7 @@ async def test_media_store_persistence(
     await setup_platform()
 
     device_registry = dr.async_get(hass)
-    device = device_registry.async_get_device({(DOMAIN, DEVICE_ID)})
+    device = device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
     assert device
     assert device.name == DEVICE_NAME
 
@@ -1174,7 +1174,7 @@ async def test_media_store_persistence(
     await hass.async_block_till_done()
 
     device_registry = dr.async_get(hass)
-    device = device_registry.async_get_device({(DOMAIN, DEVICE_ID)})
+    device = device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
     assert device
     assert device.name == DEVICE_NAME
 
@@ -1233,7 +1233,7 @@ async def test_media_store_save_filesystem_error(
     assert camera is not None
 
     device_registry = dr.async_get(hass)
-    device = device_registry.async_get_device({(DOMAIN, DEVICE_ID)})
+    device = device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
     assert device
     assert device.name == DEVICE_NAME
 
@@ -1272,7 +1272,7 @@ async def test_media_store_load_filesystem_error(
     assert camera is not None
 
     device_registry = dr.async_get(hass)
-    device = device_registry.async_get_device({(DOMAIN, DEVICE_ID)})
+    device = device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
     assert device
     assert device.name == DEVICE_NAME
 
@@ -1322,7 +1322,7 @@ async def test_camera_event_media_eviction(
     await setup_platform()
 
     device_registry = dr.async_get(hass)
-    device = device_registry.async_get_device({(DOMAIN, DEVICE_ID)})
+    device = device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
     assert device
     assert device.name == DEVICE_NAME
 
@@ -1399,7 +1399,7 @@ async def test_camera_image_resize(
     await setup_platform()
 
     device_registry = dr.async_get(hass)
-    device = device_registry.async_get_device({(DOMAIN, DEVICE_ID)})
+    device = device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
     assert device
     assert device.name == DEVICE_NAME
 

--- a/tests/components/netatmo/test_device_trigger.py
+++ b/tests/components/netatmo/test_device_trigger.py
@@ -161,7 +161,7 @@ async def test_if_fires_on_event(
         },
     )
 
-    device = device_registry.async_get_device(set(), {connection})
+    device = device_registry.async_get_device(connections={connection})
     assert device is not None
 
     # Fake that the entity is turning on.
@@ -244,7 +244,7 @@ async def test_if_fires_on_event_legacy(
         },
     )
 
-    device = device_registry.async_get_device(set(), {connection})
+    device = device_registry.async_get_device(connections={connection})
     assert device is not None
 
     # Fake that the entity is turning on.
@@ -328,7 +328,7 @@ async def test_if_fires_on_event_with_subtype(
         },
     )
 
-    device = device_registry.async_get_device(set(), {connection})
+    device = device_registry.async_get_device(connections={connection})
     assert device is not None
 
     # Fake that the entity is turning on.

--- a/tests/components/purpleair/test_config_flow.py
+++ b/tests/components/purpleair/test_config_flow.py
@@ -288,7 +288,9 @@ async def test_options_remove_sensor(
     assert result["step_id"] == "remove_sensor"
 
     device_registry = dr.async_get(hass)
-    device_entry = device_registry.async_get_device({(DOMAIN, str(TEST_SENSOR_INDEX1))})
+    device_entry = device_registry.async_get_device(
+        identifiers={(DOMAIN, str(TEST_SENSOR_INDEX1))}
+    )
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={"sensor_device_id": device_entry.id},

--- a/tests/components/radarr/test_init.py
+++ b/tests/components/radarr/test_init.py
@@ -51,7 +51,7 @@ async def test_device_info(
     entry = await setup_integration(hass, aioclient_mock)
     device_registry = dr.async_get(hass)
     await hass.async_block_till_done()
-    device = device_registry.async_get_device({(DOMAIN, entry.entry_id)})
+    device = device_registry.async_get_device(identifiers={(DOMAIN, entry.entry_id)})
 
     assert device.configuration_url == "http://192.168.1.189:7887/test"
     assert device.identifiers == {(DOMAIN, entry.entry_id)}

--- a/tests/components/rainbird/test_number.py
+++ b/tests/components/rainbird/test_number.py
@@ -67,7 +67,7 @@ async def test_set_value(
     assert await setup_integration()
 
     device_registry = dr.async_get(hass)
-    device = device_registry.async_get_device({(DOMAIN, SERIAL_NUMBER)})
+    device = device_registry.async_get_device(identifiers={(DOMAIN, SERIAL_NUMBER)})
     assert device
     assert device.name == "Rain Bird Controller"
     assert device.model == "ST8x-WiFi"

--- a/tests/components/renault/__init__.py
+++ b/tests/components/renault/__init__.py
@@ -37,7 +37,9 @@ def check_device_registry(
 ) -> None:
     """Ensure that the expected_device is correctly registered."""
     assert len(device_registry.devices) == 1
-    registry_entry = device_registry.async_get_device(expected_device[ATTR_IDENTIFIERS])
+    registry_entry = device_registry.async_get_device(
+        identifiers=expected_device[ATTR_IDENTIFIERS]
+    )
     assert registry_entry is not None
     assert registry_entry.identifiers == expected_device[ATTR_IDENTIFIERS]
     assert registry_entry.manufacturer == expected_device[ATTR_MANUFACTURER]

--- a/tests/components/renault/test_diagnostics.py
+++ b/tests/components/renault/test_diagnostics.py
@@ -197,7 +197,9 @@ async def test_device_diagnostics(
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device({(DOMAIN, "VF1AAAAA555777999")})
+    device = device_registry.async_get_device(
+        identifiers={(DOMAIN, "VF1AAAAA555777999")}
+    )
     assert device is not None
 
     assert await get_diagnostics_for_device(

--- a/tests/components/renault/test_services.py
+++ b/tests/components/renault/test_services.py
@@ -55,7 +55,7 @@ def get_device_id(hass: HomeAssistant) -> str:
     """Get device_id."""
     device_registry = dr.async_get(hass)
     identifiers = {(DOMAIN, "VF1AAAAA555777999")}
-    device = device_registry.async_get_device(identifiers)
+    device = device_registry.async_get_device(identifiers=identifiers)
     return device.id
 
 
@@ -272,7 +272,9 @@ async def test_service_invalid_device_id2(
         model=extra_vehicle[ATTR_MODEL],
         sw_version=extra_vehicle[ATTR_SW_VERSION],
     )
-    device_id = device_registry.async_get_device(extra_vehicle[ATTR_IDENTIFIERS]).id
+    device_id = device_registry.async_get_device(
+        identifiers=extra_vehicle[ATTR_IDENTIFIERS]
+    ).id
 
     data = {ATTR_VEHICLE: device_id}
 

--- a/tests/components/rfxtrx/test_device_action.py
+++ b/tests/components/rfxtrx/test_device_action.py
@@ -86,7 +86,9 @@ async def test_get_actions(
     """Test we get the expected actions from a rfxtrx."""
     await setup_entry(hass, {device.code: {}})
 
-    device_entry = device_registry.async_get_device(device.device_identifiers, set())
+    device_entry = device_registry.async_get_device(
+        identifiers=device.device_identifiers
+    )
     assert device_entry
 
     # Add alternate identifiers, to make sure we can handle future formats
@@ -94,7 +96,9 @@ async def test_get_actions(
     device_registry.async_update_device(
         device_entry.id, merge_identifiers={(identifiers[0], "_".join(identifiers[1:]))}
     )
-    device_entry = device_registry.async_get_device(device.device_identifiers, set())
+    device_entry = device_registry.async_get_device(
+        identifiers=device.device_identifiers
+    )
     assert device_entry
 
     actions = await async_get_device_automations(
@@ -142,7 +146,9 @@ async def test_action(
 
     await setup_entry(hass, {device.code: {}})
 
-    device_entry = device_registry.async_get_device(device.device_identifiers, set())
+    device_entry = device_registry.async_get_device(
+        identifiers=device.device_identifiers
+    )
     assert device_entry
 
     assert await async_setup_component(
@@ -181,8 +187,8 @@ async def test_invalid_action(
 
     await setup_entry(hass, {device.code: {}})
 
-    device_identifers: Any = device.device_identifiers
-    device_entry = device_registry.async_get_device(device_identifers, set())
+    device_identifiers: Any = device.device_identifiers
+    device_entry = device_registry.async_get_device(identifiers=device_identifiers)
     assert device_entry
 
     assert await async_setup_component(

--- a/tests/components/rfxtrx/test_device_trigger.py
+++ b/tests/components/rfxtrx/test_device_trigger.py
@@ -87,7 +87,9 @@ async def test_get_triggers(
     """Test we get the expected triggers from a rfxtrx."""
     await setup_entry(hass, {event.code: {}})
 
-    device_entry = device_registry.async_get_device(event.device_identifiers, set())
+    device_entry = device_registry.async_get_device(
+        identifiers=event.device_identifiers
+    )
     assert device_entry
 
     # Add alternate identifiers, to make sure we can handle future formats
@@ -95,7 +97,9 @@ async def test_get_triggers(
     device_registry.async_update_device(
         device_entry.id, merge_identifiers={(identifiers[0], "_".join(identifiers[1:]))}
     )
-    device_entry = device_registry.async_get_device(event.device_identifiers, set())
+    device_entry = device_registry.async_get_device(
+        identifiers=event.device_identifiers
+    )
     assert device_entry
 
     expected_triggers = [
@@ -131,7 +135,9 @@ async def test_firing_event(
 
     await setup_entry(hass, {event.code: {"fire_event": True}})
 
-    device_entry = device_registry.async_get_device(event.device_identifiers, set())
+    device_entry = device_registry.async_get_device(
+        identifiers=event.device_identifiers
+    )
     assert device_entry
 
     calls = async_mock_service(hass, "test", "automation")
@@ -175,8 +181,8 @@ async def test_invalid_trigger(
 
     await setup_entry(hass, {event.code: {"fire_event": True}})
 
-    device_identifers: Any = event.device_identifiers
-    device_entry = device_registry.async_get_device(device_identifers, set())
+    device_identifiers: Any = event.device_identifiers
+    device_entry = device_registry.async_get_device(identifiers=device_identifiers)
     assert device_entry
 
     assert await async_setup_component(

--- a/tests/components/risco/test_alarm_control_panel.py
+++ b/tests/components/risco/test_alarm_control_panel.py
@@ -149,11 +149,11 @@ async def test_cloud_setup(
     assert registry.async_is_registered(SECOND_CLOUD_ENTITY_ID)
 
     registry = dr.async_get(hass)
-    device = registry.async_get_device({(DOMAIN, TEST_SITE_UUID + "_0")})
+    device = registry.async_get_device(identifiers={(DOMAIN, TEST_SITE_UUID + "_0")})
     assert device is not None
     assert device.manufacturer == "Risco"
 
-    device = registry.async_get_device({(DOMAIN, TEST_SITE_UUID + "_1")})
+    device = registry.async_get_device(identifiers={(DOMAIN, TEST_SITE_UUID + "_1")})
     assert device is not None
     assert device.manufacturer == "Risco"
 
@@ -485,11 +485,15 @@ async def test_local_setup(
     assert registry.async_is_registered(SECOND_LOCAL_ENTITY_ID)
 
     registry = dr.async_get(hass)
-    device = registry.async_get_device({(DOMAIN, TEST_SITE_UUID + "_0_local")})
+    device = registry.async_get_device(
+        identifiers={(DOMAIN, TEST_SITE_UUID + "_0_local")}
+    )
     assert device is not None
     assert device.manufacturer == "Risco"
 
-    device = registry.async_get_device({(DOMAIN, TEST_SITE_UUID + "_1_local")})
+    device = registry.async_get_device(
+        identifiers={(DOMAIN, TEST_SITE_UUID + "_1_local")}
+    )
     assert device is not None
     assert device.manufacturer == "Risco"
     with patch("homeassistant.components.risco.RiscoLocal.disconnect") as mock_close:

--- a/tests/components/risco/test_binary_sensor.py
+++ b/tests/components/risco/test_binary_sensor.py
@@ -41,11 +41,15 @@ async def test_cloud_setup(
     assert registry.async_is_registered(SECOND_ENTITY_ID)
 
     registry = dr.async_get(hass)
-    device = registry.async_get_device({(DOMAIN, TEST_SITE_UUID + "_zone_0")})
+    device = registry.async_get_device(
+        identifiers={(DOMAIN, TEST_SITE_UUID + "_zone_0")}
+    )
     assert device is not None
     assert device.manufacturer == "Risco"
 
-    device = registry.async_get_device({(DOMAIN, TEST_SITE_UUID + "_zone_1")})
+    device = registry.async_get_device(
+        identifiers={(DOMAIN, TEST_SITE_UUID + "_zone_1")}
+    )
     assert device is not None
     assert device.manufacturer == "Risco"
 
@@ -99,11 +103,15 @@ async def test_local_setup(
     assert registry.async_is_registered(SECOND_ALARMED_ENTITY_ID)
 
     registry = dr.async_get(hass)
-    device = registry.async_get_device({(DOMAIN, TEST_SITE_UUID + "_zone_0_local")})
+    device = registry.async_get_device(
+        identifiers={(DOMAIN, TEST_SITE_UUID + "_zone_0_local")}
+    )
     assert device is not None
     assert device.manufacturer == "Risco"
 
-    device = registry.async_get_device({(DOMAIN, TEST_SITE_UUID + "_zone_1_local")})
+    device = registry.async_get_device(
+        identifiers={(DOMAIN, TEST_SITE_UUID + "_zone_1_local")}
+    )
     assert device is not None
     assert device.manufacturer == "Risco"
 

--- a/tests/components/sharkiq/test_vacuum.py
+++ b/tests/components/sharkiq/test_vacuum.py
@@ -218,7 +218,7 @@ async def test_device_properties(
 ) -> None:
     """Test device properties."""
     registry = dr.async_get(hass)
-    device = registry.async_get_device({(DOMAIN, "AC000Wxxxxxxxxx")})
+    device = registry.async_get_device(identifiers={(DOMAIN, "AC000Wxxxxxxxxx")})
     assert getattr(device, device_property) == target_value
 
 

--- a/tests/components/smartthings/test_binary_sensor.py
+++ b/tests/components/smartthings/test_binary_sensor.py
@@ -69,7 +69,7 @@ async def test_entity_and_device_attributes(
     entry = entity_registry.async_get("binary_sensor.motion_sensor_1_motion")
     assert entry
     assert entry.unique_id == f"{device.device_id}.{Attribute.motion}"
-    entry = device_registry.async_get_device({(DOMAIN, device.device_id)})
+    entry = device_registry.async_get_device(identifiers={(DOMAIN, device.device_id)})
     assert entry
     assert entry.configuration_url == "https://account.smartthings.com"
     assert entry.identifiers == {(DOMAIN, device.device_id)}

--- a/tests/components/smartthings/test_climate.py
+++ b/tests/components/smartthings/test_climate.py
@@ -580,7 +580,9 @@ async def test_entity_and_device_attributes(hass: HomeAssistant, thermostat) -> 
     assert entry
     assert entry.unique_id == thermostat.device_id
 
-    entry = device_registry.async_get_device({(DOMAIN, thermostat.device_id)})
+    entry = device_registry.async_get_device(
+        identifiers={(DOMAIN, thermostat.device_id)}
+    )
     assert entry
     assert entry.configuration_url == "https://account.smartthings.com"
     assert entry.identifiers == {(DOMAIN, thermostat.device_id)}

--- a/tests/components/smartthings/test_cover.py
+++ b/tests/components/smartthings/test_cover.py
@@ -52,7 +52,7 @@ async def test_entity_and_device_attributes(
     assert entry
     assert entry.unique_id == device.device_id
 
-    entry = device_registry.async_get_device({(DOMAIN, device.device_id)})
+    entry = device_registry.async_get_device(identifiers={(DOMAIN, device.device_id)})
     assert entry
     assert entry.configuration_url == "https://account.smartthings.com"
     assert entry.identifiers == {(DOMAIN, device.device_id)}

--- a/tests/components/smartthings/test_fan.py
+++ b/tests/components/smartthings/test_fan.py
@@ -66,7 +66,7 @@ async def test_entity_and_device_attributes(
     assert entry
     assert entry.unique_id == device.device_id
 
-    entry = device_registry.async_get_device({(DOMAIN, device.device_id)})
+    entry = device_registry.async_get_device(identifiers={(DOMAIN, device.device_id)})
     assert entry
     assert entry.configuration_url == "https://account.smartthings.com"
     assert entry.identifiers == {(DOMAIN, device.device_id)}

--- a/tests/components/smartthings/test_light.py
+++ b/tests/components/smartthings/test_light.py
@@ -128,7 +128,7 @@ async def test_entity_and_device_attributes(
     assert entry
     assert entry.unique_id == device.device_id
 
-    entry = device_registry.async_get_device({(DOMAIN, device.device_id)})
+    entry = device_registry.async_get_device(identifiers={(DOMAIN, device.device_id)})
     assert entry
     assert entry.configuration_url == "https://account.smartthings.com"
     assert entry.identifiers == {(DOMAIN, device.device_id)}

--- a/tests/components/smartthings/test_lock.py
+++ b/tests/components/smartthings/test_lock.py
@@ -42,7 +42,7 @@ async def test_entity_and_device_attributes(
     assert entry
     assert entry.unique_id == device.device_id
 
-    entry = device_registry.async_get_device({(DOMAIN, device.device_id)})
+    entry = device_registry.async_get_device(identifiers={(DOMAIN, device.device_id)})
     assert entry
     assert entry.configuration_url == "https://account.smartthings.com"
     assert entry.identifiers == {(DOMAIN, device.device_id)}

--- a/tests/components/smartthings/test_sensor.py
+++ b/tests/components/smartthings/test_sensor.py
@@ -110,7 +110,7 @@ async def test_entity_and_device_attributes(
     assert entry
     assert entry.unique_id == f"{device.device_id}.{Attribute.battery}"
     assert entry.entity_category is EntityCategory.DIAGNOSTIC
-    entry = device_registry.async_get_device({(DOMAIN, device.device_id)})
+    entry = device_registry.async_get_device(identifiers={(DOMAIN, device.device_id)})
     assert entry
     assert entry.configuration_url == "https://account.smartthings.com"
     assert entry.identifiers == {(DOMAIN, device.device_id)}
@@ -151,7 +151,7 @@ async def test_energy_sensors_for_switch_device(
     assert entry
     assert entry.unique_id == f"{device.device_id}.{Attribute.energy}"
     assert entry.entity_category is None
-    entry = device_registry.async_get_device({(DOMAIN, device.device_id)})
+    entry = device_registry.async_get_device(identifiers={(DOMAIN, device.device_id)})
     assert entry
     assert entry.configuration_url == "https://account.smartthings.com"
     assert entry.identifiers == {(DOMAIN, device.device_id)}
@@ -168,7 +168,7 @@ async def test_energy_sensors_for_switch_device(
     assert entry
     assert entry.unique_id == f"{device.device_id}.{Attribute.power}"
     assert entry.entity_category is None
-    entry = device_registry.async_get_device({(DOMAIN, device.device_id)})
+    entry = device_registry.async_get_device(identifiers={(DOMAIN, device.device_id)})
     assert entry
     assert entry.configuration_url == "https://account.smartthings.com"
     assert entry.identifiers == {(DOMAIN, device.device_id)}
@@ -213,7 +213,7 @@ async def test_power_consumption_sensor(hass: HomeAssistant, device_factory) -> 
     entry = entity_registry.async_get("sensor.refrigerator_energy")
     assert entry
     assert entry.unique_id == f"{device.device_id}.energy_meter"
-    entry = device_registry.async_get_device({(DOMAIN, device.device_id)})
+    entry = device_registry.async_get_device(identifiers={(DOMAIN, device.device_id)})
     assert entry
     assert entry.configuration_url == "https://account.smartthings.com"
     assert entry.identifiers == {(DOMAIN, device.device_id)}
@@ -231,7 +231,7 @@ async def test_power_consumption_sensor(hass: HomeAssistant, device_factory) -> 
     entry = entity_registry.async_get("sensor.refrigerator_power")
     assert entry
     assert entry.unique_id == f"{device.device_id}.power_meter"
-    entry = device_registry.async_get_device({(DOMAIN, device.device_id)})
+    entry = device_registry.async_get_device(identifiers={(DOMAIN, device.device_id)})
     assert entry
     assert entry.configuration_url == "https://account.smartthings.com"
     assert entry.identifiers == {(DOMAIN, device.device_id)}
@@ -263,7 +263,7 @@ async def test_power_consumption_sensor(hass: HomeAssistant, device_factory) -> 
     entry = entity_registry.async_get("sensor.vacuum_energy")
     assert entry
     assert entry.unique_id == f"{device.device_id}.energy_meter"
-    entry = device_registry.async_get_device({(DOMAIN, device.device_id)})
+    entry = device_registry.async_get_device(identifiers={(DOMAIN, device.device_id)})
     assert entry
     assert entry.configuration_url == "https://account.smartthings.com"
     assert entry.identifiers == {(DOMAIN, device.device_id)}

--- a/tests/components/smartthings/test_switch.py
+++ b/tests/components/smartthings/test_switch.py
@@ -41,7 +41,7 @@ async def test_entity_and_device_attributes(
     assert entry
     assert entry.unique_id == device.device_id
 
-    entry = device_registry.async_get_device({(DOMAIN, device.device_id)})
+    entry = device_registry.async_get_device(identifiers={(DOMAIN, device.device_id)})
     assert entry
     assert entry.configuration_url == "https://account.smartthings.com"
     assert entry.identifiers == {(DOMAIN, device.device_id)}

--- a/tests/components/steam_online/test_init.py
+++ b/tests/components/steam_online/test_init.py
@@ -43,7 +43,7 @@ async def test_device_info(hass: HomeAssistant) -> None:
         await hass.config_entries.async_setup(entry.entry_id)
     device_registry = dr.async_get(hass)
     await hass.async_block_till_done()
-    device = device_registry.async_get_device({(DOMAIN, entry.entry_id)})
+    device = device_registry.async_get_device(identifiers={(DOMAIN, entry.entry_id)})
 
     assert device.configuration_url == "https://store.steampowered.com"
     assert device.entry_type == dr.DeviceEntryType.SERVICE

--- a/tests/components/steamist/test_init.py
+++ b/tests/components/steamist/test_init.py
@@ -105,7 +105,7 @@ async def test_config_entry_fills_unique_id_with_directed_discovery(
 
     device_registry = dr.async_get(hass)
     device_entry = device_registry.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, FORMATTED_MAC_ADDRESS)}, identifiers={}
+        connections={(dr.CONNECTION_NETWORK_MAC, FORMATTED_MAC_ADDRESS)}
     )
     assert isinstance(device_entry, dr.DeviceEntry)
     assert device_entry.name == DEVICE_NAME

--- a/tests/components/tasmota/test_common.py
+++ b/tests/components/tasmota/test_common.py
@@ -413,7 +413,7 @@ async def help_test_discovery_removal(
 
     # Verify device and entity registry entries are created
     device_entry = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, config1[CONF_MAC])}
+        connections={(dr.CONNECTION_NETWORK_MAC, config1[CONF_MAC])}
     )
     assert device_entry is not None
     entity_entry = entity_reg.async_get(f"{domain}.{entity_id}")
@@ -436,7 +436,7 @@ async def help_test_discovery_removal(
 
     # Verify entity registry entries are cleared
     device_entry = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, config2[CONF_MAC])}
+        connections={(dr.CONNECTION_NETWORK_MAC, config2[CONF_MAC])}
     )
     assert device_entry is not None
     entity_entry = entity_reg.async_get(f"{domain}.{entity_id}")
@@ -522,7 +522,7 @@ async def help_test_discovery_device_remove(
         await hass.async_block_till_done()
 
     device = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, config[CONF_MAC])}
+        connections={(dr.CONNECTION_NETWORK_MAC, config[CONF_MAC])}
     )
     assert device is not None
     assert entity_reg.async_get_entity_id(domain, "tasmota", unique_id)
@@ -531,7 +531,7 @@ async def help_test_discovery_device_remove(
     await hass.async_block_till_done()
 
     device = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, config[CONF_MAC])}
+        connections={(dr.CONNECTION_NETWORK_MAC, config[CONF_MAC])}
     )
     assert device is None
     assert not entity_reg.async_get_entity_id(domain, "tasmota", unique_id)

--- a/tests/components/tasmota/test_device_trigger.py
+++ b/tests/components/tasmota/test_device_trigger.py
@@ -49,7 +49,7 @@ async def test_get_triggers_btn(
     await hass.async_block_till_done()
 
     device_entry = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, mac)}
+        connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     expected_triggers = [
         {
@@ -93,7 +93,7 @@ async def test_get_triggers_swc(
     await hass.async_block_till_done()
 
     device_entry = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, mac)}
+        connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     expected_triggers = [
         {
@@ -129,7 +129,7 @@ async def test_get_unknown_triggers(
     await hass.async_block_till_done()
 
     device_entry = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, mac)}
+        connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
 
     assert await async_setup_component(
@@ -178,7 +178,7 @@ async def test_get_non_existing_triggers(
     await hass.async_block_till_done()
 
     device_entry = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, mac)}
+        connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_entry.id
@@ -210,7 +210,7 @@ async def test_discover_bad_triggers(
         await hass.async_block_till_done()
 
     device_entry = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, mac)}
+        connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_entry.id
@@ -246,7 +246,7 @@ async def test_discover_bad_triggers(
         await hass.async_block_till_done()
 
     device_entry = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, mac)}
+        connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_entry.id
@@ -299,7 +299,7 @@ async def test_update_remove_triggers(
     await hass.async_block_till_done()
 
     device_entry = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, mac)}
+        connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
 
     expected_triggers1 = [
@@ -365,7 +365,7 @@ async def test_if_fires_on_mqtt_message_btn(
     async_fire_mqtt_message(hass, f"{DEFAULT_PREFIX}/{mac}/config", json.dumps(config))
     await hass.async_block_till_done()
     device_entry = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, mac)}
+        connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
 
     assert await async_setup_component(
@@ -437,7 +437,7 @@ async def test_if_fires_on_mqtt_message_swc(
     async_fire_mqtt_message(hass, f"{DEFAULT_PREFIX}/{mac}/config", json.dumps(config))
     await hass.async_block_till_done()
     device_entry = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, mac)}
+        connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
 
     assert await async_setup_component(
@@ -535,7 +535,7 @@ async def test_if_fires_on_mqtt_message_late_discover(
     await hass.async_block_till_done()
 
     device_entry = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, mac)}
+        connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
 
     assert await async_setup_component(
@@ -611,7 +611,7 @@ async def test_if_fires_on_mqtt_message_after_update(
     await hass.async_block_till_done()
 
     device_entry = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, mac)}
+        connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
 
     assert await async_setup_component(
@@ -692,7 +692,7 @@ async def test_no_resubscribe_same_topic(
     await hass.async_block_till_done()
 
     device_entry = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, mac)}
+        connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
 
     assert await async_setup_component(
@@ -740,7 +740,7 @@ async def test_not_fires_on_mqtt_message_after_remove_by_mqtt(
     await hass.async_block_till_done()
 
     device_entry = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, mac)}
+        connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
 
     assert await async_setup_component(
@@ -817,7 +817,7 @@ async def test_not_fires_on_mqtt_message_after_remove_from_registry(
     await hass.async_block_till_done()
 
     device_entry = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, mac)}
+        connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
 
     assert await async_setup_component(
@@ -876,7 +876,7 @@ async def test_attach_remove(
     await hass.async_block_till_done()
 
     device_entry = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, mac)}
+        connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
 
     calls = []
@@ -939,7 +939,7 @@ async def test_attach_remove_late(
     await hass.async_block_till_done()
 
     device_entry = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, mac)}
+        connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
 
     calls = []
@@ -1012,7 +1012,7 @@ async def test_attach_remove_late2(
     await hass.async_block_till_done()
 
     device_entry = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, mac)}
+        connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
 
     calls = []
@@ -1066,7 +1066,7 @@ async def test_attach_remove_unknown1(
     await hass.async_block_till_done()
 
     device_entry = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, mac)}
+        connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
 
     remove = await async_initialize_triggers(
@@ -1119,7 +1119,7 @@ async def test_attach_unknown_remove_device_from_registry(
     await hass.async_block_till_done()
 
     device_entry = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, mac)}
+        connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
 
     await async_initialize_triggers(
@@ -1160,7 +1160,7 @@ async def test_attach_remove_config_entry(
     await hass.async_block_till_done()
 
     device_entry = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, mac)}
+        connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
 
     calls = []

--- a/tests/components/tasmota/test_discovery.py
+++ b/tests/components/tasmota/test_discovery.py
@@ -140,7 +140,7 @@ async def test_correct_config_discovery(
 
     # Verify device and registry entries are created
     device_entry = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, mac)}
+        connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     assert device_entry is not None
     entity_entry = entity_reg.async_get("switch.test")
@@ -174,7 +174,7 @@ async def test_device_discover(
 
     # Verify device and registry entries are created
     device_entry = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, mac)}
+        connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     assert device_entry is not None
     assert device_entry.configuration_url == f"http://{config['ip']}/"
@@ -205,7 +205,7 @@ async def test_device_discover_deprecated(
 
     # Verify device and registry entries are created
     device_entry = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, mac)}
+        connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     assert device_entry is not None
     assert device_entry.manufacturer == "Tasmota"
@@ -238,7 +238,7 @@ async def test_device_update(
 
     # Verify device entry is created
     device_entry = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, mac)}
+        connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     assert device_entry is not None
 
@@ -256,7 +256,7 @@ async def test_device_update(
 
     # Verify device entry is updated
     device_entry = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, mac)}
+        connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     assert device_entry is not None
     assert device_entry.model == "Another model"
@@ -285,7 +285,7 @@ async def test_device_remove(
 
     # Verify device entry is created
     device_entry = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, mac)}
+        connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     assert device_entry is not None
 
@@ -298,7 +298,7 @@ async def test_device_remove(
 
     # Verify device entry is removed
     device_entry = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, mac)}
+        connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     assert device_entry is None
 
@@ -334,7 +334,7 @@ async def test_device_remove_multiple_config_entries_1(
 
     # Verify device entry is created
     device_entry = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, mac)}
+        connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     assert device_entry is not None
     assert device_entry.config_entries == {tasmota_entry.entry_id, mock_entry.entry_id}
@@ -348,7 +348,7 @@ async def test_device_remove_multiple_config_entries_1(
 
     # Verify device entry is not removed
     device_entry = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, mac)}
+        connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     assert device_entry is not None
     assert device_entry.config_entries == {mock_entry.entry_id}
@@ -390,7 +390,7 @@ async def test_device_remove_multiple_config_entries_2(
 
     # Verify device entry is created
     device_entry = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, mac)}
+        connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     assert device_entry is not None
     assert device_entry.config_entries == {tasmota_entry.entry_id, mock_entry.entry_id}
@@ -404,7 +404,7 @@ async def test_device_remove_multiple_config_entries_2(
 
     # Verify device entry is not removed
     device_entry = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, mac)}
+        connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     assert device_entry is not None
     assert device_entry.config_entries == {tasmota_entry.entry_id}
@@ -440,7 +440,7 @@ async def test_device_remove_stale(
 
     # Verify device entry was created
     device_entry = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, mac)}
+        connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     assert device_entry is not None
 
@@ -449,7 +449,7 @@ async def test_device_remove_stale(
 
     # Verify device entry is removed
     device_entry = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, mac)}
+        connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     assert device_entry is None
 
@@ -475,7 +475,7 @@ async def test_device_rediscover(
 
     # Verify device entry is created
     device_entry1 = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, mac)}
+        connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     assert device_entry1 is not None
 
@@ -488,7 +488,7 @@ async def test_device_rediscover(
 
     # Verify device entry is removed
     device_entry = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, mac)}
+        connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     assert device_entry is None
 
@@ -501,7 +501,7 @@ async def test_device_rediscover(
 
     # Verify device entry is created, and id is reused
     device_entry = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, mac)}
+        connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     assert device_entry is not None
     assert device_entry1.id == device_entry.id
@@ -602,7 +602,7 @@ async def test_same_topic(
     # Verify device registry entries are created for both devices
     for config in configs[0:2]:
         device_entry = device_reg.async_get_device(
-            set(), {(dr.CONNECTION_NETWORK_MAC, config["mac"])}
+            connections={(dr.CONNECTION_NETWORK_MAC, config["mac"])}
         )
         assert device_entry is not None
         assert device_entry.configuration_url == f"http://{config['ip']}/"
@@ -613,11 +613,11 @@ async def test_same_topic(
 
     # Verify entities are created only for the first device
     device_entry = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, configs[0]["mac"])}
+        connections={(dr.CONNECTION_NETWORK_MAC, configs[0]["mac"])}
     )
     assert len(er.async_entries_for_device(entity_reg, device_entry.id, True)) == 1
     device_entry = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, configs[1]["mac"])}
+        connections={(dr.CONNECTION_NETWORK_MAC, configs[1]["mac"])}
     )
     assert len(er.async_entries_for_device(entity_reg, device_entry.id, True)) == 0
 
@@ -637,7 +637,7 @@ async def test_same_topic(
 
     # Verify device registry entries was created
     device_entry = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, configs[2]["mac"])}
+        connections={(dr.CONNECTION_NETWORK_MAC, configs[2]["mac"])}
     )
     assert device_entry is not None
     assert device_entry.configuration_url == f"http://{configs[2]['ip']}/"
@@ -648,7 +648,7 @@ async def test_same_topic(
 
     # Verify no entities were created
     device_entry = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, configs[2]["mac"])}
+        connections={(dr.CONNECTION_NETWORK_MAC, configs[2]["mac"])}
     )
     assert len(er.async_entries_for_device(entity_reg, device_entry.id, True)) == 0
 
@@ -667,7 +667,7 @@ async def test_same_topic(
 
     # Verify entities are created also for the third device
     device_entry = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, configs[2]["mac"])}
+        connections={(dr.CONNECTION_NETWORK_MAC, configs[2]["mac"])}
     )
     assert len(er.async_entries_for_device(entity_reg, device_entry.id, True)) == 1
 
@@ -686,7 +686,7 @@ async def test_same_topic(
 
     # Verify entities are created also for the second device
     device_entry = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, configs[1]["mac"])}
+        connections={(dr.CONNECTION_NETWORK_MAC, configs[1]["mac"])}
     )
     assert len(er.async_entries_for_device(entity_reg, device_entry.id, True)) == 1
 
@@ -716,7 +716,7 @@ async def test_topic_no_prefix(
 
     # Verify device registry entry is created
     device_entry = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, config["mac"])}
+        connections={(dr.CONNECTION_NETWORK_MAC, config["mac"])}
     )
     assert device_entry is not None
     assert device_entry.configuration_url == f"http://{config['ip']}/"
@@ -727,7 +727,7 @@ async def test_topic_no_prefix(
 
     # Verify entities are not created
     device_entry = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, config["mac"])}
+        connections={(dr.CONNECTION_NETWORK_MAC, config["mac"])}
     )
     assert len(er.async_entries_for_device(entity_reg, device_entry.id, True)) == 0
 
@@ -747,7 +747,7 @@ async def test_topic_no_prefix(
 
     # Verify entities are created
     device_entry = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, config["mac"])}
+        connections={(dr.CONNECTION_NETWORK_MAC, config["mac"])}
     )
     assert len(er.async_entries_for_device(entity_reg, device_entry.id, True)) == 1
 

--- a/tests/components/tasmota/test_init.py
+++ b/tests/components/tasmota/test_init.py
@@ -44,7 +44,7 @@ async def test_device_remove(
 
     # Verify device entry is created
     device_entry = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, mac)}
+        connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     assert device_entry is not None
 
@@ -53,7 +53,7 @@ async def test_device_remove(
 
     # Verify device entry is removed
     device_entry = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, mac)}
+        connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     assert device_entry is None
 
@@ -104,7 +104,7 @@ async def test_device_remove_non_tasmota_device(
 
     # Verify device entry is removed
     device_entry = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, mac)}
+        connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     assert device_entry is None
 
@@ -135,7 +135,7 @@ async def test_device_remove_stale_tasmota_device(
 
     # Verify device entry is removed
     device_entry = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, mac)}
+        connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     assert device_entry is None
 
@@ -161,7 +161,7 @@ async def test_tasmota_ws_remove_discovered_device(
 
     # Verify device entry is created
     device_entry = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, mac)}
+        connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     assert device_entry is not None
 
@@ -180,6 +180,6 @@ async def test_tasmota_ws_remove_discovered_device(
 
     # Verify device entry is cleared
     device_entry = device_reg.async_get_device(
-        set(), {(dr.CONNECTION_NETWORK_MAC, mac)}
+        connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     assert device_entry is None

--- a/tests/components/twinkly/test_light.py
+++ b/tests/components/twinkly/test_light.py
@@ -342,7 +342,7 @@ async def _create_entries(
 
     entity_id = entity_registry.async_get_entity_id("light", TWINKLY_DOMAIN, client.id)
     entity_entry = entity_registry.async_get(entity_id)
-    device = device_registry.async_get_device({(TWINKLY_DOMAIN, client.id)})
+    device = device_registry.async_get_device(identifiers={(TWINKLY_DOMAIN, client.id)})
 
     assert entity_entry is not None
     assert device is not None

--- a/tests/components/velbus/test_init.py
+++ b/tests/components/velbus/test_init.py
@@ -45,17 +45,17 @@ async def test_device_identifier_migration(
         sw_version="module_sw_version",
     )
     assert device_registry.async_get_device(
-        original_identifiers  # type: ignore[arg-type]
+        identifiers=original_identifiers  # type: ignore[arg-type]
     )
-    assert not device_registry.async_get_device(target_identifiers)
+    assert not device_registry.async_get_device(identifiers=target_identifiers)
 
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
     assert not device_registry.async_get_device(
-        original_identifiers  # type: ignore[arg-type]
+        identifiers=original_identifiers  # type: ignore[arg-type]
     )
-    device_entry = device_registry.async_get_device(target_identifiers)
+    device_entry = device_registry.async_get_device(identifiers=target_identifiers)
     assert device_entry
     assert device_entry.name == "channel_name"
     assert device_entry.manufacturer == "Velleman"

--- a/tests/components/voip/test_devices.py
+++ b/tests/components/voip/test_devices.py
@@ -19,7 +19,9 @@ async def test_device_registry_info(
     voip_device = voip_devices.async_get_or_create(call_info)
     assert not voip_device.async_allow_call(hass)
 
-    device = device_registry.async_get_device({(DOMAIN, call_info.caller_ip)})
+    device = device_registry.async_get_device(
+        identifiers={(DOMAIN, call_info.caller_ip)}
+    )
     assert device is not None
     assert device.name == call_info.caller_ip
     assert device.manufacturer == "Grandstream"
@@ -32,7 +34,9 @@ async def test_device_registry_info(
 
     assert not voip_device.async_allow_call(hass)
 
-    device = device_registry.async_get_device({(DOMAIN, call_info.caller_ip)})
+    device = device_registry.async_get_device(
+        identifiers={(DOMAIN, call_info.caller_ip)}
+    )
     assert device.sw_version == "2.0.0.0"
 
 
@@ -47,7 +51,9 @@ async def test_device_registry_info_from_unknown_phone(
     voip_device = voip_devices.async_get_or_create(call_info)
     assert not voip_device.async_allow_call(hass)
 
-    device = device_registry.async_get_device({(DOMAIN, call_info.caller_ip)})
+    device = device_registry.async_get_device(
+        identifiers={(DOMAIN, call_info.caller_ip)}
+    )
     assert device.manufacturer is None
     assert device.model == "Unknown"
     assert device.sw_version is None

--- a/tests/components/webostv/test_media_player.py
+++ b/tests/components/webostv/test_media_player.py
@@ -279,7 +279,7 @@ async def test_device_info_startup_off(
 
     assert hass.states.get(ENTITY_ID).state == STATE_OFF
 
-    device = device_registry.async_get_device({(DOMAIN, entry.unique_id)})
+    device = device_registry.async_get_device(identifiers={(DOMAIN, entry.unique_id)})
 
     assert device
     assert device.identifiers == {(DOMAIN, entry.unique_id)}
@@ -326,7 +326,7 @@ async def test_entity_attributes(
     assert attrs[ATTR_MEDIA_TITLE] == "Channel Name 2"
 
     # Device Info
-    device = device_registry.async_get_device({(DOMAIN, entry.unique_id)})
+    device = device_registry.async_get_device(identifiers={(DOMAIN, entry.unique_id)})
 
     assert device
     assert device.identifiers == {(DOMAIN, entry.unique_id)}

--- a/tests/components/xiaomi_ble/test_device_trigger.py
+++ b/tests/components/xiaomi_ble/test_device_trigger.py
@@ -99,7 +99,7 @@ async def test_get_triggers(
     await hass.async_block_till_done()
     assert len(events) == 1
 
-    device = device_registry.async_get_device({get_device_id(mac)})
+    device = device_registry.async_get_device(identifiers={get_device_id(mac)})
     assert device
     expected_trigger = {
         CONF_PLATFORM: "device",
@@ -196,7 +196,7 @@ async def test_if_fires_on_motion_detected(
     # wait for the event
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device({get_device_id(mac)})
+    device = device_registry.async_get_device(identifiers={get_device_id(mac)})
     device_id = device.id
 
     assert await async_setup_component(
@@ -256,7 +256,7 @@ async def test_automation_with_invalid_trigger_type(
     # wait for the event
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device({get_device_id(mac)})
+    device = device_registry.async_get_device(identifiers={get_device_id(mac)})
     device_id = device.id
 
     assert await async_setup_component(
@@ -305,7 +305,7 @@ async def test_automation_with_invalid_trigger_event_property(
     # wait for the event
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device({get_device_id(mac)})
+    device = device_registry.async_get_device(identifiers={get_device_id(mac)})
     device_id = device.id
 
     assert await async_setup_component(

--- a/tests/components/yolink/test_device_trigger.py
+++ b/tests/components/yolink/test_device_trigger.py
@@ -154,7 +154,7 @@ async def test_if_fires_on_event(
         },
     )
 
-    device = device_registry.async_get_device(set(), {connection})
+    device = device_registry.async_get_device(connections={connection})
     assert device is not None
     # Fake remote button long press.
     hass.bus.async_fire(

--- a/tests/components/youtube/test_init.py
+++ b/tests/components/youtube/test_init.py
@@ -126,7 +126,7 @@ async def test_device_info(
     entry = hass.config_entries.async_entries(DOMAIN)[0]
     channel_id = entry.options[CONF_CHANNELS][0]
     device = device_registry.async_get_device(
-        {(DOMAIN, f"{entry.entry_id}_{channel_id}")}
+        identifiers={(DOMAIN, f"{entry.entry_id}_{channel_id}")}
     )
 
     assert device.entry_type is dr.DeviceEntryType.SERVICE

--- a/tests/components/zha/test_device_action.py
+++ b/tests/components/zha/test_device_action.py
@@ -113,7 +113,9 @@ async def test_get_actions(hass: HomeAssistant, device_ias) -> None:
     ieee_address = str(device_ias[0].ieee)
 
     ha_device_registry = dr.async_get(hass)
-    reg_device = ha_device_registry.async_get_device({(DOMAIN, ieee_address)})
+    reg_device = ha_device_registry.async_get_device(
+        identifiers={(DOMAIN, ieee_address)}
+    )
     ha_entity_registry = er.async_get(hass)
     siren_level_select = ha_entity_registry.async_get(
         "select.fakemanufacturer_fakemodel_default_siren_level"
@@ -175,7 +177,7 @@ async def test_get_inovelli_actions(hass: HomeAssistant, device_inovelli) -> Non
     inovelli_ieee_address = str(device_inovelli[0].ieee)
     ha_device_registry = dr.async_get(hass)
     inovelli_reg_device = ha_device_registry.async_get_device(
-        {(DOMAIN, inovelli_ieee_address)}
+        identifiers={(DOMAIN, inovelli_ieee_address)}
     )
     ha_entity_registry = er.async_get(hass)
     inovelli_button = ha_entity_registry.async_get("button.inovelli_vzm31_sn_identify")
@@ -265,9 +267,11 @@ async def test_action(hass: HomeAssistant, device_ias, device_inovelli) -> None:
     inovelli_ieee_address = str(inovelli_zha_device.ieee)
 
     ha_device_registry = dr.async_get(hass)
-    reg_device = ha_device_registry.async_get_device({(DOMAIN, ieee_address)})
+    reg_device = ha_device_registry.async_get_device(
+        identifiers={(DOMAIN, ieee_address)}
+    )
     inovelli_reg_device = ha_device_registry.async_get_device(
-        {(DOMAIN, inovelli_ieee_address)}
+        identifiers={(DOMAIN, inovelli_ieee_address)}
     )
 
     cluster = inovelli_zigpy_device.endpoints[1].in_clusters[0xFC31]

--- a/tests/components/zha/test_device_trigger.py
+++ b/tests/components/zha/test_device_trigger.py
@@ -105,7 +105,9 @@ async def test_triggers(hass: HomeAssistant, mock_devices) -> None:
     ieee_address = str(zha_device.ieee)
 
     ha_device_registry = dr.async_get(hass)
-    reg_device = ha_device_registry.async_get_device({("zha", ieee_address)})
+    reg_device = ha_device_registry.async_get_device(
+        identifiers={("zha", ieee_address)}
+    )
 
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, reg_device.id
@@ -171,7 +173,9 @@ async def test_no_triggers(hass: HomeAssistant, mock_devices) -> None:
     ieee_address = str(zha_device.ieee)
 
     ha_device_registry = dr.async_get(hass)
-    reg_device = ha_device_registry.async_get_device({("zha", ieee_address)})
+    reg_device = ha_device_registry.async_get_device(
+        identifiers={("zha", ieee_address)}
+    )
 
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, reg_device.id
@@ -203,7 +207,9 @@ async def test_if_fires_on_event(hass: HomeAssistant, mock_devices, calls) -> No
 
     ieee_address = str(zha_device.ieee)
     ha_device_registry = dr.async_get(hass)
-    reg_device = ha_device_registry.async_get_device({("zha", ieee_address)})
+    reg_device = ha_device_registry.async_get_device(
+        identifiers={("zha", ieee_address)}
+    )
 
     assert await async_setup_component(
         hass,
@@ -312,7 +318,9 @@ async def test_exception_no_triggers(
 
     ieee_address = str(zha_device.ieee)
     ha_device_registry = dr.async_get(hass)
-    reg_device = ha_device_registry.async_get_device({("zha", ieee_address)})
+    reg_device = ha_device_registry.async_get_device(
+        identifiers={("zha", ieee_address)}
+    )
 
     await async_setup_component(
         hass,
@@ -359,7 +367,9 @@ async def test_exception_bad_trigger(
 
     ieee_address = str(zha_device.ieee)
     ha_device_registry = dr.async_get(hass)
-    reg_device = ha_device_registry.async_get_device({("zha", ieee_address)})
+    reg_device = ha_device_registry.async_get_device(
+        identifiers={("zha", ieee_address)}
+    )
 
     await async_setup_component(
         hass,

--- a/tests/components/zha/test_diagnostics.py
+++ b/tests/components/zha/test_diagnostics.py
@@ -94,7 +94,7 @@ async def test_diagnostics_for_device(
 
     zha_device: ZHADevice = await zha_device_joined(zigpy_device)
     dev_reg = async_get(hass)
-    device = dev_reg.async_get_device({("zha", str(zha_device.ieee))})
+    device = dev_reg.async_get_device(identifiers={("zha", str(zha_device.ieee))})
     assert device
     diagnostics_data = await get_diagnostics_for_device(
         hass, hass_client, config_entry, device

--- a/tests/components/zha/test_logbook.py
+++ b/tests/components/zha/test_logbook.py
@@ -78,7 +78,9 @@ async def test_zha_logbook_event_device_with_triggers(
     ieee_address = str(zha_device.ieee)
 
     ha_device_registry = dr.async_get(hass)
-    reg_device = ha_device_registry.async_get_device({("zha", ieee_address)})
+    reg_device = ha_device_registry.async_get_device(
+        identifiers={("zha", ieee_address)}
+    )
 
     hass.config.components.add("recorder")
     assert await async_setup_component(hass, "logbook", {})
@@ -154,7 +156,9 @@ async def test_zha_logbook_event_device_no_triggers(
     zigpy_device, zha_device = mock_devices
     ieee_address = str(zha_device.ieee)
     ha_device_registry = dr.async_get(hass)
-    reg_device = ha_device_registry.async_get_device({("zha", ieee_address)})
+    reg_device = ha_device_registry.async_get_device(
+        identifiers={("zha", ieee_address)}
+    )
 
     hass.config.components.add("recorder")
     assert await async_setup_component(hass, "logbook", {})

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -94,7 +94,7 @@ def get_device(hass: HomeAssistant, node):
     """Get device ID for a node."""
     dev_reg = dr.async_get(hass)
     device_id = get_device_id(node.client.driver, node)
-    return dev_reg.async_get_device({device_id})
+    return dev_reg.async_get_device(identifiers={device_id})
 
 
 async def test_no_driver(
@@ -462,7 +462,7 @@ async def test_node_comments(
     ws_client = await hass_ws_client(hass)
 
     dev_reg = dr.async_get(hass)
-    device = dev_reg.async_get_device({(DOMAIN, "3245146787-35")})
+    device = dev_reg.async_get_device(identifiers={(DOMAIN, "3245146787-35")})
     assert device
 
     await ws_client.send_json(

--- a/tests/components/zwave_js/test_device_action.py
+++ b/tests/components/zwave_js/test_device_action.py
@@ -32,7 +32,7 @@ async def test_get_actions(
     node = lock_schlage_be469
     driver = client.driver
     assert driver
-    device = device_registry.async_get_device({get_device_id(driver, node)})
+    device = device_registry.async_get_device(identifiers={get_device_id(driver, node)})
     assert device
     expected_actions = [
         {
@@ -94,7 +94,7 @@ async def test_get_actions(
 
     # Test that we don't return actions for a controller node
     device = device_registry.async_get_device(
-        {get_device_id(driver, client.driver.controller.nodes[1])}
+        identifiers={get_device_id(driver, client.driver.controller.nodes[1])}
     )
     assert device
     assert (
@@ -114,7 +114,7 @@ async def test_get_actions_meter(
     node = aeon_smart_switch_6
     driver = client.driver
     assert driver
-    device = device_registry.async_get_device({get_device_id(driver, node)})
+    device = device_registry.async_get_device(identifiers={get_device_id(driver, node)})
     assert device
     actions = await async_get_device_automations(
         hass, DeviceAutomationType.ACTION, device.id
@@ -135,7 +135,7 @@ async def test_actions(
     driver = client.driver
     assert driver
     device_id = get_device_id(driver, node)
-    device = device_registry.async_get_device({device_id})
+    device = device_registry.async_get_device(identifiers={device_id})
     assert device
 
     assert await async_setup_component(
@@ -285,7 +285,7 @@ async def test_actions_multiple_calls(
     driver = client.driver
     assert driver
     device_id = get_device_id(driver, node)
-    device = device_registry.async_get_device({device_id})
+    device = device_registry.async_get_device(identifiers={device_id})
     assert device
 
     assert await async_setup_component(
@@ -332,7 +332,7 @@ async def test_lock_actions(
     driver = client.driver
     assert driver
     device_id = get_device_id(driver, node)
-    device = device_registry.async_get_device({device_id})
+    device = device_registry.async_get_device(identifiers={device_id})
     assert device
 
     assert await async_setup_component(
@@ -403,7 +403,7 @@ async def test_reset_meter_action(
     driver = client.driver
     assert driver
     device_id = get_device_id(driver, node)
-    device = device_registry.async_get_device({device_id})
+    device = device_registry.async_get_device(identifiers={device_id})
     assert device
 
     assert await async_setup_component(
@@ -448,7 +448,7 @@ async def test_get_action_capabilities(
 ) -> None:
     """Test we get the expected action capabilities."""
     device = device_registry.async_get_device(
-        {get_device_id(client.driver, climate_radio_thermostat_ct100_plus)}
+        identifiers={get_device_id(client.driver, climate_radio_thermostat_ct100_plus)}
     )
     assert device
 
@@ -668,7 +668,7 @@ async def test_get_action_capabilities_meter_triggers(
     node = aeon_smart_switch_6
     driver = client.driver
     assert driver
-    device = device_registry.async_get_device({get_device_id(driver, node)})
+    device = device_registry.async_get_device(identifiers={get_device_id(driver, node)})
     assert device
     capabilities = await device_action.async_get_action_capabilities(
         hass,
@@ -724,7 +724,7 @@ async def test_unavailable_entity_actions(
     node = lock_schlage_be469
     driver = client.driver
     assert driver
-    device = device_registry.async_get_device({get_device_id(driver, node)})
+    device = device_registry.async_get_device(identifiers={get_device_id(driver, node)})
     assert device
     actions = await async_get_device_automations(
         hass, DeviceAutomationType.ACTION, device.id

--- a/tests/components/zwave_js/test_device_condition.py
+++ b/tests/components/zwave_js/test_device_condition.py
@@ -42,7 +42,7 @@ async def test_get_conditions(
 ) -> None:
     """Test we get the expected onditions from a zwave_js."""
     device = device_registry.async_get_device(
-        {get_device_id(client.driver, lock_schlage_be469)}
+        identifiers={get_device_id(client.driver, lock_schlage_be469)}
     )
     assert device
     config_value = list(lock_schlage_be469.get_configuration_values().values())[0]
@@ -82,7 +82,7 @@ async def test_get_conditions(
 
     # Test that we don't return actions for a controller node
     device = device_registry.async_get_device(
-        {get_device_id(client.driver, client.driver.controller.nodes[1])}
+        identifiers={get_device_id(client.driver, client.driver.controller.nodes[1])}
     )
     assert device
     assert (
@@ -103,7 +103,7 @@ async def test_node_status_state(
 ) -> None:
     """Test for node_status conditions."""
     device = device_registry.async_get_device(
-        {get_device_id(client.driver, lock_schlage_be469)}
+        identifiers={get_device_id(client.driver, lock_schlage_be469)}
     )
     assert device
 
@@ -268,7 +268,7 @@ async def test_config_parameter_state(
 ) -> None:
     """Test for config_parameter conditions."""
     device = device_registry.async_get_device(
-        {get_device_id(client.driver, lock_schlage_be469)}
+        identifiers={get_device_id(client.driver, lock_schlage_be469)}
     )
     assert device
 
@@ -388,7 +388,7 @@ async def test_value_state(
 ) -> None:
     """Test for value conditions."""
     device = device_registry.async_get_device(
-        {get_device_id(client.driver, lock_schlage_be469)}
+        identifiers={get_device_id(client.driver, lock_schlage_be469)}
     )
     assert device
 
@@ -439,7 +439,7 @@ async def test_get_condition_capabilities_node_status(
 ) -> None:
     """Test we don't get capabilities from a node_status condition."""
     device = device_registry.async_get_device(
-        {get_device_id(client.driver, lock_schlage_be469)}
+        identifiers={get_device_id(client.driver, lock_schlage_be469)}
     )
     assert device
 
@@ -479,7 +479,7 @@ async def test_get_condition_capabilities_value(
 ) -> None:
     """Test we get the expected capabilities from a value condition."""
     device = device_registry.async_get_device(
-        {get_device_id(client.driver, lock_schlage_be469)}
+        identifiers={get_device_id(client.driver, lock_schlage_be469)}
     )
     assert device
 
@@ -532,7 +532,7 @@ async def test_get_condition_capabilities_config_parameter(
     """Test we get the expected capabilities from a config_parameter condition."""
     node = climate_radio_thermostat_ct100_plus
     device = device_registry.async_get_device(
-        {get_device_id(client.driver, climate_radio_thermostat_ct100_plus)}
+        identifiers={get_device_id(client.driver, climate_radio_thermostat_ct100_plus)}
     )
     assert device
 
@@ -617,7 +617,7 @@ async def test_failure_scenarios(
 ) -> None:
     """Test failure scenarios."""
     device = device_registry.async_get_device(
-        {get_device_id(client.driver, hank_binary_switch)}
+        identifiers={get_device_id(client.driver, hank_binary_switch)}
     )
     assert device
 

--- a/tests/components/zwave_js/test_device_trigger.py
+++ b/tests/components/zwave_js/test_device_trigger.py
@@ -41,7 +41,7 @@ async def test_no_controller_triggers(hass: HomeAssistant, client, integration) 
     """Test that we do not get triggers for the controller."""
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device(
-        {get_device_id(client.driver, client.driver.controller.nodes[1])}
+        identifiers={get_device_id(client.driver, client.driver.controller.nodes[1])}
     )
     assert device
     assert (
@@ -58,7 +58,7 @@ async def test_get_notification_notification_triggers(
     """Test we get the expected triggers from a zwave_js device with the Notification CC."""
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device(
-        {get_device_id(client.driver, lock_schlage_be469)}
+        identifiers={get_device_id(client.driver, lock_schlage_be469)}
     )
     assert device
     expected_trigger = {
@@ -82,7 +82,7 @@ async def test_if_notification_notification_fires(
     node: Node = lock_schlage_be469
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device(
-        {get_device_id(client.driver, lock_schlage_be469)}
+        identifiers={get_device_id(client.driver, lock_schlage_be469)}
     )
     assert device
 
@@ -178,7 +178,7 @@ async def test_get_trigger_capabilities_notification_notification(
     """Test we get the expected capabilities from a notification.notification trigger."""
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device(
-        {get_device_id(client.driver, lock_schlage_be469)}
+        identifiers={get_device_id(client.driver, lock_schlage_be469)}
     )
     assert device
     capabilities = await device_trigger.async_get_trigger_capabilities(
@@ -212,7 +212,7 @@ async def test_if_entry_control_notification_fires(
     node: Node = lock_schlage_be469
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device(
-        {get_device_id(client.driver, lock_schlage_be469)}
+        identifiers={get_device_id(client.driver, lock_schlage_be469)}
     )
     assert device
 
@@ -307,7 +307,7 @@ async def test_get_trigger_capabilities_entry_control_notification(
     """Test we get the expected capabilities from a notification.entry_control trigger."""
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device(
-        {get_device_id(client.driver, lock_schlage_be469)}
+        identifiers={get_device_id(client.driver, lock_schlage_be469)}
     )
     assert device
     capabilities = await device_trigger.async_get_trigger_capabilities(
@@ -338,7 +338,7 @@ async def test_get_node_status_triggers(
     """Test we get the expected triggers from a device with node status sensor enabled."""
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device(
-        {get_device_id(client.driver, lock_schlage_be469)}
+        identifiers={get_device_id(client.driver, lock_schlage_be469)}
     )
     assert device
     ent_reg = async_get_ent_reg(hass)
@@ -370,7 +370,7 @@ async def test_if_node_status_change_fires(
     node: Node = lock_schlage_be469
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device(
-        {get_device_id(client.driver, lock_schlage_be469)}
+        identifiers={get_device_id(client.driver, lock_schlage_be469)}
     )
     assert device
     ent_reg = async_get_ent_reg(hass)
@@ -448,7 +448,7 @@ async def test_get_trigger_capabilities_node_status(
     """Test we get the expected capabilities from a node_status trigger."""
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device(
-        {get_device_id(client.driver, lock_schlage_be469)}
+        identifiers={get_device_id(client.driver, lock_schlage_be469)}
     )
     assert device
     ent_reg = async_get_ent_reg(hass)
@@ -506,7 +506,7 @@ async def test_get_basic_value_notification_triggers(
     """Test we get the expected triggers from a zwave_js device with the Basic CC."""
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device(
-        {get_device_id(client.driver, ge_in_wall_dimmer_switch)}
+        identifiers={get_device_id(client.driver, ge_in_wall_dimmer_switch)}
     )
     assert device
     expected_trigger = {
@@ -534,7 +534,7 @@ async def test_if_basic_value_notification_fires(
     node: Node = ge_in_wall_dimmer_switch
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device(
-        {get_device_id(client.driver, ge_in_wall_dimmer_switch)}
+        identifiers={get_device_id(client.driver, ge_in_wall_dimmer_switch)}
     )
     assert device
 
@@ -645,7 +645,7 @@ async def test_get_trigger_capabilities_basic_value_notification(
     """Test we get the expected capabilities from a value_notification.basic trigger."""
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device(
-        {get_device_id(client.driver, ge_in_wall_dimmer_switch)}
+        identifiers={get_device_id(client.driver, ge_in_wall_dimmer_switch)}
     )
     assert device
     capabilities = await device_trigger.async_get_trigger_capabilities(
@@ -683,7 +683,7 @@ async def test_get_central_scene_value_notification_triggers(
     """Test we get the expected triggers from a zwave_js device with the Central Scene CC."""
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device(
-        {get_device_id(client.driver, wallmote_central_scene)}
+        identifiers={get_device_id(client.driver, wallmote_central_scene)}
     )
     assert device
     expected_trigger = {
@@ -711,7 +711,7 @@ async def test_if_central_scene_value_notification_fires(
     node: Node = wallmote_central_scene
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device(
-        {get_device_id(client.driver, wallmote_central_scene)}
+        identifiers={get_device_id(client.driver, wallmote_central_scene)}
     )
     assert device
 
@@ -828,7 +828,7 @@ async def test_get_trigger_capabilities_central_scene_value_notification(
     """Test we get the expected capabilities from a value_notification.central_scene trigger."""
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device(
-        {get_device_id(client.driver, wallmote_central_scene)}
+        identifiers={get_device_id(client.driver, wallmote_central_scene)}
     )
     assert device
     capabilities = await device_trigger.async_get_trigger_capabilities(
@@ -865,7 +865,7 @@ async def test_get_scene_activation_value_notification_triggers(
     """Test we get the expected triggers from a zwave_js device with the SceneActivation CC."""
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device(
-        {get_device_id(client.driver, hank_binary_switch)}
+        identifiers={get_device_id(client.driver, hank_binary_switch)}
     )
     assert device
     expected_trigger = {
@@ -893,7 +893,7 @@ async def test_if_scene_activation_value_notification_fires(
     node: Node = hank_binary_switch
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device(
-        {get_device_id(client.driver, hank_binary_switch)}
+        identifiers={get_device_id(client.driver, hank_binary_switch)}
     )
     assert device
 
@@ -1004,7 +1004,7 @@ async def test_get_trigger_capabilities_scene_activation_value_notification(
     """Test we get the expected capabilities from a value_notification.scene_activation trigger."""
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device(
-        {get_device_id(client.driver, hank_binary_switch)}
+        identifiers={get_device_id(client.driver, hank_binary_switch)}
     )
     assert device
     capabilities = await device_trigger.async_get_trigger_capabilities(
@@ -1042,7 +1042,7 @@ async def test_get_value_updated_value_triggers(
     """Test we get the zwave_js.value_updated.value trigger from a zwave_js device."""
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device(
-        {get_device_id(client.driver, lock_schlage_be469)}
+        identifiers={get_device_id(client.driver, lock_schlage_be469)}
     )
     assert device
     expected_trigger = {
@@ -1065,7 +1065,7 @@ async def test_if_value_updated_value_fires(
     node: Node = lock_schlage_be469
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device(
-        {get_device_id(client.driver, lock_schlage_be469)}
+        identifiers={get_device_id(client.driver, lock_schlage_be469)}
     )
     assert device
 
@@ -1157,7 +1157,7 @@ async def test_value_updated_value_no_driver(
     node: Node = lock_schlage_be469
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device(
-        {get_device_id(client.driver, lock_schlage_be469)}
+        identifiers={get_device_id(client.driver, lock_schlage_be469)}
     )
     assert device
     driver = client.driver
@@ -1227,7 +1227,7 @@ async def test_get_trigger_capabilities_value_updated_value(
     """Test we get the expected capabilities from a zwave_js.value_updated.value trigger."""
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device(
-        {get_device_id(client.driver, lock_schlage_be469)}
+        identifiers={get_device_id(client.driver, lock_schlage_be469)}
     )
     assert device
     capabilities = await device_trigger.async_get_trigger_capabilities(
@@ -1278,7 +1278,7 @@ async def test_get_value_updated_config_parameter_triggers(
     """Test we get the zwave_js.value_updated.config_parameter trigger from a zwave_js device."""
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device(
-        {get_device_id(client.driver, lock_schlage_be469)}
+        identifiers={get_device_id(client.driver, lock_schlage_be469)}
     )
     assert device
     expected_trigger = {
@@ -1306,7 +1306,7 @@ async def test_if_value_updated_config_parameter_fires(
     node: Node = lock_schlage_be469
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device(
-        {get_device_id(client.driver, lock_schlage_be469)}
+        identifiers={get_device_id(client.driver, lock_schlage_be469)}
     )
     assert device
 
@@ -1376,7 +1376,7 @@ async def test_get_trigger_capabilities_value_updated_config_parameter_range(
     """Test we get the expected capabilities from a range zwave_js.value_updated.config_parameter trigger."""
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device(
-        {get_device_id(client.driver, lock_schlage_be469)}
+        identifiers={get_device_id(client.driver, lock_schlage_be469)}
     )
     assert device
     capabilities = await device_trigger.async_get_trigger_capabilities(
@@ -1421,7 +1421,7 @@ async def test_get_trigger_capabilities_value_updated_config_parameter_enumerate
     """Test we get the expected capabilities from an enumerated zwave_js.value_updated.config_parameter trigger."""
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device(
-        {get_device_id(client.driver, lock_schlage_be469)}
+        identifiers={get_device_id(client.driver, lock_schlage_be469)}
     )
     assert device
     capabilities = await device_trigger.async_get_trigger_capabilities(
@@ -1477,7 +1477,7 @@ async def test_failure_scenarios(
 
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device(
-        {get_device_id(client.driver, hank_binary_switch)}
+        identifiers={get_device_id(client.driver, hank_binary_switch)}
     )
     assert device
 

--- a/tests/components/zwave_js/test_diagnostics.py
+++ b/tests/components/zwave_js/test_diagnostics.py
@@ -58,7 +58,9 @@ async def test_device_diagnostics(
 ) -> None:
     """Test the device level diagnostics data dump."""
     dev_reg = dr.async_get(hass)
-    device = dev_reg.async_get_device({get_device_id(client.driver, multisensor_6)})
+    device = dev_reg.async_get_device(
+        identifiers={get_device_id(client.driver, multisensor_6)}
+    )
     assert device
 
     # Create mock config entry for fake entity
@@ -151,7 +153,9 @@ async def test_device_diagnostics_missing_primary_value(
 ) -> None:
     """Test that device diagnostics handles an entity with a missing primary value."""
     dev_reg = dr.async_get(hass)
-    device = dev_reg.async_get_device({get_device_id(client.driver, multisensor_6)})
+    device = dev_reg.async_get_device(
+        identifiers={get_device_id(client.driver, multisensor_6)}
+    )
     assert device
 
     entity_id = "sensor.multisensor_6_air_temperature"
@@ -240,7 +244,7 @@ async def test_device_diagnostics_secret_value(
     client.driver.controller.emit("node added", {"node": node})
     await hass.async_block_till_done()
     dev_reg = dr.async_get(hass)
-    device = dev_reg.async_get_device({get_device_id(client.driver, node)})
+    device = dev_reg.async_get_device(identifiers={get_device_id(client.driver, node)})
     assert device
 
     diagnostics_data = await get_diagnostics_for_device(

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -976,7 +976,9 @@ async def test_removed_device(
     assert len(device_entries) == 2
     entity_entries = er.async_entries_for_config_entry(ent_reg, integration.entry_id)
     assert len(entity_entries) == 60
-    assert dev_reg.async_get_device({get_device_id(driver, old_node)}) is None
+    assert (
+        dev_reg.async_get_device(identifiers={get_device_id(driver, old_node)}) is None
+    )
 
 
 async def test_suggested_area(hass: HomeAssistant, client, eaton_rf9640_dimmer) -> None:

--- a/tests/components/zwave_js/test_services.py
+++ b/tests/components/zwave_js/test_services.py
@@ -410,7 +410,9 @@ async def test_bulk_set_config_parameters(
 ) -> None:
     """Test the bulk_set_partial_config_parameters service."""
     dev_reg = async_get_dev_reg(hass)
-    device = dev_reg.async_get_device({get_device_id(client.driver, multisensor_6)})
+    device = dev_reg.async_get_device(
+        identifiers={get_device_id(client.driver, multisensor_6)}
+    )
     assert device
     # Test setting config parameter by property and property_key
     await hass.services.async_call(
@@ -757,7 +759,7 @@ async def test_set_value(
     """Test set_value service."""
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device(
-        {get_device_id(client.driver, climate_danfoss_lc_13)}
+        identifiers={get_device_id(client.driver, climate_danfoss_lc_13)}
     )
     assert device
 
@@ -1103,11 +1105,11 @@ async def test_multicast_set_value(
     # Test using area ID
     dev_reg = async_get_dev_reg(hass)
     device_eurotronic = dev_reg.async_get_device(
-        {get_device_id(client.driver, climate_eurotronic_spirit_z)}
+        identifiers={get_device_id(client.driver, climate_eurotronic_spirit_z)}
     )
     assert device_eurotronic
     device_danfoss = dev_reg.async_get_device(
-        {get_device_id(client.driver, climate_danfoss_lc_13)}
+        identifiers={get_device_id(client.driver, climate_danfoss_lc_13)}
     )
     assert device_danfoss
     area_reg = async_get_area_reg(hass)
@@ -1416,7 +1418,7 @@ async def test_ping(
     """Test ping service."""
     dev_reg = async_get_dev_reg(hass)
     device_radio_thermostat = dev_reg.async_get_device(
-        {
+        identifiers={
             get_device_id(
                 client.driver, climate_radio_thermostat_ct100_plus_different_endpoints
             )
@@ -1424,7 +1426,7 @@ async def test_ping(
     )
     assert device_radio_thermostat
     device_danfoss = dev_reg.async_get_device(
-        {get_device_id(client.driver, climate_danfoss_lc_13)}
+        identifiers={get_device_id(client.driver, climate_danfoss_lc_13)}
     )
     assert device_danfoss
 
@@ -1566,7 +1568,7 @@ async def test_invoke_cc_api(
     """Test invoke_cc_api service."""
     dev_reg = async_get_dev_reg(hass)
     device_radio_thermostat = dev_reg.async_get_device(
-        {
+        identifiers={
             get_device_id(
                 client.driver, climate_radio_thermostat_ct100_plus_different_endpoints
             )
@@ -1574,7 +1576,7 @@ async def test_invoke_cc_api(
     )
     assert device_radio_thermostat
     device_danfoss = dev_reg.async_get_device(
-        {get_device_id(client.driver, climate_danfoss_lc_13)}
+        identifiers={get_device_id(client.driver, climate_danfoss_lc_13)}
     )
     assert device_danfoss
 

--- a/tests/components/zwave_js/test_trigger.py
+++ b/tests/components/zwave_js/test_trigger.py
@@ -35,7 +35,7 @@ async def test_zwave_js_value_updated(
     node: Node = lock_schlage_be469
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device(
-        {get_device_id(client.driver, lock_schlage_be469)}
+        identifiers={get_device_id(client.driver, lock_schlage_be469)}
     )
     assert device
 
@@ -459,7 +459,7 @@ async def test_zwave_js_event(
     node: Node = lock_schlage_be469
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device(
-        {get_device_id(client.driver, lock_schlage_be469)}
+        identifiers={get_device_id(client.driver, lock_schlage_be469)}
     )
     assert device
 
@@ -1013,7 +1013,7 @@ async def test_zwave_js_trigger_config_entry_unloaded(
     """Test zwave_js triggers bypass dynamic validation when needed."""
     dev_reg = async_get_dev_reg(hass)
     device = dev_reg.async_get_device(
-        {get_device_id(client.driver, lock_schlage_be469)}
+        identifiers={get_device_id(client.driver, lock_schlage_be469)}
     )
     assert device
 

--- a/tests/components/zwave_me/test_remove_stale_devices.py
+++ b/tests/components/zwave_me/test_remove_stale_devices.py
@@ -60,7 +60,7 @@ async def test_remove_stale_devices(
     assert (
         bool(
             device_registry.async_get_device(
-                {
+                identifiers={
                     (
                         "zwave_me",
                         f"{config_entry.unique_id}-{identifier}",

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -530,8 +530,10 @@ async def test_removing_config_entries(
     assert entry2.config_entries == {"123", "456"}
 
     device_registry.async_clear_config_entry("123")
-    entry = device_registry.async_get_device({("bridgeid", "0123")})
-    entry3_removed = device_registry.async_get_device({("bridgeid", "4567")})
+    entry = device_registry.async_get_device(identifiers={("bridgeid", "0123")})
+    entry3_removed = device_registry.async_get_device(
+        identifiers={("bridgeid", "4567")}
+    )
 
     assert entry.config_entries == {"456"}
     assert entry3_removed is None
@@ -664,7 +666,7 @@ async def test_removing_area_id(device_registry: dr.DeviceRegistry) -> None:
     entry_w_area = device_registry.async_update_device(entry.id, area_id="12345A")
 
     device_registry.async_clear_area_id("12345A")
-    entry_wo_area = device_registry.async_get_device({("bridgeid", "0123")})
+    entry_wo_area = device_registry.async_get_device(identifiers={("bridgeid", "0123")})
 
     assert not entry_wo_area.area_id
     assert entry_w_area != entry_wo_area
@@ -692,7 +694,7 @@ async def test_specifying_via_device_create(device_registry: dr.DeviceRegistry) 
     assert light.via_device_id == via.id
 
     device_registry.async_remove_device(via.id)
-    light = device_registry.async_get_device({("hue", "456")})
+    light = device_registry.async_get_device(identifiers={("hue", "456")})
     assert light.via_device_id is None
 
 
@@ -821,9 +823,9 @@ async def test_loading_saving_data(
     assert list(device_registry.devices) == list(registry2.devices)
     assert list(device_registry.deleted_devices) == list(registry2.deleted_devices)
 
-    new_via = registry2.async_get_device({("hue", "0123")})
-    new_light = registry2.async_get_device({("hue", "456")})
-    new_light4 = registry2.async_get_device({("hue", "abc")})
+    new_via = registry2.async_get_device(identifiers={("hue", "0123")})
+    new_light = registry2.async_get_device(identifiers={("hue", "456")})
+    new_light4 = registry2.async_get_device(identifiers={("hue", "abc")})
 
     assert orig_via == new_via
     assert orig_light == new_light
@@ -839,7 +841,7 @@ async def test_loading_saving_data(
         assert old.entry_type is new.entry_type
 
     # Ensure a save/load cycle does not keep suggested area
-    new_kitchen_light = registry2.async_get_device({("hue", "999")})
+    new_kitchen_light = registry2.async_get_device(identifiers={("hue", "999")})
     assert orig_kitchen_light.suggested_area == "Kitchen"
 
     orig_kitchen_light_witout_suggested_area = device_registry.async_update_device(
@@ -951,15 +953,19 @@ async def test_update(
         via_device_id="98765B",
     )
 
-    assert device_registry.async_get_device({("hue", "456")}) is None
-    assert device_registry.async_get_device({("bla", "123")}) is None
+    assert device_registry.async_get_device(identifiers={("hue", "456")}) is None
+    assert device_registry.async_get_device(identifiers={("bla", "123")}) is None
 
-    assert device_registry.async_get_device({("hue", "654")}) == updated_entry
-    assert device_registry.async_get_device({("bla", "321")}) == updated_entry
+    assert (
+        device_registry.async_get_device(identifiers={("hue", "654")}) == updated_entry
+    )
+    assert (
+        device_registry.async_get_device(identifiers={("bla", "321")}) == updated_entry
+    )
 
     assert (
         device_registry.async_get_device(
-            {}, {(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")}
+            connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")}
         )
         == updated_entry
     )
@@ -1032,7 +1038,7 @@ async def test_update_remove_config_entries(
     assert updated_entry.config_entries == {"456"}
     assert removed_entry is None
 
-    removed_entry = device_registry.async_get_device({("bridgeid", "4567")})
+    removed_entry = device_registry.async_get_device(identifiers={("bridgeid", "4567")})
 
     assert removed_entry is None
 
@@ -1137,10 +1143,10 @@ async def test_cleanup_device_registry(
 
     dr.async_cleanup(hass, device_registry, ent_reg)
 
-    assert device_registry.async_get_device({("hue", "d1")}) is not None
-    assert device_registry.async_get_device({("hue", "d2")}) is not None
-    assert device_registry.async_get_device({("hue", "d3")}) is not None
-    assert device_registry.async_get_device({("something", "d4")}) is None
+    assert device_registry.async_get_device(identifiers={("hue", "d1")}) is not None
+    assert device_registry.async_get_device(identifiers={("hue", "d2")}) is not None
+    assert device_registry.async_get_device(identifiers={("hue", "d3")}) is not None
+    assert device_registry.async_get_device(identifiers={("something", "d4")}) is None
 
 
 async def test_cleanup_device_registry_removes_expired_orphaned_devices(

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -1162,7 +1162,9 @@ async def test_device_info_not_overrides(hass: HomeAssistant) -> None:
     assert await entity_platform.async_setup_entry(config_entry)
     await hass.async_block_till_done()
 
-    device2 = registry.async_get_device(set(), {(dr.CONNECTION_NETWORK_MAC, "abcd")})
+    device2 = registry.async_get_device(
+        connections={(dr.CONNECTION_NETWORK_MAC, "abcd")}
+    )
     assert device2 is not None
     assert device.id == device2.id
     assert device2.manufacturer == "test-manufacturer"
@@ -1836,7 +1838,7 @@ async def test_device_name_defaulting_config_entry(
     await hass.async_block_till_done()
 
     dev_reg = dr.async_get(hass)
-    device = dev_reg.async_get_device(set(), {(dr.CONNECTION_NETWORK_MAC, "1234")})
+    device = dev_reg.async_get_device(connections={(dr.CONNECTION_NETWORK_MAC, "1234")})
     assert device is not None
     assert device.name == expected_device_name
 

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -1108,7 +1108,7 @@ async def test_device_info_called(hass: HomeAssistant) -> None:
 
     assert len(hass.states.async_entity_ids()) == 2
 
-    device = registry.async_get_device({("hue", "1234")})
+    device = registry.async_get_device(identifiers={("hue", "1234")})
     assert device is not None
     assert device.identifiers == {("hue", "1234")}
     assert device.configuration_url == "http://192.168.0.100/config"
@@ -1209,7 +1209,7 @@ async def test_device_info_homeassistant_url(
 
     assert len(hass.states.async_entity_ids()) == 1
 
-    device = registry.async_get_device({("mqtt", "1234")})
+    device = registry.async_get_device(identifiers={("mqtt", "1234")})
     assert device is not None
     assert device.identifiers == {("mqtt", "1234")}
     assert device.configuration_url == "homeassistant://config/mqtt"
@@ -1256,7 +1256,7 @@ async def test_device_info_change_to_no_url(
 
     assert len(hass.states.async_entity_ids()) == 1
 
-    device = registry.async_get_device({("mqtt", "1234")})
+    device = registry.async_get_device(identifiers={("mqtt", "1234")})
     assert device is not None
     assert device.identifiers == {("mqtt", "1234")}
     assert device.configuration_url is None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Don't require passing `identifiers` to `DeviceRegistry.async_get_device`

Rationale:
- Avoid unnecessary creation of an empty `set` when getting a device via its connections

Enforcing keyword arguments would make the API clearer, but would cause unnecessary breakage of custom components

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
