### PR TITLE
Implement workday sensor language option support

### DIFF
--- a/homeassistant/components/workday/binary_sensor.py
+++ b/homeassistant/components/workday/binary_sensor.py
@@ -4,8 +4,14 @@ from __future__ import annotations
 from datetime import date, timedelta
 from typing import Any
 
-import holidays
-from holidays import DateLike, HolidayBase
+from holidays import (
+    DateLike,
+    HolidayBase,
+    __version__ as python_holidays_version,
+    country_holidays,
+    list_localized_countries,
+    list_supported_countries,
+)
 import voluptuous as vol
 
 from homeassistant.components.binary_sensor import (
@@ -28,6 +34,7 @@ from .const import (
     CONF_ADD_HOLIDAYS,
     CONF_COUNTRY,
     CONF_EXCLUDES,
+    CONF_LANGUAGE,
     CONF_OFFSET,
     CONF_PROVINCE,
     CONF_REMOVE_HOLIDAYS,
@@ -44,7 +51,7 @@ from .const import (
 def valid_country(value: Any) -> str:
     """Validate that the given country is supported."""
     value = cv.string(value)
-    all_supported_countries = holidays.list_supported_countries()
+    all_supported_countries = list_supported_countries()
 
     try:
         raw_value = value.encode("utf-8")
@@ -122,19 +129,26 @@ async def async_setup_entry(
     days_offset: int = int(entry.options[CONF_OFFSET])
     excludes: list[str] = entry.options[CONF_EXCLUDES]
     province: str | None = entry.options.get(CONF_PROVINCE)
+    language: str | None = entry.options.get(CONF_LANGUAGE)
     sensor_name: str = entry.options[CONF_NAME]
     workdays: list[str] = entry.options[CONF_WORKDAYS]
 
-    cls: HolidayBase = getattr(holidays, country)
     year: int = (dt_util.now() + timedelta(days=days_offset)).year
 
-    if province and province not in cls.subdivisions:
+    if province and province not in list_supported_countries()[country]:
         LOGGER.error("There is no subdivision %s in country %s", province, country)
-        return
+        return None
 
-    obj_holidays = cls(
-        subdiv=province, years=year, language=cls.default_language
-    )  # type: ignore[operator]
+    if language and language not in list_localized_countries()[country]:
+        LOGGER.error("Language %s is not supported", language)
+        return None
+
+    obj_holidays: HolidayBase = country_holidays(
+        country=country,
+        subdiv=province,
+        language=language,
+        years=year,
+    )
 
     # Add custom holidays
     try:
@@ -210,7 +224,7 @@ class IsWorkdaySensor(BinarySensorEntity):
             entry_type=DeviceEntryType.SERVICE,
             identifiers={(DOMAIN, entry_id)},
             manufacturer="python-holidays",
-            model=holidays.__version__,
+            model=python_holidays_version,
             name=name,
         )
 

--- a/homeassistant/components/workday/const.py
+++ b/homeassistant/components/workday/const.py
@@ -14,6 +14,7 @@ PLATFORMS = [Platform.BINARY_SENSOR]
 
 CONF_COUNTRY = "country"
 CONF_PROVINCE = "province"
+CONF_LANGUAGE = "language"
 CONF_WORKDAYS = "workdays"
 CONF_EXCLUDES = "excludes"
 CONF_OFFSET = "days_offset"

--- a/homeassistant/components/workday/strings.json
+++ b/homeassistant/components/workday/strings.json
@@ -20,7 +20,8 @@
           "workdays": "Workdays",
           "add_holidays": "Add holidays",
           "remove_holidays": "Remove Holidays",
-          "province": "Subdivision of country"
+          "province": "Subdivision of country",
+          "language": "Language"
         },
         "data_description": {
           "excludes": "List of workdays to exclude",
@@ -28,13 +29,15 @@
           "workdays": "List of workdays",
           "add_holidays": "Add custom holidays as YYYY-MM-DD",
           "remove_holidays": "Remove holidays as YYYY-MM-DD or by using partial of name",
-          "province": "State, Territory, Province, Region of Country"
+          "province": "State, Territory, Province, Region of Country",
+          "language": "Language for holidays output and add/remove actions"
         }
       }
     },
     "error": {
       "add_holiday_error": "Incorrect format on date (YYYY-MM-DD)",
-      "remove_holiday_error": "Incorrect format on date (YYYY-MM-DD) or holiday name not found"
+      "remove_holiday_error": "Incorrect format on date (YYYY-MM-DD) or holiday name not found",
+      "incorrect_language": "This country holidays localization is not supported"
     }
   },
   "options": {
@@ -47,7 +50,8 @@
           "workdays": "[%key:component::workday::config::step::options::data::workdays%]",
           "add_holidays": "[%key:component::workday::config::step::options::data::add_holidays%]",
           "remove_holidays": "[%key:component::workday::config::step::options::data::remove_holidays%]",
-          "province": "[%key:component::workday::config::step::options::data::province%]"
+          "province": "[%key:component::workday::config::step::options::data::province%]",
+          "language": "[%key:component::workday::config::step::options::data::language%]"
         },
         "data_description": {
           "excludes": "[%key:component::workday::config::step::options::data_description::excludes%]",
@@ -55,7 +59,8 @@
           "workdays": "[%key:component::workday::config::step::options::data_description::workdays%]",
           "add_holidays": "[%key:component::workday::config::step::options::data_description::add_holidays%]",
           "remove_holidays": "[%key:component::workday::config::step::options::data_description::remove_holidays%]",
-          "province": "[%key:component::workday::config::step::options::data_description::province%]"
+          "province": "[%key:component::workday::config::step::options::data_description::province%]",
+          "language": "[%key:component::workday::config::step::options::data_description::language%]"
         }
       }
     },
