### PR TITLE
Bump pydiscovergy to 2.0.1

### DIFF
--- a/homeassistant/components/discovergy/config_flow.py
+++ b/homeassistant/components/discovergy/config_flow.py
@@ -16,7 +16,7 @@ from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.httpx_client import get_async_client
 
-from .const import APP_NAME, DOMAIN
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -82,10 +82,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 await pydiscovergy.Discovergy(
                     email=user_input[CONF_EMAIL],
                     password=user_input[CONF_PASSWORD],
-                    app_name=APP_NAME,
                     httpx_client=get_async_client(self.hass),
                     authentication=BasicAuth(),
-                ).get_meters()
+                ).meters()
             except discovergyError.HTTPError:
                 errors["base"] = "cannot_connect"
             except discovergyError.InvalidLogin:

--- a/homeassistant/components/discovergy/const.py
+++ b/homeassistant/components/discovergy/const.py
@@ -3,4 +3,3 @@ from __future__ import annotations
 
 DOMAIN = "discovergy"
 MANUFACTURER = "Discovergy"
-APP_NAME = "homeassistant"

--- a/homeassistant/components/discovergy/coordinator.py
+++ b/homeassistant/components/discovergy/coordinator.py
@@ -47,9 +47,7 @@ class DiscovergyUpdateCoordinator(DataUpdateCoordinator[Reading]):
     async def _async_update_data(self) -> Reading:
         """Get last reading for meter."""
         try:
