### PR TITLE
Plugwise prepare value_fn for sensor

### DIFF
--- a/homeassistant/components/plugwise/sensor.py
+++ b/homeassistant/components/plugwise/sensor.py
@@ -1,6 +1,11 @@
 """Plugwise Sensor component for Home Assistant."""
 from __future__ import annotations
 
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from plugwise import SmileSensors
+
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -27,374 +32,430 @@ from .const import DOMAIN
 from .coordinator import PlugwiseDataUpdateCoordinator
 from .entity import PlugwiseEntity
 
-SENSORS: tuple[SensorEntityDescription, ...] = (
-    SensorEntityDescription(
+
+@dataclass
+class PlugwiseSensorBaseMixin:
+    """Mixin for required Plugwise sensor description keys."""
+
+    value_fn: Callable[[SmileSensors], float | int]
+
+
+@dataclass
+class PlugwiseSensorEntityDescription(SensorEntityDescription, PlugwiseSensorBaseMixin):
+    """Describes Plugwise sensor entity."""
+
+    state_class: str | None = SensorStateClass.MEASUREMENT
+
+
+SENSORS: tuple[PlugwiseSensorEntityDescription, ...] = (
+    PlugwiseSensorEntityDescription(
         key="setpoint",
         translation_key="setpoint",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: data["setpoint"],
     ),
-    SensorEntityDescription(
+    PlugwiseSensorEntityDescription(
         key="setpoint_high",
         translation_key="cooling_setpoint",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: data["setpoint_high"],
     ),
-    SensorEntityDescription(
+    PlugwiseSensorEntityDescription(
         key="setpoint_low",
         translation_key="heating_setpoint",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: data["setpoint_low"],
     ),
-    SensorEntityDescription(
+    PlugwiseSensorEntityDescription(
         key="temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data["temperature"],
     ),
-    SensorEntityDescription(
+    PlugwiseSensorEntityDescription(
         key="intended_boiler_temperature",
         translation_key="intended_boiler_temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data["intended_boiler_temperature"],
     ),
-    SensorEntityDescription(
+    PlugwiseSensorEntityDescription(
         key="temperature_difference",
         translation_key="temperature_difference",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data["temperature_difference"],
     ),
-    SensorEntityDescription(
+    PlugwiseSensorEntityDescription(
         key="outdoor_temperature",
         translation_key="outdoor_temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data["outdoor_temperature"],
     ),
-    SensorEntityDescription(
+    PlugwiseSensorEntityDescription(
         key="outdoor_air_temperature",
         translation_key="outdoor_air_temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data["outdoor_air_temperature"],
     ),
-    SensorEntityDescription(
+    PlugwiseSensorEntityDescription(
         key="water_temperature",
         translation_key="water_temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data["water_temperature"],
     ),
-    SensorEntityDescription(
+    PlugwiseSensorEntityDescription(
         key="return_temperature",
         translation_key="return_temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data["return_temperature"],
     ),
-    SensorEntityDescription(
+    PlugwiseSensorEntityDescription(
         key="electricity_consumed",
         translation_key="electricity_consumed",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data["electricity_consumed"],
     ),
-    SensorEntityDescription(
+    PlugwiseSensorEntityDescription(
         key="electricity_produced",
         translation_key="electricity_produced",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
+        value_fn=lambda data: data["electricity_produced"],
     ),
-    SensorEntityDescription(
+    PlugwiseSensorEntityDescription(
         key="electricity_consumed_interval",
         translation_key="electricity_consumed_interval",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL,
+        value_fn=lambda data: data["electricity_consumed_interval"],
     ),
-    SensorEntityDescription(
+    PlugwiseSensorEntityDescription(
         key="electricity_consumed_peak_interval",
         translation_key="electricity_consumed_peak_interval",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL,
+        value_fn=lambda data: data["electricity_consumed_peak_interval"],
     ),
-    SensorEntityDescription(
+    PlugwiseSensorEntityDescription(
         key="electricity_consumed_off_peak_interval",
         translation_key="electricity_consumed_off_peak_interval",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL,
+        value_fn=lambda data: data["electricity_consumed_off_peak_interval"],
     ),
-    SensorEntityDescription(
+    PlugwiseSensorEntityDescription(
         key="electricity_produced_interval",
         translation_key="electricity_produced_interval",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL,
         entity_registry_enabled_default=False,
+        value_fn=lambda data: data["electricity_produced_interval"],
     ),
-    SensorEntityDescription(
+    PlugwiseSensorEntityDescription(
         key="electricity_produced_peak_interval",
         translation_key="electricity_produced_peak_interval",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL,
+        value_fn=lambda data: data["electricity_produced_peak_interval"],
     ),
-    SensorEntityDescription(
+    PlugwiseSensorEntityDescription(
         key="electricity_produced_off_peak_interval",
         translation_key="electricity_produced_off_peak_interval",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL,
+        value_fn=lambda data: data["electricity_produced_off_peak_interval"],
     ),
-    SensorEntityDescription(
+    PlugwiseSensorEntityDescription(
         key="electricity_consumed_point",
         translation_key="electricity_consumed_point",
         device_class=SensorDeviceClass.POWER,
         native_unit_of_measurement=UnitOfPower.WATT,
         state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data["electricity_consumed_point"],
     ),
-    SensorEntityDescription(
+    PlugwiseSensorEntityDescription(
         key="electricity_consumed_off_peak_point",
         translation_key="electricity_consumed_off_peak_point",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data["electricity_consumed_off_peak_point"],
     ),
-    SensorEntityDescription(
+    PlugwiseSensorEntityDescription(
         key="electricity_consumed_peak_point",
         translation_key="electricity_consumed_peak_point",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data["electricity_consumed_peak_point"],
     ),
-    SensorEntityDescription(
+    PlugwiseSensorEntityDescription(
         key="electricity_consumed_off_peak_cumulative",
         translation_key="electricity_consumed_off_peak_cumulative",
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
+        value_fn=lambda data: data["electricity_consumed_off_peak_cumulative"],
     ),
-    SensorEntityDescription(
+    PlugwiseSensorEntityDescription(
         key="electricity_consumed_peak_cumulative",
         translation_key="electricity_consumed_peak_cumulative",
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
+        value_fn=lambda data: data["electricity_consumed_peak_cumulative"],
     ),
-    SensorEntityDescription(
+    PlugwiseSensorEntityDescription(
         key="electricity_produced_point",
         translation_key="electricity_produced_point",
         device_class=SensorDeviceClass.POWER,
         native_unit_of_measurement=UnitOfPower.WATT,
         state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data["electricity_produced_point"],
     ),
-    SensorEntityDescription(
+    PlugwiseSensorEntityDescription(
         key="electricity_produced_off_peak_point",
         translation_key="electricity_produced_off_peak_point",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data["electricity_produced_off_peak_point"],
     ),
-    SensorEntityDescription(
+    PlugwiseSensorEntityDescription(
         key="electricity_produced_peak_point",
         translation_key="electricity_produced_peak_point",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data["electricity_produced_peak_point"],
     ),
-    SensorEntityDescription(
+    PlugwiseSensorEntityDescription(
         key="electricity_produced_off_peak_cumulative",
         translation_key="electricity_produced_off_peak_cumulative",
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
+        value_fn=lambda data: data["electricity_produced_off_peak_cumulative"],
     ),
-    SensorEntityDescription(
+    PlugwiseSensorEntityDescription(
         key="electricity_produced_peak_cumulative",
         translation_key="electricity_produced_peak_cumulative",
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
+        value_fn=lambda data: data["electricity_produced_peak_cumulative"],
     ),
-    SensorEntityDescription(
+    PlugwiseSensorEntityDescription(
         key="electricity_phase_one_consumed",
         translation_key="electricity_phase_one_consumed",
         device_class=SensorDeviceClass.POWER,
         native_unit_of_measurement=UnitOfPower.WATT,
         state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data["electricity_phase_one_consumed"],
     ),
-    SensorEntityDescription(
+    PlugwiseSensorEntityDescription(
         key="electricity_phase_two_consumed",
         translation_key="electricity_phase_two_consumed",
         device_class=SensorDeviceClass.POWER,
         native_unit_of_measurement=UnitOfPower.WATT,
         state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data["electricity_phase_two_consumed"],
     ),
-    SensorEntityDescription(
+    PlugwiseSensorEntityDescription(
         key="electricity_phase_three_consumed",
         translation_key="electricity_phase_three_consumed",
         device_class=SensorDeviceClass.POWER,
         native_unit_of_measurement=UnitOfPower.WATT,
         state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data["electricity_phase_three_consumed"],
     ),
-    SensorEntityDescription(
+    PlugwiseSensorEntityDescription(
         key="electricity_phase_one_produced",
         translation_key="electricity_phase_one_produced",
         device_class=SensorDeviceClass.POWER,
         native_unit_of_measurement=UnitOfPower.WATT,
         state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data["electricity_phase_one_produced"],
     ),
-    SensorEntityDescription(
+    PlugwiseSensorEntityDescription(
         key="electricity_phase_two_produced",
         translation_key="electricity_phase_two_produced",
         device_class=SensorDeviceClass.POWER,
         native_unit_of_measurement=UnitOfPower.WATT,
         state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data["electricity_phase_two_produced"],
     ),
-    SensorEntityDescription(
+    PlugwiseSensorEntityDescription(
         key="electricity_phase_three_produced",
         translation_key="electricity_phase_three_produced",
         device_class=SensorDeviceClass.POWER,
         native_unit_of_measurement=UnitOfPower.WATT,
         state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data["electricity_phase_three_produced"],
     ),
-    SensorEntityDescription(
+    PlugwiseSensorEntityDescription(
         key="voltage_phase_one",
         translation_key="voltage_phase_one",
         device_class=SensorDeviceClass.VOLTAGE,
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
+        value_fn=lambda data: data["voltage_phase_one"],
     ),
-    SensorEntityDescription(
+    PlugwiseSensorEntityDescription(
         key="voltage_phase_two",
         translation_key="voltage_phase_two",
         device_class=SensorDeviceClass.VOLTAGE,
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
+        value_fn=lambda data: data["voltage_phase_two"],
     ),
-    SensorEntityDescription(
+    PlugwiseSensorEntityDescription(
         key="voltage_phase_three",
         translation_key="voltage_phase_three",
         device_class=SensorDeviceClass.VOLTAGE,
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
+        value_fn=lambda data: data["voltage_phase_three"],
     ),
-    SensorEntityDescription(
+    PlugwiseSensorEntityDescription(
         key="gas_consumed_interval",
         translation_key="gas_consumed_interval",
         icon="mdi:meter-gas",
         native_unit_of_measurement=UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
         state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data["gas_consumed_interval"],
     ),
-    SensorEntityDescription(
+    PlugwiseSensorEntityDescription(
         key="gas_consumed_cumulative",
         translation_key="gas_consumed_cumulative",
         native_unit_of_measurement=UnitOfVolume.CUBIC_METERS,
         device_class=SensorDeviceClass.GAS,
         state_class=SensorStateClass.TOTAL,
+        value_fn=lambda data: data["gas_consumed_cumulative"],
     ),
-    SensorEntityDescription(
+    PlugwiseSensorEntityDescription(
         key="net_electricity_point",
         translation_key="net_electricity_point",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data["net_electricity_point"],
     ),
-    SensorEntityDescription(
+    PlugwiseSensorEntityDescription(
         key="net_electricity_cumulative",
         translation_key="net_electricity_cumulative",
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL,
+        value_fn=lambda data: data["net_electricity_cumulative"],
     ),
-    SensorEntityDescription(
+    PlugwiseSensorEntityDescription(
         key="battery",
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.BATTERY,
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data["battery"],
     ),
-    SensorEntityDescription(
+    PlugwiseSensorEntityDescription(
         key="illuminance",
         native_unit_of_measurement=LIGHT_LUX,
         device_class=SensorDeviceClass.ILLUMINANCE,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: data["illuminance"],
     ),
-    SensorEntityDescription(
+    PlugwiseSensorEntityDescription(
         key="modulation_level",
         translation_key="modulation_level",
         icon="mdi:percent",
         native_unit_of_measurement=PERCENTAGE,
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data["modulation_level"],
     ),
-    SensorEntityDescription(
+    PlugwiseSensorEntityDescription(
         key="valve_position",
         translation_key="valve_position",
         icon="mdi:valve",
         entity_category=EntityCategory.DIAGNOSTIC,
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data["valve_position"],
     ),
-    SensorEntityDescription(
+    PlugwiseSensorEntityDescription(
         key="water_pressure",
         translation_key="water_pressure",
         native_unit_of_measurement=UnitOfPressure.BAR,
         device_class=SensorDeviceClass.PRESSURE,
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data["water_pressure"],
     ),
-    SensorEntityDescription(
+    PlugwiseSensorEntityDescription(
         key="humidity",
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.HUMIDITY,
         state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data["humidity"],
     ),
-    SensorEntityDescription(
+    PlugwiseSensorEntityDescription(
         key="dhw_temperature",
         translation_key="dhw_temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data["dhw_temperature"],
     ),
-    SensorEntityDescription(
+    PlugwiseSensorEntityDescription(
         key="domestic_hot_water_setpoint",
         translation_key="domestic_hot_water_setpoint",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.MEASUREMENT,
-    ),
-    SensorEntityDescription(
-        key="maximum_boiler_temperature",
-        translation_key="maximum_boiler_temperature",
-        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-        device_class=SensorDeviceClass.TEMPERATURE,
-        entity_category=EntityCategory.DIAGNOSTIC,
-        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data["domestic_hot_water_setpoint"],
     ),
 )
 
@@ -409,11 +470,10 @@ async def async_setup_entry(
 
     entities: list[PlugwiseSensorEntity] = []
     for device_id, device in coordinator.data.devices.items():
+        if not (sensors := device.get("sensors")):
+            continue
         for description in SENSORS:
-            if (
-                "sensors" not in device
-                or device["sensors"].get(description.key) is None
-            ):
+            if description.key not in sensors:
                 continue
 
             entities.append(
@@ -430,11 +490,13 @@ async def async_setup_entry(
 class PlugwiseSensorEntity(PlugwiseEntity, SensorEntity):
     """Represent Plugwise Sensors."""
 
+    entity_description: PlugwiseSensorEntityDescription
+
     def __init__(
         self,
         coordinator: PlugwiseDataUpdateCoordinator,
         device_id: str,
-        description: SensorEntityDescription,
+        description: PlugwiseSensorEntityDescription,
     ) -> None:
         """Initialise the sensor."""
         super().__init__(coordinator, device_id)
@@ -444,4 +506,4 @@ class PlugwiseSensorEntity(PlugwiseEntity, SensorEntity):
     @property
     def native_value(self) -> int | float | None:
         """Return the value reported by the sensor."""
-        return self.device["sensors"].get(self.entity_description.key)
+        return self.entity_description.value_fn(self.device["sensors"])


### PR DESCRIPTION
## Proposed change
Change entitydescription approach for sensor preparing for upcoming strict typing and module version bump PRs. Following the incorporated recent feedback from binary_sensor and number.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
Walking our platforms as outlined in https://github.com/home-assistant/core/pull/93088 leading up to dependency bump and strict typing.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
