### PR TITLE
Ensure async_get_system_info does not fail if supervisor is unavailable

### DIFF
--- a/homeassistant/helpers/system_info.py
+++ b/homeassistant/helpers/system_info.py
@@ -22,6 +22,11 @@ def is_official_image() -> bool:
     return os.path.isfile("/OFFICIAL_IMAGE")
 
 
+# Cache the result of getuser() because it can call getpwuid() which
+# can do blocking I/O to look up the username in /etc/passwd.
+cached_get_user = cache(getuser)
+
+
 @bind_hass
 async def async_get_system_info(hass: HomeAssistant) -> dict[str, Any]:
     """Return info about the system."""
@@ -44,7 +49,7 @@ async def async_get_system_info(hass: HomeAssistant) -> dict[str, Any]:
     }
 
     try:
-        info_object["user"] = getuser()
+        info_object["user"] = cached_get_user()
     except KeyError:
         info_object["user"] = None
 

--- a/homeassistant/helpers/system_info.py
+++ b/homeassistant/helpers/system_info.py
@@ -10,7 +10,7 @@ from typing import Any
 from homeassistant.const import __version__ as current_version
 from homeassistant.core import HomeAssistant
 from homeassistant.loader import bind_hass
-from homeassistant.util.package import is_virtual_env
+from homeassistant.util.package import is_docker_env, is_virtual_env
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -44,7 +44,7 @@ async def async_get_system_info(hass: HomeAssistant) -> dict[str, Any]:
     if platform.system() == "Darwin":
         info_object["os_version"] = platform.mac_ver()[0]
     elif platform.system() == "Linux":
-        info_object["docker"] = os.path.isfile("/.dockerenv")
+        info_object["docker"] = is_docker_env()
 
     # Determine installation type on current data
     if info_object["docker"]:

--- a/homeassistant/helpers/system_info.py
+++ b/homeassistant/helpers/system_info.py
@@ -82,9 +82,5 @@ async def async_get_system_info(hass: HomeAssistant) -> dict[str, Any]:
             info_object["installation_type"] = "Home Assistant OS"
         else:
             info_object["installation_type"] = "Home Assistant Supervised"
-    elif "SUPERVISOR" in os.environ:
-        # hassio is not loaded, but we know we are running supervised
-        # because the SUPERVISOR env var is set
-        info_object["installation_type"] = "Home Assistant Supervised"
 
     return info_object

--- a/homeassistant/helpers/system_info.py
+++ b/homeassistant/helpers/system_info.py
@@ -1,6 +1,7 @@
 """Helper to gather system info."""
 from __future__ import annotations
 
+from functools import cache
 from getpass import getuser
 import logging
 import os
@@ -13,6 +14,12 @@ from homeassistant.loader import bind_hass
 from homeassistant.util.package import is_docker_env, is_virtual_env
 
 _LOGGER = logging.getLogger(__name__)
+
+
+@cache
+def is_official_image() -> bool:
+    """Return True if Home Assistant is running in an official container."""
+    return os.path.isfile("/OFFICIAL_IMAGE")
 
 
 @bind_hass
@@ -48,7 +55,7 @@ async def async_get_system_info(hass: HomeAssistant) -> dict[str, Any]:
 
     # Determine installation type on current data
     if info_object["docker"]:
-        if info_object["user"] == "root" and os.path.isfile("/OFFICIAL_IMAGE"):
+        if info_object["user"] == "root" and is_official_image():
             info_object["installation_type"] = "Home Assistant Container"
         else:
             info_object["installation_type"] = "Unsupported Third Party Container"

--- a/homeassistant/helpers/system_info.py
+++ b/homeassistant/helpers/system_info.py
@@ -67,10 +67,9 @@ async def async_get_system_info(hass: HomeAssistant) -> dict[str, Any]:
     if is_hassio:
         if not (info := hass.components.hassio.get_info()):
             _LOGGER.warning("No Home Assistant Supervisor info available")
-            return info_object
+            info = {}
 
-        host = hass.components.hassio.get_host_info()
-
+        host = hass.components.hassio.get_host_info() or {}
         info_object["supervisor"] = info.get("supervisor")
         info_object["host_os"] = host.get("operating_system")
         info_object["docker_version"] = info.get("docker")
@@ -80,5 +79,9 @@ async def async_get_system_info(hass: HomeAssistant) -> dict[str, Any]:
             info_object["installation_type"] = "Home Assistant OS"
         else:
             info_object["installation_type"] = "Home Assistant Supervised"
