### PR TITLE
Add event entities to homekit_controller

### DIFF
--- a/homeassistant/components/homekit_controller/const.py
+++ b/homeassistant/components/homekit_controller/const.py
@@ -53,6 +53,9 @@ HOMEKIT_ACCESSORY_DISPATCH = {
     ServicesTypes.TELEVISION: "media_player",
     ServicesTypes.VALVE: "switch",
     ServicesTypes.CAMERA_RTP_STREAM_MANAGEMENT: "camera",
+    ServicesTypes.DOORBELL: "event",
+    ServicesTypes.STATELESS_PROGRAMMABLE_SWITCH: "event",
+    ServicesTypes.SERVICE_LABEL: "event",
 }
 
 CHARACTERISTIC_PLATFORMS = {

--- a/homeassistant/components/homekit_controller/const.py
+++ b/homeassistant/components/homekit_controller/const.py
@@ -53,6 +53,9 @@ HOMEKIT_ACCESSORY_DISPATCH = {
     ServicesTypes.TELEVISION: "media_player",
     ServicesTypes.VALVE: "switch",
     ServicesTypes.CAMERA_RTP_STREAM_MANAGEMENT: "camera",
+    ServicesTypes.DOORBELL: "event",
+    ServicesTypes.STATELESS_PROGRAMMABLE_SWITCH: "event",
+    ServicesTypes.SERVICE_LABEL: "event",
 }
 
 CHARACTERISTIC_PLATFORMS = {
@@ -98,7 +101,6 @@ CHARACTERISTIC_PLATFORMS = {
     CharacteristicsTypes.MUTE: "switch",
     CharacteristicsTypes.FILTER_LIFE_LEVEL: "sensor",
     CharacteristicsTypes.VENDOR_AIRVERSA_SLEEP_MODE: "switch",
-    CharacteristicsTypes.INPUT_EVENT: "event",
 }
 
 STARTUP_EXCEPTIONS = (

--- a/homeassistant/components/homekit_controller/const.py
+++ b/homeassistant/components/homekit_controller/const.py
@@ -53,9 +53,6 @@ HOMEKIT_ACCESSORY_DISPATCH = {
     ServicesTypes.TELEVISION: "media_player",
     ServicesTypes.VALVE: "switch",
     ServicesTypes.CAMERA_RTP_STREAM_MANAGEMENT: "camera",
-    ServicesTypes.DOORBELL: "event",
-    ServicesTypes.STATELESS_PROGRAMMABLE_SWITCH: "event",
-    ServicesTypes.SERVICE_LABEL: "event",
 }
 
 CHARACTERISTIC_PLATFORMS = {
@@ -101,6 +98,7 @@ CHARACTERISTIC_PLATFORMS = {
     CharacteristicsTypes.MUTE: "switch",
     CharacteristicsTypes.FILTER_LIFE_LEVEL: "sensor",
     CharacteristicsTypes.VENDOR_AIRVERSA_SLEEP_MODE: "switch",
+    CharacteristicsTypes.INPUT_EVENT: "event",
 }
 
 STARTUP_EXCEPTIONS = (

--- a/homeassistant/components/homekit_controller/device_trigger.py
+++ b/homeassistant/components/homekit_controller/device_trigger.py
@@ -211,7 +211,7 @@ async def async_setup_triggers_for_entry(
     conn: HKDevice = hass.data[KNOWN_DEVICES][hkid]
 
     @callback
-    def async_add_service(service):
+    def async_add_characteristic(service: Service):
         aid = service.accessory.aid
         service_type = service.type
 
@@ -238,7 +238,7 @@ async def async_setup_triggers_for_entry(
 
         return True
 
-    conn.add_listener(async_add_service)
+    conn.add_trigger_factory(async_add_characteristic)
 
 
 @callback

--- a/homeassistant/components/homekit_controller/event.py
+++ b/homeassistant/components/homekit_controller/event.py
@@ -1,7 +1,7 @@
 """Support for Homekit motion sensors."""
 from __future__ import annotations
 
-from aiohomekit.model.characteristics import Characteristic, CharacteristicsTypes
+from aiohomekit.model.characteristics import CharacteristicsTypes
 from aiohomekit.model.characteristics.const import InputEventValues
 from aiohomekit.model.services import Service, ServicesTypes
 from aiohomekit.utils import clamp_enum_to_char
@@ -89,8 +89,7 @@ async def async_setup_entry(
     conn: HKDevice = hass.data[KNOWN_DEVICES][hkid]
 
     @callback
-    def async_add_characteristic(char: Characteristic) -> bool:
-        service = char.service
+    def async_add_service(service: Service) -> bool:
         entities = []
 
         if service.type == ServicesTypes.DOORBELL:
@@ -153,4 +152,4 @@ async def async_setup_entry(
 
         return False
 
-    conn.add_char_factory(async_add_characteristic)
+    conn.add_listener(async_add_service)

--- a/homeassistant/components/homekit_controller/event.py
+++ b/homeassistant/components/homekit_controller/event.py
@@ -1,0 +1,119 @@
+"""Support for Homekit motion sensors."""
+from __future__ import annotations
+
+from aiohomekit.model.characteristics import CharacteristicsTypes
+from aiohomekit.model.characteristics.const import InputEventValues
+from aiohomekit.model.services import Service, ServicesTypes
+from aiohomekit.utils import clamp_enum_to_char
+
+from homeassistant.components.event import EventDeviceClass, EventEntity, EventEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import KNOWN_DEVICES
+from .connection import HKDevice
+from .entity import HomeKitEntity
+
+INPUT_EVENT_VALUES = {
+    InputEventValues.SINGLE_PRESS: "single_press",
+    InputEventValues.DOUBLE_PRESS: "double_press",
+    InputEventValues.LONG_PRESS: "long_press",
+}
+
+
+class HomeKitEventEntity(HomeKitEntity, EventEntity):
+    """Representation of a Homekit event entity."""
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+
+    def __init__(self, connection: HKDevice, service: Service, entity_description: EventEntityDescription):
+        super().__init__(connection, {
+            "aid": service.accessory.aid,
+            "iid": service.iid,
+        })
+        self._service = service
+        self._characteristic = service.characteristics_by_type[CharacteristicsTypes.INPUT_EVENT]
+
+        self.entity_description = entity_description
+
+        # An INPUT_EVENT may support single_press, long_press and double_press. All are optional. So we have to
+        # clamp InputEventValues for this exact device
+        self._attr_event_types = list(INPUT_EVENT_VALUES[v] for v in clamp_enum_to_char(InputEventValues, self._characteristic))
+
+    async def async_added_to_hass(self) -> None:
+        """Entity added to hass."""
+        self.async_on_remove(
+            self._accessory.async_subscribe(
+                [(self._aid, self._characteristic.iid)], self._handle_event,
+            )
+        )
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Prepare to be removed from hass."""
+        pass
+
+    @callback
+    def _handle_event(self):
+        self._trigger_event(INPUT_EVENT_VALUES[self._doorbell.value])
+        self.async_write_ha_state()
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Homekit event."""
+    hkid: str = config_entry.data["AccessoryPairingID"]
+    conn: HKDevice = hass.data[KNOWN_DEVICES][hkid]
+
+    @callback
+    def async_add_service(service: Service) -> bool:
+        entities = []
+
+        if service.type == ServicesTypes.DOORBELL:
+            entities.append(
+                HomeKitEventEntity(conn, service, EventEntityDescription(
+                    device_class=EventDeviceClass.DOORBELL,
+                    translation_key="doorbell",
+                    name="Doorbell"
+                ))
+            )
+
+        elif service.type == ServicesTypes.SERVICE_LABEL:
+            switches = list(
+                service.accessory.services.filter(
+                    service_type=ServicesTypes.STATELESS_PROGRAMMABLE_SWITCH,
+                    child_service=service,
+                    order_by=[CharacteristicsTypes.SERVICE_LABEL_INDEX],
+                )
+            )
+
+            for idx, switch in enumerate(switches):
+                entities.append(HomeKitEventEntity(conn, service, EventEntityDescription(
+                    device_class=EventDeviceClass.BUTTON,
+                    translation_key="button",
+                    name=f"Button {idx}"
+                )))
+
+                char = switch[CharacteristicsTypes.INPUT_EVENT]
+
+        elif service.type == ServicesTypes.STATELESS_PROGRAMMABLE_SWITCH:
+            # A stateless switch that has a SERVICE_LABEL_INDEX is part of a group
+            # And is handled separately
+            if not service.has(CharacteristicsTypes.SERVICE_LABEL_INDEX):
+                entities.append(HomeKitEventEntity(conn, service, EventEntityDescription(
+                    device_class=EventDeviceClass.BUTTON,
+                    translation_key="button",
+                    name=f"Button"
+                )))
+
+        if entities:
+            async_add_entities(entities)
+            return True
+
+        return False
+
+    conn.add_listener(async_add_service)

--- a/homeassistant/components/homekit_controller/event.py
+++ b/homeassistant/components/homekit_controller/event.py
@@ -29,7 +29,6 @@ INPUT_EVENT_VALUES = {
 class HomeKitEventEntity(HomeKitEntity, EventEntity):
     """Representation of a Homekit event entity."""
 
-    _attr_has_entity_name = True
     _attr_should_poll = False
 
     def __init__(
@@ -46,7 +45,6 @@ class HomeKitEventEntity(HomeKitEntity, EventEntity):
                 "iid": service.iid,
             },
         )
-        self._service = service
         self._characteristic = service.characteristics_by_type[
             CharacteristicsTypes.INPUT_EVENT
         ]

--- a/homeassistant/components/homekit_controller/event.py
+++ b/homeassistant/components/homekit_controller/event.py
@@ -115,7 +115,10 @@ async def async_setup_entry(
                 )
             )
 
-            for idx, switch in enumerate(switches):
+            for switch in switches:
+                # The Apple docs say that if we number the buttons ourselves
+                # We do it in service label index order. `switches` is already in
+                # that order.
                 entities.append(
                     HomeKitEventEntity(
                         conn,

--- a/homeassistant/components/homekit_controller/event.py
+++ b/homeassistant/components/homekit_controller/event.py
@@ -6,7 +6,11 @@ from aiohomekit.model.characteristics.const import InputEventValues
 from aiohomekit.model.services import Service, ServicesTypes
 from aiohomekit.utils import clamp_enum_to_char
 
-from homeassistant.components.event import EventDeviceClass, EventEntity, EventEntityDescription
+from homeassistant.components.event import (
+    EventDeviceClass,
+    EventEntity,
+    EventEntityDescription,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -28,35 +32,52 @@ class HomeKitEventEntity(HomeKitEntity, EventEntity):
     _attr_has_entity_name = True
     _attr_should_poll = False
 
-    def __init__(self, connection: HKDevice, service: Service, entity_description: EventEntityDescription):
-        super().__init__(connection, {
-            "aid": service.accessory.aid,
-            "iid": service.iid,
-        })
+    def __init__(
+        self,
+        connection: HKDevice,
+        service: Service,
+        entity_description: EventEntityDescription,
+    ) -> None:
+        """Initialise a generic HomeKit event entity."""
+        super().__init__(
+            connection,
+            {
+                "aid": service.accessory.aid,
+                "iid": service.iid,
+            },
+        )
         self._service = service
-        self._characteristic = service.characteristics_by_type[CharacteristicsTypes.INPUT_EVENT]
+        self._characteristic = service.characteristics_by_type[
+            CharacteristicsTypes.INPUT_EVENT
+        ]
 
         self.entity_description = entity_description
 
         # An INPUT_EVENT may support single_press, long_press and double_press. All are optional. So we have to
         # clamp InputEventValues for this exact device
-        self._attr_event_types = list(INPUT_EVENT_VALUES[v] for v in clamp_enum_to_char(InputEventValues, self._characteristic))
+        self._attr_event_types = [
+            INPUT_EVENT_VALUES[v]
+            for v in clamp_enum_to_char(InputEventValues, self._characteristic)
+        ]
+
+    def get_characteristic_types(self) -> list[str]:
+        """Define the homekit characteristics the entity cares about."""
+        return [CharacteristicsTypes.INPUT_EVENT]
 
     async def async_added_to_hass(self) -> None:
         """Entity added to hass."""
+        await super().async_added_to_hass()
+
         self.async_on_remove(
             self._accessory.async_subscribe(
-                [(self._aid, self._characteristic.iid)], self._handle_event,
+                [(self._aid, self._characteristic.iid)],
+                self._handle_event,
             )
         )
 
-    async def async_will_remove_from_hass(self) -> None:
-        """Prepare to be removed from hass."""
-        pass
-
     @callback
     def _handle_event(self):
-        self._trigger_event(INPUT_EVENT_VALUES[self._doorbell.value])
+        self._trigger_event(INPUT_EVENT_VALUES[self._characteristic.value])
         self.async_write_ha_state()
 
 
@@ -70,16 +91,21 @@ async def async_setup_entry(
     conn: HKDevice = hass.data[KNOWN_DEVICES][hkid]
 
     @callback
-    def async_add_service(service: Service) -> bool:
+    def async_add_services(service: Service) -> bool:
         entities = []
 
         if service.type == ServicesTypes.DOORBELL:
             entities.append(
-                HomeKitEventEntity(conn, service, EventEntityDescription(
-                    device_class=EventDeviceClass.DOORBELL,
-                    translation_key="doorbell",
-                    name="Doorbell"
-                ))
+                HomeKitEventEntity(
+                    conn,
+                    service,
+                    EventEntityDescription(
+                        key=f"{service.accessory.aid}_{service.iid}",
+                        device_class=EventDeviceClass.DOORBELL,
+                        translation_key="doorbell",
+                        name="Doorbell",
+                    ),
+                )
             )
 
         elif service.type == ServicesTypes.SERVICE_LABEL:
@@ -92,23 +118,35 @@ async def async_setup_entry(
             )
 
             for idx, switch in enumerate(switches):
-                entities.append(HomeKitEventEntity(conn, service, EventEntityDescription(
-                    device_class=EventDeviceClass.BUTTON,
-                    translation_key="button",
-                    name=f"Button {idx}"
-                )))
-
-                char = switch[CharacteristicsTypes.INPUT_EVENT]
+                entities.append(
+                    HomeKitEventEntity(
+                        conn,
+                        switch,
+                        EventEntityDescription(
+                            key=f"{service.accessory.aid}_{service.iid}",
+                            device_class=EventDeviceClass.BUTTON,
+                            translation_key="button",
+                            name=f"Button {idx}",
+                        ),
+                    )
+                )
 
         elif service.type == ServicesTypes.STATELESS_PROGRAMMABLE_SWITCH:
             # A stateless switch that has a SERVICE_LABEL_INDEX is part of a group
             # And is handled separately
             if not service.has(CharacteristicsTypes.SERVICE_LABEL_INDEX):
-                entities.append(HomeKitEventEntity(conn, service, EventEntityDescription(
-                    device_class=EventDeviceClass.BUTTON,
-                    translation_key="button",
-                    name=f"Button"
-                )))
+                entities.append(
+                    HomeKitEventEntity(
+                        conn,
+                        service,
+                        EventEntityDescription(
+                            key=f"{service.accessory.aid}_{service.iid}",
+                            device_class=EventDeviceClass.BUTTON,
+                            translation_key="button",
+                            name="Button",
+                        ),
+                    )
+                )
 
         if entities:
             async_add_entities(entities)
@@ -116,4 +154,4 @@ async def async_setup_entry(
 
         return False
 
-    conn.add_listener(async_add_service)
+    conn.add_listener(async_add_services)

--- a/homeassistant/components/homekit_controller/event.py
+++ b/homeassistant/components/homekit_controller/event.py
@@ -1,7 +1,7 @@
 """Support for Homekit motion sensors."""
 from __future__ import annotations
 
-from aiohomekit.model.characteristics import CharacteristicsTypes
+from aiohomekit.model.characteristics import Characteristic, CharacteristicsTypes
 from aiohomekit.model.characteristics.const import InputEventValues
 from aiohomekit.model.services import Service, ServicesTypes
 from aiohomekit.utils import clamp_enum_to_char
@@ -91,7 +91,8 @@ async def async_setup_entry(
     conn: HKDevice = hass.data[KNOWN_DEVICES][hkid]
 
     @callback
-    def async_add_services(service: Service) -> bool:
+    def async_add_characteristic(char: Characteristic) -> bool:
+        service = char.service
         entities = []
 
         if service.type == ServicesTypes.DOORBELL:
@@ -154,4 +155,4 @@ async def async_setup_entry(
 
         return False
 
-    conn.add_listener(async_add_services)
+    conn.add_char_factory(async_add_characteristic)

--- a/homeassistant/components/homekit_controller/event.py
+++ b/homeassistant/components/homekit_controller/event.py
@@ -75,6 +75,11 @@ class HomeKitEventEntity(HomeKitEntity, EventEntity):
 
     @callback
     def _handle_event(self):
+        if self._characteristic.value is None:
+            # For IP backed devices the characteristic is marked as
+            # pollable, but always returns None when polled
+            # Make sure we don't explode if we see that edge case.
+            return
         self._trigger_event(INPUT_EVENT_VALUES[self._characteristic.value])
         self.async_write_ha_state()
 

--- a/homeassistant/components/homekit_controller/event.py
+++ b/homeassistant/components/homekit_controller/event.py
@@ -102,7 +102,6 @@ async def async_setup_entry(
                         key=f"{service.accessory.aid}_{service.iid}",
                         device_class=EventDeviceClass.DOORBELL,
                         translation_key="doorbell",
-                        name="Doorbell",
                     ),
                 )
             )
@@ -125,7 +124,6 @@ async def async_setup_entry(
                             key=f"{service.accessory.aid}_{service.iid}",
                             device_class=EventDeviceClass.BUTTON,
                             translation_key="button",
-                            name=f"Button {idx}",
                         ),
                     )
                 )
@@ -142,7 +140,6 @@ async def async_setup_entry(
                             key=f"{service.accessory.aid}_{service.iid}",
                             device_class=EventDeviceClass.BUTTON,
                             translation_key="button",
-                            name="Button",
                         ),
                     )
                 )

--- a/homeassistant/components/homekit_controller/strings.json
+++ b/homeassistant/components/homekit_controller/strings.json
@@ -77,8 +77,8 @@
           "event_type": {
             "state": {
               "double_press": "Double Press",
-               "long_press": "Long Press",
-               "single_press": "Single Press"
+              "long_press": "Long Press",
+              "single_press": "Single Press"
             }
           }
         }

--- a/homeassistant/components/homekit_controller/strings.json
+++ b/homeassistant/components/homekit_controller/strings.json
@@ -87,9 +87,9 @@
         "state_attributes": {
           "event_type": {
             "state": {
-              "double_press": "Double Press",
-              "long_press": "Long Press",
-              "single_press": "Single Press"
+              "double_press": "[%key:component::homekit_controller::entity::event::doorbell::state_attributes::event_type::state::double_press%]",
+              "long_press": "[%key:component::homekit_controller::entity::event::doorbell::state_attributes::event_type::state::long_press%]",
+              "single_press": "[%key:component::homekit_controller::entity::event::doorbell::state_attributes::event_type::state::single_press%]"
             }
           }
         }

--- a/homeassistant/components/homekit_controller/strings.json
+++ b/homeassistant/components/homekit_controller/strings.json
@@ -71,6 +71,30 @@
     }
   },
   "entity": {
+    "event": {
+      "doorbell": {
+        "state_attributes": {
+          "event_type": {
+              "state": {
+                  "double_press": "Double Press",
+                  "long_press": "Long Press",
+                  "single_press": "Single Press"
+              }
+          }
+      }
+      },
+      "button": {
+        "state_attributes": {
+          "event_type": {
+              "state": {
+                  "double_press": "Double Press",
+                  "long_press": "Long Press",
+                  "single_press": "Single Press"
+              }
+          }
+      }
+      }
+    },
     "select": {
       "ecobee_mode": {
         "state": {

--- a/homeassistant/components/homekit_controller/strings.json
+++ b/homeassistant/components/homekit_controller/strings.json
@@ -75,24 +75,24 @@
       "doorbell": {
         "state_attributes": {
           "event_type": {
-              "state": {
-                  "double_press": "Double Press",
-                  "long_press": "Long Press",
-                  "single_press": "Single Press"
-              }
+            "state": {
+              "double_press": "Double Press",
+               "long_press": "Long Press",
+               "single_press": "Single Press"
+            }
           }
-      }
+        }
       },
       "button": {
         "state_attributes": {
           "event_type": {
-              "state": {
-                  "double_press": "Double Press",
-                  "long_press": "Long Press",
-                  "single_press": "Single Press"
-              }
+            "state": {
+              "double_press": "Double Press",
+              "long_press": "Long Press",
+              "single_press": "Single Press"
+            }
           }
-      }
+        }
       }
     },
     "select": {

--- a/homeassistant/components/homekit_controller/strings.json
+++ b/homeassistant/components/homekit_controller/strings.json
@@ -76,9 +76,9 @@
         "state_attributes": {
           "event_type": {
             "state": {
-              "double_press": "Double Press",
-              "long_press": "Long Press",
-              "single_press": "Single Press"
+              "double_press": "Double press",
+              "long_press": "Long press",
+              "single_press": "Single press"
             }
           }
         }

--- a/tests/components/homekit_controller/test_event.py
+++ b/tests/components/homekit_controller/test_event.py
@@ -1,0 +1,183 @@
+"""Test homekit_controller stateless triggers."""
+from aiohomekit.model.characteristics import CharacteristicsTypes
+from aiohomekit.model.services import ServicesTypes
+
+from homeassistant.components.event import EventDeviceClass
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from .common import setup_test_component
+
+
+def create_remote(accessory):
+    """Define characteristics for a button (that is inn a group)."""
+    service_label = accessory.add_service(ServicesTypes.SERVICE_LABEL)
+
+    char = service_label.add_char(CharacteristicsTypes.SERVICE_LABEL_NAMESPACE)
+    char.value = 1
+
+    for i in range(4):
+        button = accessory.add_service(ServicesTypes.STATELESS_PROGRAMMABLE_SWITCH)
+        button.linked.append(service_label)
+
+        char = button.add_char(CharacteristicsTypes.INPUT_EVENT)
+        char.value = 0
+        char.perms = ["pw", "pr", "ev"]
+
+        char = button.add_char(CharacteristicsTypes.NAME)
+        char.value = f"Button {i + 1}"
+
+        char = button.add_char(CharacteristicsTypes.SERVICE_LABEL_INDEX)
+        char.value = i
+
+    battery = accessory.add_service(ServicesTypes.BATTERY_SERVICE)
+    battery.add_char(CharacteristicsTypes.BATTERY_LEVEL)
+
+
+def create_button(accessory):
+    """Define a button (that is not in a group)."""
+    button = accessory.add_service(ServicesTypes.STATELESS_PROGRAMMABLE_SWITCH)
+
+    char = button.add_char(CharacteristicsTypes.INPUT_EVENT)
+    char.value = 0
+    char.perms = ["pw", "pr", "ev"]
+
+    char = button.add_char(CharacteristicsTypes.NAME)
+    char.value = "Button 1"
+
+    battery = accessory.add_service(ServicesTypes.BATTERY_SERVICE)
+    battery.add_char(CharacteristicsTypes.BATTERY_LEVEL)
+
+
+def create_doorbell(accessory):
+    """Define a button (that is not in a group)."""
+    button = accessory.add_service(ServicesTypes.DOORBELL)
+
+    char = button.add_char(CharacteristicsTypes.INPUT_EVENT)
+    char.value = 0
+    char.perms = ["pw", "pr", "ev"]
+
+    char = button.add_char(CharacteristicsTypes.NAME)
+    char.value = "Doorbell"
+
+    battery = accessory.add_service(ServicesTypes.BATTERY_SERVICE)
+    battery.add_char(CharacteristicsTypes.BATTERY_LEVEL)
+
+
+async def test_remote(hass: HomeAssistant, utcnow) -> None:
+    """Test that remote is supported."""
+    helper = await setup_test_component(hass, create_remote)
+
+    entities = [
+        ("event.testdevice_testdevice_button_1", "Button 1"),
+        ("event.testdevice_testdevice_button_2", "Button 2"),
+        ("event.testdevice_testdevice_button_3", "Button 3"),
+        ("event.testdevice_testdevice_button_4", "Button 4"),
+    ]
+
+    entity_registry = er.async_get(hass)
+
+    for entity_id, service in entities:
+        button = entity_registry.async_get(entity_id)
+
+        assert button.original_device_class == EventDeviceClass.BUTTON
+        assert button.capabilities["event_types"] == [
+            "single_press",
+            "double_press",
+            "long_press",
+        ]
+
+        helper.pairing.testing.update_named_service(
+            service, {CharacteristicsTypes.INPUT_EVENT: 0}
+        )
+        await hass.async_block_till_done()
+        state = hass.states.get(entity_id)
+        assert state.attributes["event_type"] == "single_press"
+
+        helper.pairing.testing.update_named_service(
+            service, {CharacteristicsTypes.INPUT_EVENT: 1}
+        )
+        await hass.async_block_till_done()
+        state = hass.states.get(entity_id)
+        assert state.attributes["event_type"] == "double_press"
+
+        helper.pairing.testing.update_named_service(
+            service, {CharacteristicsTypes.INPUT_EVENT: 2}
+        )
+        await hass.async_block_till_done()
+        state = hass.states.get(entity_id)
+        assert state.attributes["event_type"] == "long_press"
+
+
+async def test_button(hass: HomeAssistant, utcnow) -> None:
+    """Test that a button is correctly enumerated."""
+    helper = await setup_test_component(hass, create_button)
+    entity_id = "event.testdevice_testdevice_button_1"
+
+    entity_registry = er.async_get(hass)
+    button = entity_registry.async_get(entity_id)
+
+    assert button.original_device_class == EventDeviceClass.BUTTON
+    assert button.capabilities["event_types"] == [
+        "single_press",
+        "double_press",
+        "long_press",
+    ]
+
+    helper.pairing.testing.update_named_service(
+        "Button 1", {CharacteristicsTypes.INPUT_EVENT: 0}
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get(entity_id)
+    assert state.attributes["event_type"] == "single_press"
+
+    helper.pairing.testing.update_named_service(
+        "Button 1", {CharacteristicsTypes.INPUT_EVENT: 1}
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get(entity_id)
+    assert state.attributes["event_type"] == "double_press"
+
+    helper.pairing.testing.update_named_service(
+        "Button 1", {CharacteristicsTypes.INPUT_EVENT: 2}
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get(entity_id)
+    assert state.attributes["event_type"] == "long_press"
+
+
+async def test_doorbell(hass: HomeAssistant, utcnow) -> None:
+    """Test that doorbell service is handled."""
+    helper = await setup_test_component(hass, create_doorbell)
+    entity_id = "event.testdevice_testdevice_doorbell"
+
+    entity_registry = er.async_get(hass)
+    doorbell = entity_registry.async_get(entity_id)
+
+    assert doorbell.original_device_class == EventDeviceClass.DOORBELL
+    assert doorbell.capabilities["event_types"] == [
+        "single_press",
+        "double_press",
+        "long_press",
+    ]
+
+    helper.pairing.testing.update_named_service(
+        "Doorbell", {CharacteristicsTypes.INPUT_EVENT: 0}
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get(entity_id)
+    assert state.attributes["event_type"] == "single_press"
+
+    helper.pairing.testing.update_named_service(
+        "Doorbell", {CharacteristicsTypes.INPUT_EVENT: 1}
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get(entity_id)
+    assert state.attributes["event_type"] == "double_press"
+
+    helper.pairing.testing.update_named_service(
+        "Doorbell", {CharacteristicsTypes.INPUT_EVENT: 2}
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get(entity_id)
+    assert state.attributes["event_type"] == "long_press"

--- a/tests/components/homekit_controller/test_event.py
+++ b/tests/components/homekit_controller/test_event.py
@@ -69,10 +69,10 @@ async def test_remote(hass: HomeAssistant, utcnow) -> None:
     helper = await setup_test_component(hass, create_remote)
 
     entities = [
-        ("event.testdevice_testdevice_button_1", "Button 1"),
-        ("event.testdevice_testdevice_button_2", "Button 2"),
-        ("event.testdevice_testdevice_button_3", "Button 3"),
-        ("event.testdevice_testdevice_button_4", "Button 4"),
+        ("event.testdevice_button_1", "Button 1"),
+        ("event.testdevice_button_2", "Button 2"),
+        ("event.testdevice_button_3", "Button 3"),
+        ("event.testdevice_button_4", "Button 4"),
     ]
 
     entity_registry = er.async_get(hass)
@@ -112,7 +112,7 @@ async def test_remote(hass: HomeAssistant, utcnow) -> None:
 async def test_button(hass: HomeAssistant, utcnow) -> None:
     """Test that a button is correctly enumerated."""
     helper = await setup_test_component(hass, create_button)
-    entity_id = "event.testdevice_testdevice_button_1"
+    entity_id = "event.testdevice_button_1"
 
     entity_registry = er.async_get(hass)
     button = entity_registry.async_get(entity_id)
@@ -149,7 +149,7 @@ async def test_button(hass: HomeAssistant, utcnow) -> None:
 async def test_doorbell(hass: HomeAssistant, utcnow) -> None:
     """Test that doorbell service is handled."""
     helper = await setup_test_component(hass, create_doorbell)
-    entity_id = "event.testdevice_testdevice_doorbell"
+    entity_id = "event.testdevice_doorbell"
 
     entity_registry = er.async_get(hass)
     doorbell = entity_registry.async_get(entity_id)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add `event` entities for homekit_controller doorbell and buttons.

Todo:

* [x] Tests
* [x] Manual tests


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
