### PR TITLE
Import names from typing instead of typing_extensions [3.11]

### DIFF
--- a/homeassistant/backports/enum.py
+++ b/homeassistant/backports/enum.py
@@ -2,9 +2,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any
-
-from typing_extensions import Self
+from typing import Any, Self
 
 
 class StrEnum(str, Enum):

--- a/homeassistant/backports/functools.py
+++ b/homeassistant/backports/functools.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from types import GenericAlias
-from typing import Any, Generic, TypeVar, overload
-
-from typing_extensions import Self
+from typing import Any, Generic, Self, TypeVar, overload
 
 _T = TypeVar("_T")
 _R = TypeVar("_R")

--- a/homeassistant/components/counter/__init__.py
+++ b/homeassistant/components/counter/__init__.py
@@ -2,8 +2,8 @@
 from __future__ import annotations
 
 import logging
+from typing import Self
 
-from typing_extensions import Self
 import voluptuous as vol
 
 from homeassistant.const import (

--- a/homeassistant/components/esphome/domain_data.py
+++ b/homeassistant/components/esphome/domain_data.py
@@ -2,9 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import cast
-
-from typing_extensions import Self
+from typing import Self, cast
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant

--- a/homeassistant/components/event/__init__.py
+++ b/homeassistant/components/event/__init__.py
@@ -4,9 +4,7 @@ from __future__ import annotations
 from dataclasses import asdict, dataclass
 from datetime import datetime, timedelta
 import logging
-from typing import Any, final
-
-from typing_extensions import Self
+from typing import Any, Self, final
 
 from homeassistant.backports.enum import StrEnum
 from homeassistant.config_entries import ConfigEntry

--- a/homeassistant/components/hassio/issues.py
+++ b/homeassistant/components/hassio/issues.py
@@ -4,9 +4,7 @@ from __future__ import annotations
 import asyncio
 from dataclasses import dataclass, field
 import logging
-from typing import Any, TypedDict
-
-from typing_extensions import NotRequired
+from typing import Any, NotRequired, TypedDict
 
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect

--- a/homeassistant/components/input_boolean/__init__.py
+++ b/homeassistant/components/input_boolean/__init__.py
@@ -2,9 +2,8 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, Self
 
-from typing_extensions import Self
 import voluptuous as vol
 
 from homeassistant.const import (

--- a/homeassistant/components/input_button/__init__.py
+++ b/homeassistant/components/input_button/__init__.py
@@ -2,9 +2,8 @@
 from __future__ import annotations
 
 import logging
-from typing import cast
+from typing import Self, cast
 
-from typing_extensions import Self
 import voluptuous as vol
 
 from homeassistant.components.button import SERVICE_PRESS, ButtonEntity

--- a/homeassistant/components/input_datetime/__init__.py
+++ b/homeassistant/components/input_datetime/__init__.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 
 import datetime as py_datetime
 import logging
-from typing import Any
+from typing import Any, Self
 
-from typing_extensions import Self
 import voluptuous as vol
 
 from homeassistant.const import (

--- a/homeassistant/components/input_number/__init__.py
+++ b/homeassistant/components/input_number/__init__.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 
 from contextlib import suppress
 import logging
+from typing import Self
 
-from typing_extensions import Self
 import voluptuous as vol
 
 from homeassistant.const import (

--- a/homeassistant/components/input_select/__init__.py
+++ b/homeassistant/components/input_select/__init__.py
@@ -2,9 +2,8 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, cast
+from typing import Any, Self, cast
 
-from typing_extensions import Self
 import voluptuous as vol
 
 from homeassistant.components.select import (

--- a/homeassistant/components/input_text/__init__.py
+++ b/homeassistant/components/input_text/__init__.py
@@ -2,8 +2,8 @@
 from __future__ import annotations
 
 import logging
+from typing import Self
 
-from typing_extensions import Self
 import voluptuous as vol
 
 from homeassistant.const import (

--- a/homeassistant/components/integration/sensor.py
+++ b/homeassistant/components/integration/sensor.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from decimal import Decimal, DecimalException, InvalidOperation
 import logging
-from typing import Any, Final
+from typing import Any, Final, Self
 
-from typing_extensions import Self
 import voluptuous as vol
 
 from homeassistant.components.sensor import (

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -8,9 +8,8 @@ from datetime import timedelta
 from enum import IntFlag
 import logging
 import os
-from typing import Any, cast, final
+from typing import Any, Self, cast, final
 
-from typing_extensions import Self
 import voluptuous as vol
 
 from homeassistant.backports.enum import StrEnum

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -12,14 +12,13 @@ import hashlib
 from http import HTTPStatus
 import logging
 import secrets
-from typing import Any, Final, TypedDict, final
+from typing import Any, Final, Required, TypedDict, final
 from urllib.parse import quote, urlparse
 
 from aiohttp import web
 from aiohttp.hdrs import CACHE_CONTROL, CONTENT_TYPE
 from aiohttp.typedefs import LooseHeaders
 import async_timeout
-from typing_extensions import Required
 import voluptuous as vol
 from yarl import URL
 

--- a/homeassistant/components/met/__init__.py
+++ b/homeassistant/components/met/__init__.py
@@ -6,10 +6,9 @@ from datetime import timedelta
 import logging
 from random import randrange
 from types import MappingProxyType
-from typing import Any
+from typing import Any, Self
 
 import metno
-from typing_extensions import Self
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (

--- a/homeassistant/components/minio/minio_helper.py
+++ b/homeassistant/components/minio/minio_helper.py
@@ -8,10 +8,10 @@ from queue import Queue
 import re
 import threading
 import time
+from typing import Self
 from urllib.parse import unquote
 
 from minio import Minio
-from typing_extensions import Self
 from urllib3.exceptions import HTTPError
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/number/__init__.py
+++ b/homeassistant/components/number/__init__.py
@@ -8,9 +8,8 @@ from datetime import timedelta
 import inspect
 import logging
 from math import ceil, floor
-from typing import Any, final
+from typing import Any, Self, final
 
-from typing_extensions import Self
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry

--- a/homeassistant/components/recorder/db_schema.py
+++ b/homeassistant/components/recorder/db_schema.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 from datetime import datetime, timedelta
 import logging
 import time
-from typing import Any, cast
+from typing import Any, Self, cast
 
 import ciso8601
 from fnv_hash_fast import fnv1a_32
@@ -33,7 +33,6 @@ from sqlalchemy.engine.interfaces import Dialect
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.orm import DeclarativeBase, Mapped, aliased, mapped_column, relationship
 from sqlalchemy.types import TypeDecorator
-from typing_extensions import Self
 
 from homeassistant.const import (
     MAX_LENGTH_EVENT_EVENT_TYPE,

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -11,9 +11,7 @@ import logging
 from math import ceil, floor, log10
 import re
 import sys
-from typing import Any, Final, cast, final
-
-from typing_extensions import Self
+from typing import Any, Final, Self, cast, final
 
 from homeassistant.config_entries import ConfigEntry
 

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -8,11 +8,10 @@ import datetime
 from io import SEEK_END, BytesIO
 import logging
 from threading import Event
-from typing import Any, cast
+from typing import Any, Self, cast
 
 import attr
 import av
-from typing_extensions import Self
 
 from homeassistant.core import HomeAssistant
 

--- a/homeassistant/components/template/binary_sensor.py
+++ b/homeassistant/components/template/binary_sensor.py
@@ -5,9 +5,8 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from functools import partial
 import logging
-from typing import Any
+from typing import Any, Self
 
-from typing_extensions import Self
 import voluptuous as vol
 
 from homeassistant.components.binary_sensor import (

--- a/homeassistant/components/timer/__init__.py
+++ b/homeassistant/components/timer/__init__.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 from collections.abc import Callable
 from datetime import datetime, timedelta
 import logging
+from typing import Self
 
-from typing_extensions import Self
 import voluptuous as vol
 
 from homeassistant.const import (

--- a/homeassistant/components/tuya/base.py
+++ b/homeassistant/components/tuya/base.py
@@ -5,10 +5,9 @@ import base64
 from dataclasses import dataclass
 import json
 import struct
-from typing import Any, Literal, overload
+from typing import Any, Literal, Self, overload
 
 from tuya_iot import TuyaDevice, TuyaDeviceManager
-from typing_extensions import Self
 
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import DeviceInfo, Entity

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -5,10 +5,9 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from decimal import Decimal, DecimalException, InvalidOperation
 import logging
-from typing import Any
+from typing import Any, Self
 
 from croniter import croniter
-from typing_extensions import Self
 import voluptuous as vol
 
 from homeassistant.components.sensor import (

--- a/homeassistant/components/weather/__init__.py
+++ b/homeassistant/components/weather/__init__.py
@@ -7,9 +7,7 @@ from dataclasses import dataclass
 from datetime import timedelta
 import inspect
 import logging
-from typing import Any, Final, Literal, TypedDict, final
-
-from typing_extensions import Required
+from typing import Any, Final, Literal, Required, TypedDict, final
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (

--- a/homeassistant/components/yeelight/scanner.py
+++ b/homeassistant/components/yeelight/scanner.py
@@ -7,12 +7,12 @@ import contextlib
 from datetime import datetime
 from ipaddress import IPv4Address
 import logging
+from typing import Self
 from urllib.parse import urlparse
 
 import async_timeout
 from async_upnp_client.search import SsdpSearchListener
 from async_upnp_client.utils import CaseInsensitiveDict
-from typing_extensions import Self
 
 from homeassistant import config_entries
 from homeassistant.components import network, ssdp

--- a/homeassistant/components/zha/button.py
+++ b/homeassistant/components/zha/button.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 import abc
 import functools
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Self
 
-from typing_extensions import Self
 import zigpy.exceptions
 from zigpy.zcl.foundation import Status
 

--- a/homeassistant/components/zha/core/device.py
+++ b/homeassistant/components/zha/core/device.py
@@ -8,9 +8,8 @@ from enum import Enum
 import logging
 import random
 import time
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Self
 
-from typing_extensions import Self
 from zigpy import types
 import zigpy.device
 import zigpy.exceptions

--- a/homeassistant/components/zha/entity.py
+++ b/homeassistant/components/zha/entity.py
@@ -5,9 +5,7 @@ import asyncio
 from collections.abc import Callable
 import functools
 import logging
-from typing import TYPE_CHECKING, Any
-
-from typing_extensions import Self
+from typing import TYPE_CHECKING, Any, Self
 
 from homeassistant.const import ATTR_NAME
 from homeassistant.core import CALLBACK_TYPE, Event, callback

--- a/homeassistant/components/zha/number.py
+++ b/homeassistant/components/zha/number.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 
 import functools
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Self
 
-from typing_extensions import Self
 import zigpy.exceptions
 from zigpy.zcl.foundation import Status
 

--- a/homeassistant/components/zha/select.py
+++ b/homeassistant/components/zha/select.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 from enum import Enum
 import functools
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Self
 
-from typing_extensions import Self
 from zigpy import types
 from zigpy.zcl.clusters.general import OnOff
 from zigpy.zcl.clusters.security import IasWd

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -5,9 +5,8 @@ import enum
 import functools
 import numbers
 import sys
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Self
 
-from typing_extensions import Self
 from zigpy import types
 
 from homeassistant.components.climate import HVACAction

--- a/homeassistant/components/zha/switch.py
+++ b/homeassistant/components/zha/switch.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 
 import functools
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Self
 
-from typing_extensions import Self
 import zigpy.exceptions
 from zigpy.zcl.clusters.general import OnOff
 from zigpy.zcl.foundation import Status

--- a/homeassistant/components/zone/__init__.py
+++ b/homeassistant/components/zone/__init__.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 from collections.abc import Callable
 import logging
 from operator import attrgetter
-from typing import Any, cast
+from typing import Any, Self, cast
 
-from typing_extensions import Self
 import voluptuous as vol
 
 from homeassistant import config_entries

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -11,9 +11,7 @@ import functools
 import logging
 from random import randint
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, TypeVar, cast
-
-from typing_extensions import Self
+from typing import TYPE_CHECKING, Any, Self, TypeVar, cast
 
 from . import data_entry_flow, loader
 from .backports.enum import StrEnum

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -31,6 +31,7 @@ from typing import (
     Any,
     Generic,
     ParamSpec,
+    Self,
     TypeVar,
     cast,
     overload,
@@ -38,7 +39,6 @@ from typing import (
 from urllib.parse import urlparse
 
 import async_timeout
-from typing_extensions import Self
 import voluptuous as vol
 import yarl
 

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -7,9 +7,8 @@ import copy
 from dataclasses import dataclass
 import logging
 from types import MappingProxyType
-from typing import Any, TypedDict
+from typing import Any, Required, TypedDict
 
-from typing_extensions import Required
 import voluptuous as vol
 
 from .backports.enum import StrEnum

--- a/homeassistant/helpers/check_config.py
+++ b/homeassistant/helpers/check_config.py
@@ -5,9 +5,8 @@ from collections import OrderedDict
 import logging
 import os
 from pathlib import Path
-from typing import NamedTuple
+from typing import NamedTuple, Self
 
-from typing_extensions import Self
 import voluptuous as vol
 
 from homeassistant import loader

--- a/homeassistant/helpers/httpx_client.py
+++ b/homeassistant/helpers/httpx_client.py
@@ -3,10 +3,9 @@ from __future__ import annotations
 
 from collections.abc import Callable
 import sys
-from typing import Any
+from typing import Any, Self
 
 import httpx
-from typing_extensions import Self
 
 from homeassistant.const import APPLICATION_NAME, EVENT_HOMEASSISTANT_CLOSE, __version__
 from homeassistant.core import Event, HomeAssistant, callback

--- a/homeassistant/helpers/restore_state.py
+++ b/homeassistant/helpers/restore_state.py
@@ -4,9 +4,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta
 import logging
-from typing import Any, cast
-
-from typing_extensions import Self
+from typing import Any, Self, cast
 
 from homeassistant.const import ATTR_RESTORED, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant, State, callback, valid_entity_id

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping, Sequence
 from enum import IntFlag
 from functools import cache
-from typing import Any, Generic, Literal, TypedDict, TypeVar, cast
+from typing import Any, Generic, Literal, Required, TypedDict, TypeVar, cast
 from uuid import UUID
 
-from typing_extensions import Required
 import voluptuous as vol
 
 from homeassistant.backports.enum import StrEnum

--- a/homeassistant/util/timeout.py
+++ b/homeassistant/util/timeout.py
@@ -8,9 +8,7 @@ from __future__ import annotations
 import asyncio
 import enum
 from types import TracebackType
-from typing import Any
-
-from typing_extensions import Self
+from typing import Any, Self
 
 from .async_ import run_callback_threadsafe
 

--- a/tests/components/recorder/db_schema_30.py
+++ b/tests/components/recorder/db_schema_30.py
@@ -9,7 +9,7 @@ from collections.abc import Callable
 from datetime import datetime, timedelta
 import logging
 import time
-from typing import Any, TypedDict, cast, overload
+from typing import Any, Self, TypedDict, cast, overload
 
 import ciso8601
 from fnv_hash_fast import fnv1a_32
@@ -34,7 +34,6 @@ from sqlalchemy import (
 from sqlalchemy.dialects import mysql, oracle, postgresql, sqlite
 from sqlalchemy.orm import aliased, declarative_base, relationship
 from sqlalchemy.orm.session import Session
-from typing_extensions import Self
 
 from homeassistant.components.recorder.const import SupportedDialect
 from homeassistant.const import (

--- a/tests/components/recorder/db_schema_32.py
+++ b/tests/components/recorder/db_schema_32.py
@@ -9,7 +9,7 @@ from collections.abc import Callable
 from datetime import datetime, timedelta
 import logging
 import time
-from typing import Any, TypedDict, cast, overload
+from typing import Any, Self, TypedDict, cast, overload
 
 import ciso8601
 from fnv_hash_fast import fnv1a_32
@@ -34,7 +34,6 @@ from sqlalchemy import (
 from sqlalchemy.dialects import mysql, oracle, postgresql, sqlite
 from sqlalchemy.orm import aliased, declarative_base, relationship
 from sqlalchemy.orm.session import Session
-from typing_extensions import Self
 
 from homeassistant.components.recorder.const import SupportedDialect
 from homeassistant.const import (


### PR DESCRIPTION
## Proposed change
Import `Self`, `Required`, and `NotRequired` from `typing` instead of `typing_extensions`.

**Note**: `typing_extensions` is still used is a few places which already use the TypeVar `default` argument. E.g.
https://github.com/home-assistant/core/blob/ce1f5f997eb35fafc308179b145e079306734705/homeassistant/helpers/collection.py#L39

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