+    elif "SUPERVISOR" in os.environ:
+        # hassio is not loaded, but we know we are running supervised
+        # because the SUPERVISOR env var is set
+        info_object["installation_type"] = "Home Assistant Supervised"
 
     return info_object

--- a/homeassistant/helpers/system_info.py
+++ b/homeassistant/helpers/system_info.py
@@ -30,9 +30,7 @@ cached_get_user = cache(getuser)
 @bind_hass
 async def async_get_system_info(hass: HomeAssistant) -> dict[str, Any]:
     """Return info about the system."""
-    is_hassio = (
-        "hassio" in hass.config.components and hass.components.hassio.is_hassio()
-    )
+    is_hassio = hass.components.hassio.is_hassio()
 
     info_object = {
         "installation_type": "Unknown",

--- a/tests/helpers/test_system_info.py
+++ b/tests/helpers/test_system_info.py
@@ -2,6 +2,8 @@
 import json
 from unittest.mock import patch
 
+import pytest
+
 from homeassistant.const import __version__ as current_version
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.system_info import async_get_system_info
@@ -16,17 +18,40 @@ async def test_get_system_info(hass: HomeAssistant) -> None:
     assert json.dumps(info) is not None
 
 
+async def test_get_system_info_supervisor_not_available(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test the get system info when supervisor is not available."""
+    hass.config.components.add("hassio")
+    with patch("homeassistant.components.hassio.is_hassio", return_value=True), patch(
+        "homeassistant.components.hassio.get_info", return_value=None
+    ):
+        info = await async_get_system_info(hass)
+        assert isinstance(info, dict)
+        assert info["version"] == current_version
+        assert info["user"] is not None
+        assert json.dumps(info) is not None
+
+
 async def test_container_installationtype(hass: HomeAssistant) -> None:
     """Test container installation type."""
     with patch("platform.system", return_value="Linux"), patch(
-        "os.path.isfile", return_value=True
-    ), patch("homeassistant.helpers.system_info.getuser", return_value="root"):
+        "homeassistant.helpers.system_info.is_docker_env", return_value=True
+    ), patch(
+        "homeassistant.helpers.system_info.is_official_image", return_value=True
+    ), patch(
+        "homeassistant.helpers.system_info.getuser", return_value="root"
+    ):
         info = await async_get_system_info(hass)
         assert info["installation_type"] == "Home Assistant Container"
 
     with patch("platform.system", return_value="Linux"), patch(
-        "os.path.isfile", side_effect=lambda file: file == "/.dockerenv"
-    ), patch("homeassistant.helpers.system_info.getuser", return_value="user"):
+        "homeassistant.helpers.system_info.is_docker_env", return_value=True
+    ), patch(
+        "homeassistant.helpers.system_info.is_official_image", return_value=False
+    ), patch(
+        "homeassistant.helpers.system_info.getuser", return_value="user"
+    ):
         info = await async_get_system_info(hass)
         assert info["installation_type"] == "Unsupported Third Party Container"
 

--- a/tests/helpers/test_system_info.py
+++ b/tests/helpers/test_system_info.py
@@ -41,11 +41,10 @@ async def test_get_system_info_supervisor_not_available(
         assert info["user"] is not None
         assert json.dumps(info) is not None
         assert info["installation_type"] == "Home Assistant Supervised"
+        assert "No Home Assistant Supervisor info available" in caplog.text
 
 
-async def test_get_system_info_supervisor_not_loaded(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
-) -> None:
+async def test_get_system_info_supervisor_not_loaded(hass: HomeAssistant) -> None:
     """Test the get system info when supervisor is not loaded is in use."""
     with patch("platform.system", return_value="Linux"), patch(
         "homeassistant.helpers.system_info.is_docker_env", return_value=True

--- a/tests/helpers/test_system_info.py
+++ b/tests/helpers/test_system_info.py
@@ -33,7 +33,7 @@ async def test_get_system_info_supervisor_not_available(
     ), patch(
         "homeassistant.components.hassio.get_info", return_value=None
     ), patch(
-        "homeassistant.helpers.system_info.getuser", return_value="root"
+        "homeassistant.helpers.system_info.cached_get_user", return_value="root"
     ):
         info = await async_get_system_info(hass)
         assert isinstance(info, dict)
@@ -71,7 +71,7 @@ async def test_container_installationtype(hass: HomeAssistant) -> None:
     ), patch(
         "homeassistant.helpers.system_info.is_official_image", return_value=True
     ), patch(
-        "homeassistant.helpers.system_info.getuser", return_value="root"
+        "homeassistant.helpers.system_info.cached_get_user", return_value="root"
     ):
         info = await async_get_system_info(hass)
         assert info["installation_type"] == "Home Assistant Container"
@@ -81,7 +81,7 @@ async def test_container_installationtype(hass: HomeAssistant) -> None:
     ), patch(
         "homeassistant.helpers.system_info.is_official_image", return_value=False
     ), patch(
-        "homeassistant.helpers.system_info.getuser", return_value="user"
+        "homeassistant.helpers.system_info.cached_get_user", return_value="user"
     ):
         info = await async_get_system_info(hass)
         assert info["installation_type"] == "Unsupported Third Party Container"
@@ -89,6 +89,8 @@ async def test_container_installationtype(hass: HomeAssistant) -> None:
 
 async def test_getuser_keyerror(hass: HomeAssistant) -> None:
     """Test getuser keyerror."""
-    with patch("homeassistant.helpers.system_info.getuser", side_effect=KeyError):
+    with patch(
+        "homeassistant.helpers.system_info.cached_get_user", side_effect=KeyError
+    ):
         info = await async_get_system_info(hass)
         assert info["user"] is None

--- a/tests/helpers/test_system_info.py
+++ b/tests/helpers/test_system_info.py
@@ -7,7 +7,17 @@ import pytest
 
 from homeassistant.const import __version__ as current_version
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.system_info import async_get_system_info
+from homeassistant.helpers.system_info import async_get_system_info, is_official_image
+
+
+async def test_is_official_image() -> None:
+    """Test is_official_image."""
+    is_official_image.cache_clear()
+    with patch("homeassistant.helpers.system_info.os.path.isfile", return_value=True):
+        assert is_official_image() is True
+    is_official_image.cache_clear()
+    with patch("homeassistant.helpers.system_info.os.path.isfile", return_value=False):
+        assert is_official_image() is False
 
 
 async def test_get_system_info(hass: HomeAssistant) -> None:

--- a/tests/helpers/test_system_info.py
+++ b/tests/helpers/test_system_info.py
@@ -70,7 +70,7 @@ async def test_get_system_info_supervisor_not_loaded(hass: HomeAssistant) -> Non
         assert info["version"] == current_version
         assert info["user"] is not None
         assert json.dumps(info) is not None
-        assert info["installation_type"] == "Home Assistant Supervised"
+        assert info["installation_type"] == "Unsupported Third Party Container"
 
 
 async def test_container_installationtype(hass: HomeAssistant) -> None:

--- a/tests/helpers/test_system_info.py
+++ b/tests/helpers/test_system_info.py
@@ -55,7 +55,7 @@ async def test_get_system_info_supervisor_not_available(
 
 
 async def test_get_system_info_supervisor_not_loaded(hass: HomeAssistant) -> None:
-    """Test the get system info when supervisor is not loaded is in use."""
+    """Test the get system info when supervisor is not loaded."""
     with patch("platform.system", return_value="Linux"), patch(
         "homeassistant.helpers.system_info.is_docker_env", return_value=True
     ), patch(


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The current design requires `hassio` to be added as a dep when using the helper which isn't feasible for discovery integrations.  We need system info to still work when hassio is not available.

```
Error during setup of component ssdp
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/setup.py", line 288, in _async_setup_component
    result = await task
             ^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/ssdp/__init__.py", line 206, in async_setup
    await server.async_start()
  File "/usr/src/homeassistant/homeassistant/components/ssdp/__init__.py", line 732, in async_start
    await self._async_start_upnp_servers()
  File "/usr/src/homeassistant/homeassistant/components/ssdp/__init__.py", line 743, in _async_start_upnp_servers
    system_info = await async_get_system_info(self.hass)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/helpers/system_info.py", line 57, in async_get_system_info
    info_object["supervisor"] = info.get("supervisor")
                                ^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'get'
```

Also caches places where we can do I/O in the event loop (`stat` files, reading `/etc/passwd`, etc)

Additional backstory https://github.com/home-assistant/core/issues/95887#issuecomment-1634670000

fixes #96470

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
