### PR TITLE
Allow multiple configs for srp energy

### DIFF
--- a/homeassistant/components/srp_energy/config_flow.py
+++ b/homeassistant/components/srp_energy/config_flow.py
@@ -7,12 +7,12 @@ from srpenergy.client import SrpEnergyClient
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.const import CONF_ID, CONF_PASSWORD, CONF_USERNAME
-from homeassistant.core import HomeAssistant
+from homeassistant.const import CONF_ID, CONF_NAME, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
 
-from .const import CONF_IS_TOU, DEFAULT_NAME, DOMAIN, LOGGER
+from .const import CONF_IS_TOU, DOMAIN, LOGGER
 
 
 async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
@@ -40,33 +40,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
-    async def async_step_user(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
-        """Handle a flow initialized by the user."""
-        errors = {}
-        default_title: str = DEFAULT_NAME
-
-        if self._async_current_entries():
-            return self.async_abort(reason="single_instance_allowed")
-
-        if self.hass.config.location_name:
-            default_title = self.hass.config.location_name
-
-        if user_input:
-            try:
-                await validate_input(self.hass, user_input)
-            except ValueError:
-                # Thrown when the account id is malformed
-                errors["base"] = "invalid_account"
-            except InvalidAuth:
-                errors["base"] = "invalid_auth"
-            except Exception:  # pylint: disable=broad-except
-                LOGGER.exception("Unexpected exception")
-                return self.async_abort(reason="unknown")
-            else:
-                return self.async_create_entry(title=default_title, data=user_input)
-
+    @callback
+    def _show_form(self, errors: dict[str, Any] | None = None) -> FlowResult:
+        """Show the form to the user."""
+        LOGGER.debug("Show Form")
         return self.async_show_form(
             step_id="user",
             data_schema=vol.Schema(
@@ -74,11 +51,42 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     vol.Required(CONF_ID): str,
                     vol.Required(CONF_USERNAME): str,
                     vol.Required(CONF_PASSWORD): str,
+                    vol.Optional(
+                        CONF_NAME, default=self.hass.config.location_name
+                    ): str,
                     vol.Optional(CONF_IS_TOU, default=False): bool,
                 }
             ),
             errors=errors or {},
         )
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle a flow initialized by the user."""
+        LOGGER.debug("Config entry")
+        if not user_input:
+            return self._show_form()
+
+        errors = {}
+
+        try:
+            await validate_input(self.hass, user_input)
+        except ValueError:
+            # Thrown when the account id is malformed
+            errors["base"] = "invalid_account"
+            return self._show_form(errors)
+        except InvalidAuth:
+            errors["base"] = "invalid_auth"
+            return self._show_form(errors)
+        except Exception:  # pylint: disable=broad-except
+            LOGGER.exception("Unexpected exception")
+            return self.async_abort(reason="unknown")
+
+        await self.async_set_unique_id(user_input.get(CONF_ID))
+        self._abort_if_unique_id_configured()
+
+        return self.async_create_entry(title=user_input[CONF_NAME], data=user_input)
 
 
 class InvalidAuth(HomeAssistantError):

--- a/homeassistant/components/srp_energy/const.py
+++ b/homeassistant/components/srp_energy/const.py
@@ -11,3 +11,12 @@ CONF_IS_TOU = "is_tou"
 
 PHOENIX_TIME_ZONE = "America/Phoenix"
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=1440)
+
+SENSOR_NAME = "Energy Usage"
+SENSOR_TYPE = "usage"
+
+DEVICE_CONFIG_URL = "https://www.srpnet.com/"
+DEVICE_MANUFACTURER = "srpnet.com"
+DEVICE_MODEL = "Service Api"
+DEVICE_NAME_ENERGY = "Energy consumption"
+DEVICE_NAME_PRICE = "Energy consumption price"

--- a/homeassistant/components/srp_energy/const.py
+++ b/homeassistant/components/srp_energy/const.py
@@ -12,11 +12,6 @@ CONF_IS_TOU = "is_tou"
 PHOENIX_TIME_ZONE = "America/Phoenix"
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=1440)
 
-SENSOR_NAME = "Energy Usage"
-SENSOR_TYPE = "usage"
-
 DEVICE_CONFIG_URL = "https://www.srpnet.com/"
 DEVICE_MANUFACTURER = "srpnet.com"
 DEVICE_MODEL = "Service Api"
-DEVICE_NAME_ENERGY = "Energy consumption"
-DEVICE_NAME_PRICE = "Energy consumption price"

--- a/homeassistant/components/srp_energy/sensor.py
+++ b/homeassistant/components/srp_energy/sensor.py
@@ -82,6 +82,10 @@ async def async_setup_entry(
                 return previous_daily_usage
         except TimeoutError as timeout_err:
             raise UpdateFailed("Timeout communicating with API") from timeout_err
+        except KeyError as missing_data_err:
+            raise UpdateFailed(
+                f"Verify account and credentials. Missing Data: {missing_data_err}"
+            ) from missing_data_err
         except (ConnectError, HTTPError, Timeout, ValueError, TypeError) as err:
             raise UpdateFailed(f"Error communicating with API: {err}") from err
 

--- a/homeassistant/components/srp_energy/sensor.py
+++ b/homeassistant/components/srp_energy/sensor.py
@@ -1,34 +1,115 @@
 """Support for SRP Energy Sensor."""
 from __future__ import annotations
 
+import asyncio
+from datetime import timedelta
+from requests.exceptions import ConnectionError as ConnectError, HTTPError, Timeout
+
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import UnitOfEnergy
+from homeassistant.const import CONF_NAME, UnitOfEnergy
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.helpers.typing import StateType
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import dt as dt_util
 
-from . import SRPEnergyDataUpdateCoordinator
-from .const import DOMAIN
+from .const import (
+    CONF_IS_TOU,
+    DEVICE_CONFIG_URL,
+    DEVICE_MANUFACTURER,
+    DEVICE_MODEL,
+    DOMAIN,
+    LOGGER,
+    MIN_TIME_BETWEEN_UPDATES,
+    PHOENIX_TIME_ZONE,
+    SENSOR_NAME,
+    SENSOR_TYPE,
+)
 
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up the SRP Energy Usage sensor."""
-    coordinator: SRPEnergyDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    # API object stored here by __init__.py
+    api = hass.data[DOMAIN][entry.entry_id]
+    is_time_of_use = entry.data[CONF_IS_TOU]
+    config_name = entry.data[CONF_NAME]
 
