### PR TITLE
Add tomorrow.io state translations and dynamically assign enum device class

### DIFF
--- a/homeassistant/components/tomorrowio/sensor.py
+++ b/homeassistant/components/tomorrowio/sensor.py
@@ -301,8 +301,6 @@ SENSOR_TYPES = (
         key=TMRW_ATTR_UV_HEALTH_CONCERN,
         name="UV Radiation Health Concern",
         value_map=UVDescription,
-        device_class=SensorDeviceClass.ENUM,
-        options=["high", "low", "moderate", "very_high", "extreme"],
         translation_key="uv_index",
         icon="mdi:sun-wireless",
     ),

--- a/homeassistant/components/tomorrowio/sensor.py
+++ b/homeassistant/components/tomorrowio/sensor.py
@@ -95,6 +95,10 @@ class TomorrowioSensorEntityDescription(SensorEntityDescription):
                 "they must both be None"
             )
 
+        if self.value_map is not None:
+            self.device_class = SensorDeviceClass.ENUM
+            self.options = [item.name.lower() for item in self.value_map]
+
 
 # From https://cfpub.epa.gov/ncer_abstracts/index.cfm/fuseaction/display.files/fileID/14285
 # x ug/m^3 = y ppb * molecular weight / 24.45
@@ -176,8 +180,6 @@ SENSOR_TYPES = (
         key=TMRW_ATTR_PRECIPITATION_TYPE,
         name="Precipitation Type",
         value_map=PrecipitationType,
-        device_class=SensorDeviceClass.ENUM,
-        options=["freezing_rain", "ice_pellets", "none", "rain", "snow"],
         translation_key="precipitation_type",
         icon="mdi:weather-snowy-rainy",
     ),
@@ -237,20 +239,12 @@ SENSOR_TYPES = (
         key=TMRW_ATTR_EPA_PRIMARY_POLLUTANT,
         name="US EPA Primary Pollutant",
         value_map=PrimaryPollutantType,
+        translation_key="primary_pollutant",
     ),
     TomorrowioSensorEntityDescription(
         key=TMRW_ATTR_EPA_HEALTH_CONCERN,
         name="US EPA Health Concern",
         value_map=HealthConcernType,
-        device_class=SensorDeviceClass.ENUM,
-        options=[
-            "good",
-            "hazardous",
-            "moderate",
-            "unhealthy_for_sensitive_groups",
-            "unhealthy",
-            "very_unhealthy",
-        ],
         translation_key="health_concern",
         icon="mdi:hospital",
     ),
@@ -263,20 +257,12 @@ SENSOR_TYPES = (
         key=TMRW_ATTR_CHINA_PRIMARY_POLLUTANT,
         name="China MEP Primary Pollutant",
         value_map=PrimaryPollutantType,
+        translation_key="primary_pollutant",
     ),
     TomorrowioSensorEntityDescription(
         key=TMRW_ATTR_CHINA_HEALTH_CONCERN,
         name="China MEP Health Concern",
         value_map=HealthConcernType,
-        device_class=SensorDeviceClass.ENUM,
-        options=[
-            "good",
-            "hazardous",
-            "moderate",
-            "unhealthy_for_sensitive_groups",
-            "unhealthy",
-            "very_unhealthy",
-        ],
         translation_key="health_concern",
         icon="mdi:hospital",
     ),
@@ -284,8 +270,6 @@ SENSOR_TYPES = (
         key=TMRW_ATTR_POLLEN_TREE,
         name="Tree Pollen Index",
         value_map=PollenIndex,
-        device_class=SensorDeviceClass.ENUM,
-        options=["high", "low", "medium", "none", "very_high", "very_low"],
         translation_key="pollen_index",
         icon="mdi:flower-pollen",
     ),
@@ -293,8 +277,6 @@ SENSOR_TYPES = (
         key=TMRW_ATTR_POLLEN_WEED,
         name="Weed Pollen Index",
         value_map=PollenIndex,
-        device_class=SensorDeviceClass.ENUM,
-        options=["high", "low", "medium", "none", "very_high", "very_low"],
         translation_key="pollen_index",
         icon="mdi:flower-pollen",
     ),
@@ -302,8 +284,6 @@ SENSOR_TYPES = (
         key=TMRW_ATTR_POLLEN_GRASS,
         name="Grass Pollen Index",
         value_map=PollenIndex,
-        device_class=SensorDeviceClass.ENUM,
-        options=["high", "low", "medium", "none", "very_high", "very_low"],
         translation_key="pollen_index",
         icon="mdi:flower-pollen",
     ),

--- a/homeassistant/components/tomorrowio/strings.json
+++ b/homeassistant/components/tomorrowio/strings.json
@@ -64,12 +64,12 @@
       },
       "primary_pollutant": {
         "state": {
-          "pm25": "Particulate Matter < 2.5 μm",
-          "pm10": "Particulate Matter < 10 μm",
-          "o3": "Ozone",
-          "no2": "Nitrogen Dioxide",
-          "co": "Carbon Monoxide",
-          "so2": "Sulphur Dioxide"
+          "pm25": "[%key:component::sensor::entity_component::pm25::name%]",
+          "pm10": "[%key:component::sensor::entity_component::pm10::name%]",
+          "o3": "[%key:component::sensor::entity_component::ozone::name%]",
+          "no2": "[%key:component::sensor::entity_component::nitrogen_dioxide::name%]",
+          "co": "[%key:component::sensor::entity_component::carbon_monoxide::name%]",
+          "so2": "[%key:component::sensor::entity_component::sulphur_dioxide::name%]"
         }
       },
       "uv_index": {

--- a/homeassistant/components/tomorrowio/strings.json
+++ b/homeassistant/components/tomorrowio/strings.json
@@ -62,6 +62,16 @@
           "ice_pellets": "Ice Pellets"
         }
       },
+      "primary_pollutant": {
+        "state": {
+          "pm25": "Particulate Matter < 2.5 μm",
+          "pm10": "Particulate Matter < 10 μm",
+          "o3": "Ozone",
+          "no2": "Nitrogen Dioxide",
+          "co": "Carbon Monoxide",
+          "so2": "Sulphur Dioxide"
+        }
+      },
       "uv_index": {
         "state": {
           "low": "Low",


### PR DESCRIPTION
## Proposed change
Adds state translations for primary pollutant. Also assigns the enum device class to sensors dynamically as well as the valid options for the enum


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
