### PR TITLE
Fix SmartThings Cover Set Position (for window shades)

### DIFF
--- a/homeassistant/components/smartthings/manifest.json
+++ b/homeassistant/components/smartthings/manifest.json
@@ -30,5 +30,5 @@
   "documentation": "https://www.home-assistant.io/integrations/smartthings",
   "iot_class": "cloud_push",
   "loggers": ["httpsig", "pysmartapp", "pysmartthings"],
-  "requirements": ["pysmartapp==0.3.3", "pysmartthings==0.7.6"]
+  "requirements": ["pysmartapp==0.3.5", "pysmartthings==0.7.8"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2006,10 +2006,10 @@ pysma==0.7.3
 pysmappee==0.2.29
 
 # homeassistant.components.smartthings
-pysmartapp==0.3.3
+pysmartapp==0.3.5
 
 # homeassistant.components.smartthings
-pysmartthings==0.7.6
+pysmartthings==0.7.8
 
 # homeassistant.components.edl21
 pysml==0.0.12

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1492,10 +1492,10 @@ pysma==0.7.3
 pysmappee==0.2.29
 
 # homeassistant.components.smartthings
-pysmartapp==0.3.3
+pysmartapp==0.3.5
 
 # homeassistant.components.smartthings
-pysmartthings==0.7.6
+pysmartthings==0.7.8
 
 # homeassistant.components.edl21
 pysml==0.0.12

--- a/tests/components/smartthings/test_cover.py
+++ b/tests/components/smartthings/test_cover.py
@@ -113,13 +113,46 @@ async def test_close(hass: HomeAssistant, device_factory) -> None:
         assert state.state == STATE_CLOSING
 
 
-async def test_set_cover_position(hass: HomeAssistant, device_factory) -> None:
-    """Test the cover sets to the specific position."""
+async def test_set_cover_position_switch_level(
+    hass: HomeAssistant, device_factory
+) -> None:
+    """Test the cover sets to the specific position for legacy devices that use Capability.switch_level."""
     # Arrange
     device = device_factory(
         "Shade",
         [Capability.window_shade, Capability.battery, Capability.switch_level],
         {Attribute.window_shade: "opening", Attribute.battery: 95, Attribute.level: 10},
+    )
+    await setup_platform(hass, COVER_DOMAIN, devices=[device])
+    # Act
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_SET_COVER_POSITION,
+        {ATTR_POSITION: 50, "entity_id": "all"},
+        blocking=True,
+    )
+
+    state = hass.states.get("cover.shade")
+    # Result of call does not update state
+    assert state.state == STATE_OPENING
+    assert state.attributes[ATTR_BATTERY_LEVEL] == 95
+    assert state.attributes[ATTR_CURRENT_POSITION] == 10
+    # Ensure API called
+
+    assert device._api.post_device_command.call_count == 1  # type: ignore
+
+
+async def test_set_cover_position(hass: HomeAssistant, device_factory) -> None:
+    """Test the cover sets to the specific position."""
+    # Arrange
+    device = device_factory(
+        "Shade",
+        [Capability.window_shade, Capability.battery, Capability.window_shade_level],
+        {
+            Attribute.window_shade: "opening",
+            Attribute.battery: 95,
+            Attribute.shade_level: 10,
+        },
     )
     await setup_platform(hass, COVER_DOMAIN, devices=[device])
     # Act


### PR DESCRIPTION
## Proposed change
Restores the ability to set the cover position for SmartThings window shades.

## Type of change
- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
SmartThings Edge Drivers now utilize the capability `windowShadeLevel` to represent the position of shades. As users are being migrated over to these new drivers, those that relied on the former `switchLevel` capability lost the ability in HA to set the position of their window shades. This PR adds support for the new capability while maintaining backward compabilility for `switchLevel`. Underlying library updates were required:
* pysmartthings: https://github.com/andrewsayre/pysmartthings/releases/tag/0.7.8
* pysmartapp: https://github.com/andrewsayre/pysmartapp/releases/tag/0.3.5

- This PR fixes or closes issue: fixes #88370
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/28218

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository] 

If the code communicates with devices, web services, or third-party tools:

- [] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