-    async_add_entities([SrpEntity(coordinator, entry)])
+    async def async_update_data():
+        """Fetch data from API endpoint.
+
+        This is the place to pre-process the data to lookup tables
+        so entities can quickly look up their data.
+        """
+        LOGGER.debug("async_update_data enter")
+        try:
+            # Fetch srp_energy data
+            phx_time_zone = dt_util.get_time_zone(PHOENIX_TIME_ZONE)
+            end_date = dt_util.now(phx_time_zone)
+            start_date = end_date - timedelta(days=1)
+
+            async with asyncio.timeout(10):
+                hourly_usage = await hass.async_add_executor_job(
+                    api.usage,
+                    start_date,
+                    end_date,
+                    is_time_of_use,
+                )
+
+                LOGGER.debug(
+                    "async_update_data: Received %s record(s) from %s to %s",
+                    len(hourly_usage) if hourly_usage else "None",
+                    start_date,
+                    end_date,
+                )
+
+                previous_daily_usage = 0.0
+                for _, _, _, kwh, _ in hourly_usage:
+                    previous_daily_usage += float(kwh)
+
+                LOGGER.debug(
+                    "async_update_data: previous_daily_usage %s",
+                    previous_daily_usage,
+                )
+
+                return previous_daily_usage
+        except TimeoutError as timeout_err:
+            raise UpdateFailed("Timeout communicating with API") from timeout_err
+        except (ConnectError, HTTPError, Timeout, ValueError, TypeError) as err:
+            raise UpdateFailed(f"Error communicating with API: {err}") from err
+
+    coordinator = DataUpdateCoordinator(
+        hass,
+        LOGGER,
+        name="sensor",
+        update_method=async_update_data,
+        update_interval=MIN_TIME_BETWEEN_UPDATES,
+    )
+
+    # Fetch initial data so we have data when entities subscribe
+    await coordinator.async_refresh()
+
+    async_add_entities(
+        [
+            SrpEntity(
+                coordinator,
+                config_name=config_name,
+            )
+        ]
+    )
 
 
-class SrpEntity(CoordinatorEntity[SRPEnergyDataUpdateCoordinator], SensorEntity):
+class SrpEntity(SensorEntity):
     """Implementation of a Srp Energy Usage sensor."""
 
+    _attr_has_entity_name = True
     _attr_attribution = "Powered by SRP Energy"
     _attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
     _attr_device_class = SensorDeviceClass.ENERGY
