### PR TITLE
Initialize energy_state without price

### DIFF
--- a/homeassistant/components/energy/sensor.py
+++ b/homeassistant/components/energy/sensor.py
@@ -318,8 +318,9 @@ class EnergyCostSensor(SensorEntity):
                 energy_price = float(energy_price_state.state)
             except ValueError:
                 if self._last_energy_sensor_state is None:
-                    # Initialize as it's the first time all required entities except price are in place.
-                    # This means that the cost will update the first time that the energy is updated after the price entity is in place
+                    # Initialize as it's the first time all required entities except
+                    # price are in place. This means that the cost will update the first
+                    # time the energy is updated after the price entity is in place.
                     self._reset(energy_state)
                 return
 

--- a/homeassistant/components/energy/sensor.py
+++ b/homeassistant/components/energy/sensor.py
@@ -317,6 +317,10 @@ class EnergyCostSensor(SensorEntity):
             try:
                 energy_price = float(energy_price_state.state)
             except ValueError:
+                if self._last_energy_sensor_state is None:
+                    # Initialize as it's the first time all required entities except price are in place.
+                    # This means that the cost will update the first time that the energy is updated after the price entity is in place
+                    self._reset(energy_state)
                 return
 
             energy_price_unit: str | None = energy_price_state.attributes.get(

--- a/tests/components/energy/test_sensor.py
+++ b/tests/components/energy/test_sensor.py
@@ -924,7 +924,7 @@ async def test_cost_sensor_handle_late_price_sensor(
     await setup_integration(hass)
 
     state = hass.states.get("sensor.energy_consumption_cost")
-    assert state.state == "unknown"
+    assert state.state == "0.0"
 
     # Energy use bumped by 10 kWh, price sensor still not yet available
     hass.states.async_set(
@@ -935,7 +935,7 @@ async def test_cost_sensor_handle_late_price_sensor(
     await hass.async_block_till_done()
 
     state = hass.states.get("sensor.energy_consumption_cost")
-    assert state.state == "unknown"
+    assert state.state == "0.0"
 
     # Energy use bumped by 10 kWh, price sensor now available
     hass.states.async_set("sensor.energy_price", "1", price_attributes)
@@ -947,7 +947,7 @@ async def test_cost_sensor_handle_late_price_sensor(
     await hass.async_block_till_done()
 
     state = hass.states.get("sensor.energy_consumption_cost")
-    assert state.state == "0.0"
+    assert state.state == "20.0"
 
     # Energy use bumped by 10 kWh, price sensor available
     hass.states.async_set(
@@ -958,7 +958,7 @@ async def test_cost_sensor_handle_late_price_sensor(
     await hass.async_block_till_done()
 
     state = hass.states.get("sensor.energy_consumption_cost")
-    assert state.state == "10.0"
+    assert state.state == "30.0"
 
     # Energy use bumped by 10 kWh, price sensor no longer available
     hass.states.async_set("sensor.energy_price", "unknown", price_attributes)
@@ -970,7 +970,7 @@ async def test_cost_sensor_handle_late_price_sensor(
     await hass.async_block_till_done()
 
     state = hass.states.get("sensor.energy_consumption_cost")
-    assert state.state == "10.0"
+    assert state.state == "30.0"
 
     # Energy use bumped by 10 kWh, price sensor again available
     hass.states.async_set("sensor.energy_price", "2", price_attributes)
@@ -982,7 +982,7 @@ async def test_cost_sensor_handle_late_price_sensor(
     await hass.async_block_till_done()
 
     state = hass.states.get("sensor.energy_consumption_cost")
-    assert state.state == "50.0"
+    assert state.state == "70.0"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When home assistant first starts, it attempts to set up a cost entity under the energy integration. If the energy price cannot be parsed as a float, the cost entity is not initialised and the entity is set to 'unknown'.

The issue is that sometimes the energy price is not available yet on start up. For example, if it is a template. This results in the 'unknown' state after boot. When the energy sensor is first changed after boot, the energy integration checks the price again and since it is now a float, it initialises the cost entity to 0.

However, this means that any energy consumed between boot and when the energy sensor first changes is lost. This is particularly noticeable on some gas meters which are only updated once every half hour, resulting in half an hour of consumption to be lost.

This proposed fix will initialise the the cost sensor to 0 if the price entity cannot be parsed as a float (price is checked last, so it will be the only entity not in place). This results in the first update to the sensor after boot to be included in the cost calculation.

This fix will only initialise the cost sensor if it hasn't already been initialised. This means that if the price entity becomes unavailable after initial set up, then my changes will not change the behaviour, so I don't think this is a breaking change.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #95922
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
