### PR TITLE
Add force_update attribute to mqtt device discovery; related tests

### DIFF
--- a/homeassistant/components/mqtt/mixins.py
+++ b/homeassistant/components/mqtt/mixins.py
@@ -22,6 +22,7 @@ from homeassistant.const import (
     ATTR_VIA_DEVICE,
     CONF_DEVICE,
     CONF_ENTITY_CATEGORY,
+    CONF_FORCE_UPDATE,
     CONF_ICON,
     CONF_MODEL,
     CONF_NAME,
@@ -221,6 +222,7 @@ MQTT_ENTITY_COMMON_SCHEMA = MQTT_AVAILABILITY_SCHEMA.extend(
         vol.Optional(CONF_DEVICE): MQTT_ENTITY_DEVICE_INFO_SCHEMA,
         vol.Optional(CONF_ENABLED_BY_DEFAULT, default=True): cv.boolean,
         vol.Optional(CONF_ENTITY_CATEGORY): ENTITY_CATEGORIES_SCHEMA,
+        vol.Optional(CONF_FORCE_UPDATE, default=False): cv.boolean,
         vol.Optional(CONF_ICON): cv.icon,
         vol.Optional(CONF_JSON_ATTRS_TOPIC): valid_subscribe_topic,
         vol.Optional(CONF_JSON_ATTRS_TEMPLATE): cv.template,
@@ -1119,6 +1121,7 @@ class MqttEntity(
         self._attr_entity_registry_enabled_default = bool(
             config.get(CONF_ENABLED_BY_DEFAULT)
         )
+        self._attr_force_update = bool(config.get(CONF_FORCE_UPDATE))
         self._attr_icon = config.get(CONF_ICON)
         self._attr_name = config.get(CONF_NAME)
 

--- a/tests/components/mqtt/test_alarm_control_panel.py
+++ b/tests/components/mqtt/test_alarm_control_panel.py
@@ -53,6 +53,7 @@ from .test_common import (
     help_test_entity_device_info_update,
     help_test_entity_device_info_with_connection,
     help_test_entity_device_info_with_identifier,
+    help_test_entity_force_update,
     help_test_entity_id_update_discovery_update,
     help_test_entity_id_update_subscriptions,
     help_test_publishing_with_custom_encoding,
@@ -991,6 +992,22 @@ async def test_entity_device_info_remove(
     await help_test_entity_device_info_remove(
         hass,
         mqtt_mock_entry,
+        alarm_control_panel.DOMAIN,
+        DEFAULT_CONFIG,
+    )
+
+
+@pytest.mark.parametrize("hass_config", [DEFAULT_CONFIG])
+async def test_entity_force_update(
+    hass: HomeAssistant,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test force_update attribute."""
+    await help_test_entity_force_update(
+        hass,
+        mqtt_mock_entry,
+        caplog,
         alarm_control_panel.DOMAIN,
         DEFAULT_CONFIG,
     )

--- a/tests/components/mqtt/test_binary_sensor.py
+++ b/tests/components/mqtt/test_binary_sensor.py
@@ -39,6 +39,7 @@ from .test_common import (
     help_test_entity_device_info_update,
     help_test_entity_device_info_with_connection,
     help_test_entity_device_info_with_identifier,
+    help_test_entity_force_update,
     help_test_entity_id_update_discovery_update,
     help_test_entity_id_update_subscriptions,
     help_test_reload_with_config,
@@ -1039,6 +1040,22 @@ async def test_entity_device_info_remove(
     await help_test_entity_device_info_remove(
         hass,
         mqtt_mock_entry,
+        binary_sensor.DOMAIN,
+        DEFAULT_CONFIG,
+    )
+
+
+@pytest.mark.parametrize("hass_config", [DEFAULT_CONFIG])
+async def test_entity_force_update(
+    hass: HomeAssistant,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test force_update attribute."""
+    await help_test_entity_force_update(
+        hass,
+        mqtt_mock_entry,
+        caplog,
         binary_sensor.DOMAIN,
         DEFAULT_CONFIG,
     )

--- a/tests/components/mqtt/test_button.py
+++ b/tests/components/mqtt/test_button.py
@@ -29,6 +29,7 @@ from .test_common import (
     help_test_entity_device_info_update,
     help_test_entity_device_info_with_connection,
     help_test_entity_device_info_with_identifier,
+    help_test_entity_force_update,
     help_test_entity_id_update_discovery_update,
     help_test_publishing_with_custom_encoding,
     help_test_reloadable,
@@ -408,6 +409,22 @@ async def test_entity_device_info_remove(
     """Test device registry remove."""
     await help_test_entity_device_info_remove(
         hass, mqtt_mock_entry, button.DOMAIN, DEFAULT_CONFIG
+    )
+
+
+@pytest.mark.parametrize("hass_config", [DEFAULT_CONFIG])
+async def test_entity_force_update(
+    hass: HomeAssistant,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test force_update attribute."""
+    await help_test_entity_force_update(
+        hass,
+        mqtt_mock_entry,
+        caplog,
+        button.DOMAIN,
+        DEFAULT_CONFIG,
     )
 
 

--- a/tests/components/mqtt/test_camera.py
+++ b/tests/components/mqtt/test_camera.py
@@ -26,6 +26,7 @@ from .test_common import (
     help_test_entity_device_info_update,
     help_test_entity_device_info_with_connection,
     help_test_entity_device_info_with_identifier,
+    help_test_entity_force_update,
     help_test_entity_id_update_discovery_update,
     help_test_entity_id_update_subscriptions,
     help_test_reloadable,
@@ -389,6 +390,22 @@ async def test_entity_device_info_remove(
     """Test device registry remove."""
     await help_test_entity_device_info_remove(
         hass, mqtt_mock_entry, camera.DOMAIN, DEFAULT_CONFIG
+    )
+
+
+@pytest.mark.parametrize("hass_config", [DEFAULT_CONFIG])
+async def test_entity_force_update(
+    hass: HomeAssistant,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test force_update attribute."""
+    await help_test_entity_force_update(
+        hass,
+        mqtt_mock_entry,
+        caplog,
+        camera.DOMAIN,
+        DEFAULT_CONFIG,
     )
 
 

--- a/tests/components/mqtt/test_climate.py
+++ b/tests/components/mqtt/test_climate.py
@@ -51,6 +51,7 @@ from .test_common import (
     help_test_entity_device_info_update,
     help_test_entity_device_info_with_connection,
     help_test_entity_device_info_with_identifier,
+    help_test_entity_force_update,
     help_test_entity_id_update_discovery_update,
     help_test_entity_id_update_subscriptions,
     help_test_publishing_with_custom_encoding,
@@ -2166,6 +2167,22 @@ async def test_entity_device_info_remove(
     """Test device registry remove."""
     await help_test_entity_device_info_remove(
         hass, mqtt_mock_entry, climate.DOMAIN, DEFAULT_CONFIG
+    )
+
+
+@pytest.mark.parametrize("hass_config", [DEFAULT_CONFIG])
+async def test_entity_force_update(
+    hass: HomeAssistant,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test force_update attribute."""
+    await help_test_entity_force_update(
+        hass,
+        mqtt_mock_entry,
+        caplog,
+        climate.DOMAIN,
+        DEFAULT_CONFIG,
     )
 
 

--- a/tests/components/mqtt/test_cover.py
+++ b/tests/components/mqtt/test_cover.py
@@ -62,6 +62,7 @@ from .test_common import (
     help_test_entity_device_info_update,
     help_test_entity_device_info_with_connection,
     help_test_entity_device_info_with_identifier,
+    help_test_entity_force_update,
     help_test_entity_id_update_discovery_update,
     help_test_entity_id_update_subscriptions,
     help_test_publishing_with_custom_encoding,
@@ -2860,6 +2861,22 @@ async def test_entity_device_info_remove(
     """Test device registry remove."""
     await help_test_entity_device_info_remove(
         hass, mqtt_mock_entry, cover.DOMAIN, DEFAULT_CONFIG
+    )
+
+
+@pytest.mark.parametrize("hass_config", [DEFAULT_CONFIG])
+async def test_entity_force_update(
+    hass: HomeAssistant,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test force_update attribute."""
+    await help_test_entity_force_update(
+        hass,
+        mqtt_mock_entry,
+        caplog,
+        cover.DOMAIN,
+        DEFAULT_CONFIG,
     )
 
 

--- a/tests/components/mqtt/test_fan.py
+++ b/tests/components/mqtt/test_fan.py
@@ -53,6 +53,7 @@ from .test_common import (
     help_test_entity_device_info_update,
     help_test_entity_device_info_with_connection,
     help_test_entity_device_info_with_identifier,
+    help_test_entity_force_update,
     help_test_entity_id_update_discovery_update,
     help_test_entity_id_update_subscriptions,
     help_test_publishing_with_custom_encoding,
@@ -2099,6 +2100,22 @@ async def test_entity_device_info_remove(
     """Test device registry remove."""
     await help_test_entity_device_info_remove(
         hass, mqtt_mock_entry, fan.DOMAIN, DEFAULT_CONFIG
+    )
+
+
+@pytest.mark.parametrize("hass_config", [DEFAULT_CONFIG])
+async def test_entity_force_update(
+    hass: HomeAssistant,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test force_update attribute."""
+    await help_test_entity_force_update(
+        hass,
+        mqtt_mock_entry,
+        caplog,
+        fan.DOMAIN,
+        DEFAULT_CONFIG,
     )
 
 

--- a/tests/components/mqtt/test_humidifier.py
+++ b/tests/components/mqtt/test_humidifier.py
@@ -53,6 +53,7 @@ from .test_common import (
     help_test_entity_device_info_update,
     help_test_entity_device_info_with_connection,
     help_test_entity_device_info_with_identifier,
+    help_test_entity_force_update,
     help_test_entity_id_update_discovery_update,
     help_test_entity_id_update_subscriptions,
     help_test_publishing_with_custom_encoding,
@@ -1438,6 +1439,22 @@ async def test_entity_device_info_remove(
     """Test device registry remove."""
     await help_test_entity_device_info_remove(
         hass, mqtt_mock_entry, humidifier.DOMAIN, DEFAULT_CONFIG
+    )
+
+
+@pytest.mark.parametrize("hass_config", [DEFAULT_CONFIG])
+async def test_entity_force_update(
+    hass: HomeAssistant,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test force_update attribute."""
+    await help_test_entity_force_update(
+        hass,
+        mqtt_mock_entry,
+        caplog,
+        humidifier.DOMAIN,
+        DEFAULT_CONFIG,
     )
 
 

--- a/tests/components/mqtt/test_image.py
+++ b/tests/components/mqtt/test_image.py
@@ -29,6 +29,7 @@ from .test_common import (
     help_test_entity_device_info_update,
     help_test_entity_device_info_with_connection,
     help_test_entity_device_info_with_identifier,
+    help_test_entity_force_update,
     help_test_entity_id_update_discovery_update,
     help_test_entity_id_update_subscriptions,
     help_test_reloadable,
@@ -740,6 +741,22 @@ async def test_entity_device_info_remove(
     """Test device registry remove."""
     await help_test_entity_device_info_remove(
         hass, mqtt_mock_entry, image.DOMAIN, DEFAULT_CONFIG
+    )
+
+
+@pytest.mark.parametrize("hass_config", [DEFAULT_CONFIG])
+async def test_entity_force_update(
+    hass: HomeAssistant,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test force_update attribute."""
+    await help_test_entity_force_update(
+        hass,
+        mqtt_mock_entry,
+        caplog,
+        image.DOMAIN,
+        DEFAULT_CONFIG,
     )
 
 

--- a/tests/components/mqtt/test_legacy_vacuum.py
+++ b/tests/components/mqtt/test_legacy_vacuum.py
@@ -56,6 +56,7 @@ from .test_common import (
     help_test_entity_device_info_update,
     help_test_entity_device_info_with_connection,
     help_test_entity_device_info_with_identifier,
+    help_test_entity_force_update,
     help_test_entity_id_update_discovery_update,
     help_test_entity_id_update_subscriptions,
     help_test_publishing_with_custom_encoding,
@@ -883,6 +884,22 @@ async def test_entity_device_info_remove(
     """Test device registry remove."""
     await help_test_entity_device_info_remove(
         hass, mqtt_mock_entry, vacuum.DOMAIN, DEFAULT_CONFIG_2
+    )
+
+
+@pytest.mark.parametrize("hass_config", [DEFAULT_CONFIG])
+async def test_entity_force_update(
+    hass: HomeAssistant,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test force_update attribute."""
+    await help_test_entity_force_update(
+        hass,
+        mqtt_mock_entry,
+        caplog,
+        vacuum.DOMAIN,
+        DEFAULT_CONFIG,
     )
 
 

--- a/tests/components/mqtt/test_light.py
+++ b/tests/components/mqtt/test_light.py
@@ -213,6 +213,7 @@ from .test_common import (
     help_test_entity_device_info_update,
     help_test_entity_device_info_with_connection,
     help_test_entity_device_info_with_identifier,
+    help_test_entity_force_update,
     help_test_entity_id_update_discovery_update,
     help_test_entity_id_update_subscriptions,
     help_test_publishing_with_custom_encoding,
@@ -2977,6 +2978,22 @@ async def test_entity_device_info_remove(
     """Test device registry remove."""
     await help_test_entity_device_info_remove(
         hass, mqtt_mock_entry, light.DOMAIN, DEFAULT_CONFIG
+    )
+
+
+@pytest.mark.parametrize("hass_config", [DEFAULT_CONFIG])
+async def test_entity_force_update(
+    hass: HomeAssistant,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test force_update attribute."""
+    await help_test_entity_force_update(
+        hass,
+        mqtt_mock_entry,
+        caplog,
+        light.DOMAIN,
+        DEFAULT_CONFIG,
     )
 
 

--- a/tests/components/mqtt/test_light_json.py
+++ b/tests/components/mqtt/test_light_json.py
@@ -117,6 +117,7 @@ from .test_common import (
     help_test_entity_device_info_update,
     help_test_entity_device_info_with_connection,
     help_test_entity_device_info_with_identifier,
+    help_test_entity_force_update,
     help_test_entity_id_update_discovery_update,
     help_test_entity_id_update_subscriptions,
     help_test_publishing_with_custom_encoding,
@@ -2263,6 +2264,22 @@ async def test_entity_device_info_remove(
     await help_test_entity_device_info_remove(
         hass,
         mqtt_mock_entry,
+        light.DOMAIN,
+        DEFAULT_CONFIG,
+    )
+
+
+@pytest.mark.parametrize("hass_config", [DEFAULT_CONFIG])
+async def test_entity_force_update(
+    hass: HomeAssistant,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test force_update attribute."""
+    await help_test_entity_force_update(
+        hass,
+        mqtt_mock_entry,
+        caplog,
         light.DOMAIN,
         DEFAULT_CONFIG,
     )

--- a/tests/components/mqtt/test_light_template.py
+++ b/tests/components/mqtt/test_light_template.py
@@ -61,6 +61,7 @@ from .test_common import (
     help_test_entity_device_info_update,
     help_test_entity_device_info_with_connection,
     help_test_entity_device_info_with_identifier,
+    help_test_entity_force_update,
     help_test_entity_id_update_discovery_update,
     help_test_entity_id_update_subscriptions,
     help_test_publishing_with_custom_encoding,
@@ -1181,6 +1182,22 @@ async def test_entity_device_info_remove(
     """Test device registry remove."""
     await help_test_entity_device_info_remove(
         hass, mqtt_mock_entry, light.DOMAIN, DEFAULT_CONFIG
+    )
+
+
+@pytest.mark.parametrize("hass_config", [DEFAULT_CONFIG])
+async def test_entity_force_update(
+    hass: HomeAssistant,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test force_update attribute."""
+    await help_test_entity_force_update(
+        hass,
+        mqtt_mock_entry,
+        caplog,
+        light.DOMAIN,
+        DEFAULT_CONFIG,
     )
 
 

--- a/tests/components/mqtt/test_lock.py
+++ b/tests/components/mqtt/test_lock.py
@@ -43,6 +43,7 @@ from .test_common import (
     help_test_entity_device_info_update,
     help_test_entity_device_info_with_connection,
     help_test_entity_device_info_with_identifier,
+    help_test_entity_force_update,
     help_test_entity_id_update_discovery_update,
     help_test_entity_id_update_subscriptions,
     help_test_publishing_with_custom_encoding,
@@ -894,6 +895,22 @@ async def test_entity_device_info_remove(
     """Test device registry remove."""
     await help_test_entity_device_info_remove(
         hass, mqtt_mock_entry, lock.DOMAIN, DEFAULT_CONFIG
+    )
+
+
+@pytest.mark.parametrize("hass_config", [DEFAULT_CONFIG])
+async def test_entity_force_update(
+    hass: HomeAssistant,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test force_update attribute."""
+    await help_test_entity_force_update(
+        hass,
+        mqtt_mock_entry,
+        caplog,
+        lock.DOMAIN,
+        DEFAULT_CONFIG,
     )
 
 

--- a/tests/components/mqtt/test_number.py
+++ b/tests/components/mqtt/test_number.py
@@ -46,6 +46,7 @@ from .test_common import (
     help_test_entity_device_info_update,
     help_test_entity_device_info_with_connection,
     help_test_entity_device_info_with_identifier,
+    help_test_entity_force_update,
     help_test_entity_id_update_discovery_update,
     help_test_entity_id_update_subscriptions,
     help_test_publishing_with_custom_encoding,
@@ -735,6 +736,22 @@ async def test_entity_device_info_remove(
     """Test device registry remove."""
     await help_test_entity_device_info_remove(
         hass, mqtt_mock_entry, number.DOMAIN, DEFAULT_CONFIG
+    )
+
+
+@pytest.mark.parametrize("hass_config", [DEFAULT_CONFIG])
+async def test_entity_force_update(
+    hass: HomeAssistant,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test force_update attribute."""
+    await help_test_entity_force_update(
+        hass,
+        mqtt_mock_entry,
+        caplog,
+        number.DOMAIN,
+        DEFAULT_CONFIG,
     )
 
 

--- a/tests/components/mqtt/test_select.py
+++ b/tests/components/mqtt/test_select.py
@@ -41,6 +41,7 @@ from .test_common import (
     help_test_entity_device_info_update,
     help_test_entity_device_info_with_connection,
     help_test_entity_device_info_with_identifier,
+    help_test_entity_force_update,
     help_test_entity_id_update_discovery_update,
     help_test_entity_id_update_subscriptions,
     help_test_publishing_with_custom_encoding,
@@ -576,6 +577,22 @@ async def test_entity_device_info_remove(
     """Test device registry remove."""
     await help_test_entity_device_info_remove(
         hass, mqtt_mock_entry, select.DOMAIN, DEFAULT_CONFIG
+    )
+
+
+@pytest.mark.parametrize("hass_config", [DEFAULT_CONFIG])
+async def test_entity_force_update(
+    hass: HomeAssistant,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test force_update attribute."""
+    await help_test_entity_force_update(
+        hass,
+        mqtt_mock_entry,
+        caplog,
+        select.DOMAIN,
+        DEFAULT_CONFIG,
     )
 
 

--- a/tests/components/mqtt/test_sensor.py
+++ b/tests/components/mqtt/test_sensor.py
@@ -51,6 +51,7 @@ from .test_common import (
     help_test_entity_device_info_with_connection,
     help_test_entity_device_info_with_identifier,
     help_test_entity_disabled_by_default,
+    help_test_entity_force_update,
     help_test_entity_id_update_discovery_update,
     help_test_entity_id_update_subscriptions,
     help_test_reload_with_config,
@@ -1096,6 +1097,22 @@ async def test_entity_device_info_remove(
     """Test device registry remove."""
     await help_test_entity_device_info_remove(
         hass, mqtt_mock_entry, sensor.DOMAIN, DEFAULT_CONFIG
+    )
+
+
+@pytest.mark.parametrize("hass_config", [DEFAULT_CONFIG])
+async def test_entity_force_update(
+    hass: HomeAssistant,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test force_update attribute."""
+    await help_test_entity_force_update(
+        hass,
+        mqtt_mock_entry,
+        caplog,
+        sensor.DOMAIN,
+        DEFAULT_CONFIG,
     )
 
 

--- a/tests/components/mqtt/test_text.py
+++ b/tests/components/mqtt/test_text.py
@@ -31,6 +31,7 @@ from .test_common import (
     help_test_entity_device_info_update,
     help_test_entity_device_info_with_connection,
     help_test_entity_device_info_with_identifier,
+    help_test_entity_force_update,
     help_test_entity_id_update_discovery_update,
     help_test_entity_id_update_subscriptions,
     help_test_publishing_with_custom_encoding,
@@ -631,6 +632,22 @@ async def test_entity_device_info_remove(
     """Test device registry remove."""
     await help_test_entity_device_info_remove(
         hass, mqtt_mock_entry, text.DOMAIN, DEFAULT_CONFIG
+    )
+
+
+@pytest.mark.parametrize("hass_config", [DEFAULT_CONFIG])
+async def test_entity_force_update(
+    hass: HomeAssistant,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test force_update attribute."""
+    await help_test_entity_force_update(
+        hass,
+        mqtt_mock_entry,
+        caplog,
+        text.DOMAIN,
+        DEFAULT_CONFIG,
     )
 
 

--- a/tests/components/mqtt/test_water_heater.py
+++ b/tests/components/mqtt/test_water_heater.py
@@ -45,6 +45,7 @@ from .test_common import (
     help_test_entity_device_info_update,
     help_test_entity_device_info_with_connection,
     help_test_entity_device_info_with_identifier,
+    help_test_entity_force_update,
     help_test_entity_id_update_discovery_update,
     help_test_entity_id_update_subscriptions,
     help_test_publishing_with_custom_encoding,
@@ -919,6 +920,22 @@ async def test_entity_device_info_remove(
     """Test device registry remove."""
     await help_test_entity_device_info_remove(
         hass, mqtt_mock_entry, water_heater.DOMAIN, DEFAULT_CONFIG
+    )
+
+
+@pytest.mark.parametrize("hass_config", [DEFAULT_CONFIG])
+async def test_entity_force_update(
+    hass: HomeAssistant,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test force_update attribute."""
+    await help_test_entity_force_update(
+        hass,
+        mqtt_mock_entry,
+        caplog,
+        water_heater.DOMAIN,
+        DEFAULT_CONFIG,
     )
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
There MQTT component does not currently recognize the setting of the entity attribute `force_update` during device discovery/setup. This change enables the setting of the `force_update` attribute, via the expected parameter in the discovery topic message.

I believe the implementation itself is straightforward, and in line with other components usage of the attribute. The majority of the PR changes are unit tests for each device class.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
