### PR TITLE
Limit websocket message coalescing to aiohttp default max message size of 4MiB

### DIFF
--- a/homeassistant/components/websocket_api/http.py
+++ b/homeassistant/components/websocket_api/http.py
@@ -174,9 +174,9 @@ class WebSocketHandler:
                     "indicates an integration is sending too much data, one of the "
                     "registries is too large, or the system cannot "
                     "keep up; trying to send individually",
+                    self.description,
                     len(coalesced_messages),
                     _MAX_MESSAGE_SIZE,
-                    self.description,
                 )
                 for message in messages:
                     if debug_enabled:

--- a/homeassistant/components/websocket_api/http.py
+++ b/homeassistant/components/websocket_api/http.py
@@ -175,7 +175,7 @@ class WebSocketHandler:
                     await send_str(coalesced_messages)
                     continue
 
-                logger.warning(
+                logger.info(
                     "%s: Coalesced messages exceeded maximum size (%s/%s), this usually "
                     "indicates an integration is sending too much data, one of the "
                     "registries is too large, or the system cannot "

--- a/homeassistant/components/websocket_api/http.py
+++ b/homeassistant/components/websocket_api/http.py
@@ -224,7 +224,7 @@ class WebSocketHandler:
                     chunks = [message]
                     chunk_size = json_array_wrapper_byte_count + message_size
 
-                # If the last messages were not sent send them now.
+                # If the last messages was not sent, send them now.
                 if chunks:
                     coalesced_messages = f"[{','.join(chunks)}]"
                     if debug_enabled:

--- a/homeassistant/components/websocket_api/http.py
+++ b/homeassistant/components/websocket_api/http.py
@@ -179,7 +179,7 @@ class WebSocketHandler:
                     "%s: Coalesced messages exceeded maximum size (%s/%s), this usually "
                     "indicates an integration is sending too much data, one of the "
                     "registries is too large, or the system cannot "
-                    "keep up; trying to send individually",
+                    "keep up",
                     self.description,
                     len(coalesced_messages),
                     max_message_size,

--- a/homeassistant/components/websocket_api/http.py
+++ b/homeassistant/components/websocket_api/http.py
@@ -130,7 +130,7 @@ class WebSocketHandler:
         logging_debug = logging.DEBUG
         max_message_size = _MAX_MESSAGE_SIZE
         # Exceptions if Socket disconnected or cancelled by connection handler
-        try:
+        try:  # pylint: disable=too-many-nested-blocks
             while not wsock.closed:
                 if (messages_remaining := len(message_queue)) == 0:
                     self._ready_future = loop.create_future()
@@ -184,10 +184,54 @@ class WebSocketHandler:
                     len(coalesced_messages),
                     max_message_size,
                 )
+                json_array_wrapper_byte_count = 2  # 2 for the []s
+                json_seperator_byte_count = 1  # 1 for the comma
+
+                chunks: list[str] = []
+                chunk_size = json_array_wrapper_byte_count
                 for message in messages:
+                    message_size = len(message) + json_seperator_byte_count
+                    if chunk_size + message_size < max_message_size:
+                        chunks.append(message)
+                        chunk_size += message_size
+                        continue
+
+                    if chunks:
+                        # If there are no chunks it means that all of the messages
+                        # are larger than the max message size.
+                        coalesced_messages = f"[{','.join(chunks)}]"
+                        if debug_enabled:
+                            debug(
+                                "%s: Sending %s", self.description, coalesced_messages
+                            )
+                        await send_str(coalesced_messages)
+
+                    # If a single message is larger than the max message size
+                    # we send it individually.
+                    if message_size > max_message_size:
+                        if debug_enabled:
+                            debug(
+                                "%s: Sending oversized message %s",
+                                self.description,
+                                message,
+                            )
+                        await send_str(message)
+                        chunks = []
+                        chunk_size = json_array_wrapper_byte_count
+                        continue
+
+                    # Start a new bucket with the current message
+                    chunks = [message]
+                    chunk_size = json_array_wrapper_byte_count + message_size
+
+                # If the last messages were not send
+                # send them now.
+                if chunks:
+                    coalesced_messages = f"[{','.join(chunks)}]"
                     if debug_enabled:
-                        debug("%s: Sending %s", self.description, message)
-                    await send_str(message)
+                        debug("%s: Sending %s", self.description, coalesced_messages)
+                    await send_str(coalesced_messages)
+
         except asyncio.CancelledError:
             debug("%s: Writer cancelled", self.description)
             raise

--- a/homeassistant/components/websocket_api/http.py
+++ b/homeassistant/components/websocket_api/http.py
@@ -169,13 +169,14 @@ class WebSocketHandler:
                     await send_str(coalesced_messages)
                     continue
 
-                if debug_enabled:
-                    debug(
-                        "%s: Coalesced messages exceed maximum size, this usually indicates "
-                        "an integration is sending too much data or the system cannot "
-                        "keep up; trying to send individually",
-                        self.description,
-                    )
+                logger.warning(
+                    "%s: Coalesced messages exceeded maximum size (%s/%s), this usually "
+                    "indicates an integration is sending too much data or the system cannot "
+                    "keep up; trying to send individually",
+                    len(coalesced_messages),
+                    _MAX_MESSAGE_SIZE,
+                    self.description,
+                )
                 for message in messages:
                     if debug_enabled:
                         debug("%s: Sending %s", self.description, message)

--- a/homeassistant/components/websocket_api/http.py
+++ b/homeassistant/components/websocket_api/http.py
@@ -224,8 +224,7 @@ class WebSocketHandler:
                     chunks = [message]
                     chunk_size = json_array_wrapper_byte_count + message_size
 
-                # If the last messages were not send
-                # send them now.
+                # If the last messages were not sent send them now.
                 if chunks:
                     coalesced_messages = f"[{','.join(chunks)}]"
                     if debug_enabled:

--- a/homeassistant/components/websocket_api/http.py
+++ b/homeassistant/components/websocket_api/http.py
@@ -171,7 +171,8 @@ class WebSocketHandler:
 
                 logger.warning(
                     "%s: Coalesced messages exceeded maximum size (%s/%s), this usually "
-                    "indicates an integration is sending too much data or the system cannot "
+                    "indicates an integration is sending too much data, one of the "
+                    "registries is too large, or the system cannot "
                     "keep up; trying to send individually",
                     len(coalesced_messages),
                     _MAX_MESSAGE_SIZE,

--- a/tests/components/websocket_api/test_http.py
+++ b/tests/components/websocket_api/test_http.py
@@ -540,7 +540,6 @@ async def test_coalesce_is_overloaded(
 
     assert ids == returned_ids
     assert "Coalesced messages exceeded maximum size" in caplog.text
-    assert "send individually" in caplog.text
 
 
 async def test_binary_message(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Send websocket message in coalesced chunks individually if the system gets overloaded and got too far behind that the coalesced messages became too large to fit under the limit

If HA gets too overloaded and can't get around to picking up the websocket messages to be sent, they build up. When it finally does they coalesce into a giant message which is too big and causes a disconnect.

This won't fix the cases where the user's entity registry is so large that it exceeds a 4MiB payload but it will prevent the ones that are under 4MiB from being combined with other messages.  I'm not sure we can fix that since we can't control the downstream limits.

related issue https://github.com/home-assistant/supervisor/issues/4392

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
