### PR TITLE
Fully unload wemo config entry

### DIFF
--- a/homeassistant/components/wemo/__init__.py
+++ b/homeassistant/components/wemo/__init__.py
@@ -19,7 +19,7 @@ from homeassistant.helpers.typing import ConfigType
 from homeassistant.util.async_ import gather_with_concurrency
 
 from .const import DOMAIN
-from .models import WemoConfigEntryData, WemoData, _async_wemo_data
+from .models import WemoConfigEntryData, WemoData, async_wemo_data
 from .wemo_device import DeviceCoordinator, async_register_device
 
 # Max number of devices to initialize at once. This limit is in place to
@@ -116,7 +116,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up a wemo config entry."""
-    wemo_data = _async_wemo_data(hass)
+    wemo_data = async_wemo_data(hass)
     dispatcher = WemoDispatcher(entry)
     discovery = WemoDiscovery(hass, dispatcher, wemo_data.static_config)
     wemo_data.config_entry_data = WemoConfigEntryData(
@@ -137,7 +137,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a wemo config entry."""
     _LOGGER.debug("Unloading WeMo")
-    wemo_data = _async_wemo_data(hass)
+    wemo_data = async_wemo_data(hass)
 
     wemo_data.config_entry_data.discovery.async_stop_discovery()
 