@@ -37,18 +118,32 @@ class SrpEntity(CoordinatorEntity[SRPEnergyDataUpdateCoordinator], SensorEntity)
     _attr_translation_key = "energy_usage"
 
     def __init__(
-        self, coordinator: SRPEnergyDataUpdateCoordinator, config_entry: ConfigEntry
+        self,
+        coordinator: DataUpdateCoordinator,
+        config_name: str,
     ) -> None:
         """Initialize the SrpEntity class."""
-        super().__init__(coordinator)
-        self._attr_unique_id = f"{config_entry.entry_id}_total_usage"
+        self._name = SENSOR_NAME
+        self.type = SENSOR_TYPE
+        self.coordinator = coordinator
+        self._unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
+        self._state = None
+        self._config_name = config_name
+        unique_id: str = f"{config_name}_energy_usage".lower()
+        LOGGER.debug("Setting unique id %s", unique_id)
+        self._attr_unique_id = unique_id
+
+        # Configure device
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, config_entry.entry_id)},
-            name="SRP Energy",
             entry_type=DeviceEntryType.SERVICE,
+            identifiers={(DOMAIN, f"{config_name}_Energy usage")},
+            configuration_url=DEVICE_CONFIG_URL,
+            manufacturer=DEVICE_MANUFACTURER,
+            model=DEVICE_MODEL,
+            name=f"{config_name} Energy consumption",
         )
 
     @property
-    def native_value(self) -> float:
+    def native_value(self) -> StateType:
         """Return the state of the device."""
         return self.coordinator.data

--- a/homeassistant/components/srp_energy/sensor.py
+++ b/homeassistant/components/srp_energy/sensor.py
@@ -132,7 +132,6 @@ class SrpEntity(SensorEntity):
         self.coordinator = coordinator
         self._unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
         self._state = None
-        self._config_name = config_name
         unique_id: str = f"{config_name}_energy_usage".lower()
         LOGGER.debug("Setting unique id %s", unique_id)
         self._attr_unique_id = unique_id

