### PR TITLE
Rename 'life' to 'lifetime' in Brother

### DIFF
--- a/homeassistant/components/brother/strings.json
+++ b/homeassistant/components/brother/strings.json
@@ -44,7 +44,7 @@
         "name": "Duplex unit page counter"
       },
       "drum_remaining_life": {
-        "name": "Drum remaining life"
+        "name": "Drum remaining lifetime"
       },
       "drum_remaining_pages": {
         "name": "Drum remaining pages"
@@ -53,7 +53,7 @@
         "name": "Drum page counter"
       },
       "black_drum_remaining_life": {
-        "name": "Black drum remaining life"
+        "name": "Black drum remaining lifetime"
       },
       "black_drum_remaining_pages": {
         "name": "Black drum remaining pages"
@@ -62,7 +62,7 @@
         "name": "Black drum page counter"
       },
       "cyan_drum_remaining_life": {
-        "name": "Cyan drum remaining life"
+        "name": "Cyan drum remaining lifetime"
       },
       "cyan_drum_remaining_pages": {
         "name": "Cyan drum remaining pages"
@@ -71,7 +71,7 @@
         "name": "Cyan drum page counter"
       },
       "magenta_drum_remaining_life": {
-        "name": "Magenta drum remaining life"
+        "name": "Magenta drum remaining lifetime"
       },
       "magenta_drum_remaining_pages": {
         "name": "Magenta drum remaining pages"
@@ -80,7 +80,7 @@
         "name": "Magenta drum page counter"
       },
       "yellow_drum_remaining_life": {
-        "name": "Yellow drum remaining life"
+        "name": "Yellow drum remaining lifetime"
       },
       "yellow_drum_remaining_pages": {
         "name": "Yellow drum remaining pages"
@@ -89,19 +89,19 @@
         "name": "Yellow drum page counter"
       },
       "belt_unit_remaining_life": {
-        "name": "Belt unit remaining life"
+        "name": "Belt unit remaining lifetime"
       },
       "fuser_remaining_life": {
-        "name": "Fuser remaining life"
+        "name": "Fuser remaining lifetime"
       },
       "laser_remaining_life": {
-        "name": "Laser remaining life"
+        "name": "Laser remaining lifetime"
       },
       "pf_kit_1_remaining_life": {
-        "name": "PF Kit 1 remaining life"
+        "name": "PF Kit 1 remaining lifetime"
       },
       "pf_kit_mp_remaining_life": {
-        "name": "PF Kit MP remaining life"
+        "name": "PF Kit MP remaining lifetime"
       },
       "black_toner_remaining": {
         "name": "Black toner remaining"

--- a/tests/components/brother/test_sensor.py
+++ b/tests/components/brother/test_sensor.py
@@ -110,14 +110,14 @@ async def test_sensors(hass: HomeAssistant) -> None:
     assert entry
     assert entry.unique_id == "0123456789_yellow_toner_remaining"
 
-    state = hass.states.get("sensor.hl_l2340dw_drum_remaining_lifetime")
+    state = hass.states.get("sensor.hl_l2340dw_drum_remaining_life")
     assert state
     assert state.attributes.get(ATTR_ICON) == "mdi:chart-donut"
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == PERCENTAGE
     assert state.state == "92"
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
 
-    entry = registry.async_get("sensor.hl_l2340dw_drum_remaining_lifetime")
+    entry = registry.async_get("sensor.hl_l2340dw_drum_remaining_life")
     assert entry
     assert entry.unique_id == "0123456789_drum_remaining_lifetime"
 

--- a/tests/components/brother/test_sensor.py
+++ b/tests/components/brother/test_sensor.py
@@ -110,16 +110,16 @@ async def test_sensors(hass: HomeAssistant) -> None:
     assert entry
     assert entry.unique_id == "0123456789_yellow_toner_remaining"
 
-    state = hass.states.get("sensor.hl_l2340dw_drum_remaining_life")
+    state = hass.states.get("sensor.hl_l2340dw_drum_remaining_lifetime")
     assert state
     assert state.attributes.get(ATTR_ICON) == "mdi:chart-donut"
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == PERCENTAGE
     assert state.state == "92"
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
 
-    entry = registry.async_get("sensor.hl_l2340dw_drum_remaining_life")
+    entry = registry.async_get("sensor.hl_l2340dw_drum_remaining_lifetime")
     assert entry
-    assert entry.unique_id == "0123456789_drum_remaining_life"
+    assert entry.unique_id == "0123456789_drum_remaining_lifetime"
 
     state = hass.states.get("sensor.hl_l2340dw_drum_remaining_pages")
     assert state
@@ -143,16 +143,16 @@ async def test_sensors(hass: HomeAssistant) -> None:
     assert entry
     assert entry.unique_id == "0123456789_drum_counter"
 
-    state = hass.states.get("sensor.hl_l2340dw_black_drum_remaining_life")
+    state = hass.states.get("sensor.hl_l2340dw_black_drum_remaining_lifetime")
     assert state
     assert state.attributes.get(ATTR_ICON) == "mdi:chart-donut"
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == PERCENTAGE
     assert state.state == "92"
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
 
-    entry = registry.async_get("sensor.hl_l2340dw_black_drum_remaining_life")
+    entry = registry.async_get("sensor.hl_l2340dw_black_drum_remaining_lifetime")
     assert entry
-    assert entry.unique_id == "0123456789_black_drum_remaining_life"
+    assert entry.unique_id == "0123456789_black_drum_remaining_lifetime"
 
     state = hass.states.get("sensor.hl_l2340dw_black_drum_remaining_pages")
     assert state
@@ -176,16 +176,16 @@ async def test_sensors(hass: HomeAssistant) -> None:
     assert entry
     assert entry.unique_id == "0123456789_black_drum_counter"
 
-    state = hass.states.get("sensor.hl_l2340dw_cyan_drum_remaining_life")
+    state = hass.states.get("sensor.hl_l2340dw_cyan_drum_remaining_lifetime")
     assert state
     assert state.attributes.get(ATTR_ICON) == "mdi:chart-donut"
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == PERCENTAGE
     assert state.state == "92"
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
 
-    entry = registry.async_get("sensor.hl_l2340dw_cyan_drum_remaining_life")
+    entry = registry.async_get("sensor.hl_l2340dw_cyan_drum_remaining_lifetime")
     assert entry
-    assert entry.unique_id == "0123456789_cyan_drum_remaining_life"
+    assert entry.unique_id == "0123456789_cyan_drum_remaining_lifetime"
 
     state = hass.states.get("sensor.hl_l2340dw_cyan_drum_remaining_pages")
     assert state
@@ -209,16 +209,16 @@ async def test_sensors(hass: HomeAssistant) -> None:
     assert entry
     assert entry.unique_id == "0123456789_cyan_drum_counter"
 
-    state = hass.states.get("sensor.hl_l2340dw_magenta_drum_remaining_life")
+    state = hass.states.get("sensor.hl_l2340dw_magenta_drum_remaining_lifetime")
     assert state
     assert state.attributes.get(ATTR_ICON) == "mdi:chart-donut"
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == PERCENTAGE
     assert state.state == "92"
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
 
-    entry = registry.async_get("sensor.hl_l2340dw_magenta_drum_remaining_life")
+    entry = registry.async_get("sensor.hl_l2340dw_magenta_drum_remaining_lifetime")
     assert entry
-    assert entry.unique_id == "0123456789_magenta_drum_remaining_life"
+    assert entry.unique_id == "0123456789_magenta_drum_remaining_lifetime"
 
     state = hass.states.get("sensor.hl_l2340dw_magenta_drum_remaining_pages")
     assert state
@@ -242,16 +242,16 @@ async def test_sensors(hass: HomeAssistant) -> None:
     assert entry
     assert entry.unique_id == "0123456789_magenta_drum_counter"
 
-    state = hass.states.get("sensor.hl_l2340dw_yellow_drum_remaining_life")
+    state = hass.states.get("sensor.hl_l2340dw_yellow_drum_remaining_lifetime")
     assert state
     assert state.attributes.get(ATTR_ICON) == "mdi:chart-donut"
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == PERCENTAGE
     assert state.state == "92"
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
 
-    entry = registry.async_get("sensor.hl_l2340dw_yellow_drum_remaining_life")
+    entry = registry.async_get("sensor.hl_l2340dw_yellow_drum_remaining_lifetime")
     assert entry
-    assert entry.unique_id == "0123456789_yellow_drum_remaining_life"
+    assert entry.unique_id == "0123456789_yellow_drum_remaining_lifetime"
 
     state = hass.states.get("sensor.hl_l2340dw_yellow_drum_remaining_pages")
     assert state
@@ -275,38 +275,38 @@ async def test_sensors(hass: HomeAssistant) -> None:
     assert entry
     assert entry.unique_id == "0123456789_yellow_drum_counter"
 
-    state = hass.states.get("sensor.hl_l2340dw_fuser_remaining_life")
+    state = hass.states.get("sensor.hl_l2340dw_fuser_remaining_lifetime")
     assert state
     assert state.attributes.get(ATTR_ICON) == "mdi:water-outline"
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == PERCENTAGE
     assert state.state == "97"
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
 
-    entry = registry.async_get("sensor.hl_l2340dw_fuser_remaining_life")
+    entry = registry.async_get("sensor.hl_l2340dw_fuser_remaining_lifetime")
     assert entry
-    assert entry.unique_id == "0123456789_fuser_remaining_life"
+    assert entry.unique_id == "0123456789_fuser_remaining_lifetime"
 
-    state = hass.states.get("sensor.hl_l2340dw_belt_unit_remaining_life")
+    state = hass.states.get("sensor.hl_l2340dw_belt_unit_remaining_lifetime")
     assert state
     assert state.attributes.get(ATTR_ICON) == "mdi:current-ac"
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == PERCENTAGE
     assert state.state == "97"
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
 
-    entry = registry.async_get("sensor.hl_l2340dw_belt_unit_remaining_life")
+    entry = registry.async_get("sensor.hl_l2340dw_belt_unit_remaining_lifetime")
     assert entry
-    assert entry.unique_id == "0123456789_belt_unit_remaining_life"
+    assert entry.unique_id == "0123456789_belt_unit_remaining_lifetime"
 
-    state = hass.states.get("sensor.hl_l2340dw_pf_kit_1_remaining_life")
+    state = hass.states.get("sensor.hl_l2340dw_pf_kit_1_remaining_lifetime")
     assert state
     assert state.attributes.get(ATTR_ICON) == "mdi:printer-3d"
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == PERCENTAGE
     assert state.state == "98"
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
 
-    entry = registry.async_get("sensor.hl_l2340dw_pf_kit_1_remaining_life")
+    entry = registry.async_get("sensor.hl_l2340dw_pf_kit_1_remaining_lifetime")
     assert entry
-    assert entry.unique_id == "0123456789_pf_kit_1_remaining_life"
+    assert entry.unique_id == "0123456789_pf_kit_1_remaining_lifetime"
 
     state = hass.states.get("sensor.hl_l2340dw_page_counter")
     assert state

--- a/tests/components/brother/test_sensor.py
+++ b/tests/components/brother/test_sensor.py
@@ -110,16 +110,16 @@ async def test_sensors(hass: HomeAssistant) -> None:
     assert entry
     assert entry.unique_id == "0123456789_yellow_toner_remaining"
 
-    state = hass.states.get("sensor.hl_l2340dw_drum_remaining_life")
+    state = hass.states.get("sensor.hl_l2340dw_drum_remaining_lifetime")
     assert state
     assert state.attributes.get(ATTR_ICON) == "mdi:chart-donut"
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == PERCENTAGE
     assert state.state == "92"
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
 
-    entry = registry.async_get("sensor.hl_l2340dw_drum_remaining_life")
+    entry = registry.async_get("sensor.hl_l2340dw_drum_remaining_lifetime")
     assert entry
-    assert entry.unique_id == "0123456789_drum_remaining_lifetime"
+    assert entry.unique_id == "0123456789_drum_remaining_life"
 
     state = hass.states.get("sensor.hl_l2340dw_drum_remaining_pages")
     assert state
@@ -152,7 +152,7 @@ async def test_sensors(hass: HomeAssistant) -> None:
 
     entry = registry.async_get("sensor.hl_l2340dw_black_drum_remaining_lifetime")
     assert entry
-    assert entry.unique_id == "0123456789_black_drum_remaining_lifetime"
+    assert entry.unique_id == "0123456789_black_drum_remaining_life"
 
     state = hass.states.get("sensor.hl_l2340dw_black_drum_remaining_pages")
     assert state
@@ -185,7 +185,7 @@ async def test_sensors(hass: HomeAssistant) -> None:
 
     entry = registry.async_get("sensor.hl_l2340dw_cyan_drum_remaining_lifetime")
     assert entry
-    assert entry.unique_id == "0123456789_cyan_drum_remaining_lifetime"
+    assert entry.unique_id == "0123456789_cyan_drum_remaining_life"
 
     state = hass.states.get("sensor.hl_l2340dw_cyan_drum_remaining_pages")
     assert state
@@ -218,7 +218,7 @@ async def test_sensors(hass: HomeAssistant) -> None:
 
     entry = registry.async_get("sensor.hl_l2340dw_magenta_drum_remaining_lifetime")
     assert entry
-    assert entry.unique_id == "0123456789_magenta_drum_remaining_lifetime"
+    assert entry.unique_id == "0123456789_magenta_drum_remaining_life"
 
     state = hass.states.get("sensor.hl_l2340dw_magenta_drum_remaining_pages")
     assert state
@@ -251,7 +251,7 @@ async def test_sensors(hass: HomeAssistant) -> None:
 
     entry = registry.async_get("sensor.hl_l2340dw_yellow_drum_remaining_lifetime")
     assert entry
-    assert entry.unique_id == "0123456789_yellow_drum_remaining_lifetime"
+    assert entry.unique_id == "0123456789_yellow_drum_remaining_life"
 
     state = hass.states.get("sensor.hl_l2340dw_yellow_drum_remaining_pages")
     assert state
@@ -284,7 +284,7 @@ async def test_sensors(hass: HomeAssistant) -> None:
 
     entry = registry.async_get("sensor.hl_l2340dw_fuser_remaining_lifetime")
     assert entry
-    assert entry.unique_id == "0123456789_fuser_remaining_lifetime"
+    assert entry.unique_id == "0123456789_fuser_remaining_life"
 
     state = hass.states.get("sensor.hl_l2340dw_belt_unit_remaining_lifetime")
     assert state
@@ -295,7 +295,7 @@ async def test_sensors(hass: HomeAssistant) -> None:
 
     entry = registry.async_get("sensor.hl_l2340dw_belt_unit_remaining_lifetime")
     assert entry
-    assert entry.unique_id == "0123456789_belt_unit_remaining_lifetime"
+    assert entry.unique_id == "0123456789_belt_unit_remaining_life"
 
     state = hass.states.get("sensor.hl_l2340dw_pf_kit_1_remaining_lifetime")
     assert state
@@ -306,7 +306,7 @@ async def test_sensors(hass: HomeAssistant) -> None:
 
     entry = registry.async_get("sensor.hl_l2340dw_pf_kit_1_remaining_lifetime")
     assert entry
-    assert entry.unique_id == "0123456789_pf_kit_1_remaining_lifetime"
+    assert entry.unique_id == "0123456789_pf_kit_1_remaining_life"
 
     state = hass.states.get("sensor.hl_l2340dw_page_counter")
     assert state


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
String review: rename 'life' to 'lifetime'
- The term life, such as in 'filter life' can be ambiguous.
- Renamed to 'lifetime', as quite a few integrations use the term 'lifetime' to express this concept
- Improves consistency and should be easier to understand.

 
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests: Terminology review

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