-            return await self.discovergy_client.get_last_reading(
-                self.meter.get_meter_id()
-            )
+            return await self.discovergy_client.meter_last_reading(self.meter.meter_id)
         except AccessTokenExpired as err:
             raise ConfigEntryAuthFailed(
                 f"Auth expired while fetching last reading for meter {self.meter.get_meter_id()}"

--- a/homeassistant/components/discovergy/diagnostics.py
+++ b/homeassistant/components/discovergy/diagnostics.py
@@ -19,9 +19,9 @@ TO_REDACT_METER = {
     "serial_number",
     "full_serial_number",
     "location",
-    "fullSerialNumber",
-    "printedFullSerialNumber",
-    "administrationNumber",
+    "full_serial_number",
+    "printed_full_serial_number",
+    "administration_number",
 }
 
 
@@ -39,8 +39,8 @@ async def async_get_config_entry_diagnostics(
         flattened_meter.append(async_redact_data(meter.__dict__, TO_REDACT_METER))
 
         # get last reading for meter and make a dict of it
-        coordinator = data.coordinators[meter.get_meter_id()]
-        last_readings[meter.get_meter_id()] = coordinator.data.__dict__
+        coordinator = data.coordinators[meter.meter_id]
+        last_readings[meter.meter_id] = coordinator.data.__dict__
 
     return {
         "entry": async_redact_data(entry.as_dict(), TO_REDACT_CONFIG_ENTRY),

--- a/homeassistant/components/discovergy/manifest.json
+++ b/homeassistant/components/discovergy/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/discovergy",
   "integration_type": "hub",
   "iot_class": "cloud_polling",
-  "requirements": ["pydiscovergy==2.0.0"]
+  "requirements": ["pydiscovergy==2.0.1"]
 }

--- a/homeassistant/components/discovergy/manifest.json
+++ b/homeassistant/components/discovergy/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/discovergy",
   "integration_type": "hub",
   "iot_class": "cloud_polling",
-  "requirements": ["pydiscovergy==1.2.1"]
+  "requirements": ["pydiscovergy==2.0.0"]
 }

--- a/homeassistant/components/discovergy/sensor.py
+++ b/homeassistant/components/discovergy/sensor.py
@@ -154,8 +154,6 @@ async def async_setup_entry(
 
     entities: list[DiscovergySensor] = []
     for meter in meters:
-        meter_id = meter.get_meter_id()
-
         sensors = None
         if meter.measurement_type == "ELECTRICITY":
             sensors = ELECTRICITY_SENSORS
@@ -167,7 +165,7 @@ async def async_setup_entry(
                 # check if this meter has this data, then add this sensor
                 for key in {description.key, *description.alternative_keys}:
                     coordinator: DiscovergyUpdateCoordinator = data.coordinators[
-                        meter_id
+                        meter.meter_id
                     ]
                     if key in coordinator.data.values:
                         entities.append(
@@ -199,7 +197,7 @@ class DiscovergySensor(CoordinatorEntity[DiscovergyUpdateCoordinator], SensorEnt
         self.entity_description = description
         self._attr_unique_id = f"{meter.full_serial_number}-{data_key}"
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, meter.get_meter_id())},
+            identifiers={(DOMAIN, meter.meter_id)},
             name=f"{meter.measurement_type.capitalize()} {meter.location.street} {meter.location.street_number}",
             model=f"{meter.type} {meter.full_serial_number}",
             manufacturer=MANUFACTURER,

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1635,7 +1635,7 @@ pydelijn==1.1.0
 pydexcom==0.2.3
 
 # homeassistant.components.discovergy
-pydiscovergy==2.0.0
+pydiscovergy==2.0.1
 
 # homeassistant.components.doods
 pydoods==1.0.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1635,7 +1635,7 @@ pydelijn==1.1.0
 pydexcom==0.2.3
 
 # homeassistant.components.discovergy
-pydiscovergy==1.2.1
+pydiscovergy==2.0.0
 
 # homeassistant.components.doods
 pydoods==1.0.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1214,7 +1214,7 @@ pydeconz==113
 pydexcom==0.2.3
 
 # homeassistant.components.discovergy
-pydiscovergy==1.2.1
+pydiscovergy==2.0.0
 
 # homeassistant.components.android_ip_webcam
 pydroid-ipcam==2.0.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1214,7 +1214,7 @@ pydeconz==113
 pydexcom==0.2.3
 
 # homeassistant.components.discovergy
-pydiscovergy==2.0.0
+pydiscovergy==2.0.1
 
 # homeassistant.components.android_ip_webcam
 pydroid-ipcam==2.0.0

--- a/tests/components/discovergy/conftest.py
+++ b/tests/components/discovergy/conftest.py
@@ -14,7 +14,7 @@ from tests.components.discovergy.const import GET_METERS
 @pytest.fixture
 def mock_meters() -> Mock:
     """Patch libraries."""
-    with patch("pydiscovergy.Discovergy.get_meters") as discovergy:
+    with patch("pydiscovergy.Discovergy.meters") as discovergy:
         discovergy.side_effect = AsyncMock(return_value=GET_METERS)
         yield discovergy
 

--- a/tests/components/discovergy/const.py
+++ b/tests/components/discovergy/const.py
@@ -1,31 +1,34 @@
 """Constants for Discovergy integration tests."""
 import datetime
 
-from pydiscovergy.models import Meter, Reading
+from pydiscovergy.models import Location, Meter, Reading
 
 GET_METERS = [
     Meter(
-        meterId="f8d610b7a8cc4e73939fa33b990ded54",
-        serialNumber="abc123",
-        fullSerialNumber="abc123",
+        meter_id="f8d610b7a8cc4e73939fa33b990ded54",
+        serial_number="abc123",
+        full_serial_number="abc123",
         type="TST",
-        measurementType="ELECTRICITY",
-        loadProfileType="SLP",
-        location={
-            "city": "Testhause",
-            "street": "Teststraße",
-            "streetNumber": "1",
-            "country": "Germany",
+        measurement_type="ELECTRICITY",
+        load_profile_type="SLP",
+        location=Location(
+            zip=12345,
+            city="Testhause",
+            street="Teststraße",
+            street_number="1",
+            country="Germany",
+        ),
+        additional={
+            "manufacturer_id": "TST",
+            "printed_full_serial_number": "abc123",
+            "administration_number": "12345",
+            "scaling_factor": 1,
+            "current_scaling_factor": 1,
+            "voltage_scaling_factor": 1,
+            "internal_meters": 1,
+            "first_measurement_time": 1517569090926,
+            "last_measurement_time": 1678430543742,
         },
-        manufacturerId="TST",
-        printedFullSerialNumber="abc123",
-        administrationNumber="12345",
-        scalingFactor=1,
-        currentScalingFactor=1,
-        voltageScalingFactor=1,
-        internalMeters=1,
-        firstMeasurementTime=1517569090926,
-        lastMeasurementTime=1678430543742,
     ),
 ]
 

--- a/tests/components/discovergy/test_config_flow.py
+++ b/tests/components/discovergy/test_config_flow.py
@@ -80,7 +80,7 @@ async def test_form_invalid_auth(hass: HomeAssistant) -> None:
     )
 
     with patch(
-        "pydiscovergy.Discovergy.get_meters",
+        "pydiscovergy.Discovergy.meters",
         side_effect=InvalidLogin,
     ):
         result2 = await hass.config_entries.flow.async_configure(
@@ -101,7 +101,7 @@ async def test_form_cannot_connect(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    with patch("pydiscovergy.Discovergy.get_meters", side_effect=HTTPError):
+    with patch("pydiscovergy.Discovergy.meters", side_effect=HTTPError):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
@@ -120,7 +120,7 @@ async def test_form_unknown_exception(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    with patch("pydiscovergy.Discovergy.get_meters", side_effect=Exception):
+    with patch("pydiscovergy.Discovergy.meters", side_effect=Exception):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {

--- a/tests/components/discovergy/test_diagnostics.py
+++ b/tests/components/discovergy/test_diagnostics.py
@@ -16,8 +16,8 @@ async def test_entry_diagnostics(
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test config entry diagnostics."""
-    with patch("pydiscovergy.Discovergy.get_meters", return_value=GET_METERS), patch(
-        "pydiscovergy.Discovergy.get_last_reading", return_value=LAST_READING
+    with patch("pydiscovergy.Discovergy.meters", return_value=GET_METERS), patch(
+        "pydiscovergy.Discovergy.meter_last_reading", return_value=LAST_READING
     ):
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
@@ -43,18 +43,15 @@ async def test_entry_diagnostics(
     assert result["meters"] == [
         {
             "additional": {
-                "administrationNumber": REDACTED,
-                "currentScalingFactor": 1,
-                "firstMeasurementTime": 1517569090926,
-                "fullSerialNumber": REDACTED,
-                "internalMeters": 1,
-                "lastMeasurementTime": 1678430543742,
-                "loadProfileType": "SLP",
-                "manufacturerId": "TST",
-                "printedFullSerialNumber": REDACTED,
-                "scalingFactor": 1,
-                "type": "TST",
-                "voltageScalingFactor": 1,
+                "administration_number": REDACTED,
+                "current_scaling_factor": 1,
+                "first_measurement_time": 1517569090926,
+                "internal_meters": 1,
+                "last_measurement_time": 1678430543742,
+                "manufacturer_id": "TST",
+                "printed_full_serial_number": REDACTED,
+                "scaling_factor": 1,
+                "voltage_scaling_factor": 1,
             },
             "full_serial_number": REDACTED,
             "load_profile_type": "SLP",


### PR DESCRIPTION
## Proposed change
Bump pydiscovergy to 2.0.0, which is more strictly typed, uses more dataclasses, and therefore changes some function signatures.

https://github.com/jpbede/pydiscovergy/releases/tag/2.0.0
https://github.com/jpbede/pydiscovergy/compare/1.2.1...2.0.0

https://github.com/jpbede/pydiscovergy/releases/tag/2.0.1
https://github.com/jpbede/pydiscovergy/compare/2.0.0...2.0.1

## Type of change
- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
