### PR TITLE
Create an issue if Shelly TRV is not calibrated

### DIFF
--- a/homeassistant/components/shelly/climate.py
+++ b/homeassistant/components/shelly/climate.py
@@ -20,6 +20,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.core import HomeAssistant, State, callback
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -33,7 +34,12 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util.unit_conversion import TemperatureConverter
 from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
-from .const import LOGGER, SHTRV_01_TEMPERATURE_SETTINGS
+from .const import (
+    DOMAIN,
+    LOGGER,
+    NOT_CALIBRATED_ISSUE_ID,
+    SHTRV_01_TEMPERATURE_SETTINGS,
+)
 from .coordinator import ShellyBlockCoordinator, get_entry_data
 
 
@@ -338,6 +344,27 @@ class BlockSleepingClimate(
         if not self.coordinator.device.initialized:
             self.async_write_ha_state()
             return
+
+        if self.coordinator.device.status.get("calibrated") is False:
+            ir.async_create_issue(
+                self.hass,
+                DOMAIN,
+                NOT_CALIBRATED_ISSUE_ID.format(unique=self.coordinator.mac),
+                is_fixable=False,
+                is_persistent=False,
+                severity=ir.IssueSeverity.ERROR,
+                translation_key="device_not_calibrated",
+                translation_placeholders={
+                    "device_name": self.name,
+                    "ip_address": self.coordinator.device.ip_address,
+                },
+            )
+        else:
+            ir.async_delete_issue(
+                self.hass,
+                DOMAIN,
+                NOT_CALIBRATED_ISSUE_ID.format(unique=self.coordinator.mac),
+            )
 
         assert self.coordinator.device.blocks
 

--- a/homeassistant/components/shelly/const.py
+++ b/homeassistant/components/shelly/const.py
@@ -178,3 +178,5 @@ class BLEScannerMode(StrEnum):
 
 MAX_PUSH_UPDATE_FAILURES = 5
 PUSH_UPDATE_ISSUE_ID = "push_update_{unique}"
+
+NOT_CALIBRATED_ISSUE_ID = "not_calibrated_{unique}"

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -120,6 +120,10 @@
     }
   },
   "issues": {
+    "device_not_calibrated": {
+      "title": "Shelly device {device_name} is not calibrated",
+      "description": "Shelly device {device_name} with IP address {ip_address} requires calibration, you can calibrate it in the device's web panel."
+    },
     "push_update_failure": {
       "title": "Shelly device {device_name} push update failure",
       "description": "Home Assistant is not receiving push updates from the Shelly device {device_name} with IP address {ip_address}. Check the CoIoT configuration in the web panel of the device and your network configuration."

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -122,7 +122,7 @@
   "issues": {
     "device_not_calibrated": {
       "title": "Shelly device {device_name} is not calibrated",
-      "description": "Shelly device {device_name} with IP address {ip_address} requires calibration, you can calibrate it in the device's web panel."
+      "description": "Shelly device {device_name} with IP address {ip_address} requires calibration. To calibrate the device, it must be restarted after proper installation on the valve. You can reboot the device in its web panel, go to 'Settings' > 'Device Reboot'."
     },
     "push_update_failure": {
       "title": "Shelly device {device_name} push update failure",

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -122,7 +122,7 @@
   "issues": {
     "device_not_calibrated": {
       "title": "Shelly device {device_name} is not calibrated",
-      "description": "Shelly device {device_name} with IP address {ip_address} requires calibration. To calibrate the device, it must be restarted after proper installation on the valve. You can reboot the device in its web panel, go to 'Settings' > 'Device Reboot'."
+      "description": "Shelly device {device_name} with IP address {ip_address} requires calibration. To calibrate the device, it must be rebooted after proper installation on the valve. You can reboot the device in its web panel, go to 'Settings' > 'Device Reboot'."
     },
     "push_update_failure": {
       "title": "Shelly device {device_name} push update failure",

--- a/tests/components/shelly/test_climate.py
+++ b/tests/components/shelly/test_climate.py
@@ -21,9 +21,11 @@ from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_TEMPERATURE, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant, State
 from homeassistant.exceptions import HomeAssistantError
+import homeassistant.helpers.issue_registry as ir
 from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
-from . import init_integration, register_device, register_entity
+from . import MOCK_MAC, init_integration, register_device, register_entity
+from .conftest import MOCK_STATUS_COAP
 
 from tests.common import mock_restore_cache, mock_restore_cache_with_extra_data
 
@@ -486,3 +488,30 @@ async def test_block_restored_climate_auth_error(
     assert "context" in flow
     assert flow["context"].get("source") == SOURCE_REAUTH
     assert flow["context"].get("entry_id") == entry.entry_id
+
+
+async def test_device_not_calibrated(
+    hass: HomeAssistant, mock_block_device, monkeypatch
+) -> None:
+    """Test to create an issue when the device is not calibrated."""
+    issue_registry: ir.IssueRegistry = ir.async_get(hass)
+
+    await init_integration(hass, 1, sleep_period=1000, model="SHTRV-01")
+
+    # Make device online
+    mock_block_device.mock_update()
+    await hass.async_block_till_done()
+
+    mock_status = MOCK_STATUS_COAP
+    mock_status["calibrated"] = False
+    monkeypatch.setattr(
+        mock_block_device,
+        "status",
+        mock_status,
+    )
+    mock_block_device.mock_update()
+    await hass.async_block_till_done()
+
+    assert issue_registry.async_get_issue(
+        domain=DOMAIN, issue_id=f"not_calibrated_{MOCK_MAC}"
+    )

--- a/tests/components/shelly/test_climate.py
+++ b/tests/components/shelly/test_climate.py
@@ -502,7 +502,7 @@ async def test_device_not_calibrated(
     mock_block_device.mock_update()
     await hass.async_block_till_done()
 
-    mock_status = MOCK_STATUS_COAP
+    mock_status = MOCK_STATUS_COAP.copy()
     mock_status["calibrated"] = False
     monkeypatch.setattr(
         mock_block_device,
@@ -513,5 +513,18 @@ async def test_device_not_calibrated(
     await hass.async_block_till_done()
 
     assert issue_registry.async_get_issue(
+        domain=DOMAIN, issue_id=f"not_calibrated_{MOCK_MAC}"
+    )
+
+    # The device has been calibrated
+    monkeypatch.setattr(
+        mock_block_device,
+        "status",
+        MOCK_STATUS_COAP,
+    )
+    mock_block_device.mock_update()
+    await hass.async_block_till_done()
+
+    assert not issue_registry.async_get_issue(
         domain=DOMAIN, issue_id=f"not_calibrated_{MOCK_MAC}"
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Sometimes users try to configure Shelly TRV when the device is not calibrated (or mounted on a valve) and report that the integration doesn't work. With this change, the integration will notify the user by issue when the device needs to be calibrated.

![Zrzut ekranu 2023-07-20 153549](https://github.com/home-assistant/core/assets/478555/b445383f-05c1-4653-9139-2226d9473f92)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
