### PR TITLE
Avoid multiple options and current_option lookups in select entites

### DIFF
--- a/homeassistant/components/select/__init__.py
+++ b/homeassistant/components/select/__init__.py
@@ -210,21 +210,24 @@ class SelectEntity(Entity):
     async def _async_offset_index(self, offset: int, cycle: bool) -> None:
         """Offset current index."""
         current_index = 0
-        if self.current_option is not None and self.current_option in self.options:
-            current_index = self.options.index(self.current_option)
+        current_option = self.current_option
+        options = self.options
+        if current_option is not None and current_option in self.options:
+            current_index = self.options.index(current_option)
 
         new_index = current_index + offset
         if cycle:
-            new_index = new_index % len(self.options)
+            new_index = new_index % len(options)
         elif new_index < 0:
             new_index = 0
-        elif new_index >= len(self.options):
-            new_index = len(self.options) - 1
+        elif new_index >= len(options):
+            new_index = len(options) - 1
 
-        await self.async_select_option(self.options[new_index])
+        await self.async_select_option(options[new_index])
 
     @final
     async def _async_select_index(self, idx: int) -> None:
         """Select new option by index."""
-        new_index = idx % len(self.options)
-        await self.async_select_option(self.options[new_index])
+        options = self.options
+        new_index = idx % len(options)
+        await self.async_select_option(options[new_index])

--- a/homeassistant/components/select/__init__.py
+++ b/homeassistant/components/select/__init__.py
@@ -144,9 +144,10 @@ class SelectEntity(Entity):
     @final
     def state(self) -> str | None:
         """Return the entity state."""
-        if self.current_option is None or self.current_option not in self.options:
+        current_option = self.current_option
+        if current_option is None or current_option not in self.options:
             return None
-        return self.current_option
+        return current_option
 
     @property
     def options(self) -> list[str]:


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Noticed while optimizing unifiprotect that the `current_option` was being looked up up 3x

There were a few more places where we would lookup the same property multiple times in the function.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
