### PR TITLE
Revert "Adding new supported language code to Google translate"

### DIFF
--- a/homeassistant/components/google_translate/const.py
+++ b/homeassistant/components/google_translate/const.py
@@ -40,7 +40,6 @@ SUPPORT_LANGUAGES = [
     "ko",
     "la",
     "lv",
-    "lt",
     "mk",
     "ml",
     "mr",


### PR DESCRIPTION
Reverts home-assistant/core#93926

Hi, @frenck, can you explain, what's wrong with this integration ? Why Lithuanian language not supported, in google language list this language is supported. 