### PR TITLE
Add service to OpenAI to Generate an image

### DIFF
--- a/homeassistant/components/openai_conversation/__init__.py
+++ b/homeassistant/components/openai_conversation/__init__.py
@@ -44,6 +44,8 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 SERVICE_GENERATE_IMAGE = "generate_image"
 
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
+
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up OpenAI Conversation."""

--- a/homeassistant/components/openai_conversation/__init__.py
+++ b/homeassistant/components/openai_conversation/__init__.py
@@ -7,13 +7,24 @@ from typing import Literal
 
 import openai
 from openai import error
+import voluptuous as vol
 
 from homeassistant.components import conversation
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_API_KEY, MATCH_ALL
-from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady, TemplateError
-from homeassistant.helpers import intent, template
+from homeassistant.core import (
+    HomeAssistant,
+    ServiceCall,
+    ServiceResponse,
+    SupportsResponse,
+    callback,
+)
+from homeassistant.exceptions import (
+    ConfigEntryNotReady,
+    HomeAssistantError,
+    TemplateError,
+)
+from homeassistant.helpers import config_validation as cv, intent, selector, template
 from homeassistant.util import ulid
 
 from .const import (
@@ -27,18 +38,22 @@ from .const import (
     DEFAULT_PROMPT,
     DEFAULT_TEMPERATURE,
     DEFAULT_TOP_P,
+    DOMAIN,
 )
 
 _LOGGER = logging.getLogger(__name__)
+SERVICE_GENERATE_IMAGE = "generate_image"
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up OpenAI Conversation from a config entry."""
-    openai.api_key = entry.data[CONF_API_KEY]
-
     try:
         await hass.async_add_executor_job(
-            partial(openai.Engine.list, request_timeout=10)
+            partial(
+                openai.Engine.list,
+                api_key=entry.data[CONF_API_KEY],
+                request_timeout=10,
+            )
         )
     except error.AuthenticationError as err:
         _LOGGER.error("Invalid API key: %s", err)
