### PR TITLE
Avoid accessing coordinator in gardena_bluetooth tests

### DIFF
--- a/tests/components/gardena_bluetooth/__init__.py
+++ b/tests/components/gardena_bluetooth/__init__.py
@@ -2,8 +2,6 @@
 
 from unittest.mock import patch
 
-from homeassistant.components.gardena_bluetooth.const import DOMAIN
-from homeassistant.components.gardena_bluetooth.coordinator import Coordinator
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.service_info.bluetooth import BluetoothServiceInfo
@@ -74,7 +72,7 @@ UNSUPPORTED_GROUP_SERVICE_INFO = BluetoothServiceInfo(
 
 async def setup_entry(
     hass: HomeAssistant, mock_entry: MockConfigEntry, platforms: list[Platform]
-) -> Coordinator:
+) -> None:
     """Make sure the device is available."""
 
     inject_bluetooth_service_info(hass, WATER_TIMER_SERVICE_INFO)
@@ -83,5 +81,3 @@ async def setup_entry(
         mock_entry.add_to_hass(hass)
         await hass.config_entries.async_setup(mock_entry.entry_id)
         await hass.async_block_till_done()
-
-    return hass.data[DOMAIN][mock_entry.entry_id]

--- a/tests/components/gardena_bluetooth/conftest.py
+++ b/tests/components/gardena_bluetooth/conftest.py
@@ -1,5 +1,5 @@
 """Common fixtures for the Gardena Bluetooth tests."""
-from collections.abc import Generator
+from collections.abc import Awaitable, Callable, Generator
 from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -11,11 +11,13 @@ from gardena_bluetooth.parse import Characteristic
 import pytest
 
 from homeassistant.components.gardena_bluetooth.const import DOMAIN
+from homeassistant.components.gardena_bluetooth.coordinator import SCAN_INTERVAL
 from homeassistant.const import CONF_ADDRESS
+from homeassistant.core import HomeAssistant
 
 from . import WATER_TIMER_SERVICE_INFO
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 
 @pytest.fixture
@@ -45,8 +47,27 @@ def mock_read_char_raw():
     }
 
 
+@pytest.fixture
+async def scan_step(
+    hass: HomeAssistant,
+) -> Generator[None, None, Callable[[], Awaitable[None]]]:
+    """Step system time forward."""
+
+    with freeze_time("2023-01-01", tz_offset=1) as frozen_time:
+
+        async def delay():
+            """Trigger delay in system."""
+            frozen_time.tick(delta=SCAN_INTERVAL)
+            async_fire_time_changed(hass)
+            await hass.async_block_till_done()
+
+        yield delay
+
+
 @pytest.fixture(autouse=True)
-def mock_client(enable_bluetooth: None, mock_read_char_raw: dict[str, Any]) -> None:
+def mock_client(
+    enable_bluetooth: None, scan_step, mock_read_char_raw: dict[str, Any]
+) -> None:
     """Auto mock bluetooth."""
 
     client = Mock(spec_set=Client)
@@ -82,11 +103,7 @@ def mock_client(enable_bluetooth: None, mock_read_char_raw: dict[str, Any]) -> N
     with patch(
         "homeassistant.components.gardena_bluetooth.config_flow.Client",
         return_value=client,
-    ), patch(
-        "homeassistant.components.gardena_bluetooth.Client", return_value=client
-    ), freeze_time(
-        "2023-01-01", tz_offset=1
-    ):
+    ), patch("homeassistant.components.gardena_bluetooth.Client", return_value=client):
         yield client
 
 

--- a/tests/components/gardena_bluetooth/snapshots/test_sensor.ambr
+++ b/tests/components/gardena_bluetooth/snapshots/test_sensor.ambr
@@ -22,7 +22,7 @@
     'entity_id': 'sensor.mock_title_valve_closing',
     'last_changed': <ANY>,
     'last_updated': <ANY>,
