### PR TITLE
Add Pegel Online integration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -918,6 +918,7 @@ build.json @home-assistant/supervisor
 /homeassistant/components/peco/ @IceBotYT
 /tests/components/peco/ @IceBotYT
 /homeassistant/components/pegel_online/ @mib1185
+/tests/components/pegel_online/ @mib1185
 /homeassistant/components/persistent_notification/ @home-assistant/core
 /tests/components/persistent_notification/ @home-assistant/core
 /homeassistant/components/philips_js/ @elupus

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -917,6 +917,7 @@ build.json @home-assistant/supervisor
 /tests/components/panel_iframe/ @home-assistant/frontend
 /homeassistant/components/peco/ @IceBotYT
 /tests/components/peco/ @IceBotYT
+/homeassistant/components/pegel_online/ @mib1185
 /homeassistant/components/persistent_notification/ @home-assistant/core
 /tests/components/persistent_notification/ @home-assistant/core
 /homeassistant/components/philips_js/ @elupus

--- a/homeassistant/components/pegel_online/__init__.py
+++ b/homeassistant/components/pegel_online/__init__.py
@@ -1,4 +1,4 @@
-"""The pegel_online component."""
+"""The PEGELONLINE component."""
 from __future__ import annotations
 
 import logging
@@ -27,7 +27,7 @@ PLATFORMS = [Platform.SENSOR]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Set up pegel_online entry."""
+    """Set up PEGELONLINE entry."""
     station_uuid = entry.data[CONF_STATION]
     name = entry.title
 
@@ -64,7 +64,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Unload pegel_online entry."""
+    """Unload PEGELONLINE entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id)

--- a/homeassistant/components/pegel_online/__init__.py
+++ b/homeassistant/components/pegel_online/__init__.py
@@ -1,0 +1,71 @@
+"""The pegel_online component."""
+from __future__ import annotations
+
+import logging
+
+from aiopegelonline import CONNECT_ERRORS, PegelOnline
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.update_coordinator import (
+    DataUpdateCoordinator,
+    UpdateFailed,
+)
+
+from .const import (
+    CONF_STATION,
+    DOMAIN,
+    MIN_TIME_BETWEEN_UPDATES,
+)
+from .model import PegelOnlineData
+
+_LOGGER = logging.getLogger(__name__)
+
+PLATFORMS = [Platform.SENSOR]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up pegel_online entry."""
+    station_uuid = entry.data[CONF_STATION]
+    name = entry.title
+
+    _LOGGER.debug("Setting up station with uuid %s", station_uuid)
+
+    api = PegelOnline(async_get_clientsession(hass))
+    station = await api.async_get_station_details(station_uuid)
+
+    async def async_update_data() -> PegelOnlineData:
+        """Fetch data from API endpoint."""
+        try:
+            current_measurement = await api.async_get_station_measurement(station_uuid)
+        except CONNECT_ERRORS as err:
+            raise UpdateFailed(f"Failed to communicate with API: {err}") from err
+
+        return {"current_measurement": current_measurement}
+
+    coordinator = DataUpdateCoordinator(
+        hass,
+        _LOGGER,
+        name=name,
+        update_method=async_update_data,
+        update_interval=MIN_TIME_BETWEEN_UPDATES,
+    )
+
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][entry.entry_id] = (coordinator, station)
+
+    await coordinator.async_config_entry_first_refresh()
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload pegel_online entry."""
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id)
+    return unload_ok

--- a/homeassistant/components/pegel_online/__init__.py
+++ b/homeassistant/components/pegel_online/__init__.py
@@ -3,23 +3,18 @@ from __future__ import annotations
 
 import logging
 
-from aiopegelonline import CONNECT_ERRORS, PegelOnline
+from aiopegelonline import PegelOnline
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.update_coordinator import (
-    DataUpdateCoordinator,
-    UpdateFailed,
-)
 
 from .const import (
     CONF_STATION,
     DOMAIN,
-    MIN_TIME_BETWEEN_UPDATES,
 )
-from .model import PegelOnlineData
+from .coordinator import PegelOnlineDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,34 +24,18 @@ PLATFORMS = [Platform.SENSOR]
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up PEGELONLINE entry."""
     station_uuid = entry.data[CONF_STATION]
-    name = entry.title
 
     _LOGGER.debug("Setting up station with uuid %s", station_uuid)
 
     api = PegelOnline(async_get_clientsession(hass))
     station = await api.async_get_station_details(station_uuid)
 
