### PR TITLE
Create an issue if push updates fail for Shelly gen1 devices

### DIFF
--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -309,15 +309,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if not entry.data.get(CONF_SLEEP_PERIOD):
         platforms = RPC_PLATFORMS
 
-    # delete push update issue if it exists
-    if get_device_entry_gen(entry) == 1:
-        LOGGER.debug(
-            "Deleting issue %s", PUSH_UPDATE_ISSUE_ID.format(unique=entry.unique_id)
-        )
-        ir.async_delete_issue(
-            hass, DOMAIN, PUSH_UPDATE_ISSUE_ID.format(unique=entry.unique_id)
-        )
-
     if get_device_entry_gen(entry) == 2:
         if unload_ok := await hass.config_entries.async_unload_platforms(
             entry, platforms
@@ -333,6 +324,14 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             get_entry_data(hass).pop(entry.entry_id)
 
         return unload_ok
+
+    # delete push update issue if it exists
+    LOGGER.debug(
+        "Deleting issue %s", PUSH_UPDATE_ISSUE_ID.format(unique=entry.unique_id)
+    )
+    ir.async_delete_issue(
+        hass, DOMAIN, PUSH_UPDATE_ISSUE_ID.format(unique=entry.unique_id)
+    )
 
     platforms = BLOCK_SLEEPING_PLATFORMS
 

--- a/homeassistant/components/shelly/const.py
+++ b/homeassistant/components/shelly/const.py
@@ -174,3 +174,7 @@ class BLEScannerMode(StrEnum):
     DISABLED = "disabled"
     ACTIVE = "active"
     PASSIVE = "passive"
+
+
+MAX_PUSH_UPDATE_FAILURES = 5
+PUSH_UPDATE_ISSUE_ID = "push_update"

--- a/homeassistant/components/shelly/const.py
+++ b/homeassistant/components/shelly/const.py
@@ -176,5 +176,5 @@ class BLEScannerMode(StrEnum):
     PASSIVE = "passive"
 
 
-MAX_PUSH_UPDATE_FAILURES = 2
+MAX_PUSH_UPDATE_FAILURES = 5
 PUSH_UPDATE_ISSUE_ID = "push_update_{unique}"

--- a/homeassistant/components/shelly/const.py
+++ b/homeassistant/components/shelly/const.py
@@ -176,5 +176,5 @@ class BLEScannerMode(StrEnum):
     PASSIVE = "passive"
 
 
-MAX_PUSH_UPDATE_FAILURES = 5
-PUSH_UPDATE_ISSUE_ID = "push_update"
+MAX_PUSH_UPDATE_FAILURES = 2
+PUSH_UPDATE_ISSUE_ID = "push_update_{unique}"

--- a/homeassistant/components/shelly/coordinator.py
+++ b/homeassistant/components/shelly/coordinator.py
@@ -285,7 +285,10 @@ class ShellyBlockCoordinator(ShellyCoordinatorBase[BlockDevice]):
                     severity=ir.IssueSeverity.ERROR,
                     learn_more_url="https://www.home-assistant.io/integrations/shelly/#shelly-device-configuration-generation-1",
                     translation_key="push_update_failure",
-                    translation_placeholders={"ip_address": self.device.ip_address},
+                    translation_placeholders={
+                        "device_name": self.entry.title,
+                        "ip_address": self.device.ip_address,
+                    },
                 )
             device_update_info(self.hass, self.device, self.entry)
 

--- a/homeassistant/components/shelly/coordinator.py
+++ b/homeassistant/components/shelly/coordinator.py
@@ -276,10 +276,13 @@ class ShellyBlockCoordinator(ShellyCoordinatorBase[BlockDevice]):
         else:
             self._push_update_failures += 1
             if self._push_update_failures > MAX_PUSH_UPDATE_FAILURES:
+                LOGGER.debug(
+                    "Creating issue %s", PUSH_UPDATE_ISSUE_ID.format(unique=self.mac)
+                )
                 ir.async_create_issue(
                     self.hass,
                     DOMAIN,
-                    PUSH_UPDATE_ISSUE_ID,
+                    PUSH_UPDATE_ISSUE_ID.format(unique=self.mac),
                     is_fixable=False,
                     is_persistent=False,
                     severity=ir.IssueSeverity.ERROR,

--- a/homeassistant/components/shelly/coordinator.py
+++ b/homeassistant/components/shelly/coordinator.py
@@ -17,6 +17,7 @@ from awesomeversion import AwesomeVersion
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import ATTR_DEVICE_ID, CONF_HOST, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant, callback
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.device_registry import (
     CONNECTION_NETWORK_MAC,
@@ -41,7 +42,9 @@ from .const import (
     EVENT_SHELLY_CLICK,
     INPUTS_EVENTS_DICT,
     LOGGER,
+    MAX_PUSH_UPDATE_FAILURES,
     MODELS_SUPPORTING_LIGHT_EFFECTS,
+    PUSH_UPDATE_ISSUE_ID,
     REST_SENSORS_UPDATE_INTERVAL,
     RPC_INPUTS_EVENTS_TYPES,
     RPC_RECONNECT_INTERVAL,
@@ -162,6 +165,7 @@ class ShellyBlockCoordinator(ShellyCoordinatorBase[BlockDevice]):
         self._last_effect: int | None = None
         self._last_input_events_count: dict = {}
         self._last_target_temp: float | None = None
+        self._push_update_failures: int = 0
 
         entry.async_on_unload(
             self.async_add_listener(self._async_device_updates_handler)
@@ -270,6 +274,19 @@ class ShellyBlockCoordinator(ShellyCoordinatorBase[BlockDevice]):
         except InvalidAuthError:
             self.entry.async_start_reauth(self.hass)
         else:
+            self._push_update_failures += 1
+            if self._push_update_failures > MAX_PUSH_UPDATE_FAILURES:
+                ir.async_create_issue(
+                    self.hass,
+                    DOMAIN,
+                    PUSH_UPDATE_ISSUE_ID,
+                    is_fixable=False,
+                    is_persistent=False,
+                    severity=ir.IssueSeverity.ERROR,
+                    learn_more_url="https://www.home-assistant.io/integrations/shelly/#shelly-device-configuration-generation-1",
+                    translation_key="push_update_failure",
+                    translation_placeholders={"ip_address": self.device.ip_address},
+                )
             device_update_info(self.hass, self.device, self.entry)
 
     def async_setup(self) -> None:

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -118,5 +118,11 @@
         }
       }
     }
+  },
+  "issues": {
+    "push_update_failure": {
+      "title": "Shelly device push update failure.",
+      "description": "Push updates from the Shelly device with IP address {ip_address} do not reach the Home Assistant server. You need to check CoIoT configuration in the web panel of the device."
+    }
   }
 }

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -122,7 +122,7 @@
   "issues": {
     "push_update_failure": {
       "title": "Shelly device push update failure.",
-      "description": "Push updates from the Shelly device with IP address {ip_address} do not reach the Home Assistant server. You need to check CoIoT configuration in the web panel of the device."
+      "description": "Push updates from the Shelly device {device_name} with IP address {ip_address} do not reach the Home Assistant server. You need to check CoIoT configuration in the web panel of the device."
     }
   }
 }

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -122,7 +122,7 @@
   "issues": {
     "push_update_failure": {
       "title": "Shelly device {device_name} push update failure",
-      "description": "Push updates from the Shelly device {device_name} with IP address {ip_address} do not reach the Home Assistant server. You need to check CoIoT configuration in the web panel of the device and your network configuration."
+      "description": "Home Assistant is not receiving push updates from the Shelly device {device_name} with IP address {ip_address}. Check the CoIoT configuration in the web panel of the device and your network configuration."
     }
   }
 }

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -121,8 +121,8 @@
   },
   "issues": {
     "push_update_failure": {
-      "title": "Shelly device push update failure.",
-      "description": "Push updates from the Shelly device {device_name} with IP address {ip_address} do not reach the Home Assistant server. You need to check CoIoT configuration in the web panel of the device."
+      "title": "Shelly device {device_name} push update failure",
+      "description": "Push updates from the Shelly device {device_name} with IP address {ip_address} do not reach the Home Assistant server. You need to check CoIoT configuration in the web panel of the device and your network configuration."
     }
   }
 }

--- a/tests/components/shelly/test_coordinator.py
+++ b/tests/components/shelly/test_coordinator.py
@@ -13,6 +13,7 @@ from homeassistant.components.shelly.const import (
     ATTR_GENERATION,
     DOMAIN,
     ENTRY_RELOAD_COOLDOWN,
+    MAX_PUSH_UPDATE_FAILURES,
     RPC_RECONNECT_INTERVAL,
     SLEEP_PERIOD_MULTIPLIER,
     UPDATE_PERIOD_MULTIPLIER,
@@ -266,35 +267,11 @@ async def test_block_device_push_updates_failure(
     await init_integration(hass, 1)
 
     # Move time to force polling
-    async_fire_time_changed(
-        hass, dt_util.utcnow() + timedelta(seconds=UPDATE_PERIOD_MULTIPLIER * 15)
-    )
-    await hass.async_block_till_done()
-
-    async_fire_time_changed(
-        hass, dt_util.utcnow() + timedelta(seconds=UPDATE_PERIOD_MULTIPLIER * 15)
-    )
-    await hass.async_block_till_done()
-
-    async_fire_time_changed(
-        hass, dt_util.utcnow() + timedelta(seconds=UPDATE_PERIOD_MULTIPLIER * 15)
-    )
-    await hass.async_block_till_done()
-
-    async_fire_time_changed(
-        hass, dt_util.utcnow() + timedelta(seconds=UPDATE_PERIOD_MULTIPLIER * 15)
-    )
-    await hass.async_block_till_done()
-
-    async_fire_time_changed(
-        hass, dt_util.utcnow() + timedelta(seconds=UPDATE_PERIOD_MULTIPLIER * 15)
-    )
-    await hass.async_block_till_done()
-
-    async_fire_time_changed(
-        hass, dt_util.utcnow() + timedelta(seconds=UPDATE_PERIOD_MULTIPLIER * 15)
-    )
-    await hass.async_block_till_done()
+    for _ in range(MAX_PUSH_UPDATE_FAILURES + 1):
+        async_fire_time_changed(
+            hass, dt_util.utcnow() + timedelta(seconds=UPDATE_PERIOD_MULTIPLIER * 15)
+        )
+        await hass.async_block_till_done()
 
     assert issue_registry.async_get_issue(
         domain=DOMAIN, issue_id=f"push_update_{MOCK_MAC}"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Users often open issues that are caused by push updates from Shelly gen1 devices not reaching the HA server. This is due to missing or incorrect CoIoT configuration or incorrect network configuration (for example, separate VLAN for Shelly devices).
With this PR, the integration will open an issue with information for the user if the push notification fails to reach the HA server 5 times.

![obraz](https://github.com/home-assistant/core/assets/478555/294fd748-a348-4a11-9b11-37f72a91e5f4)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
