### PR TITLE
Fix has_entity_name not always being set in ESPHome

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -306,7 +306,6 @@ omit =
     homeassistant/components/escea/climate.py
     homeassistant/components/escea/discovery.py
     homeassistant/components/esphome/bluetooth/*
-    homeassistant/components/esphome/entry_data.py
     homeassistant/components/esphome/manager.py
     homeassistant/components/etherscan/sensor.py
     homeassistant/components/eufy/*

--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -59,6 +59,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     entry_data = RuntimeEntryData(
         client=cli,
         entry_id=entry.entry_id,
+        title=entry.title,
         store=domain_data.get_or_create_store(hass, entry),
         original_options=dict(entry.options),
     )

--- a/homeassistant/components/esphome/entity.py
+++ b/homeassistant/components/esphome/entity.py
@@ -140,6 +140,7 @@ class EsphomeEntity(Entity, Generic[_InfoT, _StateT]):
     """Define a base esphome entity."""
 
     _attr_should_poll = False
+    _attr_has_entity_name = True
     _static_info: _InfoT
     _state: _StateT
     _has_state: bool
@@ -164,7 +165,6 @@ class EsphomeEntity(Entity, Generic[_InfoT, _StateT]):
         if object_id := entity_info.object_id:
             # Use the object_id to suggest the entity_id
             self.entity_id = f"{domain}.{device_info.name}_{object_id}"
-        self._attr_has_entity_name = bool(device_info.friendly_name)
         self._attr_device_info = DeviceInfo(
             connections={(dr.CONNECTION_NETWORK_MAC, device_info.mac_address)}
         )

--- a/homeassistant/components/esphome/entry_data.py
+++ b/homeassistant/components/esphome/entry_data.py
@@ -135,9 +135,9 @@ class RuntimeEntryData:
     def friendly_name(self) -> str:
         """Return the friendly name of the device."""
         device_info = self.device_info
-        return (device_info and device_info.friendly_name) or self.name.replace(
+        return (device_info and device_info.friendly_name) or self.name.title().replace(
             "_", " "
-        ).title()
+        )
 
     @property
     def signal_device_updated(self) -> str:

--- a/homeassistant/components/esphome/manager.py
+++ b/homeassistant/components/esphome/manager.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from aioesphomeapi import (
     APIClient,
@@ -395,9 +395,7 @@ class ESPHomeManager:
                     )
                 )
 
-            self.device_id = _async_setup_device_registry(
-                hass, entry, entry_data.device_info
-            )
+            self.device_id = _async_setup_device_registry(hass, entry, entry_data)
             entry_data.async_update_device_state(hass)
 
             entity_infos, services = await cli.list_entities_services()
@@ -515,9 +513,12 @@ class ESPHomeManager:
 
 @callback
 def _async_setup_device_registry(
-    hass: HomeAssistant, entry: ConfigEntry, device_info: EsphomeDeviceInfo
+    hass: HomeAssistant, entry: ConfigEntry, entry_data: RuntimeEntryData
 ) -> str:
     """Set up device registry feature for a particular config entry."""
+    device_info = entry_data.device_info
+    if TYPE_CHECKING:
+        assert device_info is not None
     sw_version = device_info.esphome_version
     if device_info.compilation_time:
         sw_version += f" ({device_info.compilation_time})"
@@ -544,7 +545,7 @@ def _async_setup_device_registry(
         config_entry_id=entry.entry_id,
         configuration_url=configuration_url,
         connections={(dr.CONNECTION_NETWORK_MAC, device_info.mac_address)},
-        name=device_info.friendly_name or device_info.name,
+        name=entry_data.friendly_name,
         manufacturer=manufacturer,
         model=model,
         sw_version=sw_version,

--- a/tests/components/esphome/conftest.py
+++ b/tests/components/esphome/conftest.py
@@ -211,13 +211,13 @@ async def _mock_generic_device_entry(
 
     mock_device = MockESPHomeDevice(entry)
 
-    device_info = DeviceInfo(
-        name="test",
-        friendly_name="Test",
-        mac_address="11:22:33:44:55:aa",
-        esphome_version="1.0.0",
-        **mock_device_info,
-    )
+    default_device_info = {
+        "name": "test",
+        "friendly_name": "Test",
+        "esphome_version": "1.0.0",
+        "mac_address": "11:22:33:44:55:aa",
+    }
+    device_info = DeviceInfo(**(default_device_info | mock_device_info))
 
     async def _subscribe_states(callback: Callable[[EntityState], None]) -> None:
         """Subscribe to state."""

--- a/tests/components/esphome/test_entity.py
+++ b/tests/components/esphome/test_entity.py
@@ -184,3 +184,38 @@ async def test_deep_sleep_device(
     state = hass.states.get("binary_sensor.test_mybinary_sensor")
     assert state is not None
     assert state.state == STATE_ON
+
+
+async def test_esphome_device_without_friendly_name(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    hass_storage: dict[str, Any],
+    mock_esphome_device: Callable[
+        [APIClient, list[EntityInfo], list[UserService], list[EntityState]],
+        Awaitable[MockESPHomeDevice],
+    ],
+) -> None:
+    """Test a device without friendly_name set."""
+    entity_info = [
+        BinarySensorInfo(
+            object_id="mybinary_sensor",
+            key=1,
+            name="my binary_sensor",
+            unique_id="my_binary_sensor",
+        ),
+    ]
+    states = [
+        BinarySensorState(key=1, state=True, missing_state=False),
+        BinarySensorState(key=2, state=True, missing_state=False),
+    ]
+    user_service = []
+    await mock_esphome_device(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        user_service=user_service,
+        states=states,
+        device_info={"friendly_name": None},
+    )
+    state = hass.states.get("binary_sensor.test_mybinary_sensor")
+    assert state is not None
+    assert state.state == STATE_ON

--- a/tests/components/esphome/test_sensor.py
+++ b/tests/components/esphome/test_sensor.py
@@ -1,30 +1,45 @@
 """Test ESPHome sensors."""
+from collections.abc import Awaitable, Callable
+import logging
 import math
 
 from aioesphomeapi import (
     APIClient,
     EntityCategory as ESPHomeEntityCategory,
+    EntityInfo,
+    EntityState,
     LastResetType,
     SensorInfo,
     SensorState,
     SensorStateClass as ESPHomeSensorStateClass,
     TextSensorInfo,
     TextSensorState,
+    UserService,
 )
 
 from homeassistant.components.sensor import ATTR_STATE_CLASS, SensorStateClass
-from homeassistant.const import ATTR_ICON, ATTR_UNIT_OF_MEASUREMENT, STATE_UNKNOWN
+from homeassistant.const import (
+    ATTR_ICON,
+    ATTR_UNIT_OF_MEASUREMENT,
+    STATE_UNKNOWN,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity import EntityCategory
+
+from .conftest import MockESPHomeDevice
 
 
 async def test_generic_numeric_sensor(
     hass: HomeAssistant,
     mock_client: APIClient,
-    mock_generic_device_entry,
+    mock_esphome_device: Callable[
+        [APIClient, list[EntityInfo], list[UserService], list[EntityState]],
+        Awaitable[MockESPHomeDevice],
+    ],
 ) -> None:
     """Test a generic sensor entity."""
+    logging.getLogger("homeassistant.components.esphome").setLevel(logging.DEBUG)
     entity_info = [
         SensorInfo(
             object_id="mysensor",
@@ -35,7 +50,7 @@ async def test_generic_numeric_sensor(
     ]
     states = [SensorState(key=1, state=50)]
     user_service = []
-    await mock_generic_device_entry(
+    mock_device = await mock_esphome_device(
         mock_client=mock_client,
         entity_info=entity_info,
         user_service=user_service,
@@ -44,6 +59,34 @@ async def test_generic_numeric_sensor(
     state = hass.states.get("sensor.test_mysensor")
     assert state is not None
     assert state.state == "50"
+
+    # Test updating state
+    mock_device.set_state(SensorState(key=1, state=60))
+    await hass.async_block_till_done()
+    state = hass.states.get("sensor.test_mysensor")
+    assert state is not None
+    assert state.state == "60"
+
+    # Test sending the same state again
+    mock_device.set_state(SensorState(key=1, state=60))
+    await hass.async_block_till_done()
+    state = hass.states.get("sensor.test_mysensor")
+    assert state is not None
+    assert state.state == "60"
+
+    # Test we can still update after the same state
+    mock_device.set_state(SensorState(key=1, state=70))
+    await hass.async_block_till_done()
+    state = hass.states.get("sensor.test_mysensor")
+    assert state is not None
+    assert state.state == "70"
+
+    # Test invalid data from the underlying api does not crash us
+    mock_device.set_state(SensorState(key=1, state=object()))
+    await hass.async_block_till_done()
+    state = hass.states.get("sensor.test_mysensor")
+    assert state is not None
+    assert state.state == "70"
 
 
 async def test_generic_numeric_sensor_with_entity_category_and_icon(


### PR DESCRIPTION
This change was partially reverted in https://github.com/home-assistant/core/pull/97488  (The debug logging will continue to have the device name + entity name in it but the entity name itself will not use device name unless friendly name is set)

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
fixes #94118

We always have the device name so we should always be setting this to true

This appears to be the intent in https://github.com/home-assistant/core/pull/85976 but because of various other refactoring it was not effective unless friendly_name was configured on the ESPHome device itself (edit: I didn't get the git archaeology right when I traced the change backwards and thought this was a regression based on the linked issue so this part will get reverted in https://github.com/home-assistant/core/pull/97488)

Add coverage for this case which allows us to remove `entry_data.py` from `.coveragerc`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
