### PR TITLE
Airvisual Pro Outside Station Support

### DIFF
--- a/homeassistant/components/airvisual_pro/__init__.py
+++ b/homeassistant/components/airvisual_pro/__init__.py
@@ -60,6 +60,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         """Get data from the device."""
         try:
             data = await node.async_get_latest_measurements()
+            # If an outdoor sensor use the history to get its values.
+            # Without an outdoor sensor there's no point in pulling history.
+            data['history'] = {}
+            if data['settings'].get("follow_mode") == "device":
+                history = await node.async_get_history(include_trends=False)
+                data['history'] = history.get('measurements', [])[-1]
         except InvalidAuthenticationError as err:
             raise ConfigEntryAuthFailed("Invalid Samba password") from err
         except NodeConnectionError as err:

--- a/homeassistant/components/airvisual_pro/__init__.py
+++ b/homeassistant/components/airvisual_pro/__init__.py
@@ -60,10 +60,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         """Get data from the device."""
         try:
             data = await node.async_get_latest_measurements()
-            data['history'] = {}
-            if data['settings'].get("follow_mode") == "device":
+            data["history"] = {}
+            if data["settings"].get("follow_mode") == "device":
                 history = await node.async_get_history(include_trends=False)
-                data['history'] = history.get('measurements', [])[-1]
+                data["history"] = history.get("measurements", [])[-1]
         except InvalidAuthenticationError as err:
             raise ConfigEntryAuthFailed("Invalid Samba password") from err
         except NodeConnectionError as err:

--- a/homeassistant/components/airvisual_pro/__init__.py
+++ b/homeassistant/components/airvisual_pro/__init__.py
@@ -60,8 +60,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         """Get data from the device."""
         try:
             data = await node.async_get_latest_measurements()
-            # If an outdoor sensor use the history to get its values.
-            # Without an outdoor sensor there's no point in pulling history.
             data['history'] = {}
             if data['settings'].get("follow_mode") == "device":
                 history = await node.async_get_history(include_trends=False)

--- a/homeassistant/components/airvisual_pro/sensor.py
+++ b/homeassistant/components/airvisual_pro/sensor.py
@@ -30,7 +30,9 @@ from .const import DOMAIN
 class AirVisualProMeasurementKeyMixin:
     """Define an entity description mixin to include a measurement key."""
 
-    value_fn: Callable[[dict[str, Any], dict[str, Any], dict[str, Any]], float | int]
+    value_fn: Callable[
+        [dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any]], float | int
+    ]
 
 
 @dataclass
