### PR TITLE
Use datetime.UTC alias [3.11]

### DIFF
--- a/homeassistant/components/google/api.py
+++ b/homeassistant/components/google/api.py
@@ -51,9 +51,7 @@ class DeviceAuth(AuthImplementation):
     async def async_resolve_external_data(self, external_data: Any) -> dict:
         """Resolve a Google API Credentials object to Home Assistant token."""
         creds: Credentials = external_data[DEVICE_AUTH_CREDS]
-        delta = (
-            creds.token_expiry.replace(tzinfo=datetime.timezone.utc) - dt_util.utcnow()
-        )
+        delta = creds.token_expiry.replace(tzinfo=datetime.UTC) - dt_util.utcnow()
         _LOGGER.debug(
             "Token expires at %s (in %s)", creds.token_expiry, delta.total_seconds()
         )
@@ -116,7 +114,7 @@ class DeviceFlow:
         # For some reason, oauth.step1_get_device_and_user_codes() returns a datetime
         # object without tzinfo. For the comparison below to work, it needs one.
         user_code_expiry = self._device_flow_info.user_code_expiry.replace(
-            tzinfo=datetime.timezone.utc
+            tzinfo=datetime.UTC
         )
         expiration_time = min(user_code_expiry, max_timeout)
 

--- a/homeassistant/components/withings/common.py
+++ b/homeassistant/components/withings/common.py
@@ -449,7 +449,7 @@ class DataManager:
             0,
             0,
             0,
-            datetime.timezone.utc,
+            datetime.UTC,
         )
 
         def get_sleep_summary() -> SleepGetSummaryResponse:

--- a/tests/components/gdacs/test_geo_location.py
+++ b/tests/components/gdacs/test_geo_location.py
@@ -58,8 +58,8 @@ async def test_setup(hass: HomeAssistant) -> None:
         alert_level="Alert Level 1",
         country="Country 1",
         attribution="Attribution 1",
-        from_date=datetime.datetime(2020, 1, 10, 8, 0, tzinfo=datetime.timezone.utc),
-        to_date=datetime.datetime(2020, 1, 20, 8, 0, tzinfo=datetime.timezone.utc),
+        from_date=datetime.datetime(2020, 1, 10, 8, 0, tzinfo=datetime.UTC),
+        to_date=datetime.datetime(2020, 1, 20, 8, 0, tzinfo=datetime.UTC),
         duration_in_week=1,
         population="Population 1",
         severity="Severity 1",
@@ -120,12 +120,8 @@ async def test_setup(hass: HomeAssistant) -> None:
             ATTR_DESCRIPTION: "Description 1",
             ATTR_COUNTRY: "Country 1",
             ATTR_ATTRIBUTION: "Attribution 1",
-            ATTR_FROM_DATE: datetime.datetime(
-                2020, 1, 10, 8, 0, tzinfo=datetime.timezone.utc
-            ),
-            ATTR_TO_DATE: datetime.datetime(
-                2020, 1, 20, 8, 0, tzinfo=datetime.timezone.utc
-            ),
+            ATTR_FROM_DATE: datetime.datetime(2020, 1, 10, 8, 0, tzinfo=datetime.UTC),
+            ATTR_TO_DATE: datetime.datetime(2020, 1, 20, 8, 0, tzinfo=datetime.UTC),
             ATTR_DURATION_IN_WEEK: 1,
             ATTR_ALERT_LEVEL: "Alert Level 1",
             ATTR_POPULATION: "Population 1",

--- a/tests/components/generic_hygrostat/test_humidifier.py
+++ b/tests/components/generic_hygrostat/test_humidifier.py
@@ -869,9 +869,7 @@ async def test_humidity_change_dry_trigger_on_long_enough(
     hass: HomeAssistant, setup_comp_4
 ) -> None:
     """Test if humidity change turn dry on."""
-    fake_changed = datetime.datetime(
-        1970, 11, 11, 11, 11, 11, tzinfo=datetime.timezone.utc
-    )
+    fake_changed = datetime.datetime(1970, 11, 11, 11, 11, 11, tzinfo=datetime.UTC)
     with freeze_time(fake_changed):
         calls = await _setup_switch(hass, False)
     _setup_sensor(hass, 35)
