### PR TITLE
recorder: Refactor import statements for improved code quality

### DIFF
--- a/homeassistant/components/analytics/analytics.py
+++ b/homeassistant/components/analytics/analytics.py
@@ -10,16 +10,12 @@ import uuid
 import aiohttp
 import async_timeout
 
-from homeassistant.components import hassio
+from homeassistant.components import hassio, recorder
 from homeassistant.components.api import ATTR_INSTALLATION_TYPE
 from homeassistant.components.automation import DOMAIN as AUTOMATION_DOMAIN
 from homeassistant.components.energy import (
     DOMAIN as ENERGY_DOMAIN,
     is_configured as energy_is_configured,
-)
-from homeassistant.components.recorder import (
-    DOMAIN as RECORDER_DOMAIN,
-    get_instance as get_recorder_instance,
 )
 import homeassistant.config as conf_util
 from homeassistant.config_entries import (
@@ -289,8 +285,8 @@ class Analytics:
                     ATTR_CONFIGURED: await energy_is_configured(self.hass)
                 }
 
-            if RECORDER_DOMAIN in enabled_domains:
-                instance = get_recorder_instance(self.hass)
+            if recorder.DOMAIN in enabled_domains:
+                instance = recorder.get_instance(self.hass)
                 engine = instance.database_engine
                 if engine and engine.version is not None:
                     payload[ATTR_RECORDER] = {

--- a/homeassistant/components/energy/websocket_api.py
+++ b/homeassistant/components/energy/websocket_api.py
@@ -13,7 +13,6 @@ from typing import Any, cast
 import voluptuous as vol
 
 from homeassistant.components import recorder, websocket_api
-from homeassistant.components.recorder.statistics import StatisticsRow
 from homeassistant.const import UnitOfEnergy
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.integration_platform import (
@@ -278,7 +277,8 @@ async def ws_get_fossil_energy_consumption(
     )
 
     def _combine_sum_statistics(
-        stats: dict[str, list[StatisticsRow]], statistic_ids: list[str]
+        stats: dict[str, list[recorder.statistics.StatisticsRow]],
+        statistic_ids: list[str],
     ) -> dict[float, float]:
         """Combine multiple statistics, returns a dict indexed by start time."""
         result: defaultdict[float, float] = defaultdict(float)

--- a/homeassistant/components/filter/sensor.py
+++ b/homeassistant/components/filter/sensor.py
@@ -13,9 +13,9 @@ from typing import Any, cast
 
 import voluptuous as vol
 
+from homeassistant.components import recorder
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.components.input_number import DOMAIN as INPUT_NUMBER_DOMAIN
-from homeassistant.components.recorder import get_instance, history
 from homeassistant.components.sensor import (
     ATTR_STATE_CLASS,
     DOMAIN as SENSOR_DOMAIN,
@@ -311,9 +311,11 @@ class SensorFilter(SensorEntity):
 
             # Retrieve the largest window_size of each type
             if largest_window_items > 0:
-                filter_history = await get_instance(self.hass).async_add_executor_job(
+                filter_history = await recorder.get_instance(
+                    self.hass
+                ).async_add_executor_job(
                     partial(
-                        history.get_last_state_changes,
+                        recorder.history.get_last_state_changes,
                         self.hass,
                         largest_window_items,
                         entity_id=self._entity,
@@ -323,9 +325,11 @@ class SensorFilter(SensorEntity):
                     history_list.extend(filter_history[self._entity])
             if largest_window_time > timedelta(seconds=0):
                 start = dt_util.utcnow() - largest_window_time
-                filter_history = await get_instance(self.hass).async_add_executor_job(
+                filter_history = await recorder.get_instance(
+                    self.hass
+                ).async_add_executor_job(
                     partial(
-                        history.state_changes_during_period,
+                        recorder.history.state_changes_during_period,
                         self.hass,
                         start,
                         entity_id=self._entity,

--- a/homeassistant/components/history/__init__.py
+++ b/homeassistant/components/history/__init__.py
@@ -8,10 +8,8 @@ from typing import cast
 from aiohttp import web
 import voluptuous as vol
 
-from homeassistant.components import frontend
+from homeassistant.components import frontend, recorder
 from homeassistant.components.http import HomeAssistantView
-from homeassistant.components.recorder import get_instance, history
-from homeassistant.components.recorder.util import session_scope
 from homeassistant.const import CONF_EXCLUDE, CONF_INCLUDE
 from homeassistant.core import HomeAssistant, valid_entity_id
 import homeassistant.helpers.config_validation as cv
@@ -116,7 +114,7 @@ class HistoryPeriodView(HomeAssistantView):
 
         return cast(
             web.Response,
-            await get_instance(hass).async_add_executor_job(
+            await recorder.get_instance(hass).async_add_executor_job(
                 self._sorted_significant_states_json,
                 hass,
                 start_time,
@@ -141,10 +139,10 @@ class HistoryPeriodView(HomeAssistantView):
         no_attributes: bool,
     ) -> web.Response:
         """Fetch significant stats from the database as json."""
-        with session_scope(hass=hass, read_only=True) as session:
+        with recorder.util.session_scope(hass=hass, read_only=True) as session:
             return self.json(
                 list(
-                    history.get_significant_states_with_session(
+                    recorder.history.get_significant_states_with_session(
                         hass,
                         session,
                         start_time,

--- a/homeassistant/components/history_stats/data.py
+++ b/homeassistant/components/history_stats/data.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import datetime
 
-from homeassistant.components.recorder import get_instance, history
+from homeassistant.components import recorder
 from homeassistant.core import Event, HomeAssistant, State
 from homeassistant.helpers.template import Template
 import homeassistant.util.dt as dt_util
@@ -141,7 +141,7 @@ class HistoryStats:
         current_period_end_timestamp: float,
     ) -> None:
         """Update history data for the current period from the database."""
-        instance = get_instance(self.hass)
+        instance = recorder.get_instance(self.hass)
         states = await instance.async_add_executor_job(
             self._state_changes_during_period,
             current_period_start_timestamp,
@@ -158,7 +158,7 @@ class HistoryStats:
         """Return state changes during a period."""
         start = dt_util.utc_from_timestamp(start_ts)
         end = dt_util.utc_from_timestamp(end_ts)
-        return history.state_changes_during_period(
+        return recorder.history.state_changes_during_period(
             self.hass,
             start,
             end,

--- a/homeassistant/components/logbook/__init__.py
+++ b/homeassistant/components/logbook/__init__.py
@@ -6,13 +6,7 @@ from typing import Any
 
 import voluptuous as vol
 
-from homeassistant.components import frontend
-from homeassistant.components.recorder import DOMAIN as RECORDER_DOMAIN
-from homeassistant.components.recorder.filters import (
-    extract_include_exclude_filter_conf,
-    merge_include_exclude_filters,
-    sqlalchemy_filter_from_include_exclude_conf,
-)
+from homeassistant.components import frontend, recorder
 from homeassistant.const import (
     ATTR_DOMAIN,
     ATTR_ENTITY_ID,
@@ -118,15 +112,21 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         hass, "logbook", "logbook", "hass:format-list-bulleted-type"
     )
 
-    recorder_conf = config.get(RECORDER_DOMAIN, {})
+    recorder_conf = config.get(recorder.DOMAIN, {})
     logbook_conf = config.get(DOMAIN, {})
-    recorder_filter = extract_include_exclude_filter_conf(recorder_conf)
-    logbook_filter = extract_include_exclude_filter_conf(logbook_conf)
-    merged_filter = merge_include_exclude_filters(recorder_filter, logbook_filter)
+    recorder_filter = recorder.filters.extract_include_exclude_filter_conf(
+        recorder_conf
+    )
+    logbook_filter = recorder.filters.extract_include_exclude_filter_conf(logbook_conf)
+    merged_filter = recorder.filters.merge_include_exclude_filters(
+        recorder_filter, logbook_filter
+    )
 
     possible_merged_entities_filter = convert_include_exclude_filter(merged_filter)
     if not possible_merged_entities_filter.empty_filter:
-        filters = sqlalchemy_filter_from_include_exclude_conf(merged_filter)
+        filters = recorder.filters.sqlalchemy_filter_from_include_exclude_conf(
+            merged_filter
+        )
         entities_filter = possible_merged_entities_filter.get_filter()
     else:
         filters = None

--- a/homeassistant/components/logbook/queries/__init__.py
+++ b/homeassistant/components/logbook/queries/__init__.py
@@ -6,8 +6,7 @@ from datetime import datetime as dt
 
 from sqlalchemy.sql.lambdas import StatementLambdaElement
 
-from homeassistant.components.recorder.filters import Filters
-from homeassistant.components.recorder.models import ulid_to_bytes_or_none
+from homeassistant.components import recorder
 from homeassistant.helpers.json import json_dumps
 from homeassistant.util import dt as dt_util
 
@@ -24,7 +23,7 @@ def statement_for_request(
     entity_ids: list[str] | None = None,
     states_metadata_ids: Collection[int] | None = None,
     device_ids: list[str] | None = None,
-    filters: Filters | None = None,
+    filters: recorder.filters.Filters | None = None,
     context_id: str | None = None,
 ) -> StatementLambdaElement:
     """Generate the logbook statement for a logbook request."""
@@ -33,7 +32,7 @@ def statement_for_request(
     # No entities: logbook sends everything for the timeframe
     # limited by the context_id and the yaml configured filter
     if not entity_ids and not device_ids:
-        context_id_bin = ulid_to_bytes_or_none(context_id)
+        context_id_bin = recorder.models.ulid_to_bytes_or_none(context_id)
         return all_stmt(
             start_day,
             end_day,

--- a/homeassistant/components/logbook/queries/all.py
+++ b/homeassistant/components/logbook/queries/all.py
@@ -5,12 +5,7 @@ from sqlalchemy import lambda_stmt
 from sqlalchemy.sql.lambdas import StatementLambdaElement
 from sqlalchemy.sql.selectable import Select
 
-from homeassistant.components.recorder.db_schema import (
-    LAST_UPDATED_INDEX_TS,
-    Events,
-    States,
-)
-from homeassistant.components.recorder.filters import Filters
+from homeassistant.components import recorder
 
 from .common import apply_states_filters, select_events_without_states, select_states
 
@@ -19,7 +14,7 @@ def all_stmt(
     start_day: float,
     end_day: float,
     event_type_ids: tuple[int, ...],
-    filters: Filters | None,
+    filters: recorder.filters.Filters | None,
     context_id_bin: bytes | None = None,
 ) -> StatementLambdaElement:
     """Generate a logbook query for all entities."""
@@ -27,7 +22,9 @@ def all_stmt(
         lambda: select_events_without_states(start_day, end_day, event_type_ids)
     )
     if context_id_bin is not None:
-        stmt += lambda s: s.where(Events.context_id_bin == context_id_bin).union_all(
+        stmt += lambda s: s.where(
+            recorder.db_schema.Events.context_id_bin == context_id_bin
+        ).union_all(
             _states_query_for_context_id(
                 start_day,
                 end_day,
@@ -47,7 +44,7 @@ def all_stmt(
     else:
         stmt += lambda s: s.union_all(_states_query_for_all(start_day, end_day))
 
-    stmt += lambda s: s.order_by(Events.time_fired_ts)
+    stmt += lambda s: s.order_by(recorder.db_schema.Events.time_fired_ts)
     return stmt
 
 
@@ -58,9 +55,13 @@ def _states_query_for_all(start_day: float, end_day: float) -> Select:
 def _apply_all_hints(sel: Select) -> Select:
     """Force mysql to use the right index on large selects."""
     return sel.with_hint(
-        States, f"FORCE INDEX ({LAST_UPDATED_INDEX_TS})", dialect_name="mysql"
+        recorder.db_schema.States,
+        f"FORCE INDEX ({recorder.db_schema.LAST_UPDATED_INDEX_TS})",
+        dialect_name="mysql",
     ).with_hint(
-        States, f"FORCE INDEX ({LAST_UPDATED_INDEX_TS})", dialect_name="mariadb"
+        recorder.db_schema.States,
+        f"FORCE INDEX ({recorder.db_schema.LAST_UPDATED_INDEX_TS})",
+        dialect_name="mariadb",
     )
 
 
@@ -68,5 +69,5 @@ def _states_query_for_context_id(
     start_day: float, end_day: float, context_id_bin: bytes
 ) -> Select:
     return apply_states_filters(select_states(), start_day, end_day).where(
-        States.context_id_bin == context_id_bin
+        recorder.db_schema.States.context_id_bin == context_id_bin
     )

--- a/homeassistant/components/logbook/queries/common.py
+++ b/homeassistant/components/logbook/queries/common.py
@@ -9,37 +9,28 @@ from sqlalchemy.sql.elements import BooleanClauseList, ColumnElement
 from sqlalchemy.sql.expression import literal
 from sqlalchemy.sql.selectable import Select
 
-from homeassistant.components.recorder.db_schema import (
-    EVENTS_CONTEXT_ID_BIN_INDEX,
-    OLD_FORMAT_ATTRS_JSON,
-    OLD_STATE,
-    SHARED_ATTRS_JSON,
-    SHARED_DATA_OR_LEGACY_EVENT_DATA,
-    STATES_CONTEXT_ID_BIN_INDEX,
-    EventData,
-    Events,
-    EventTypes,
-    StateAttributes,
-    States,
-    StatesMeta,
-)
-from homeassistant.components.recorder.filters import like_domain_matchers
+from homeassistant.components import recorder
 
 from ..const import ALWAYS_CONTINUOUS_DOMAINS, CONDITIONALLY_CONTINUOUS_DOMAINS
 
 # Domains that are continuous if there is a UOM set on the entity
-CONDITIONALLY_CONTINUOUS_ENTITY_ID_LIKE = like_domain_matchers(
+CONDITIONALLY_CONTINUOUS_ENTITY_ID_LIKE = recorder.filters.like_domain_matchers(
     CONDITIONALLY_CONTINUOUS_DOMAINS
 )
 # Domains that are always continuous
-ALWAYS_CONTINUOUS_ENTITY_ID_LIKE = like_domain_matchers(ALWAYS_CONTINUOUS_DOMAINS)
+ALWAYS_CONTINUOUS_ENTITY_ID_LIKE = recorder.filters.like_domain_matchers(
+    ALWAYS_CONTINUOUS_DOMAINS
+)
 
 UNIT_OF_MEASUREMENT_JSON = '"unit_of_measurement":'
 UNIT_OF_MEASUREMENT_JSON_LIKE = f"%{UNIT_OF_MEASUREMENT_JSON}%"
 
 ICON_OR_OLD_FORMAT_ICON_JSON = sqlalchemy.case(
-    (SHARED_ATTRS_JSON["icon"].is_(None), OLD_FORMAT_ATTRS_JSON["icon"].as_string()),
-    else_=SHARED_ATTRS_JSON["icon"].as_string(),
+    (
+        recorder.db_schema.SHARED_ATTRS_JSON["icon"].is_(None),
+        recorder.db_schema.OLD_FORMAT_ATTRS_JSON["icon"].as_string(),
+    ),
+    else_=recorder.db_schema.SHARED_ATTRS_JSON["icon"].as_string(),
 ).label("icon")
 
 PSEUDO_EVENT_STATE_CHANGED: Final = None
@@ -51,29 +42,29 @@ PSEUDO_EVENT_STATE_CHANGED: Final = None
 # in the payload
 
 EVENT_COLUMNS = (
-    Events.event_id.label("row_id"),
-    EventTypes.event_type.label("event_type"),
-    SHARED_DATA_OR_LEGACY_EVENT_DATA,
-    Events.time_fired_ts.label("time_fired_ts"),
-    Events.context_id_bin.label("context_id_bin"),
-    Events.context_user_id_bin.label("context_user_id_bin"),
-    Events.context_parent_id_bin.label("context_parent_id_bin"),
+    recorder.db_schema.Events.event_id.label("row_id"),
+    recorder.db_schema.EventTypes.event_type.label("event_type"),
+    recorder.db_schema.SHARED_DATA_OR_LEGACY_EVENT_DATA,
+    recorder.db_schema.Events.time_fired_ts.label("time_fired_ts"),
+    recorder.db_schema.Events.context_id_bin.label("context_id_bin"),
+    recorder.db_schema.Events.context_user_id_bin.label("context_user_id_bin"),
+    recorder.db_schema.Events.context_parent_id_bin.label("context_parent_id_bin"),
 )
 
 STATE_COLUMNS = (
-    States.state.label("state"),
-    StatesMeta.entity_id.label("entity_id"),
+    recorder.db_schema.States.state.label("state"),
+    recorder.db_schema.StatesMeta.entity_id.label("entity_id"),
     ICON_OR_OLD_FORMAT_ICON_JSON,
 )
 
 STATE_CONTEXT_ONLY_COLUMNS = (
-    States.state.label("state"),
-    StatesMeta.entity_id.label("entity_id"),
+    recorder.db_schema.States.state.label("state"),
+    recorder.db_schema.StatesMeta.entity_id.label("entity_id"),
     literal(value=None, type_=sqlalchemy.String).label("icon"),
 )
 
 EVENT_COLUMNS_FOR_STATE_SELECT = (
-    States.state_id.label("row_id"),
+    recorder.db_schema.States.state_id.label("row_id"),
     # We use PSEUDO_EVENT_STATE_CHANGED aka None for
     # state_changed events since it takes up less
     # space in the response and every row has to be
@@ -82,10 +73,10 @@ EVENT_COLUMNS_FOR_STATE_SELECT = (
         "event_type"
     ),
     literal(value=None, type_=sqlalchemy.Text).label("event_data"),
-    States.last_updated_ts.label("time_fired_ts"),
-    States.context_id_bin.label("context_id_bin"),
-    States.context_user_id_bin.label("context_user_id_bin"),
-    States.context_parent_id_bin.label("context_parent_id_bin"),
+    recorder.db_schema.States.last_updated_ts.label("time_fired_ts"),
+    recorder.db_schema.States.context_id_bin.label("context_id_bin"),
+    recorder.db_schema.States.context_user_id_bin.label("context_user_id_bin"),
+    recorder.db_schema.States.context_parent_id_bin.label("context_parent_id_bin"),
 )
 
 EMPTY_STATE_COLUMNS = (
@@ -113,11 +104,23 @@ def select_events_context_id_subquery(
 ) -> Select:
     """Generate the select for a context_id subquery."""
     return (
-        select(Events.context_id_bin)
-        .where((Events.time_fired_ts > start_day) & (Events.time_fired_ts < end_day))
-        .where(Events.event_type_id.in_(event_type_ids))
-        .outerjoin(EventTypes, (Events.event_type_id == EventTypes.event_type_id))
-        .outerjoin(EventData, (Events.data_id == EventData.data_id))
+        select(recorder.db_schema.Events.context_id_bin)
+        .where(
+            (recorder.db_schema.Events.time_fired_ts > start_day)
+            & (recorder.db_schema.Events.time_fired_ts < end_day)
+        )
+        .where(recorder.db_schema.Events.event_type_id.in_(event_type_ids))
+        .outerjoin(
+            recorder.db_schema.EventTypes,
+            (
+                recorder.db_schema.Events.event_type_id
+                == recorder.db_schema.EventTypes.event_type_id
+            ),
+        )
+        .outerjoin(
+            recorder.db_schema.EventData,
+            (recorder.db_schema.Events.data_id == recorder.db_schema.EventData.data_id),
+        )
     )
 
 
@@ -147,10 +150,22 @@ def select_events_without_states(
     """Generate an events select that does not join states."""
     return (
         select(*EVENT_ROWS_NO_STATES, NOT_CONTEXT_ONLY)
-        .where((Events.time_fired_ts > start_day) & (Events.time_fired_ts < end_day))
-        .where(Events.event_type_id.in_(event_type_ids))
-        .outerjoin(EventTypes, (Events.event_type_id == EventTypes.event_type_id))
-        .outerjoin(EventData, (Events.data_id == EventData.data_id))
+        .where(
+            (recorder.db_schema.Events.time_fired_ts > start_day)
+            & (recorder.db_schema.Events.time_fired_ts < end_day)
+        )
+        .where(recorder.db_schema.Events.event_type_id.in_(event_type_ids))
+        .outerjoin(
+            recorder.db_schema.EventTypes,
+            (
+                recorder.db_schema.Events.event_type_id
+                == recorder.db_schema.EventTypes.event_type_id
+            ),
+        )
+        .outerjoin(
+            recorder.db_schema.EventData,
+            (recorder.db_schema.Events.data_id == recorder.db_schema.EventData.data_id),
+        )
     )
 
 
@@ -172,19 +187,33 @@ def apply_states_filters(sel: Select, start_day: float, end_day: float) -> Selec
     """
     return (
         sel.filter(
-            (States.last_updated_ts > start_day) & (States.last_updated_ts < end_day)
+            (recorder.db_schema.States.last_updated_ts > start_day)
+            & (recorder.db_schema.States.last_updated_ts < end_day)
         )
-        .outerjoin(OLD_STATE, (States.old_state_id == OLD_STATE.state_id))
+        .outerjoin(
+            recorder.db_schema.OLD_STATE,
+            recorder.db_schema.States.old_state_id
+            == recorder.db_schema.OLD_STATE.state_id,
+        )
         .where(_missing_state_matcher())
         .where(_not_continuous_entity_matcher())
         .where(
-            (States.last_updated_ts == States.last_changed_ts)
-            | States.last_changed_ts.is_(None)
+            (
+                recorder.db_schema.States.last_updated_ts
+                == recorder.db_schema.States.last_changed_ts
+            )
+            | recorder.db_schema.States.last_changed_ts.is_(None)
         )
         .outerjoin(
-            StateAttributes, (States.attributes_id == StateAttributes.attributes_id)
+            recorder.db_schema.StateAttributes,
+            recorder.db_schema.States.attributes_id
+            == recorder.db_schema.StateAttributes.attributes_id,
         )
-        .outerjoin(StatesMeta, (States.metadata_id == StatesMeta.metadata_id))
+        .outerjoin(
+            recorder.db_schema.StatesMeta,
+            recorder.db_schema.States.metadata_id
+            == recorder.db_schema.StatesMeta.metadata_id,
+        )
     )
 
 
@@ -193,9 +222,9 @@ def _missing_state_matcher() -> ColumnElement[bool]:
     # and old_state or the old_state is missing (newly added entities)
     # or the new_state is missing (removed entities)
     return sqlalchemy.and_(
-        OLD_STATE.state_id.is_not(None),
-        (States.state != OLD_STATE.state),
-        States.state.is_not(None),
+        recorder.db_schema.OLD_STATE.state_id.is_not(None),
+        recorder.db_schema.States.state != recorder.db_schema.OLD_STATE.state,
+        recorder.db_schema.States.state.is_not(None),
     )
 
 
@@ -221,7 +250,7 @@ def _not_possible_continuous_domain_matcher() -> ColumnElement[bool]:
     """
     return sqlalchemy.and_(
         *[
-            ~StatesMeta.entity_id.like(entity_domain)
+            ~recorder.db_schema.StatesMeta.entity_id.like(entity_domain)
             for entity_domain in (
                 *ALWAYS_CONTINUOUS_ENTITY_ID_LIKE,
                 *CONDITIONALLY_CONTINUOUS_ENTITY_ID_LIKE,
@@ -238,7 +267,7 @@ def _conditionally_continuous_domain_matcher() -> ColumnElement[bool]:
     """
     return sqlalchemy.or_(
         *[
-            StatesMeta.entity_id.like(entity_domain)
+            recorder.db_schema.StatesMeta.entity_id.like(entity_domain)
             for entity_domain in CONDITIONALLY_CONTINUOUS_ENTITY_ID_LIKE
         ],
     ).self_group()
@@ -246,24 +275,32 @@ def _conditionally_continuous_domain_matcher() -> ColumnElement[bool]:
 
 def _not_uom_attributes_matcher() -> BooleanClauseList:
     """Prefilter ATTR_UNIT_OF_MEASUREMENT as its much faster in sql."""
-    return ~StateAttributes.shared_attrs.like(
+    return ~recorder.db_schema.StateAttributes.shared_attrs.like(
         UNIT_OF_MEASUREMENT_JSON_LIKE
-    ) | ~States.attributes.like(UNIT_OF_MEASUREMENT_JSON_LIKE)
+    ) | ~recorder.db_schema.States.attributes.like(UNIT_OF_MEASUREMENT_JSON_LIKE)
 
 
 def apply_states_context_hints(sel: Select) -> Select:
     """Force mysql to use the right index on large context_id selects."""
     return sel.with_hint(
-        States, f"FORCE INDEX ({STATES_CONTEXT_ID_BIN_INDEX})", dialect_name="mysql"
+        recorder.db_schema.States,
+        f"FORCE INDEX ({recorder.db_schema.STATES_CONTEXT_ID_BIN_INDEX})",
+        dialect_name="mysql",
     ).with_hint(
-        States, f"FORCE INDEX ({STATES_CONTEXT_ID_BIN_INDEX})", dialect_name="mariadb"
+        recorder.db_schema.States,
+        f"FORCE INDEX ({recorder.db_schema.STATES_CONTEXT_ID_BIN_INDEX})",
+        dialect_name="mariadb",
     )
 
 
 def apply_events_context_hints(sel: Select) -> Select:
     """Force mysql to use the right index on large context_id selects."""
     return sel.with_hint(
-        Events, f"FORCE INDEX ({EVENTS_CONTEXT_ID_BIN_INDEX})", dialect_name="mysql"
+        recorder.db_schema.Events,
+        f"FORCE INDEX ({recorder.db_schema.EVENTS_CONTEXT_ID_BIN_INDEX})",
+        dialect_name="mysql",
     ).with_hint(
-        Events, f"FORCE INDEX ({EVENTS_CONTEXT_ID_BIN_INDEX})", dialect_name="mariadb"
+        recorder.db_schema.Events,
+        f"FORCE INDEX ({recorder.db_schema.EVENTS_CONTEXT_ID_BIN_INDEX})",
+        dialect_name="mariadb",
     )

--- a/homeassistant/components/logbook/rest_api.py
+++ b/homeassistant/components/logbook/rest_api.py
@@ -9,9 +9,8 @@ from typing import Any, cast
 from aiohttp import web
 import voluptuous as vol
 
+from homeassistant.components import recorder
 from homeassistant.components.http import HomeAssistantView
-from homeassistant.components.recorder import get_instance
-from homeassistant.components.recorder.filters import Filters
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import InvalidEntityFormatError
 from homeassistant.helpers import config_validation as cv
@@ -26,7 +25,7 @@ from .processor import EventProcessor
 def async_setup(
     hass: HomeAssistant,
     conf: ConfigType,
-    filters: Filters | None,
+    filters: recorder.Filters | None,
     entities_filter: Callable[[str], bool] | None,
 ) -> None:
     """Set up the logbook rest API."""
@@ -43,12 +42,12 @@ class LogbookView(HomeAssistantView):
     def __init__(
         self,
         config: dict[str, Any],
-        filters: Filters | None,
+        filters: recorder.Filters | None,
         entities_filter: Callable[[str], bool] | None,
     ) -> None:
         """Initialize the logbook view."""
         self.config = config
-        self.filters = filters
+        self.filters = recorder.filters
         self.entities_filter = entities_filter
 
     async def get(
@@ -116,5 +115,6 @@ class LogbookView(HomeAssistantView):
             )
 
         return cast(
-            web.Response, await get_instance(hass).async_add_executor_job(json_events)
+            web.Response,
+            await recorder.get_instance(hass).async_add_executor_job(json_events),
         )

--- a/homeassistant/components/logbook/websocket_api.py
+++ b/homeassistant/components/logbook/websocket_api.py
@@ -10,8 +10,7 @@ from typing import Any
 
 import voluptuous as vol
 
-from homeassistant.components import websocket_api
-from homeassistant.components.recorder import get_instance
+from homeassistant.components import recorder, websocket_api
 from homeassistant.components.websocket_api import messages
 from homeassistant.components.websocket_api.connection import ActiveConnection
 from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant, callback
@@ -167,7 +166,7 @@ async def _async_get_ws_stream_events(
     partial: bool,
 ) -> tuple[str, dt | None]:
     """Async wrapper around _ws_formatted_get_events."""
-    return await get_instance(hass).async_add_executor_job(
+    return await recorder.get_instance(hass).async_add_executor_job(
         _ws_stream_get_events,
         msg_id,
         start_time,
@@ -405,7 +404,7 @@ async def ws_event_stream(
     )
 
     live_stream.wait_sync_task = asyncio.create_task(
-        get_instance(hass).async_block_till_done()
+        recorder.get_instance(hass).async_block_till_done()
     )
     await live_stream.wait_sync_task
 
@@ -504,7 +503,7 @@ async def ws_get_events(
     )
 
     connection.send_message(
-        await get_instance(hass).async_add_executor_job(
+        await recorder.get_instance(hass).async_add_executor_job(
             _ws_formatted_get_events,
             msg["id"],
             start_time,

--- a/homeassistant/components/plant/__init__.py
+++ b/homeassistant/components/plant/__init__.py
@@ -6,7 +6,7 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.components.recorder import get_instance, history
+from homeassistant.components import recorder
 from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT,
     CONDUCTIVITY,
@@ -273,7 +273,7 @@ class Plant(Entity):
         """After being added to hass, load from history."""
         if "recorder" in self.hass.config.components:
             # only use the database if it's configured
-            await get_instance(self.hass).async_add_executor_job(
+            await recorder.get_instance(self.hass).async_add_executor_job(
                 self._load_history_from_db
             )
             self.async_write_ha_state()
@@ -302,7 +302,7 @@ class Plant(Entity):
             return
         _LOGGER.debug("Initializing values for %s from the database", self._name)
         lower_entity_id = entity_id.lower()
-        history_list = history.state_changes_during_period(
+        history_list = recorder.history.state_changes_during_period(
             self.hass,
             start_date,
             entity_id=lower_entity_id,

--- a/homeassistant/components/sql/__init__.py
+++ b/homeassistant/components/sql/__init__.py
@@ -5,7 +5,7 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.components.recorder import CONF_DB_URL, get_instance
+from homeassistant.components import recorder
 from homeassistant.components.sensor import (
     CONF_STATE_CLASS,
     DEVICE_CLASSES_SCHEMA,
@@ -46,7 +46,7 @@ QUERY_SCHEMA = vol.Schema(
         vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
         vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
         vol.Optional(CONF_UNIQUE_ID): cv.string,
-        vol.Optional(CONF_DB_URL): cv.string,
+        vol.Optional(recorder.CONF_DB_URL): cv.string,
         vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
         vol.Optional(CONF_STATE_CLASS): STATE_CLASSES_SCHEMA,
     }
@@ -65,7 +65,9 @@ def remove_configured_db_url_if_not_needed(
     hass.config_entries.async_update_entry(
         entry,
         options={
-            key: value for key, value in entry.options.items() if key != CONF_DB_URL
+            key: value
+            for key, value in entry.options.items()
+            if key != recorder.CONF_DB_URL
         },
     )
 
@@ -92,10 +94,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up SQL from a config entry."""
     _LOGGER.debug(
         "Comparing %s and %s",
-        redact_credentials(entry.options.get(CONF_DB_URL)),
-        redact_credentials(get_instance(hass).db_url),
+        redact_credentials(entry.options.get(recorder.CONF_DB_URL)),
+        redact_credentials(recorder.get_instance(hass).db_url),
     )
-    if entry.options.get(CONF_DB_URL) == get_instance(hass).db_url:
+    if entry.options.get(recorder.CONF_DB_URL) == recorder.get_instance(hass).db_url:
         remove_configured_db_url_if_not_needed(hass, entry)
 
     entry.async_on_unload(entry.add_update_listener(async_update_listener))

--- a/homeassistant/components/sql/config_flow.py
+++ b/homeassistant/components/sql/config_flow.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import Session, scoped_session, sessionmaker
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.components.recorder import CONF_DB_URL, get_instance
+from homeassistant.components import recorder
 from homeassistant.components.sensor import (
     CONF_STATE_CLASS,
     SensorDeviceClass,
@@ -37,7 +37,7 @@ NONE_SENTINEL = "none"
 OPTIONS_SCHEMA: vol.Schema = vol.Schema(
     {
         vol.Optional(
-            CONF_DB_URL,
+            recorder.CONF_DB_URL,
         ): selector.TextSelector(),
         vol.Required(
             CONF_COLUMN_NAME,
@@ -151,7 +151,7 @@ class SQLConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         description_placeholders = {}
 
         if user_input is not None:
-            db_url = user_input.get(CONF_DB_URL)
+            db_url = user_input.get(recorder.CONF_DB_URL)
             query = user_input[CONF_QUERY]
             column = user_input[CONF_COLUMN_NAME]
             db_url_for_validation = None
@@ -183,8 +183,8 @@ class SQLConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 options[CONF_DEVICE_CLASS] = device_class
             if (state_class := user_input[CONF_STATE_CLASS]) != NONE_SENTINEL:
                 options[CONF_STATE_CLASS] = state_class
-            if db_url_for_validation != get_instance(self.hass).db_url:
-                options[CONF_DB_URL] = db_url_for_validation
+            if db_url_for_validation != recorder.get_instance(self.hass).db_url:
+                options[recorder.CONF_DB_URL] = db_url_for_validation
 
             if not errors:
                 return self.async_create_entry(
@@ -212,7 +212,7 @@ class SQLOptionsFlowHandler(config_entries.OptionsFlowWithConfigEntry):
         description_placeholders = {}
 
         if user_input is not None:
-            db_url = user_input.get(CONF_DB_URL)
+            db_url = user_input.get(recorder.CONF_DB_URL)
             query = user_input[CONF_QUERY]
             column = user_input[CONF_COLUMN_NAME]
             name = self.options.get(CONF_NAME, self.config_entry.title)
@@ -231,7 +231,7 @@ class SQLOptionsFlowHandler(config_entries.OptionsFlowWithConfigEntry):
             except ValueError:
                 errors["query"] = "query_invalid"
             else:
-                recorder_db = get_instance(self.hass).db_url
+                recorder_db = recorder.get_instance(self.hass).db_url
                 _LOGGER.debug(
                     "db_url: %s, resolved db_url: %s, recorder: %s",
                     db_url,
@@ -252,8 +252,8 @@ class SQLOptionsFlowHandler(config_entries.OptionsFlowWithConfigEntry):
                     options[CONF_DEVICE_CLASS] = device_class
                 if (state_class := user_input[CONF_STATE_CLASS]) != NONE_SENTINEL:
                     options[CONF_STATE_CLASS] = state_class
-                if db_url_for_validation != get_instance(self.hass).db_url:
-                    options[CONF_DB_URL] = db_url_for_validation
+                if db_url_for_validation != recorder.get_instance(self.hass).db_url:
+                    options[recorder.CONF_DB_URL] = db_url_for_validation
 
                 return self.async_create_entry(
                     data=options,

--- a/homeassistant/components/sql/util.py
+++ b/homeassistant/components/sql/util.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import logging
 
-from homeassistant.components.recorder import get_instance
+from homeassistant.components import recorder
 from homeassistant.core import HomeAssistant
 
 from .const import DB_URL_RE
@@ -23,4 +23,4 @@ def resolve_db_url(hass: HomeAssistant, db_url: str | None) -> str:
     _LOGGER.debug("db_url: %s", redact_credentials(db_url))
     if db_url and not db_url.isspace():
         return db_url
-    return get_instance(hass).db_url
+    return recorder.get_instance(hass).db_url

--- a/homeassistant/components/statistics/sensor.py
+++ b/homeassistant/components/statistics/sensor.py
@@ -11,8 +11,8 @@ from typing import Any, cast
 
 import voluptuous as vol
 
+from homeassistant.components import recorder
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
-from homeassistant.components.recorder import get_instance, history
 from homeassistant.components.sensor import (
     DEVICE_CLASS_STATE_CLASSES,
     PLATFORM_SCHEMA,
@@ -511,7 +511,7 @@ class StatisticsSensor(SensorEntity):
         else:
             start_date = datetime.fromtimestamp(0, tz=dt_util.UTC)
             _LOGGER.debug("%s: retrieving all records", self.entity_id)
-        return history.state_changes_during_period(
+        return recorder.history.state_changes_during_period(
             self.hass,
             start_date,
             entity_id=lower_entity_id,
@@ -530,7 +530,7 @@ class StatisticsSensor(SensorEntity):
         If MaxAge is provided then query will restrict to entries younger then
         current datetime - MaxAge.
         """
-        if states := await get_instance(self.hass).async_add_executor_job(
+        if states := await recorder.get_instance(self.hass).async_add_executor_job(
             self._fetch_states_from_database
         ):
             for state in reversed(states):

--- a/homeassistant/components/websocket_api/permissions.py
+++ b/homeassistant/components/websocket_api/permissions.py
@@ -6,14 +6,11 @@ from __future__ import annotations
 
 from typing import Final
 
+from homeassistant.components import recorder
 from homeassistant.components.frontend import EVENT_PANELS_UPDATED
 from homeassistant.components.lovelace import EVENT_LOVELACE_UPDATED
 from homeassistant.components.persistent_notification import (
     EVENT_PERSISTENT_NOTIFICATIONS_UPDATED,
-)
-from homeassistant.components.recorder import (
-    EVENT_RECORDER_5MIN_STATISTICS_GENERATED,
-    EVENT_RECORDER_HOURLY_STATISTICS_GENERATED,
 )
 from homeassistant.components.shopping_list import EVENT_SHOPPING_LIST_UPDATED
 from homeassistant.const import (
@@ -39,8 +36,8 @@ SUBSCRIBE_ALLOWLIST: Final[set[str]] = {
     EVENT_LOVELACE_UPDATED,
     EVENT_PANELS_UPDATED,
     EVENT_PERSISTENT_NOTIFICATIONS_UPDATED,
-    EVENT_RECORDER_5MIN_STATISTICS_GENERATED,
-    EVENT_RECORDER_HOURLY_STATISTICS_GENERATED,
+    recorder.EVENT_RECORDER_5MIN_STATISTICS_GENERATED,
+    recorder.EVENT_RECORDER_HOURLY_STATISTICS_GENERATED,
     EVENT_SERVICE_REGISTERED,
     EVENT_SERVICE_REMOVED,
     EVENT_SHOPPING_LIST_UPDATED,

--- a/tests/components/analytics/test_analytics.py
+++ b/tests/components/analytics/test_analytics.py
@@ -6,6 +6,7 @@ from unittest.mock import ANY, AsyncMock, Mock, PropertyMock, patch
 import aiohttp
 import pytest
 
+from homeassistant.components import recorder
 from homeassistant.components.analytics.analytics import Analytics
 from homeassistant.components.analytics.const import (
     ANALYTICS_ENDPOINT_URL,
@@ -15,7 +16,6 @@ from homeassistant.components.analytics.const import (
     ATTR_STATISTICS,
     ATTR_USAGE,
 )
-from homeassistant.components.recorder import Recorder
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_DOMAIN
 from homeassistant.core import HomeAssistant
@@ -627,7 +627,7 @@ async def test_send_with_no_energy(
 
 
 async def test_send_with_no_energy_config(
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
     mock_hass_config: None,
@@ -654,7 +654,7 @@ async def test_send_with_no_energy_config(
 
 
 async def test_send_with_energy_config(
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
     mock_hass_config: None,
@@ -702,7 +702,7 @@ async def test_send_usage_with_certificate(
 
 
 async def test_send_with_recorder(
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
 ) -> None:

--- a/tests/components/automation/test_recorder.py
+++ b/tests/components/automation/test_recorder.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import pytest
 
-from homeassistant.components import automation
+from homeassistant.components import automation, recorder
 from homeassistant.components.automation import (
     ATTR_CUR,
     ATTR_LAST_TRIGGERED,
@@ -11,8 +11,6 @@ from homeassistant.components.automation import (
     ATTR_MODE,
     CONF_ID,
 )
-from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_FRIENDLY_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -29,7 +27,7 @@ def calls(hass):
 
 
 async def test_exclude_attributes(
-    recorder_mock: Recorder, hass: HomeAssistant, calls
+    recorder_mock: recorder.Recorder, hass: HomeAssistant, calls
 ) -> None:
     """Test automation registered attributes to be excluded."""
     now = dt_util.utcnow()
@@ -51,7 +49,11 @@ async def test_exclude_attributes(
     await async_wait_recording_done(hass)
 
     states = await hass.async_add_executor_job(
-        get_significant_states, hass, now, None, hass.states.async_entity_ids()
+        recorder.history.get_significant_states,
+        hass,
+        now,
+        None,
+        hass.states.async_entity_ids(),
     )
     assert len(states) == 1
     for entity_states in states.values():

--- a/tests/components/calendar/test_recorder.py
+++ b/tests/components/calendar/test_recorder.py
@@ -4,8 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.history import get_significant_states
+from homeassistant.components import recorder
 from homeassistant.const import ATTR_FRIENDLY_NAME, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -30,7 +29,9 @@ async def calendar_only() -> None:
         yield
 
 
-async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) -> None:
+async def test_exclude_attributes(
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
+) -> None:
     """Test sensor attributes to be excluded."""
     now = dt_util.utcnow()
     await async_setup_component(hass, "homeassistant", {})
@@ -48,7 +49,11 @@ async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) 
     await async_wait_recording_done(hass)
 
     states = await hass.async_add_executor_job(
-        get_significant_states, hass, now, None, hass.states.async_entity_ids()
+        recorder.history.get_significant_states,
+        hass,
+        now,
+        None,
+        hass.states.async_entity_ids(),
     )
     assert len(states) > 1
     for entity_states in states.values():

--- a/tests/components/camera/test_recorder.py
+++ b/tests/components/camera/test_recorder.py
@@ -5,9 +5,7 @@ from datetime import timedelta
 
 import pytest
 
-from homeassistant.components import camera
-from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.history import get_significant_states
+from homeassistant.components import camera, recorder
 from homeassistant.const import (
     ATTR_ATTRIBUTION,
     ATTR_ENTITY_PICTURE,
@@ -27,7 +25,9 @@ async def setup_homeassistant():
     """Override the fixture in calendar.conftest."""
 
 
-async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) -> None:
+async def test_exclude_attributes(
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
+) -> None:
     """Test camera registered attributes to be excluded."""
     now = dt_util.utcnow()
     await async_setup_component(hass, "homeassistant", {})
@@ -40,7 +40,11 @@ async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) 
     await async_wait_recording_done(hass)
 
     states = await hass.async_add_executor_job(
-        get_significant_states, hass, now, None, hass.states.async_entity_ids()
+        recorder.history.get_significant_states,
+        hass,
+        now,
+        None,
+        hass.states.async_entity_ids(),
     )
     assert len(states) > 1
     for entity_states in states.values():

--- a/tests/components/climate/test_recorder.py
+++ b/tests/components/climate/test_recorder.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant.components import climate
+from homeassistant.components import climate, recorder
 from homeassistant.components.climate import (
     ATTR_FAN_MODES,
     ATTR_HVAC_MODES,
@@ -18,8 +18,6 @@ from homeassistant.components.climate import (
     ATTR_SWING_MODES,
     ATTR_TARGET_TEMP_STEP,
 )
-from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.const import ATTR_FRIENDLY_NAME, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -39,7 +37,9 @@ async def climate_only() -> None:
         yield
 
 
-async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) -> None:
+async def test_exclude_attributes(
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
+) -> None:
     """Test climate registered attributes to be excluded."""
     now = dt_util.utcnow()
     await async_setup_component(hass, "homeassistant", {})
@@ -52,7 +52,11 @@ async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) 
     await async_wait_recording_done(hass)
 
     states = await hass.async_add_executor_job(
-        get_significant_states, hass, now, None, hass.states.async_entity_ids()
+        recorder.history.get_significant_states,
+        hass,
+        now,
+        None,
+        hass.states.async_entity_ids(),
     )
     assert len(states) > 1
     for entity_states in states.values():

--- a/tests/components/energy/test_websocket_api.py
+++ b/tests/components/energy/test_websocket_api.py
@@ -4,9 +4,8 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 
+from homeassistant.components import recorder
 from homeassistant.components.energy import data, is_configured
-from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.statistics import async_add_external_statistics
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
@@ -311,7 +310,9 @@ async def test_get_solar_forecast(
 
 @pytest.mark.freeze_time("2021-08-01 00:00:00+00:00")
 async def test_fossil_energy_consumption_no_co2(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test fossil_energy_consumption when co2 data is missing."""
     now = dt_util.utcnow()
@@ -397,10 +398,10 @@ async def test_fossil_energy_consumption_no_co2(
         "unit_of_measurement": "kWh",
     }
 
-    async_add_external_statistics(
+    recorder.statistics.async_add_external_statistics(
         hass, external_energy_metadata_1, external_energy_statistics_1
     )
-    async_add_external_statistics(
+    recorder.statistics.async_add_external_statistics(
         hass, external_energy_metadata_2, external_energy_statistics_2
     )
     await async_wait_recording_done(hass)
@@ -474,7 +475,9 @@ async def test_fossil_energy_consumption_no_co2(
 
 @pytest.mark.freeze_time("2021-08-01 00:00:00+00:00")
 async def test_fossil_energy_consumption_hole(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test fossil_energy_consumption when some data points lack sum."""
     now = dt_util.utcnow()
@@ -560,10 +563,10 @@ async def test_fossil_energy_consumption_hole(
         "unit_of_measurement": "kWh",
     }
 
-    async_add_external_statistics(
+    recorder.statistics.async_add_external_statistics(
         hass, external_energy_metadata_1, external_energy_statistics_1
     )
-    async_add_external_statistics(
+    recorder.statistics.async_add_external_statistics(
         hass, external_energy_metadata_2, external_energy_statistics_2
     )
     await async_wait_recording_done(hass)
@@ -637,7 +640,9 @@ async def test_fossil_energy_consumption_hole(
 
 @pytest.mark.freeze_time("2021-08-01 00:00:00+00:00")
 async def test_fossil_energy_consumption_no_data(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test fossil_energy_consumption when there is no data."""
     now = dt_util.utcnow()
@@ -721,10 +726,10 @@ async def test_fossil_energy_consumption_no_data(
         "unit_of_measurement": "kWh",
     }
 
-    async_add_external_statistics(
+    recorder.statistics.async_add_external_statistics(
         hass, external_energy_metadata_1, external_energy_statistics_1
     )
-    async_add_external_statistics(
+    recorder.statistics.async_add_external_statistics(
         hass, external_energy_metadata_2, external_energy_statistics_2
     )
     await async_wait_recording_done(hass)
@@ -787,7 +792,9 @@ async def test_fossil_energy_consumption_no_data(
 
 @pytest.mark.freeze_time("2021-08-01 00:00:00+00:00")
 async def test_fossil_energy_consumption(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test fossil_energy_consumption with co2 sensor data."""
     now = dt_util.utcnow()
@@ -903,13 +910,15 @@ async def test_fossil_energy_consumption(
         "unit_of_measurement": "%",
     }
 
-    async_add_external_statistics(
+    recorder.statistics.async_add_external_statistics(
         hass, external_energy_metadata_1, external_energy_statistics_1
     )
-    async_add_external_statistics(
+    recorder.statistics.async_add_external_statistics(
         hass, external_energy_metadata_2, external_energy_statistics_2
     )
-    async_add_external_statistics(hass, external_co2_metadata, external_co2_statistics)
+    recorder.statistics.async_add_external_statistics(
+        hass, external_co2_metadata, external_co2_statistics
+    )
     await async_wait_recording_done(hass)
 
     client = await hass_ws_client()

--- a/tests/components/fan/test_recorder.py
+++ b/tests/components/fan/test_recorder.py
@@ -6,10 +6,8 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant.components import fan
+from homeassistant.components import fan, recorder
 from homeassistant.components.fan import ATTR_PRESET_MODES
-from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.const import ATTR_FRIENDLY_NAME, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -29,7 +27,9 @@ async def fan_only() -> None:
         yield
 
 
-async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) -> None:
+async def test_exclude_attributes(
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
+) -> None:
     """Test fan registered attributes to be excluded."""
     now = dt_util.utcnow()
     await async_setup_component(hass, "homeassistant", {})
@@ -40,7 +40,11 @@ async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) 
     await async_wait_recording_done(hass)
 
     states = await hass.async_add_executor_job(
-        get_significant_states, hass, now, None, hass.states.async_entity_ids()
+        recorder.history.get_significant_states,
+        hass,
+        now,
+        None,
+        hass.states.async_entity_ids(),
     )
     assert len(states) > 1
     for entity_states in states.values():

--- a/tests/components/filter/test_sensor.py
+++ b/tests/components/filter/test_sensor.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant import config as hass_config
+from homeassistant.components import recorder
 from homeassistant.components.filter.sensor import (
     DOMAIN,
     LowPassFilter,
@@ -14,7 +15,6 @@ from homeassistant.components.filter.sensor import (
     TimeSMAFilter,
     TimeThrottleFilter,
 )
-from homeassistant.components.recorder import Recorder
 from homeassistant.components.sensor import (
     ATTR_STATE_CLASS,
     SensorDeviceClass,
@@ -63,7 +63,7 @@ async def test_setup_fail(hass: HomeAssistant) -> None:
 
 
 async def test_chain(
-    recorder_mock: Recorder, hass: HomeAssistant, values: list[State]
+    recorder_mock: recorder.Recorder, hass: HomeAssistant, values: list[State]
 ) -> None:
     """Test if filter chaining works."""
     config = {
@@ -93,7 +93,7 @@ async def test_chain(
 
 @pytest.mark.parametrize("missing", (True, False))
 async def test_chain_history(
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
     values: list[State],
     missing: bool,
@@ -151,7 +151,9 @@ async def test_chain_history(
             assert state.state == "17.05"
 
 
-async def test_source_state_none(recorder_mock: Recorder, hass: HomeAssistant) -> None:
+async def test_source_state_none(
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
+) -> None:
     """Test is source sensor state is null and sets state to STATE_UNKNOWN."""
 
     config = {
@@ -211,7 +213,9 @@ async def test_source_state_none(recorder_mock: Recorder, hass: HomeAssistant) -
     assert state.state == STATE_UNKNOWN
 
 
-async def test_history_time(recorder_mock: Recorder, hass: HomeAssistant) -> None:
+async def test_history_time(
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
+) -> None:
     """Test loading from history based on a time window."""
     config = {
         "sensor": {
@@ -249,7 +253,7 @@ async def test_history_time(recorder_mock: Recorder, hass: HomeAssistant) -> Non
         assert state.state == "18.0"
 
 
-async def test_setup(recorder_mock: Recorder, hass: HomeAssistant) -> None:
+async def test_setup(recorder_mock: recorder.Recorder, hass: HomeAssistant) -> None:
     """Test if filter attributes are inherited."""
     config = {
         "sensor": {
@@ -291,7 +295,9 @@ async def test_setup(recorder_mock: Recorder, hass: HomeAssistant) -> None:
         assert entity_id == "sensor.test"
 
 
-async def test_invalid_state(recorder_mock: Recorder, hass: HomeAssistant) -> None:
+async def test_invalid_state(
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
+) -> None:
     """Test if filter attributes are inherited."""
     config = {
         "sensor": {
@@ -327,7 +333,9 @@ async def test_invalid_state(recorder_mock: Recorder, hass: HomeAssistant) -> No
         assert state.state == STATE_UNAVAILABLE
 
 
-async def test_timestamp_state(recorder_mock: Recorder, hass: HomeAssistant) -> None:
+async def test_timestamp_state(
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
+) -> None:
     """Test if filter state is a datetime."""
     config = {
         "sensor": {
@@ -485,7 +493,7 @@ def test_time_sma(values: list[State]) -> None:
     assert filtered.state == 21.5
 
 
-async def test_reload(recorder_mock: Recorder, hass: HomeAssistant) -> None:
+async def test_reload(recorder_mock: recorder.Recorder, hass: HomeAssistant) -> None:
     """Verify we can reload filter sensors."""
     hass.states.async_set("sensor.test_monitored", 12345)
     await async_setup_component(

--- a/tests/components/group/test_recorder.py
+++ b/tests/components/group/test_recorder.py
@@ -5,10 +5,8 @@ from datetime import timedelta
 
 import pytest
 
-from homeassistant.components import group
+from homeassistant.components import group, recorder
 from homeassistant.components.group import ATTR_AUTO, ATTR_ENTITY_ID, ATTR_ORDER
-from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.const import ATTR_FRIENDLY_NAME, STATE_ON
 from homeassistant.core import HomeAssistant, split_entity_id
 from homeassistant.setup import async_setup_component
@@ -23,7 +21,9 @@ async def setup_homeassistant():
     """Override the fixture in group.conftest."""
 
 
-async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) -> None:
+async def test_exclude_attributes(
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
+) -> None:
     """Test number registered attributes to be excluded."""
     now = dt_util.utcnow()
     hass.states.async_set("light.bowl", STATE_ON)
@@ -46,7 +46,11 @@ async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) 
     await async_wait_recording_done(hass)
 
     states = await hass.async_add_executor_job(
-        get_significant_states, hass, now, None, hass.states.async_entity_ids()
+        recorder.history.get_significant_states,
+        hass,
+        now,
+        None,
+        hass.states.async_entity_ids(),
     )
     assert len(states) > 1
     for entity_states in states.values():

--- a/tests/components/history/test_websocket_api.py
+++ b/tests/components/history/test_websocket_api.py
@@ -8,9 +8,8 @@ import async_timeout
 from freezegun import freeze_time
 import pytest
 
-from homeassistant.components import history
+from homeassistant.components import history, recorder
 from homeassistant.components.history import websocket_api
-from homeassistant.components.recorder import Recorder
 from homeassistant.const import EVENT_HOMEASSISTANT_FINAL_WRITE
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -40,7 +39,9 @@ def test_setup() -> None:
 
 
 async def test_history_during_period(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test history_during_period."""
     now = dt_util.utcnow()
@@ -174,7 +175,9 @@ async def test_history_during_period(
 
 
 async def test_history_during_period_impossible_conditions(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test history_during_period returns when condition cannot be true."""
     await async_setup_component(hass, "history", {})
@@ -237,7 +240,7 @@ async def test_history_during_period_impossible_conditions(
 )
 async def test_history_during_period_significant_domain(
     time_zone,
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
 ) -> None:
@@ -404,7 +407,9 @@ async def test_history_during_period_significant_domain(
 
 
 async def test_history_during_period_bad_start_time(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test history_during_period bad state time."""
     await async_setup_component(
@@ -428,7 +433,9 @@ async def test_history_during_period_bad_start_time(
 
 
 async def test_history_during_period_bad_end_time(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test history_during_period bad end time."""
     now = dt_util.utcnow()
@@ -455,7 +462,9 @@ async def test_history_during_period_bad_end_time(
 
 
 async def test_history_stream_historical_only(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test history stream."""
     now = dt_util.utcnow()
@@ -526,7 +535,9 @@ async def test_history_stream_historical_only(
 
 
 async def test_history_stream_significant_domain_historical_only(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test the stream with climate domain with historical states only."""
     now = dt_util.utcnow()
@@ -727,7 +738,9 @@ async def test_history_stream_significant_domain_historical_only(
 
 
 async def test_history_stream_bad_start_time(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test history stream bad state time."""
     await async_setup_component(
@@ -751,7 +764,9 @@ async def test_history_stream_bad_start_time(
 
 
 async def test_history_stream_end_time_before_start_time(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test history stream with an end_time before the start_time."""
     end_time = dt_util.utcnow() - timedelta(seconds=2)
@@ -779,7 +794,9 @@ async def test_history_stream_end_time_before_start_time(
 
 
 async def test_history_stream_bad_end_time(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test history stream bad end time."""
     now = dt_util.utcnow()
@@ -806,7 +823,9 @@ async def test_history_stream_bad_end_time(
 
 
 async def test_history_stream_live_no_attributes_minimal_response(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test history stream with history and live data and no_attributes and minimal_response."""
     now = dt_util.utcnow()
@@ -883,7 +902,9 @@ async def test_history_stream_live_no_attributes_minimal_response(
 
 
 async def test_history_stream_live(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test history stream with history and live data."""
     now = dt_util.utcnow()
@@ -986,7 +1007,9 @@ async def test_history_stream_live(
 
 
 async def test_history_stream_live_minimal_response(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test history stream with history and live data and minimal_response."""
     now = dt_util.utcnow()
@@ -1083,7 +1106,9 @@ async def test_history_stream_live_minimal_response(
 
 
 async def test_history_stream_live_no_attributes(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test history stream with history and live data and no_attributes."""
     now = dt_util.utcnow()
@@ -1164,7 +1189,9 @@ async def test_history_stream_live_no_attributes(
 
 
 async def test_history_stream_live_no_attributes_minimal_response_specific_entities(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test history stream with history and live data and no_attributes and minimal_response with specific entities."""
     now = dt_util.utcnow()
@@ -1242,7 +1269,9 @@ async def test_history_stream_live_no_attributes_minimal_response_specific_entit
 
 
 async def test_history_stream_live_with_future_end_time(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test history stream with history and live data with future end time."""
     now = dt_util.utcnow()
@@ -1335,7 +1364,7 @@ async def test_history_stream_live_with_future_end_time(
 
 @pytest.mark.parametrize("include_start_time_state", (True, False))
 async def test_history_stream_before_history_starts(
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     include_start_time_state,
@@ -1386,7 +1415,9 @@ async def test_history_stream_before_history_starts(
 
 
 async def test_history_stream_for_entity_with_no_possible_changes(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test history stream for future with no possible changes where end time is less than or equal to now."""
     await async_setup_component(
@@ -1437,7 +1468,9 @@ async def test_history_stream_for_entity_with_no_possible_changes(
 
 
 async def test_overflow_queue(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test overflowing the history stream queue."""
     now = dt_util.utcnow()
@@ -1514,7 +1547,9 @@ async def test_overflow_queue(
 
 
 async def test_history_during_period_for_invalid_entity_ids(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test history_during_period for valid and invalid entity ids."""
     now = dt_util.utcnow()
@@ -1657,7 +1692,9 @@ async def test_history_during_period_for_invalid_entity_ids(
 
 
 async def test_history_stream_for_invalid_entity_ids(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test history stream for invalid and valid entity ids."""
 
@@ -1825,7 +1862,9 @@ async def test_history_stream_for_invalid_entity_ids(
 
 
 async def test_history_stream_historical_only_with_start_time_state_past(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test history stream."""
     await async_setup_component(

--- a/tests/components/history/test_websocket_api_schema_32.py
+++ b/tests/components/history/test_websocket_api_schema_32.py
@@ -4,7 +4,6 @@
 import pytest
 
 from homeassistant.components import recorder
-from homeassistant.components.recorder import Recorder
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
@@ -25,7 +24,9 @@ def db_schema_32():
 
 
 async def test_history_during_period(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test history_during_period."""
     now = dt_util.utcnow()

--- a/tests/components/history_stats/test_sensor.py
+++ b/tests/components/history_stats/test_sensor.py
@@ -7,11 +7,11 @@ import pytest
 import voluptuous as vol
 
 from homeassistant import config as hass_config
+from homeassistant.components import recorder
 from homeassistant.components.history_stats import DOMAIN
 from homeassistant.components.history_stats.sensor import (
     PLATFORM_SCHEMA as SENSOR_SCHEMA,
 )
-from homeassistant.components.recorder import Recorder
 from homeassistant.const import ATTR_DEVICE_CLASS, SERVICE_RELOAD, STATE_UNKNOWN
 import homeassistant.core as ha
 from homeassistant.core import HomeAssistant
@@ -25,7 +25,7 @@ from tests.components.recorder.common import async_wait_recording_done
 from tests.typing import RecorderInstanceGenerator
 
 
-async def test_setup(recorder_mock: Recorder, hass: HomeAssistant) -> None:
+async def test_setup(recorder_mock: recorder.Recorder, hass: HomeAssistant) -> None:
     """Test the history statistics sensor setup."""
 
     config = {
@@ -48,7 +48,7 @@ async def test_setup(recorder_mock: Recorder, hass: HomeAssistant) -> None:
 
 
 async def test_setup_multiple_states(
-    recorder_mock: Recorder, hass: HomeAssistant
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
 ) -> None:
     """Test the history statistics sensor setup for multiple states."""
 
@@ -108,7 +108,7 @@ def test_setup_invalid_config(config) -> None:
 
 
 async def test_invalid_date_for_start(
-    recorder_mock: Recorder, hass: HomeAssistant
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
 ) -> None:
     """Verify with an invalid date for start."""
     await async_setup_component(
@@ -135,7 +135,7 @@ async def test_invalid_date_for_start(
 
 
 async def test_invalid_date_for_end(
-    recorder_mock: Recorder, hass: HomeAssistant
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
 ) -> None:
     """Verify with an invalid date for end."""
     await async_setup_component(
@@ -162,7 +162,7 @@ async def test_invalid_date_for_end(
 
 
 async def test_invalid_entity_in_template(
-    recorder_mock: Recorder, hass: HomeAssistant
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
 ) -> None:
     """Verify with an invalid entity in the template."""
     await async_setup_component(
@@ -189,7 +189,7 @@ async def test_invalid_entity_in_template(
 
 
 async def test_invalid_entity_returning_none_in_template(
-    recorder_mock: Recorder, hass: HomeAssistant
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
 ) -> None:
     """Verify with an invalid entity returning none in the template."""
     await async_setup_component(
@@ -215,7 +215,7 @@ async def test_invalid_entity_returning_none_in_template(
     assert hass.states.get("sensor.test") is None
 
 
-async def test_reload(recorder_mock: Recorder, hass: HomeAssistant) -> None:
+async def test_reload(recorder_mock: recorder.Recorder, hass: HomeAssistant) -> None:
     """Verify we can reload history_stats sensors."""
     hass.state = ha.CoreState.not_running
     hass.states.async_set("binary_sensor.test_id", "on")
@@ -258,7 +258,9 @@ async def test_reload(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     assert hass.states.get("sensor.second_test")
 
 
-async def test_measure_multiple(recorder_mock: Recorder, hass: HomeAssistant) -> None:
+async def test_measure_multiple(
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
+) -> None:
     """Test the history statistics sensor measure for multiple ."""
     start_time = dt_util.utcnow() - timedelta(minutes=60)
     t0 = start_time + timedelta(minutes=20)
@@ -340,7 +342,7 @@ async def test_measure_multiple(recorder_mock: Recorder, hass: HomeAssistant) ->
     assert hass.states.get("sensor.sensor4").state == "50.0"
 
 
-async def test_measure(recorder_mock: Recorder, hass: HomeAssistant) -> None:
+async def test_measure(recorder_mock: recorder.Recorder, hass: HomeAssistant) -> None:
     """Test the history statistics sensor measure."""
     start_time = dt_util.utcnow() - timedelta(minutes=60)
     t0 = start_time + timedelta(minutes=20)
@@ -420,7 +422,7 @@ async def test_measure(recorder_mock: Recorder, hass: HomeAssistant) -> None:
 
 
 async def test_async_on_entire_period(
-    recorder_mock: Recorder, hass: HomeAssistant
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
 ) -> None:
     """Test the history statistics sensor measuring as on the entire period."""
     start_time = dt_util.utcnow() - timedelta(minutes=60)
@@ -502,7 +504,7 @@ async def test_async_on_entire_period(
 
 
 async def test_async_off_entire_period(
-    recorder_mock: Recorder, hass: HomeAssistant
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
 ) -> None:
     """Test the history statistics sensor measuring as off the entire period."""
     start_time = dt_util.utcnow() - timedelta(minutes=60)
@@ -585,7 +587,7 @@ async def test_async_off_entire_period(
 
 
 async def test_async_start_from_history_and_switch_to_watching_state_changes_single(
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
 ) -> None:
     """Test we startup from history and switch to watching state changes."""
@@ -683,7 +685,7 @@ async def test_async_start_from_history_and_switch_to_watching_state_changes_sin
 
 
 async def test_async_start_from_history_and_switch_to_watching_state_changes_single_expanding_window(
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
 ) -> None:
     """Test we startup from history and switch to watching state changes with an expanding end time."""
@@ -780,7 +782,7 @@ async def test_async_start_from_history_and_switch_to_watching_state_changes_sin
 
 
 async def test_async_start_from_history_and_switch_to_watching_state_changes_multiple(
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
 ) -> None:
     """Test we startup from history and switch to watching state changes."""
@@ -916,7 +918,7 @@ async def test_async_start_from_history_and_switch_to_watching_state_changes_mul
 
 
 async def test_does_not_work_into_the_future(
-    recorder_mock: Recorder, hass: HomeAssistant
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
 ) -> None:
     """Test history cannot tell the future.
 
@@ -1057,7 +1059,7 @@ async def test_does_not_work_into_the_future(
 
 
 async def test_reload_before_start_event(
-    recorder_mock: Recorder, hass: HomeAssistant
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
 ) -> None:
     """Verify we can reload history_stats sensors before the start event."""
     hass.state = ha.CoreState.not_running
@@ -1100,7 +1102,7 @@ async def test_reload_before_start_event(
 
 
 async def test_measure_sliding_window(
-    recorder_mock: Recorder, hass: HomeAssistant
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
 ) -> None:
     """Test the history statistics sensor with a moving end and a moving start."""
     start_time = dt_util.utcnow() - timedelta(minutes=60)
@@ -1195,7 +1197,7 @@ async def test_measure_sliding_window(
 
 
 async def test_measure_from_end_going_backwards(
-    recorder_mock: Recorder, hass: HomeAssistant
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
 ) -> None:
     """Test the history statistics sensor with a moving end and a duration to find the start."""
     start_time = dt_util.utcnow() - timedelta(minutes=60)
@@ -1288,7 +1290,9 @@ async def test_measure_from_end_going_backwards(
     assert hass.states.get("sensor.sensor4").state == "83.3"
 
 
-async def test_measure_cet(recorder_mock: Recorder, hass: HomeAssistant) -> None:
+async def test_measure_cet(
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
+) -> None:
     """Test the history statistics sensor measure with a non-UTC timezone."""
     hass.config.set_time_zone("Europe/Berlin")
     start_time = dt_util.utcnow() - timedelta(minutes=60)
@@ -1494,7 +1498,9 @@ async def test_end_time_with_microseconds_zeroed(
         assert hass.states.get("sensor.heatpump_compressor_today").state == "16.0"
 
 
-async def test_device_classes(recorder_mock: Recorder, hass: HomeAssistant) -> None:
+async def test_device_classes(
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
+) -> None:
     """Test the device classes."""
     await async_setup_component(
         hass,
@@ -1538,7 +1544,7 @@ async def test_device_classes(recorder_mock: Recorder, hass: HomeAssistant) -> N
 
 
 async def test_history_stats_handles_floored_timestamps(
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
 ) -> None:
     """Test we account for microseconds when doing the data calculation."""
@@ -1592,7 +1598,7 @@ async def test_history_stats_handles_floored_timestamps(
     assert last_times == (start_time, start_time + timedelta(hours=2))
 
 
-async def test_unique_id(recorder_mock: Recorder, hass: HomeAssistant) -> None:
+async def test_unique_id(recorder_mock: recorder.Recorder, hass: HomeAssistant) -> None:
     """Test unique_id property."""
 
     config = {

--- a/tests/components/humidifier/test_recorder.py
+++ b/tests/components/humidifier/test_recorder.py
@@ -3,14 +3,12 @@ from __future__ import annotations
 
 from datetime import timedelta
 
-from homeassistant.components import humidifier
+from homeassistant.components import humidifier, recorder
 from homeassistant.components.humidifier import (
     ATTR_AVAILABLE_MODES,
     ATTR_MAX_HUMIDITY,
     ATTR_MIN_HUMIDITY,
 )
-from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.const import ATTR_FRIENDLY_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -20,7 +18,9 @@ from tests.common import async_fire_time_changed
 from tests.components.recorder.common import async_wait_recording_done
 
 
-async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) -> None:
+async def test_exclude_attributes(
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
+) -> None:
     """Test humidifier registered attributes to be excluded."""
     now = dt_util.utcnow()
     await async_setup_component(
@@ -32,7 +32,11 @@ async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) 
     await async_wait_recording_done(hass)
 
     states = await hass.async_add_executor_job(
-        get_significant_states, hass, now, None, hass.states.async_entity_ids()
+        recorder.history.get_significant_states,
+        hass,
+        now,
+        None,
+        hass.states.async_entity_ids(),
     )
     assert len(states) >= 1
     for entity_states in states.values():

--- a/tests/components/image/test_recorder.py
+++ b/tests/components/image/test_recorder.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 
-from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.history import get_significant_states
+from homeassistant.components import recorder
 from homeassistant.const import (
     ATTR_ATTRIBUTION,
     ATTR_ENTITY_PICTURE,
@@ -19,7 +18,7 @@ from tests.components.recorder.common import async_wait_recording_done
 
 
 async def test_exclude_attributes(
-    recorder_mock: Recorder, hass: HomeAssistant, mock_image_platform
+    recorder_mock: recorder.Recorder, hass: HomeAssistant, mock_image_platform
 ) -> None:
     """Test camera registered attributes to be excluded."""
     now = dt_util.utcnow()
@@ -28,7 +27,11 @@ async def test_exclude_attributes(
     await async_wait_recording_done(hass)
 
     states = await hass.async_add_executor_job(
-        get_significant_states, hass, now, None, hass.states.async_entity_ids()
+        recorder.history.get_significant_states,
+        hass,
+        now,
+        None,
+        hass.states.async_entity_ids(),
     )
     assert len(states) == 1
     for entity_states in states.values():

--- a/tests/components/input_boolean/test_recorder.py
+++ b/tests/components/input_boolean/test_recorder.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 
 from datetime import timedelta
 
+from homeassistant.components import recorder
 from homeassistant.components.input_boolean import DOMAIN
-from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.const import ATTR_EDITABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -16,7 +15,9 @@ from tests.components.recorder.common import async_wait_recording_done
 
 
 async def test_exclude_attributes(
-    recorder_mock: Recorder, hass: HomeAssistant, enable_custom_integrations: None
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
 ) -> None:
     """Test attributes to be excluded."""
     now = dt_util.utcnow()
@@ -31,7 +32,11 @@ async def test_exclude_attributes(
     await hass.async_block_till_done()
     await async_wait_recording_done(hass)
     states = await hass.async_add_executor_job(
-        get_significant_states, hass, now, None, hass.states.async_entity_ids()
+        recorder.history.get_significant_states,
+        hass,
+        now,
+        None,
+        hass.states.async_entity_ids(),
     )
     assert len(states) >= 1
     for entity_states in states.values():

--- a/tests/components/input_button/test_recorder.py
+++ b/tests/components/input_button/test_recorder.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 
 from datetime import timedelta
 
+from homeassistant.components import recorder
 from homeassistant.components.input_button import DOMAIN
-from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.const import ATTR_EDITABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -16,7 +15,9 @@ from tests.components.recorder.common import async_wait_recording_done
 
 
 async def test_exclude_attributes(
-    recorder_mock: Recorder, hass: HomeAssistant, enable_custom_integrations: None
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
 ) -> None:
     """Test attributes to be excluded."""
     now = dt_util.utcnow()
@@ -32,7 +33,11 @@ async def test_exclude_attributes(
     await async_wait_recording_done(hass)
 
     states = await hass.async_add_executor_job(
-        get_significant_states, hass, now, None, hass.states.async_entity_ids()
+        recorder.history.get_significant_states,
+        hass,
+        now,
+        None,
+        hass.states.async_entity_ids(),
     )
     assert len(states) >= 1
     for entity_states in states.values():

--- a/tests/components/input_datetime/test_recorder.py
+++ b/tests/components/input_datetime/test_recorder.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 
 from datetime import timedelta
 
+from homeassistant.components import recorder
 from homeassistant.components.input_datetime import CONF_HAS_DATE, CONF_HAS_TIME, DOMAIN
-from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.const import ATTR_EDITABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -16,7 +15,9 @@ from tests.components.recorder.common import async_wait_recording_done
 
 
 async def test_exclude_attributes(
-    recorder_mock: Recorder, hass: HomeAssistant, enable_custom_integrations: None
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
 ) -> None:
     """Test attributes to be excluded."""
     now = dt_util.utcnow()
@@ -36,7 +37,11 @@ async def test_exclude_attributes(
     await async_wait_recording_done(hass)
 
     states = await hass.async_add_executor_job(
-        get_significant_states, hass, now, None, hass.states.async_entity_ids()
+        recorder.history.get_significant_states,
+        hass,
+        now,
+        None,
+        hass.states.async_entity_ids(),
     )
     assert len(states) >= 1
     for entity_states in states.values():

--- a/tests/components/input_number/test_recorder.py
+++ b/tests/components/input_number/test_recorder.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 
+from homeassistant.components import recorder
 from homeassistant.components.input_number import (
     ATTR_MAX,
     ATTR_MIN,
@@ -10,8 +11,6 @@ from homeassistant.components.input_number import (
     ATTR_STEP,
     DOMAIN,
 )
-from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.const import ATTR_EDITABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -22,7 +21,9 @@ from tests.components.recorder.common import async_wait_recording_done
 
 
 async def test_exclude_attributes(
-    recorder_mock: Recorder, hass: HomeAssistant, enable_custom_integrations: None
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
 ) -> None:
     """Test attributes to be excluded."""
     now = dt_util.utcnow()
@@ -44,7 +45,11 @@ async def test_exclude_attributes(
     await async_wait_recording_done(hass)
 
     states = await hass.async_add_executor_job(
-        get_significant_states, hass, now, None, hass.states.async_entity_ids()
+        recorder.history.get_significant_states,
+        hass,
+        now,
+        None,
+        hass.states.async_entity_ids(),
     )
     assert len(states) >= 1
     for entity_states in states.values():

--- a/tests/components/input_select/test_recorder.py
+++ b/tests/components/input_select/test_recorder.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 
 from datetime import timedelta
 
+from homeassistant.components import recorder
 from homeassistant.components.input_select import ATTR_OPTIONS, DOMAIN
-from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.const import ATTR_EDITABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -16,7 +15,9 @@ from tests.components.recorder.common import async_wait_recording_done
 
 
 async def test_exclude_attributes(
-    recorder_mock: Recorder, hass: HomeAssistant, enable_custom_integrations: None
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
 ) -> None:
     """Test attributes to be excluded."""
     now = dt_util.utcnow()
@@ -43,7 +44,11 @@ async def test_exclude_attributes(
     await async_wait_recording_done(hass)
 
     states = await hass.async_add_executor_job(
-        get_significant_states, hass, now, None, hass.states.async_entity_ids()
+        recorder.history.get_significant_states,
+        hass,
+        now,
+        None,
+        hass.states.async_entity_ids(),
     )
     assert len(states) >= 1
     for entity_states in states.values():

--- a/tests/components/input_text/test_recorder.py
+++ b/tests/components/input_text/test_recorder.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 
+from homeassistant.components import recorder
 from homeassistant.components.input_text import (
     ATTR_MAX,
     ATTR_MIN,
@@ -11,8 +12,6 @@ from homeassistant.components.input_text import (
     DOMAIN,
     MODE_TEXT,
 )
-from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.const import ATTR_EDITABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -23,7 +22,9 @@ from tests.components.recorder.common import async_wait_recording_done
 
 
 async def test_exclude_attributes(
-    recorder_mock: Recorder, hass: HomeAssistant, enable_custom_integrations: None
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
 ) -> None:
     """Test attributes to be excluded."""
     now = dt_util.utcnow()
@@ -43,7 +44,11 @@ async def test_exclude_attributes(
     await async_wait_recording_done(hass)
 
     states = await hass.async_add_executor_job(
-        get_significant_states, hass, now, None, hass.states.async_entity_ids()
+        recorder.history.get_significant_states,
+        hass,
+        now,
+        None,
+        hass.states.async_entity_ids(),
     )
     assert len(states) >= 1
     for entity_states in states.values():

--- a/tests/components/light/test_recorder.py
+++ b/tests/components/light/test_recorder.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant.components import light
+from homeassistant.components import light, recorder
 from homeassistant.components.light import (
     ATTR_EFFECT,
     ATTR_MAX_COLOR_TEMP_KELVIN,
@@ -15,8 +15,6 @@ from homeassistant.components.light import (
     ATTR_MIN_MIREDS,
     ATTR_SUPPORTED_COLOR_MODES,
 )
-from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.const import ATTR_FRIENDLY_NAME, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -36,7 +34,9 @@ async def light_only() -> None:
         yield
 
 
-async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) -> None:
+async def test_exclude_attributes(
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
+) -> None:
     """Test light registered attributes to be excluded."""
     now = dt_util.utcnow()
     assert await async_setup_component(hass, "homeassistant", {})
@@ -49,7 +49,11 @@ async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) 
     await async_wait_recording_done(hass)
 
     states = await hass.async_add_executor_job(
-        get_significant_states, hass, now, None, hass.states.async_entity_ids()
+        recorder.history.get_significant_states,
+        hass,
+        now,
+        None,
+        hass.states.async_entity_ids(),
     )
     assert len(states) >= 1
     for entity_states in states.values():

--- a/tests/components/logbook/common.py
+++ b/tests/components/logbook/common.py
@@ -4,14 +4,9 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from homeassistant.components import logbook
+from homeassistant.components import logbook, recorder
 from homeassistant.components.logbook import processor
 from homeassistant.components.logbook.models import LogbookConfig
-from homeassistant.components.recorder.models import (
-    process_timestamp_to_utc_isoformat,
-    ulid_to_bytes_or_none,
-    uuid_hex_to_bytes_or_none,
-)
 from homeassistant.core import Context
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.json import JSONEncoder
@@ -34,12 +29,18 @@ class MockRow:
         self.time_fired = dt_util.utcnow()
         self.time_fired_ts = dt_util.utc_to_timestamp(self.time_fired)
         self.context_parent_id_bin = (
-            ulid_to_bytes_or_none(context.parent_id) if context else None
+            recorder.models.ulid_to_bytes_or_none(context.parent_id)
+            if context
+            else None
         )
         self.context_user_id_bin = (
-            uuid_hex_to_bytes_or_none(context.user_id) if context else None
+            recorder.models.uuid_hex_to_bytes_or_none(context.user_id)
+            if context
+            else None
         )
-        self.context_id_bin = ulid_to_bytes_or_none(context.id) if context else None
+        self.context_id_bin = (
+            recorder.models.ulid_to_bytes_or_none(context.id) if context else None
+        )
         self.state = None
         self.entity_id = None
         self.row_id = None
@@ -55,7 +56,7 @@ class MockRow:
     @property
     def time_fired_isoformat(self):
         """Time event was fired in utc isoformat."""
-        return process_timestamp_to_utc_isoformat(self.time_fired)
+        return recorder.models.process_timestamp_to_utc_isoformat(self.time_fired)
 
 
 def mock_humanify(hass_, rows):

--- a/tests/components/logbook/test_init.py
+++ b/tests/components/logbook/test_init.py
@@ -17,7 +17,6 @@ from homeassistant.components.automation import EVENT_AUTOMATION_TRIGGERED
 from homeassistant.components.logbook.models import LazyEventPartialState
 from homeassistant.components.logbook.processor import EventProcessor
 from homeassistant.components.logbook.queries.common import PSEUDO_EVENT_STATE_CHANGED
-from homeassistant.components.recorder import Recorder
 from homeassistant.components.script import EVENT_SCRIPT_STARTED
 from homeassistant.components.sensor import SensorStateClass
 from homeassistant.const import (
@@ -126,7 +125,7 @@ async def test_service_call_create_logbook_entry(hass_) -> None:
 
 
 async def test_service_call_create_logbook_entry_invalid_entity_id(
-    recorder_mock: Recorder, hass: HomeAssistant
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
 ) -> None:
     """Test if service call create log book entry with an invalid entity id."""
     await async_setup_component(hass, "logbook", {})
@@ -360,7 +359,9 @@ def create_state_changed_event_from_old_new(
 
 
 async def test_logbook_view(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
 ) -> None:
     """Test the logbook view."""
     await async_setup_component(hass, "logbook", {})
@@ -371,7 +372,9 @@ async def test_logbook_view(
 
 
 async def test_logbook_view_invalid_start_date_time(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
 ) -> None:
     """Test the logbook view with an invalid date time."""
     await async_setup_component(hass, "logbook", {})
@@ -382,7 +385,9 @@ async def test_logbook_view_invalid_start_date_time(
 
 
 async def test_logbook_view_invalid_end_date_time(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
 ) -> None:
     """Test the logbook view."""
     await async_setup_component(hass, "logbook", {})
@@ -395,7 +400,7 @@ async def test_logbook_view_invalid_end_date_time(
 
 
 async def test_logbook_view_period_entity(
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
     set_utc,
@@ -481,7 +486,9 @@ async def test_logbook_view_period_entity(
 
 
 async def test_logbook_describe_event(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
 ) -> None:
     """Test teaching logbook about a new event."""
 
@@ -528,7 +535,9 @@ async def test_logbook_describe_event(
 
 
 async def test_exclude_described_event(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
 ) -> None:
     """Test exclusions of events that are described by another integration."""
     name = "My Automation Rule"
@@ -602,7 +611,9 @@ async def test_exclude_described_event(
 
 
 async def test_logbook_view_end_time_entity(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
 ) -> None:
     """Test the logbook view with end_time and entity."""
     await async_setup_component(hass, "logbook", {})
@@ -662,7 +673,9 @@ async def test_logbook_view_end_time_entity(
 
 
 async def test_logbook_entity_filter_with_automations(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
 ) -> None:
     """Test the logbook view with end_time and entity with automations and scripts."""
     await asyncio.gather(
@@ -748,7 +761,9 @@ async def test_logbook_entity_filter_with_automations(
 
 
 async def test_logbook_entity_no_longer_in_state_machine(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
 ) -> None:
     """Test the logbook view with an entity that hass been removed from the state machine."""
     await async_setup_component(hass, "logbook", {})
@@ -787,7 +802,7 @@ async def test_logbook_entity_no_longer_in_state_machine(
 
 
 async def test_filter_continuous_sensor_values(
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
     set_utc,
@@ -831,7 +846,7 @@ async def test_filter_continuous_sensor_values(
 
 
 async def test_exclude_new_entities(
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
     set_utc,
@@ -873,7 +888,7 @@ async def test_exclude_new_entities(
 
 
 async def test_exclude_removed_entities(
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
     set_utc,
@@ -922,7 +937,7 @@ async def test_exclude_removed_entities(
 
 
 async def test_exclude_attribute_changes(
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
     set_utc,
@@ -967,7 +982,9 @@ async def test_exclude_attribute_changes(
 
 
 async def test_logbook_entity_context_id(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
 ) -> None:
     """Test the logbook view with end_time and entity with automations and scripts."""
     await asyncio.gather(
@@ -1120,7 +1137,9 @@ async def test_logbook_entity_context_id(
 
 
 async def test_logbook_context_id_automation_script_started_manually(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
 ) -> None:
     """Test the logbook populates context_ids for scripts and automations started manually."""
     await asyncio.gather(
@@ -1212,7 +1231,9 @@ async def test_logbook_context_id_automation_script_started_manually(
 
 
 async def test_logbook_entity_context_parent_id(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
 ) -> None:
     """Test the logbook view links events via context parent_id."""
     await asyncio.gather(
@@ -1394,7 +1415,9 @@ async def test_logbook_entity_context_parent_id(
 
 
 async def test_logbook_context_from_template(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
 ) -> None:
     """Test the logbook view with end_time and entity with automations and scripts."""
     await asyncio.gather(
@@ -1484,7 +1507,9 @@ async def test_logbook_context_from_template(
 
 
 async def test_logbook_(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
 ) -> None:
     """Test the logbook view with a single entity and ."""
     await async_setup_component(hass, "logbook", {})
@@ -1555,7 +1580,9 @@ async def test_logbook_(
 
 
 async def test_logbook_many_entities_multiple_calls(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
 ) -> None:
     """Test the logbook view with a many entities called multiple times."""
     await async_setup_component(hass, "logbook", {})
@@ -1627,7 +1654,9 @@ async def test_logbook_many_entities_multiple_calls(
 
 
 async def test_custom_log_entry_discoverable_via_(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
 ) -> None:
     """Test if a custom log entry is later discoverable via ."""
     await async_setup_component(hass, "logbook", {})
@@ -1664,7 +1693,9 @@ async def test_custom_log_entry_discoverable_via_(
 
 
 async def test_logbook_multiple_entities(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
 ) -> None:
     """Test the logbook view with a multiple entities."""
     await async_setup_component(hass, "logbook", {})
@@ -1790,7 +1821,9 @@ async def test_logbook_multiple_entities(
 
 
 async def test_logbook_invalid_entity(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
 ) -> None:
     """Test the logbook view with requesting an invalid entity."""
     await async_setup_component(hass, "logbook", {})
@@ -1810,7 +1843,9 @@ async def test_logbook_invalid_entity(
 
 
 async def test_icon_and_state(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
 ) -> None:
     """Test to ensure state and custom icons are returned."""
     await asyncio.gather(
@@ -1855,7 +1890,9 @@ async def test_icon_and_state(
 
 
 async def test_fire_logbook_entries(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
 ) -> None:
     """Test many logbook entry calls."""
     await async_setup_component(hass, "logbook", {})
@@ -1893,7 +1930,9 @@ async def test_fire_logbook_entries(
 
 
 async def test_exclude_events_domain(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
 ) -> None:
     """Test if events are filtered if domain is excluded in config."""
     entity_id = "switch.bla"
@@ -1929,7 +1968,9 @@ async def test_exclude_events_domain(
 
 
 async def test_exclude_events_domain_glob(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
 ) -> None:
     """Test if events are filtered if domain or glob is excluded in config."""
     entity_id = "switch.bla"
@@ -1974,7 +2015,9 @@ async def test_exclude_events_domain_glob(
 
 
 async def test_include_events_entity(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
 ) -> None:
     """Test if events are filtered if entity is included in config."""
     entity_id = "sensor.bla"
@@ -2016,7 +2059,9 @@ async def test_include_events_entity(
 
 
 async def test_exclude_events_entity(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
 ) -> None:
     """Test if events are filtered if entity is excluded in config."""
     entity_id = "sensor.bla"
@@ -2052,7 +2097,9 @@ async def test_exclude_events_entity(
 
 
 async def test_include_events_domain(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
 ) -> None:
     """Test if events are filtered if domain is included in config."""
     assert await async_setup_component(hass, "alexa", {})
@@ -2096,7 +2143,9 @@ async def test_include_events_domain(
 
 
 async def test_include_events_domain_glob(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
 ) -> None:
     """Test if events are filtered if domain or glob is included in config."""
     assert await async_setup_component(hass, "alexa", {})
@@ -2155,7 +2204,9 @@ async def test_include_events_domain_glob(
 
 
 async def test_include_exclude_events_no_globs(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
 ) -> None:
     """Test if events are filtered if include and exclude is configured."""
     entity_id = "switch.bla"
@@ -2213,7 +2264,9 @@ async def test_include_exclude_events_no_globs(
 
 
 async def test_include_exclude_events_with_glob_filters(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
 ) -> None:
     """Test if events are filtered if include and exclude is configured."""
     entity_id = "switch.bla"
@@ -2279,7 +2332,9 @@ async def test_include_exclude_events_with_glob_filters(
 
 
 async def test_empty_config(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
 ) -> None:
     """Test we can handle an empty entity filter."""
     entity_id = "sensor.blu"
@@ -2313,7 +2368,9 @@ async def test_empty_config(
 
 
 async def test_context_filter(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
 ) -> None:
     """Test we can filter by context."""
     assert await async_setup_component(hass, "logbook", {})
@@ -2390,7 +2447,9 @@ def _assert_entry(
 
 
 async def test_get_events(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test logbook get_events."""
     now = dt_util.utcnow()
@@ -2510,7 +2569,9 @@ async def test_get_events(
 
 
 async def test_get_events_future_start_time(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test get_events with a future start time."""
     await async_setup_component(hass, "logbook", {})
@@ -2535,7 +2596,9 @@ async def test_get_events_future_start_time(
 
 
 async def test_get_events_bad_start_time(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test get_events bad start time."""
     await async_setup_component(hass, "logbook", {})
@@ -2555,7 +2618,9 @@ async def test_get_events_bad_start_time(
 
 
 async def test_get_events_bad_end_time(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test get_events bad end time."""
     now = dt_util.utcnow()
@@ -2577,7 +2642,9 @@ async def test_get_events_bad_end_time(
 
 
 async def test_get_events_invalid_filters(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test get_events invalid filters."""
     await async_setup_component(hass, "logbook", {})
@@ -2607,7 +2674,7 @@ async def test_get_events_invalid_filters(
 
 
 async def test_get_events_with_device_ids(
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     device_registry: dr.DeviceRegistry,
@@ -2748,7 +2815,9 @@ async def test_get_events_with_device_ids(
 
 
 async def test_logbook_select_entities_context_id(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_client: ClientSessionGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
 ) -> None:
     """Test the logbook view with end_time and entity with automations and scripts."""
     await asyncio.gather(
@@ -2883,7 +2952,9 @@ async def test_logbook_select_entities_context_id(
 
 
 async def test_get_events_with_context_state(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test logbook get_events with a context state."""
     now = dt_util.utcnow()
@@ -2948,7 +3019,7 @@ async def test_get_events_with_context_state(
 
 
 async def test_logbook_with_empty_config(
-    recorder_mock: Recorder, hass: HomeAssistant
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
 ) -> None:
     """Test we handle a empty configuration."""
     assert await async_setup_component(
@@ -2963,7 +3034,7 @@ async def test_logbook_with_empty_config(
 
 
 async def test_logbook_with_non_iterable_entity_filter(
-    recorder_mock: Recorder, hass: HomeAssistant
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
 ) -> None:
     """Test we handle a non-iterable entity filter."""
     assert await async_setup_component(

--- a/tests/components/logbook/test_websocket_api.py
+++ b/tests/components/logbook/test_websocket_api.py
@@ -11,8 +11,6 @@ from homeassistant import core
 from homeassistant.components import logbook, recorder
 from homeassistant.components.automation import ATTR_SOURCE, EVENT_AUTOMATION_TRIGGERED
 from homeassistant.components.logbook import websocket_api
-from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.util import get_instance
 from homeassistant.components.script import EVENT_SCRIPT_STARTED
 from homeassistant.components.websocket_api.const import TYPE_RESULT
 from homeassistant.const import (
@@ -176,7 +174,9 @@ async def _async_mock_devices_with_logbook_platform(
 
 
 async def test_get_events(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test logbook get_events."""
     now = dt_util.utcnow()
@@ -296,7 +296,9 @@ async def test_get_events(
 
 
 async def test_get_events_entities_filtered_away(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test logbook get_events all entities filtered away."""
     now = dt_util.utcnow()
@@ -360,7 +362,9 @@ async def test_get_events_entities_filtered_away(
 
 
 async def test_get_events_future_start_time(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test get_events with a future start time."""
     await async_setup_component(hass, "logbook", {})
@@ -385,7 +389,9 @@ async def test_get_events_future_start_time(
 
 
 async def test_get_events_bad_start_time(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test get_events bad start time."""
     await async_setup_component(hass, "logbook", {})
@@ -405,7 +411,9 @@ async def test_get_events_bad_start_time(
 
 
 async def test_get_events_bad_end_time(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test get_events bad end time."""
     now = dt_util.utcnow()
@@ -427,7 +435,9 @@ async def test_get_events_bad_end_time(
 
 
 async def test_get_events_invalid_filters(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test get_events invalid filters."""
     await async_setup_component(hass, "logbook", {})
@@ -457,7 +467,7 @@ async def test_get_events_invalid_filters(
 
 
 async def test_get_events_with_device_ids(
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     device_registry: dr.DeviceRegistry,
@@ -573,7 +583,9 @@ async def test_get_events_with_device_ids(
 
 @patch("homeassistant.components.logbook.websocket_api.EVENT_COALESCE_TIME", 0)
 async def test_subscribe_unsubscribe_logbook_stream_excluded_entities(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test subscribe/unsubscribe logbook stream with excluded entities."""
     now = dt_util.utcnow()
@@ -636,7 +648,7 @@ async def test_subscribe_unsubscribe_logbook_stream_excluded_entities(
     assert msg["event"]["end_time"] > msg["event"]["start_time"]
     assert msg["event"]["partial"] is True
 
-    await get_instance(hass).async_block_till_done()
+    await recorder.get_instance(hass).async_block_till_done()
     await hass.async_block_till_done()
 
     msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
@@ -667,7 +679,7 @@ async def test_subscribe_unsubscribe_logbook_stream_excluded_entities(
     await hass.async_block_till_done()
 
     hass.states.async_set("light.zulu", "on", {"effect": "help", "color": "blue"})
-    await get_instance(hass).async_block_till_done()
+    await recorder.get_instance(hass).async_block_till_done()
     await hass.async_block_till_done()
 
     msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
@@ -760,7 +772,9 @@ async def test_subscribe_unsubscribe_logbook_stream_excluded_entities(
 
 @patch("homeassistant.components.logbook.websocket_api.EVENT_COALESCE_TIME", 0)
 async def test_subscribe_unsubscribe_logbook_stream_included_entities(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test subscribe/unsubscribe logbook stream with included entities."""
     test_entities = (
@@ -970,7 +984,9 @@ async def test_subscribe_unsubscribe_logbook_stream_included_entities(
 
 @patch("homeassistant.components.logbook.websocket_api.EVENT_COALESCE_TIME", 0)
 async def test_logbook_stream_excluded_entities_inherits_filters_from_recorder(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test subscribe/unsubscribe logbook stream inherits filters from recorder."""
     now = dt_util.utcnow()
@@ -1163,7 +1179,9 @@ async def test_logbook_stream_excluded_entities_inherits_filters_from_recorder(
 
 @patch("homeassistant.components.logbook.websocket_api.EVENT_COALESCE_TIME", 0)
 async def test_subscribe_unsubscribe_logbook_stream(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test subscribe/unsubscribe logbook stream."""
     now = dt_util.utcnow()
@@ -1468,7 +1486,9 @@ async def test_subscribe_unsubscribe_logbook_stream(
 
 @patch("homeassistant.components.logbook.websocket_api.EVENT_COALESCE_TIME", 0)
 async def test_subscribe_unsubscribe_logbook_stream_entities(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test subscribe/unsubscribe logbook stream with specific entities."""
     now = dt_util.utcnow()
@@ -1517,7 +1537,7 @@ async def test_subscribe_unsubscribe_logbook_stream_entities(
         }
     ]
 
-    await get_instance(hass).async_block_till_done()
+    await recorder.get_instance(hass).async_block_till_done()
     await hass.async_block_till_done()
     msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
     assert msg["id"] == 7
@@ -1531,7 +1551,7 @@ async def test_subscribe_unsubscribe_logbook_stream_entities(
     hass.states.async_set("light.alpha", STATE_OFF)
     hass.states.async_set("light.small", STATE_OFF, {"effect": "help", "color": "blue"})
 
-    await get_instance(hass).async_block_till_done()
+    await recorder.get_instance(hass).async_block_till_done()
     await hass.async_block_till_done()
 
     msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
@@ -1548,7 +1568,7 @@ async def test_subscribe_unsubscribe_logbook_stream_entities(
 
     hass.states.async_remove("light.alpha")
     hass.states.async_remove("light.small")
-    await get_instance(hass).async_block_till_done()
+    await recorder.get_instance(hass).async_block_till_done()
     await hass.async_block_till_done()
 
     await websocket_client.send_json(
@@ -1568,7 +1588,9 @@ async def test_subscribe_unsubscribe_logbook_stream_entities(
 
 @patch("homeassistant.components.logbook.websocket_api.EVENT_COALESCE_TIME", 0)
 async def test_subscribe_unsubscribe_logbook_stream_entities_with_end_time(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test subscribe/unsubscribe logbook stream with specific entities and an end_time."""
     now = dt_util.utcnow()
@@ -1616,7 +1638,7 @@ async def test_subscribe_unsubscribe_logbook_stream_entities_with_end_time(
         }
     ]
 
-    await get_instance(hass).async_block_till_done()
+    await recorder.get_instance(hass).async_block_till_done()
     await hass.async_block_till_done()
 
     msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
@@ -1672,7 +1694,9 @@ async def test_subscribe_unsubscribe_logbook_stream_entities_with_end_time(
 
 @patch("homeassistant.components.logbook.websocket_api.EVENT_COALESCE_TIME", 0)
 async def test_subscribe_unsubscribe_logbook_stream_entities_past_only(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test subscribe/unsubscribe logbook stream with specific entities in the past."""
     now = dt_util.utcnow()
@@ -1742,7 +1766,9 @@ async def test_subscribe_unsubscribe_logbook_stream_entities_past_only(
 
 @patch("homeassistant.components.logbook.websocket_api.EVENT_COALESCE_TIME", 0)
 async def test_subscribe_unsubscribe_logbook_stream_big_query(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test subscribe/unsubscribe logbook stream and ask for a large time frame.
 
@@ -1844,7 +1870,7 @@ async def test_subscribe_unsubscribe_logbook_stream_big_query(
 
 @patch("homeassistant.components.logbook.websocket_api.EVENT_COALESCE_TIME", 0)
 async def test_subscribe_unsubscribe_logbook_stream_device(
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     device_registry: dr.DeviceRegistry,
@@ -1952,7 +1978,9 @@ async def test_subscribe_unsubscribe_logbook_stream_device(
 
 
 async def test_event_stream_bad_start_time(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test event_stream bad start time."""
     await async_setup_component(hass, "logbook", {})
@@ -1973,7 +2001,7 @@ async def test_event_stream_bad_start_time(
 
 @patch("homeassistant.components.logbook.websocket_api.EVENT_COALESCE_TIME", 0)
 async def test_logbook_stream_match_multiple_entities(
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     entity_registry: er.EntityRegistry,
@@ -2083,7 +2111,7 @@ async def test_logbook_stream_match_multiple_entities(
 
 @patch("homeassistant.components.logbook.websocket_api.EVENT_COALESCE_TIME", 0)
 async def test_logbook_stream_match_multiple_entities_one_with_broken_logbook_platform(
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     entity_registry: er.EntityRegistry,
@@ -2189,7 +2217,9 @@ async def test_logbook_stream_match_multiple_entities_one_with_broken_logbook_pl
 
 
 async def test_event_stream_bad_end_time(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test event_stream bad end time."""
     await async_setup_component(hass, "logbook", {})
@@ -2318,7 +2348,9 @@ async def test_live_stream_with_one_second_commit_interval(
 
 @patch("homeassistant.components.logbook.websocket_api.EVENT_COALESCE_TIME", 0)
 async def test_subscribe_disconnected(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test subscribe/unsubscribe logbook stream gets disconnected."""
     now = dt_util.utcnow()
@@ -2377,7 +2409,9 @@ async def test_subscribe_disconnected(
 
 @patch("homeassistant.components.logbook.websocket_api.EVENT_COALESCE_TIME", 0)
 async def test_stream_consumer_stop_processing(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test we unsubscribe if the stream consumer fails or is canceled."""
     now = dt_util.utcnow()
@@ -2438,7 +2472,7 @@ async def test_stream_consumer_stop_processing(
 
 @patch("homeassistant.components.logbook.websocket_api.EVENT_COALESCE_TIME", 0)
 async def test_recorder_is_far_behind(
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     caplog: pytest.LogCaptureFixture,
@@ -2525,7 +2559,9 @@ async def test_recorder_is_far_behind(
 
 @patch("homeassistant.components.logbook.websocket_api.EVENT_COALESCE_TIME", 0)
 async def test_subscribe_all_entities_are_continuous(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test subscribe/unsubscribe logbook stream with entities that are always filtered."""
     now = dt_util.utcnow()
@@ -2585,7 +2621,9 @@ async def test_subscribe_all_entities_are_continuous(
 
 @patch("homeassistant.components.logbook.websocket_api.EVENT_COALESCE_TIME", 0)
 async def test_subscribe_all_entities_have_uom_multiple(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test logbook stream with specific request for multiple entities that are always filtered."""
     now = dt_util.utcnow()
@@ -2644,7 +2682,9 @@ async def test_subscribe_all_entities_have_uom_multiple(
 
 @patch("homeassistant.components.logbook.websocket_api.EVENT_COALESCE_TIME", 0)
 async def test_subscribe_entities_some_have_uom_multiple(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test logbook stream with uom filtered entities and non-filtered entities."""
     now = dt_util.utcnow()
@@ -2689,7 +2729,7 @@ async def test_subscribe_entities_some_have_uom_multiple(
     assert msg["type"] == TYPE_RESULT
     assert msg["success"]
 
-    await get_instance(hass).async_block_till_done()
+    await recorder.get_instance(hass).async_block_till_done()
     await hass.async_block_till_done()
 
     msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
@@ -2701,7 +2741,7 @@ async def test_subscribe_entities_some_have_uom_multiple(
     ]
     assert msg["event"]["partial"] is True
 
-    await get_instance(hass).async_block_till_done()
+    await recorder.get_instance(hass).async_block_till_done()
     await hass.async_block_till_done()
 
     msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
@@ -2711,10 +2751,10 @@ async def test_subscribe_entities_some_have_uom_multiple(
     assert msg["event"]["events"] == []
 
     _cycle_entities()
-    await get_instance(hass).async_block_till_done()
+    await recorder.get_instance(hass).async_block_till_done()
     await hass.async_block_till_done()
     _cycle_entities()
-    await get_instance(hass).async_block_till_done()
+    await recorder.get_instance(hass).async_block_till_done()
     await hass.async_block_till_done()
 
     msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
@@ -2751,7 +2791,9 @@ async def test_subscribe_entities_some_have_uom_multiple(
 
 @patch("homeassistant.components.logbook.websocket_api.EVENT_COALESCE_TIME", 0)
 async def test_logbook_stream_ignores_forced_updates(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test logbook live stream ignores forced updates."""
     now = dt_util.utcnow()
@@ -2867,7 +2909,7 @@ async def test_logbook_stream_ignores_forced_updates(
 
 @patch("homeassistant.components.logbook.websocket_api.EVENT_COALESCE_TIME", 0)
 async def test_subscribe_all_entities_are_continuous_with_device(
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     device_registry: dr.DeviceRegistry,

--- a/tests/components/media_player/test_recorder.py
+++ b/tests/components/media_player/test_recorder.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant.components import media_player
+from homeassistant.components import media_player, recorder
 from homeassistant.components.media_player import (
     ATTR_ENTITY_PICTURE_LOCAL,
     ATTR_INPUT_SOURCE_LIST,
@@ -14,8 +14,6 @@ from homeassistant.components.media_player import (
     ATTR_MEDIA_POSITION_UPDATED_AT,
     ATTR_SOUND_MODE_LIST,
 )
-from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.const import ATTR_ENTITY_PICTURE, ATTR_FRIENDLY_NAME, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -35,7 +33,9 @@ async def media_player_only() -> None:
         yield
 
 
-async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) -> None:
+async def test_exclude_attributes(
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
+) -> None:
     """Test media_player registered attributes to be excluded."""
     now = dt_util.utcnow()
     await async_setup_component(hass, "homeassistant", {})
@@ -48,7 +48,11 @@ async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) 
     await async_wait_recording_done(hass)
 
     states = await hass.async_add_executor_job(
-        get_significant_states, hass, now, None, hass.states.async_entity_ids()
+        recorder.history.get_significant_states,
+        hass,
+        now,
+        None,
+        hass.states.async_entity_ids(),
     )
     assert len(states) >= 1
     for entity_states in states.values():

--- a/tests/components/number/test_recorder.py
+++ b/tests/components/number/test_recorder.py
@@ -6,10 +6,8 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant.components import number
+from homeassistant.components import number, recorder
 from homeassistant.components.number import ATTR_MAX, ATTR_MIN, ATTR_MODE, ATTR_STEP
-from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.const import ATTR_FRIENDLY_NAME, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -29,7 +27,9 @@ async def number_only() -> None:
         yield
 
 
-async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) -> None:
+async def test_exclude_attributes(
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
+) -> None:
     """Test number registered attributes to be excluded."""
     assert await async_setup_component(hass, "homeassistant", {})
     await async_setup_component(
@@ -42,7 +42,11 @@ async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) 
     await async_wait_recording_done(hass)
 
     states = await hass.async_add_executor_job(
-        get_significant_states, hass, now, None, hass.states.async_entity_ids()
+        recorder.history.get_significant_states,
+        hass,
+        now,
+        None,
+        hass.states.async_entity_ids(),
     )
     assert len(states) > 1
     for entity_states in states.values():

--- a/tests/components/opower/test_config_flow.py
+++ b/tests/components/opower/test_config_flow.py
@@ -5,9 +5,8 @@ from unittest.mock import AsyncMock, patch
 from opower import CannotConnect, InvalidAuth
 import pytest
 
-from homeassistant import config_entries
+from homeassistant import config_entries, recorder
 from homeassistant.components.opower.const import DOMAIN
-from homeassistant.components.recorder import Recorder
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -35,7 +34,7 @@ def mock_unload_entry() -> Generator[AsyncMock, None, None]:
 
 
 async def test_form(
-    recorder_mock: Recorder, hass: HomeAssistant, mock_setup_entry: AsyncMock
+    recorder_mock: recorder.Recorder, hass: HomeAssistant, mock_setup_entry: AsyncMock
 ) -> None:
     """Test we get the form."""
     result = await hass.config_entries.flow.async_init(
@@ -76,7 +75,7 @@ async def test_form(
     ],
 )
 async def test_form_exceptions(
-    recorder_mock: Recorder, hass: HomeAssistant, api_exception, expected_error
+    recorder_mock: recorder.Recorder, hass: HomeAssistant, api_exception, expected_error
 ) -> None:
     """Test we handle exceptions."""
     result = await hass.config_entries.flow.async_init(
@@ -102,7 +101,7 @@ async def test_form_exceptions(
 
 
 async def test_form_already_configured(
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
 ) -> None:
@@ -129,7 +128,7 @@ async def test_form_already_configured(
 
 
 async def test_form_not_already_configured(
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
     mock_config_entry: MockConfigEntry,
@@ -166,7 +165,7 @@ async def test_form_not_already_configured(
 
 
 async def test_form_valid_reauth(
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
     mock_unload_entry: AsyncMock,

--- a/tests/components/person/test_recorder.py
+++ b/tests/components/person/test_recorder.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 
 from datetime import timedelta
 
+from homeassistant.components import recorder
 from homeassistant.components.person import ATTR_DEVICE_TRACKERS, DOMAIN
-from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
@@ -15,7 +14,7 @@ from tests.components.recorder.common import async_wait_recording_done
 
 
 async def test_exclude_attributes(
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
     enable_custom_integrations: None,
     hass_admin_user: MockUser,
@@ -39,7 +38,11 @@ async def test_exclude_attributes(
     await async_wait_recording_done(hass)
 
     states = await hass.async_add_executor_job(
-        get_significant_states, hass, now, None, hass.states.async_entity_ids()
+        recorder.history.get_significant_states,
+        hass,
+        now,
+        None,
+        hass.states.async_entity_ids(),
     )
     assert len(states) >= 1
     for entity_states in states.values():

--- a/tests/components/plant/test_init.py
+++ b/tests/components/plant/test_init.py
@@ -1,8 +1,8 @@
 """Unit tests for platform/plant.py."""
 from datetime import datetime, timedelta
 
+from homeassistant.components import recorder
 import homeassistant.components.plant as plant
-from homeassistant.components.recorder import Recorder
 from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT,
     CONDUCTIVITY,
@@ -145,7 +145,9 @@ async def test_state_problem_if_unavailable(hass: HomeAssistant) -> None:
     assert state.attributes[plant.READING_MOISTURE] == STATE_UNAVAILABLE
 
 
-async def test_load_from_db(recorder_mock: Recorder, hass: HomeAssistant) -> None:
+async def test_load_from_db(
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
+) -> None:
     """Test bootstrapping the brightness history from the database.
 
     This test can should only be executed if the loading of the history

--- a/tests/components/recorder/db_schema_25.py
+++ b/tests/components/recorder/db_schema_25.py
@@ -26,7 +26,7 @@ from sqlalchemy.engine.row import Row
 from sqlalchemy.orm import declarative_base, relationship
 from sqlalchemy.orm.session import Session
 
-from homeassistant.components.recorder.const import ALL_DOMAIN_EXCLUDE_ATTRS, JSON_DUMP
+from homeassistant.components import recorder
 from homeassistant.const import (
     MAX_LENGTH_EVENT_CONTEXT_ID,
     MAX_LENGTH_EVENT_EVENT_TYPE,
@@ -118,7 +118,9 @@ class Events(Base):  # type: ignore[misc,valid-type]
         """Create an event database object from a native event."""
         return Events(
             event_type=event.event_type,
-            event_data=JSON_DUMP(event.data) if event_data is UNDEFINED else event_data,
+            event_data=recorder.const.JSON_DUMP(event.data)
+            if event_data is UNDEFINED
+            else event_data,
             origin=str(event.origin.value),
             time_fired=event.time_fired,
             context_id=event.context.id,
@@ -252,7 +254,9 @@ class StateAttributes(Base):  # type: ignore[misc,valid-type]
         state: State | None = event.data.get("new_state")
         # None state means the state was removed from the state machine
         dbstate = StateAttributes(
-            shared_attrs="{}" if state is None else JSON_DUMP(state.attributes)
+            shared_attrs="{}"
+            if state is None
+            else recorder.const.JSON_DUMP(state.attributes)
         )
         dbstate.hash = StateAttributes.hash_shared_attrs(dbstate.shared_attrs)
         return dbstate
@@ -268,9 +272,10 @@ class StateAttributes(Base):  # type: ignore[misc,valid-type]
             return "{}"
         domain = split_entity_id(state.entity_id)[0]
         exclude_attrs = (
-            exclude_attrs_by_domain.get(domain, set()) | ALL_DOMAIN_EXCLUDE_ATTRS
+            exclude_attrs_by_domain.get(domain, set())
+            | recorder.const.ALL_DOMAIN_EXCLUDE_ATTRS
         )
-        return JSON_DUMP(
+        return recorder.const.JSON_DUMP(
             {k: v for k, v in state.attributes.items() if k not in exclude_attrs}
         )
 

--- a/tests/components/recorder/db_schema_28.py
+++ b/tests/components/recorder/db_schema_28.py
@@ -33,7 +33,7 @@ from sqlalchemy.engine.row import Row
 from sqlalchemy.orm import declarative_base, relationship
 from sqlalchemy.orm.session import Session
 
-from homeassistant.components.recorder.const import ALL_DOMAIN_EXCLUDE_ATTRS, JSON_DUMP
+from homeassistant.components import recorder
 from homeassistant.const import (
     MAX_LENGTH_EVENT_CONTEXT_ID,
     MAX_LENGTH_EVENT_EVENT_TYPE,
@@ -222,7 +222,7 @@ class EventData(Base):  # type: ignore[misc,valid-type]
     @staticmethod
     def from_event(event: Event) -> EventData:
         """Create object from an event."""
-        shared_data = JSON_DUMP(event.data)
+        shared_data = recorder.const.JSON_DUMP(event.data)
         return EventData(
             shared_data=shared_data, hash=EventData.hash_shared_data(shared_data)
         )
@@ -230,7 +230,7 @@ class EventData(Base):  # type: ignore[misc,valid-type]
     @staticmethod
     def shared_data_from_event(event: Event) -> str:
         """Create shared_attrs from an event."""
-        return JSON_DUMP(event.data)
+        return recorder.const.JSON_DUMP(event.data)
 
     @staticmethod
     def hash_shared_data(shared_data: str) -> int:
@@ -396,7 +396,9 @@ class StateAttributes(Base):  # type: ignore[misc,valid-type]
         state: State | None = event.data.get("new_state")
         # None state means the state was removed from the state machine
         dbstate = StateAttributes(
-            shared_attrs="{}" if state is None else JSON_DUMP(state.attributes)
+            shared_attrs="{}"
+            if state is None
+            else recorder.const.JSON_DUMP(state.attributes)
         )
         dbstate.hash = StateAttributes.hash_shared_attrs(dbstate.shared_attrs)
         return dbstate
@@ -412,9 +414,10 @@ class StateAttributes(Base):  # type: ignore[misc,valid-type]
             return "{}"
         domain = split_entity_id(state.entity_id)[0]
         exclude_attrs = (
-            exclude_attrs_by_domain.get(domain, set()) | ALL_DOMAIN_EXCLUDE_ATTRS
+            exclude_attrs_by_domain.get(domain, set())
+            | recorder.const.ALL_DOMAIN_EXCLUDE_ATTRS
         )
-        return JSON_DUMP(
+        return recorder.const.JSON_DUMP(
             {k: v for k, v in state.attributes.items() if k not in exclude_attrs}
         )
 

--- a/tests/components/recorder/db_schema_30.py
+++ b/tests/components/recorder/db_schema_30.py
@@ -36,7 +36,7 @@ from sqlalchemy.orm import aliased, declarative_base, relationship
 from sqlalchemy.orm.session import Session
 from typing_extensions import Self
 
-from homeassistant.components.recorder.const import SupportedDialect
+from homeassistant.components import recorder
 from homeassistant.const import (
     ATTR_ATTRIBUTION,
     ATTR_RESTORED,
@@ -315,7 +315,7 @@ class EventData(Base):  # type: ignore[misc,valid-type]
 
     @staticmethod
     def shared_data_bytes_from_event(
-        event: Event, dialect: SupportedDialect | None
+        event: Event, dialect: recorder.const.SupportedDialect | None
     ) -> bytes:
         """Create shared_data from an event."""
         return json_bytes(event.data)
@@ -508,7 +508,7 @@ class StateAttributes(Base):  # type: ignore[misc,valid-type]
         event: Event,
         entity_registry: er.EntityRegistry,
         exclude_attrs_by_domain: dict[str, set[str]],
-        dialect: SupportedDialect | None,
+        dialect: recorder.const.SupportedDialect | None,
     ) -> bytes:
         """Create shared_attrs from a state_changed event."""
         state: State | None = event.data.get("new_state")

--- a/tests/components/recorder/db_schema_32.py
+++ b/tests/components/recorder/db_schema_32.py
@@ -36,7 +36,7 @@ from sqlalchemy.orm import aliased, declarative_base, relationship
 from sqlalchemy.orm.session import Session
 from typing_extensions import Self
 
-from homeassistant.components.recorder.const import SupportedDialect
+from homeassistant.components import recorder
 from homeassistant.const import (
     ATTR_ATTRIBUTION,
     ATTR_RESTORED,
@@ -314,7 +314,7 @@ class EventData(Base):  # type: ignore[misc,valid-type]
 
     @staticmethod
     def shared_data_bytes_from_event(
-        event: Event, dialect: SupportedDialect | None
+        event: Event, dialect: recorder.const.SupportedDialect | None
     ) -> bytes:
         """Create shared_data from an event."""
         return json_bytes(event.data)
@@ -506,7 +506,7 @@ class StateAttributes(Base):  # type: ignore[misc,valid-type]
         event: Event,
         entity_registry: er.EntityRegistry,
         exclude_attrs_by_domain: dict[str, set[str]],
-        dialect: SupportedDialect | None,
+        dialect: recorder.const.SupportedDialect | None,
     ) -> bytes:
         """Create shared_attrs from a state_changed event."""
         state: State | None = event.data.get("new_state")

--- a/tests/components/recorder/table_managers/test_recorder_runs.py
+++ b/tests/components/recorder/table_managers/test_recorder_runs.py
@@ -3,16 +3,15 @@ from datetime import timedelta
 from unittest.mock import patch
 
 from homeassistant.components import recorder
-from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.db_schema import RecorderRuns
-from homeassistant.components.recorder.models import process_timestamp
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
 from tests.typing import RecorderInstanceGenerator
 
 
-async def test_run_history(recorder_mock: Recorder, hass: HomeAssistant) -> None:
+async def test_run_history(
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
+) -> None:
     """Test the run history gives the correct run."""
     instance = recorder.get_instance(hass)
     now = dt_util.utcnow()
@@ -21,14 +20,22 @@ async def test_run_history(recorder_mock: Recorder, hass: HomeAssistant) -> None
     one_day_ago = now - timedelta(days=1)
 
     with instance.get_session() as session:
-        session.add(RecorderRuns(start=three_days_ago, created=three_days_ago))
-        session.add(RecorderRuns(start=two_days_ago, created=two_days_ago))
-        session.add(RecorderRuns(start=one_day_ago, created=one_day_ago))
+        session.add(
+            recorder.db_schema.RecorderRuns(
+                start=three_days_ago, created=three_days_ago
+            )
+        )
+        session.add(
+            recorder.db_schema.RecorderRuns(start=two_days_ago, created=two_days_ago)
+        )
+        session.add(
+            recorder.db_schema.RecorderRuns(start=one_day_ago, created=one_day_ago)
+        )
         session.commit()
         instance.recorder_runs_manager.load_from_db(session)
 
     assert (
-        process_timestamp(
+        recorder.models.process_timestamp(
             instance.recorder_runs_manager.get(
                 three_days_ago + timedelta(microseconds=1)
             ).start
@@ -36,7 +43,7 @@ async def test_run_history(recorder_mock: Recorder, hass: HomeAssistant) -> None
         == three_days_ago
     )
     assert (
-        process_timestamp(
+        recorder.models.process_timestamp(
             instance.recorder_runs_manager.get(
                 two_days_ago + timedelta(microseconds=1)
             ).start
@@ -44,7 +51,7 @@ async def test_run_history(recorder_mock: Recorder, hass: HomeAssistant) -> None
         == two_days_ago
     )
     assert (
-        process_timestamp(
+        recorder.models.process_timestamp(
             instance.recorder_runs_manager.get(
                 one_day_ago + timedelta(microseconds=1)
             ).start
@@ -52,7 +59,7 @@ async def test_run_history(recorder_mock: Recorder, hass: HomeAssistant) -> None
         == one_day_ago
     )
     assert (
-        process_timestamp(instance.recorder_runs_manager.get(now).start)
+        recorder.models.process_timestamp(instance.recorder_runs_manager.get(now).start)
         == instance.recorder_runs_manager.recording_start
     )
 

--- a/tests/components/recorder/table_managers/test_statistics_meta.py
+++ b/tests/components/recorder/table_managers/test_statistics_meta.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import pytest
 
 from homeassistant.components import recorder
-from homeassistant.components.recorder.util import session_scope
 from homeassistant.core import HomeAssistant
 
 from tests.typing import RecorderInstanceGenerator
@@ -17,7 +16,7 @@ async def test_passing_mutually_exclusive_options_to_get_many(
     instance = await async_setup_recorder_instance(
         hass, {recorder.CONF_COMMIT_INTERVAL: 0}
     )
-    with session_scope(session=instance.get_session()) as session:
+    with recorder.util.session_scope(session=instance.get_session()) as session:
         with pytest.raises(ValueError):
             instance.statistics_meta_manager.get_many(
                 session,
@@ -44,7 +43,9 @@ async def test_unsafe_calls_to_statistics_meta_manager(
     instance = await async_setup_recorder_instance(
         hass, {recorder.CONF_COMMIT_INTERVAL: 0}
     )
-    with session_scope(session=instance.get_session()) as session, pytest.raises(
+    with recorder.util.session_scope(
+        session=instance.get_session()
+    ) as session, pytest.raises(
         RuntimeError, match="Detected unsafe call not in recorder thread"
     ):
         instance.statistics_meta_manager.delete(

--- a/tests/components/recorder/test_backup.py
+++ b/tests/components/recorder/test_backup.py
@@ -3,60 +3,63 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.backup import async_post_backup, async_pre_backup
+from homeassistant.components import recorder
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 
 
-async def test_async_pre_backup(recorder_mock: Recorder, hass: HomeAssistant) -> None:
+async def test_async_pre_backup(
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
+) -> None:
     """Test pre backup."""
     with patch(
         "homeassistant.components.recorder.core.Recorder.lock_database"
     ) as lock_mock:
-        await async_pre_backup(hass)
+        await recorder.backup.async_pre_backup(hass)
         assert lock_mock.called
 
 
 async def test_async_pre_backup_with_timeout(
-    recorder_mock: Recorder, hass: HomeAssistant
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
 ) -> None:
     """Test pre backup with timeout."""
     with patch(
         "homeassistant.components.recorder.core.Recorder.lock_database",
         side_effect=TimeoutError(),
     ) as lock_mock, pytest.raises(TimeoutError):
-        await async_pre_backup(hass)
+        await recorder.backup.async_pre_backup(hass)
         assert lock_mock.called
 
 
 async def test_async_pre_backup_with_migration(
-    recorder_mock: Recorder, hass: HomeAssistant
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
 ) -> None:
     """Test pre backup with migration."""
     with patch(
         "homeassistant.components.recorder.backup.async_migration_in_progress",
         return_value=True,
     ), pytest.raises(HomeAssistantError):
-        await async_pre_backup(hass)
+        await recorder.backup.async_pre_backup(hass)
 
 
-async def test_async_post_backup(recorder_mock: Recorder, hass: HomeAssistant) -> None:
+async def test_async_post_backup(
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
+) -> None:
     """Test post backup."""
     with patch(
         "homeassistant.components.recorder.core.Recorder.unlock_database"
     ) as unlock_mock:
-        await async_post_backup(hass)
+        await recorder.backup.async_post_backup(hass)
         assert unlock_mock.called
 
 
 async def test_async_post_backup_failure(
-    recorder_mock: Recorder, hass: HomeAssistant
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
 ) -> None:
     """Test post backup failure."""
     with patch(
         "homeassistant.components.recorder.core.Recorder.unlock_database",
         return_value=False,
     ) as unlock_mock, pytest.raises(HomeAssistantError):
-        await async_post_backup(hass)
+        await recorder.backup.async_post_backup(hass)
         assert unlock_mock.called

--- a/tests/components/recorder/test_filters.py
+++ b/tests/components/recorder/test_filters.py
@@ -2,11 +2,7 @@
 
 import pytest
 
-from homeassistant.components.recorder.filters import (
-    Filters,
-    extract_include_exclude_filter_conf,
-    merge_include_exclude_filters,
-)
+from homeassistant.components import recorder
 from homeassistant.helpers.entityfilter import (
     CONF_DOMAINS,
     CONF_ENTITIES,
@@ -48,7 +44,9 @@ SIMPLE_INCLUDE_EXCLUDE_FILTER = {**SIMPLE_INCLUDE_FILTER, **SIMPLE_EXCLUDE_FILTE
 
 def test_extract_include_exclude_filter_conf() -> None:
     """Test we can extract a filter from configuration without altering it."""
-    include_filter = extract_include_exclude_filter_conf(SIMPLE_INCLUDE_FILTER)
+    include_filter = recorder.filters.extract_include_exclude_filter_conf(
+        SIMPLE_INCLUDE_FILTER
+    )
     assert include_filter == {
         CONF_EXCLUDE: {
             CONF_DOMAINS: set(),
@@ -62,7 +60,9 @@ def test_extract_include_exclude_filter_conf() -> None:
         },
     }
 
-    exclude_filter = extract_include_exclude_filter_conf(SIMPLE_EXCLUDE_FILTER)
+    exclude_filter = recorder.filters.extract_include_exclude_filter_conf(
+        SIMPLE_EXCLUDE_FILTER
+    )
     assert exclude_filter == {
         CONF_INCLUDE: {
             CONF_DOMAINS: set(),
@@ -76,7 +76,7 @@ def test_extract_include_exclude_filter_conf() -> None:
         },
     }
 
-    include_exclude_filter = extract_include_exclude_filter_conf(
+    include_exclude_filter = recorder.filters.extract_include_exclude_filter_conf(
         SIMPLE_INCLUDE_EXCLUDE_FILTER
     )
     assert include_exclude_filter == {
@@ -97,7 +97,9 @@ def test_extract_include_exclude_filter_conf() -> None:
     assert SIMPLE_INCLUDE_EXCLUDE_FILTER[CONF_EXCLUDE][CONF_ENTITIES] != {
         "cover.altered"
     }
-    empty_include_filter = extract_include_exclude_filter_conf(EMPTY_INCLUDE_FILTER)
+    empty_include_filter = recorder.filters.extract_include_exclude_filter_conf(
+        EMPTY_INCLUDE_FILTER
+    )
     assert empty_include_filter == {
         CONF_EXCLUDE: {
             CONF_DOMAINS: set(),
@@ -114,13 +116,13 @@ def test_extract_include_exclude_filter_conf() -> None:
 
 def test_merge_include_exclude_filters() -> None:
     """Test we can merge two filters together."""
-    include_exclude_filter_base = extract_include_exclude_filter_conf(
+    include_exclude_filter_base = recorder.filters.extract_include_exclude_filter_conf(
         SIMPLE_INCLUDE_EXCLUDE_FILTER
     )
-    include_filter_add = extract_include_exclude_filter_conf(
+    include_filter_add = recorder.filters.extract_include_exclude_filter_conf(
         SIMPLE_INCLUDE_FILTER_DIFFERENT_ENTITIES
     )
-    merged_filter = merge_include_exclude_filters(
+    merged_filter = recorder.filters.merge_include_exclude_filters(
         include_exclude_filter_base, include_filter_add
     )
     assert merged_filter == {
@@ -139,7 +141,7 @@ def test_merge_include_exclude_filters() -> None:
 
 async def test_an_empty_filter_raises() -> None:
     """Test empty filter raises when not guarding with has_config."""
-    filters = Filters()
+    filters = recorder.filters.Filters()
     assert not filters.has_config
     with pytest.raises(
         RuntimeError,

--- a/tests/components/recorder/test_history_db_schema_32.py
+++ b/tests/components/recorder/test_history_db_schema_32.py
@@ -13,10 +13,6 @@ from freezegun import freeze_time
 import pytest
 
 from homeassistant.components import recorder
-from homeassistant.components.recorder import history
-from homeassistant.components.recorder.filters import Filters
-from homeassistant.components.recorder.models import process_timestamp
-from homeassistant.components.recorder.util import session_scope
 from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers.json import JSONEncoder
 import homeassistant.util.dt as dt_util
@@ -46,17 +42,17 @@ def test_get_full_significant_states_with_session_entity_no_matches(
     now = dt_util.utcnow()
     time_before_recorder_ran = now - timedelta(days=1000)
     instance = recorder.get_instance(hass)
-    with session_scope(hass=hass) as session, patch.object(
+    with recorder.util.session_scope(hass=hass) as session, patch.object(
         instance.states_meta_manager, "active", False
     ):
         assert (
-            history.get_full_significant_states_with_session(
+            recorder.history.get_full_significant_states_with_session(
                 hass, session, time_before_recorder_ran, now, entity_ids=["demo.id"]
             )
             == {}
         )
         assert (
-            history.get_full_significant_states_with_session(
+            recorder.history.get_full_significant_states_with_session(
                 hass,
                 session,
                 time_before_recorder_ran,
@@ -75,11 +71,11 @@ def test_significant_states_with_session_entity_minimal_response_no_matches(
     now = dt_util.utcnow()
     time_before_recorder_ran = now - timedelta(days=1000)
     instance = recorder.get_instance(hass)
-    with session_scope(hass=hass) as session, patch.object(
+    with recorder.util.session_scope(hass=hass) as session, patch.object(
         instance.states_meta_manager, "active", False
     ):
         assert (
-            history.get_significant_states_with_session(
+            recorder.history.get_significant_states_with_session(
                 hass,
                 session,
                 time_before_recorder_ran,
@@ -90,7 +86,7 @@ def test_significant_states_with_session_entity_minimal_response_no_matches(
             == {}
         )
         assert (
-            history.get_significant_states_with_session(
+            recorder.history.get_significant_states_with_session(
                 hass,
                 session,
                 time_before_recorder_ran,
@@ -146,7 +142,7 @@ def test_state_changes_during_period(
             set_state("Netflix")
             set_state("Plex")
 
-        hist = history.state_changes_during_period(
+        hist = recorder.history.state_changes_during_period(
             hass, start, end, entity_id, no_attributes, limit=limit
         )
 
@@ -195,12 +191,12 @@ def test_state_changes_during_period_descending(
             set_state("Netflix")
             set_state("Plex")
 
-        hist = history.state_changes_during_period(
+        hist = recorder.history.state_changes_during_period(
             hass, start, end, entity_id, no_attributes=False, descending=False
         )
         assert_multiple_states_equal_without_context(states, hist[entity_id])
 
-        hist = history.state_changes_during_period(
+        hist = recorder.history.state_changes_during_period(
             hass, start, end, entity_id, no_attributes=False, descending=True
         )
         assert_multiple_states_equal_without_context(
@@ -235,7 +231,7 @@ def test_get_last_state_changes(hass_recorder: Callable[..., HomeAssistant]) -> 
             freezer.move_to(point2)
             states.append(set_state("3"))
 
-        hist = history.get_last_state_changes(hass, 2, entity_id)
+        hist = recorder.history.get_last_state_changes(hass, 2, entity_id)
 
         assert_multiple_states_equal_without_context(states, hist[entity_id])
 
@@ -268,7 +264,7 @@ def test_ensure_state_can_be_copied(
             freezer.move_to(point)
             set_state("2")
 
-        hist = history.get_last_state_changes(hass, 2, entity_id)
+        hist = recorder.history.get_last_state_changes(hass, 2, entity_id)
 
         assert_states_equal_without_context(
             copy(hist[entity_id][0]), hist[entity_id][0]
@@ -289,7 +285,9 @@ def test_get_significant_states(hass_recorder: Callable[..., HomeAssistant]) -> 
     instance = recorder.get_instance(hass)
     with patch.object(instance.states_meta_manager, "active", False):
         zero, four, states = record_states(hass)
-        hist = history.get_significant_states(hass, zero, four, entity_ids=list(states))
+        hist = recorder.history.get_significant_states(
+            hass, zero, four, entity_ids=list(states)
+        )
         assert_dict_of_states_equal_without_context_and_last_changed(states, hist)
 
 
@@ -308,7 +306,7 @@ def test_get_significant_states_minimal_response(
     instance = recorder.get_instance(hass)
     with patch.object(instance.states_meta_manager, "active", False):
         zero, four, states = record_states(hass)
-        hist = history.get_significant_states(
+        hist = recorder.history.get_significant_states(
             hass, zero, four, minimal_response=True, entity_ids=list(states)
         )
         entites_with_reducable_states = [
@@ -327,7 +325,7 @@ def test_get_significant_states_minimal_response(
             for state_idx in range(1, len(entity_states)):
                 input_state = entity_states[state_idx]
                 orig_last_changed = orig_last_changed = json.dumps(
-                    process_timestamp(input_state.last_changed),
+                    recorder.models.process_timestamp(input_state.last_changed),
                     cls=JSONEncoder,
                 ).replace('"', "")
                 orig_state = input_state.state
@@ -384,7 +382,7 @@ def test_get_significant_states_with_initial(
             if state.last_changed == one:
                 state.last_changed = one_and_half
 
-    hist = history.get_significant_states(
+    hist = recorder.history.get_significant_states(
         hass, one_and_half, four, include_start_time_state=True, entity_ids=list(states)
     )
     assert_dict_of_states_equal_without_context_and_last_changed(states, hist)
@@ -416,7 +414,7 @@ def test_get_significant_states_without_initial(
             )
         del states["media_player.test2"]
 
-        hist = history.get_significant_states(
+        hist = recorder.history.get_significant_states(
             hass,
             one_and_half,
             four,
@@ -440,7 +438,9 @@ def test_get_significant_states_entity_id(
         del states["thermostat.test2"]
         del states["script.can_cancel_this_one"]
 
-        hist = history.get_significant_states(hass, zero, four, ["media_player.test"])
+        hist = recorder.history.get_significant_states(
+            hass, zero, four, ["media_player.test"]
+        )
         assert_dict_of_states_equal_without_context_and_last_changed(states, hist)
 
 
@@ -457,7 +457,7 @@ def test_get_significant_states_multiple_entity_ids(
         del states["thermostat.test2"]
         del states["script.can_cancel_this_one"]
 
-        hist = history.get_significant_states(
+        hist = recorder.history.get_significant_states(
             hass,
             zero,
             four,
@@ -485,10 +485,10 @@ def test_get_significant_states_are_ordered(
     with patch.object(instance.states_meta_manager, "active", False):
         zero, four, _states = record_states(hass)
         entity_ids = ["media_player.test", "media_player.test2"]
-        hist = history.get_significant_states(hass, zero, four, entity_ids)
+        hist = recorder.history.get_significant_states(hass, zero, four, entity_ids)
         assert list(hist.keys()) == entity_ids
         entity_ids = ["media_player.test2", "media_player.test"]
-        hist = history.get_significant_states(hass, zero, four, entity_ids)
+        hist = recorder.history.get_significant_states(hass, zero, four, entity_ids)
         assert list(hist.keys()) == entity_ids
 
 
@@ -528,7 +528,7 @@ def test_get_significant_states_only(
             # everything is different
             states.append(set_state("412", attributes={"attribute": 54.23}))
 
-        hist = history.get_significant_states(
+        hist = recorder.history.get_significant_states(
             hass,
             start,
             significant_changes_only=True,
@@ -546,7 +546,7 @@ def test_get_significant_states_only(
             state.last_updated == states[2].last_updated for state in hist[entity_id]
         )
 
-        hist = history.get_significant_states(
+        hist = recorder.history.get_significant_states(
             hass,
             start,
             significant_changes_only=False,
@@ -655,7 +655,9 @@ def test_state_changes_during_period_multiple_entities_single_test(
         end = dt_util.utcnow()
 
         for entity_id, value in test_entites.items():
-            hist = history.state_changes_during_period(hass, start, end, entity_id)
+            hist = recorder.history.state_changes_during_period(
+                hass, start, end, entity_id
+            )
             assert len(hist) == 1
             assert hist[entity_id][0].state == value
 
@@ -667,7 +669,7 @@ def test_get_significant_states_without_entity_ids_raises(
     hass = hass_recorder()
     now = dt_util.utcnow()
     with pytest.raises(ValueError, match="entity_ids must be provided"):
-        history.get_significant_states(hass, now, None)
+        recorder.history.get_significant_states(hass, now, None)
 
 
 def test_state_changes_during_period_without_entity_ids_raises(
@@ -677,7 +679,7 @@ def test_state_changes_during_period_without_entity_ids_raises(
     hass = hass_recorder()
     now = dt_util.utcnow()
     with pytest.raises(ValueError, match="entity_id must be provided"):
-        history.state_changes_during_period(hass, now, None)
+        recorder.history.state_changes_during_period(hass, now, None)
 
 
 def test_get_significant_states_with_filters_raises(
@@ -687,8 +689,8 @@ def test_get_significant_states_with_filters_raises(
     hass = hass_recorder()
     now = dt_util.utcnow()
     with pytest.raises(NotImplementedError, match="Filters are no longer supported"):
-        history.get_significant_states(
-            hass, now, None, ["media_player.test"], Filters()
+        recorder.history.get_significant_states(
+            hass, now, None, ["media_player.test"], recorder.filters.Filters()
         )
 
 
@@ -698,7 +700,10 @@ def test_get_significant_states_with_non_existent_entity_ids_returns_empty(
     """Test get_significant_states returns an empty dict when entities not in the db."""
     hass = hass_recorder()
     now = dt_util.utcnow()
-    assert history.get_significant_states(hass, now, None, ["nonexistent.entity"]) == {}
+    assert (
+        recorder.history.get_significant_states(hass, now, None, ["nonexistent.entity"])
+        == {}
+    )
 
 
 def test_state_changes_during_period_with_non_existent_entity_ids_returns_empty(
@@ -708,7 +713,10 @@ def test_state_changes_during_period_with_non_existent_entity_ids_returns_empty(
     hass = hass_recorder()
     now = dt_util.utcnow()
     assert (
-        history.state_changes_during_period(hass, now, None, "nonexistent.entity") == {}
+        recorder.history.state_changes_during_period(
+            hass, now, None, "nonexistent.entity"
+        )
+        == {}
     )
 
 
@@ -717,4 +725,4 @@ def test_get_last_state_changes_with_non_existent_entity_ids_returns_empty(
 ) -> None:
     """Test get_last_state_changes returns an empty dict when entities not in the db."""
     hass = hass_recorder()
-    assert history.get_last_state_changes(hass, 1, "nonexistent.entity") == {}
+    assert recorder.history.get_last_state_changes(hass, 1, "nonexistent.entity") == {}

--- a/tests/components/recorder/test_models.py
+++ b/tests/components/recorder/test_models.py
@@ -5,21 +5,7 @@ from unittest.mock import PropertyMock
 from freezegun import freeze_time
 import pytest
 
-from homeassistant.components.recorder.const import SupportedDialect
-from homeassistant.components.recorder.db_schema import (
-    EventData,
-    Events,
-    StateAttributes,
-    States,
-)
-from homeassistant.components.recorder.models import (
-    LazyState,
-    bytes_to_ulid_or_none,
-    process_datetime_to_timestamp,
-    process_timestamp,
-    process_timestamp_to_utc_isoformat,
-    ulid_to_bytes_or_none,
-)
+from homeassistant.components import recorder
 from homeassistant.const import EVENT_STATE_CHANGED
 import homeassistant.core as ha
 from homeassistant.core import HomeAssistant
@@ -38,9 +24,11 @@ def test_from_event_to_db_event() -> None:
             user_id="12345678901234567890123456789012",
         ),
     )
-    db_event = Events.from_event(event)
-    dialect = SupportedDialect.MYSQL
-    db_event.event_data = EventData.shared_data_bytes_from_event(event, dialect)
+    db_event = recorder.db_schema.Events.from_event(event)
+    dialect = recorder.const.SupportedDialect.MYSQL
+    db_event.event_data = recorder.db_schema.EventData.shared_data_bytes_from_event(
+        event, dialect
+    )
     db_event.event_type = event.event_type
     assert event.as_dict() == db_event.to_native().as_dict()
 
@@ -61,7 +49,10 @@ def test_from_event_to_db_state() -> None:
         {"entity_id": "sensor.temperature", "old_state": None, "new_state": state},
         context=state.context,
     )
-    assert state.as_dict() == States.from_event(event).to_native().as_dict()
+    assert (
+        state.as_dict()
+        == recorder.db_schema.States.from_event(event).to_native().as_dict()
+    )
 
 
 def test_from_event_to_db_state_attributes() -> None:
@@ -73,11 +64,13 @@ def test_from_event_to_db_state_attributes() -> None:
         {"entity_id": "sensor.temperature", "old_state": None, "new_state": state},
         context=state.context,
     )
-    db_attrs = StateAttributes()
-    dialect = SupportedDialect.MYSQL
+    db_attrs = recorder.db_schema.StateAttributes()
+    dialect = recorder.const.SupportedDialect.MYSQL
 
-    db_attrs.shared_attrs = StateAttributes.shared_attrs_bytes_from_event(
-        event, {}, {}, dialect
+    db_attrs.shared_attrs = (
+        recorder.db_schema.StateAttributes.shared_attrs_bytes_from_event(
+            event, {}, {}, dialect
+        )
     )
     assert db_attrs.to_native() == attrs
 
@@ -99,14 +92,18 @@ def test_repr() -> None:
         context=state.context,
         time_fired=fixed_time,
     )
-    assert "2016-07-09 11:00:00+00:00" in repr(States.from_event(event))
-    assert "2016-07-09 11:00:00+00:00" in repr(Events.from_event(event))
+    assert "2016-07-09 11:00:00+00:00" in repr(
+        recorder.db_schema.States.from_event(event)
+    )
+    assert "2016-07-09 11:00:00+00:00" in repr(
+        recorder.db_schema.Events.from_event(event)
+    )
 
 
 def test_states_repr_without_timestamp() -> None:
     """Test repr for a state without last_updated_ts."""
     fixed_time = datetime(2016, 7, 9, 11, 0, 0, tzinfo=dt_util.UTC, microsecond=432432)
-    states = States(
+    states = recorder.db_schema.States(
         entity_id="sensor.temp",
         attributes=None,
         context_id=None,
@@ -124,7 +121,7 @@ def test_states_repr_without_timestamp() -> None:
 def test_events_repr_without_timestamp() -> None:
     """Test repr for an event without time_fired_ts."""
     fixed_time = datetime(2016, 7, 9, 11, 0, 0, tzinfo=dt_util.UTC, microsecond=432432)
-    events = Events(
+    events = recorder.db_schema.Events(
         event_type="any",
         event_data=None,
         origin_idx=None,
@@ -141,7 +138,7 @@ def test_handling_broken_json_state_attributes(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test we handle broken json in state attributes."""
-    state_attributes = StateAttributes(
+    state_attributes = recorder.db_schema.StateAttributes(
         attributes_id=444, hash=1234, shared_attrs="{NOT_PARSE}"
     )
     assert state_attributes.to_native() == {}
@@ -158,7 +155,7 @@ def test_from_event_to_delete_state() -> None:
             "new_state": None,
         },
     )
-    db_state = States.from_event(event)
+    db_state = recorder.db_schema.States.from_event(event)
 
     assert db_state.entity_id == "sensor.temperature"
     assert db_state.state == ""
@@ -168,7 +165,7 @@ def test_from_event_to_delete_state() -> None:
 
 def test_states_from_native_invalid_entity_id() -> None:
     """Test loading a state from an invalid entity ID."""
-    state = States()
+    state = recorder.db_schema.States()
     state.entity_id = "test.invalid__id"
     state.attributes = "{}"
     with pytest.raises(InvalidEntityFormatError):
@@ -189,22 +186,22 @@ async def test_process_timestamp() -> None:
     hst = dt_util.get_time_zone("US/Hawaii")
     datetime_hst_timezone = datetime(2016, 7, 9, 11, 0, 0, tzinfo=hst)
 
-    assert process_timestamp(datetime_with_tzinfo) == datetime(
+    assert recorder.models.process_timestamp(datetime_with_tzinfo) == datetime(
         2016, 7, 9, 11, 0, 0, tzinfo=dt_util.UTC
     )
-    assert process_timestamp(datetime_without_tzinfo) == datetime(
+    assert recorder.models.process_timestamp(datetime_without_tzinfo) == datetime(
         2016, 7, 9, 11, 0, 0, tzinfo=dt_util.UTC
     )
-    assert process_timestamp(datetime_est_timezone) == datetime(
+    assert recorder.models.process_timestamp(datetime_est_timezone) == datetime(
         2016, 7, 9, 15, 0, tzinfo=dt_util.UTC
     )
-    assert process_timestamp(datetime_nst_timezone) == datetime(
+    assert recorder.models.process_timestamp(datetime_nst_timezone) == datetime(
         2016, 7, 9, 13, 30, tzinfo=dt_util.UTC
     )
-    assert process_timestamp(datetime_hst_timezone) == datetime(
+    assert recorder.models.process_timestamp(datetime_hst_timezone) == datetime(
         2016, 7, 9, 21, 0, tzinfo=dt_util.UTC
     )
-    assert process_timestamp(None) is None
+    assert recorder.models.process_timestamp(None) is None
 
 
 async def test_process_timestamp_to_utc_isoformat() -> None:
@@ -221,26 +218,26 @@ async def test_process_timestamp_to_utc_isoformat() -> None:
     datetime_hst_timezone = datetime(2016, 7, 9, 11, 0, 0, tzinfo=hst)
 
     assert (
-        process_timestamp_to_utc_isoformat(datetime_with_tzinfo)
+        recorder.models.process_timestamp_to_utc_isoformat(datetime_with_tzinfo)
         == "2016-07-09T11:00:00+00:00"
     )
     assert (
-        process_timestamp_to_utc_isoformat(datetime_without_tzinfo)
+        recorder.models.process_timestamp_to_utc_isoformat(datetime_without_tzinfo)
         == "2016-07-09T11:00:00+00:00"
     )
     assert (
-        process_timestamp_to_utc_isoformat(datetime_est_timezone)
+        recorder.models.process_timestamp_to_utc_isoformat(datetime_est_timezone)
         == "2016-07-09T15:00:00+00:00"
     )
     assert (
-        process_timestamp_to_utc_isoformat(datetime_nst_timezone)
+        recorder.models.process_timestamp_to_utc_isoformat(datetime_nst_timezone)
         == "2016-07-09T13:30:00+00:00"
     )
     assert (
-        process_timestamp_to_utc_isoformat(datetime_hst_timezone)
+        recorder.models.process_timestamp_to_utc_isoformat(datetime_hst_timezone)
         == "2016-07-09T21:00:00+00:00"
     )
-    assert process_timestamp_to_utc_isoformat(None) is None
+    assert recorder.models.process_timestamp_to_utc_isoformat(None) is None
 
 
 async def test_event_to_db_model() -> None:
@@ -248,14 +245,16 @@ async def test_event_to_db_model() -> None:
     event = ha.Event(
         "state_changed", {"some": "attr"}, ha.EventOrigin.local, dt_util.utcnow()
     )
-    db_event = Events.from_event(event)
-    dialect = SupportedDialect.MYSQL
-    db_event.event_data = EventData.shared_data_bytes_from_event(event, dialect)
+    db_event = recorder.db_schema.Events.from_event(event)
+    dialect = recorder.const.SupportedDialect.MYSQL
+    db_event.event_data = recorder.db_schema.EventData.shared_data_bytes_from_event(
+        event, dialect
+    )
     db_event.event_type = event.event_type
     native = db_event.to_native()
     assert native.as_dict() == event.as_dict()
 
-    native = Events.from_event(event).to_native()
+    native = recorder.db_schema.Events.from_event(event).to_native()
     native.data = (
         event.data
     )  # data is not set by from_event as its in the event_data table
@@ -271,7 +270,10 @@ async def test_lazy_state_handles_include_json(
         entity_id="sensor.invalid",
         shared_attrs="{INVALID_JSON}",
     )
-    assert LazyState(row, {}, None, row.entity_id, "", 1, False).attributes == {}
+    assert (
+        recorder.models.LazyState(row, {}, None, row.entity_id, "", 1, False).attributes
+        == {}
+    )
     assert "Error converting row to state attributes" in caplog.text
 
 
@@ -283,9 +285,9 @@ async def test_lazy_state_can_decode_attributes(
         entity_id="sensor.invalid",
         attributes='{"shared":true}',
     )
-    assert LazyState(row, {}, None, row.entity_id, "", 1, False).attributes == {
-        "shared": True
-    }
+    assert recorder.models.LazyState(
+        row, {}, None, row.entity_id, "", 1, False
+    ).attributes == {"shared": True}
 
 
 async def test_lazy_state_handles_different_last_updated_and_last_changed(
@@ -300,7 +302,7 @@ async def test_lazy_state_handles_different_last_updated_and_last_changed(
         last_updated_ts=now.timestamp(),
         last_changed_ts=(now - timedelta(seconds=60)).timestamp(),
     )
-    lstate = LazyState(
+    lstate = recorder.models.LazyState(
         row, {}, None, row.entity_id, row.state, row.last_updated_ts, False
     )
     assert lstate.as_dict() == {
@@ -333,7 +335,7 @@ async def test_lazy_state_handles_same_last_updated_and_last_changed(
         last_updated_ts=now.timestamp(),
         last_changed_ts=now.timestamp(),
     )
-    lstate = LazyState(
+    lstate = recorder.models.LazyState(
         row, {}, None, row.entity_id, row.state, row.last_updated_ts, False
     )
     assert lstate.as_dict() == {
@@ -377,9 +379,9 @@ def test_process_datetime_to_timestamp(time_zone, hass: HomeAssistant) -> None:
     """Test we can handle processing database datatimes to timestamps."""
     hass.config.set_time_zone(time_zone)
     utc_now = dt_util.utcnow()
-    assert process_datetime_to_timestamp(utc_now) == utc_now.timestamp()
+    assert recorder.models.process_datetime_to_timestamp(utc_now) == utc_now.timestamp()
     now = dt_util.now()
-    assert process_datetime_to_timestamp(now) == now.timestamp()
+    assert recorder.models.process_datetime_to_timestamp(now) == now.timestamp()
 
 
 @pytest.mark.parametrize(
@@ -396,9 +398,9 @@ def test_process_datetime_to_timestamp_freeze_time(
     utc_now = dt_util.utcnow()
     with freeze_time(utc_now):
         epoch = utc_now.timestamp()
-        assert process_datetime_to_timestamp(dt_util.utcnow()) == epoch
+        assert recorder.models.process_datetime_to_timestamp(dt_util.utcnow()) == epoch
         now = dt_util.now()
-        assert process_datetime_to_timestamp(now) == epoch
+        assert recorder.models.process_datetime_to_timestamp(now) == epoch
 
 
 @pytest.mark.parametrize(
@@ -421,23 +423,23 @@ async def test_process_datetime_to_timestamp_mirrors_utc_isoformat_behavior(
     datetime_hst_timezone = datetime(2016, 7, 9, 11, 0, 0, tzinfo=hst)
 
     assert (
-        process_datetime_to_timestamp(datetime_with_tzinfo)
+        recorder.models.process_datetime_to_timestamp(datetime_with_tzinfo)
         == dt_util.parse_datetime("2016-07-09T11:00:00+00:00").timestamp()
     )
     assert (
-        process_datetime_to_timestamp(datetime_without_tzinfo)
+        recorder.models.process_datetime_to_timestamp(datetime_without_tzinfo)
         == dt_util.parse_datetime("2016-07-09T11:00:00+00:00").timestamp()
     )
     assert (
-        process_datetime_to_timestamp(datetime_est_timezone)
+        recorder.models.process_datetime_to_timestamp(datetime_est_timezone)
         == dt_util.parse_datetime("2016-07-09T15:00:00+00:00").timestamp()
     )
     assert (
-        process_datetime_to_timestamp(datetime_nst_timezone)
+        recorder.models.process_datetime_to_timestamp(datetime_nst_timezone)
         == dt_util.parse_datetime("2016-07-09T13:30:00+00:00").timestamp()
     )
     assert (
-        process_datetime_to_timestamp(datetime_hst_timezone)
+        recorder.models.process_datetime_to_timestamp(datetime_hst_timezone)
         == dt_util.parse_datetime("2016-07-09T21:00:00+00:00").timestamp()
     )
 
@@ -446,21 +448,23 @@ def test_ulid_to_bytes_or_none(caplog: pytest.LogCaptureFixture) -> None:
     """Test ulid_to_bytes_or_none."""
 
     assert (
-        ulid_to_bytes_or_none("01EYQZJXZ5Z1Z1Z1Z1Z1Z1Z1Z1")
+        recorder.models.ulid_to_bytes_or_none("01EYQZJXZ5Z1Z1Z1Z1Z1Z1Z1Z1")
         == b"\x01w\xaf\xf9w\xe5\xf8~\x1f\x87\xe1\xf8~\x1f\x87\xe1"
     )
-    assert ulid_to_bytes_or_none("invalid") is None
+    assert recorder.models.ulid_to_bytes_or_none("invalid") is None
     assert "invalid" in caplog.text
-    assert ulid_to_bytes_or_none(None) is None
+    assert recorder.models.ulid_to_bytes_or_none(None) is None
 
 
 def test_bytes_to_ulid_or_none(caplog: pytest.LogCaptureFixture) -> None:
     """Test bytes_to_ulid_or_none."""
 
     assert (
-        bytes_to_ulid_or_none(b"\x01w\xaf\xf9w\xe5\xf8~\x1f\x87\xe1\xf8~\x1f\x87\xe1")
+        recorder.models.bytes_to_ulid_or_none(
+            b"\x01w\xaf\xf9w\xe5\xf8~\x1f\x87\xe1\xf8~\x1f\x87\xe1"
+        )
         == "01EYQZJXZ5Z1Z1Z1Z1Z1Z1Z1Z1"
     )
-    assert bytes_to_ulid_or_none(b"invalid") is None
+    assert recorder.models.bytes_to_ulid_or_none(b"invalid") is None
     assert "invalid" in caplog.text
-    assert bytes_to_ulid_or_none(None) is None
+    assert recorder.models.bytes_to_ulid_or_none(None) is None

--- a/tests/components/recorder/test_models_legacy.py
+++ b/tests/components/recorder/test_models_legacy.py
@@ -4,7 +4,7 @@ from unittest.mock import PropertyMock
 
 import pytest
 
-from homeassistant.components.recorder.models.legacy import LegacyLazyState
+from homeassistant.components import recorder
 from homeassistant.util import dt as dt_util
 
 
@@ -17,7 +17,9 @@ async def test_legacy_lazy_state_prefers_shared_attrs_over_attrs(
         shared_attrs='{"shared":true}',
         attributes='{"shared":false}',
     )
-    assert LegacyLazyState(row, {}, None).attributes == {"shared": True}
+    assert recorder.models.legacy.LegacyLazyState(row, {}, None).attributes == {
+        "shared": True
+    }
 
 
 async def test_legacy_lazy_state_handles_different_last_updated_and_last_changed(
@@ -32,7 +34,7 @@ async def test_legacy_lazy_state_handles_different_last_updated_and_last_changed
         last_updated_ts=now.timestamp(),
         last_changed_ts=(now - timedelta(seconds=60)).timestamp(),
     )
-    lstate = LegacyLazyState(row, {}, None)
+    lstate = recorder.models.legacy.LegacyLazyState(row, {}, None)
     assert lstate.as_dict() == {
         "attributes": {"shared": True},
         "entity_id": "sensor.valid",
@@ -63,7 +65,7 @@ async def test_legacy_lazy_state_handles_same_last_updated_and_last_changed(
         last_updated_ts=now.timestamp(),
         last_changed_ts=now.timestamp(),
     )
-    lstate = LegacyLazyState(row, {}, None)
+    lstate = recorder.models.legacy.LegacyLazyState(row, {}, None)
     assert lstate.as_dict() == {
         "attributes": {"shared": True},
         "entity_id": "sensor.valid",

--- a/tests/components/recorder/test_statistics_v23_migration.py
+++ b/tests/components/recorder/test_statistics_v23_migration.py
@@ -15,8 +15,6 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant.components import recorder
-from homeassistant.components.recorder import SQLITE_URL_PREFIX
-from homeassistant.components.recorder.util import session_scope
 from homeassistant.helpers import recorder as recorder_helper
 from homeassistant.setup import setup_component
 import homeassistant.util.dt as dt_util
@@ -41,7 +39,7 @@ def test_delete_duplicates(caplog: pytest.LogCaptureFixture, tmp_path: Path) -> 
     test_dir = tmp_path.joinpath("sqlite")
     test_dir.mkdir()
     test_db_file = test_dir.joinpath("test_run_info.db")
-    dburl = f"{SQLITE_URL_PREFIX}//{test_db_file}"
+    dburl = f"{recorder.SQLITE_URL_PREFIX}//{test_db_file}"
 
     importlib.import_module(SCHEMA_MODULE)
     old_db_schema = sys.modules[SCHEMA_MODULE]
@@ -178,7 +176,7 @@ def test_delete_duplicates(caplog: pytest.LogCaptureFixture, tmp_path: Path) -> 
         wait_recording_done(hass)
         wait_recording_done(hass)
 
-        with session_scope(hass=hass) as session:
+        with recorder.util.session_scope(hass=hass) as session:
             session.add(
                 recorder.db_schema.StatisticsMeta.from_meta(external_energy_metadata_1)
             )
@@ -188,7 +186,7 @@ def test_delete_duplicates(caplog: pytest.LogCaptureFixture, tmp_path: Path) -> 
             session.add(
                 recorder.db_schema.StatisticsMeta.from_meta(external_co2_metadata)
             )
-        with session_scope(hass=hass) as session:
+        with recorder.util.session_scope(hass=hass) as session:
             for stat in external_energy_statistics_1:
                 session.add(recorder.db_schema.Statistics.from_stats(1, stat))
             for stat in external_energy_statistics_2:
@@ -221,7 +219,7 @@ def test_delete_duplicates_many(
     test_dir = tmp_path.joinpath("sqlite")
     test_dir.mkdir()
     test_db_file = test_dir.joinpath("test_run_info.db")
-    dburl = f"{SQLITE_URL_PREFIX}//{test_db_file}"
+    dburl = f"{recorder.SQLITE_URL_PREFIX}//{test_db_file}"
 
     importlib.import_module(SCHEMA_MODULE)
     old_db_schema = sys.modules[SCHEMA_MODULE]
@@ -358,7 +356,7 @@ def test_delete_duplicates_many(
         wait_recording_done(hass)
         wait_recording_done(hass)
 
-        with session_scope(hass=hass) as session:
+        with recorder.util.session_scope(hass=hass) as session:
             session.add(
                 recorder.db_schema.StatisticsMeta.from_meta(external_energy_metadata_1)
             )
@@ -368,7 +366,7 @@ def test_delete_duplicates_many(
             session.add(
                 recorder.db_schema.StatisticsMeta.from_meta(external_co2_metadata)
             )
-        with session_scope(hass=hass) as session:
+        with recorder.util.session_scope(hass=hass) as session:
             for stat in external_energy_statistics_1:
                 session.add(recorder.db_schema.Statistics.from_stats(1, stat))
             for _ in range(3000):
@@ -408,7 +406,7 @@ def test_delete_duplicates_non_identical(
     test_dir = tmp_path.joinpath("sqlite")
     test_dir.mkdir()
     test_db_file = test_dir.joinpath("test_run_info.db")
-    dburl = f"{SQLITE_URL_PREFIX}//{test_db_file}"
+    dburl = f"{recorder.SQLITE_URL_PREFIX}//{test_db_file}"
 
     importlib.import_module(SCHEMA_MODULE)
     old_db_schema = sys.modules[SCHEMA_MODULE]
@@ -515,14 +513,14 @@ def test_delete_duplicates_non_identical(
         wait_recording_done(hass)
         wait_recording_done(hass)
 
-        with session_scope(hass=hass) as session:
+        with recorder.util.session_scope(hass=hass) as session:
             session.add(
                 recorder.db_schema.StatisticsMeta.from_meta(external_energy_metadata_1)
             )
             session.add(
                 recorder.db_schema.StatisticsMeta.from_meta(external_energy_metadata_2)
             )
-        with session_scope(hass=hass) as session:
+        with recorder.util.session_scope(hass=hass) as session:
             for stat in external_energy_statistics_1:
                 session.add(recorder.db_schema.Statistics.from_stats(1, stat))
             for stat in external_energy_statistics_2:
@@ -589,7 +587,7 @@ def test_delete_duplicates_short_term(
     test_dir = tmp_path.joinpath("sqlite")
     test_dir.mkdir()
     test_db_file = test_dir.joinpath("test_run_info.db")
-    dburl = f"{SQLITE_URL_PREFIX}//{test_db_file}"
+    dburl = f"{recorder.SQLITE_URL_PREFIX}//{test_db_file}"
 
     importlib.import_module(SCHEMA_MODULE)
     old_db_schema = sys.modules[SCHEMA_MODULE]
@@ -627,11 +625,11 @@ def test_delete_duplicates_short_term(
         wait_recording_done(hass)
         wait_recording_done(hass)
 
-        with session_scope(hass=hass) as session:
+        with recorder.util.session_scope(hass=hass) as session:
             session.add(
                 recorder.db_schema.StatisticsMeta.from_meta(external_energy_metadata_1)
             )
-        with session_scope(hass=hass) as session:
+        with recorder.util.session_scope(hass=hass) as session:
             session.add(
                 recorder.db_schema.StatisticsShortTerm.from_stats(1, statistic_row)
             )

--- a/tests/components/recorder/test_websocket_api.py
+++ b/tests/components/recorder/test_websocket_api.py
@@ -10,15 +10,6 @@ from freezegun import freeze_time
 import pytest
 
 from homeassistant.components import recorder
-from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.db_schema import Statistics, StatisticsShortTerm
-from homeassistant.components.recorder.statistics import (
-    async_add_external_statistics,
-    get_last_statistics,
-    get_metadata,
-    list_statistic_ids,
-)
-from homeassistant.components.recorder.websocket_api import UNIT_SCHEMA
 from homeassistant.components.sensor import UNIT_CONVERTERS
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import recorder as recorder_helper
@@ -132,14 +123,16 @@ VOLUME_SENSOR_M3_ATTRIBUTES_TOTAL = {
 def test_converters_align_with_sensor() -> None:
     """Ensure UNIT_SCHEMA is aligned with sensor UNIT_CONVERTERS."""
     for converter in UNIT_CONVERTERS.values():
-        assert converter.UNIT_CLASS in UNIT_SCHEMA.schema
+        assert converter.UNIT_CLASS in recorder.websocket_api.UNIT_SCHEMA.schema
 
-    for unit_class in UNIT_SCHEMA.schema:
+    for unit_class in recorder.websocket_api.UNIT_SCHEMA.schema:
         assert any(c for c in UNIT_CONVERTERS.values() if unit_class == c.UNIT_CLASS)
 
 
 async def test_statistics_during_period(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test statistics_during_period."""
     now = dt_util.utcnow()
@@ -220,7 +213,7 @@ async def test_statistics_during_period(
 )
 @pytest.mark.parametrize("offset", (0, 1, 2))
 async def test_statistic_during_period(
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     offset,
@@ -296,12 +289,12 @@ async def test_statistic_during_period(
     recorder.get_instance(hass).async_import_statistics(
         imported_metadata,
         imported_stats,
-        Statistics,
+        recorder.db_schema.Statistics,
     )
     recorder.get_instance(hass).async_import_statistics(
         imported_metadata,
         imported_stats_5min,
-        StatisticsShortTerm,
+        recorder.db_schema.StatisticsShortTerm,
     )
     await async_wait_recording_done(hass)
 
@@ -636,7 +629,9 @@ async def test_statistic_during_period(
     datetime.datetime(2022, 10, 21, 7, 25, tzinfo=datetime.timezone.utc)
 )
 async def test_statistic_during_period_hole(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test statistic_during_period when there are holes in the data."""
     id = 1
@@ -677,7 +672,7 @@ async def test_statistic_during_period_hole(
     recorder.get_instance(hass).async_import_statistics(
         imported_metadata,
         imported_stats,
-        Statistics,
+        recorder.db_schema.Statistics,
     )
     await async_wait_recording_done(hass)
 
@@ -856,7 +851,7 @@ async def test_statistic_during_period_hole(
     ),
 )
 async def test_statistic_during_period_calendar(
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     calendar_period,
@@ -910,7 +905,7 @@ async def test_statistic_during_period_calendar(
     ],
 )
 async def test_statistics_during_period_unit_conversion(
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     attributes,
@@ -997,7 +992,7 @@ async def test_statistics_during_period_unit_conversion(
     ],
 )
 async def test_sum_statistics_during_period_unit_conversion(
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     attributes,
@@ -1084,7 +1079,7 @@ async def test_sum_statistics_during_period_unit_conversion(
     ],
 )
 async def test_statistics_during_period_invalid_unit_conversion(
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     custom_units,
@@ -1128,7 +1123,9 @@ async def test_statistics_during_period_invalid_unit_conversion(
 
 
 async def test_statistics_during_period_in_the_past(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test statistics_during_period in the past."""
     hass.config.set_time_zone("UTC")
@@ -1245,7 +1242,9 @@ async def test_statistics_during_period_in_the_past(
 
 
 async def test_statistics_during_period_bad_start_time(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test statistics_during_period."""
     client = await hass_ws_client()
@@ -1264,7 +1263,9 @@ async def test_statistics_during_period_bad_start_time(
 
 
 async def test_statistics_during_period_bad_end_time(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test statistics_during_period."""
     now = dt_util.utcnow()
@@ -1286,7 +1287,9 @@ async def test_statistics_during_period_bad_end_time(
 
 
 async def test_statistics_during_period_no_statistic_ids(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test statistics_during_period without passing statistic_ids."""
     now = dt_util.utcnow()
@@ -1307,7 +1310,9 @@ async def test_statistics_during_period_no_statistic_ids(
 
 
 async def test_statistics_during_period_empty_statistic_ids(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test statistics_during_period with passing an empty list of statistic_ids."""
     now = dt_util.utcnow()
@@ -1386,7 +1391,7 @@ async def test_statistics_during_period_empty_statistic_ids(
     ],
 )
 async def test_list_statistic_ids(
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     units,
@@ -1550,7 +1555,7 @@ async def test_list_statistic_ids(
     ],
 )
 async def test_list_statistic_ids_unit_change(
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     attributes,
@@ -1616,7 +1621,9 @@ async def test_list_statistic_ids_unit_change(
 
 
 async def test_validate_statistics(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test validate_statistics can be called."""
     id = 1
@@ -1640,7 +1647,9 @@ async def test_validate_statistics(
 
 
 async def test_clear_statistics(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test removing statistics."""
     now = dt_util.utcnow()
@@ -1763,7 +1772,7 @@ async def test_clear_statistics(
     [("dogs", None, "dogs"), (None, "unitless", None), ("W", "power", "kW")],
 )
 async def test_update_statistics_metadata(
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     new_unit,
@@ -1859,7 +1868,9 @@ async def test_update_statistics_metadata(
 
 
 async def test_change_statistics_unit(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test change unit of recorded statistics."""
     now = dt_util.utcnow()
@@ -2005,7 +2016,7 @@ async def test_change_statistics_unit(
 
 
 async def test_change_statistics_unit_errors(
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     caplog: pytest.LogCaptureFixture,
@@ -2124,7 +2135,9 @@ async def test_change_statistics_unit_errors(
 
 
 async def test_recorder_info(
-    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test getting recorder status."""
     client = await hass_ws_client()
@@ -2264,7 +2277,7 @@ async def test_backup_start_no_recorder(
 
 
 async def test_backup_start_timeout(
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     hass_supervisor_access_token: str,
@@ -2291,7 +2304,7 @@ async def test_backup_start_timeout(
 
 
 async def test_backup_end(
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     hass_supervisor_access_token: str,
@@ -2312,7 +2325,7 @@ async def test_backup_end(
 
 
 async def test_backup_end_without_start(
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     hass_supervisor_access_token: str,
@@ -2354,7 +2367,7 @@ async def test_backup_end_without_start(
     ],
 )
 async def test_get_statistics_metadata(
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     units,
@@ -2416,7 +2429,7 @@ async def test_get_statistics_metadata(
         "unit_of_measurement": unit,
     }
 
-    async_add_external_statistics(
+    recorder.statistics.async_add_external_statistics(
         hass, external_energy_metadata_1, external_energy_statistics_1
     )
     await async_wait_recording_done(hass)
@@ -2508,7 +2521,7 @@ async def test_get_statistics_metadata(
     ),
 )
 async def test_import_statistics(
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     caplog: pytest.LogCaptureFixture,
@@ -2581,7 +2594,7 @@ async def test_import_statistics(
             },
         ]
     }
-    statistic_ids = list_statistic_ids(hass)  # TODO
+    statistic_ids = recorder.statistics.list_statistic_ids(hass)  # TODO
     assert statistic_ids == [
         {
             "display_unit_of_measurement": "kWh",
@@ -2594,7 +2607,7 @@ async def test_import_statistics(
             "unit_class": "energy",
         }
     ]
-    metadata = get_metadata(hass, statistic_ids={statistic_id})
+    metadata = recorder.statistics.get_metadata(hass, statistic_ids={statistic_id})
     assert metadata == {
         statistic_id: (
             1,
@@ -2608,7 +2621,7 @@ async def test_import_statistics(
             },
         )
     }
-    last_stats = get_last_statistics(
+    last_stats = recorder.statistics.get_last_statistics(
         hass,
         1,
         statistic_id,
@@ -2725,7 +2738,7 @@ async def test_import_statistics(
     ),
 )
 async def test_adjust_sum_statistics_energy(
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     caplog: pytest.LogCaptureFixture,
@@ -2802,7 +2815,7 @@ async def test_adjust_sum_statistics_energy(
             },
         ]
     }
-    statistic_ids = list_statistic_ids(hass)  # TODO
+    statistic_ids = recorder.statistics.list_statistic_ids(hass)  # TODO
     assert statistic_ids == [
         {
             "display_unit_of_measurement": "kWh",
@@ -2815,7 +2828,7 @@ async def test_adjust_sum_statistics_energy(
             "unit_class": "energy",
         }
     ]
-    metadata = get_metadata(hass, statistic_ids={statistic_id})
+    metadata = recorder.statistics.get_metadata(hass, statistic_ids={statistic_id})
     assert metadata == {
         statistic_id: (
             1,
@@ -2921,7 +2934,7 @@ async def test_adjust_sum_statistics_energy(
     ),
 )
 async def test_adjust_sum_statistics_gas(
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     caplog: pytest.LogCaptureFixture,
@@ -2998,7 +3011,7 @@ async def test_adjust_sum_statistics_gas(
             },
         ]
     }
-    statistic_ids = list_statistic_ids(hass)  # TODO
+    statistic_ids = recorder.statistics.list_statistic_ids(hass)  # TODO
     assert statistic_ids == [
         {
             "display_unit_of_measurement": "m³",
@@ -3011,7 +3024,7 @@ async def test_adjust_sum_statistics_gas(
             "unit_class": "volume",
         }
     ]
-    metadata = get_metadata(hass, statistic_ids={statistic_id})
+    metadata = recorder.statistics.get_metadata(hass, statistic_ids={statistic_id})
     assert metadata == {
         statistic_id: (
             1,
@@ -3128,7 +3141,7 @@ async def test_adjust_sum_statistics_gas(
     ),
 )
 async def test_adjust_sum_statistics_errors(
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     caplog: pytest.LogCaptureFixture,
@@ -3212,7 +3225,7 @@ async def test_adjust_sum_statistics_errors(
         ]
     }
     previous_stats = stats
-    statistic_ids = list_statistic_ids(hass)
+    statistic_ids = recorder.statistics.list_statistic_ids(hass)
     assert statistic_ids == [
         {
             "display_unit_of_measurement": state_unit,
@@ -3225,7 +3238,7 @@ async def test_adjust_sum_statistics_errors(
             "unit_class": unit_class,
         }
     ]
-    metadata = get_metadata(hass, statistic_ids={statistic_id})
+    metadata = recorder.statistics.get_metadata(hass, statistic_ids={statistic_id})
     assert metadata == {
         statistic_id: (
             1,

--- a/tests/components/schedule/test_recorder.py
+++ b/tests/components/schedule/test_recorder.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 
-from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.history import get_significant_states
+from homeassistant.components import recorder
 from homeassistant.components.schedule.const import ATTR_NEXT_EVENT, DOMAIN
 from homeassistant.const import ATTR_EDITABLE, ATTR_FRIENDLY_NAME, ATTR_ICON
 from homeassistant.core import HomeAssistant
@@ -16,7 +15,7 @@ from tests.components.recorder.common import async_wait_recording_done
 
 
 async def test_exclude_attributes(
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
     enable_custom_integrations: None,
 ) -> None:
@@ -55,7 +54,11 @@ async def test_exclude_attributes(
     await async_wait_recording_done(hass)
 
     states = await hass.async_add_executor_job(
-        get_significant_states, hass, now, None, hass.states.async_entity_ids()
+        recorder.history.get_significant_states,
+        hass,
+        now,
+        None,
+        hass.states.async_entity_ids(),
     )
     assert len(states) >= 1
     for entity_states in states.values():

--- a/tests/components/script/test_recorder.py
+++ b/tests/components/script/test_recorder.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 
 import pytest
 
-from homeassistant.components import script
-from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.history import get_significant_states
+from homeassistant.components import recorder, script
 from homeassistant.components.script import (
     ATTR_CUR,
     ATTR_LAST_ACTION,
@@ -29,7 +27,7 @@ def calls(hass):
 
 
 async def test_exclude_attributes(
-    recorder_mock: Recorder, hass: HomeAssistant, calls
+    recorder_mock: recorder.Recorder, hass: HomeAssistant, calls
 ) -> None:
     """Test automation registered attributes to be excluded."""
     now = dt_util.utcnow()
@@ -67,7 +65,11 @@ async def test_exclude_attributes(
     assert len(calls) == 1
 
     states = await hass.async_add_executor_job(
-        get_significant_states, hass, now, None, hass.states.async_entity_ids()
+        recorder.history.get_significant_states,
+        hass,
+        now,
+        None,
+        hass.states.async_entity_ids(),
     )
     assert len(states) >= 1
     for entity_states in states.values():

--- a/tests/components/select/test_recorder.py
+++ b/tests/components/select/test_recorder.py
@@ -6,9 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant.components import select
-from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.history import get_significant_states
+from homeassistant.components import recorder, select
 from homeassistant.components.select import ATTR_OPTIONS
 from homeassistant.const import ATTR_FRIENDLY_NAME, Platform
 from homeassistant.core import HomeAssistant
@@ -29,7 +27,9 @@ async def select_only() -> None:
         yield
 
 
-async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) -> None:
+async def test_exclude_attributes(
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
+) -> None:
     """Test select registered attributes to be excluded."""
     now = dt_util.utcnow()
     assert await async_setup_component(hass, "homeassistant", {})
@@ -42,7 +42,11 @@ async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) 
     await async_wait_recording_done(hass)
 
     states = await hass.async_add_executor_job(
-        get_significant_states, hass, now, None, hass.states.async_entity_ids()
+        recorder.history.get_significant_states,
+        hass,
+        now,
+        None,
+        hass.states.async_entity_ids(),
     )
     assert len(states) >= 1
     for entity_states in states.values():

--- a/tests/components/siren/test_recorder.py
+++ b/tests/components/siren/test_recorder.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 
-from homeassistant.components import siren
-from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.history import get_significant_states
+from homeassistant.components import recorder, siren
 from homeassistant.components.siren import ATTR_AVAILABLE_TONES
 from homeassistant.const import ATTR_FRIENDLY_NAME
 from homeassistant.core import HomeAssistant
@@ -16,7 +14,9 @@ from tests.common import async_fire_time_changed
 from tests.components.recorder.common import async_wait_recording_done
 
 
-async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) -> None:
+async def test_exclude_attributes(
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
+) -> None:
     """Test siren registered attributes to be excluded."""
     now = dt_util.utcnow()
     await async_setup_component(
@@ -28,7 +28,11 @@ async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) 
     await async_wait_recording_done(hass)
 
     states = await hass.async_add_executor_job(
-        get_significant_states, hass, now, None, hass.states.async_entity_ids()
+        recorder.history.get_significant_states,
+        hass,
+        now,
+        None,
+        hass.states.async_entity_ids(),
     )
     assert len(states) >= 1
     for entity_states in states.values():

--- a/tests/components/sql/__init__.py
+++ b/tests/components/sql/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from homeassistant.components.recorder import CONF_DB_URL
+from homeassistant.components import recorder
 from homeassistant.components.sensor import (
     CONF_STATE_CLASS,
     SensorDeviceClass,
@@ -74,7 +74,7 @@ ENTRY_CONFIG_NO_RESULTS = {
 
 YAML_CONFIG = {
     "sql": {
-        CONF_DB_URL: "sqlite://",
+        recorder.CONF_DB_URL: "sqlite://",
         CONF_NAME: "Get Value",
         CONF_QUERY: "SELECT 5 as value",
         CONF_COLUMN_NAME: "value",
@@ -123,7 +123,7 @@ YAML_CONFIG_WITH_VIEW_THAT_CONTAINS_ENTITY_ID = {
 
 YAML_CONFIG_BINARY = {
     "sql": {
-        CONF_DB_URL: "sqlite://",
+        recorder.CONF_DB_URL: "sqlite://",
         CONF_NAME: "Get Binary Value",
         CONF_QUERY: "SELECT cast(x'd34324324230392032' as blob) as value, cast(x'd343aa' as blob) as test_attr",
         CONF_COLUMN_NAME: "value",

--- a/tests/components/sql/test_config_flow.py
+++ b/tests/components/sql/test_config_flow.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 from sqlalchemy.exc import SQLAlchemyError
 
 from homeassistant import config_entries
-from homeassistant.components.recorder import Recorder
+from homeassistant.components import recorder
 from homeassistant.components.sensor.const import SensorDeviceClass, SensorStateClass
 from homeassistant.components.sql.config_flow import NONE_SENTINEL
 from homeassistant.components.sql.const import DOMAIN
@@ -26,7 +26,7 @@ from . import (
 from tests.common import MockConfigEntry
 
 
-async def test_form(recorder_mock: Recorder, hass: HomeAssistant) -> None:
+async def test_form(recorder_mock: recorder.Recorder, hass: HomeAssistant) -> None:
     """Test we get the form."""
 
     result = await hass.config_entries.flow.async_init(
@@ -59,7 +59,7 @@ async def test_form(recorder_mock: Recorder, hass: HomeAssistant) -> None:
 
 
 async def test_form_with_value_template(
-    recorder_mock: Recorder, hass: HomeAssistant
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
 ) -> None:
     """Test for with value template."""
 
@@ -91,7 +91,9 @@ async def test_form_with_value_template(
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_flow_fails_db_url(recorder_mock: Recorder, hass: HomeAssistant) -> None:
+async def test_flow_fails_db_url(
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
+) -> None:
     """Test config flow fails incorrect db url."""
     result4 = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -113,7 +115,7 @@ async def test_flow_fails_db_url(recorder_mock: Recorder, hass: HomeAssistant) -
 
 
 async def test_flow_fails_invalid_query(
-    recorder_mock: Recorder, hass: HomeAssistant
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
 ) -> None:
     """Test config flow fails incorrect db url."""
     result4 = await hass.config_entries.flow.async_init(
@@ -161,7 +163,7 @@ async def test_flow_fails_invalid_query(
 
 
 async def test_flow_fails_invalid_column_name(
-    recorder_mock: Recorder, hass: HomeAssistant
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
 ) -> None:
     """Test config flow fails invalid column name."""
     result4 = await hass.config_entries.flow.async_init(
@@ -198,7 +200,9 @@ async def test_flow_fails_invalid_column_name(
     }
 
 
-async def test_options_flow(recorder_mock: Recorder, hass: HomeAssistant) -> None:
+async def test_options_flow(
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
+) -> None:
     """Test options config flow."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -253,7 +257,7 @@ async def test_options_flow(recorder_mock: Recorder, hass: HomeAssistant) -> Non
 
 
 async def test_options_flow_name_previously_removed(
-    recorder_mock: Recorder, hass: HomeAssistant
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
 ) -> None:
     """Test options config flow where the name was missing."""
     entry = MockConfigEntry(
@@ -303,7 +307,7 @@ async def test_options_flow_name_previously_removed(
 
 
 async def test_options_flow_fails_db_url(
-    recorder_mock: Recorder, hass: HomeAssistant
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
 ) -> None:
     """Test options flow fails incorrect db url."""
     entry = MockConfigEntry(
@@ -346,7 +350,7 @@ async def test_options_flow_fails_db_url(
 
 
 async def test_options_flow_fails_invalid_query(
-    recorder_mock: Recorder, hass: HomeAssistant
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
 ) -> None:
     """Test options flow fails incorrect query and template."""
     entry = MockConfigEntry(
@@ -401,7 +405,7 @@ async def test_options_flow_fails_invalid_query(
 
 
 async def test_options_flow_fails_invalid_column_name(
-    recorder_mock: Recorder, hass: HomeAssistant
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
 ) -> None:
     """Test options flow fails invalid column name."""
     entry = MockConfigEntry(
@@ -454,7 +458,7 @@ async def test_options_flow_fails_invalid_column_name(
 
 
 async def test_options_flow_db_url_empty(
-    recorder_mock: Recorder, hass: HomeAssistant
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
 ) -> None:
     """Test options config flow with leaving db_url empty."""
     entry = MockConfigEntry(
@@ -508,7 +512,7 @@ async def test_options_flow_db_url_empty(
 
 
 async def test_full_flow_not_recorder_db(
-    recorder_mock: Recorder, hass: HomeAssistant
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
 ) -> None:
     """Test full config flow with not using recorder db."""
     result = await hass.config_entries.flow.async_init(
@@ -610,7 +614,9 @@ async def test_full_flow_not_recorder_db(
     }
 
 
-async def test_device_state_class(recorder_mock: Recorder, hass: HomeAssistant) -> None:
+async def test_device_state_class(
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
+) -> None:
     """Test we get the form."""
 
     entry = MockConfigEntry(

--- a/tests/components/sql/test_init.py
+++ b/tests/components/sql/test_init.py
@@ -7,8 +7,7 @@ import pytest
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.util import get_instance
+from homeassistant.components import recorder
 from homeassistant.components.sql import validate_sql_select
 from homeassistant.components.sql.const import DOMAIN
 from homeassistant.core import HomeAssistant
@@ -17,13 +16,17 @@ from homeassistant.setup import async_setup_component
 from . import YAML_CONFIG_INVALID, YAML_CONFIG_NO_DB, init_integration
 
 
-async def test_setup_entry(recorder_mock: Recorder, hass: HomeAssistant) -> None:
+async def test_setup_entry(
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
+) -> None:
     """Test setup entry."""
     config_entry = await init_integration(hass)
     assert config_entry.state == config_entries.ConfigEntryState.LOADED
 
 
-async def test_unload_entry(recorder_mock: Recorder, hass: HomeAssistant) -> None:
+async def test_unload_entry(
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
+) -> None:
     """Test unload an entry."""
     config_entry = await init_integration(hass)
     assert config_entry.state == config_entries.ConfigEntryState.LOADED
@@ -33,7 +36,9 @@ async def test_unload_entry(recorder_mock: Recorder, hass: HomeAssistant) -> Non
     assert config_entry.state is config_entries.ConfigEntryState.NOT_LOADED
 
 
-async def test_setup_config(recorder_mock: Recorder, hass: HomeAssistant) -> None:
+async def test_setup_config(
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
+) -> None:
     """Test setup from yaml config."""
     with patch(
         "homeassistant.components.sql.config_flow.sqlalchemy.create_engine",
@@ -43,7 +48,7 @@ async def test_setup_config(recorder_mock: Recorder, hass: HomeAssistant) -> Non
 
 
 async def test_setup_invalid_config(
-    recorder_mock: Recorder, hass: HomeAssistant
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
 ) -> None:
     """Test setup from yaml with invalid config."""
     with patch(
@@ -60,11 +65,11 @@ async def test_invalid_query(hass: HomeAssistant) -> None:
 
 
 async def test_remove_configured_db_url_if_not_needed_when_not_needed(
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
 ) -> None:
     """Test configured db_url is replaced with None if matching the recorder db."""
-    recorder_db_url = get_instance(hass).db_url
+    recorder_db_url = recorder.util.get_instance(hass).db_url
 
     config = {
         "db_url": recorder_db_url,
@@ -79,7 +84,7 @@ async def test_remove_configured_db_url_if_not_needed_when_not_needed(
 
 
 async def test_remove_configured_db_url_if_not_needed_when_needed(
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
 ) -> None:
     """Test configured db_url is not replaced if it differs from the recorder db."""

--- a/tests/components/sql/test_sensor.py
+++ b/tests/components/sql/test_sensor.py
@@ -9,7 +9,7 @@ import pytest
 from sqlalchemy import text as sql_text
 from sqlalchemy.exc import SQLAlchemyError
 
-from homeassistant.components.recorder import Recorder
+from homeassistant.components import recorder
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.components.sql.const import CONF_QUERY, DOMAIN
 from homeassistant.config_entries import SOURCE_USER
@@ -32,7 +32,7 @@ from . import (
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 
-async def test_query(recorder_mock: Recorder, hass: HomeAssistant) -> None:
+async def test_query(recorder_mock: recorder.Recorder, hass: HomeAssistant) -> None:
     """Test the SQL sensor."""
     config = {
         "db_url": "sqlite://",
@@ -48,7 +48,7 @@ async def test_query(recorder_mock: Recorder, hass: HomeAssistant) -> None:
 
 
 async def test_query_value_template(
-    recorder_mock: Recorder, hass: HomeAssistant
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
 ) -> None:
     """Test the SQL sensor."""
     config = {
@@ -65,7 +65,7 @@ async def test_query_value_template(
 
 
 async def test_query_value_template_invalid(
-    recorder_mock: Recorder, hass: HomeAssistant
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
 ) -> None:
     """Test the SQL sensor."""
     config = {
@@ -81,7 +81,9 @@ async def test_query_value_template_invalid(
     assert state.state == "5.01"
 
 
-async def test_query_limit(recorder_mock: Recorder, hass: HomeAssistant) -> None:
+async def test_query_limit(
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
+) -> None:
     """Test the SQL sensor with a query containing 'LIMIT' in lowercase."""
     config = {
         "db_url": "sqlite://",
@@ -97,7 +99,9 @@ async def test_query_limit(recorder_mock: Recorder, hass: HomeAssistant) -> None
 
 
 async def test_query_no_value(
-    recorder_mock: Recorder, hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test the SQL sensor with a query that returns no value."""
     config = {
@@ -116,7 +120,9 @@ async def test_query_no_value(
 
 
 async def test_query_mssql_no_result(
-    recorder_mock: Recorder, hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test the SQL sensor with a query that returns no value."""
     config = {
@@ -154,7 +160,7 @@ async def test_query_mssql_no_result(
     ],
 )
 async def test_invalid_url_setup(
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
     url: str,
@@ -192,7 +198,7 @@ async def test_invalid_url_setup(
 
 
 async def test_invalid_url_on_update(
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -225,7 +231,9 @@ async def test_invalid_url_on_update(
     assert "sqlite://****:****@homeassistant.local" in caplog.text
 
 
-async def test_query_from_yaml(recorder_mock: Recorder, hass: HomeAssistant) -> None:
+async def test_query_from_yaml(
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
+) -> None:
     """Test the SQL sensor from yaml config."""
 
     assert await async_setup_component(hass, DOMAIN, YAML_CONFIG)
@@ -236,7 +244,7 @@ async def test_query_from_yaml(recorder_mock: Recorder, hass: HomeAssistant) -> 
 
 
 async def test_config_from_old_yaml(
-    recorder_mock: Recorder, hass: HomeAssistant
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
 ) -> None:
     """Test the SQL sensor from old yaml config does not create any entity."""
     config = {
@@ -275,7 +283,7 @@ async def test_config_from_old_yaml(
     ],
 )
 async def test_invalid_url_setup_from_yaml(
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
     url: str,
@@ -306,7 +314,7 @@ async def test_invalid_url_setup_from_yaml(
 
 
 async def test_attributes_from_yaml_setup(
-    recorder_mock: Recorder, hass: HomeAssistant
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
 ) -> None:
     """Test attributes from yaml config."""
 
@@ -322,7 +330,7 @@ async def test_attributes_from_yaml_setup(
 
 
 async def test_binary_data_from_yaml_setup(
-    recorder_mock: Recorder, hass: HomeAssistant
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
 ) -> None:
     """Test binary data from yaml config."""
 
@@ -334,7 +342,9 @@ async def test_binary_data_from_yaml_setup(
 
 
 async def test_issue_when_using_old_query(
-    recorder_mock: Recorder, hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test we create an issue for an old query that will do a full table scan."""
 
@@ -363,7 +373,7 @@ async def test_issue_when_using_old_query(
     ],
 )
 async def test_issue_when_using_old_query_without_unique_id(
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
     yaml_config: dict[str, Any],
@@ -387,7 +397,9 @@ async def test_issue_when_using_old_query_without_unique_id(
 
 
 async def test_no_issue_when_view_has_the_text_entity_id_in_it(
-    recorder_mock: Recorder, hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test we do not trigger the full table scan issue for a custom view."""
 
@@ -410,7 +422,7 @@ async def test_no_issue_when_view_has_the_text_entity_id_in_it(
 
 
 async def test_multiple_sensors_using_same_db(
-    recorder_mock: Recorder, hass: HomeAssistant
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
 ) -> None:
     """Test multiple sensors using the same db."""
     config = {
@@ -438,7 +450,7 @@ async def test_multiple_sensors_using_same_db(
 
 
 async def test_engine_is_disposed_at_stop(
-    recorder_mock: Recorder, hass: HomeAssistant
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
 ) -> None:
     """Test we dispose of the engine at stop."""
     config = {
@@ -460,7 +472,7 @@ async def test_engine_is_disposed_at_stop(
 
 
 async def test_attributes_from_entry_config(
-    recorder_mock: Recorder, hass: HomeAssistant
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
 ) -> None:
     """Test attributes from entry config."""
 

--- a/tests/components/sql/test_util.py
+++ b/tests/components/sql/test_util.py
@@ -1,18 +1,18 @@
 """Test the sql utils."""
-from homeassistant.components.recorder import Recorder, get_instance
+from homeassistant.components import recorder
 from homeassistant.components.sql.util import resolve_db_url
 from homeassistant.core import HomeAssistant
 
 
 async def test_resolve_db_url_when_none_configured(
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
 ) -> None:
     """Test return recorder db_url if provided db_url is None."""
     db_url = None
     resolved_url = resolve_db_url(hass, db_url)
 
-    assert resolved_url == get_instance(hass).db_url
+    assert resolved_url == recorder.get_instance(hass).db_url
 
 
 async def test_resolve_db_url_when_configured(hass: HomeAssistant) -> None:

--- a/tests/components/statistics/test_sensor.py
+++ b/tests/components/statistics/test_sensor.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 from freezegun import freeze_time
 
 from homeassistant import config as hass_config
-from homeassistant.components.recorder import Recorder
+from homeassistant.components import recorder
 from homeassistant.components.sensor import (
     ATTR_STATE_CLASS,
     SensorDeviceClass,
@@ -1246,7 +1246,7 @@ async def test_invalid_state_characteristic(hass: HomeAssistant) -> None:
 
 
 async def test_initialize_from_database(
-    recorder_mock: Recorder, hass: HomeAssistant
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
 ) -> None:
     """Test initializing the statistics from the recorder database."""
     # enable and pre-fill the recorder
@@ -1287,7 +1287,7 @@ async def test_initialize_from_database(
 
 
 async def test_initialize_from_database_with_maxage(
-    recorder_mock: Recorder, hass: HomeAssistant
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
 ) -> None:
     """Test initializing the statistics from the database."""
     now = dt_util.utcnow()
@@ -1345,7 +1345,7 @@ async def test_initialize_from_database_with_maxage(
     ) + timedelta(hours=1)
 
 
-async def test_reload(recorder_mock: Recorder, hass: HomeAssistant) -> None:
+async def test_reload(recorder_mock: recorder.Recorder, hass: HomeAssistant) -> None:
     """Verify we can reload statistics sensors."""
 
     await async_setup_component(

--- a/tests/components/sun/test_recorder.py
+++ b/tests/components/sun/test_recorder.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 
-from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.history import get_significant_states
+from homeassistant.components import recorder
 from homeassistant.components.sun import (
     DOMAIN,
     STATE_ATTR_AZIMUTH,
@@ -26,7 +25,9 @@ from tests.common import async_fire_time_changed
 from tests.components.recorder.common import async_wait_recording_done
 
 
-async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) -> None:
+async def test_exclude_attributes(
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
+) -> None:
     """Test sun attributes to be excluded."""
     now = dt_util.utcnow()
     await async_setup_component(hass, DOMAIN, {})
@@ -36,7 +37,11 @@ async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) 
     await async_wait_recording_done(hass)
 
     states = await hass.async_add_executor_job(
-        get_significant_states, hass, now, None, hass.states.async_entity_ids()
+        recorder.history.get_significant_states,
+        hass,
+        now,
+        None,
+        hass.states.async_entity_ids(),
     )
     assert len(states) >= 1
     for entity_states in states.values():

--- a/tests/components/text/test_recorder.py
+++ b/tests/components/text/test_recorder.py
@@ -6,9 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant.components import text
-from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.history import get_significant_states
+from homeassistant.components import recorder, text
 from homeassistant.components.text import ATTR_MAX, ATTR_MIN, ATTR_MODE, ATTR_PATTERN
 from homeassistant.const import ATTR_FRIENDLY_NAME, Platform
 from homeassistant.core import HomeAssistant
@@ -29,7 +27,9 @@ async def text_only() -> None:
         yield
 
 
-async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) -> None:
+async def test_exclude_attributes(
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
+) -> None:
     """Test siren registered attributes to be excluded."""
     now = dt_util.utcnow()
     assert await async_setup_component(hass, "homeassistant", {})
@@ -40,7 +40,11 @@ async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) 
     await async_wait_recording_done(hass)
 
     states = await hass.async_add_executor_job(
-        get_significant_states, hass, now, None, hass.states.async_entity_ids()
+        recorder.history.get_significant_states,
+        hass,
+        now,
+        None,
+        hass.states.async_entity_ids(),
     )
     assert len(states) >= 1
     for entity_states in states.values():

--- a/tests/components/tibber/test_config_flow.py
+++ b/tests/components/tibber/test_config_flow.py
@@ -7,7 +7,7 @@ import pytest
 from tibber import FatalHttpException, InvalidLogin, RetryableHttpException
 
 from homeassistant import config_entries
-from homeassistant.components.recorder import Recorder
+from homeassistant.components import recorder
 from homeassistant.components.tibber.config_flow import (
     ERR_CLIENT,
     ERR_TIMEOUT,
@@ -26,7 +26,9 @@ def tibber_setup_fixture():
         yield
 
 
-async def test_show_config_form(recorder_mock: Recorder, hass: HomeAssistant) -> None:
+async def test_show_config_form(
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
+) -> None:
     """Test show configuration form."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -36,7 +38,9 @@ async def test_show_config_form(recorder_mock: Recorder, hass: HomeAssistant) ->
     assert result["step_id"] == "user"
 
 
-async def test_create_entry(recorder_mock: Recorder, hass: HomeAssistant) -> None:
+async def test_create_entry(
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
+) -> None:
     """Test create entry from user input."""
     test_data = {
         CONF_ACCESS_TOKEN: "valid",
@@ -71,7 +75,7 @@ async def test_create_entry(recorder_mock: Recorder, hass: HomeAssistant) -> Non
     ],
 )
 async def test_create_entry_exceptions(
-    recorder_mock: Recorder, hass: HomeAssistant, exception, expected_error
+    recorder_mock: recorder.Recorder, hass: HomeAssistant, exception, expected_error
 ) -> None:
     """Test create entry from user input."""
     test_data = {
@@ -96,7 +100,7 @@ async def test_create_entry_exceptions(
 
 
 async def test_flow_entry_already_exists(
-    recorder_mock: Recorder, hass: HomeAssistant, config_entry
+    recorder_mock: recorder.Recorder, hass: HomeAssistant, config_entry
 ) -> None:
     """Test user input for config_entry that already exists."""
     test_data = {

--- a/tests/components/tibber/test_diagnostics.py
+++ b/tests/components/tibber/test_diagnostics.py
@@ -1,7 +1,7 @@
 """Test the Netatmo diagnostics."""
 from unittest.mock import patch
 
-from homeassistant.components.recorder import Recorder
+from homeassistant.components import recorder
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -12,7 +12,7 @@ from tests.typing import ClientSessionGenerator
 
 
 async def test_entry_diagnostics(
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
     config_entry,

--- a/tests/components/tibber/test_statistics.py
+++ b/tests/components/tibber/test_statistics.py
@@ -1,8 +1,7 @@
 """Test adding external statistics from Tibber."""
 from unittest.mock import AsyncMock
 
-from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.statistics import statistics_during_period
+from homeassistant.components import recorder
 from homeassistant.components.tibber.sensor import TibberDataCoordinator
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
@@ -12,7 +11,9 @@ from .test_common import CONSUMPTION_DATA_1, PRODUCTION_DATA_1, mock_get_homes
 from tests.components.recorder.common import async_wait_recording_done
 
 
-async def test_async_setup_entry(recorder_mock: Recorder, hass: HomeAssistant) -> None:
+async def test_async_setup_entry(
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
+) -> None:
     """Test setup Tibber."""
     tibber_connection = AsyncMock()
     tibber_connection.name = "tibber"
@@ -31,7 +32,7 @@ async def test_async_setup_entry(recorder_mock: Recorder, hass: HomeAssistant) -
         ("tibber:energy_profit_home_id", PRODUCTION_DATA_1, "profit"),
     ):
         stats = await hass.async_add_executor_job(
-            statistics_during_period,
+            recorder.statistics.statistics_during_period,
             hass,
             dt_util.parse_datetime(data[0]["from"]),
             None,

--- a/tests/components/unifiprotect/test_recorder.py
+++ b/tests/components/unifiprotect/test_recorder.py
@@ -6,8 +6,7 @@ from unittest.mock import Mock
 
 from pyunifiprotect.data import Camera, Event, EventType
 
-from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.history import get_significant_states
+from homeassistant.components import recorder
 from homeassistant.components.unifiprotect.binary_sensor import EVENT_SENSORS
 from homeassistant.components.unifiprotect.const import (
     ATTR_EVENT_ID,
@@ -23,7 +22,7 @@ from tests.components.recorder.common import async_wait_recording_done
 
 
 async def test_exclude_attributes(
-    recorder_mock: Recorder,
+    recorder_mock: recorder.Recorder,
     hass: HomeAssistant,
     ufp: MockUFPFixture,
     doorbell: Camera,
@@ -70,7 +69,11 @@ async def test_exclude_attributes(
     await async_wait_recording_done(hass)
 
     states = await hass.async_add_executor_job(
-        get_significant_states, hass, now, None, hass.states.async_entity_ids()
+        recorder.history.get_significant_states,
+        hass,
+        now,
+        None,
+        hass.states.async_entity_ids(),
     )
     assert len(states) >= 1
     for entity_states in states.values():

--- a/tests/components/update/test_recorder.py
+++ b/tests/components/update/test_recorder.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 
-from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.history import get_significant_states
+from homeassistant.components import recorder
 from homeassistant.components.update.const import (
     ATTR_IN_PROGRESS,
     ATTR_INSTALLED_VERSION,
@@ -21,7 +20,9 @@ from tests.components.recorder.common import async_wait_recording_done
 
 
 async def test_exclude_attributes(
-    recorder_mock: Recorder, hass: HomeAssistant, enable_custom_integrations: None
+    recorder_mock: recorder.Recorder,
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
 ) -> None:
     """Test update attributes to be excluded."""
     now = dt_util.utcnow()
@@ -43,7 +44,11 @@ async def test_exclude_attributes(
     await async_wait_recording_done(hass)
 
     states = await hass.async_add_executor_job(
-        get_significant_states, hass, now, None, hass.states.async_entity_ids()
+        recorder.history.get_significant_states,
+        hass,
+        now,
+        None,
+        hass.states.async_entity_ids(),
     )
     assert len(states) >= 1
     for entity_states in states.values():

--- a/tests/components/vacuum/test_recorder.py
+++ b/tests/components/vacuum/test_recorder.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 
-from homeassistant.components import vacuum
-from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.history import get_significant_states
+from homeassistant.components import recorder, vacuum
 from homeassistant.components.vacuum import ATTR_FAN_SPEED_LIST
 from homeassistant.const import ATTR_FRIENDLY_NAME
 from homeassistant.core import HomeAssistant
@@ -16,7 +14,9 @@ from tests.common import async_fire_time_changed
 from tests.components.recorder.common import async_wait_recording_done
 
 
-async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) -> None:
+async def test_exclude_attributes(
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
+) -> None:
     """Test vacuum registered attributes to be excluded."""
     now = dt_util.utcnow()
     await async_setup_component(
@@ -28,7 +28,11 @@ async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) 
     await async_wait_recording_done(hass)
 
     states = await hass.async_add_executor_job(
-        get_significant_states, hass, now, None, hass.states.async_entity_ids()
+        recorder.history.get_significant_states,
+        hass,
+        now,
+        None,
+        hass.states.async_entity_ids(),
     )
     assert len(states) >= 1
     for entity_states in states.values():

--- a/tests/components/water_heater/test_recorder.py
+++ b/tests/components/water_heater/test_recorder.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 
-from homeassistant.components import water_heater
-from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.history import get_significant_states
+from homeassistant.components import recorder, water_heater
 from homeassistant.components.water_heater import (
     ATTR_MAX_TEMP,
     ATTR_MIN_TEMP,
@@ -20,7 +18,9 @@ from tests.common import async_fire_time_changed
 from tests.components.recorder.common import async_wait_recording_done
 
 
-async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) -> None:
+async def test_exclude_attributes(
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
+) -> None:
     """Test water_heater registered attributes to be excluded."""
     now = dt_util.utcnow()
     await async_setup_component(
@@ -32,7 +32,11 @@ async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) 
     await async_wait_recording_done(hass)
 
     states = await hass.async_add_executor_job(
-        get_significant_states, hass, now, None, hass.states.async_entity_ids()
+        recorder.history.get_significant_states,
+        hass,
+        now,
+        None,
+        hass.states.async_entity_ids(),
     )
     assert len(states) >= 1
     for entity_states in states.values():

--- a/tests/components/weather/test_recorder.py
+++ b/tests/components/weather/test_recorder.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 
-from homeassistant.components.recorder import Recorder
-from homeassistant.components.recorder.history import get_significant_states
+from homeassistant.components import recorder
 from homeassistant.components.weather import ATTR_FORECAST, DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -15,7 +14,9 @@ from tests.common import async_fire_time_changed
 from tests.components.recorder.common import async_wait_recording_done
 
 
-async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) -> None:
+async def test_exclude_attributes(
+    recorder_mock: recorder.Recorder, hass: HomeAssistant
+) -> None:
     """Test weather attributes to be excluded."""
     now = dt_util.utcnow()
     await async_setup_component(hass, "homeassistant", {})
@@ -32,7 +33,11 @@ async def test_exclude_attributes(recorder_mock: Recorder, hass: HomeAssistant) 
     await async_wait_recording_done(hass)
 
     states = await hass.async_add_executor_job(
-        get_significant_states, hass, now, None, hass.states.async_entity_ids()
+        recorder.history.get_significant_states,
+        hass,
+        now,
+        None,
+        hass.states.async_entity_ids(),
     )
     assert len(states) >= 1
     for entity_states in states.values():


### PR DESCRIPTION
## Proposed change
This commit aims to enhance the codebase by refactoring import statements to align with best practices for improved code readability and maintainability.

Instead of importing specific objects directly, this commit modifies the import statements to import modules or packages and references objects using the module/package prefix. This approach helps provide clearer visibility of the source of imported objects, making the code easier to understand and maintain.

By following this best practice, we ensure a consistent style throughout the codebase, making it more readable and reducing potential issues related to namespace conflicts or unclear object origins.

This is only done for the recorder module.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
Note that there is one test case that fails this transformation, `tests/components/recorder/test_filters_with_entityfilter_schema_37.py` for some reason produces:
```
>           warnings.warn(message, category, stacklevel=stacklevel + 1)
E           sqlalchemy.exc.SAWarning: SELECT statement has a cartesian product between FROM element(s) "states" and FROM element "states".  Apply join condition(s) between each element to resolve.
```
which might indicate an SQL error. It is unclear why this would be triggered from a change of the includes however. As this is probably just a side effect from potentially a per-existing bug, it is left out of this set for now. If someone knows how to address this and fixes it on master in the meantime, we can update also this test to be 'complete'.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
