### PR TITLE
Wyoming Piper 1.1

### DIFF
--- a/homeassistant/components/wyoming/__init__.py
+++ b/homeassistant/components/wyoming/__init__.py
@@ -7,10 +7,15 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
-from .const import DOMAIN
+from .const import ATTR_SPEAKER, DOMAIN
 from .data import WyomingService
 
 _LOGGER = logging.getLogger(__name__)
+
+__all__ = [
+    "ATTR_SPEAKER",
+    "DOMAIN",
+]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/wyoming/const.py
+++ b/homeassistant/components/wyoming/const.py
@@ -5,3 +5,6 @@ DOMAIN = "wyoming"
 SAMPLE_RATE = 16000
 SAMPLE_WIDTH = 2
 SAMPLE_CHANNELS = 1
+
+# For multi-speaker voices, this is the name of the selected speaker.
+ATTR_SPEAKER = "speaker"

--- a/homeassistant/components/wyoming/manifest.json
+++ b/homeassistant/components/wyoming/manifest.json
@@ -5,5 +5,5 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/wyoming",
   "iot_class": "local_push",
-  "requirements": ["wyoming==0.0.1"]
+  "requirements": ["wyoming==1.0.0"]
 }

--- a/homeassistant/components/wyoming/tts.py
+++ b/homeassistant/components/wyoming/tts.py
@@ -101,19 +101,17 @@ class WyomingTtsProvider(tts.TextToSpeechEntity):
         return self._voices.get(language)
 
     async def async_get_tts_audio(self, message, language, options):
-        """Load TTS from UNIX socket."""
+        """Load TTS from TCP socket."""
         voice_name: str | None = options.get(tts.ATTR_VOICE)
         voice_speaker: str | None = options.get(ATTR_SPEAKER)
 
         try:
             async with AsyncTcpClient(self.service.host, self.service.port) as client:
-                synthesize = Synthesize(
-                    text=message,
-                    voice=SynthesizeVoice(name=voice_name, speaker=voice_speaker)
-                    if voice_name is not None
-                    else None,
-                )
+                voice: SynthesizeVoice | None = None
+                if voice_name is not None:
+                    voice = SynthesizeVoice(name=voice_name, speaker=voice_speaker)
 
+                synthesize = Synthesize(text=message, voice=voice)
                 await client.write_event(synthesize.event())
 
                 with io.BytesIO() as wav_io:

--- a/homeassistant/components/wyoming/tts.py
+++ b/homeassistant/components/wyoming/tts.py
@@ -57,7 +57,7 @@ class WyomingTtsProvider(tts.TextToSpeechEntity):
                 self._voices[language].append(
                     tts.Voice(
                         voice_id=voice.name,
-                        name=voice.name,
+                        name=voice.description or voice.name,
                     )
                 )
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2681,7 +2681,7 @@ wled==0.16.0
 wolf-smartset==0.1.11
 
 # homeassistant.components.wyoming
-wyoming==0.0.1
+wyoming==1.0.0
 
 # homeassistant.components.xbox
 xbox-webapi==2.0.11

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1963,7 +1963,7 @@ wled==0.16.0
 wolf-smartset==0.1.11
 
 # homeassistant.components.wyoming
-wyoming==0.0.1
+wyoming==1.0.0
 
 # homeassistant.components.xbox
 xbox-webapi==2.0.11

--- a/tests/components/wyoming/__init__.py
+++ b/tests/components/wyoming/__init__.py
@@ -1,5 +1,13 @@
 """Tests for the Wyoming integration."""
-from wyoming.info import AsrModel, AsrProgram, Attribution, Info, TtsProgram, TtsVoice
+from wyoming.info import (
+    AsrModel,
+    AsrProgram,
+    Attribution,
+    Info,
+    TtsProgram,
+    TtsVoice,
+    TtsVoiceSpeaker,
+)
 
 TEST_ATTR = Attribution(name="Test", url="http://www.test.com")
 STT_INFO = Info(
@@ -31,6 +39,7 @@ TTS_INFO = Info(
                     installed=True,
                     attribution=TEST_ATTR,
                     languages=["en-US"],
+                    speakers=[TtsVoiceSpeaker(name="Test Speaker")],
                 )
             ],
         )

--- a/tests/components/wyoming/__init__.py
+++ b/tests/components/wyoming/__init__.py
@@ -14,11 +14,13 @@ STT_INFO = Info(
     asr=[
         AsrProgram(
             name="Test ASR",
+            description="Test ASR",
             installed=True,
             attribution=TEST_ATTR,
             models=[
                 AsrModel(
                     name="Test Model",
+                    description="Test Model",
                     installed=True,
                     attribution=TEST_ATTR,
                     languages=["en-US"],
@@ -31,11 +33,13 @@ TTS_INFO = Info(
     tts=[
         TtsProgram(
             name="Test TTS",
+            description="Test TTS",
             installed=True,
             attribution=TEST_ATTR,
             voices=[
                 TtsVoice(
                     name="Test Voice",
+                    description="Test Voice",
                     installed=True,
                     attribution=TEST_ATTR,
                     languages=["en-US"],

--- a/tests/components/wyoming/snapshots/test_tts.ambr
+++ b/tests/components/wyoming/snapshots/test_tts.ambr
@@ -21,3 +21,18 @@
     }),
   ])
 # ---
+# name: test_voice_speaker
+  list([
+    dict({
+      'data': dict({
+        'text': 'Hello world',
+        'voice': dict({
+          'name': 'voice1',
+          'speaker': 'speaker1',
+        }),
+      }),
+      'payload': None,
+      'type': 'synthesize',
+    }),
+  ])
+# ---


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Upgrades Wyoming TTS to support [Piper 1.1](https://github.com/rhasspy/piper/releases/tag/v1.1.0).
This will allow the Piper add-on to show [all of the possible voices](https://rhasspy.github.io/piper-samples/) to Home Assistant, and download them as needed without restarting the add-on.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