@@ -905,9 +903,7 @@ async def test_humidity_change_dry_trigger_off_long_enough(
     hass: HomeAssistant, setup_comp_4
 ) -> None:
     """Test if humidity change turn dry on."""
-    fake_changed = datetime.datetime(
-        1970, 11, 11, 11, 11, 11, tzinfo=datetime.timezone.utc
-    )
+    fake_changed = datetime.datetime(1970, 11, 11, 11, 11, 11, tzinfo=datetime.UTC)
     with freeze_time(fake_changed):
         calls = await _setup_switch(hass, True)
     _setup_sensor(hass, 45)
@@ -1031,9 +1027,7 @@ async def test_humidity_change_humidifier_trigger_on_long_enough(
     hass: HomeAssistant, setup_comp_6
 ) -> None:
     """Test if humidity change turn humidifier on after min cycle."""
-    fake_changed = datetime.datetime(
-        1970, 11, 11, 11, 11, 11, tzinfo=datetime.timezone.utc
-    )
+    fake_changed = datetime.datetime(1970, 11, 11, 11, 11, 11, tzinfo=datetime.UTC)
     with freeze_time(fake_changed):
         calls = await _setup_switch(hass, False)
     _setup_sensor(hass, 45)
@@ -1053,9 +1047,7 @@ async def test_humidity_change_humidifier_trigger_off_long_enough(
     hass: HomeAssistant, setup_comp_6
 ) -> None:
     """Test if humidity change turn humidifier off after min cycle."""
-    fake_changed = datetime.datetime(
-        1970, 11, 11, 11, 11, 11, tzinfo=datetime.timezone.utc
-    )
+    fake_changed = datetime.datetime(1970, 11, 11, 11, 11, 11, tzinfo=datetime.UTC)
     with freeze_time(fake_changed):
         calls = await _setup_switch(hass, True)
     _setup_sensor(hass, 35)

--- a/tests/components/geonetnz_quakes/test_geo_location.py
+++ b/tests/components/geonetnz_quakes/test_geo_location.py
@@ -48,7 +48,7 @@ async def test_setup(hass: HomeAssistant) -> None:
         (38.0, -3.0),
         locality="Locality 1",
         attribution="Attribution 1",
-        time=datetime.datetime(2018, 9, 22, 8, 0, tzinfo=datetime.timezone.utc),
+        time=datetime.datetime(2018, 9, 22, 8, 0, tzinfo=datetime.UTC),
         magnitude=5.7,
         mmi=5,
         depth=10.5,
@@ -93,9 +93,7 @@ async def test_setup(hass: HomeAssistant) -> None:
             ATTR_FRIENDLY_NAME: "Title 1",
             ATTR_LOCALITY: "Locality 1",
             ATTR_ATTRIBUTION: "Attribution 1",
-            ATTR_TIME: datetime.datetime(
-                2018, 9, 22, 8, 0, tzinfo=datetime.timezone.utc
-            ),
+            ATTR_TIME: datetime.datetime(2018, 9, 22, 8, 0, tzinfo=datetime.UTC),
             ATTR_MAGNITUDE: 5.7,
             ATTR_DEPTH: 10.5,
             ATTR_MMI: 5,

--- a/tests/components/geonetnz_quakes/test_sensor.py
+++ b/tests/components/geonetnz_quakes/test_sensor.py
@@ -41,7 +41,7 @@ async def test_setup(hass: HomeAssistant) -> None:
         (38.0, -3.0),
         locality="Locality 1",
         attribution="Attribution 1",
-        time=datetime.datetime(2018, 9, 22, 8, 0, tzinfo=datetime.timezone.utc),
+        time=datetime.datetime(2018, 9, 22, 8, 0, tzinfo=datetime.UTC),
         magnitude=5.7,
         mmi=5,
         depth=10.5,

--- a/tests/components/ign_sismologia/test_geo_location.py
+++ b/tests/components/ign_sismologia/test_geo_location.py
@@ -81,7 +81,7 @@ async def test_setup(hass: HomeAssistant) -> None:
         (38.0, -3.0),
         region="Region 1",
         attribution="Attribution 1",
