### PR TITLE
Fix shell_command timeout test

### DIFF
--- a/tests/components/shell_command/test_init.py
+++ b/tests/components/shell_command/test_init.py
@@ -173,23 +173,25 @@ async def test_do_not_run_forever(
 
     mock_process = Mock()
     mock_process.communicate = block
+    mock_process.kill = Mock()
     mock_create_subprocess_shell = AsyncMock(return_value=mock_process)
+
+    assert await async_setup_component(
+        hass,
+        shell_command.DOMAIN,
+        {shell_command.DOMAIN: {"test_service": "mock_sleep 10000"}},
+    )
+    await hass.async_block_till_done()
 
     with patch.object(shell_command, "COMMAND_TIMEOUT", 0.001), patch(
         "homeassistant.components.shell_command.asyncio.create_subprocess_shell",
         side_effect=mock_create_subprocess_shell,
     ):
-        assert await async_setup_component(
-            hass,
-            shell_command.DOMAIN,
-            {shell_command.DOMAIN: {"test_service": "mock_sleep 10000"}},
-        )
-        await hass.async_block_till_done()
-
         await hass.services.async_call(
             shell_command.DOMAIN, "test_service", blocking=True
         )
         await hass.async_block_till_done()
 
+    mock_process.kill.assert_called_once()
     assert "Timed out" in caplog.text
     assert "mock_sleep 10000" in caplog.text

--- a/tests/components/shell_command/test_init.py
+++ b/tests/components/shell_command/test_init.py
@@ -1,9 +1,10 @@
 """The tests for the Shell command component."""
 from __future__ import annotations
 
+import asyncio
 import os
 import tempfile
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
@@ -160,17 +161,28 @@ async def test_stderr_captured(mock_output, hass: HomeAssistant) -> None:
     assert test_phrase.encode() + b"\n" == mock_output.call_args_list[0][0][-1]
 
 
-@pytest.mark.skip(reason="disabled to check if it fixes flaky CI")
-async def test_do_no_run_forever(
+async def test_do_not_run_forever(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test subprocesses terminate after the timeout."""
 
-    with patch.object(shell_command, "COMMAND_TIMEOUT", 0.001):
+    async def block():
+        event = asyncio.Event()
+        await event.wait()
+        return (None, None)
+
+    mock_process = Mock()
+    mock_process.communicate = block
+    mock_create_subprocess_shell = AsyncMock(return_value=mock_process)
+
+    with patch.object(shell_command, "COMMAND_TIMEOUT", 0.001), patch(
+        "homeassistant.components.shell_command.asyncio.create_subprocess_shell",
+        side_effect=mock_create_subprocess_shell,
+    ):
         assert await async_setup_component(
             hass,
             shell_command.DOMAIN,
-            {shell_command.DOMAIN: {"test_service": "sleep 10000"}},
+            {shell_command.DOMAIN: {"test_service": "mock_sleep 10000"}},
         )
         await hass.async_block_till_done()
 
@@ -180,4 +192,4 @@ async def test_do_no_run_forever(
         await hass.async_block_till_done()
 
     assert "Timed out" in caplog.text
-    assert "sleep 10000" in caplog.text
+    assert "mock_sleep 10000" in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix `shell_command` timeout test by mocking out command execution

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
