### PR TITLE
Add yolink finger support

### DIFF
--- a/homeassistant/components/yolink/__init__.py
+++ b/homeassistant/components/yolink/__init__.py
@@ -129,7 +129,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             device_pairing_mapping[parent_id] = device.device_id
 
     for device in yolink_home.get_devices():
-        paried_device: YoLinkDevice = None
+        paried_device: YoLinkDevice | None = None
         if (
             paried_device_id := device_pairing_mapping.get(device.device_id)
         ) is not None:

--- a/homeassistant/components/yolink/__init__.py
+++ b/homeassistant/components/yolink/__init__.py
@@ -121,8 +121,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         raise ConfigEntryNotReady from err
 
     device_coordinators = {}
+
+    # revese mapping
+    device_pairing_mapping = {}
     for device in yolink_home.get_devices():
-        device_coordinator = YoLinkCoordinator(hass, device)
+        if (parent_id := device.get_paired_device_id()) is not None:
+            device_pairing_mapping[parent_id] = device.device_id
+
+    for device in yolink_home.get_devices():
+        paried_device: YoLinkDevice = None
+        if (
+            paried_device_id := device_pairing_mapping.get(device.device_id)
+        ) is not None:
+            paried_device = yolink_home.get_device(paried_device_id)
+        device_coordinator = YoLinkCoordinator(hass, device, paried_device)
         try:
             await device_coordinator.async_config_entry_first_refresh()
         except ConfigEntryNotReady:

--- a/homeassistant/components/yolink/coordinator.py
+++ b/homeassistant/components/yolink/coordinator.py
@@ -20,7 +20,12 @@ _LOGGER = logging.getLogger(__name__)
 class YoLinkCoordinator(DataUpdateCoordinator[dict]):
     """YoLink DataUpdateCoordinator."""
 
