### PR TITLE
Improve `async_track_template_result` callback typing

### DIFF
--- a/homeassistant/components/bayesian/binary_sensor.py
+++ b/homeassistant/components/bayesian/binary_sensor.py
@@ -27,7 +27,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
-from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConditionError, TemplateError
 from homeassistant.helpers import condition
 import homeassistant.helpers.config_validation as cv
@@ -259,14 +259,13 @@ class BayesianBinarySensor(BinarySensorEntity):
 
         @callback
         def _async_template_result_changed(
-            event: Event | None, updates: list[TrackTemplateResult]
+            event: EventType[EventStateChangedData] | None,
+            updates: list[TrackTemplateResult],
         ) -> None:
             track_template_result = updates.pop()
             template = track_template_result.template
             result = track_template_result.result
-            entity: str | None = (
-                None if event is None else event.data.get(CONF_ENTITY_ID)
-            )
+            entity_id = None if event is None else event.data["entity_id"]
             if isinstance(result, TemplateError):
                 _LOGGER.error(
                     "TemplateError('%s') while processing template '%s' in entity '%s'",
@@ -283,8 +282,8 @@ class BayesianBinarySensor(BinarySensorEntity):
                 observation.observed = observed
 
                 # in some cases a template may update because of the absence of an entity
-                if entity is not None:
-                    observation.entity_id = entity
+                if entity_id is not None:
+                    observation.entity_id = entity_id
 
                 self.current_observations[observation.id] = observation
 

--- a/homeassistant/components/universal/media_player.py
+++ b/homeassistant/components/universal/media_player.py
@@ -87,6 +87,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import (
     EventStateChangedData,
     TrackTemplate,
+    TrackTemplateResult,
     async_track_state_change_event,
     async_track_template_result,
 )
@@ -192,7 +193,10 @@ class UniversalMediaPlayer(MediaPlayerEntity):
             self.async_schedule_update_ha_state(True)
 
         @callback
-        def _async_on_template_update(event, updates):
+        def _async_on_template_update(
+            event: EventType[EventStateChangedData] | None,
+            updates: list[TrackTemplateResult],
+        ) -> None:
             """Update state when template state changes."""
             for data in updates:
                 template = data.template

--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -26,6 +26,7 @@ from homeassistant.exceptions import (
 from homeassistant.helpers import config_validation as cv, entity, template
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.event import (
+    EventStateChangedData,
     TrackTemplate,
     TrackTemplateResult,
     async_track_template_result,
@@ -37,6 +38,7 @@ from homeassistant.helpers.json import (
     json_dumps,
 )
 from homeassistant.helpers.service import async_get_all_descriptions
+from homeassistant.helpers.typing import EventType
 from homeassistant.loader import (
     Integration,
     IntegrationNotFound,
@@ -535,7 +537,8 @@ async def handle_render_template(
 
     @callback
     def _template_listener(
-        event: Event | None, updates: list[TrackTemplateResult]
+        event: EventType[EventStateChangedData] | None,
+        updates: list[TrackTemplateResult],
     ) -> None:
         nonlocal info
         track_template_result = updates.pop()

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -888,9 +888,7 @@ class TrackTemplateResultInfo:
         self,
         hass: HomeAssistant,
         track_templates: Sequence[TrackTemplate],
-        action: Callable[
-            [EventType[EventStateChangedData] | None, list[TrackTemplateResult]], None
-        ],
+        action: TrackTemplateResultListener,
         has_super_template: bool = False,
     ) -> None:
         """Handle removal / refresh of tracker init."""
@@ -1209,7 +1207,7 @@ TrackTemplateResultListener = Callable[
         EventType[EventStateChangedData] | None,
         list[TrackTemplateResult],
     ],
-    None,
+    Coroutine[Any, Any, None] | None,
 ]
 """Type for the listener for template results.
 

--- a/homeassistant/helpers/template_entity.py
+++ b/homeassistant/helpers/template_entity.py
@@ -15,7 +15,6 @@ from homeassistant.components.sensor import (
     SensorEntity,
 )
 from homeassistant.const import (
-    ATTR_ENTITY_ID,
     ATTR_ENTITY_PICTURE,
     ATTR_FRIENDLY_NAME,
     ATTR_ICON,
@@ -33,7 +32,12 @@ from homeassistant.util.json import JSON_DECODE_EXCEPTIONS, json_loads
 
 from . import config_validation as cv
 from .entity import Entity
-from .event import TrackTemplate, TrackTemplateResult, async_track_template_result
+from .event import (
+    EventStateChangedData,
+    TrackTemplate,
+    TrackTemplateResult,
+    async_track_template_result,
+)
 from .script import Script, _VarsType
 from .template import (
     Template,
@@ -42,7 +46,7 @@ from .template import (
     render_complex,
     result_as_boolean,
 )
-from .typing import ConfigType
+from .typing import ConfigType, EventType
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -327,14 +331,14 @@ class TemplateEntity(Entity):
     @callback
     def _handle_results(
         self,
-        event: Event | None,
+        event: EventType[EventStateChangedData] | None,
         updates: list[TrackTemplateResult],
     ) -> None:
         """Call back the results to the attributes."""
         if event:
             self.async_set_context(event.context)
 
-        entity_id = event and event.data.get(ATTR_ENTITY_ID)
+        entity_id = event and event.data["entity_id"]
 
         if entity_id and entity_id == self.entity_id:
             self._self_ref_update_count += 1

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -965,7 +965,10 @@ async def test_track_template_result(hass: HomeAssistant) -> None:
         "{{(states.sensor.test.state|int) + test }}", hass
     )
 
-    def specific_run_callback(event, updates):
+    def specific_run_callback(
+        event: EventType[EventStateChangedData] | None,
+        updates: list[TrackTemplateResult],
+    ) -> None:
         track_result = updates.pop()
         specific_runs.append(int(track_result.result))
 
@@ -974,7 +977,10 @@ async def test_track_template_result(hass: HomeAssistant) -> None:
     )
 
     @ha.callback
-    def wildcard_run_callback(event, updates):
+    def wildcard_run_callback(
+        event: EventType[EventStateChangedData] | None,
+        updates: list[TrackTemplateResult],
+    ) -> None:
         track_result = updates.pop()
         wildcard_runs.append(
             (int(track_result.last_result or 0), int(track_result.result))
@@ -984,7 +990,10 @@ async def test_track_template_result(hass: HomeAssistant) -> None:
         hass, [TrackTemplate(template_condition, None)], wildcard_run_callback
     )
 
-    async def wildercard_run_callback(event, updates):
+    async def wildercard_run_callback(
+        event: EventType[EventStateChangedData] | None,
+        updates: list[TrackTemplateResult],
+    ) -> None:
         track_result = updates.pop()
         wildercard_runs.append(
             (int(track_result.last_result or 0), int(track_result.result))
@@ -1051,7 +1060,10 @@ async def test_track_template_result_none(hass: HomeAssistant) -> None:
         "{{(state_attr('sensor.test', 'battery')|int(default=0)) + test }}", hass
     )
 
-    def specific_run_callback(event, updates):
+    def specific_run_callback(
+        event: EventType[EventStateChangedData] | None,
+        updates: list[TrackTemplateResult],
+    ) -> None:
         track_result = updates.pop()
         result = int(track_result.result) if track_result.result is not None else None
         specific_runs.append(result)
@@ -1061,7 +1073,10 @@ async def test_track_template_result_none(hass: HomeAssistant) -> None:
     )
 
     @ha.callback
-    def wildcard_run_callback(event, updates):
+    def wildcard_run_callback(
+        event: EventType[EventStateChangedData] | None,
+        updates: list[TrackTemplateResult],
+    ) -> None:
         track_result = updates.pop()
         last_result = (
             int(track_result.last_result)
@@ -1075,7 +1090,10 @@ async def test_track_template_result_none(hass: HomeAssistant) -> None:
         hass, [TrackTemplate(template_condition, None)], wildcard_run_callback
     )
 
-    async def wildercard_run_callback(event, updates):
+    async def wildercard_run_callback(
+        event: EventType[EventStateChangedData] | None,
+        updates: list[TrackTemplateResult],
+    ) -> None:
         track_result = updates.pop()
         last_result = (
             int(track_result.last_result)
@@ -1122,7 +1140,10 @@ async def test_track_template_result_super_template(hass: HomeAssistant) -> None
         "{{(states.sensor.test.state|int) + test }}", hass
     )
 
-    def specific_run_callback(event, updates):
+    def specific_run_callback(
+        event: EventType[EventStateChangedData] | None,
+        updates: list[TrackTemplateResult],
+    ) -> None:
         for track_result in updates:
             if track_result.template is template_condition:
                 specific_runs.append(int(track_result.result))
@@ -1140,7 +1161,10 @@ async def test_track_template_result_super_template(hass: HomeAssistant) -> None
     )
 
     @ha.callback
-    def wildcard_run_callback(event, updates):
+    def wildcard_run_callback(
+        event: EventType[EventStateChangedData] | None,
+        updates: list[TrackTemplateResult],
+    ) -> None:
         for track_result in updates:
             if track_result.template is template_condition:
                 wildcard_runs.append(
@@ -1159,7 +1183,10 @@ async def test_track_template_result_super_template(hass: HomeAssistant) -> None
         has_super_template=True,
     )
 
-    async def wildercard_run_callback(event, updates):
+    async def wildercard_run_callback(
+        event: EventType[EventStateChangedData] | None,
+        updates: list[TrackTemplateResult],
+    ) -> None:
         for track_result in updates:
             if track_result.template is template_condition_var:
                 wildercard_runs.append(
@@ -1272,7 +1299,10 @@ async def test_track_template_result_super_template_initially_false(
     hass.states.async_set("sensor.test", "unavailable")
     await hass.async_block_till_done()
 
-    def specific_run_callback(event, updates):
+    def specific_run_callback(
+        event: EventType[EventStateChangedData] | None,
+        updates: list[TrackTemplateResult],
+    ) -> None:
         for track_result in updates:
             if track_result.template is template_condition:
                 specific_runs.append(int(track_result.result))
@@ -1290,7 +1320,10 @@ async def test_track_template_result_super_template_initially_false(
     )
 
     @ha.callback
-    def wildcard_run_callback(event, updates):
+    def wildcard_run_callback(
+        event: EventType[EventStateChangedData] | None,
+        updates: list[TrackTemplateResult],
+    ) -> None:
         for track_result in updates:
             if track_result.template is template_condition:
                 wildcard_runs.append(
@@ -1309,7 +1342,10 @@ async def test_track_template_result_super_template_initially_false(
         has_super_template=True,
     )
 
-    async def wildercard_run_callback(event, updates):
+    async def wildercard_run_callback(
+        event: EventType[EventStateChangedData] | None,
+        updates: list[TrackTemplateResult],
+    ) -> None:
         for track_result in updates:
             if track_result.template is template_condition_var:
                 wildercard_runs.append(
@@ -1434,7 +1470,10 @@ async def test_track_template_result_super_template_2(
 
         return result_as_boolean(result)
 
-    def specific_run_callback(event, updates):
+    def specific_run_callback(
+        event: EventType[EventStateChangedData] | None,
+        updates: list[TrackTemplateResult],
+    ) -> None:
         for track_result in updates:
             if track_result.template is template_condition:
                 specific_runs.append(int(track_result.result))
@@ -1454,7 +1493,10 @@ async def test_track_template_result_super_template_2(
     )
 
     @ha.callback
-    def wildcard_run_callback(event, updates):
+    def wildcard_run_callback(
+        event: EventType[EventStateChangedData] | None,
+        updates: list[TrackTemplateResult],
+    ) -> None:
         for track_result in updates:
             if track_result.template is template_condition:
                 wildcard_runs.append(
@@ -1475,7 +1517,10 @@ async def test_track_template_result_super_template_2(
         has_super_template=True,
     )
 
-    async def wildercard_run_callback(event, updates):
+    async def wildercard_run_callback(
+        event: EventType[EventStateChangedData] | None,
+        updates: list[TrackTemplateResult],
+    ) -> None:
         for track_result in updates:
             if track_result.template is template_condition_var:
                 wildercard_runs.append(
@@ -1580,7 +1625,10 @@ async def test_track_template_result_super_template_2_initially_false(
 
         return result_as_boolean(result)
 
-    def specific_run_callback(event, updates):
+    def specific_run_callback(
+        event: EventType[EventStateChangedData] | None,
+        updates: list[TrackTemplateResult],
+    ) -> None:
         for track_result in updates:
             if track_result.template is template_condition:
                 specific_runs.append(int(track_result.result))
@@ -1600,7 +1648,10 @@ async def test_track_template_result_super_template_2_initially_false(
     )
 
     @ha.callback
-    def wildcard_run_callback(event, updates):
+    def wildcard_run_callback(
+        event: EventType[EventStateChangedData] | None,
+        updates: list[TrackTemplateResult],
+    ) -> None:
         for track_result in updates:
             if track_result.template is template_condition:
                 wildcard_runs.append(
@@ -1621,7 +1672,10 @@ async def test_track_template_result_super_template_2_initially_false(
         has_super_template=True,
     )
 
-    async def wildercard_run_callback(event, updates):
+    async def wildercard_run_callback(
+        event: EventType[EventStateChangedData] | None,
+        updates: list[TrackTemplateResult],
+    ) -> None:
         for track_result in updates:
             if track_result.template is template_condition_var:
                 wildercard_runs.append(
@@ -1701,7 +1755,10 @@ async def test_track_template_result_complex(hass: HomeAssistant) -> None:
 """
     template_complex = Template(template_complex_str, hass)
 
-    def specific_run_callback(event, updates):
+    def specific_run_callback(
+        event: EventType[EventStateChangedData] | None,
+        updates: list[TrackTemplateResult],
+    ) -> None:
         specific_runs.append(updates.pop().result)
 
     hass.states.async_set("light.one", "on")
@@ -1854,7 +1911,10 @@ async def test_track_template_result_with_wildcard(hass: HomeAssistant) -> None:
 """
     template_complex = Template(template_complex_str, hass)
 
-    def specific_run_callback(event, updates):
+    def specific_run_callback(
+        event: EventType[EventStateChangedData] | None,
+        updates: list[TrackTemplateResult],
+    ) -> None:
         specific_runs.append(updates.pop().result)
 
     hass.states.async_set("cover.office_drapes", "closed")
@@ -1906,7 +1966,10 @@ async def test_track_template_result_with_group(hass: HomeAssistant) -> None:
 """
     template_complex = Template(template_complex_str, hass)
 
-    def specific_run_callback(event, updates):
+    def specific_run_callback(
+        event: EventType[EventStateChangedData] | None,
+        updates: list[TrackTemplateResult],
+    ) -> None:
         specific_runs.append(updates.pop().result)
 
     info = async_track_template_result(
@@ -1963,7 +2026,10 @@ async def test_track_template_result_and_conditional(hass: HomeAssistant) -> Non
 
     template = Template(template_str, hass)
 
-    def specific_run_callback(event, updates):
+    def specific_run_callback(
+        event: EventType[EventStateChangedData] | None,
+        updates: list[TrackTemplateResult],
+    ) -> None:
         specific_runs.append(updates.pop().result)
 
     info = async_track_template_result(
@@ -2028,7 +2094,10 @@ async def test_track_template_result_and_conditional_upper_case(
 
     template = Template(template_str, hass)
 
-    def specific_run_callback(event, updates):
+    def specific_run_callback(
+        event: EventType[EventStateChangedData] | None,
+        updates: list[TrackTemplateResult],
+    ) -> None:
         specific_runs.append(updates.pop().result)
 
     info = async_track_template_result(
@@ -2087,7 +2156,10 @@ async def test_track_template_result_iterator(hass: HomeAssistant) -> None:
     iterator_runs = []
 
     @ha.callback
-    def iterator_callback(event, updates):
+    def iterator_callback(
+        event: EventType[EventStateChangedData] | None,
+        updates: list[TrackTemplateResult],
+    ) -> None:
         iterator_runs.append(updates.pop().result)
 
     async_track_template_result(
@@ -2120,7 +2192,10 @@ async def test_track_template_result_iterator(hass: HomeAssistant) -> None:
     filter_runs = []
 
     @ha.callback
-    def filter_callback(event, updates):
+    def filter_callback(
+        event: EventType[EventStateChangedData] | None,
+        updates: list[TrackTemplateResult],
+    ) -> None:
         filter_runs.append(updates.pop().result)
 
     info = async_track_template_result(
@@ -2170,7 +2245,10 @@ async def test_track_template_result_errors(
     not_exist_runs = []
 
     @ha.callback
-    def syntax_error_listener(event, updates):
+    def syntax_error_listener(
+        event: EventType[EventStateChangedData] | None,
+        updates: list[TrackTemplateResult],
+    ) -> None:
         track_result = updates.pop()
         syntax_error_runs.append(
             (
@@ -2190,7 +2268,10 @@ async def test_track_template_result_errors(
     assert "TemplateSyntaxError" in caplog.text
 
     @ha.callback
-    def not_exist_runs_error_listener(event, updates):
+    def not_exist_runs_error_listener(
+        event: EventType[EventStateChangedData] | None,
+        updates: list[TrackTemplateResult],
+    ) -> None:
         template_track = updates.pop()
         not_exist_runs.append(
             (
@@ -2255,7 +2336,10 @@ async def test_track_template_result_transient_errors(
     sometimes_error_runs = []
 
     @ha.callback
-    def sometimes_error_listener(event, updates):
+    def sometimes_error_listener(
+        event: EventType[EventStateChangedData] | None,
+        updates: list[TrackTemplateResult],
+    ) -> None:
         track_result = updates.pop()
         sometimes_error_runs.append(
             (
@@ -2300,7 +2384,10 @@ async def test_static_string(hass: HomeAssistant) -> None:
     refresh_runs = []
 
     @ha.callback
-    def refresh_listener(event, updates):
+    def refresh_listener(
+        event: EventType[EventStateChangedData] | None,
+        updates: list[TrackTemplateResult],
+    ) -> None:
         refresh_runs.append(updates.pop().result)
 
     info = async_track_template_result(
@@ -2320,7 +2407,10 @@ async def test_track_template_rate_limit(hass: HomeAssistant) -> None:
     refresh_runs = []
 
     @ha.callback
-    def refresh_listener(event, updates):
+    def refresh_listener(
+        event: EventType[EventStateChangedData] | None,
+        updates: list[TrackTemplateResult],
+    ) -> None:
         refresh_runs.append(updates.pop().result)
 
     info = async_track_template_result(
@@ -2379,7 +2469,10 @@ async def test_track_template_rate_limit_super(hass: HomeAssistant) -> None:
     refresh_runs = []
 
     @ha.callback
-    def refresh_listener(event, updates):
+    def refresh_listener(
+        event: EventType[EventStateChangedData] | None,
+        updates: list[TrackTemplateResult],
+    ) -> None:
         for track_result in updates:
             if track_result.template is template_refresh:
                 refresh_runs.append(track_result.result)
@@ -2452,7 +2545,10 @@ async def test_track_template_rate_limit_super_2(hass: HomeAssistant) -> None:
     refresh_runs = []
 
     @ha.callback
-    def refresh_listener(event, updates):
+    def refresh_listener(
+        event: EventType[EventStateChangedData] | None,
+        updates: list[TrackTemplateResult],
+    ) -> None:
         for track_result in updates:
             if track_result.template is template_refresh:
                 refresh_runs.append(track_result.result)
@@ -2521,7 +2617,10 @@ async def test_track_template_rate_limit_super_3(hass: HomeAssistant) -> None:
     refresh_runs = []
 
     @ha.callback
-    def refresh_listener(event, updates):
+    def refresh_listener(
+        event: EventType[EventStateChangedData] | None,
+        updates: list[TrackTemplateResult],
+    ) -> None:
         for track_result in updates:
             if track_result.template is template_refresh:
                 refresh_runs.append(track_result.result)
@@ -2592,7 +2691,10 @@ async def test_track_template_rate_limit_suppress_listener(hass: HomeAssistant) 
     refresh_runs = []
 
     @ha.callback
-    def refresh_listener(event, updates):
+    def refresh_listener(
+        event: EventType[EventStateChangedData] | None,
+        updates: list[TrackTemplateResult],
+    ) -> None:
         refresh_runs.append(updates.pop().result)
 
     info = async_track_template_result(
@@ -2689,7 +2791,10 @@ async def test_track_template_rate_limit_five(hass: HomeAssistant) -> None:
     refresh_runs = []
 
     @ha.callback
-    def refresh_listener(event, updates):
+    def refresh_listener(
+        event: EventType[EventStateChangedData] | None,
+        updates: list[TrackTemplateResult],
+    ) -> None:
         refresh_runs.append(updates.pop().result)
 
     info = async_track_template_result(
@@ -2725,7 +2830,10 @@ async def test_track_template_has_default_rate_limit(hass: HomeAssistant) -> Non
     refresh_runs = []
 
     @ha.callback
-    def refresh_listener(event, updates):
+    def refresh_listener(
+        event: EventType[EventStateChangedData] | None,
+        updates: list[TrackTemplateResult],
+    ) -> None:
         refresh_runs.append(updates.pop().result)
 
     info = async_track_template_result(
@@ -2766,7 +2874,10 @@ async def test_track_template_unavailable_states_has_default_rate_limit(
     refresh_runs = []
 
     @ha.callback
-    def refresh_listener(event, updates):
+    def refresh_listener(
+        event: EventType[EventStateChangedData] | None,
+        updates: list[TrackTemplateResult],
+    ) -> None:
         refresh_runs.append(updates.pop().result)
 
     info = async_track_template_result(
@@ -2807,7 +2918,10 @@ async def test_specifically_referenced_entity_is_not_rate_limited(
     refresh_runs = []
 
     @ha.callback
-    def refresh_listener(event, updates):
+    def refresh_listener(
+        event: EventType[EventStateChangedData] | None,
+        updates: list[TrackTemplateResult],
+    ) -> None:
         refresh_runs.append(updates.pop().result)
 
     info = async_track_template_result(
@@ -2850,7 +2964,10 @@ async def test_track_two_templates_with_different_rate_limits(
     }
 
     @ha.callback
-    def refresh_listener(event, updates):
+    def refresh_listener(
+        event: EventType[EventStateChangedData] | None,
+        updates: list[TrackTemplateResult],
+    ) -> None:
         for update in updates:
             refresh_runs[update.template].append(update.result)
 
@@ -2911,7 +3028,10 @@ async def test_string(hass: HomeAssistant) -> None:
     refresh_runs = []
 
     @ha.callback
-    def refresh_listener(event, updates):
+    def refresh_listener(
+        event: EventType[EventStateChangedData] | None,
+        updates: list[TrackTemplateResult],
+    ) -> None:
         refresh_runs.append(updates.pop().result)
 
     info = async_track_template_result(
@@ -2931,7 +3051,10 @@ async def test_track_template_result_refresh_cancel(hass: HomeAssistant) -> None
     refresh_runs = []
 
     @ha.callback
-    def refresh_listener(event, updates):
+    def refresh_listener(
+        event: EventType[EventStateChangedData] | None,
+        updates: list[TrackTemplateResult],
+    ) -> None:
         refresh_runs.append(updates.pop().result)
 
     info = async_track_template_result(
@@ -2993,7 +3116,10 @@ async def test_async_track_template_result_multiple_templates(
     refresh_runs = []
 
     @ha.callback
-    def refresh_listener(event, updates):
+    def refresh_listener(
+        event: EventType[EventStateChangedData] | None,
+        updates: list[TrackTemplateResult],
+    ) -> None:
         refresh_runs.append(updates)
 
     async_track_template_result(
@@ -3054,7 +3180,10 @@ async def test_async_track_template_result_multiple_templates_mixing_domain(
     refresh_runs = []
 
     @ha.callback
-    def refresh_listener(event, updates):
+    def refresh_listener(
+        event: EventType[EventStateChangedData] | None,
+        updates: list[TrackTemplateResult],
+    ) -> None:
         refresh_runs.append(updates)
 
     async_track_template_result(
@@ -3139,7 +3268,10 @@ async def test_track_template_with_time(hass: HomeAssistant) -> None:
     specific_runs = []
     template_complex = Template("{{ states.switch.test.state and now() }}", hass)
 
-    def specific_run_callback(event, updates):
+    def specific_run_callback(
+        event: EventType[EventStateChangedData] | None,
+        updates: list[TrackTemplateResult],
+    ) -> None:
         specific_runs.append(updates.pop().result)
 
     info = async_track_template_result(
@@ -3169,7 +3301,10 @@ async def test_track_template_with_time_default(hass: HomeAssistant) -> None:
     specific_runs = []
     template_complex = Template("{{ now() }}", hass)
 
-    def specific_run_callback(event, updates):
+    def specific_run_callback(
+        event: EventType[EventStateChangedData] | None,
+        updates: list[TrackTemplateResult],
+    ) -> None:
         specific_runs.append(updates.pop().result)
 
     info = async_track_template_result(
@@ -3218,7 +3353,10 @@ async def test_track_template_with_time_that_leaves_scope(hass: HomeAssistant) -
             hass,
         )
 
-        def specific_run_callback(event, updates):
+        def specific_run_callback(
+            event: EventType[EventStateChangedData] | None,
+            updates: list[TrackTemplateResult],
+        ) -> None:
             specific_runs.append(updates.pop().result)
 
         info = async_track_template_result(
@@ -3283,7 +3421,10 @@ async def test_async_track_template_result_multiple_templates_mixing_listeners(
     refresh_runs = []
 
     @ha.callback
-    def refresh_listener(event, updates):
+    def refresh_listener(
+        event: EventType[EventStateChangedData] | None,
+        updates: list[TrackTemplateResult],
+    ) -> None:
         refresh_runs.append(updates)
 
     now = dt_util.utcnow()


### PR DESCRIPTION
## Proposed change
Use `EventType` to improve the callback typing.

_Most of the line changes are the added type hints in `helpers/test_event.py`._

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