--- a/homeassistant/components/srp_energy/sensor.py
+++ b/homeassistant/components/srp_energy/sensor.py
@@ -15,14 +15,13 @@ from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import SRPEnergyDataUpdateCoordinator
-from .const import DOMAIN
+from .const import DEVICE_CONFIG_URL, DEVICE_MANUFACTURER, DEVICE_MODEL, DOMAIN
 
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up the SRP Energy Usage sensor."""
-    # API object stored here by __init__.py
     coordinator: SRPEnergyDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
 
     async_add_entities([SrpEntity(coordinator, entry)])
@@ -46,12 +45,13 @@ class SrpEntity(CoordinatorEntity[SRPEnergyDataUpdateCoordinator], SensorEntity)
         """Initialize the SrpEntity class."""
         super().__init__(coordinator)
         self._attr_unique_id = f"{config_entry.entry_id}_total_usage"
-
-        # Configure device
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, config_entry.entry_id)},
-            name="SRP Energy",
+            name=f"SRP Energy {config_entry.title}",
             entry_type=DeviceEntryType.SERVICE,
+            manufacturer=DEVICE_MANUFACTURER,
+            model=DEVICE_MODEL,
+            configuration_url=DEVICE_CONFIG_URL,
         )
 
     @property

--- a/homeassistant/components/srp_energy/sensor.py
+++ b/homeassistant/components/srp_energy/sensor.py
@@ -1,36 +1,21 @@
 """Support for SRP Energy Sensor."""
 from __future__ import annotations
 
-import asyncio
-from datetime import timedelta
-from requests.exceptions import ConnectionError as ConnectError, HTTPError, Timeout
-
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_NAME, UnitOfEnergy
+from homeassistant.const import UnitOfEnergy
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
-from homeassistant.util import dt as dt_util
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import (
-    CONF_IS_TOU,
-    DEVICE_CONFIG_URL,
-    DEVICE_MANUFACTURER,
-    DEVICE_MODEL,
-    DOMAIN,
-    LOGGER,
-    MIN_TIME_BETWEEN_UPDATES,
-    PHOENIX_TIME_ZONE,
-    SENSOR_NAME,
-    SENSOR_TYPE,
-)
+from . import SRPEnergyDataUpdateCoordinator
+from .const import DOMAIN
 
 
 async def async_setup_entry(
@@ -38,82 +23,14 @@ async def async_setup_entry(
 ) -> None:
     """Set up the SRP Energy Usage sensor."""
     # API object stored here by __init__.py
-    api = hass.data[DOMAIN][entry.entry_id]
-    is_time_of_use = entry.data[CONF_IS_TOU]
-    config_name = entry.data[CONF_NAME]
+    coordinator: SRPEnergyDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
 
-    async def async_update_data():
-        """Fetch data from API endpoint.
-
-        This is the place to pre-process the data to lookup tables
-        so entities can quickly look up their data.
-        """
-        LOGGER.debug("async_update_data enter")
-        try:
-            # Fetch srp_energy data
-            phx_time_zone = dt_util.get_time_zone(PHOENIX_TIME_ZONE)
-            end_date = dt_util.now(phx_time_zone)
-            start_date = end_date - timedelta(days=1)
-
-            async with asyncio.timeout(10):
-                hourly_usage = await hass.async_add_executor_job(
-                    api.usage,
-                    start_date,
-                    end_date,
-                    is_time_of_use,
-                )
-
-                LOGGER.debug(
-                    "async_update_data: Received %s record(s) from %s to %s",
-                    len(hourly_usage) if hourly_usage else "None",
-                    start_date,
-                    end_date,
-                )
-
-                previous_daily_usage = 0.0
-                for _, _, _, kwh, _ in hourly_usage:
-                    previous_daily_usage += float(kwh)
-
-                LOGGER.debug(
-                    "async_update_data: previous_daily_usage %s",
-                    previous_daily_usage,
-                )
-
-                return previous_daily_usage
-        except TimeoutError as timeout_err:
-            raise UpdateFailed("Timeout communicating with API") from timeout_err
-        except KeyError as missing_data_err:
-            raise UpdateFailed(
-                f"Verify account and credentials. Missing Data: {missing_data_err}"
-            ) from missing_data_err
-        except (ConnectError, HTTPError, Timeout, ValueError, TypeError) as err:
-            raise UpdateFailed(f"Error communicating with API: {err}") from err
-
-    coordinator = DataUpdateCoordinator(
-        hass,
-        LOGGER,
-        name="sensor",
-        update_method=async_update_data,
-        update_interval=MIN_TIME_BETWEEN_UPDATES,
-    )
-
-    # Fetch initial data so we have data when entities subscribe
-    await coordinator.async_refresh()
-
-    async_add_entities(
-        [
-            SrpEntity(
-                coordinator,
-                config_name=config_name,
-            )
-        ]
-    )
+    async_add_entities([SrpEntity(coordinator, entry)])
 
 
-class SrpEntity(SensorEntity):
+class SrpEntity(CoordinatorEntity[SRPEnergyDataUpdateCoordinator], SensorEntity):
     """Implementation of a Srp Energy Usage sensor."""
 
-    _attr_has_entity_name = True
     _attr_attribution = "Powered by SRP Energy"
     _attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
     _attr_device_class = SensorDeviceClass.ENERGY
@@ -123,27 +40,18 @@ class SrpEntity(SensorEntity):
 
     def __init__(
         self,
-        coordinator: DataUpdateCoordinator,
-        config_name: str,
+        coordinator: SRPEnergyDataUpdateCoordinator,
+        config_entry: ConfigEntry,
     ) -> None:
         """Initialize the SrpEntity class."""
-        self._name = SENSOR_NAME
-        self.type = SENSOR_TYPE
-        self.coordinator = coordinator
-        self._unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
-        self._state = None
-        unique_id: str = f"{config_name}_energy_usage".lower()
-        LOGGER.debug("Setting unique id %s", unique_id)
-        self._attr_unique_id = unique_id
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{config_entry.entry_id}_total_usage"
 
         # Configure device
         self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, config_entry.entry_id)},
+            name="SRP Energy",
             entry_type=DeviceEntryType.SERVICE,
-            identifiers={(DOMAIN, f"{config_name}_Energy usage")},
-            configuration_url=DEVICE_CONFIG_URL,
-            manufacturer=DEVICE_MANUFACTURER,
-            model=DEVICE_MODEL,
-            name=f"{config_name} Energy consumption",
         )
 
     @property

--- a/homeassistant/components/srp_energy/strings.json
+++ b/homeassistant/components/srp_energy/strings.json
@@ -17,7 +17,7 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
-      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     }
   },
   "entity": {

--- a/tests/components/srp_energy/__init__.py
+++ b/tests/components/srp_energy/__init__.py
@@ -1,16 +1,27 @@
 """Tests for the SRP Energy integration."""
 
 from homeassistant.components.srp_energy.const import CONF_IS_TOU
-from homeassistant.const import CONF_ID, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import CONF_ID, CONF_NAME, CONF_PASSWORD, CONF_USERNAME
 
 ACCNT_ID = "123456789"
+ACCNT_ID_2 = "987654321"
 ACCNT_IS_TOU = False
-ACCNT_USERNAME = "abba"
-ACCNT_PASSWORD = "ana"
-ACCNT_NAME = "Home"
+ACCNT_USERNAME = "test_username"
+ACCNT_PASSWORD = "test_password"
+ACCNT_NAME = "Test Home"
+ACCNT_NAME_2 = "Test Cabin"
 
 TEST_USER_INPUT = {
+    CONF_NAME: ACCNT_NAME,
     CONF_ID: ACCNT_ID,
+    CONF_USERNAME: ACCNT_USERNAME,
+    CONF_PASSWORD: ACCNT_PASSWORD,
+    CONF_IS_TOU: ACCNT_IS_TOU,
+}
+
+TEST_USER_INPUT_2 = {
+    CONF_NAME: ACCNT_NAME_2,
+    CONF_ID: ACCNT_ID_2,
     CONF_USERNAME: ACCNT_USERNAME,
     CONF_PASSWORD: ACCNT_PASSWORD,
     CONF_IS_TOU: ACCNT_IS_TOU,

--- a/tests/components/srp_energy/__init__.py
+++ b/tests/components/srp_energy/__init__.py
@@ -1,17 +1,18 @@
 """Tests for the SRP Energy integration."""
 
+from typing import Final
+
 from homeassistant.components.srp_energy.const import CONF_IS_TOU
 from homeassistant.const import CONF_ID, CONF_NAME, CONF_PASSWORD, CONF_USERNAME
 
-ACCNT_ID = "123456789"
-ACCNT_ID_2 = "987654321"
-ACCNT_IS_TOU = False
-ACCNT_USERNAME = "test_username"
-ACCNT_PASSWORD = "test_password"
-ACCNT_NAME = "Test Home"
-ACCNT_NAME_2 = "Test Cabin"
+ACCNT_ID: Final = "123456789"
+ACCNT_IS_TOU: Final = False
+ACCNT_USERNAME: Final = "test_username"
+ACCNT_PASSWORD: Final = "test_password"
+ACCNT_NAME: Final = "Test Home"
 
-TEST_USER_INPUT = {
+
+TEST_CONFIG_HOME: Final[dict[str, str]] = {
     CONF_NAME: ACCNT_NAME,
     CONF_ID: ACCNT_ID,
     CONF_USERNAME: ACCNT_USERNAME,
@@ -19,7 +20,10 @@ TEST_USER_INPUT = {
     CONF_IS_TOU: ACCNT_IS_TOU,
 }
 
-TEST_USER_INPUT_2 = {
+ACCNT_ID_2: Final = "987654321"
+ACCNT_NAME_2: Final = "Test Cabin"
+
+TEST_CONFIG_CABIN: Final[dict[str, str]] = {
     CONF_NAME: ACCNT_NAME_2,
     CONF_ID: ACCNT_ID_2,
     CONF_USERNAME: ACCNT_USERNAME,

--- a/tests/components/srp_energy/conftest.py
+++ b/tests/components/srp_energy/conftest.py
@@ -13,7 +13,7 @@ from homeassistant.const import CONF_ID
 from homeassistant.core import HomeAssistant
 import homeassistant.util.dt as dt_util
 
-from . import MOCK_USAGE, TEST_USER_INPUT
+from . import MOCK_USAGE, TEST_CONFIG_HOME
 
 from tests.common import MockConfigEntry
 
@@ -43,7 +43,7 @@ def fixture_test_date(hass: HomeAssistant, hass_tz_info) -> dt.datetime | None:
 def fixture_mock_config_entry() -> MockConfigEntry:
     """Return the default mocked config entry."""
     return MockConfigEntry(
-        domain=DOMAIN, data=TEST_USER_INPUT, unique_id=TEST_USER_INPUT[CONF_ID]
+        domain=DOMAIN, data=TEST_CONFIG_HOME, unique_id=TEST_CONFIG_HOME[CONF_ID]
     )
 
 
@@ -81,7 +81,6 @@ async def init_integration(
     mock_srp_energy_config_flow,
 ) -> MockConfigEntry:
     """Set up the Srp Energy integration for testing."""
-
     freezer.move_to(test_date)
     mock_config_entry.add_to_hass(hass)
 

--- a/tests/components/srp_energy/conftest.py
+++ b/tests/components/srp_energy/conftest.py
@@ -9,6 +9,7 @@ from freezegun.api import FrozenDateTimeFactory
 import pytest
 
 from homeassistant.components.srp_energy.const import DOMAIN, PHOENIX_TIME_ZONE
+from homeassistant.const import CONF_ID
 from homeassistant.core import HomeAssistant
 import homeassistant.util.dt as dt_util
 
@@ -42,8 +43,7 @@ def fixture_test_date(hass: HomeAssistant, hass_tz_info) -> dt.datetime | None:
 def fixture_mock_config_entry() -> MockConfigEntry:
     """Return the default mocked config entry."""
     return MockConfigEntry(
-        domain=DOMAIN,
-        data=TEST_USER_INPUT,
+        domain=DOMAIN, data=TEST_USER_INPUT, unique_id=TEST_USER_INPUT[CONF_ID]
     )
 
 

--- a/tests/components/srp_energy/test_config_flow.py
+++ b/tests/components/srp_energy/test_config_flow.py
@@ -1,13 +1,23 @@
 """Test the SRP Energy config flow."""
 from unittest.mock import MagicMock, patch
 
-from homeassistant import config_entries
 from homeassistant.components.srp_energy.const import CONF_IS_TOU, DOMAIN
+from homeassistant.config_entries import SOURCE_USER, ConfigEntryState
 from homeassistant.const import CONF_ID, CONF_PASSWORD, CONF_SOURCE, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
-from . import ACCNT_ID, ACCNT_IS_TOU, ACCNT_PASSWORD, ACCNT_USERNAME, TEST_USER_INPUT
+from . import (
+    ACCNT_ID,
+    ACCNT_ID_2,
+    ACCNT_IS_TOU,
+    ACCNT_NAME,
+    ACCNT_NAME_2,
+    ACCNT_PASSWORD,
+    ACCNT_USERNAME,
+    TEST_USER_INPUT,
+    TEST_USER_INPUT_2,
+)
 
 from tests.common import MockConfigEntry
 
@@ -17,7 +27,7 @@ async def test_show_form(
 ) -> None:
     """Test show configuration form."""
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={CONF_SOURCE: config_entries.SOURCE_USER}
+        DOMAIN, context={CONF_SOURCE: SOURCE_USER}
     )
 
     assert result["type"] == FlowResultType.FORM
@@ -34,7 +44,7 @@ async def test_show_form(
         await hass.async_block_till_done()
 
         assert result["type"] == FlowResultType.CREATE_ENTRY
-        assert result["title"] == "test home"
+        assert result["title"] == ACCNT_NAME
 
         assert "data" in result
         assert result["data"][CONF_ID] == ACCNT_ID
@@ -56,7 +66,7 @@ async def test_form_invalid_account(
     mock_srp_energy_config_flow.validate.side_effect = ValueError
 
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={CONF_SOURCE: config_entries.SOURCE_USER}
+        DOMAIN, context={CONF_SOURCE: SOURCE_USER}
     )
 
     result = await hass.config_entries.flow.async_configure(
@@ -75,7 +85,7 @@ async def test_form_invalid_auth(
     mock_srp_energy_config_flow.validate.return_value = False
 
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={CONF_SOURCE: config_entries.SOURCE_USER}
+        DOMAIN, context={CONF_SOURCE: SOURCE_USER}
     )
 
     result = await hass.config_entries.flow.async_configure(
@@ -94,7 +104,7 @@ async def test_form_unknown_error(
     mock_srp_energy_config_flow.validate.side_effect = Exception
 
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={CONF_SOURCE: config_entries.SOURCE_USER}
+        DOMAIN, context={CONF_SOURCE: SOURCE_USER}
     )
 
     result = await hass.config_entries.flow.async_configure(
@@ -109,18 +119,53 @@ async def test_flow_entry_already_configured(
     hass: HomeAssistant, init_integration: MockConfigEntry
 ) -> None:
     """Test user input for config_entry that already exists."""
-    user_input = {
-        CONF_ID: init_integration.data[CONF_ID],
-        CONF_USERNAME: "abba2",
-        CONF_PASSWORD: "ana2",
-        CONF_IS_TOU: False,
-    }
+
+    # Verify mock config setup from fixture
+    assert init_integration.state == ConfigEntryState.LOADED
+    assert init_integration.data[CONF_ID] == ACCNT_ID
+    assert init_integration.unique_id == ACCNT_ID
+
+    # Attempt a second config using same account id. This is the unique id between configs.
+    user_input = TEST_USER_INPUT_2
+    user_input[CONF_ID] = init_integration.data[CONF_ID]
 
     assert user_input[CONF_ID] == ACCNT_ID
 
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={CONF_SOURCE: config_entries.SOURCE_USER}, data=user_input
+        DOMAIN, context={CONF_SOURCE: SOURCE_USER}, data=user_input
     )
 
     assert result["type"] == FlowResultType.ABORT
-    assert result["reason"] == "single_instance_allowed"
+    assert result["reason"] == "already_configured"
+
+
+async def test_flow_multiple_configs(
+    hass: HomeAssistant, init_integration: MockConfigEntry, capsys
+) -> None:
+    """Test multiple config entries."""
+    # Verify mock config setup from fixture
+    assert init_integration.state == ConfigEntryState.LOADED
+    assert init_integration.data[CONF_ID] == ACCNT_ID
+    assert init_integration.unique_id == ACCNT_ID
+
+    # Attempt a second config using different account id. This is the unique id between configs.
+    assert TEST_USER_INPUT_2[CONF_ID] != ACCNT_ID
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={CONF_SOURCE: SOURCE_USER}, data=TEST_USER_INPUT_2
+    )
+
+    # Verify created
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == ACCNT_NAME_2
+
+    assert "data" in result
+    assert result["data"][CONF_ID] == ACCNT_ID_2
+    assert result["data"][CONF_USERNAME] == ACCNT_USERNAME
+    assert result["data"][CONF_PASSWORD] == ACCNT_PASSWORD
+    assert result["data"][CONF_IS_TOU] == ACCNT_IS_TOU
+
+    # Verify multiple configs
+    entries = hass.config_entries.async_entries()
+    domain_entries = [entry for entry in entries if entry.domain == DOMAIN]
+    assert len(domain_entries) == 2

--- a/tests/components/srp_energy/test_config_flow.py
+++ b/tests/components/srp_energy/test_config_flow.py
@@ -15,8 +15,8 @@ from . import (
     ACCNT_NAME_2,
     ACCNT_PASSWORD,
     ACCNT_USERNAME,
-    TEST_USER_INPUT,
-    TEST_USER_INPUT_2,
+    TEST_CONFIG_CABIN,
+    TEST_CONFIG_HOME,
 )
 
 from tests.common import MockConfigEntry
@@ -39,7 +39,7 @@ async def test_show_form(
         return_value=True,
     ) as mock_setup_entry:
         result = await hass.config_entries.flow.async_configure(
-            flow_id=result["flow_id"], user_input=TEST_USER_INPUT
+            flow_id=result["flow_id"], user_input=TEST_CONFIG_HOME
         )
         await hass.async_block_till_done()
 
@@ -70,7 +70,7 @@ async def test_form_invalid_account(
     )
 
     result = await hass.config_entries.flow.async_configure(
-        flow_id=result["flow_id"], user_input=TEST_USER_INPUT
+        flow_id=result["flow_id"], user_input=TEST_CONFIG_HOME
     )
 
     assert result["type"] == FlowResultType.FORM
@@ -89,7 +89,7 @@ async def test_form_invalid_auth(
     )
 
     result = await hass.config_entries.flow.async_configure(
-        flow_id=result["flow_id"], user_input=TEST_USER_INPUT
+        flow_id=result["flow_id"], user_input=TEST_CONFIG_HOME
     )
 
     assert result["type"] == FlowResultType.FORM
@@ -108,7 +108,7 @@ async def test_form_unknown_error(
     )
 
     result = await hass.config_entries.flow.async_configure(
-        flow_id=result["flow_id"], user_input=TEST_USER_INPUT
+        flow_id=result["flow_id"], user_input=TEST_CONFIG_HOME
     )
 
     assert result["type"] == FlowResultType.ABORT
@@ -119,20 +119,19 @@ async def test_flow_entry_already_configured(
     hass: HomeAssistant, init_integration: MockConfigEntry
 ) -> None:
     """Test user input for config_entry that already exists."""
-
     # Verify mock config setup from fixture
     assert init_integration.state == ConfigEntryState.LOADED
     assert init_integration.data[CONF_ID] == ACCNT_ID
     assert init_integration.unique_id == ACCNT_ID
 
     # Attempt a second config using same account id. This is the unique id between configs.
-    user_input = TEST_USER_INPUT_2
-    user_input[CONF_ID] = init_integration.data[CONF_ID]
+    user_input_second = TEST_CONFIG_HOME
+    user_input_second[CONF_ID] = init_integration.data[CONF_ID]
 
-    assert user_input[CONF_ID] == ACCNT_ID
+    assert user_input_second[CONF_ID] == ACCNT_ID
 
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={CONF_SOURCE: SOURCE_USER}, data=user_input
+        DOMAIN, context={CONF_SOURCE: SOURCE_USER}, data=user_input_second
     )
 
     assert result["type"] == FlowResultType.ABORT
@@ -149,10 +148,10 @@ async def test_flow_multiple_configs(
     assert init_integration.unique_id == ACCNT_ID
 
     # Attempt a second config using different account id. This is the unique id between configs.
-    assert TEST_USER_INPUT_2[CONF_ID] != ACCNT_ID
+    assert TEST_CONFIG_CABIN[CONF_ID] != ACCNT_ID
 
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={CONF_SOURCE: SOURCE_USER}, data=TEST_USER_INPUT_2
+        DOMAIN, context={CONF_SOURCE: SOURCE_USER}, data=TEST_CONFIG_CABIN
     )
 
     # Verify created

--- a/tests/components/srp_energy/test_sensor.py
+++ b/tests/components/srp_energy/test_sensor.py
@@ -28,7 +28,7 @@ async def test_loading_sensors(hass: HomeAssistant, init_integration) -> None:
 
 async def test_srp_entity(hass: HomeAssistant, init_integration) -> None:
     """Test the SrpEntity."""
-    usage_state = hass.states.get("sensor.srp_energy_energy_usage")
+    usage_state = hass.states.get("sensor.srp_energy_mock_title_energy_usage")
     assert usage_state.state == "150.8"
 
     # Validate attributions
@@ -61,7 +61,7 @@ async def test_srp_entity_update_failed(
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 
-    usage_state = hass.states.get("sensor.home_energy_usage")
+    usage_state = hass.states.get("sensor.srp_energy_mock_title_energy_usage")
     assert usage_state is None
 
 
@@ -84,5 +84,5 @@ async def test_srp_entity_timeout(
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 
-    usage_state = hass.states.get("sensor.home_energy_usage")
+    usage_state = hass.states.get("sensor.srp_energy_mock_title_energy_usage")
     assert usage_state is None

--- a/tests/components/srp_energy/test_sensor.py
+++ b/tests/components/srp_energy/test_sensor.py
@@ -28,7 +28,7 @@ async def test_loading_sensors(hass: HomeAssistant, init_integration) -> None:
 
 async def test_srp_entity(hass: HomeAssistant, init_integration) -> None:
     """Test the SrpEntity."""
-    usage_state = hass.states.get("sensor.test_home_energy_consumption_energy")
+    usage_state = hass.states.get("sensor.srp_energy_energy_usage")
     assert usage_state.state == "150.8"
 
     # Validate attributions

--- a/tests/components/srp_energy/test_sensor.py
+++ b/tests/components/srp_energy/test_sensor.py
@@ -28,7 +28,7 @@ async def test_loading_sensors(hass: HomeAssistant, init_integration) -> None:
 
 async def test_srp_entity(hass: HomeAssistant, init_integration) -> None:
     """Test the SrpEntity."""
-    usage_state = hass.states.get("sensor.test_home_energy_consumption")
+    usage_state = hass.states.get("sensor.test_home_energy_consumption_energy")
     assert usage_state.state == "150.8"
 
     # Validate attributions

--- a/tests/components/srp_energy/test_sensor.py
+++ b/tests/components/srp_energy/test_sensor.py
@@ -28,7 +28,7 @@ async def test_loading_sensors(hass: HomeAssistant, init_integration) -> None:
 
 async def test_srp_entity(hass: HomeAssistant, init_integration) -> None:
     """Test the SrpEntity."""
-    usage_state = hass.states.get("sensor.srp_energy_energy_usage")
+    usage_state = hass.states.get("sensor.test_home_energy_consumption")
     assert usage_state.state == "150.8"
 
     # Validate attributions


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow multiple configurations for different locations. This includes adding a separate device for each location. The sensor name uses the device name to distinguish between the two energy consumption sensors.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #95578
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
