### PR TITLE
Add more complete test coverage to gardena bluetooth

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -406,13 +406,6 @@ omit =
     homeassistant/components/garages_amsterdam/__init__.py
     homeassistant/components/garages_amsterdam/binary_sensor.py
     homeassistant/components/garages_amsterdam/sensor.py
-    homeassistant/components/gardena_bluetooth/__init__.py
-    homeassistant/components/gardena_bluetooth/binary_sensor.py
-    homeassistant/components/gardena_bluetooth/const.py
-    homeassistant/components/gardena_bluetooth/coordinator.py
-    homeassistant/components/gardena_bluetooth/number.py
-    homeassistant/components/gardena_bluetooth/sensor.py
-    homeassistant/components/gardena_bluetooth/switch.py
     homeassistant/components/gc100/*
     homeassistant/components/geniushub/*
     homeassistant/components/geocaching/__init__.py

--- a/homeassistant/components/gardena_bluetooth/switch.py
+++ b/homeassistant/components/gardena_bluetooth/switch.py
@@ -35,7 +35,7 @@ class GardenaBluetoothValveSwitch(GardenaBluetoothEntity, SwitchEntity):
     characteristics = {
         Valve.state.uuid,
         Valve.manual_watering_time.uuid,
-        Valve.manual_watering_time.uuid,
+        Valve.remaining_open_time.uuid,
     }
 
     def __init__(

--- a/tests/components/gardena_bluetooth/conftest.py
+++ b/tests/components/gardena_bluetooth/conftest.py
@@ -63,7 +63,10 @@ def mock_client(enable_bluetooth: None, mock_read_char_raw: dict[str, Any]) -> N
 
     def _read_char_raw(uuid: str, default: Any = SENTINEL):
         try:
-            return mock_read_char_raw[uuid]
+            val = mock_read_char_raw[uuid]
+            if isinstance(val, Exception):
+                raise val
+            return val
         except KeyError:
             if default is SENTINEL:
                 raise CharacteristicNotFound from KeyError
@@ -85,3 +88,13 @@ def mock_client(enable_bluetooth: None, mock_read_char_raw: dict[str, Any]) -> N
         "2023-01-01", tz_offset=1
     ):
         yield client
+
+
+@pytest.fixture(autouse=True)
+def enable_all_entities():
+    """Make sure all entities are enabled."""
+    with patch(
+        "homeassistant.components.gardena_bluetooth.coordinator.GardenaBluetoothEntity.entity_registry_enabled_default",
+        new=Mock(return_value=True),
+    ):
+        yield

--- a/tests/components/gardena_bluetooth/snapshots/test_number.ambr
+++ b/tests/components/gardena_bluetooth/snapshots/test_number.ambr
@@ -1,4 +1,72 @@
 # serializer version: 1
+# name: test_bluetooth_error_unavailable
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title Remaining open time',
+      'max': 86400,
+      'min': 0.0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 60.0,
+      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.mock_title_remaining_open_time',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
+# name: test_bluetooth_error_unavailable.1
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title Manual watering time',
+      'max': 86400,
+      'min': 0.0,
+      'mode': <NumberMode.BOX: 'box'>,
+      'step': 60,
+      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.mock_title_manual_watering_time',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
+# name: test_bluetooth_error_unavailable.2
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title Remaining open time',
+      'max': 86400,
+      'min': 0.0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 60.0,
+      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.mock_title_remaining_open_time',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_bluetooth_error_unavailable.3
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title Manual watering time',
+      'max': 86400,
+      'min': 0.0,
+      'mode': <NumberMode.BOX: 'box'>,
+      'step': 60,
+      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.mock_title_manual_watering_time',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_setup[98bd0f13-0b0e-421a-84e5-ddbf75dc6de4-raw1-number.mock_title_remaining_open_time]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -31,6 +99,40 @@
     'last_changed': <ANY>,
     'last_updated': <ANY>,
     'state': '10.0',
+  })
+# ---
+# name: test_setup[98bd0f13-0b0e-421a-84e5-ddbf75dc6de4-raw1-number.mock_title_remaining_open_time].2
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title Remaining open time',
+      'max': 86400,
+      'min': 0.0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 60.0,
+      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.mock_title_remaining_open_time',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_setup[98bd0f13-0b0e-421a-84e5-ddbf75dc6de4-raw1-number.mock_title_remaining_open_time].3
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title Remaining open time',
+      'max': 86400,
+      'min': 0.0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 60.0,
+      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.mock_title_remaining_open_time',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
   })
 # ---
 # name: test_setup[98bd0f13-0b0e-421a-84e5-ddbf75dc6de4-raw2-number.mock_title_open_for]

--- a/tests/components/gardena_bluetooth/snapshots/test_sensor.ambr
+++ b/tests/components/gardena_bluetooth/snapshots/test_sensor.ambr
@@ -25,6 +25,19 @@
     'state': '2023-01-01T01:00:10+00:00',
   })
 # ---
+# name: test_setup[98bd0f13-0b0e-421a-84e5-ddbf75dc6de4-raw1-sensor.mock_title_valve_closing].2
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'Mock Title Valve closing',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_title_valve_closing',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
 # name: test_setup[98bd2a19-0b0e-421a-84e5-ddbf75dc6de4-raw0-sensor.mock_title_battery]
   StateSnapshot({
     'attributes': ReadOnlyDict({

--- a/tests/components/gardena_bluetooth/snapshots/test_switch.ambr
+++ b/tests/components/gardena_bluetooth/snapshots/test_switch.ambr
@@ -1,0 +1,25 @@
+# serializer version: 1
+# name: test_setup
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title Open',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.mock_title_open',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_setup.1
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title Open',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.mock_title_open',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---

--- a/tests/components/gardena_bluetooth/test_number.py
+++ b/tests/components/gardena_bluetooth/test_number.py
@@ -1,11 +1,27 @@
 """Test Gardena Bluetooth sensor."""
 
 
+from typing import Any
+from unittest.mock import Mock, call
+
 from gardena_bluetooth.const import Valve
+from gardena_bluetooth.exceptions import (
+    CharacteristicNoAccess,
+    GardenaBluetoothException,
+)
+from gardena_bluetooth.parse import Characteristic
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.const import Platform
+from homeassistant.components.number import (
+    ATTR_VALUE,
+    DOMAIN as NUMBER_DOMAIN,
+    SERVICE_SET_VALUE,
+)
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    Platform,
+)
 from homeassistant.core import HomeAssistant
 
 from . import setup_entry
@@ -29,6 +45,8 @@ from tests.common import MockConfigEntry
             [
                 Valve.remaining_open_time.encode(100),
                 Valve.remaining_open_time.encode(10),
+                CharacteristicNoAccess("Test for no access"),
+                GardenaBluetoothException("Test for errors on bluetooth"),
             ],
             "number.mock_title_remaining_open_time",
         ),
@@ -58,3 +76,76 @@ async def test_setup(
         mock_read_char_raw[uuid] = char_raw
         await coordinator.async_refresh()
         assert hass.states.get(entity_id) == snapshot
+
+
+@pytest.mark.parametrize(
+    ("char", "value", "expected", "entity_id"),
+    [
+        (
+            Valve.manual_watering_time,
+            100,
+            100,
+            "number.mock_title_manual_watering_time",
+        ),
+        (
+            Valve.remaining_open_time,
+            100,
+            100 * 60,
+            "number.mock_title_open_for",
+        ),
+    ],
+)
+async def test_config(
+    hass: HomeAssistant,
+    mock_entry: MockConfigEntry,
+    mock_read_char_raw: dict[str, bytes],
+    mock_client: Mock,
+    char: Characteristic,
+    value: Any,
+    expected: Any,
+    entity_id: str,
+) -> None:
+    """Test setup creates expected entities."""
+
+    mock_read_char_raw[char.uuid] = char.encode(value)
+    await setup_entry(hass, mock_entry, [Platform.NUMBER])
+    assert hass.states.get(entity_id)
+
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: entity_id, ATTR_VALUE: value},
+        blocking=True,
+    )
+
+    assert mock_client.write_char.mock_calls == [
+        call(char, expected),
+    ]
+
+
+async def test_bluetooth_error_unavailable(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    mock_entry: MockConfigEntry,
+    mock_read_char_raw: dict[str, bytes],
+) -> None:
+    """Verify that a connectivity error makes all entities unavailable."""
+
+    mock_read_char_raw[
+        Valve.manual_watering_time.uuid
+    ] = Valve.manual_watering_time.encode(0)
+    mock_read_char_raw[
+        Valve.remaining_open_time.uuid
+    ] = Valve.remaining_open_time.encode(0)
+
+    coordinator = await setup_entry(hass, mock_entry, [Platform.NUMBER])
+    assert hass.states.get("number.mock_title_remaining_open_time") == snapshot
+    assert hass.states.get("number.mock_title_manual_watering_time") == snapshot
+
+    mock_read_char_raw[Valve.manual_watering_time.uuid] = GardenaBluetoothException(
+        "Test for errors on bluetooth"
+    )
+
+    await coordinator.async_refresh()
+    assert hass.states.get("number.mock_title_remaining_open_time") == snapshot
+    assert hass.states.get("number.mock_title_manual_watering_time") == snapshot

--- a/tests/components/gardena_bluetooth/test_sensor.py
+++ b/tests/components/gardena_bluetooth/test_sensor.py
@@ -26,6 +26,7 @@ from tests.common import MockConfigEntry
             [
                 Valve.remaining_open_time.encode(100),
                 Valve.remaining_open_time.encode(10),
+                Valve.remaining_open_time.encode(0),
             ],
             "sensor.mock_title_valve_closing",
         ),

--- a/tests/components/gardena_bluetooth/test_switch.py
+++ b/tests/components/gardena_bluetooth/test_switch.py
@@ -1,0 +1,84 @@
+"""Test Gardena Bluetooth sensor."""
+
+
+from unittest.mock import Mock, call
+
+from gardena_bluetooth.const import Valve
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    Platform,
+)
+from homeassistant.core import HomeAssistant
+
+from . import setup_entry
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture
+def mock_switch_chars(mock_read_char_raw):
+    """Mock data on device."""
+    mock_read_char_raw[Valve.state.uuid] = b"\x00"
+    mock_read_char_raw[
+        Valve.remaining_open_time.uuid
+    ] = Valve.remaining_open_time.encode(0)
+    mock_read_char_raw[
+        Valve.manual_watering_time.uuid
+    ] = Valve.manual_watering_time.encode(1000)
+    return mock_read_char_raw
+
+
+async def test_setup(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    mock_entry: MockConfigEntry,
+    mock_client: Mock,
+    mock_switch_chars: dict[str, bytes],
+) -> None:
+    """Test setup creates expected entities."""
+
+    entity_id = "switch.mock_title_open"
+    coordinator = await setup_entry(hass, mock_entry, [Platform.SWITCH])
+    assert hass.states.get(entity_id) == snapshot
+
+    mock_switch_chars[Valve.state.uuid] = b"\x01"
+    await coordinator.async_refresh()
+    assert hass.states.get(entity_id) == snapshot
+
+
+async def test_switching(
+    hass: HomeAssistant,
+    mock_entry: MockConfigEntry,
+    mock_client: Mock,
+    mock_switch_chars: dict[str, bytes],
+) -> None:
+    """Test switching makes correct calls."""
+
+    entity_id = "switch.mock_title_open"
+    await setup_entry(hass, mock_entry, [Platform.SWITCH])
+    assert hass.states.get(entity_id)
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+
+    assert mock_client.write_char.mock_calls == [
+        call(Valve.remaining_open_time, 1000),
+        call(Valve.remaining_open_time, 0),
+    ]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add more complete test coverage to gardena bluetooth

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