@@ -46,15 +61,57 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     except error.OpenAIError as err:
         raise ConfigEntryNotReady(err) from err
 
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = entry.data[CONF_API_KEY]
+
+    _register_services(hass)
     conversation.async_set_agent(hass, entry, OpenAIAgent(hass, entry))
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload OpenAI."""
-    openai.api_key = None
+    hass.data[DOMAIN].pop(entry.entry_id)
     conversation.async_unset_agent(hass, entry)
     return True
+
+
+@callback
+def _register_services(hass: HomeAssistant) -> None:
+    """Register services if they are not provided yet."""
+    if hass.services.has_service(DOMAIN, SERVICE_GENERATE_IMAGE):
+        return
+
+    async def render_image(call: ServiceCall) -> ServiceResponse:
+        """Render an image with dall-e."""
+        try:
+            response = await openai.Image.acreate(
+                api_key=hass.data[DOMAIN][call.data["config_entry"]],
+                prompt=call.data["prompt"],
+                n=1,
+                size=f'{call.data["size"]}x{call.data["size"]}',
+            )
+        except error.OpenAIError as err:
+            raise HomeAssistantError(f"Error generating image: {err}") from err
+
+        return response["data"][0]
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_GENERATE_IMAGE,
+        render_image,
+        schema=vol.Schema(
+            {
+                vol.Required("config_entry"): selector.ConfigEntrySelector(
+                    {
+                        "integration": DOMAIN,
+                    }
+                ),
+                vol.Required("prompt"): cv.string,
+                vol.Optional("size", default="512"): vol.In(("256", "512", "1024")),
+            }
+        ),
+        supports_response=SupportsResponse.ONLY,
+    )
 
 
 class OpenAIAgent(conversation.AbstractConversationAgent):
@@ -106,6 +163,7 @@ class OpenAIAgent(conversation.AbstractConversationAgent):
 
         try:
             result = await openai.ChatCompletion.acreate(
+                api_key=self.entry.data[CONF_API_KEY],
                 model=model,
                 messages=messages,
                 max_tokens=max_tokens,

--- a/homeassistant/components/openai_conversation/services.yaml
+++ b/homeassistant/components/openai_conversation/services.yaml
@@ -7,7 +7,6 @@ generate_image:
           integration: openai_conversation
     prompt:
       required: true
-      example: "A photo of a dog"
       selector:
         text:
           multiline: true

--- a/homeassistant/components/openai_conversation/services.yaml
+++ b/homeassistant/components/openai_conversation/services.yaml
@@ -1,0 +1,23 @@
+generate_image:
+  fields:
+    config_entry:
+      required: true
+      selector:
+        config_entry:
+          integration: openai_conversation
+    prompt:
+      required: true
+      example: "A photo of a dog"
+      selector:
+        text:
+          multiline: true
+    size:
+      required: true
+      example: "512"
+      default: "512"
+      selector:
+        select:
+          options:
+            - "256"
+            - "512"
+            - "1024"

--- a/homeassistant/components/openai_conversation/strings.json
+++ b/homeassistant/components/openai_conversation/strings.json
@@ -25,5 +25,25 @@
         }
       }
     }
+  },
+  "services": {
+    "generate_image": {
+      "name": "Generate image",
+      "description": "Turn a prompt into an image",
+      "fields": {
+        "config_entry": {
+          "name": "Config Entry",
+          "description": "The config entry to use for this service"
+        },
+        "prompt": {
+          "name": "Prompt",
+          "description": "The text to turn into an image"
+        },
+        "size": {
+          "name": "Size",
+          "description": "The size of the image to generate"
+        }
+      }
+    }
   }
 }

--- a/homeassistant/components/openai_conversation/strings.json
+++ b/homeassistant/components/openai_conversation/strings.json
@@ -37,7 +37,8 @@
         },
         "prompt": {
           "name": "Prompt",
-          "description": "The text to turn into an image"
+          "description": "The text to turn into an image",
+          "example": "A photo of a dog"
         },
         "size": {
           "name": "Size",

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -539,7 +539,7 @@ class ConversationAgentSelectorConfig(TypedDict, total=False):
 
 
 @SELECTORS.register("conversation_agent")
-class COnversationAgentSelector(Selector[ConversationAgentSelectorConfig]):
+class ConversationAgentSelector(Selector[ConversationAgentSelectorConfig]):
     """Selector for a conversation agent."""
 
     selector_type = "conversation_agent"

--- a/tests/components/openai_conversation/test_init.py
+++ b/tests/components/openai_conversation/test_init.py
@@ -2,6 +2,7 @@
 from unittest.mock import patch
 
 from openai import error
+import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components import conversation
@@ -158,3 +159,48 @@ async def test_conversation_agent(
         mock_config_entry.entry_id
     )
     assert agent.supported_languages == "*"
+
+
+@pytest.mark.parametrize(
+    ("service_data", "expected_args"),
+    [
+        (
+            {"prompt": "Picture of a dog"},
+            {"prompt": "Picture of a dog", "size": "512x512"},
+        ),
+        (
+            {"prompt": "Picture of a dog", "size": "256"},
+            {"prompt": "Picture of a dog", "size": "256x256"},
+        ),
+        (
+            {"prompt": "Picture of a dog", "size": "1024"},
+            {"prompt": "Picture of a dog", "size": "1024x1024"},
+        ),
+    ],
+)
+async def test_generate_image_service(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_init_component,
+    service_data,
+    expected_args,
+) -> None:
+    """Test generate image service."""
+    service_data["config_entry"] = mock_config_entry.entry_id
+    expected_args["api_key"] = mock_config_entry.data["api_key"]
+    expected_args["n"] = 1
+
+    with patch(
+        "openai.Image.acreate", return_value={"data": [{"url": "A"}]}
+    ) as mock_create:
+        response = await hass.services.async_call(
+            "openai_conversation",
+            "generate_image",
+            service_data,
+            blocking=True,
+            return_response=True,
+        )
+
+    assert response == {"url": "A"}
+    assert len(mock_create.mock_calls) == 1
+    assert mock_create.mock_calls[0][2] == expected_args


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add a new service with response value to the OpenAI integration to generate an image.

Use it with this script + template image combo:

```yaml
script:
  update_image:
    alias: Update image
    sequence:
    - service: openai_conversation.generate_image
      data:
        size: '512'
        config_entry: f29e6b8696a15e107b4bd843de722249
        prompt: New York when the weather is {{ states.weather.forecast_home.state }}
      response_variable: result
    - event: new_image
      event_data:
        url: '{{ result.url }}'
    mode: single

template:
  trigger:
    platform: event
    event_type: new_image
  image:
    name: Generated
    url: "{{ trigger.event.data.url }}"
```

![CleanShot 2023-07-21 at 13 45 26](https://github.com/home-assistant/core/assets/1444314/270a4529-a02c-4cd1-8863-e464074cccb2)

Raw response:

![CleanShot 2023-07-21 at 10 15 04](https://github.com/home-assistant/core/assets/1444314/cc7cbf5a-a4eb-4d3f-99d1-789ff2d70915)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
