### PR TITLE
Guard expensive debug formatting with calls with isEnabledFor

### DIFF
--- a/homeassistant/components/deconz/config_flow.py
+++ b/homeassistant/components/deconz/config_flow.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Mapping
+import logging
 from pprint import pformat
 from typing import Any, cast
 from urllib.parse import urlparse
@@ -106,7 +107,8 @@ class DeconzFlowHandler(ConfigFlow, domain=DOMAIN):
         except (asyncio.TimeoutError, ResponseError):
             self.bridges = []
 
-        LOGGER.debug("Discovered deCONZ gateways %s", pformat(self.bridges))
+        if LOGGER.isEnabledFor(logging.DEBUG):
+            LOGGER.debug("Discovered deCONZ gateways %s", pformat(self.bridges))
 
         if self.bridges:
             hosts = []
@@ -215,7 +217,8 @@ class DeconzFlowHandler(ConfigFlow, domain=DOMAIN):
 
     async def async_step_ssdp(self, discovery_info: ssdp.SsdpServiceInfo) -> FlowResult:
         """Handle a discovered deCONZ bridge."""
-        LOGGER.debug("deCONZ SSDP discovery %s", pformat(discovery_info))
+        if LOGGER.isEnabledFor(logging.DEBUG):
+            LOGGER.debug("deCONZ SSDP discovery %s", pformat(discovery_info))
 
         self.bridge_id = normalize_bridge_id(discovery_info.upnp[ssdp.ATTR_UPNP_SERIAL])
         parsed_url = urlparse(discovery_info.ssdp_location)