@@ -69,6 +74,11 @@
     "province": {
       "options": {
         "none": "No subdivision"
+      }
+    },
+    "language": {
+      "options": {
+        "none": "No language selected"
       }
     },
     "days": {

--- a/tests/components/workday/__init__.py
+++ b/tests/components/workday/__init__.py
@@ -88,6 +88,17 @@ TEST_CONFIG_NO_STATE = {
     "add_holidays": [],
     "remove_holidays": [],
 }
+TEST_CONFIG_INCORRECT_LANGUAGE = {
+    "name": DEFAULT_NAME,
+    "country": "DE",
+    "province": "BW",
+    "language": "zz_ZZ",
+    "excludes": DEFAULT_EXCLUDES,
+    "days_offset": DEFAULT_OFFSET,
+    "workdays": DEFAULT_WORKDAYS,
+    "add_holidays": [],
+    "remove_holidays": [],
+}
 TEST_CONFIG_INCLUDE_HOLIDAY = {
     "name": DEFAULT_NAME,
     "country": "DE",

--- a/tests/components/workday/test_binary_sensor.py
+++ b/tests/components/workday/test_binary_sensor.py
@@ -17,6 +17,7 @@ from . import (
     TEST_CONFIG_EXAMPLE_2,
     TEST_CONFIG_INCLUDE_HOLIDAY,
     TEST_CONFIG_INCORRECT_ADD_REMOVE,
+    TEST_CONFIG_INCORRECT_LANGUAGE,
     TEST_CONFIG_INCORRECT_PROVINCE,
     TEST_CONFIG_NO_PROVINCE,
     TEST_CONFIG_NO_STATE,
@@ -187,12 +188,12 @@ async def test_setup_day_after_tomorrow(
     assert state.state == "off"
 
 
-async def test_setup_faulty_province(
+async def test_setup_incorrect_province(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test setup with faulty province."""
+    """Test setup with incorrect province."""
     freezer.move_to(datetime(2017, 1, 6, 12, tzinfo=UTC))  # Friday
     await init_integration(hass, TEST_CONFIG_INCORRECT_PROVINCE)
 
@@ -200,6 +201,19 @@ async def test_setup_faulty_province(
     assert state is None
 
     assert "There is no subdivision" in caplog.text
+
+
+async def test_setup_incorrect_language(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test setup with incorrect language."""
+    freezer.move_to(datetime(2017, 1, 6, 12, tzinfo=UTC))  # Friday
+    await init_integration(hass, TEST_CONFIG_INCORRECT_LANGUAGE)
+
+    hass.states.get("binary_sensor.workday_sensor")
+    assert "Language zz_ZZ is not supported" in caplog.text
 
 
 async def test_setup_incorrect_add_remove(

--- a/tests/components/workday/test_config_flow.py
+++ b/tests/components/workday/test_config_flow.py
@@ -561,7 +561,7 @@ async def test_language_no_localization(hass: HomeAssistant) -> None:
     )
 
     with mock.patch(
-        "homeassistant.components.workday.config_flow.list_localized_countries",
+        "homeassistant.components.workday.config_flow.holidays.list_localized_countries",
         return_value={},
     ):
         result = await hass.config_entries.options.async_init(entry.entry_id)
@@ -585,7 +585,7 @@ async def test_language_no_localization(hass: HomeAssistant) -> None:
         "add_holidays": [],
         "remove_holidays": [],
         "province": "BW",
-        "language": None,
+        "language": "de",
     }
 
 

--- a/tests/components/workday/test_config_flow.py
+++ b/tests/components/workday/test_config_flow.py
@@ -560,10 +560,17 @@ async def test_language_no_localization(hass: HomeAssistant) -> None:
         },
     )
 
-    with mock.patch(
-        "homeassistant.components.workday.config_flow.holidays.list_localized_countries",
-        return_value={},
-    ):
+    class DE:
+        """DE class with no l10n support."""
+
+        default_language = None
+        subdivisions = ()
+        supported_languages = ()
+
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+    with mock.patch("homeassistant.components.workday.config_flow.holidays.DE", DE):
         result = await hass.config_entries.options.async_init(entry.entry_id)
         result = await hass.config_entries.options.async_configure(
             result["flow_id"],
@@ -571,7 +578,6 @@ async def test_language_no_localization(hass: HomeAssistant) -> None:
                 "excludes": ["sat", "sun", "holiday"],
                 "days_offset": 0,
                 "workdays": ["mon", "tue", "wed", "thu", "fri"],
-                "province": "BW",
             },
         )
 
@@ -584,8 +590,8 @@ async def test_language_no_localization(hass: HomeAssistant) -> None:
         "workdays": ["mon", "tue", "wed", "thu", "fri"],
         "add_holidays": [],
         "remove_holidays": [],
-        "province": "BW",
-        "language": "de",
+        "province": None,
+        "language": None,
     }
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR implements language options support for Workday sensor (based on my previous PR https://github.com/home-assistant/core/pull/95091):
  - Add binary sensor language validation
  - Add language to the config flows (move province select field
    to the schema's top and add the language select field below it)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/28197

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