@@ -156,8 +156,8 @@ async def async_wemo_dispatcher_connect(
     module = dispatch.__module__  # Example: "homeassistant.components.wemo.switch"
     platform = Platform(module.rsplit(".", 1)[1])
 
-    config_entry_data = _async_wemo_data(hass).config_entry_data
-    await config_entry_data.dispatcher.async_connect_platform(platform, dispatch)
+    dispatcher = async_wemo_data(hass).config_entry_data.dispatcher
+    await dispatcher.async_connect_platform(platform, dispatch)
 
 
 class WemoDispatcher:

--- a/homeassistant/components/wemo/binary_sensor.py
+++ b/homeassistant/components/wemo/binary_sensor.py
@@ -1,22 +1,20 @@
 """Support for WeMo binary sensors."""
-import asyncio
 
 from pywemo import Insight, Maker, StandbyState
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN as WEMO_DOMAIN
+from . import async_wemo_dispatcher_connect
 from .entity import WemoBinaryStateEntity, WemoEntity
 from .wemo_device import DeviceCoordinator
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    unused_config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up WeMo binary sensors."""
@@ -30,16 +28,7 @@ async def async_setup_entry(
         else:
             async_add_entities([WemoBinarySensor(coordinator)])
 
-    config_entry.async_on_unload(
-        async_dispatcher_connect(hass, f"{WEMO_DOMAIN}.binary_sensor", _discovered_wemo)
-    )
-
-    await asyncio.gather(
-        *(
-            _discovered_wemo(coordinator)
-            for coordinator in hass.data[WEMO_DOMAIN]["pending"].pop("binary_sensor")
-        )
-    )
+    await async_wemo_dispatcher_connect(hass, _discovered_wemo)
 
 
 class WemoBinarySensor(WemoBinaryStateEntity, BinarySensorEntity):

--- a/homeassistant/components/wemo/binary_sensor.py
+++ b/homeassistant/components/wemo/binary_sensor.py
@@ -30,7 +30,9 @@ async def async_setup_entry(
         else:
             async_add_entities([WemoBinarySensor(coordinator)])
 
-    async_dispatcher_connect(hass, f"{WEMO_DOMAIN}.binary_sensor", _discovered_wemo)
+    config_entry.async_on_unload(
+        async_dispatcher_connect(hass, f"{WEMO_DOMAIN}.binary_sensor", _discovered_wemo)
+    )
 
     await asyncio.gather(
         *(

--- a/homeassistant/components/wemo/binary_sensor.py
+++ b/homeassistant/components/wemo/binary_sensor.py
@@ -14,7 +14,7 @@ from .wemo_device import DeviceCoordinator
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    unused_config_entry: ConfigEntry,
+    _config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up WeMo binary sensors."""

--- a/homeassistant/components/wemo/fan.py
+++ b/homeassistant/components/wemo/fan.py
@@ -59,7 +59,9 @@ async def async_setup_entry(
         """Handle a discovered Wemo device."""
         async_add_entities([WemoHumidifier(coordinator)])
 
-    async_dispatcher_connect(hass, f"{WEMO_DOMAIN}.fan", _discovered_wemo)
+    config_entry.async_on_unload(
+        async_dispatcher_connect(hass, f"{WEMO_DOMAIN}.fan", _discovered_wemo)
+    )
 
     await asyncio.gather(
         *(

--- a/homeassistant/components/wemo/fan.py
+++ b/homeassistant/components/wemo/fan.py
@@ -1,7 +1,6 @@
 """Support for WeMo humidifier."""
 from __future__ import annotations
 
-import asyncio
 from datetime import timedelta
 import math
 from typing import Any
@@ -13,7 +12,6 @@ from homeassistant.components.fan import FanEntity, FanEntityFeature
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_platform
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util.percentage import (
     int_states_in_range,
@@ -21,8 +19,8 @@ from homeassistant.util.percentage import (
     ranged_value_to_percentage,
 )
 
+from . import async_wemo_dispatcher_connect
 from .const import (
-    DOMAIN as WEMO_DOMAIN,
     SERVICE_RESET_FILTER_LIFE,
     SERVICE_SET_HUMIDITY,
 )
@@ -50,7 +48,7 @@ SET_HUMIDITY_SCHEMA = {
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    unused_config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up WeMo binary sensors."""
@@ -59,16 +57,7 @@ async def async_setup_entry(
         """Handle a discovered Wemo device."""
         async_add_entities([WemoHumidifier(coordinator)])
 
-    config_entry.async_on_unload(
-        async_dispatcher_connect(hass, f"{WEMO_DOMAIN}.fan", _discovered_wemo)
-    )
-
-    await asyncio.gather(
-        *(
-            _discovered_wemo(coordinator)
-            for coordinator in hass.data[WEMO_DOMAIN]["pending"].pop("fan")
-        )
-    )
+    await async_wemo_dispatcher_connect(hass, _discovered_wemo)
 
     platform = entity_platform.async_get_current_platform()
 

--- a/homeassistant/components/wemo/fan.py
+++ b/homeassistant/components/wemo/fan.py
@@ -48,7 +48,7 @@ SET_HUMIDITY_SCHEMA = {
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    unused_config_entry: ConfigEntry,
+    _config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up WeMo binary sensors."""

--- a/homeassistant/components/wemo/light.py
+++ b/homeassistant/components/wemo/light.py
@@ -1,7 +1,6 @@
 """Support for Belkin WeMo lights."""
 from __future__ import annotations
 
-import asyncio
 from typing import Any, cast
 
 from pywemo import Bridge, BridgeLight, Dimmer
@@ -18,11 +17,11 @@ from homeassistant.components.light import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import CONNECTION_ZIGBEE
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 import homeassistant.util.color as color_util
 
+from . import async_wemo_dispatcher_connect
 from .const import DOMAIN as WEMO_DOMAIN
 from .entity import WemoBinaryStateEntity, WemoEntity
 from .wemo_device import DeviceCoordinator
@@ -45,16 +44,7 @@ async def async_setup_entry(
         else:
             async_add_entities([WemoDimmer(coordinator)])
 
-    config_entry.async_on_unload(
-        async_dispatcher_connect(hass, f"{WEMO_DOMAIN}.light", _discovered_wemo)
-    )
-
-    await asyncio.gather(
-        *(
-            _discovered_wemo(coordinator)
-            for coordinator in hass.data[WEMO_DOMAIN]["pending"].pop("light")
-        )
-    )
+    await async_wemo_dispatcher_connect(hass, _discovered_wemo)
 
 
 @callback

--- a/homeassistant/components/wemo/light.py
+++ b/homeassistant/components/wemo/light.py
@@ -45,7 +45,9 @@ async def async_setup_entry(
         else:
             async_add_entities([WemoDimmer(coordinator)])
 
-    async_dispatcher_connect(hass, f"{WEMO_DOMAIN}.light", _discovered_wemo)
+    config_entry.async_on_unload(
+        async_dispatcher_connect(hass, f"{WEMO_DOMAIN}.light", _discovered_wemo)
+    )
 
     await asyncio.gather(
         *(

--- a/homeassistant/components/wemo/models.py
+++ b/homeassistant/components/wemo/models.py
@@ -38,5 +38,6 @@ class WemoData:
 
 
 @callback
-def _async_wemo_data(hass: HomeAssistant) -> WemoData:
+def async_wemo_data(hass: HomeAssistant) -> WemoData:
+    """Fetch WemoData with proper typing."""
     return cast(WemoData, hass.data[DOMAIN])

--- a/homeassistant/components/wemo/models.py
+++ b/homeassistant/components/wemo/models.py
@@ -8,7 +8,7 @@ import pywemo
 
 from homeassistant.core import HomeAssistant, callback
 
-from . import DOMAIN
+from .const import DOMAIN
 
 if TYPE_CHECKING:  # Avoid circular dependencies.
     from . import HostPortTuple, WemoDiscovery, WemoDispatcher

--- a/homeassistant/components/wemo/models.py
+++ b/homeassistant/components/wemo/models.py
@@ -1,0 +1,42 @@
+"""Common data structures and helpers for accessing them."""
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, cast
+
+import pywemo
+
+from homeassistant.core import HomeAssistant, callback
+
+from . import DOMAIN
+
+if TYPE_CHECKING:  # Avoid circular dependencies.
+    from . import HostPortTuple, WemoDiscovery, WemoDispatcher
+    from .wemo_device import DeviceCoordinator
+
+
+@dataclass
+class WemoConfigEntryData:
+    """Config entry state data."""
+
+    device_coordinators: dict[str, "DeviceCoordinator"]
+    discovery: "WemoDiscovery"
+    dispatcher: "WemoDispatcher"
+
+
+@dataclass
+class WemoData:
+    """Component state data."""
+
+    discovery_enabled: bool
+    static_config: Sequence["HostPortTuple"]
+    registry: pywemo.SubscriptionRegistry
+    # config_entry_data is set when the config entry is loaded and unset when it's
+    # unloaded. It's a programmer error if config_entry_data is accessed when the
+    # config entry is not loaded
+    config_entry_data: WemoConfigEntryData = None  # type: ignore[assignment]
+
+
+@callback
+def _async_wemo_data(hass: HomeAssistant) -> WemoData:
+    return cast(WemoData, hass.data[DOMAIN])

--- a/homeassistant/components/wemo/sensor.py
+++ b/homeassistant/components/wemo/sensor.py
@@ -57,7 +57,7 @@ ATTRIBUTE_SENSORS = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    unused_config_entry: ConfigEntry,
+    _config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up WeMo sensors."""

--- a/homeassistant/components/wemo/sensor.py
+++ b/homeassistant/components/wemo/sensor.py
@@ -1,7 +1,6 @@
 """Support for power sensors in WeMo Insight devices."""
 from __future__ import annotations
 
-import asyncio
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import cast
@@ -15,11 +14,10 @@ from homeassistant.components.sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfEnergy, UnitOfPower
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
-from .const import DOMAIN as WEMO_DOMAIN
+from . import async_wemo_dispatcher_connect
 from .entity import WemoEntity
 from .wemo_device import DeviceCoordinator
 
@@ -59,7 +57,7 @@ ATTRIBUTE_SENSORS = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    unused_config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up WeMo sensors."""
@@ -72,16 +70,7 @@ async def async_setup_entry(
             if hasattr(coordinator.wemo, description.key)
         )
 
-    config_entry.async_on_unload(
-        async_dispatcher_connect(hass, f"{WEMO_DOMAIN}.sensor", _discovered_wemo)
-    )
-
-    await asyncio.gather(
-        *(
-            _discovered_wemo(coordinator)
-            for coordinator in hass.data[WEMO_DOMAIN]["pending"].pop("sensor")
-        )
-    )
+    await async_wemo_dispatcher_connect(hass, _discovered_wemo)
 
 
 class AttributeSensor(WemoEntity, SensorEntity):

--- a/homeassistant/components/wemo/sensor.py
+++ b/homeassistant/components/wemo/sensor.py
@@ -72,7 +72,9 @@ async def async_setup_entry(
             if hasattr(coordinator.wemo, description.key)
         )
 
-    async_dispatcher_connect(hass, f"{WEMO_DOMAIN}.sensor", _discovered_wemo)
+    config_entry.async_on_unload(
+        async_dispatcher_connect(hass, f"{WEMO_DOMAIN}.sensor", _discovered_wemo)
+    )
 
     await asyncio.gather(
         *(

--- a/homeassistant/components/wemo/switch.py
+++ b/homeassistant/components/wemo/switch.py
@@ -34,7 +34,7 @@ MAKER_SWITCH_TOGGLE = "toggle"
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    unused_config_entry: ConfigEntry,
+    _config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up WeMo switches."""

--- a/homeassistant/components/wemo/switch.py
+++ b/homeassistant/components/wemo/switch.py
@@ -1,7 +1,6 @@
 """Support for WeMo switches."""
 from __future__ import annotations
 
-import asyncio
 from datetime import datetime, timedelta
 from typing import Any
 
@@ -11,10 +10,9 @@ from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_STANDBY, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN as WEMO_DOMAIN
+from . import async_wemo_dispatcher_connect
 from .entity import WemoBinaryStateEntity
 from .wemo_device import DeviceCoordinator
 
@@ -36,7 +34,7 @@ MAKER_SWITCH_TOGGLE = "toggle"
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    unused_config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up WeMo switches."""
@@ -45,16 +43,7 @@ async def async_setup_entry(
         """Handle a discovered Wemo device."""
         async_add_entities([WemoSwitch(coordinator)])
 
-    config_entry.async_on_unload(
-        async_dispatcher_connect(hass, f"{WEMO_DOMAIN}.switch", _discovered_wemo)
-    )
-
-    await asyncio.gather(
-        *(
-            _discovered_wemo(coordinator)
-            for coordinator in hass.data[WEMO_DOMAIN]["pending"].pop("switch")
-        )
-    )
+    await async_wemo_dispatcher_connect(hass, _discovered_wemo)
 
 
 class WemoSwitch(WemoBinaryStateEntity, SwitchEntity):

--- a/homeassistant/components/wemo/switch.py
+++ b/homeassistant/components/wemo/switch.py
@@ -45,7 +45,9 @@ async def async_setup_entry(
         """Handle a discovered Wemo device."""
         async_add_entities([WemoSwitch(coordinator)])
 
-    async_dispatcher_connect(hass, f"{WEMO_DOMAIN}.switch", _discovered_wemo)
+    config_entry.async_on_unload(
+        async_dispatcher_connect(hass, f"{WEMO_DOMAIN}.switch", _discovered_wemo)
+    )
 
     await asyncio.gather(
         *(

--- a/homeassistant/components/wemo/wemo_device.py
+++ b/homeassistant/components/wemo/wemo_device.py
@@ -30,6 +30,7 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN, WEMO_SUBSCRIPTION_EVENT
+from .models import _async_wemo_data
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -290,13 +291,9 @@ def async_get_coordinator(hass: HomeAssistant, device_id: str) -> DeviceCoordina
 
 @callback
 def _async_coordinators(hass: HomeAssistant) -> dict[str, DeviceCoordinator]:
-    coordinators = hass.data[DOMAIN].config_entry_data.device_coordinators
-    assert isinstance(coordinators, dict)
-    return coordinators
+    return _async_wemo_data(hass).config_entry_data.device_coordinators
 
 
 @callback
 def _async_registry(hass: HomeAssistant) -> SubscriptionRegistry:
-    registry = hass.data[DOMAIN].registry
-    assert isinstance(registry, SubscriptionRegistry)
-    return registry
+    return _async_wemo_data(hass).registry

--- a/homeassistant/components/wemo/wemo_device.py
+++ b/homeassistant/components/wemo/wemo_device.py
@@ -30,7 +30,7 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN, WEMO_SUBSCRIPTION_EVENT
-from .models import _async_wemo_data
+from .models import async_wemo_data
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -291,9 +291,9 @@ def async_get_coordinator(hass: HomeAssistant, device_id: str) -> DeviceCoordina
 
 @callback
 def _async_coordinators(hass: HomeAssistant) -> dict[str, DeviceCoordinator]:
-    return _async_wemo_data(hass).config_entry_data.device_coordinators
+    return async_wemo_data(hass).config_entry_data.device_coordinators
 
 
 @callback
 def _async_registry(hass: HomeAssistant) -> SubscriptionRegistry:
-    return _async_wemo_data(hass).registry
+    return async_wemo_data(hass).registry

--- a/homeassistant/components/wemo/wemo_device.py
+++ b/homeassistant/components/wemo/wemo_device.py
@@ -128,8 +128,7 @@ class DeviceCoordinator(DataUpdateCoordinator[None]):
         """Unregister push subscriptions and remove from coordinators dict."""
         await super().async_shutdown()
         del _async_coordinators(self.hass)[self.device_id]
-        if not self.options:
-            return
+        assert self.options  # Always set by async_register_device.
         if self.options.enable_subscription:
             await self._async_set_enable_subscription(False)
         # Check that the device is available (last_update_success) before disabling long

--- a/homeassistant/components/wemo/wemo_device.py
+++ b/homeassistant/components/wemo/wemo_device.py
@@ -9,7 +9,7 @@ from typing import Literal
 
 from pywemo import Insight, LongPressMixin, WeMoDevice
 from pywemo.exceptions import ActionException, PyWeMoException
-from pywemo.subscribe import EVENT_TYPE_LONG_PRESS
+from pywemo.subscribe import EVENT_TYPE_LONG_PRESS, SubscriptionRegistry
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -124,9 +124,22 @@ class DeviceCoordinator(DataUpdateCoordinator[None]):
             updated = self.wemo.subscription_update(event_type, params)
             self.hass.create_task(self._async_subscription_callback(updated))
 
+    async def async_shutdown(self) -> None:
+        """Unregister push subscriptions and remove from coordinators dict."""
+        await super().async_shutdown()
+        del _async_coordinators(self.hass)[self.device_id]
+        if not self.options:
+            return
+        if self.options.enable_subscription:
+            await self._async_set_enable_subscription(False)
+        # Check that the device is available (last_update_success) before disabling long
+        # press. That avoids long shutdown times for devices that are no longer connected.
+        if self.options.enable_long_press and self.last_update_success:
+            await self._async_set_enable_long_press(False)
+
     async def _async_set_enable_subscription(self, enable_subscription: bool) -> None:
         """Turn on/off push updates from the device."""
-        registry = self.hass.data[DOMAIN]["registry"]
+        registry = _async_registry(self.hass)
         if enable_subscription:
             registry.on(self.wemo, None, self.subscription_callback)
             await self.hass.async_add_executor_job(registry.register, self.wemo)
@@ -199,8 +212,10 @@ class DeviceCoordinator(DataUpdateCoordinator[None]):
             # this case so the Sensor entities are properly populated.
             return True
 
-        registry = self.hass.data[DOMAIN]["registry"]
-        return not (registry.is_subscribed(self.wemo) and self.last_update_success)
+        return not (
+            _async_registry(self.hass).is_subscribed(self.wemo)
+            and self.last_update_success
+        )
 
     async def _async_update_data(self) -> None:
         """Update WeMo state."""
@@ -258,7 +273,7 @@ async def async_register_device(
     )
 
     device = DeviceCoordinator(hass, wemo, entry.id)
-    hass.data[DOMAIN].setdefault("devices", {})[entry.id] = device
+    _async_coordinators(hass)[entry.id] = device
 
     config_entry.async_on_unload(
         config_entry.add_update_listener(device.async_set_options)
@@ -271,5 +286,18 @@ async def async_register_device(
 @callback
 def async_get_coordinator(hass: HomeAssistant, device_id: str) -> DeviceCoordinator:
     """Return DeviceCoordinator for device_id."""
-    coordinator: DeviceCoordinator = hass.data[DOMAIN]["devices"][device_id]
-    return coordinator
+    return _async_coordinators(hass)[device_id]
+
+
+@callback
+def _async_coordinators(hass: HomeAssistant) -> dict[str, DeviceCoordinator]:
+    coordinators = hass.data[DOMAIN].config_entry_data.device_coordinators
+    assert isinstance(coordinators, dict)
+    return coordinators
+
+
+@callback
+def _async_registry(hass: HomeAssistant) -> SubscriptionRegistry:
+    registry = hass.data[DOMAIN].registry
+    assert isinstance(registry, SubscriptionRegistry)
+    return registry

--- a/tests/components/wemo/conftest.py
+++ b/tests/components/wemo/conftest.py
@@ -1,5 +1,4 @@
 """Fixtures for pywemo."""
-import asyncio
 import contextlib
 from unittest.mock import create_autospec, patch
 
@@ -33,11 +32,9 @@ async def async_pywemo_registry_fixture():
     registry = create_autospec(pywemo.SubscriptionRegistry, instance=True)
 
     registry.callbacks = {}
-    registry.semaphore = asyncio.Semaphore(value=0)
 
     def on_func(device, type_filter, callback):
         registry.callbacks[device.name] = callback
-        registry.semaphore.release()
 
     registry.on.side_effect = on_func
     registry.is_subscribed.return_value = False

--- a/tests/components/wemo/test_init.py
+++ b/tests/components/wemo/test_init.py
@@ -119,8 +119,6 @@ async def test_reload_config_entry(
 
     async def _async_test_entry_and_entity() -> tuple[str, str]:
         await hass.async_block_till_done()
-        entries = hass.config_entries.async_entries(DOMAIN)
-        assert len(entries) == 1
 
         pywemo_device.get_state.assert_called()
         pywemo_device.reset_mock()
@@ -135,14 +133,19 @@ async def test_reload_config_entry(
             hass, entity_entries[0], SWITCH_DOMAIN
         )
 
+        entries = hass.config_entries.async_entries(DOMAIN)
+        assert len(entries) == 1
+
         return entries[0].entry_id, entity_entries[0].entity_id
 
-    pywemo_registry.unregister.assert_not_called()
     entry_id, entity_id = await _async_test_entry_and_entity()
+    pywemo_registry.unregister.assert_not_called()
+
     assert await hass.config_entries.async_reload(entry_id)
+
     ids = await _async_test_entry_and_entity()
-    assert ids == (entry_id, entity_id)
     pywemo_registry.unregister.assert_called_once_with(pywemo_device)
+    assert ids == (entry_id, entity_id)
 
 
 async def test_static_config_with_invalid_host(hass: HomeAssistant) -> None:

--- a/tests/components/wemo/test_init.py
+++ b/tests/components/wemo/test_init.py
@@ -121,7 +121,7 @@ async def test_reload_config_entry(
         await hass.async_block_till_done()
 
         pywemo_device.get_state.assert_called()
-        pywemo_device.reset_mock()
+        pywemo_device.get_state.reset_mock()
 
         pywemo_registry.register.assert_called_once_with(pywemo_device)
         pywemo_registry.register.reset_mock()

--- a/tests/components/wemo/test_init.py
+++ b/tests/components/wemo/test_init.py
@@ -92,6 +92,24 @@ async def test_static_config_without_port(hass: HomeAssistant, pywemo_device) ->
     assert len(entity_entries) == 1
 
 
+async def test_reload_config_entry(hass: HomeAssistant, pywemo_device) -> None:
+    """Config entry can be reloaded without errors."""
+    assert await async_setup_component(
+        hass,
+        DOMAIN,
+        {
+            DOMAIN: {
+                CONF_DISCOVERY: False,
+                CONF_STATIC: [MOCK_HOST],
+            },
+        },
+    )
+    await hass.async_block_till_done()
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+    assert await hass.config_entries.async_reload(entries[0].entry_id)
+
+
 async def test_static_config_with_invalid_host(hass: HomeAssistant) -> None:
     """Component setup fails if a static host is invalid."""
     setup_success = await async_setup_component(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The wemo component has never properly implemented support for reloading its config entry. When users reload the integration, they get the following error:

```
Logger: homeassistant.config_entries
Source: components/wemo/__init__.py:102
First occurred: 12:17:37 PM (3 occurrences)
Last logged: 3:11:57 PM

Error setting up entry Wemo for wemo
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 390, in async_setup
    result = await component.async_setup_entry(hass, self)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/wemo/__init__.py", line 102, in async_setup_entry
    config = hass.data[DOMAIN].pop("config")
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'config'
```

This PR resolves that error and implements the ability to unload and then re-setup the component.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #96174
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