@@ -248,7 +251,8 @@ class DeconzFlowHandler(ConfigFlow, domain=DOMAIN):
 
         This flow is triggered by the discovery component.
         """
-        LOGGER.debug("deCONZ HASSIO discovery %s", pformat(discovery_info.config))
+        if LOGGER.isEnabledFor(logging.DEBUG):
+            LOGGER.debug("deCONZ HASSIO discovery %s", pformat(discovery_info.config))
 
         self.bridge_id = normalize_bridge_id(discovery_info.config[CONF_SERIAL])
         await self.async_set_unique_id(self.bridge_id)

--- a/homeassistant/components/dlna_dmr/config_flow.py
+++ b/homeassistant/components/dlna_dmr/config_flow.py
@@ -126,7 +126,8 @@ class DlnaDmrFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_ssdp(self, discovery_info: ssdp.SsdpServiceInfo) -> FlowResult:
         """Handle a flow initialized by SSDP discovery."""
-        LOGGER.debug("async_step_ssdp: discovery_info %s", pformat(discovery_info))
+        if LOGGER.isEnabledFor(logging.DEBUG):
+            LOGGER.debug("async_step_ssdp: discovery_info %s", pformat(discovery_info))
 
         await self._async_set_info_from_discovery(discovery_info)
 

--- a/homeassistant/components/dlna_dms/config_flow.py
+++ b/homeassistant/components/dlna_dms/config_flow.py
@@ -67,7 +67,8 @@ class DlnaDmsFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_ssdp(self, discovery_info: ssdp.SsdpServiceInfo) -> FlowResult:
         """Handle a flow initialized by SSDP discovery."""
-        LOGGER.debug("async_step_ssdp: discovery_info %s", pformat(discovery_info))
+        if LOGGER.isEnabledFor(logging.DEBUG):
+            LOGGER.debug("async_step_ssdp: discovery_info %s", pformat(discovery_info))
 
         await self._async_parse_discovery(discovery_info)
 

--- a/homeassistant/components/onvif/config_flow.py
+++ b/homeassistant/components/onvif/config_flow.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+import logging
 from pprint import pformat
 from typing import Any
 from urllib.parse import urlparse
@@ -218,7 +219,8 @@ class OnvifFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             if not configured:
                 self.devices.append(device)
 
-        LOGGER.debug("Discovered ONVIF devices %s", pformat(self.devices))
+        if LOGGER.isEnabledFor(logging.DEBUG):
+            LOGGER.debug("Discovered ONVIF devices %s", pformat(self.devices))
 
         if self.devices:
             devices = {CONF_MANUAL_INPUT: CONF_MANUAL_INPUT}
@@ -274,9 +276,10 @@ class OnvifFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self, configure_unique_id: bool = True
     ) -> tuple[dict[str, str], dict[str, str]]:
         """Fetch ONVIF device profiles."""
-        LOGGER.debug(
-            "Fetching profiles from ONVIF device %s", pformat(self.onvif_config)
-        )
+        if LOGGER.isEnabledFor(logging.DEBUG):
+            LOGGER.debug(
+                "Fetching profiles from ONVIF device %s", pformat(self.onvif_config)
+            )
 
         device = get_device(
             self.hass,

--- a/tests/components/deconz/test_config_flow.py
+++ b/tests/components/deconz/test_config_flow.py
@@ -1,5 +1,6 @@
 """Tests for deCONZ config flow."""
 import asyncio
+import logging
 from unittest.mock import patch
 
 import pydeconz
@@ -42,6 +43,9 @@ async def test_flow_discovered_bridges(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test that config flow works for discovered bridges."""
+    logging.getLogger("homeassistant.components.deconz.config_flow").setLevel(
+        logging.DEBUG
+    )
     aioclient_mock.get(
         pydeconz.utils.URL_DISCOVER,
         json=[

--- a/tests/components/deconz/test_config_flow.py
+++ b/tests/components/deconz/test_config_flow.py
@@ -43,9 +43,7 @@ async def test_flow_discovered_bridges(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test that config flow works for discovered bridges."""
-    logging.getLogger("homeassistant.components.deconz.config_flow").setLevel(
-        logging.DEBUG
-    )
+    logging.getLogger("homeassistant.components.deconz").setLevel(logging.DEBUG)
     aioclient_mock.get(
         pydeconz.utils.URL_DISCOVER,
         json=[
@@ -146,9 +144,7 @@ async def test_flow_manual_configuration(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test that config flow works with manual configuration after no discovered bridges."""
-    logging.getLogger("homeassistant.components.deconz.config_flow").setLevel(
-        logging.DEBUG
-    )
+    logging.getLogger("homeassistant.components.deconz").setLevel(logging.DEBUG)
     aioclient_mock.get(
         pydeconz.utils.URL_DISCOVER,
         json=[],

--- a/tests/components/deconz/test_config_flow.py
+++ b/tests/components/deconz/test_config_flow.py
@@ -146,6 +146,9 @@ async def test_flow_manual_configuration(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test that config flow works with manual configuration after no discovered bridges."""
+    logging.getLogger("homeassistant.components.deconz.config_flow").setLevel(
+        logging.DEBUG
+    )
     aioclient_mock.get(
         pydeconz.utils.URL_DISCOVER,
         json=[],

--- a/tests/components/dlna_dmr/test_config_flow.py
+++ b/tests/components/dlna_dmr/test_config_flow.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 import dataclasses
+import logging
 from unittest.mock import Mock, patch
 
 from async_upnp_client.client import UpnpDevice
@@ -286,6 +287,9 @@ async def test_user_flow_wrong_st(hass: HomeAssistant, domain_data_mock: Mock) -
 
 async def test_ssdp_flow_success(hass: HomeAssistant) -> None:
     """Test that SSDP discovery with an available device works."""
+    logging.getLogger("homeassistant.components.dlna_dmr.config_flow").setLevel(
+        logging.DEBUG
+    )
     result = await hass.config_entries.flow.async_init(
         DLNA_DOMAIN,
         context={"source": config_entries.SOURCE_SSDP},

--- a/tests/components/dlna_dms/test_config_flow.py
+++ b/tests/components/dlna_dms/test_config_flow.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 import dataclasses
+import logging
 from typing import Final
 from unittest.mock import Mock, patch
 
@@ -125,6 +126,9 @@ async def test_user_flow_no_devices(
 
 async def test_ssdp_flow_success(hass: HomeAssistant) -> None:
     """Test that SSDP discovery with an available device works."""
+    logging.getLogger("homeassistant.components.dlna_dms.config_flow").setLevel(
+        logging.DEBUG
+    )
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_SSDP},

--- a/tests/components/onvif/test_config_flow.py
+++ b/tests/components/onvif/test_config_flow.py
@@ -176,6 +176,9 @@ async def test_flow_discovered_devices_ignore_configured_manual_input(
     hass: HomeAssistant,
 ) -> None:
     """Test that config flow discovery ignores configured devices."""
+    logging.getLogger("homeassistant.components.onvif.config_flow").setLevel(
+        logging.DEBUG
+    )
     await setup_onvif_integration(hass)
 
     result = await hass.config_entries.flow.async_init(
@@ -245,6 +248,9 @@ async def test_flow_discovered_no_device(hass: HomeAssistant) -> None:
 
 async def test_flow_discovery_ignore_existing_and_abort(hass: HomeAssistant) -> None:
     """Test that config flow discovery ignores setup devices."""
+    logging.getLogger("homeassistant.components.onvif.config_flow").setLevel(
+        logging.DEBUG
+    )
     await setup_onvif_integration(hass)
     await setup_onvif_integration(
         hass,
@@ -302,6 +308,9 @@ async def test_flow_discovery_ignore_existing_and_abort(hass: HomeAssistant) -> 
 
 async def test_flow_manual_entry(hass: HomeAssistant) -> None:
     """Test that config flow works for discovered devices."""
+    logging.getLogger("homeassistant.components.onvif.config_flow").setLevel(
+        logging.DEBUG
+    )
     result = await hass.config_entries.flow.async_init(
         config_flow.DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/onvif/test_config_flow.py
+++ b/tests/components/onvif/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test ONVIF config flow."""
+import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -103,6 +104,9 @@ def setup_mock_discovery(
 
 async def test_flow_discovered_devices(hass: HomeAssistant) -> None:
     """Test that config flow works for discovered devices."""
+    logging.getLogger("homeassistant.components.onvif.config_flow").setLevel(
+        logging.DEBUG
+    )
 
     result = await hass.config_entries.flow.async_init(
         config_flow.DOMAIN, context={"source": config_entries.SOURCE_USER}

--- a/tests/components/onvif/test_config_flow.py
+++ b/tests/components/onvif/test_config_flow.py
@@ -104,9 +104,7 @@ def setup_mock_discovery(
 
 async def test_flow_discovered_devices(hass: HomeAssistant) -> None:
     """Test that config flow works for discovered devices."""
-    logging.getLogger("homeassistant.components.onvif.config_flow").setLevel(
-        logging.DEBUG
-    )
+    logging.getLogger("homeassistant.components.onvif").setLevel(logging.DEBUG)
 
     result = await hass.config_entries.flow.async_init(
         config_flow.DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -176,9 +174,7 @@ async def test_flow_discovered_devices_ignore_configured_manual_input(
     hass: HomeAssistant,
 ) -> None:
     """Test that config flow discovery ignores configured devices."""
-    logging.getLogger("homeassistant.components.onvif.config_flow").setLevel(
-        logging.DEBUG
-    )
+    logging.getLogger("homeassistant.components.onvif").setLevel(logging.DEBUG)
     await setup_onvif_integration(hass)
 
     result = await hass.config_entries.flow.async_init(
@@ -248,9 +244,7 @@ async def test_flow_discovered_no_device(hass: HomeAssistant) -> None:
 
 async def test_flow_discovery_ignore_existing_and_abort(hass: HomeAssistant) -> None:
     """Test that config flow discovery ignores setup devices."""
-    logging.getLogger("homeassistant.components.onvif.config_flow").setLevel(
-        logging.DEBUG
-    )
+    logging.getLogger("homeassistant.components.onvif").setLevel(logging.DEBUG)
     await setup_onvif_integration(hass)
     await setup_onvif_integration(
         hass,
@@ -308,9 +302,7 @@ async def test_flow_discovery_ignore_existing_and_abort(hass: HomeAssistant) -> 
 
 async def test_flow_manual_entry(hass: HomeAssistant) -> None:
     """Test that config flow works for discovered devices."""
-    logging.getLogger("homeassistant.components.onvif.config_flow").setLevel(
-        logging.DEBUG
-    )
+    logging.getLogger("homeassistant.components.onvif").setLevel(logging.DEBUG)
     result = await hass.config_entries.flow.async_init(
         config_flow.DOMAIN, context={"source": config_entries.SOURCE_USER}
     )


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
loggers are designed to defer formatting arguments until something is actually being logged. There were a few cases where pformat was used in discovery flows where the messages get formatted and thrown away in production. These should be guarded with `LOGGER.isEnabledFor(logging.DEBUG)` as done in `google_assistant/helpers.py`

4 discoveries in 60s. The ones on the right are cheap. The one of the left has the `pformat` call

<img width="1394" alt="Screenshot 2023-07-22 at 7 17 07 PM" src="https://github.com/home-assistant/core/assets/663432/a86a8484-c56b-4470-83ef-3fa2e35fb48f">


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