-    'state': '2023-01-01T01:00:10+00:00',
+    'state': '2023-01-01T01:01:10+00:00',
   })
 # ---
 # name: test_setup[98bd0f13-0b0e-421a-84e5-ddbf75dc6de4-raw1-sensor.mock_title_valve_closing].2

--- a/tests/components/gardena_bluetooth/test_binary_sensor.py
+++ b/tests/components/gardena_bluetooth/test_binary_sensor.py
@@ -1,6 +1,8 @@
 """Test Gardena Bluetooth binary sensor."""
 
 
+from collections.abc import Awaitable, Callable
+
 from gardena_bluetooth.const import Valve
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -28,6 +30,7 @@ async def test_setup(
     snapshot: SnapshotAssertion,
     mock_entry: MockConfigEntry,
     mock_read_char_raw: dict[str, bytes],
+    scan_step: Callable[[], Awaitable[None]],
     uuid: str,
     raw: list[bytes],
     entity_id: str,
@@ -35,10 +38,10 @@ async def test_setup(
     """Test setup creates expected entities."""
 
     mock_read_char_raw[uuid] = raw[0]
-    coordinator = await setup_entry(hass, mock_entry, [Platform.BINARY_SENSOR])
+    await setup_entry(hass, mock_entry, [Platform.BINARY_SENSOR])
     assert hass.states.get(entity_id) == snapshot
 
     for char_raw in raw[1:]:
         mock_read_char_raw[uuid] = char_raw
-        await coordinator.async_refresh()
+        await scan_step()
         assert hass.states.get(entity_id) == snapshot

--- a/tests/components/gardena_bluetooth/test_button.py
+++ b/tests/components/gardena_bluetooth/test_button.py
@@ -1,6 +1,7 @@
 """Test Gardena Bluetooth sensor."""
 
 
+from collections.abc import Awaitable, Callable
 from unittest.mock import Mock, call
 
 from gardena_bluetooth.const import Reset
@@ -31,15 +32,16 @@ async def test_setup(
     snapshot: SnapshotAssertion,
     mock_entry: MockConfigEntry,
     mock_switch_chars: dict[str, bytes],
+    scan_step: Callable[[], Awaitable[None]],
 ) -> None:
     """Test setup creates expected entities."""
 
     entity_id = "button.mock_title_factory_reset"
-    coordinator = await setup_entry(hass, mock_entry, [Platform.BUTTON])
+    await setup_entry(hass, mock_entry, [Platform.BUTTON])
     assert hass.states.get(entity_id) == snapshot
 
     mock_switch_chars[Reset.factory_reset.uuid] = b"\x01"
-    await coordinator.async_refresh()
+    await scan_step()
     assert hass.states.get(entity_id) == snapshot
 
 

--- a/tests/components/gardena_bluetooth/test_number.py
+++ b/tests/components/gardena_bluetooth/test_number.py
@@ -1,6 +1,7 @@
 """Test Gardena Bluetooth sensor."""
 
 
+from collections.abc import Awaitable, Callable
 from typing import Any
 from unittest.mock import Mock, call
 
@@ -62,6 +63,7 @@ async def test_setup(
     snapshot: SnapshotAssertion,
     mock_entry: MockConfigEntry,
     mock_read_char_raw: dict[str, bytes],
+    scan_step: Callable[[], Awaitable[None]],
     uuid: str,
     raw: list[bytes],
     entity_id: str,
@@ -69,12 +71,12 @@ async def test_setup(
     """Test setup creates expected entities."""
 
     mock_read_char_raw[uuid] = raw[0]
-    coordinator = await setup_entry(hass, mock_entry, [Platform.NUMBER])
+    await setup_entry(hass, mock_entry, [Platform.NUMBER])
     assert hass.states.get(entity_id) == snapshot
 
     for char_raw in raw[1:]:
         mock_read_char_raw[uuid] = char_raw
-        await coordinator.async_refresh()
+        await scan_step()
         assert hass.states.get(entity_id) == snapshot
 
 
@@ -128,6 +130,7 @@ async def test_bluetooth_error_unavailable(
     snapshot: SnapshotAssertion,
     mock_entry: MockConfigEntry,
     mock_read_char_raw: dict[str, bytes],
+    scan_step: Callable[[], Awaitable[None]],
 ) -> None:
     """Verify that a connectivity error makes all entities unavailable."""
 
@@ -138,7 +141,7 @@ async def test_bluetooth_error_unavailable(
         Valve.remaining_open_time.uuid
     ] = Valve.remaining_open_time.encode(0)
 
-    coordinator = await setup_entry(hass, mock_entry, [Platform.NUMBER])
+    await setup_entry(hass, mock_entry, [Platform.NUMBER])
     assert hass.states.get("number.mock_title_remaining_open_time") == snapshot
     assert hass.states.get("number.mock_title_manual_watering_time") == snapshot
 
@@ -146,6 +149,6 @@ async def test_bluetooth_error_unavailable(
         "Test for errors on bluetooth"
     )
 
-    await coordinator.async_refresh()
+    await scan_step()
     assert hass.states.get("number.mock_title_remaining_open_time") == snapshot
     assert hass.states.get("number.mock_title_manual_watering_time") == snapshot

--- a/tests/components/gardena_bluetooth/test_sensor.py
+++ b/tests/components/gardena_bluetooth/test_sensor.py
@@ -1,5 +1,5 @@
 """Test Gardena Bluetooth sensor."""
-
+from collections.abc import Awaitable, Callable
 
 from gardena_bluetooth.const import Battery, Valve
 import pytest
@@ -37,6 +37,7 @@ async def test_setup(
     snapshot: SnapshotAssertion,
     mock_entry: MockConfigEntry,
     mock_read_char_raw: dict[str, bytes],
+    scan_step: Callable[[], Awaitable[None]],
     uuid: str,
     raw: list[bytes],
     entity_id: str,
@@ -44,10 +45,10 @@ async def test_setup(
     """Test setup creates expected entities."""
 
     mock_read_char_raw[uuid] = raw[0]
-    coordinator = await setup_entry(hass, mock_entry, [Platform.SENSOR])
+    await setup_entry(hass, mock_entry, [Platform.SENSOR])
     assert hass.states.get(entity_id) == snapshot
 
     for char_raw in raw[1:]:
         mock_read_char_raw[uuid] = char_raw
-        await coordinator.async_refresh()
+        await scan_step()
         assert hass.states.get(entity_id) == snapshot

--- a/tests/components/gardena_bluetooth/test_switch.py
+++ b/tests/components/gardena_bluetooth/test_switch.py
@@ -1,6 +1,7 @@
 """Test Gardena Bluetooth sensor."""
 
 
+from collections.abc import Awaitable, Callable
 from unittest.mock import Mock, call
 
 from gardena_bluetooth.const import Valve
@@ -40,15 +41,16 @@ async def test_setup(
     mock_entry: MockConfigEntry,
     mock_client: Mock,
     mock_switch_chars: dict[str, bytes],
+    scan_step: Callable[[], Awaitable[None]],
 ) -> None:
     """Test setup creates expected entities."""
 
     entity_id = "switch.mock_title_open"
-    coordinator = await setup_entry(hass, mock_entry, [Platform.SWITCH])
+    await setup_entry(hass, mock_entry, [Platform.SWITCH])
     assert hass.states.get(entity_id) == snapshot
 
     mock_switch_chars[Valve.state.uuid] = b"\x01"
-    await coordinator.async_refresh()
+    await scan_step()
     assert hass.states.get(entity_id) == snapshot
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Avoid accessing internal state of integration during tests

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to: https://github.com/home-assistant/core/pull/96777#discussion_r1267917691 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
