### PR TITLE
Remove hourly weather entity from met.no

### DIFF
--- a/homeassistant/components/met/weather.py
+++ b/homeassistant/components/met/weather.py
@@ -68,16 +68,15 @@ async def async_setup_entry(
         if TYPE_CHECKING:
             assert isinstance(name, str)
 
-    entities = [MetWeather(coordinator, config_entry, False, name, is_metric)]
+    entities = [MetWeather(coordinator, config_entry, name, is_metric)]
 
-    # Add hourly entity to legacy config entries
-    if entity_registry.async_get_entity_id(
+    # Remove hourly entity from legacy config entries
+    if hourly_entity_id := entity_registry.async_get_entity_id(
         WEATHER_DOMAIN,
         DOMAIN,
         _calculate_unique_id(config_entry.data, True),
     ):
-        name = f"{name} hourly"
-        entities.append(MetWeather(coordinator, config_entry, True, name, is_metric))
+        entity_registry.async_remove(hourly_entity_id)
 
     async_add_entities(entities)
 
@@ -121,17 +120,14 @@ class MetWeather(SingleCoordinatorWeatherEntity[MetDataUpdateCoordinator]):
         self,
         coordinator: MetDataUpdateCoordinator,
         config_entry: ConfigEntry,
-        hourly: bool,
         name: str,
         is_metric: bool,
     ) -> None:
         """Initialise the platform with a data instance and site."""
         super().__init__(coordinator)
-        self._attr_unique_id = _calculate_unique_id(config_entry.data, hourly)
+        self._attr_unique_id = _calculate_unique_id(config_entry.data, False)
         self._config = config_entry.data
         self._is_metric = is_metric
-        self._hourly = hourly
-        self._attr_entity_registry_enabled_default = not hourly
         self._attr_device_info = DeviceInfo(
             name="Forecast",
             entry_type=DeviceEntryType.SERVICE,
@@ -237,7 +233,7 @@ class MetWeather(SingleCoordinatorWeatherEntity[MetDataUpdateCoordinator]):
     @property
     def forecast(self) -> list[Forecast] | None:
         """Return the forecast array."""
-        return self._forecast(self._hourly)
+        return self._forecast(False)
 
     @callback
     def _async_forecast_daily(self) -> list[Forecast] | None:

--- a/tests/components/met/test_weather.py
+++ b/tests/components/met/test_weather.py
@@ -29,10 +29,10 @@ async def test_legacy_config_entry(
     )
     await hass.config_entries.flow.async_init("met", context={"source": "onboarding"})
     await hass.async_block_till_done()
-    assert len(hass.states.async_entity_ids("weather")) == 2
+    assert len(hass.states.async_entity_ids("weather")) == 1
 
     entry = hass.config_entries.async_entries()[0]
-    assert len(er.async_entries_for_config_entry(entity_registry, entry.entry_id)) == 2
+    assert len(er.async_entries_for_config_entry(entity_registry, entry.entry_id)) == 1
 
 
 async def test_tracking_home(hass: HomeAssistant, mock_weather) -> None:
@@ -81,3 +81,27 @@ async def test_not_tracking_home(hass: HomeAssistant, mock_weather) -> None:
     await hass.config_entries.async_remove(entry.entry_id)
     await hass.async_block_till_done()
     assert len(hass.states.async_entity_ids("weather")) == 0
+
+
+async def test_remove_hourly_entity(hass: HomeAssistant, mock_weather) -> None:
+    """Test removing the hourly entity."""
+
+    # Pre-create registry entry for disabled by default hourly weather
+    registry = er.async_get(hass)
+    registry.async_get_or_create(
+        WEATHER_DOMAIN,
+        DOMAIN,
+        "10-20-hourly",
+        suggested_object_id="forecast_somewhere_hourly",
+        disabled_by=None,
+    )
+    assert list(registry.entities.keys()) == ["weather.forecast_somewhere_hourly"]
+
+    await hass.config_entries.flow.async_init(
+        "met",
+        context={"source": config_entries.SOURCE_USER},
+        data={"name": "Somewhere", "latitude": 10, "longitude": 20, "elevation": 0},
+    )
+    await hass.async_block_till_done()
+    assert hass.states.async_entity_ids("weather") == ["weather.forecast_somewhere"]
+    assert list(registry.entities.keys()) == ["weather.forecast_somewhere"]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The `met.no` integration previously created two entities for each configured location, one entity which provided daily weather forecasts and one entity which provided hourly forecasts. The `met.no` integration now only creates a single entity which provides both daily and hourly weather forecasts.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove the hourly weather entity from met.no and instead provide hourly + daily forecasts in one entity

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
