### PR TITLE
Add lightweight API to get core state

### DIFF
--- a/homeassistant/components/api/__init__.py
+++ b/homeassistant/components/api/__init__.py
@@ -18,6 +18,7 @@ from homeassistant.const import (
     URL_API,
     URL_API_COMPONENTS,
     URL_API_CONFIG,
+    URL_API_CORE_STATE,
     URL_API_ERROR_LOG,
     URL_API_EVENTS,
     URL_API_SERVICES,
@@ -55,6 +56,7 @@ CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Register the API with the HTTP interface."""
     hass.http.register_view(APIStatusView)
+    hass.http.register_view(APICoreStateView)
     hass.http.register_view(APIEventStream)
     hass.http.register_view(APIConfigView)
     hass.http.register_view(APIStatesView)
@@ -82,6 +84,24 @@ class APIStatusView(HomeAssistantView):
     def get(self, request):
         """Retrieve if API is running."""
         return self.json_message("API running.")
+
+
+class APICoreStateView(HomeAssistantView):
+    """View to handle core state requests."""
+
+    url = URL_API_CORE_STATE
+    name = "api:core:state"
+
+    @ha.callback
+    def get(self, request: web.Request) -> web.Response:
+        """Retrieve the current core state.
+
+        This API is intended to be a fast and lightweight way to check if the
+        Home Assistant core is running. Its primary use case is for supervisor
+        to check if Home Assistant is running.
+        """
+        hass: HomeAssistant = request.app["hass"]
+        return self.json({"state": hass.state.value})
 
 
 class APIEventStream(HomeAssistantView):

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -1101,6 +1101,7 @@ SERVER_PORT: Final = 8123
 URL_ROOT: Final = "/"
 URL_API: Final = "/api/"
 URL_API_STREAM: Final = "/api/stream"
+URL_API_CORE_STATE: Final = "/api/core/state"
 URL_API_CONFIG: Final = "/api/config"
 URL_API_STATES: Final = "/api/states"
 URL_API_STATES_ENTITY: Final = "/api/states/{}"

--- a/tests/components/api/test_init.py
+++ b/tests/components/api/test_init.py
@@ -678,3 +678,19 @@ async def test_api_call_service_bad_data(
         "/api/services/test_domain/test_service", json={"hello": 5}
     )
     assert resp.status == HTTPStatus.BAD_REQUEST
+
+
+async def test_api_status(hass: HomeAssistant, mock_api_client: TestClient) -> None:
+    """Test getting the api status."""
+    resp = await mock_api_client.get("/api/")
+    assert resp.status == HTTPStatus.OK
+    json = await resp.json()
+    assert json["message"] == "API running."
+
+
+async def test_api_core_state(hass: HomeAssistant, mock_api_client: TestClient) -> None:
+    """Test getting core status."""
+    resp = await mock_api_client.get("/api/core/state")
+    assert resp.status == HTTPStatus.OK
+    json = await resp.json()
+    assert json["state"] == "RUNNING"


### PR DESCRIPTION
alternate solution, replaces and closes #96580 

related supervisor PRs: https://github.com/home-assistant/supervisor/pull/4445 https://github.com/home-assistant/supervisor/pull/4446

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Supervisor is currently calling the config api to get the running state in `check_api_state`.   This check happens frequently (see https://github.com/home-assistant/supervisor/pull/4445) and its likely the most common API call supervisor makes - 5s period at startup https://github.com/home-assistant/supervisor/pull/4445#issuecomment-1642469312

https://github.com/home-assistant/supervisor/blob/1f92ab42ca3d825a839278b84448a3c0b4700b65/supervisor/homeassistant/api.py#L118C15-L118C30

This check happens often which means core has to serialize all the config every time its called when supervisor only cares about the core state

https://github.com/home-assistant/supervisor/blob/1f92ab42ca3d825a839278b84448a3c0b4700b65/supervisor/homeassistant/api.py#L139

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