-    def __init__(self, hass: HomeAssistant, device: YoLinkDevice) -> None:
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        device: YoLinkDevice,
+        paired_device: YoLinkDevice | None = None,
+    ) -> None:
         """Init YoLink DataUpdateCoordinator.
 
         fetch state every 30 minutes base on yolink device heartbeat interval
@@ -31,16 +36,30 @@ class YoLinkCoordinator(DataUpdateCoordinator[dict]):
             hass, _LOGGER, name=DOMAIN, update_interval=timedelta(minutes=30)
         )
         self.device = device
+        self.paired_device = paired_device
 
     async def _async_update_data(self) -> dict:
         """Fetch device state."""
         try:
             async with async_timeout.timeout(10):
                 device_state_resp = await self.device.fetch_state()
+                device_state = device_state_resp.data.get(ATTR_DEVICE_STATE)
+                if self.paired_device is not None and device_state is not None:
+                    paried_device_state_resp = await self.paired_device.fetch_state()
+                    paried_device_state = paried_device_state_resp.data.get(
+                        ATTR_DEVICE_STATE
+                    )
+                    if (
+                        paried_device_state is not None
+                        and ATTR_DEVICE_STATE in paried_device_state
+                    ):
+                        device_state[ATTR_DEVICE_STATE] = paried_device_state[
+                            ATTR_DEVICE_STATE
+                        ]
         except YoLinkAuthFailError as yl_auth_err:
             raise ConfigEntryAuthFailed from yl_auth_err
         except YoLinkClientError as yl_client_err:
             raise UpdateFailed from yl_client_err
-        if ATTR_DEVICE_STATE in device_state_resp.data:
-            return device_state_resp.data[ATTR_DEVICE_STATE]
+        if device_state is not None:
+            return device_state
         return {}

--- a/homeassistant/components/yolink/manifest.json
+++ b/homeassistant/components/yolink/manifest.json
@@ -6,5 +6,5 @@
   "dependencies": ["auth", "application_credentials"],
   "documentation": "https://www.home-assistant.io/integrations/yolink",
   "iot_class": "cloud_push",
-  "requirements": ["yolink-api==0.2.9"]
+  "requirements": ["yolink-api==0.3.0"]
 }

--- a/homeassistant/components/yolink/sensor.py
+++ b/homeassistant/components/yolink/sensor.py
@@ -8,6 +8,7 @@ from yolink.const import (
     ATTR_DEVICE_CO_SMOKE_SENSOR,
     ATTR_DEVICE_DIMMER,
     ATTR_DEVICE_DOOR_SENSOR,
+    ATTR_DEVICE_FINGER,
     ATTR_DEVICE_LEAK_SENSOR,
     ATTR_DEVICE_LOCK,
     ATTR_DEVICE_MANIPULATOR,
@@ -67,6 +68,7 @@ class YoLinkSensorEntityDescription(
 SENSOR_DEVICE_TYPE = [
     ATTR_DEVICE_DIMMER,
     ATTR_DEVICE_DOOR_SENSOR,
+    ATTR_DEVICE_FINGER,
     ATTR_DEVICE_LEAK_SENSOR,
     ATTR_DEVICE_MOTION_SENSOR,
     ATTR_DEVICE_MULTI_OUTLET,
@@ -86,6 +88,7 @@ SENSOR_DEVICE_TYPE = [
 
 BATTERY_POWER_SENSOR = [
     ATTR_DEVICE_DOOR_SENSOR,
+    ATTR_DEVICE_FINGER,
     ATTR_DEVICE_LEAK_SENSOR,
     ATTR_DEVICE_MOTION_SENSOR,
     ATTR_DEVICE_POWER_FAILURE_ALARM,
@@ -129,6 +132,7 @@ SENSOR_TYPES: tuple[YoLinkSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         value=cvt_battery,
         exists_fn=lambda device: device.device_type in BATTERY_POWER_SENSOR,
+        should_update_entity=lambda value: value is not None,
     ),
     YoLinkSensorEntityDescription(
         key="humidity",

--- a/homeassistant/components/yolink/switch.py
+++ b/homeassistant/components/yolink/switch.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
+from yolink.client_request import ClientRequest
 from yolink.const import (
     ATTR_DEVICE_MANIPULATOR,
     ATTR_DEVICE_MULTI_OUTLET,
@@ -160,11 +161,17 @@ class YoLinkSwitchEntity(YoLinkEntity, SwitchEntity):
 
     async def call_state_change(self, state: str) -> None:
         """Call setState api to change switch state."""
-        await self.call_device(
-            OutletRequestBuilder.set_state_request(
+        client_request: ClientRequest = None
+        if self.coordinator.device.device_type in [
+            ATTR_DEVICE_OUTLET,
+            ATTR_DEVICE_MULTI_OUTLET,
+        ]:
+            client_request = OutletRequestBuilder.set_state_request(
                 state, self.entity_description.plug_index
             )
-        )
+        else:
+            client_request = ClientRequest("setState", {"state": state})
+        await self.call_device(client_request)
         self._attr_is_on = self._get_state(state, self.entity_description.plug_index)
         self.async_write_ha_state()
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2723,7 +2723,7 @@ yeelight==0.7.12
 yeelightsunflower==0.0.10
 
 # homeassistant.components.yolink
-yolink-api==0.2.9
+yolink-api==0.3.0
 
 # homeassistant.components.youless
 youless-api==1.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1999,7 +1999,7 @@ yalexs==1.5.1
 yeelight==0.7.12
 
 # homeassistant.components.yolink
-yolink-api==0.2.9
+yolink-api==0.3.0
 
 # homeassistant.components.youless
 youless-api==1.0.1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

1. Add yolink finger support
2. Bump yolink api to 0.3.0, Add new device support and upgrade mqtt library version fix  aiomqtt rename waring
    https://github.com/YoSmart-Inc/yolink-api/compare/v0.2.9...v0.3.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request:  https://github.com/home-assistant/home-assistant.io/pull/28260

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
