### PR TITLE
Wrap internal ZHA exceptions in `HomeAssistantError`s

### DIFF
--- a/homeassistant/components/zha/core/cluster_handlers/__init__.py
+++ b/homeassistant/components/zha/core/cluster_handlers/__init__.py
@@ -2,10 +2,11 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Awaitable, Callable, Coroutine
 from enum import Enum
-from functools import partialmethod
+import functools
 import logging
-from typing import TYPE_CHECKING, Any, TypedDict
+from typing import TYPE_CHECKING, Any, ParamSpec, TypedDict
 
 import zigpy.exceptions
 import zigpy.util
@@ -19,6 +20,7 @@ from zigpy.zcl.foundation import (
 
 from homeassistant.const import ATTR_COMMAND
 from homeassistant.core import callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from ..const import (
@@ -45,8 +47,25 @@ if TYPE_CHECKING:
     from ..endpoint import Endpoint
 
 _LOGGER = logging.getLogger(__name__)
+RETRYABLE_REQUEST_DECORATOR = zigpy.util.retryable_request(tries=3)
 
-retry_request = zigpy.util.retryable_request(tries=3)
+
+_P = ParamSpec("_P")
+_FuncType = Callable[_P, Awaitable[Any]]
+_ReturnFuncType = Callable[_P, Coroutine[Any, Any, Any]]
+
+
+def retry_request(func: _FuncType[_P]) -> _ReturnFuncType[_P]:
+    """Send a request with retries and wrap expected zigpy exceptions."""
+
+    @functools.wraps(func)
+    async def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> Any:
+        try:
+            return await RETRYABLE_REQUEST_DECORATOR(func)(*args, **kwargs)
+        except (zigpy.exceptions.ZigbeeException, asyncio.TimeoutError) as exc:
+            raise HomeAssistantError from exc
+
+    return wrapper
 
 
 class AttrReportConfig(TypedDict, total=True):
@@ -471,7 +490,7 @@ class ClusterHandler(LogMixin):
             rest = rest[ZHA_CLUSTER_HANDLER_READS_PER_REQ:]
         return result
 
-    get_attributes = partialmethod(_get_attributes, False)
+    get_attributes = functools.partialmethod(_get_attributes, False)
 
     def log(self, level, msg, *args, **kwargs):
         """Log a message."""

--- a/tests/components/zha/test_cover.py
+++ b/tests/components/zha/test_cover.py
@@ -26,6 +26,7 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import CoreState, HomeAssistant, State
+from homeassistant.exceptions import HomeAssistantError
 
 from .common import (
     async_enable_traffic,
@@ -236,7 +237,7 @@ async def test_shade(
 
     # close from UI command fails
     with patch("zigpy.zcl.Cluster.request", side_effect=asyncio.TimeoutError):
-        with pytest.raises(asyncio.TimeoutError):
+        with pytest.raises(HomeAssistantError):
             await hass.services.async_call(
                 COVER_DOMAIN,
                 SERVICE_CLOSE_COVER,
@@ -261,7 +262,7 @@ async def test_shade(
     assert ATTR_CURRENT_POSITION not in hass.states.get(entity_id).attributes
     await send_attributes_report(hass, cluster_level, {0: 0})
     with patch("zigpy.zcl.Cluster.request", side_effect=asyncio.TimeoutError):
-        with pytest.raises(asyncio.TimeoutError):
+        with pytest.raises(HomeAssistantError):
             await hass.services.async_call(
                 COVER_DOMAIN,
                 SERVICE_OPEN_COVER,
@@ -285,7 +286,7 @@ async def test_shade(
 
     # set position UI command fails
     with patch("zigpy.zcl.Cluster.request", side_effect=asyncio.TimeoutError):
-        with pytest.raises(asyncio.TimeoutError):
+        with pytest.raises(HomeAssistantError):
             await hass.services.async_call(
                 COVER_DOMAIN,
                 SERVICE_SET_COVER_POSITION,
@@ -326,7 +327,7 @@ async def test_shade(
 
     # test cover stop
     with patch("zigpy.zcl.Cluster.request", side_effect=asyncio.TimeoutError):
-        with pytest.raises(asyncio.TimeoutError):
+        with pytest.raises(HomeAssistantError):
             await hass.services.async_call(
                 COVER_DOMAIN,
                 SERVICE_STOP_COVER,
@@ -395,7 +396,7 @@ async def test_keen_vent(
     p2 = patch.object(cluster_level, "request", return_value=[4, 0])
 
     with p1, p2:
-        with pytest.raises(asyncio.TimeoutError):
+        with pytest.raises(HomeAssistantError):
             await hass.services.async_call(
                 COVER_DOMAIN,
                 SERVICE_OPEN_COVER,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
#93989 changed ZHA's behavior from swallowing exceptions in a few critical places, to propagating ZHA-internal errors into Core. This PR wraps expected Zigbee exceptions in `HomeAssistantError`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #95667
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