@@ -53,9 +55,12 @@ SENSOR_DESCRIPTIONS = (
         key="outdoor_air_quality_index",
         device_class=SensorDeviceClass.AQI,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda settings, status, measurements, history: history.get(
-            f'Outdoor {"AQI(US)" if settings["is_aqi_usa"] else "AQI(CN)"}'
+        value_fn=lambda settings, status, measurements, history: int(
+            history.get(
+                f'Outdoor {"AQI(US)" if settings["is_aqi_usa"] else "AQI(CN)"}', -1
+            )
         ),
+        translation_key="outdoor_air_quality_index",
     ),
     AirVisualProMeasurementDescription(
         key="battery_level",
@@ -75,7 +80,9 @@ SENSOR_DESCRIPTIONS = (
         key="humidity",
         device_class=SensorDeviceClass.HUMIDITY,
         native_unit_of_measurement=PERCENTAGE,
-        value_fn=lambda settings, status, measurements, history: measurements["humidity"],
+        value_fn=lambda settings, status, measurements, history: measurements[
+            "humidity"
+        ],
     ),
     AirVisualProMeasurementDescription(
         key="particulate_matter_0_1",
@@ -105,7 +112,9 @@ SENSOR_DESCRIPTIONS = (
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda settings, status, measurements, history: measurements["temperature_C"],
+        value_fn=lambda settings, status, measurements, history: measurements[
+            "temperature_C"
+        ],
     ),
     AirVisualProMeasurementDescription(
         key="voc",

--- a/homeassistant/components/airvisual_pro/sensor.py
+++ b/homeassistant/components/airvisual_pro/sensor.py
@@ -54,7 +54,7 @@ SENSOR_DESCRIPTIONS = (
         device_class=SensorDeviceClass.AQI,
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda settings, status, measurements, history: history.get(
-            f'Outdoor {"AQI(US)" if settings["is_aqi_usa"] else "AQI(CN)"}', None
+            f'Outdoor {"AQI(US)" if settings["is_aqi_usa"] else "AQI(CN)"}'
         ),
     ),
     AirVisualProMeasurementDescription(

--- a/homeassistant/components/airvisual_pro/sensor.py
+++ b/homeassistant/components/airvisual_pro/sensor.py
@@ -45,29 +45,37 @@ SENSOR_DESCRIPTIONS = (
         key="air_quality_index",
         device_class=SensorDeviceClass.AQI,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda settings, status, measurements: measurements[
+        value_fn=lambda settings, status, measurements, history: measurements[
             async_get_aqi_locale(settings)
         ],
+    ),
+    AirVisualProMeasurementDescription(
+        key="outdoor_air_quality_index",
+        device_class=SensorDeviceClass.AQI,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda settings, status, measurements, history: history.get(
+            f'Outdoor {"AQI(US)" if settings["is_aqi_usa"] else "AQI(CN)"}', None
+        ),
     ),
     AirVisualProMeasurementDescription(
         key="battery_level",
         device_class=SensorDeviceClass.BATTERY,
         entity_category=EntityCategory.DIAGNOSTIC,
         native_unit_of_measurement=PERCENTAGE,
-        value_fn=lambda settings, status, measurements: status["battery"],
+        value_fn=lambda settings, status, measurements, history: status["battery"],
     ),
     AirVisualProMeasurementDescription(
         key="carbon_dioxide",
         device_class=SensorDeviceClass.CO2,
         native_unit_of_measurement=CONCENTRATION_PARTS_PER_MILLION,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda settings, status, measurements: measurements["co2"],
+        value_fn=lambda settings, status, measurements, history: measurements["co2"],
     ),
     AirVisualProMeasurementDescription(
         key="humidity",
         device_class=SensorDeviceClass.HUMIDITY,
         native_unit_of_measurement=PERCENTAGE,
-        value_fn=lambda settings, status, measurements: measurements["humidity"],
+        value_fn=lambda settings, status, measurements, history: measurements["humidity"],
     ),
     AirVisualProMeasurementDescription(
         key="particulate_matter_0_1",
@@ -75,7 +83,7 @@ SENSOR_DESCRIPTIONS = (
         device_class=SensorDeviceClass.PM1,
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda settings, status, measurements: measurements["pm0_1"],
+        value_fn=lambda settings, status, measurements, history: measurements["pm0_1"],
     ),
     AirVisualProMeasurementDescription(
         key="particulate_matter_1_0",
@@ -83,28 +91,28 @@ SENSOR_DESCRIPTIONS = (
         device_class=SensorDeviceClass.PM10,
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda settings, status, measurements: measurements["pm1_0"],
+        value_fn=lambda settings, status, measurements, history: measurements["pm1_0"],
     ),
     AirVisualProMeasurementDescription(
         key="particulate_matter_2_5",
         device_class=SensorDeviceClass.PM25,
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda settings, status, measurements: measurements["pm2_5"],
+        value_fn=lambda settings, status, measurements, history: measurements["pm2_5"],
     ),
     AirVisualProMeasurementDescription(
         key="temperature",
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda settings, status, measurements: measurements["temperature_C"],
+        value_fn=lambda settings, status, measurements, history: measurements["temperature_C"],
     ),
     AirVisualProMeasurementDescription(
         key="voc",
         device_class=SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS,
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda settings, status, measurements: measurements["voc"],
+        value_fn=lambda settings, status, measurements, history: measurements["voc"],
     ),
 )
 
@@ -143,4 +151,5 @@ class AirVisualProSensor(AirVisualProEntity, SensorEntity):
             self.coordinator.data["settings"],
             self.coordinator.data["status"],
             self.coordinator.data["measurements"],
+            self.coordinator.data["history"],
         )

--- a/homeassistant/components/airvisual_pro/strings.json
+++ b/homeassistant/components/airvisual_pro/strings.json
@@ -24,5 +24,12 @@
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     }
+  },
+  "entity": {
+    "sensor": {
+      "outdoor_air_quality_index": {
+        "name": "Outdoor Air Quality Index"
+      }
+    }
   }
 }

--- a/homeassistant/components/airvisual_pro/strings.json
+++ b/homeassistant/components/airvisual_pro/strings.json
@@ -28,7 +28,7 @@
   "entity": {
     "sensor": {
       "outdoor_air_quality_index": {
-        "name": "Outdoor Air Quality Index"
+        "name": "Outdoor air quality index"
       }
     }
   }

--- a/tests/components/airvisual_pro/test_diagnostics.py
+++ b/tests/components/airvisual_pro/test_diagnostics.py
@@ -33,6 +33,7 @@ async def test_entry_diagnostics(
                 "time": "16:00:44",
                 "timestamp": "1665072044",
             },
+            "history": {},
             "measurements": {
                 "co2": "472",
                 "humidity": "57",


### PR DESCRIPTION
The AirVisual Pro indoor sensor can be paired with an outside device on the same network. When paired the AIQ score from the outside device is included with the history.

This PR checks the settings to see if the follow mode is "device" instead of "station", which signifies that an external outside sensor is attached. If it detects an outside sensor it pulls the most recent history file to pull the sensor data.


<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: None needed

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

Existing tests cover this.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

No user changes.

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

No new files, changes, or dependencies.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
