### PR TITLE
Shell command response

### DIFF
--- a/homeassistant/components/shell_command/__init__.py
+++ b/homeassistant/components/shell_command/__init__.py
@@ -19,6 +19,7 @@ from homeassistant.core import (
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers import config_validation as cv, template
 from homeassistant.helpers.typing import ConfigType
+from homeassistant.util.json import JsonObjectType
 
 DOMAIN = "shell_command"
 
@@ -105,7 +106,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
             return {}
 
-        service_response = {
+        service_response: JsonObjectType = {
             "stdout": "",
             "stderr": "",
             "returncode": process.returncode,
@@ -131,7 +132,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             _LOGGER.exception(
                 "Error running command: `%s`, return code: %s", cmd, process.returncode
             )
-        return cast(ServiceResponse, service_response)
+        # return cast(ServiceResponse, service_response)
+        return service_response
 
     for name in conf:
         hass.services.async_register(

--- a/homeassistant/components/shell_command/__init__.py
+++ b/homeassistant/components/shell_command/__init__.py
@@ -5,7 +5,6 @@ import asyncio
 from contextlib import suppress
 import logging
 import shlex
-from typing import cast
 
 import async_timeout
 import voluptuous as vol
@@ -132,7 +131,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             _LOGGER.exception(
                 "Error running command: `%s`, return code: %s", cmd, process.returncode
             )
-        # return cast(ServiceResponse, service_response)
+
         return service_response
 
     for name in conf:

--- a/homeassistant/components/shell_command/__init__.py
+++ b/homeassistant/components/shell_command/__init__.py
@@ -60,7 +60,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 )
             except TemplateError as ex:
                 _LOGGER.exception("Error rendering command template: %s", ex)
-                return None
+                return {}
         else:
             rendered_args = None
 
@@ -103,7 +103,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                     process._transport.close()  # type: ignore[attr-defined]
                 del process
 
-            return None
+            return {}
 
         service_response = {
             "stdout": "",

--- a/homeassistant/components/shell_command/__init__.py
+++ b/homeassistant/components/shell_command/__init__.py
@@ -5,6 +5,7 @@ import asyncio
 from contextlib import suppress
 import logging
 import shlex
+from typing import cast
 
 import async_timeout
 import voluptuous as vol
@@ -130,7 +131,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             _LOGGER.exception(
                 "Error running command: `%s`, return code: %s", cmd, process.returncode
             )
-        return service_response
+        return cast(ServiceResponse, service_response)
 
     for name in conf:
         hass.services.async_register(

--- a/homeassistant/components/shell_command/__init__.py
+++ b/homeassistant/components/shell_command/__init__.py
@@ -60,7 +60,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 )
             except TemplateError as ex:
                 _LOGGER.exception("Error rendering command template: %s", ex)
-                return {}
+                raise
         else:
             rendered_args = None
 
@@ -103,7 +103,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                     process._transport.close()  # type: ignore[attr-defined]
                 del process
 
-            return {}
+            raise
 
         service_response: JsonObjectType = {
             "stdout": "",

--- a/homeassistant/components/shell_command/__init__.py
+++ b/homeassistant/components/shell_command/__init__.py
@@ -9,7 +9,12 @@ import shlex
 import async_timeout
 import voluptuous as vol
 
-from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.core import (
+    HomeAssistant,
+    ServiceCall,
+    ServiceResponse,
+    SupportsResponse,
+)
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers import config_validation as cv, template
 from homeassistant.helpers.typing import ConfigType
@@ -31,7 +36,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     cache: dict[str, tuple[str, str | None, template.Template | None]] = {}
 
-    async def async_service_handler(service: ServiceCall) -> None:
+    async def async_service_handler(service: ServiceCall) -> ServiceResponse:
         """Execute a shell command service."""
         cmd = conf[service.service]
 
@@ -54,7 +59,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 )
             except TemplateError as ex:
                 _LOGGER.exception("Error rendering command template: %s", ex)
-                return
+                return None
         else:
             rendered_args = None
 
@@ -97,9 +102,16 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                     process._transport.close()  # type: ignore[attr-defined]
                 del process
 
-            return
+            return None
+
+        service_response = {
+            "stdout": "",
+            "stderr": "",
+            "returncode": process.returncode,
+        }
 
         if stdout_data:
+            service_response["stdout"] = stdout_data.decode("utf-8").strip()
             _LOGGER.debug(
                 "Stdout of command: `%s`, return code: %s:\n%s",
                 cmd,
@@ -107,6 +119,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 stdout_data,
             )
         if stderr_data:
+            service_response["stderr"] = stderr_data.decode("utf-8").strip()
             _LOGGER.debug(
                 "Stderr of command: `%s`, return code: %s:\n%s",
                 cmd,
@@ -117,7 +130,13 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             _LOGGER.exception(
                 "Error running command: `%s`, return code: %s", cmd, process.returncode
             )
+        return service_response
 
     for name in conf:
-        hass.services.async_register(DOMAIN, name, async_service_handler)
+        hass.services.async_register(
+            DOMAIN,
+            name,
+            async_service_handler,
+            supports_response=SupportsResponse.OPTIONAL,
+        )
     return True

--- a/tests/components/shell_command/test_init.py
+++ b/tests/components/shell_command/test_init.py
@@ -99,7 +99,7 @@ async def test_incorrect_template(mock_call, hass: HomeAssistant) -> None:
     )
 
     with pytest.raises(TemplateError):
-        response = await hass.services.async_call(
+        await hass.services.async_call(
             "shell_command", "test_service", blocking=True, return_response=True
         )
 
@@ -221,7 +221,7 @@ async def test_do_not_run_forever(
         side_effect=mock_create_subprocess_shell,
     ):
         with pytest.raises(asyncio.TimeoutError):
-            response = await hass.services.async_call(
+            await hass.services.async_call(
                 shell_command.DOMAIN,
                 "test_service",
                 blocking=True,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This adds the newly available `ServiceResponse` to `shell_command` services.
It allows users to extract data from scripts that would not make sense as for e.g. commandline sensors.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#28226

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
