### PR TITLE
Add support for multiple Russound RNET controllers

### DIFF
--- a/homeassistant/components/russound_rnet/media_player.py
+++ b/homeassistant/components/russound_rnet/media_player.py
@@ -87,7 +87,7 @@ class RussoundRNETDevice(MediaPlayerEntity):
         self._russ = russ
         self._attr_source_list = sources
         # Each controller has a maximum of 6 zones, every increment of 6 zones
-        #  maps to an additional controller for easier backward compatibility
+        # maps to an additional controller for easier backward compatibility
         self._controller_id = str(math.ceil(zone_id / 6))
         # Each zone resets to 1-6 per controller
         self._zone_id = (zone_id - 1) % 6 + 1

--- a/homeassistant/components/russound_rnet/media_player.py
+++ b/homeassistant/components/russound_rnet/media_player.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+import math
 
 from russound import russound
 import voluptuous as vol
@@ -85,17 +86,25 @@ class RussoundRNETDevice(MediaPlayerEntity):
         self._attr_name = extra["name"]
         self._russ = russ
         self._attr_source_list = sources
-        self._zone_id = zone_id
+        # Each controller has a maximum of 6 zones, every increment of 6 zones
+        #  maps to an additional controller for easier backward compatibility
+        self._controller_id = str(math.ceil(zone_id / 6))
+        # Each zone resets to 1-6 per controller
+        self._zone_id = (zone_id - 1) % 6 + 1
 
     def update(self) -> None:
         """Retrieve latest state."""
         # Updated this function to make a single call to get_zone_info, so that
         # with a single call we can get On/Off, Volume and Source, reducing the
         # amount of traffic and speeding up the update process.
-        ret = self._russ.get_zone_info("1", self._zone_id, 4)
+        ret = self._russ.get_zone_info(self._controller_id, self._zone_id, 4)
         _LOGGER.debug("ret= %s", ret)
         if ret is not None:
-            _LOGGER.debug("Updating status for zone %s", self._zone_id)
+            _LOGGER.debug(
+                "Updating status for RNET zone %s on controller %s",
+                self._zone_id,
+                self._controller_id,
+            )
             if ret[0] == 0:
                 self._attr_state = MediaPlayerState.OFF
             else:
@@ -118,23 +127,23 @@ class RussoundRNETDevice(MediaPlayerEntity):
         Translate this to a range of (0..100) as expected
         by _russ.set_volume()
         """
-        self._russ.set_volume("1", self._zone_id, volume * 100)
+        self._russ.set_volume(self._controller_id, self._zone_id, volume * 100)
 
     def turn_on(self) -> None:
         """Turn the media player on."""
-        self._russ.set_power("1", self._zone_id, "1")
+        self._russ.set_power(self._controller_id, self._zone_id, "1")
 
     def turn_off(self) -> None:
         """Turn off media player."""
-        self._russ.set_power("1", self._zone_id, "0")
+        self._russ.set_power(self._controller_id, self._zone_id, "0")
 
     def mute_volume(self, mute: bool) -> None:
         """Send mute command."""
-        self._russ.toggle_mute("1", self._zone_id)
+        self._russ.toggle_mute(self._controller_id, self._zone_id)
 
     def select_source(self, source: str) -> None:
         """Set the input source."""
         if self.source_list and source in self.source_list:
             index = self.source_list.index(source)
             # 0 based value for source
-            self._russ.set_source("1", self._zone_id, index)
+            self._russ.set_source(self._controller_id, self._zone_id, index)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
The current russound rnet integration is hardcoded for a single controller. This PR allows for multiple controllers and is backwards compatible.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: https://community.home-assistant.io/t/multiple-russound-cav6-6-configuration/ and https://community.home-assistant.io/t/russound-rnet-2-controller-config/
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/28244

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
