### PR TITLE
Cleanup EventType typing

### DIFF
--- a/homeassistant/components/history_stats/data.py
+++ b/homeassistant/components/history_stats/data.py
@@ -5,8 +5,10 @@ from dataclasses import dataclass
 import datetime
 
 from homeassistant.components.recorder import get_instance, history
-from homeassistant.core import Event, HomeAssistant, State
+from homeassistant.core import HomeAssistant, State
+from homeassistant.helpers.event import EventStateChangedData
 from homeassistant.helpers.template import Template
+from homeassistant.helpers.typing import EventType
 import homeassistant.util.dt as dt_util
 
 from .helpers import async_calculate_period, floored_timestamp
@@ -55,7 +57,9 @@ class HistoryStats:
         self._start = start
         self._end = end
 
-    async def async_update(self, event: Event | None) -> HistoryStatsState:
+    async def async_update(
+        self, event: EventType[EventStateChangedData] | None
+    ) -> HistoryStatsState:
         """Update the stats at a given time."""
         # Get previous values of start and end
         previous_period_start, previous_period_end = self._period
@@ -104,8 +108,7 @@ class HistoryStats:
             )
         ):
             new_data = False
-            if event and event.data["new_state"] is not None:
-                new_state: State = event.data["new_state"]
+            if event and (new_state := event.data["new_state"]) is not None:
                 if (
                     current_period_start_timestamp
                     <= floored_timestamp(new_state.last_changed)

--- a/homeassistant/components/homeassistant/triggers/state.py
+++ b/homeassistant/components/homeassistant/triggers/state.py
@@ -129,7 +129,7 @@ async def async_attach_trigger(
     _variables = trigger_info["variables"] or {}
 
     @callback
-    def state_automation_listener(event: EventType[EventStateChangedData]):
+    def state_automation_listener(event: EventType[EventStateChangedData]) -> None:
         """Listen for state changes and calls action."""
         entity = event.data["entity_id"]
         from_s = event.data["old_state"]

--- a/homeassistant/components/homekit/util.py
+++ b/homeassistant/components/homekit/util.py
@@ -37,9 +37,11 @@ from homeassistant.const import (
     CONF_TYPE,
     UnitOfTemperature,
 )
-from homeassistant.core import Event, HomeAssistant, State, callback, split_entity_id
+from homeassistant.core import HomeAssistant, State, callback, split_entity_id
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.event import EventStateChangedData
 from homeassistant.helpers.storage import STORAGE_DIR
+from homeassistant.helpers.typing import EventType
 from homeassistant.util.unit_conversion import TemperatureConverter
 
 from .const import (
@@ -619,9 +621,9 @@ def state_needs_accessory_mode(state: State) -> bool:
     )
 
 
-def state_changed_event_is_same_state(event: Event) -> bool:
+def state_changed_event_is_same_state(event: EventType[EventStateChangedData]) -> bool:
     """Check if a state changed event is the same state."""
     event_data = event.data
-    old_state: State | None = event_data.get("old_state")
-    new_state: State | None = event_data.get("new_state")
+    old_state = event_data["old_state"]
+    new_state = event_data["new_state"]
     return bool(new_state and old_state and new_state.state == old_state.state)

--- a/homeassistant/components/plant/__init__.py
+++ b/homeassistant/components/plant/__init__.py
@@ -179,7 +179,7 @@ class Plant(Entity):
         self._brightness_history = DailyHistory(self._conf_check_days)
 
     @callback
-    def _state_changed_event(self, event: EventType[EventStateChangedData]):
+    def _state_changed_event(self, event: EventType[EventStateChangedData]) -> None:
         """Sensor state change event."""
         self.state_changed(event.data["entity_id"], event.data["new_state"])
 

--- a/homeassistant/components/purpleair/config_flow.py
+++ b/homeassistant/components/purpleair/config_flow.py
@@ -15,7 +15,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE
-from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import (
     aiohttp_client,
@@ -23,13 +23,17 @@ from homeassistant.helpers import (
     device_registry as dr,
     entity_registry as er,
 )
-from homeassistant.helpers.event import async_track_state_change_event
+from homeassistant.helpers.event import (
+    EventStateChangedData,
+    async_track_state_change_event,
+)
 from homeassistant.helpers.selector import (
     SelectOptionDict,
     SelectSelector,
     SelectSelectorConfig,
     SelectSelectorMode,
 )
+from homeassistant.helpers.typing import EventType
 
 from .const import CONF_SENSOR_INDICES, CONF_SHOW_ON_MAP, DOMAIN, LOGGER
 
@@ -420,7 +424,9 @@ class PurpleAirOptionsFlowHandler(config_entries.OptionsFlow):
         device_entities_removed_event = asyncio.Event()
 
         @callback
-        def async_device_entity_state_changed(_: Event) -> None:
+        def async_device_entity_state_changed(
+            _: EventType[EventStateChangedData],
+        ) -> None:
             """Listen and respond when all device entities are removed."""
             if all(
                 self.hass.states.get(entity_entry.entity_id) is None

--- a/homeassistant/components/switch_as_x/cover.py
+++ b/homeassistant/components/switch_as_x/cover.py
@@ -17,9 +17,11 @@ from homeassistant.const import (
     SERVICE_TURN_ON,
     STATE_ON,
 )
-from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import EventStateChangedData
+from homeassistant.helpers.typing import EventType
 
 from .entity import BaseEntity
 
@@ -74,7 +76,9 @@ class CoverSwitch(BaseEntity, CoverEntity):
         )
 
     @callback
-    def async_state_changed_listener(self, event: Event | None = None) -> None:
+    def async_state_changed_listener(
+        self, event: EventType[EventStateChangedData] | None = None
+    ) -> None:
         """Handle child updates."""
         super().async_state_changed_listener(event)
         if (

--- a/homeassistant/components/switch_as_x/entity.py
+++ b/homeassistant/components/switch_as_x/entity.py
@@ -12,7 +12,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
 )
-from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity import DeviceInfo, Entity, ToggleEntity
 from homeassistant.helpers.event import (
@@ -67,7 +67,9 @@ class BaseEntity(Entity):
         )
 
     @callback
-    def async_state_changed_listener(self, event: Event | None = None) -> None:
+    def async_state_changed_listener(
+        self, event: EventType[EventStateChangedData] | None = None
+    ) -> None:
         """Handle child updates."""
         if (
             state := self.hass.states.get(self._switch_entity_id)
@@ -163,7 +165,9 @@ class BaseToggleEntity(BaseEntity, ToggleEntity):
         )
 
     @callback
-    def async_state_changed_listener(self, event: Event | None = None) -> None:
+    def async_state_changed_listener(
+        self, event: EventType[EventStateChangedData] | None = None
+    ) -> None:
         """Handle child updates."""
         super().async_state_changed_listener(event)
         if (

--- a/homeassistant/components/switch_as_x/lock.py
+++ b/homeassistant/components/switch_as_x/lock.py
@@ -13,9 +13,11 @@ from homeassistant.const import (
     SERVICE_TURN_ON,
     STATE_ON,
 )
-from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import EventStateChangedData
+from homeassistant.helpers.typing import EventType
 
 from .entity import BaseEntity
 
@@ -68,7 +70,9 @@ class LockSwitch(BaseEntity, LockEntity):
         )
 
     @callback
-    def async_state_changed_listener(self, event: Event | None = None) -> None:
+    def async_state_changed_listener(
+        self, event: EventType[EventStateChangedData] | None = None
+    ) -> None:
         """Handle child updates."""
         super().async_state_changed_listener(event)
         if (

--- a/homeassistant/helpers/template_entity.py
+++ b/homeassistant/helpers/template_entity.py
@@ -26,7 +26,7 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_START,
     STATE_UNKNOWN,
 )
-from homeassistant.core import Context, CoreState, Event, HomeAssistant, State, callback
+from homeassistant.core import Context, CoreState, HomeAssistant, State, callback
 from homeassistant.exceptions import TemplateError
 from homeassistant.util.json import JSON_DECODE_EXCEPTIONS, json_loads
 
@@ -131,7 +131,7 @@ class _TemplateAttribute:
     @callback
     def handle_result(
         self,
-        event: Event | None,
+        event: EventType[EventStateChangedData] | None,
         template: Template,
         last_result: str | None | TemplateError,
         result: str | TemplateError,

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -544,14 +544,14 @@ async def test_async_track_state_added_domain(hass: HomeAssistant) -> None:
     multiple_entity_id_tracker = []
 
     @ha.callback
-    def single_run_callback(event: EventType[EventStateChangedData]):
+    def single_run_callback(event: EventType[EventStateChangedData]) -> None:
         old_state = event.data["old_state"]
         new_state = event.data["new_state"]
 
         single_entity_id_tracker.append((old_state, new_state))
 
     @ha.callback
-    def multiple_run_callback(event: EventType[EventStateChangedData]):
+    def multiple_run_callback(event: EventType[EventStateChangedData]) -> None:
         old_state = event.data["old_state"]
         new_state = event.data["new_state"]
 
@@ -656,14 +656,14 @@ async def test_async_track_state_removed_domain(hass: HomeAssistant) -> None:
     multiple_entity_id_tracker = []
 
     @ha.callback
-    def single_run_callback(event: EventType[EventStateChangedData]):
+    def single_run_callback(event: EventType[EventStateChangedData]) -> None:
         old_state = event.data["old_state"]
         new_state = event.data["new_state"]
 
         single_entity_id_tracker.append((old_state, new_state))
 
     @ha.callback
-    def multiple_run_callback(event: EventType[EventStateChangedData]):
+    def multiple_run_callback(event: EventType[EventStateChangedData]) -> None:
         old_state = event.data["old_state"]
         new_state = event.data["new_state"]
 
@@ -738,14 +738,14 @@ async def test_async_track_state_removed_domain_match_all(hass: HomeAssistant) -
     match_all_entity_id_tracker = []
 
     @ha.callback
-    def single_run_callback(event: EventType[EventStateChangedData]):
+    def single_run_callback(event: EventType[EventStateChangedData]) -> None:
         old_state = event.data["old_state"]
         new_state = event.data["new_state"]
 
         single_entity_id_tracker.append((old_state, new_state))
 
     @ha.callback
-    def match_all_run_callback(event: EventType[EventStateChangedData]):
+    def match_all_run_callback(event: EventType[EventStateChangedData]) -> None:
         old_state = event.data["old_state"]
         new_state = event.data["new_state"]
 


### PR DESCRIPTION
## Proposed change
Cleanup after adding `EventType`. Add some missing type annotations.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
