### PR TITLE
Fix mock assert_called_with

### DIFF
--- a/tests/components/esphome/test_voice_assistant.py
+++ b/tests/components/esphome/test_voice_assistant.py
@@ -273,7 +273,7 @@ async def test_error_event_type(
         )
     )
 
-    assert voice_assistant_udp_server_v1.handle_event.called_with(
+    voice_assistant_udp_server_v1.handle_event.assert_called_with(
         VoiceAssistantEventType.VOICE_ASSISTANT_ERROR,
         {"code": "code", "message": "message"},
     )

--- a/tests/components/sonos/conftest.py
+++ b/tests/components/sonos/conftest.py
@@ -107,6 +107,9 @@ def config_entry_fixture():
 class MockSoCo(MagicMock):
     """Mock the Soco Object."""
 
+    audio_delay = 2
+    sub_gain = 5
+
     @property
     def visible_zones(self):
         """Return visible zones and allow property to be overridden by device classes."""

--- a/tests/components/sonos/test_number.py
+++ b/tests/components/sonos/test_number.py
@@ -44,7 +44,7 @@ async def test_number_entities(
             {ATTR_ENTITY_ID: audio_delay_number.entity_id, "value": 3},
             blocking=True,
         )
-        assert mock_audio_delay.called_with(3)
+        mock_audio_delay.assert_called_with(3)
 
     sub_gain_number = entity_registry.entities["number.zone_a_sub_gain"]
     sub_gain_state = hass.states.get(sub_gain_number.entity_id)
@@ -57,4 +57,4 @@ async def test_number_entities(
             {ATTR_ENTITY_ID: sub_gain_number.entity_id, "value": -8},
             blocking=True,
         )
-        assert mock_sub_gain.called_with(-8)
+        mock_sub_gain.assert_called_with(-8)

--- a/tests/components/sonos/test_number.py
+++ b/tests/components/sonos/test_number.py
@@ -1,5 +1,5 @@
 """Tests for the Sonos number platform."""
-from unittest.mock import patch
+from unittest.mock import PropertyMock, patch
 
 from homeassistant.components.number import DOMAIN as NUMBER_DOMAIN, SERVICE_SET_VALUE
 from homeassistant.const import ATTR_ENTITY_ID
@@ -37,24 +37,28 @@ async def test_number_entities(
     music_surround_level_state = hass.states.get(music_surround_level_number.entity_id)
     assert music_surround_level_state.state == "4"
 
-    with patch("soco.SoCo.audio_delay") as mock_audio_delay:
+    with patch.object(
+        type(soco), "audio_delay", new_callable=PropertyMock
+    ) as mock_audio_delay:
         await hass.services.async_call(
             NUMBER_DOMAIN,
             SERVICE_SET_VALUE,
             {ATTR_ENTITY_ID: audio_delay_number.entity_id, "value": 3},
             blocking=True,
         )
-        mock_audio_delay.assert_called_with(3)
+        mock_audio_delay.assert_called_once_with(3)
 
     sub_gain_number = entity_registry.entities["number.zone_a_sub_gain"]
     sub_gain_state = hass.states.get(sub_gain_number.entity_id)
     assert sub_gain_state.state == "5"
 
-    with patch("soco.SoCo.sub_gain") as mock_sub_gain:
+    with patch.object(
+        type(soco), "sub_gain", new_callable=PropertyMock
+    ) as mock_sub_gain:
         await hass.services.async_call(
             NUMBER_DOMAIN,
             SERVICE_SET_VALUE,
             {ATTR_ENTITY_ID: sub_gain_number.entity_id, "value": -8},
             blocking=True,
         )
-        mock_sub_gain.assert_called_with(-8)
+        mock_sub_gain.assert_called_once_with(-8)

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -247,7 +247,7 @@ async def test_setup_with_default_interface(
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
 
-    assert mock_async_zeroconf.called_with(interface_choice=InterfaceChoice.Default)
+    mock_async_zeroconf.assert_called_with(interface_choice=InterfaceChoice.Default)
 
 
 async def test_setup_without_default_interface(
@@ -264,7 +264,7 @@ async def test_setup_without_default_interface(
             hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {CONF_DEFAULT_INTERFACE: False}}
         )
 
-    assert mock_async_zeroconf.called_with()
+    mock_async_zeroconf.assert_called_with()
 
 
 async def test_setup_without_ipv6(
@@ -283,7 +283,7 @@ async def test_setup_without_ipv6(
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
 
-    assert mock_async_zeroconf.called_with(ip_version=IPVersion.V4Only)
+    mock_async_zeroconf.assert_called_with(ip_version=IPVersion.V4Only)
 
 
 async def test_setup_with_ipv6(hass: HomeAssistant, mock_async_zeroconf: None) -> None:
@@ -300,7 +300,7 @@ async def test_setup_with_ipv6(hass: HomeAssistant, mock_async_zeroconf: None) -
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
 
-    assert mock_async_zeroconf.called_with()
+    mock_async_zeroconf.assert_called_with()
 
 
 async def test_setup_with_ipv6_default(
@@ -317,7 +317,7 @@ async def test_setup_with_ipv6_default(
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
 
-    assert mock_async_zeroconf.called_with()
+    mock_async_zeroconf.assert_called_with()
 
 
 async def test_zeroconf_match_macaddress(

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -247,7 +247,7 @@ async def test_setup_with_default_interface(
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
 
-    mock_async_zeroconf.assert_called_with(interface_choice=InterfaceChoice.Default)
+    assert mock_async_zeroconf.called_with(interface_choice=InterfaceChoice.Default)
 
 
 async def test_setup_without_default_interface(
@@ -264,7 +264,7 @@ async def test_setup_without_default_interface(
             hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {CONF_DEFAULT_INTERFACE: False}}
         )
 
-    mock_async_zeroconf.assert_called_with()
+    assert mock_async_zeroconf.called_with()
 
 
 async def test_setup_without_ipv6(
@@ -283,7 +283,7 @@ async def test_setup_without_ipv6(
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
 
-    mock_async_zeroconf.assert_called_with(ip_version=IPVersion.V4Only)
+    assert mock_async_zeroconf.called_with(ip_version=IPVersion.V4Only)
 
 
 async def test_setup_with_ipv6(hass: HomeAssistant, mock_async_zeroconf: None) -> None:
@@ -300,7 +300,7 @@ async def test_setup_with_ipv6(hass: HomeAssistant, mock_async_zeroconf: None) -
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
 
-    mock_async_zeroconf.assert_called_with()
+    assert mock_async_zeroconf.called_with()
 
 
 async def test_setup_with_ipv6_default(
@@ -317,7 +317,7 @@ async def test_setup_with_ipv6_default(
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
 
-    mock_async_zeroconf.assert_called_with()
+    assert mock_async_zeroconf.called_with()
 
 
 async def test_zeroconf_match_macaddress(


### PR DESCRIPTION
## Proposed change
`called_with` is not a function for `unittest.Mock`. Thus using `assert mock.called_with(some_arg)` doesn't test anything. Instead `mock.assert_called_with(some_arg)` should be used.

https://docs.python.org/3.11/library/unittest.mock.html#unittest.mock.Mock.assert_called_with

_Just found out this will be an error with Python 3.12._
```
AttributeError: 'called_with' is not a valid assertion. Use a spec for the mock if 'called_with' is meant to be an attribute.
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
