### PR TITLE
Limit AndroidTV screencap calls

### DIFF
--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -2,8 +2,9 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable, Coroutine
-from datetime import datetime
+from datetime import timedelta
 import functools
+import hashlib
 import logging
 from typing import Any, Concatenate, ParamSpec, TypeVar
 
@@ -35,6 +36,7 @@ from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.util import Throttle
 
 from . import ADB_PYTHON_EXCEPTIONS, ADB_TCP_EXCEPTIONS, get_androidtv_mac
 from .const import (
@@ -64,6 +66,8 @@ ATTR_ADB_RESPONSE = "adb_response"
 ATTR_DEVICE_PATH = "device_path"
 ATTR_HDMI_INPUT = "hdmi_input"
 ATTR_LOCAL_PATH = "local_path"
+
+MIN_TIME_BETWEEN_SCREENCAPS = timedelta(seconds=60)
 
 SERVICE_ADB_COMMAND = "adb_command"
 SERVICE_DOWNLOAD = "download"
@@ -228,6 +232,9 @@ class ADBDevice(MediaPlayerEntity):
         self._entry_id = entry_id
         self._entry_data = entry_data
 
+        self._media_image: tuple[bytes | None, str | None] = None, None
+        self._attr_media_image_hash = None
+
         info = aftv.device_properties
         model = info.get(ATTR_MODEL)
         self._attr_device_info = DeviceInfo(
@@ -304,34 +311,39 @@ class ADBDevice(MediaPlayerEntity):
             )
         )
 
-    @property
-    def media_image_hash(self) -> str | None:
-        """Hash value for media image."""
-        return f"{datetime.now().timestamp()}" if self._screencap else None
-
     @adb_decorator()
     async def _adb_screencap(self) -> bytes | None:
         """Take a screen capture from the device."""
         return await self.aftv.adb_screencap()
 
-    async def async_get_media_image(self) -> tuple[bytes | None, str | None]:
-        """Fetch current playing image."""
+    async def _async_get_screencap(self, prev_app_id: str | None = None) -> None:
+        """Take a screen capture from the device when enabled."""
         if (
             not self._screencap
             or self.state in {MediaPlayerState.OFF, None}
             or not self.available
         ):
-            return None, None
+            self._media_image = None, None
+            self._attr_media_image_hash = None
+        else:
+            force: bool = prev_app_id is not None
+            if force:
+                force = prev_app_id != self._attr_app_id
+            await self._adb_get_screencap(no_throttle=force)
 
-        media_data = await self._adb_screencap()
-        if media_data:
-            return media_data, "image/png"
+    @Throttle(MIN_TIME_BETWEEN_SCREENCAPS)
+    async def _adb_get_screencap(self, **kwargs) -> None:
+        """Take a screen capture from the device every 60 seconds."""
+        if media_data := await self._adb_screencap():
+            self._media_image = media_data, "image/png"
+            self._attr_media_image_hash = hashlib.sha256(media_data).hexdigest()[:16]
+        else:
+            self._media_image = None, None
+            self._attr_media_image_hash = None
 
-        # If an exception occurred and the device is no longer available, write the state
-        if not self.available:
-            self.async_write_ha_state()
-
-        return None, None
+    async def async_get_media_image(self) -> tuple[bytes | None, str | None]:
+        """Fetch current playing image."""
+        return self._media_image
 
     @adb_decorator()
     async def async_media_play(self) -> None:
@@ -485,6 +497,7 @@ class AndroidTVDevice(ADBDevice):
         if not self.available:
             return
 
+        prev_app_id = self._attr_app_id
         # Get the updated state and attributes.
         (
             state,
@@ -513,6 +526,8 @@ class AndroidTVDevice(ADBDevice):
             self._attr_source_list = [source for source in sources if source]
         else:
             self._attr_source_list = None
+
+        await self._async_get_screencap(prev_app_id)
 
     @adb_decorator()
     async def async_media_stop(self) -> None:
@@ -575,6 +590,7 @@ class FireTVDevice(ADBDevice):
         if not self.available:
             return
 
+        prev_app_id = self._attr_app_id
         # Get the `state`, `current_app`, `running_apps` and `hdmi_input`.
         (
             state,
@@ -600,6 +616,8 @@ class FireTVDevice(ADBDevice):
             self._attr_source_list = [source for source in sources if source]
         else:
             self._attr_source_list = None
+
+        await self._async_get_screencap(prev_app_id)
 
     @adb_decorator()
     async def async_media_stop(self) -> None:

--- a/tests/components/androidtv/patchers.py
+++ b/tests/components/androidtv/patchers.py
@@ -185,6 +185,10 @@ def isfile(filepath):
     return filepath.endswith("adbkey")
 
 
+PATCH_SCREENCAP = patch(
+    "androidtv.basetv.basetv_async.BaseTVAsync.adb_screencap",
+    return_value=b"image",
+)
 PATCH_SETUP_ENTRY = patch(
     "homeassistant.components.androidtv.async_setup_entry",
     return_value=True,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Scope of this PR is to reduce the `screencap` calls frequency done by integration to provide `media_image`. The continuous calls cause a continue flickering on the UI for the related Media Player entity and probably also reduce capacity to send commands.
The call to the `screencap` function now is done every 1 minute during normal update. The resulting image is than cached and reported to the clients until the next minute.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #91209
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
