### PR TITLE
Improve availability of Tractive entities

### DIFF
--- a/homeassistant/components/tractive/__init__.py
+++ b/homeassistant/components/tractive/__init__.py
@@ -177,7 +177,7 @@ class TractiveClient:
         if self._listen_task is None:
             return False
 
-        if self._listen_task.cancelled is True:
+        if self._listen_task.cancelled() is True:
             return False
 
         return True

--- a/homeassistant/components/tractive/__init__.py
+++ b/homeassistant/components/tractive/__init__.py
@@ -177,10 +177,7 @@ class TractiveClient:
         if self._listen_task is None:
             return False
 
-        if self._listen_task.cancelled() is True:
-            return False
-
-        return True
+        return not self._listen_task.cancelled()
 
     async def trackable_objects(
         self,

--- a/homeassistant/components/tractive/__init__.py
+++ b/homeassistant/components/tractive/__init__.py
@@ -89,7 +89,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         raise ConfigEntryNotReady from error
 
     tractive = TractiveClient(hass, client, creds["user_id"], entry)
-    tractive.subscribe()
 
     try:
         trackable_objects = await client.trackable_objects()
@@ -97,7 +96,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             *(_generate_trackables(client, item) for item in trackable_objects)
         )
     except aiotractive.exceptions.TractiveError as error:
-        await tractive.unsubscribe()
         raise ConfigEntryNotReady from error
 
     # When the pet defined in Tractive has no tracker linked we get None as `trackable`.
@@ -172,6 +170,17 @@ class TractiveClient:
     def user_id(self) -> str:
         """Return user id."""
         return self._user_id
+
+    @property
+    def subscribed(self) -> bool:
+        """Return True if subscribed."""
+        if self._listen_task is None:
+            return False
+
+        if self._listen_task.cancelled is True:
+            return False
+
+        return True
 
     async def trackable_objects(
         self,

--- a/homeassistant/components/tractive/binary_sensor.py
+++ b/homeassistant/components/tractive/binary_sensor.py
@@ -45,11 +45,11 @@ class TractiveBinarySensor(TractiveEntity, BinarySensorEntity):
         self.async_write_ha_state()
 
     @callback
-    def handle_hardware_status_update(self, event: dict[str, Any]) -> None:
-        """Handle hardware status update."""
+    def handle_status_update(self, event: dict[str, Any]) -> None:
+        """Handle status update."""
         self._attr_is_on = event[self.entity_description.key]
-        self._attr_available = event[self.entity_description.key] is not None
-        self.async_write_ha_state()
+
+        super().handle_status_update(event)
 
     async def async_added_to_hass(self) -> None:
         """Handle entity which will be added."""
@@ -58,7 +58,7 @@ class TractiveBinarySensor(TractiveEntity, BinarySensorEntity):
             async_dispatcher_connect(
                 self.hass,
                 f"{TRACKER_HARDWARE_STATUS_UPDATED}-{self._tracker_id}",
-                self.handle_hardware_status_update,
+                self.handle_status_update,
             )
         )
 

--- a/homeassistant/components/tractive/binary_sensor.py
+++ b/homeassistant/components/tractive/binary_sensor.py
@@ -35,6 +35,7 @@ class TractiveBinarySensor(TractiveEntity, BinarySensorEntity):
         super().__init__(user_id, item.trackable, item.tracker_details)
 
         self._attr_unique_id = f"{item.trackable['_id']}_{description.key}"
+        self._attr_available = False
         self.entity_description = description
 
     @callback
@@ -47,7 +48,7 @@ class TractiveBinarySensor(TractiveEntity, BinarySensorEntity):
     def handle_hardware_status_update(self, event: dict[str, Any]) -> None:
         """Handle hardware status update."""
         self._attr_is_on = event[self.entity_description.key]
-        self._attr_available = True
+        self._attr_available = event[self.entity_description.key] is not None
         self.async_write_ha_state()
 
     async def async_added_to_hass(self) -> None:

--- a/homeassistant/components/tractive/binary_sensor.py
+++ b/homeassistant/components/tractive/binary_sensor.py
@@ -28,14 +28,16 @@ class TractiveBinarySensor(TractiveEntity, BinarySensorEntity):
         description: BinarySensorEntityDescription,
     ) -> None:
         """Initialize sensor entity."""
-        super().__init__(client, item.trackable, item.tracker_details)
+        super().__init__(
+            client,
+            item.trackable,
+            item.tracker_details,
+            f"{TRACKER_HARDWARE_STATUS_UPDATED}-{item.tracker_details['_id']}",
+        )
 
         self._attr_unique_id = f"{item.trackable['_id']}_{description.key}"
         self._attr_available = False
         self.entity_description = description
-        self._dispatcher_signal = (
-            f"{TRACKER_HARDWARE_STATUS_UPDATED}-{self._tracker_id}"
-        )
 
     @callback
     def handle_status_update(self, event: dict[str, Any]) -> None:

--- a/homeassistant/components/tractive/binary_sensor.py
+++ b/homeassistant/components/tractive/binary_sensor.py
@@ -14,12 +14,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import Trackables, TractiveClient
-from .const import (
-    CLIENT,
-    DOMAIN,
-    TRACKABLES,
-    TRACKER_HARDWARE_STATUS_UPDATED,
-)
+from .const import CLIENT, DOMAIN, TRACKABLES, TRACKER_HARDWARE_STATUS_UPDATED
 from .entity import TractiveEntity
 
 

--- a/homeassistant/components/tractive/binary_sensor.py
+++ b/homeassistant/components/tractive/binary_sensor.py
@@ -11,14 +11,12 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_BATTERY_CHARGING, EntityCategory
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import Trackables, TractiveClient
 from .const import (
     CLIENT,
     DOMAIN,
-    SERVER_UNAVAILABLE,
     TRACKABLES,
     TRACKER_HARDWARE_STATUS_UPDATED,
 )
@@ -40,6 +38,9 @@ class TractiveBinarySensor(TractiveEntity, BinarySensorEntity):
         self._attr_unique_id = f"{item.trackable['_id']}_{description.key}"
         self._attr_available = False
         self.entity_description = description
+        self._dispatcher_signal = (
+            f"{TRACKER_HARDWARE_STATUS_UPDATED}-{self._tracker_id}"
+        )
 
     @callback
     def handle_status_update(self, event: dict[str, Any]) -> None:
@@ -47,26 +48,6 @@ class TractiveBinarySensor(TractiveEntity, BinarySensorEntity):
         self._attr_is_on = event[self.entity_description.key]
 
         super().handle_status_update(event)
-
-    async def async_added_to_hass(self) -> None:
-        """Handle entity which will be added."""
-        await super().async_added_to_hass()
-
-        self.async_on_remove(
-            async_dispatcher_connect(
-                self.hass,
-                f"{TRACKER_HARDWARE_STATUS_UPDATED}-{self._tracker_id}",
-                self.handle_status_update,
-            )
-        )
-
-        self.async_on_remove(
-            async_dispatcher_connect(
-                self.hass,
-                f"{SERVER_UNAVAILABLE}-{self._user_id}",
-                self.handle_server_unavailable,
-            )
-        )
 
 
 SENSOR_TYPE = BinarySensorEntityDescription(

--- a/homeassistant/components/tractive/binary_sensor.py
+++ b/homeassistant/components/tractive/binary_sensor.py
@@ -35,12 +35,11 @@ class TractiveBinarySensor(TractiveEntity, BinarySensorEntity):
         description: BinarySensorEntityDescription,
     ) -> None:
         """Initialize sensor entity."""
-        super().__init__(client.user_id, item.trackable, item.tracker_details)
+        super().__init__(client, item.trackable, item.tracker_details)
 
         self._attr_unique_id = f"{item.trackable['_id']}_{description.key}"
         self._attr_available = False
         self.entity_description = description
