### PR TITLE
Fix ESPHome bluetooth client cancellation when the operation is cancelled externally

### DIFF
--- a/homeassistant/components/esphome/bluetooth/client.py
+++ b/homeassistant/components/esphome/bluetooth/client.py
@@ -72,10 +72,9 @@ def verify_connected(func: _WrapFuncType) -> _WrapFuncType:
         loop = self._loop
         disconnected_futures = self._disconnected_futures
         disconnected_future = loop.create_future()
-        disconnected_futures.add(disconnected_future)
-        task = asyncio.current_task(loop)
-        disconnect_handler = partial(_on_disconnected, task)
+        disconnect_handler = partial(_on_disconnected, asyncio.current_task(loop))
         disconnected_future.add_done_callback(disconnect_handler)
+        disconnected_futures.add(disconnected_future)
         try:
             return await func(self, *args, **kwargs)
         except asyncio.CancelledError as ex:

--- a/homeassistant/components/esphome/bluetooth/client.py
+++ b/homeassistant/components/esphome/bluetooth/client.py
@@ -57,7 +57,7 @@ def mac_to_int(address: str) -> int:
     return int(address.replace(":", ""), 16)
 
 
-def _on_disconnected(task: asyncio.Task[Any], fut: asyncio.Future[None]) -> None:
+def _on_disconnected(task: asyncio.Task[Any], _: asyncio.Future[None]) -> None:
     if task and not task.done():
         task.cancel()
 

--- a/homeassistant/components/esphome/bluetooth/client.py
+++ b/homeassistant/components/esphome/bluetooth/client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Callable, Coroutine
 import contextlib
+from functools import partial
 import logging
 from typing import Any, TypeVar, cast
 import uuid
@@ -56,38 +57,41 @@ def mac_to_int(address: str) -> int:
     return int(address.replace(":", ""), 16)
 
 
+def _on_disconnected(task: asyncio.Task[Any], fut: asyncio.Future[None]) -> None:
+    if task and not task.done():
+        task.cancel()
+
+
 def verify_connected(func: _WrapFuncType) -> _WrapFuncType:
     """Define a wrapper throw BleakError if not connected."""
 
     async def _async_wrap_bluetooth_connected_operation(
         self: ESPHomeClient, *args: Any, **kwargs: Any
     ) -> Any:
-        loop = self._loop  # pylint: disable=protected-access
-        disconnected_futures = (
-            self._disconnected_futures  # pylint: disable=protected-access
-        )
+        # pylint: disable=protected-access
+        loop = self._loop
+        disconnected_futures = self._disconnected_futures
         disconnected_future = loop.create_future()
         disconnected_futures.add(disconnected_future)
-
         task = asyncio.current_task(loop)
-
-        def _on_disconnected(fut: asyncio.Future[None]) -> None:
-            if task and not task.done():
-                task.cancel()
-
-        disconnected_future.add_done_callback(_on_disconnected)
+        disconnect_handler = partial(_on_disconnected, task)
+        disconnected_future.add_done_callback(disconnect_handler)
         try:
             return await func(self, *args, **kwargs)
         except asyncio.CancelledError as ex:
-            source_name = self._source_name  # pylint: disable=protected-access
-            ble_device = self._ble_device  # pylint: disable=protected-access
+            if not disconnected_future.done():
+                # If the disconnected future is not done, the task was cancelled
+                # externally and we need to raise cancelled error to avoid
+                # blocking the cancellation.
+                raise
+            ble_device = self._ble_device
             raise BleakError(
-                f"{source_name}: {ble_device.name} - {ble_device.address}: "
+                f"{self._source_name }: {ble_device.name} - {ble_device.address}: "
                 "Disconnected during operation"
             ) from ex
         finally:
             disconnected_futures.discard(disconnected_future)
-            disconnected_future.remove_done_callback(_on_disconnected)
+            disconnected_future.remove_done_callback(disconnect_handler)
 
     return cast(_WrapFuncType, _async_wrap_bluetooth_connected_operation)
 


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

We need to check the disconnected future to see if the cancellation was the result of a disconnect or an external factor so we do not block cancellation in the event it was not a disconnect that caused CancelledError

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
