### PR TITLE
Add sensor when meter last sent its data to Discovergy

### DIFF
--- a/homeassistant/components/discovergy/sensor.py
+++ b/homeassistant/components/discovergy/sensor.py
@@ -174,7 +174,7 @@ async def async_setup_entry(
                         )
 
         if coordinator.data.time:
-            entities.append(DiscovergyLastReadingTimeSensor(meter, coordinator))
+            entities.append(DiscovergyLastTransmittedTimeSensor(meter, coordinator))
 
     async_add_entities(entities, False)
 
@@ -203,21 +203,21 @@ class DiscovergyBaseSensor(
         )
 
 
-class DiscovergyLastReadingTimeSensor(DiscovergyBaseSensor):
-    """Represents a discovergy smart meter last reading time sensor."""
+class DiscovergyLastTransmittedTimeSensor(DiscovergyBaseSensor):
+    """Represents a discovergy smart meter last transmitted time sensor."""
 
     def __init__(
         self,
         meter: Meter,
         coordinator: DiscovergyUpdateCoordinator,
     ) -> None:
-        """Initialize the last reading time sensor."""
+        """Initialize the last transmitted time sensor."""
         super().__init__(meter, coordinator)
 
-        self._attr_unique_id = f"{meter.full_serial_number}-last_reading"
+        self._attr_unique_id = f"{meter.full_serial_number}-last_transmitted"
         self.entity_description = SensorEntityDescription(
-            key="last_reading",
-            translation_key="last_reading",
+            key="last_transmitted",
+            translation_key="last_transmitted",
             device_class=SensorDeviceClass.TIMESTAMP,
             entity_category=EntityCategory.DIAGNOSTIC,
             entity_registry_enabled_default=False,

--- a/homeassistant/components/discovergy/strings.json
+++ b/homeassistant/components/discovergy/strings.json
@@ -61,8 +61,8 @@
       "phase_3_power": {
         "name": "Phase 3 power"
       },
-      "last_reading": {
-        "name": "Last reading"
+      "last_transmitted": {
+        "name": "Last transmitted"
       }
     }
   }

--- a/homeassistant/components/discovergy/strings.json
+++ b/homeassistant/components/discovergy/strings.json
@@ -60,6 +60,9 @@
       },
       "phase_3_power": {
         "name": "Phase 3 power"
+      },
+      "last_reading": {
+        "name": "Last reading"
       }
     }
   }


### PR DESCRIPTION
## Proposed change
Adds a sensor that contains the timestamp of when the meter last sent its data to Discovergy.
This sensor is disabled by default.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue:
- This PR is related to issue: #97142
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