-        self._client = client
 
     @callback
     def handle_status_update(self, event: dict[str, Any]) -> None:
@@ -51,8 +50,7 @@ class TractiveBinarySensor(TractiveEntity, BinarySensorEntity):
 
     async def async_added_to_hass(self) -> None:
         """Handle entity which will be added."""
-        if not self._client.subscribed:
-            self._client.subscribe()
+        await super().async_added_to_hass()
 
         self.async_on_remove(
             async_dispatcher_connect(

--- a/homeassistant/components/tractive/binary_sensor.py
+++ b/homeassistant/components/tractive/binary_sensor.py
@@ -39,12 +39,6 @@ class TractiveBinarySensor(TractiveEntity, BinarySensorEntity):
         self.entity_description = description
 
     @callback
-    def handle_server_unavailable(self) -> None:
-        """Handle server unavailable."""
-        self._attr_available = False
-        self.async_write_ha_state()
-
-    @callback
     def handle_status_update(self, event: dict[str, Any]) -> None:
         """Handle status update."""
         self._attr_is_on = event[self.entity_description.key]

--- a/homeassistant/components/tractive/device_tracker.py
+++ b/homeassistant/components/tractive/device_tracker.py
@@ -94,11 +94,6 @@ class TractiveDeviceTracker(TractiveEntity, TrackerEntity):
         self._attr_available = True
         self.async_write_ha_state()
 
-    @callback
-    def _handle_server_unavailable(self) -> None:
-        self._attr_available = False
-        self.async_write_ha_state()
-
     async def async_added_to_hass(self) -> None:
         """Handle entity which will be added."""
 
@@ -122,6 +117,6 @@ class TractiveDeviceTracker(TractiveEntity, TrackerEntity):
             async_dispatcher_connect(
                 self.hass,
                 f"{SERVER_UNAVAILABLE}-{self._user_id}",
-                self._handle_server_unavailable,
+                self.handle_server_unavailable,
             )
         )

--- a/homeassistant/components/tractive/device_tracker.py
+++ b/homeassistant/components/tractive/device_tracker.py
@@ -41,7 +41,7 @@ class TractiveDeviceTracker(TractiveEntity, TrackerEntity):
 
     def __init__(self, client: TractiveClient, item: Trackables) -> None:
         """Initialize tracker entity."""
-        super().__init__(client.user_id, item.trackable, item.tracker_details)
+        super().__init__(client, item.trackable, item.tracker_details)
 
         self._battery_level: int | None = item.hw_info.get("battery_level")
         self._latitude: float = item.pos_report["latlong"][0]
@@ -49,7 +49,6 @@ class TractiveDeviceTracker(TractiveEntity, TrackerEntity):
         self._accuracy: int = item.pos_report["pos_uncertainty"]
         self._source_type: str = item.pos_report["sensor_used"]
         self._attr_unique_id = item.trackable["_id"]
-        self._client = client
 
     @property
     def source_type(self) -> SourceType:
@@ -97,8 +96,7 @@ class TractiveDeviceTracker(TractiveEntity, TrackerEntity):
 
     async def async_added_to_hass(self) -> None:
         """Handle entity which will be added."""
-        if not self._client.subscribed:
-            self._client.subscribe()
+        await super().async_added_to_hass()
 
         self.async_on_remove(
             async_dispatcher_connect(

--- a/homeassistant/components/tractive/device_tracker.py
+++ b/homeassistant/components/tractive/device_tracker.py
@@ -41,7 +41,12 @@ class TractiveDeviceTracker(TractiveEntity, TrackerEntity):
 
     def __init__(self, client: TractiveClient, item: Trackables) -> None:
         """Initialize tracker entity."""
-        super().__init__(client, item.trackable, item.tracker_details)
+        super().__init__(
+            client,
+            item.trackable,
+            item.tracker_details,
+            f"{TRACKER_HARDWARE_STATUS_UPDATED}-{item.tracker_details['_id']}",
+        )
 
         self._battery_level: int | None = item.hw_info.get("battery_level")
         self._latitude: float = item.pos_report["latlong"][0]
@@ -102,7 +107,7 @@ class TractiveDeviceTracker(TractiveEntity, TrackerEntity):
         self.async_on_remove(
             async_dispatcher_connect(
                 self.hass,
-                f"{TRACKER_HARDWARE_STATUS_UPDATED}-{self._tracker_id}",
+                self._dispatcher_signal,
                 self._handle_hardware_status_update,
             )
         )

--- a/homeassistant/components/tractive/device_tracker.py
+++ b/homeassistant/components/tractive/device_tracker.py
@@ -96,7 +96,8 @@ class TractiveDeviceTracker(TractiveEntity, TrackerEntity):
 
     async def async_added_to_hass(self) -> None:
         """Handle entity which will be added."""
-        await super().async_added_to_hass()
+        if not self._client.subscribed:
+            self._client.subscribe()
 
         self.async_on_remove(
             async_dispatcher_connect(

--- a/homeassistant/components/tractive/entity.py
+++ b/homeassistant/components/tractive/entity.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from homeassistant.core import callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity
 
@@ -29,3 +30,9 @@ class TractiveEntity(Entity):
         self._user_id = user_id
         self._tracker_id = tracker_details["_id"]
         self._trackable = trackable
+
+    @callback
+    def handle_status_update(self, event: dict[str, Any]) -> None:
+        """Handle status update."""
+        self._attr_available = event[self.entity_description.key] is not None
+        self.async_write_ha_state()

--- a/homeassistant/components/tractive/entity.py
+++ b/homeassistant/components/tractive/entity.py
@@ -36,3 +36,9 @@ class TractiveEntity(Entity):
         """Handle status update."""
         self._attr_available = event[self.entity_description.key] is not None
         self.async_write_ha_state()
+
+    @callback
+    def handle_server_unavailable(self) -> None:
+        """Handle server unavailable."""
+        self._attr_available = False
+        self.async_write_ha_state()

--- a/homeassistant/components/tractive/entity.py
+++ b/homeassistant/components/tractive/entity.py
@@ -1,7 +1,7 @@
 """A entity class for Tractive integration."""
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from homeassistant.core import callback
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -22,6 +22,7 @@ class TractiveEntity(Entity):
         client: TractiveClient,
         trackable: dict[str, Any],
         tracker_details: dict[str, Any],
+        dispatcher_signal: str,
     ) -> None:
         """Initialize tracker entity."""
         self._attr_device_info = DeviceInfo(
@@ -34,17 +35,13 @@ class TractiveEntity(Entity):
         )
         self._user_id = client.user_id
         self._tracker_id = tracker_details["_id"]
-        self._trackable = trackable
         self._client = client
-        self._dispatcher_signal: str | None = None
+        self._dispatcher_signal = dispatcher_signal
 
     async def async_added_to_hass(self) -> None:
         """Handle entity which will be added."""
         if not self._client.subscribed:
             self._client.subscribe()
-
-        if TYPE_CHECKING:
-            assert self._dispatcher_signal is not None
 
         self.async_on_remove(
             async_dispatcher_connect(

--- a/homeassistant/components/tractive/sensor.py
+++ b/homeassistant/components/tractive/sensor.py
@@ -78,12 +78,6 @@ class TractiveSensor(TractiveEntity, SensorEntity):
 
         super().handle_status_update(event)
 
-    @callback
-    def handle_server_unavailable(self) -> None:
-        """Handle server unavailable."""
-        self._attr_available = False
-        self.async_write_ha_state()
-
 
 class TractiveHardwareSensor(TractiveSensor):
     """Tractive hardware sensor."""

--- a/homeassistant/components/tractive/sensor.py
+++ b/homeassistant/components/tractive/sensor.py
@@ -18,7 +18,6 @@ from homeassistant.const import (
     UnitOfTime,
 )
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import Trackables, TractiveClient
@@ -32,7 +31,6 @@ from .const import (
     ATTR_TRACKER_STATE,
     CLIENT,
     DOMAIN,
-    SERVER_UNAVAILABLE,
     TRACKABLES,
     TRACKER_ACTIVITY_STATUS_UPDATED,
     TRACKER_HARDWARE_STATUS_UPDATED,
@@ -85,26 +83,6 @@ class TractiveSensor(TractiveEntity, SensorEntity):
         self._attr_native_value = event[self.entity_description.key]
 
         super().handle_status_update(event)
-
-    async def async_added_to_hass(self) -> None:
-        """Handle entity which will be added."""
-        await super().async_added_to_hass()
-
-        self.async_on_remove(
-            async_dispatcher_connect(
-                self.hass,
-                self._dispatcher_signal,
-                self.handle_status_update,
-            )
-        )
-
-        self.async_on_remove(
-            async_dispatcher_connect(
-                self.hass,
-                f"{SERVER_UNAVAILABLE}-{self._user_id}",
-                self.handle_server_unavailable,
-            )
-        )
 
 
 SENSOR_TYPES: tuple[TractiveSensorEntityDescription, ...] = (

--- a/homeassistant/components/tractive/sensor.py
+++ b/homeassistant/components/tractive/sensor.py
@@ -65,16 +65,18 @@ class TractiveSensor(TractiveEntity, SensorEntity):
         description: TractiveSensorEntityDescription,
     ) -> None:
         """Initialize sensor entity."""
-        super().__init__(client, item.trackable, item.tracker_details)
+        if description.hardware_sensor:
+            dispatcher_signal = (
+                f"{description.signal_prefix}-{item.tracker_details['_id']}"
+            )
+        else:
+            dispatcher_signal = f"{description.signal_prefix}-{item.trackable['_id']}"
+        super().__init__(
+            client, item.trackable, item.tracker_details, dispatcher_signal
+        )
 
         self._attr_unique_id = f"{item.trackable['_id']}_{description.key}"
         self._attr_available = False
-        if description.hardware_sensor:
-            self._dispatcher_signal = f"{description.signal_prefix}-{self._tracker_id}"
-        else:
-            self._dispatcher_signal = (
-                f"{description.signal_prefix}-{self._trackable['_id']}"
-            )
         self.entity_description = description
 
     @callback

--- a/homeassistant/components/tractive/sensor.py
+++ b/homeassistant/components/tractive/sensor.py
@@ -75,8 +75,8 @@ class TractiveSensor(TractiveEntity, SensorEntity):
     def handle_status_update(self, event: dict[str, Any]) -> None:
         """Handle status update."""
         self._attr_native_value = event[self.entity_description.key]
-        self._attr_available = event[self.entity_description.key] is not None
-        self.async_write_ha_state()
+
+        super().handle_status_update(event)
 
     @callback
     def handle_server_unavailable(self) -> None:

--- a/homeassistant/components/tractive/switch.py
+++ b/homeassistant/components/tractive/switch.py
@@ -112,11 +112,11 @@ class TractiveSwitch(TractiveEntity, SwitchEntity):
         self.async_write_ha_state()
 
     @callback
-    def handle_hardware_status_update(self, event: dict[str, Any]) -> None:
-        """Handle hardware status update."""
+    def handle_status_update(self, event: dict[str, Any]) -> None:
+        """Handle status update."""
         self._attr_is_on = event[self.entity_description.key]
-        self._attr_available = event[self.entity_description.key] is not None
-        self.async_write_ha_state()
+
+        super().handle_status_update(event)
 
     async def async_added_to_hass(self) -> None:
         """Handle entity which will be added."""
@@ -125,7 +125,7 @@ class TractiveSwitch(TractiveEntity, SwitchEntity):
             async_dispatcher_connect(
                 self.hass,
                 f"{TRACKER_HARDWARE_STATUS_UPDATED}-{self._tracker_id}",
-                self.handle_hardware_status_update,
+                self.handle_status_update,
             )
         )
 

--- a/homeassistant/components/tractive/switch.py
+++ b/homeassistant/components/tractive/switch.py
@@ -95,16 +95,18 @@ class TractiveSwitch(TractiveEntity, SwitchEntity):
         description: TractiveSwitchEntityDescription,
     ) -> None:
         """Initialize switch entity."""
-        super().__init__(client, item.trackable, item.tracker_details)
+        super().__init__(
+            client,
+            item.trackable,
+            item.tracker_details,
+            f"{TRACKER_HARDWARE_STATUS_UPDATED}-{item.tracker_details['_id']}",
+        )
 
         self._attr_unique_id = f"{item.trackable['_id']}_{description.key}"
         self._attr_available = False
         self._tracker = item.tracker
         self._method = getattr(self, description.method)
         self.entity_description = description
-        self._dispatcher_signal = (
-            f"{TRACKER_HARDWARE_STATUS_UPDATED}-{self._tracker_id}"
-        )
 
     @callback
     def handle_status_update(self, event: dict[str, Any]) -> None:

--- a/homeassistant/components/tractive/switch.py
+++ b/homeassistant/components/tractive/switch.py
@@ -114,10 +114,8 @@ class TractiveSwitch(TractiveEntity, SwitchEntity):
     @callback
     def handle_hardware_status_update(self, event: dict[str, Any]) -> None:
         """Handle hardware status update."""
-        if (state := event[self.entity_description.key]) is None:
-            return
-        self._attr_is_on = state
-        self._attr_available = True
+        self._attr_is_on = event[self.entity_description.key]
+        self._attr_available = event[self.entity_description.key] is not None
         self.async_write_ha_state()
 
     async def async_added_to_hass(self) -> None:

--- a/homeassistant/components/tractive/switch.py
+++ b/homeassistant/components/tractive/switch.py
@@ -97,14 +97,13 @@ class TractiveSwitch(TractiveEntity, SwitchEntity):
         description: TractiveSwitchEntityDescription,
     ) -> None:
         """Initialize switch entity."""
-        super().__init__(client.user_id, item.trackable, item.tracker_details)
+        super().__init__(client, item.trackable, item.tracker_details)
 
         self._attr_unique_id = f"{item.trackable['_id']}_{description.key}"
         self._attr_available = False
         self._tracker = item.tracker
         self._method = getattr(self, description.method)
         self.entity_description = description
-        self._client = client
 
     @callback
     def handle_status_update(self, event: dict[str, Any]) -> None:
@@ -115,8 +114,7 @@ class TractiveSwitch(TractiveEntity, SwitchEntity):
 
     async def async_added_to_hass(self) -> None:
         """Handle entity which will be added."""
-        if not self._client.subscribed:
-            self._client.subscribe()
+        await super().async_added_to_hass()
 
         self.async_on_remove(
             async_dispatcher_connect(

--- a/homeassistant/components/tractive/switch.py
+++ b/homeassistant/components/tractive/switch.py
@@ -106,12 +106,6 @@ class TractiveSwitch(TractiveEntity, SwitchEntity):
         self.entity_description = description
 
     @callback
-    def handle_server_unavailable(self) -> None:
-        """Handle server unavailable."""
-        self._attr_available = False
-        self.async_write_ha_state()
-
-    @callback
     def handle_status_update(self, event: dict[str, Any]) -> None:
         """Handle status update."""
         self._attr_is_on = event[self.entity_description.key]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Sometimes the API returns `null` instead of values, this causes the sensor state to be `unknown`.

![Zrzut ekranu 2023-07-23 171225](https://github.com/home-assistant/core/assets/478555/3bafd194-f500-4505-8985-bd335a0e27a3)

Also this may cause warnings for sensors that have numeric values as states and have a defined `state_class`.

With this change, entities are marked as `unavailable` during init and when an event with data is received, their availability is determined based on the condition `value is not None`. If the `value is None`, the entity will be unavailable.

Also, the `handle_server_unavailable()` and `handle_status_update()` functions have been moved to `TractiveEntity` to simplify the code.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #98351
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
