### PR TITLE
Remove deprecated state.get_changed_since

### DIFF
--- a/homeassistant/helpers/state.py
+++ b/homeassistant/helpers/state.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 import asyncio
 from collections import defaultdict
 from collections.abc import Iterable
-import datetime as dt
 import logging
-from types import ModuleType, TracebackType
+from types import ModuleType
 from typing import Any
 
 from homeassistant.components.sun import STATE_ABOVE_HORIZON, STATE_BELOW_HORIZON
@@ -23,55 +22,8 @@ from homeassistant.const import (
 )
 from homeassistant.core import Context, HomeAssistant, State
 from homeassistant.loader import IntegrationNotFound, async_get_integration, bind_hass
-import homeassistant.util.dt as dt_util
-
-from .frame import report
 
 _LOGGER = logging.getLogger(__name__)
-
-
-class AsyncTrackStates:
-    """Record the time when the with-block is entered.
-
-    Add all states that have changed since the start time to the return list
-    when with-block is exited.
-
-    Must be run within the event loop.
-
-    Deprecated. Remove after June 2021.
-    Warning added via `get_changed_since`.
-    """
-
-    def __init__(self, hass: HomeAssistant) -> None:
-        """Initialize a TrackStates block."""
-        self.hass = hass
-        self.states: list[State] = []
-
-    # pylint: disable=attribute-defined-outside-init
-    def __enter__(self) -> list[State]:
-        """Record time from which to track changes."""
-        self.now = dt_util.utcnow()
-        return self.states
-
-    def __exit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc_value: BaseException | None,
-        traceback: TracebackType | None,
-    ) -> None:
-        """Add changes states to changes list."""
-        self.states.extend(get_changed_since(self.hass.states.async_all(), self.now))
-
-
-def get_changed_since(
-    states: Iterable[State], utc_point_in_time: dt.datetime
-) -> list[State]:
-    """Return list of states that have been changed since utc_point_in_time.
-
-    Deprecated. Remove after June 2021.
-    """
-    report("uses deprecated `get_changed_since`")
-    return [state for state in states if state.last_updated >= utc_point_in_time]
 
 
 @bind_hass

--- a/tests/helpers/test_state.py
+++ b/tests/helpers/test_state.py
@@ -1,9 +1,7 @@
 """Test state helpers."""
 import asyncio
-from datetime import timedelta
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
-from freezegun import freeze_time
 import pytest
 
 from homeassistant.components.sun import STATE_ABOVE_HORIZON, STATE_BELOW_HORIZON
@@ -21,32 +19,8 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers import state
-from homeassistant.util import dt as dt_util
 
 from tests.common import async_mock_service
-
-
-async def test_async_track_states(
-    hass: HomeAssistant, mock_integration_frame: Mock
-) -> None:
-    """Test AsyncTrackStates context manager."""
-    point1 = dt_util.utcnow()
-    point2 = point1 + timedelta(seconds=5)
-    point3 = point2 + timedelta(seconds=5)
-
-    with freeze_time(point2) as freezer, state.AsyncTrackStates(hass) as states:
-        freezer.move_to(point1)
-        hass.states.async_set("light.test", "on")
-
-        freezer.move_to(point2)
-        hass.states.async_set("light.test2", "on")
-        state2 = hass.states.get("light.test2")
-
-        freezer.move_to(point3)
-        hass.states.async_set("light.test3", "on")
-        state3 = hass.states.get("light.test3")
-
-    assert [state2, state3] == sorted(states, key=lambda state: state.entity_id)
 
 
 async def test_call_to_component(hass: HomeAssistant) -> None:
@@ -80,29 +54,6 @@ async def test_call_to_component(hass: HomeAssistant) -> None:
             climate_fun.assert_called_once_with(
                 hass, [state_climate], context=context, reproduce_options=None
             )
-
-
-async def test_get_changed_since(
-    hass: HomeAssistant, mock_integration_frame: Mock
-) -> None:
-    """Test get_changed_since."""
-    point1 = dt_util.utcnow()
-    point2 = point1 + timedelta(seconds=5)
-    point3 = point2 + timedelta(seconds=5)
-
-    with freeze_time(point1) as freezer:
-        hass.states.async_set("light.test", "on")
-        state1 = hass.states.get("light.test")
-
-        freezer.move_to(point2)
-        hass.states.async_set("light.test2", "on")
-        state2 = hass.states.get("light.test2")
-
-        freezer.move_to(point3)
-        hass.states.async_set("light.test3", "on")
-        state3 = hass.states.get("light.test3")
-
-    assert [state2, state3] == state.get_changed_since([state1, state2, state3], point2)
 
 
 async def test_reproduce_with_no_entity(hass: HomeAssistant) -> None:


### PR DESCRIPTION


## Breaking change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This was deprecated in #47255 but never removed

This is technically a breaking change but its reporting it will be removed for years so we might not want to document it as such as it might just be noise.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