-        published=datetime.datetime(2018, 9, 22, 8, 0, tzinfo=datetime.timezone.utc),
+        published=datetime.datetime(2018, 9, 22, 8, 0, tzinfo=datetime.UTC),
         magnitude=5.7,
         image_url="http://image.url/map.jpg",
     )
@@ -125,7 +125,7 @@ async def test_setup(hass: HomeAssistant) -> None:
                 ATTR_REGION: "Region 1",
                 ATTR_ATTRIBUTION: "Attribution 1",
                 ATTR_PUBLICATION_DATE: datetime.datetime(
-                    2018, 9, 22, 8, 0, tzinfo=datetime.timezone.utc
+                    2018, 9, 22, 8, 0, tzinfo=datetime.UTC
                 ),
                 ATTR_IMAGE_URL: "http://image.url/map.jpg",
                 ATTR_MAGNITUDE: 5.7,

--- a/tests/components/input_datetime/test_init.py
+++ b/tests/components/input_datetime/test_init.py
@@ -736,7 +736,7 @@ async def test_timestamp(hass: HomeAssistant) -> None:
     assert (
         dt_util.as_local(
             datetime.datetime.fromtimestamp(
-                state_without_tz.attributes[ATTR_TIMESTAMP], datetime.timezone.utc
+                state_without_tz.attributes[ATTR_TIMESTAMP], datetime.UTC
             )
         ).strftime(FORMAT_DATETIME)
         == "2020-12-13 10:00:00"

--- a/tests/components/metoffice/test_init.py
+++ b/tests/components/metoffice/test_init.py
@@ -15,9 +15,7 @@ from .const import DOMAIN, METOFFICE_CONFIG_WAVERTREE, TEST_COORDINATES_WAVERTRE
 from tests.common import MockConfigEntry
 
 
-@pytest.mark.freeze_time(
-    datetime.datetime(2020, 4, 25, 12, tzinfo=datetime.timezone.utc)
-)
+@pytest.mark.freeze_time(datetime.datetime(2020, 4, 25, 12, tzinfo=datetime.UTC))
 @pytest.mark.parametrize(
     ("old_unique_id", "new_unique_id", "migration_needed"),
     [

--- a/tests/components/metoffice/test_sensor.py
+++ b/tests/components/metoffice/test_sensor.py
@@ -24,9 +24,7 @@ from .const import (
 from tests.common import MockConfigEntry, load_fixture
 
 
-@pytest.mark.freeze_time(
-    datetime.datetime(2020, 4, 25, 12, tzinfo=datetime.timezone.utc)
-)
+@pytest.mark.freeze_time(datetime.datetime(2020, 4, 25, 12, tzinfo=datetime.UTC))
 async def test_one_sensor_site_running(
     hass: HomeAssistant, requests_mock: requests_mock.Mocker
 ) -> None:
@@ -74,9 +72,7 @@ async def test_one_sensor_site_running(
         assert sensor.attributes.get("attribution") == ATTRIBUTION
 
 
-@pytest.mark.freeze_time(
-    datetime.datetime(2020, 4, 25, 12, tzinfo=datetime.timezone.utc)
-)
+@pytest.mark.freeze_time(datetime.datetime(2020, 4, 25, 12, tzinfo=datetime.UTC))
 async def test_two_sensor_sites_running(
     hass: HomeAssistant, requests_mock: requests_mock.Mocker
 ) -> None:

--- a/tests/components/metoffice/test_weather.py
+++ b/tests/components/metoffice/test_weather.py
@@ -23,9 +23,7 @@ from .const import (
 from tests.common import MockConfigEntry, async_fire_time_changed, load_fixture
 
 
-@pytest.mark.freeze_time(
-    datetime.datetime(2020, 4, 25, 12, tzinfo=datetime.timezone.utc)
-)
+@pytest.mark.freeze_time(datetime.datetime(2020, 4, 25, 12, tzinfo=datetime.UTC))
 async def test_site_cannot_connect(
     hass: HomeAssistant, requests_mock: requests_mock.Mocker
 ) -> None:
@@ -54,9 +52,7 @@ async def test_site_cannot_connect(
         assert sensor is None
 
 
-@pytest.mark.freeze_time(
-    datetime.datetime(2020, 4, 25, 12, tzinfo=datetime.timezone.utc)
-)
+@pytest.mark.freeze_time(datetime.datetime(2020, 4, 25, 12, tzinfo=datetime.UTC))
 async def test_site_cannot_update(
     hass: HomeAssistant, requests_mock: requests_mock.Mocker
 ) -> None:
@@ -104,9 +100,7 @@ async def test_site_cannot_update(
     assert weather.state == STATE_UNAVAILABLE
 
 
-@pytest.mark.freeze_time(
-    datetime.datetime(2020, 4, 25, 12, tzinfo=datetime.timezone.utc)
-)
+@pytest.mark.freeze_time(datetime.datetime(2020, 4, 25, 12, tzinfo=datetime.UTC))
 async def test_one_weather_site_running(
     hass: HomeAssistant, requests_mock: requests_mock.Mocker
 ) -> None:
@@ -189,9 +183,7 @@ async def test_one_weather_site_running(
     assert weather.attributes.get("forecast")[3]["wind_bearing"] == "SE"
 
 
-@pytest.mark.freeze_time(
-    datetime.datetime(2020, 4, 25, 12, tzinfo=datetime.timezone.utc)
-)
+@pytest.mark.freeze_time(datetime.datetime(2020, 4, 25, 12, tzinfo=datetime.UTC))
 async def test_two_weather_sites_running(
     hass: HomeAssistant, requests_mock: requests_mock.Mocker
 ) -> None:

--- a/tests/components/nsw_rural_fire_service_feed/test_geo_location.py
+++ b/tests/components/nsw_rural_fire_service_feed/test_geo_location.py
@@ -101,9 +101,7 @@ async def test_setup(hass: HomeAssistant) -> None:
         category="Category 1",
         location="Location 1",
         attribution="Attribution 1",
-        publication_date=datetime.datetime(
-            2018, 9, 22, 8, 0, tzinfo=datetime.timezone.utc
-        ),
+        publication_date=datetime.datetime(2018, 9, 22, 8, 0, tzinfo=datetime.UTC),
         council_area="Council Area 1",
         status="Status 1",
         entry_type="Type 1",
@@ -148,7 +146,7 @@ async def test_setup(hass: HomeAssistant) -> None:
                 ATTR_LOCATION: "Location 1",
                 ATTR_ATTRIBUTION: "Attribution 1",
                 ATTR_PUBLICATION_DATE: datetime.datetime(
-                    2018, 9, 22, 8, 0, tzinfo=datetime.timezone.utc
+                    2018, 9, 22, 8, 0, tzinfo=datetime.UTC
                 ),
                 ATTR_FIRE: True,
                 ATTR_COUNCIL_AREA: "Council Area 1",

--- a/tests/components/qld_bushfire/test_geo_location.py
+++ b/tests/components/qld_bushfire/test_geo_location.py
@@ -80,8 +80,8 @@ async def test_setup(hass: HomeAssistant) -> None:
         (38.0, -3.0),
         category="Category 1",
         attribution="Attribution 1",
-        published=datetime.datetime(2018, 9, 22, 8, 0, tzinfo=datetime.timezone.utc),
-        updated=datetime.datetime(2018, 9, 22, 8, 10, tzinfo=datetime.timezone.utc),
+        published=datetime.datetime(2018, 9, 22, 8, 0, tzinfo=datetime.UTC),
+        updated=datetime.datetime(2018, 9, 22, 8, 10, tzinfo=datetime.UTC),
         status="Status 1",
     )
     mock_entry_2 = _generate_mock_feed_entry("2345", "Title 2", 20.5, (38.1, -3.1))
@@ -119,10 +119,10 @@ async def test_setup(hass: HomeAssistant) -> None:
                 ATTR_CATEGORY: "Category 1",
                 ATTR_ATTRIBUTION: "Attribution 1",
                 ATTR_PUBLICATION_DATE: datetime.datetime(
-                    2018, 9, 22, 8, 0, tzinfo=datetime.timezone.utc
+                    2018, 9, 22, 8, 0, tzinfo=datetime.UTC
                 ),
                 ATTR_UPDATED_DATE: datetime.datetime(
-                    2018, 9, 22, 8, 10, tzinfo=datetime.timezone.utc
+                    2018, 9, 22, 8, 10, tzinfo=datetime.UTC
                 ),
                 ATTR_STATUS: "Status 1",
                 ATTR_UNIT_OF_MEASUREMENT: UnitOfLength.KILOMETERS,

--- a/tests/components/recorder/test_websocket_api.py
+++ b/tests/components/recorder/test_websocket_api.py
@@ -215,9 +215,7 @@ async def test_statistics_during_period(
     }
 
 
-@pytest.mark.freeze_time(
-    datetime.datetime(2022, 10, 21, 7, 25, tzinfo=datetime.timezone.utc)
-)
+@pytest.mark.freeze_time(datetime.datetime(2022, 10, 21, 7, 25, tzinfo=datetime.UTC))
 @pytest.mark.parametrize("offset", (0, 1, 2))
 async def test_statistic_during_period(
     recorder_mock: Recorder,
@@ -632,9 +630,7 @@ async def test_statistic_during_period(
     }
 
 
-@pytest.mark.freeze_time(
-    datetime.datetime(2022, 10, 21, 7, 25, tzinfo=datetime.timezone.utc)
-)
+@pytest.mark.freeze_time(datetime.datetime(2022, 10, 21, 7, 25, tzinfo=datetime.UTC))
 async def test_statistic_during_period_hole(
     recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
@@ -797,9 +793,7 @@ async def test_statistic_during_period_hole(
     }
 
 
-@pytest.mark.freeze_time(
-    datetime.datetime(2022, 10, 21, 7, 25, tzinfo=datetime.timezone.utc)
-)
+@pytest.mark.freeze_time(datetime.datetime(2022, 10, 21, 7, 25, tzinfo=datetime.UTC))
 @pytest.mark.parametrize(
     ("calendar_period", "start_time", "end_time"),
     (

--- a/tests/components/usgs_earthquakes_feed/test_geo_location.py
+++ b/tests/components/usgs_earthquakes_feed/test_geo_location.py
@@ -102,8 +102,8 @@ async def test_setup(hass: HomeAssistant) -> None:
         (-31.0, 150.0),
         place="Location 1",
         attribution="Attribution 1",
-        time=datetime.datetime(2018, 9, 22, 8, 0, tzinfo=datetime.timezone.utc),
-        updated=datetime.datetime(2018, 9, 22, 9, 0, tzinfo=datetime.timezone.utc),
+        time=datetime.datetime(2018, 9, 22, 8, 0, tzinfo=datetime.UTC),
+        updated=datetime.datetime(2018, 9, 22, 9, 0, tzinfo=datetime.UTC),
         magnitude=5.7,
         status="Status 1",
         entry_type="Type 1",
@@ -143,12 +143,8 @@ async def test_setup(hass: HomeAssistant) -> None:
                 ATTR_FRIENDLY_NAME: "Title 1",
                 ATTR_PLACE: "Location 1",
                 ATTR_ATTRIBUTION: "Attribution 1",
-                ATTR_TIME: datetime.datetime(
-                    2018, 9, 22, 8, 0, tzinfo=datetime.timezone.utc
-                ),
-                ATTR_UPDATED: datetime.datetime(
-                    2018, 9, 22, 9, 0, tzinfo=datetime.timezone.utc
-                ),
+                ATTR_TIME: datetime.datetime(2018, 9, 22, 8, 0, tzinfo=datetime.UTC),
+                ATTR_UPDATED: datetime.datetime(2018, 9, 22, 9, 0, tzinfo=datetime.UTC),
                 ATTR_STATUS: "Status 1",
                 ATTR_TYPE: "Type 1",
                 ATTR_ALERT: "Alert 1",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,7 +111,7 @@ asyncio.set_event_loop_policy = lambda policy: None
 
 def _utcnow() -> datetime.datetime:
     """Make utcnow patchable by freezegun."""
-    return datetime.datetime.now(datetime.timezone.utc)
+    return datetime.datetime.now(datetime.UTC)
 
 
 dt_util.utcnow = _utcnow  # type: ignore[assignment]


### PR DESCRIPTION
## Proposed change
`3.11` adds `datetime.UTC` as alias for `datetime.timezone.utc`.
https://docs.python.org/3/library/datetime.html#datetime.UTC

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