-    async def async_update_data() -> PegelOnlineData:
-        """Fetch data from API endpoint."""
-        try:
-            current_measurement = await api.async_get_station_measurement(station_uuid)
-        except CONNECT_ERRORS as err:
-            raise UpdateFailed(f"Failed to communicate with API: {err}") from err
-
-        return {"current_measurement": current_measurement}
-
-    coordinator = DataUpdateCoordinator(
-        hass,
-        _LOGGER,
-        name=name,
-        update_method=async_update_data,
-        update_interval=MIN_TIME_BETWEEN_UPDATES,
-    )
-
-    hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = (coordinator, station)
+    coordinator = PegelOnlineDataUpdateCoordinator(hass, entry.title, api, station)
 
     await coordinator.async_config_entry_first_refresh()
+
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][entry.entry_id] = coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
@@ -65,7 +44,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload PEGELONLINE entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-    if unload_ok:
+    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         hass.data[DOMAIN].pop(entry.entry_id)
     return unload_ok

--- a/homeassistant/components/pegel_online/config_flow.py
+++ b/homeassistant/components/pegel_online/config_flow.py
@@ -1,0 +1,134 @@
+"""Config flow for pegel_online."""
+from __future__ import annotations
+
+from typing import Any
+
+from aiopegelonline import CONNECT_ERRORS, PegelOnline
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import (
+    CONF_LATITUDE,
+    CONF_LOCATION,
+    CONF_LONGITUDE,
+    CONF_RADIUS,
+    UnitOfLength,
+)
+from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.selector import (
+    LocationSelector,
+    NumberSelector,
+    NumberSelectorConfig,
+    SelectOptionDict,
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+)
+
+from .const import CONF_STATION, DEFAULT_RADIUS, DOMAIN
+
+
+class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow."""
+
+    VERSION = 1
+
+    def __init__(self) -> None:
+        """Init the FlowHandler."""
+        super().__init__()
+        self._data: dict[str, Any] = {}
+        self._stations: dict[str, str] = {}
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle a flow initialized by the user."""
+        if not user_input:
+            return self._show_form_user()
+
+        api = PegelOnline(async_get_clientsession(self.hass))
+        try:
+            stations = await api.async_get_nearby_stations(
+                user_input[CONF_LOCATION][CONF_LATITUDE],
+                user_input[CONF_LOCATION][CONF_LONGITUDE],
+                user_input[CONF_RADIUS],
+            )
+        except CONNECT_ERRORS:
+            return self._show_form_user(user_input, errors={"base": "cannot_connect"})
+
+        if len(stations) == 0:
+            return self._show_form_user(user_input, errors={CONF_RADIUS: "no_stations"})
+
+        for uuid, station in stations.items():
+            self._stations[uuid] = f"{station.name} {station.water_name}"
+
+        self._data = user_input
+
+        return await self.async_step_select_station()
+
+    async def async_step_select_station(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle the step select_station of a flow initialized by the user."""
+        if not user_input:
+            stations = [
+                SelectOptionDict(value=k, label=v) for k, v in self._stations.items()
+            ]
+            return self.async_show_form(
+                step_id="select_station",
+                description_placeholders={"stations_count": str(len(self._stations))},
+                data_schema=vol.Schema(
+                    {
+                        vol.Required(CONF_STATION): SelectSelector(
+                            SelectSelectorConfig(
+                                options=stations, mode=SelectSelectorMode.DROPDOWN
+                            )
+                        )
+                    }
+                ),
+            )
+
+        await self.async_set_unique_id(user_input[CONF_STATION])
+        self._abort_if_unique_id_configured()
+
+        return self.async_create_entry(
+            title=self._stations[user_input[CONF_STATION]],
+            data=user_input,
+        )
+
+    def _show_form_user(
+        self,
+        user_input: dict[str, Any] | None = None,
+        errors: dict[str, Any] | None = None,
+    ) -> FlowResult:
+        if user_input is None:
+            user_input = {}
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_LOCATION,
+                        default=user_input.get(
+                            CONF_LOCATION,
+                            {
+                                "latitude": self.hass.config.latitude,
+                                "longitude": self.hass.config.longitude,
+                            },
+                        ),
+                    ): LocationSelector(),
+                    vol.Required(
+                        CONF_RADIUS, default=user_input.get(CONF_RADIUS, DEFAULT_RADIUS)
+                    ): NumberSelector(
+                        NumberSelectorConfig(
+                            min=1,
+                            max=100,
+                            step=1,
+                            unit_of_measurement=UnitOfLength.KILOMETERS,
+                        ),
+                    ),
+                }
+            ),
+            errors=errors,
+        )

--- a/homeassistant/components/pegel_online/config_flow.py
+++ b/homeassistant/components/pegel_online/config_flow.py
@@ -1,4 +1,4 @@
-"""Config flow for pegel_online."""
+"""Config flow for PEGELONLINE."""
 from __future__ import annotations
 
 from typing import Any

--- a/homeassistant/components/pegel_online/const.py
+++ b/homeassistant/components/pegel_online/const.py
@@ -1,4 +1,4 @@
-"""Constants for pegel_online."""
+"""Constants for PEGELONLINE."""
 from datetime import timedelta
 
 DOMAIN = "pegel_online"

--- a/homeassistant/components/pegel_online/const.py
+++ b/homeassistant/components/pegel_online/const.py
@@ -1,0 +1,9 @@
+"""Constants for pegel_online."""
+from datetime import timedelta
+
+DOMAIN = "pegel_online"
+
+DEFAULT_RADIUS = "25"
+CONF_STATION = "station"
+
+MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=5)

--- a/homeassistant/components/pegel_online/coordinator.py
+++ b/homeassistant/components/pegel_online/coordinator.py
@@ -1,0 +1,40 @@
+"""DataUpdateCoordinator for pegel_online."""
+import logging
+
+from aiopegelonline import CONNECT_ERRORS, PegelOnline, Station
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import MIN_TIME_BETWEEN_UPDATES
+from .model import PegelOnlineData
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class PegelOnlineDataUpdateCoordinator(DataUpdateCoordinator[PegelOnlineData]):
+    """DataUpdateCoordinator for the pegel_online integration."""
+
+    def __init__(
+        self, hass: HomeAssistant, name: str, api: PegelOnline, station: Station
+    ) -> None:
+        """Initialize the PegelOnlineDataUpdateCoordinator."""
+        self.api = api
+        self.station = station
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=name,
+            update_interval=MIN_TIME_BETWEEN_UPDATES,
+        )
+
+    async def _async_update_data(self) -> PegelOnlineData:
+        """Fetch data from API endpoint."""
+        try:
+            current_measurement = await self.api.async_get_station_measurement(
+                self.station.uuid
+            )
+        except CONNECT_ERRORS as err:
+            raise UpdateFailed(f"Failed to communicate with API: {err}") from err
+
+        return {"current_measurement": current_measurement}

--- a/homeassistant/components/pegel_online/entity.py
+++ b/homeassistant/components/pegel_online/entity.py
@@ -1,4 +1,4 @@
-"""The pegel_online base entity."""
+"""The PEGELONLINE base entity."""
 from __future__ import annotations
 
 from aiopegelonline import Station
@@ -14,7 +14,7 @@ from .model import PegelOnlineData
 
 
 class PegelOnlineEntity(CoordinatorEntity):
-    """Representation of a pegel_online entity."""
+    """Representation of a PEGELONLINE entity."""
 
     _attr_has_entity_name = True
     _attr_available = True
@@ -22,7 +22,7 @@ class PegelOnlineEntity(CoordinatorEntity):
     def __init__(
         self, coordinator: DataUpdateCoordinator[PegelOnlineData], station: Station
     ) -> None:
-        """Initialize a pegel_online entity."""
+        """Initialize a PEGELONLINE entity."""
         super().__init__(coordinator)
         self.station = station
         self._attr_extra_state_attributes = {}

--- a/homeassistant/components/pegel_online/entity.py
+++ b/homeassistant/components/pegel_online/entity.py
@@ -34,4 +34,5 @@ class PegelOnlineEntity(CoordinatorEntity):
             identifiers={(DOMAIN, self.station.uuid)},
             name=f"{self.station.name} {self.station.water_name}",
             manufacturer=self.station.agency,
+            configuration_url=self.station.base_data_url,
         )

--- a/homeassistant/components/pegel_online/entity.py
+++ b/homeassistant/components/pegel_online/entity.py
@@ -1,0 +1,37 @@
+"""The pegel_online base entity."""
+from __future__ import annotations
+
+from aiopegelonline import Station
+
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+)
+
+from .const import DOMAIN
+from .model import PegelOnlineData
+
+
+class PegelOnlineEntity(CoordinatorEntity):
+    """Representation of a pegel_online entity."""
+
+    _attr_has_entity_name = True
+    _attr_available = True
+
+    def __init__(
+        self, coordinator: DataUpdateCoordinator[PegelOnlineData], station: Station
+    ) -> None:
+        """Initialize a pegel_online entity."""
+        super().__init__(coordinator)
+        self.station = station
+        self._attr_extra_state_attributes = {}
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device information of the entity."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self.station.uuid)},
+            name=f"{self.station.name} {self.station.water_name}",
+            manufacturer=self.station.agency,
+        )

--- a/homeassistant/components/pegel_online/entity.py
+++ b/homeassistant/components/pegel_online/entity.py
@@ -1,16 +1,11 @@
 """The PEGELONLINE base entity."""
 from __future__ import annotations
 
-from aiopegelonline import Station
-
 from homeassistant.helpers.entity import DeviceInfo
-from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
-    DataUpdateCoordinator,
-)
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
-from .model import PegelOnlineData
+from .coordinator import PegelOnlineDataUpdateCoordinator
 
 
 class PegelOnlineEntity(CoordinatorEntity):
@@ -19,12 +14,10 @@ class PegelOnlineEntity(CoordinatorEntity):
     _attr_has_entity_name = True
     _attr_available = True
 
-    def __init__(
-        self, coordinator: DataUpdateCoordinator[PegelOnlineData], station: Station
-    ) -> None:
+    def __init__(self, coordinator: PegelOnlineDataUpdateCoordinator) -> None:
         """Initialize a PEGELONLINE entity."""
         super().__init__(coordinator)
-        self.station = station
+        self.station = coordinator.station
         self._attr_extra_state_attributes = {}
 
     @property

--- a/homeassistant/components/pegel_online/manifest.json
+++ b/homeassistant/components/pegel_online/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "loggers": ["aiopegelonline"],
-  "requirements": ["aiopegelonline==0.0.4"]
+  "requirements": ["aiopegelonline==0.0.5"]
 }

--- a/homeassistant/components/pegel_online/manifest.json
+++ b/homeassistant/components/pegel_online/manifest.json
@@ -1,0 +1,11 @@
+{
+  "domain": "pegel_online",
+  "name": "PEGELONLINE",
+  "codeowners": ["@mib1185"],
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/integrations/pegel_online",
+  "integration_type": "service",
+  "iot_class": "cloud_polling",
+  "loggers": ["aiopegelonline"],
+  "requirements": ["aiopegelonline==0.0.4"]
+}

--- a/homeassistant/components/pegel_online/model.py
+++ b/homeassistant/components/pegel_online/model.py
@@ -1,0 +1,11 @@
+"""Models for pegel_online."""
+
+from typing import TypedDict
+
+from aiopegelonline import CurrentMeasurement
+
+
+class PegelOnlineData(TypedDict):
+    """TypedDict for pegel_online Coordinator Data."""
+
+    current_measurement: CurrentMeasurement

--- a/homeassistant/components/pegel_online/model.py
+++ b/homeassistant/components/pegel_online/model.py
@@ -1,4 +1,4 @@
-"""Models for pegel_online."""
+"""Models for PEGELONLINE."""
 
 from typing import TypedDict
 
@@ -6,6 +6,6 @@ from aiopegelonline import CurrentMeasurement
 
 
 class PegelOnlineData(TypedDict):
-    """TypedDict for pegel_online Coordinator Data."""
+    """TypedDict for PEGELONLINE Coordinator Data."""
 
     current_measurement: CurrentMeasurement

--- a/homeassistant/components/pegel_online/sensor.py
+++ b/homeassistant/components/pegel_online/sensor.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 
-from aiopegelonline import Station
-
 from homeassistant.components.sensor import (
     SensorEntity,
     SensorEntityDescription,
@@ -15,10 +13,9 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import StateType
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import DOMAIN
+from .coordinator import PegelOnlineDataUpdateCoordinator
 from .entity import PegelOnlineEntity
 from .model import PegelOnlineData
 
@@ -28,7 +25,7 @@ class PegelOnlineRequiredKeysMixin:
     """Mixin for required keys."""
 
     fn_native_unit: Callable[[PegelOnlineData], str]
-    fn_native_value: Callable[[PegelOnlineData], StateType]
+    fn_native_value: Callable[[PegelOnlineData], float]
 
 
 @dataclass
@@ -54,12 +51,9 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up the PEGELONLINE sensor."""
-    (coordinator, station) = hass.data[DOMAIN][entry.entry_id]
+    coordinator = hass.data[DOMAIN][entry.entry_id]
     async_add_entities(
-        [
-            PegelOnlineSensor(coordinator, station, description)
-            for description in SENSORS
-        ]
+        [PegelOnlineSensor(coordinator, description) for description in SENSORS]
     )
 
 
@@ -70,24 +64,26 @@ class PegelOnlineSensor(PegelOnlineEntity, SensorEntity):
 
     def __init__(
         self,
-        coordinator: DataUpdateCoordinator,
-        station: Station,
+        coordinator: PegelOnlineDataUpdateCoordinator,
         description: PegelOnlineSensorEntityDescription,
     ) -> None:
         """Initialize a PEGELONLINE sensor."""
-        super().__init__(coordinator, station)
+        super().__init__(coordinator)
         self.entity_description = description
-        self._attr_unique_id = f"{station.uuid}/{description.key}"
+        self._attr_unique_id = f"{self.station.uuid}_{description.key}"
         self._attr_native_unit_of_measurement = self.entity_description.fn_native_unit(
             coordinator.data
         )
 
-        if station.latitude and station.longitude:
+        if self.station.latitude and self.station.longitude:
             self._attr_extra_state_attributes.update(
-                {ATTR_LATITUDE: station.latitude, ATTR_LONGITUDE: station.longitude}
+                {
+                    ATTR_LATITUDE: self.station.latitude,
+                    ATTR_LONGITUDE: self.station.longitude,
+                }
             )
 
     @property
-    def native_value(self) -> StateType:
+    def native_value(self) -> float:
         """Return the state of the device."""
         return self.entity_description.fn_native_value(self.coordinator.data)

--- a/homeassistant/components/pegel_online/sensor.py
+++ b/homeassistant/components/pegel_online/sensor.py
@@ -1,4 +1,4 @@
-"""pegel_online sensor entities."""
+"""PEGELONLINE sensor entities."""
 from __future__ import annotations
 
 from collections.abc import Callable
@@ -35,7 +35,7 @@ class PegelOnlineRequiredKeysMixin:
 class PegelOnlineSensorEntityDescription(
     SensorEntityDescription, PegelOnlineRequiredKeysMixin
 ):
-    """Generic pegel_online entity description."""
+    """PEGELONLINE sensor entity description."""
 
 
 SENSORS: tuple[PegelOnlineSensorEntityDescription, ...] = (
@@ -53,7 +53,7 @@ SENSORS: tuple[PegelOnlineSensorEntityDescription, ...] = (
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
-    """Set up the Pi-hole sensor."""
+    """Set up the PEGELONLINE sensor."""
     (coordinator, station) = hass.data[DOMAIN][entry.entry_id]
     async_add_entities(
         [
@@ -64,7 +64,7 @@ async def async_setup_entry(
 
 
 class PegelOnlineSensor(PegelOnlineEntity, SensorEntity):
-    """Representation of a pegel_online sensor."""
+    """Representation of a PEGELONLINE sensor."""
 
     entity_description: PegelOnlineSensorEntityDescription
 
@@ -74,7 +74,7 @@ class PegelOnlineSensor(PegelOnlineEntity, SensorEntity):
         station: Station,
         description: PegelOnlineSensorEntityDescription,
     ) -> None:
-        """Initialize a pegel_online sensor."""
+        """Initialize a PEGELONLINE sensor."""
         super().__init__(coordinator, station)
         self.entity_description = description
         self._attr_unique_id = f"{station.uuid}/{description.key}"

--- a/homeassistant/components/pegel_online/strings.json
+++ b/homeassistant/components/pegel_online/strings.json
@@ -1,0 +1,34 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "description": "Select the area, where you want to search for water measuring stations",
+        "data": {
+          "location": "[%key:common::config_flow::data::location%]",
+          "radius": "Search radius (in km)"
+        }
+      },
+      "select_station": {
+        "title": "Select the measuring station to add",
+        "description": "Found {stations_count} stations in radius",
+        "data": {
+          "station": "Station"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "no_stations": "Could not find any station in range."
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_service%]"
+    }
+  },
+  "entity": {
+    "sensor": {
+      "current_measurement": {
+        "name": "Water level"
+      }
+    }
+  }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -335,6 +335,7 @@ FLOWS = {
         "p1_monitor",
         "panasonic_viera",
         "peco",
+        "pegel_online",
         "philips_js",
         "pi_hole",
         "picnic",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -4124,6 +4124,12 @@
       "config_flow": true,
       "iot_class": "cloud_polling"
     },
+    "pegel_online": {
+      "name": "PEGELONLINE",
+      "integration_type": "service",
+      "config_flow": true,
+      "iot_class": "cloud_polling"
+    },
     "pencom": {
       "name": "Pencom",
       "integration_type": "hub",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -304,7 +304,7 @@ aiooncue==0.3.5
 aioopenexchangerates==0.4.0
 
 # homeassistant.components.pegel_online
-aiopegelonline==0.0.4
+aiopegelonline==0.0.5
 
 # homeassistant.components.acmeda
 aiopulse==0.4.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -303,6 +303,9 @@ aiooncue==0.3.5
 # homeassistant.components.openexchangerates
 aioopenexchangerates==0.4.0
 
+# homeassistant.components.pegel_online
+aiopegelonline==0.0.4
+
 # homeassistant.components.acmeda
 aiopulse==0.4.3
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -278,6 +278,9 @@ aiooncue==0.3.5
 # homeassistant.components.openexchangerates
 aioopenexchangerates==0.4.0
 
+# homeassistant.components.pegel_online
+aiopegelonline==0.0.4
+
 # homeassistant.components.acmeda
 aiopulse==0.4.3
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -279,7 +279,7 @@ aiooncue==0.3.5
 aioopenexchangerates==0.4.0
 
 # homeassistant.components.pegel_online
-aiopegelonline==0.0.4
+aiopegelonline==0.0.5
 
 # homeassistant.components.acmeda
 aiopulse==0.4.3

--- a/tests/components/pegel_online/__init__.py
+++ b/tests/components/pegel_online/__init__.py
@@ -1,23 +1,40 @@
 """Tests for Pegel Online component."""
-from unittest.mock import AsyncMock, MagicMock
 
 
-def _create_mocked_pegelonline(
-    nearby_stations=None,
-    station_details=None,
-    station_measurement=None,
-    side_effect=None,
-):
-    mocked_pegelonline = MagicMock()
-    type(mocked_pegelonline).async_get_nearby_stations = AsyncMock(
-        return_value=nearby_stations, side_effect=side_effect
-    )
-    type(mocked_pegelonline).async_get_station_details = AsyncMock(
-        return_value=station_details, side_effect=side_effect
-    )
+class PegelOnlineMock:
+    """Class mock of PegelOnline."""
 
-    type(mocked_pegelonline).async_get_station_measurement = AsyncMock(
-        return_value=station_measurement, side_effect=side_effect
-    )
+    def __init__(
+        self,
+        nearby_stations=None,
+        station_details=None,
+        station_measurement=None,
+        side_effect=None,
+    ) -> None:
+        """Init the mock."""
+        self.nearby_stations = nearby_stations
+        self.station_details = station_details
+        self.station_measurement = station_measurement
+        self.side_effect = side_effect
 
-    return mocked_pegelonline
+    async def async_get_nearby_stations(self, *args):
+        """Mock async_get_nearby_stations."""
+        if self.side_effect:
+            raise self.side_effect
+        return self.nearby_stations
+
+    async def async_get_station_details(self, *args):
+        """Mock async_get_station_details."""
+        if self.side_effect:
+            raise self.side_effect
+        return self.station_details
+
+    async def async_get_station_measurement(self, *args):
+        """Mock async_get_station_measurement."""
+        if self.side_effect:
+            raise self.side_effect
+        return self.station_measurement
+
+    def override_side_effect(self, side_effect):
+        """Override the side_effect."""
+        self.side_effect = side_effect

--- a/tests/components/pegel_online/__init__.py
+++ b/tests/components/pegel_online/__init__.py
@@ -1,0 +1,23 @@
+"""Tests for Pegel Online component."""
+from unittest.mock import AsyncMock, MagicMock
+
+
+def _create_mocked_pegelonline(
+    nearby_stations=None,
+    station_details=None,
+    station_measurement=None,
+    side_effect=None,
+):
+    mocked_pegelonline = MagicMock()
+    type(mocked_pegelonline).async_get_nearby_stations = AsyncMock(
+        return_value=nearby_stations, side_effect=side_effect
+    )
+    type(mocked_pegelonline).async_get_station_details = AsyncMock(
+        return_value=station_details, side_effect=side_effect
+    )
+
+    type(mocked_pegelonline).async_get_station_measurement = AsyncMock(
+        return_value=station_measurement, side_effect=side_effect
+    )
+
+    return mocked_pegelonline

--- a/tests/components/pegel_online/test_config_flow.py
+++ b/tests/components/pegel_online/test_config_flow.py
@@ -1,0 +1,157 @@
+"""Tests for Pegel Online config flow."""
+from unittest.mock import patch
+
+from aiohttp.client_exceptions import ClientError
+from aiopegelonline import Station
+
+from homeassistant.components.pegel_online.const import (
+    CONF_STATION,
+    DOMAIN,
+)
+from homeassistant.config_entries import SOURCE_USER
+from homeassistant.const import (
+    CONF_LATITUDE,
+    CONF_LOCATION,
+    CONF_LONGITUDE,
+    CONF_RADIUS,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from . import _create_mocked_pegelonline
+
+from tests.common import MockConfigEntry
+
+MOCK_USER_DATA_STEP1 = {
+    CONF_LOCATION: {CONF_LATITUDE: 51.0, CONF_LONGITUDE: 13.0},
+    CONF_RADIUS: 25,
+}
+
+MOCK_USER_DATA_STEP2 = {CONF_STATION: "3bcd61da-xxxx-xxxx-xxxx-19d5523a7ae8"}
+
+MOCK_CONFIG_ENTRY_DATA = {CONF_STATION: "3bcd61da-xxxx-xxxx-xxxx-19d5523a7ae8"}
+
+MOCK_NEARBY_STATIONS = {
+    "3bcd61da-xxxx-xxxx-xxxx-19d5523a7ae8": Station(
+        "3bcd61da-xxxx-xxxx-xxxx-19d5523a7ae8",
+        "DRESDEN",
+        "STANDORT DRESDEN",
+        55.63,
+        13.475467710324812,
+        51.16440557554545,
+        "ELBE",
+    ),
+    "85d686f1-xxxx-xxxx-xxxx-3207b50901a7": Station(
+        "85d686f1-xxxx-xxxx-xxxx-3207b50901a7",
+        "MEISSEN",
+        "STANDORT DRESDEN",
+        82.2,
+        13.738831783620384,
+        51.054459765598125,
+        "ELBE",
+    ),
+}
+
+
+async def test_user(hass: HomeAssistant) -> None:
+    """Test starting a flow by user."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    with patch(
+        "homeassistant.components.pegel_online.async_setup_entry", return_value=True
+    ) as mock_setup_entry, patch(
+        "homeassistant.components.pegel_online.config_flow.PegelOnline",
+        return_value=_create_mocked_pegelonline(nearby_stations=MOCK_NEARBY_STATIONS),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input=MOCK_USER_DATA_STEP1
+        )
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "select_station"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input=MOCK_USER_DATA_STEP2
+        )
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["data"][CONF_STATION] == "3bcd61da-xxxx-xxxx-xxxx-19d5523a7ae8"
+        assert result["title"] == "DRESDEN ELBE"
+
+        await hass.async_block_till_done()
+
+    assert mock_setup_entry.called
+
+
+async def test_user_already_configured(hass: HomeAssistant) -> None:
+    """Test starting a flow by user with an already configured statioon."""
+    mock_config = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_CONFIG_ENTRY_DATA,
+        unique_id=MOCK_CONFIG_ENTRY_DATA[CONF_STATION],
+    )
+    mock_config.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    with patch(
+        "homeassistant.components.pegel_online.config_flow.PegelOnline",
+        return_value=_create_mocked_pegelonline(nearby_stations=MOCK_NEARBY_STATIONS),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input=MOCK_USER_DATA_STEP1
+        )
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "select_station"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input=MOCK_USER_DATA_STEP2
+        )
+        assert result["type"] == FlowResultType.ABORT
+        assert result["reason"] == "already_configured"
+
+
+async def test_connection_error(hass: HomeAssistant) -> None:
+    """Test connection error during user flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    with patch(
+        "homeassistant.components.pegel_online.config_flow.PegelOnline",
+        return_value=_create_mocked_pegelonline(side_effect=ClientError),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input=MOCK_USER_DATA_STEP1
+        )
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "user"
+        assert result["errors"]["base"] == "cannot_connect"
+
+
+async def test_user_no_stations(hass: HomeAssistant) -> None:
+    """Test starting a flow by user which does not find any station."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    with patch(
+        "homeassistant.components.pegel_online.config_flow.PegelOnline",
+        return_value=_create_mocked_pegelonline(nearby_stations={}),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input=MOCK_USER_DATA_STEP1
+        )
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "user"
+        assert result["errors"][CONF_RADIUS] == "no_stations"

--- a/tests/components/pegel_online/test_config_flow.py
+++ b/tests/components/pegel_online/test_config_flow.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
-from . import _create_mocked_pegelonline
+from . import PegelOnlineMock
 
 from tests.common import MockConfigEntry
 
@@ -33,22 +33,30 @@ MOCK_CONFIG_ENTRY_DATA = {CONF_STATION: "3bcd61da-xxxx-xxxx-xxxx-19d5523a7ae8"}
 
 MOCK_NEARBY_STATIONS = {
     "3bcd61da-xxxx-xxxx-xxxx-19d5523a7ae8": Station(
-        "3bcd61da-xxxx-xxxx-xxxx-19d5523a7ae8",
-        "DRESDEN",
-        "STANDORT DRESDEN",
-        55.63,
-        13.475467710324812,
-        51.16440557554545,
-        "ELBE",
+        {
+            "uuid": "3bcd61da-xxxx-xxxx-xxxx-19d5523a7ae8",
+            "number": "501060",
+            "shortname": "DRESDEN",
+            "longname": "DRESDEN",
+            "km": 55.63,
+            "agency": "STANDORT DRESDEN",
+            "longitude": 13.738831783620384,
+            "latitude": 51.054459765598125,
+            "water": {"shortname": "ELBE", "longname": "ELBE"},
+        }
     ),
     "85d686f1-xxxx-xxxx-xxxx-3207b50901a7": Station(
-        "85d686f1-xxxx-xxxx-xxxx-3207b50901a7",
-        "MEISSEN",
-        "STANDORT DRESDEN",
-        82.2,
-        13.738831783620384,
-        51.054459765598125,
-        "ELBE",
+        {
+            "uuid": "85d686f1-xxxx-xxxx-xxxx-3207b50901a7",
+            "number": "501060",
+            "shortname": "MEISSEN",
+            "longname": "MEISSEN",
+            "km": 82.2,
+            "agency": "STANDORT DRESDEN",
+            "longitude": 13.475467710324812,
+            "latitude": 51.16440557554545,
+            "water": {"shortname": "ELBE", "longname": "ELBE"},
+        }
     ),
 }
 
@@ -65,8 +73,8 @@ async def test_user(hass: HomeAssistant) -> None:
         "homeassistant.components.pegel_online.async_setup_entry", return_value=True
     ) as mock_setup_entry, patch(
         "homeassistant.components.pegel_online.config_flow.PegelOnline",
-        return_value=_create_mocked_pegelonline(nearby_stations=MOCK_NEARBY_STATIONS),
-    ):
+    ) as pegelonline:
+        pegelonline.return_value = PegelOnlineMock(nearby_stations=MOCK_NEARBY_STATIONS)
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input=MOCK_USER_DATA_STEP1
         )
@@ -102,8 +110,8 @@ async def test_user_already_configured(hass: HomeAssistant) -> None:
 
     with patch(
         "homeassistant.components.pegel_online.config_flow.PegelOnline",
-        return_value=_create_mocked_pegelonline(nearby_stations=MOCK_NEARBY_STATIONS),
-    ):
+    ) as pegelonline:
+        pegelonline.return_value = PegelOnlineMock(nearby_stations=MOCK_NEARBY_STATIONS)
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input=MOCK_USER_DATA_STEP1
         )
@@ -127,8 +135,8 @@ async def test_connection_error(hass: HomeAssistant) -> None:
 
     with patch(
         "homeassistant.components.pegel_online.config_flow.PegelOnline",
-        return_value=_create_mocked_pegelonline(side_effect=ClientError),
-    ):
+    ) as pegelonline:
+        pegelonline.return_value = PegelOnlineMock(side_effect=ClientError)
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input=MOCK_USER_DATA_STEP1
         )
@@ -147,8 +155,8 @@ async def test_user_no_stations(hass: HomeAssistant) -> None:
 
     with patch(
         "homeassistant.components.pegel_online.config_flow.PegelOnline",
-        return_value=_create_mocked_pegelonline(nearby_stations={}),
-    ):
+    ) as pegelonline:
+        pegelonline.return_value = PegelOnlineMock(nearby_stations={})
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input=MOCK_USER_DATA_STEP1
         )

--- a/tests/components/pegel_online/test_sensor.py
+++ b/tests/components/pegel_online/test_sensor.py
@@ -1,0 +1,52 @@
+"""Test pegel_online component."""
+from unittest.mock import patch
+
+from aiopegelonline import CurrentMeasurement, Station
+
+from homeassistant.components.pegel_online.const import CONF_STATION, DOMAIN
+from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE
+from homeassistant.core import HomeAssistant
+
+from . import _create_mocked_pegelonline
+
+from tests.common import MockConfigEntry
+
+MOCK_CONFIG_ENTRY_DATA = {CONF_STATION: "3bcd61da-xxxx-xxxx-xxxx-19d5523a7ae8"}
+
+MOCK_STATION_DETAILS = Station(
+    "3bcd61da-xxxx-xxxx-xxxx-19d5523a7ae8",
+    "DRESDEN",
+    "STANDORT DRESDEN",
+    55.63,
+    13.475467710324812,
+    51.16440557554545,
+    "ELBE",
+)
+MOCK_STATION_MEASUREMENT = CurrentMeasurement("cm", 56)
+
+
+async def test_sensor(hass: HomeAssistant) -> None:
+    """Tests sensor entity."""
+    mocked_pegelonline = _create_mocked_pegelonline(
+        station_details=MOCK_STATION_DETAILS,
+        station_measurement=MOCK_STATION_MEASUREMENT,
+    )
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_CONFIG_ENTRY_DATA,
+        unique_id=MOCK_CONFIG_ENTRY_DATA[CONF_STATION],
+    )
+    entry.add_to_hass(hass)
+    with patch(
+        "homeassistant.components.pegel_online.PegelOnline",
+        return_value=mocked_pegelonline,
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.dresden_elbe_water_level")
+    assert state.name == "DRESDEN ELBE Water level"
+    assert state.state == "56"
+    assert state.attributes[ATTR_LATITUDE] == 51.16440557554545
+    assert state.attributes[ATTR_LONGITUDE] == 13.475467710324812


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This integration will (_at first_) provide sensors for water levels based on data from the German Federal Waterways and Shipping Administration (_Wasserstraßen- und Schifffahrtsverwaltung des Bundes_) [PEGELONLINE](https://www.pegelonline.wsv.de/).
According to their "terms of use", the usage of the api is free for all, without any limitation.

the integration setup is split into two steps

### first, select the area where you want to search for a water measurement station

![image](https://github.com/home-assistant/core/assets/35783820/76689ee1-149b-41fb-834d-f02329f37bce)

### second, select the station

![image](https://github.com/home-assistant/core/assets/35783820/61e394da-0d56-4abf-a8fc-185c95b95618)

### result

![image](https://github.com/home-assistant/core/assets/35783820/70dc2922-4944-42da-8059-7472cafeac46)

---

### todos:
- [x] create docs PR
- [ ] create brands PR (_in opposite to the usage of the api, the usage of their logos need a permission, which i've requested - waiting for answer_)
- [x] add tests (_especial for the config flow_)

---

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/28282

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
