### PR TITLE
Add HassShoppingListAddItem to default agent

### DIFF
--- a/homeassistant/components/conversation/manifest.json
+++ b/homeassistant/components/conversation/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "system",
   "iot_class": "local_push",
   "quality_scale": "internal",
-  "requirements": ["hassil==1.2.0", "home-assistant-intents==2023.7.24"]
+  "requirements": ["hassil==1.2.2", "home-assistant-intents==2023.7.25"]
 }

--- a/homeassistant/components/shopping_list/intent.py
+++ b/homeassistant/components/shopping_list/intent.py
@@ -29,7 +29,6 @@ class AddItemIntent(intent.IntentHandler):
         await intent_obj.hass.data[DOMAIN].async_add(item)
 
         response = intent_obj.create_response()
-        response.async_set_speech(f"I've added {item} to your shopping list")
         intent_obj.hass.bus.async_fire(EVENT_SHOPPING_LIST_UPDATED)
         return response
 

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -20,10 +20,10 @@ dbus-fast==1.87.2
 fnv-hash-fast==0.4.0
 ha-av==10.1.0
 hass-nabucasa==0.69.0
-hassil==1.2.0
+hassil==1.2.2
 home-assistant-bluetooth==1.10.2
 home-assistant-frontend==20230725.0
-home-assistant-intents==2023.7.24
+home-assistant-intents==2023.7.25
 httpx==0.24.1
 ifaddr==0.2.0
 janus==1.0.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -955,7 +955,7 @@ hass-nabucasa==0.69.0
 hass-splunk==0.1.1
 
 # homeassistant.components.conversation
-hassil==1.2.0
+hassil==1.2.2
 
 # homeassistant.components.jewish_calendar
 hdate==0.10.4
@@ -988,7 +988,7 @@ holidays==0.28
 home-assistant-frontend==20230725.0
 
 # homeassistant.components.conversation
-home-assistant-intents==2023.7.24
+home-assistant-intents==2023.7.25
 
 # homeassistant.components.home_connect
 homeconnect==0.7.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -750,7 +750,7 @@ habitipy==0.2.0
 hass-nabucasa==0.69.0
 
 # homeassistant.components.conversation
-hassil==1.2.0
+hassil==1.2.2
 
 # homeassistant.components.jewish_calendar
 hdate==0.10.4
@@ -774,7 +774,7 @@ holidays==0.28
 home-assistant-frontend==20230725.0
 
 # homeassistant.components.conversation
-home-assistant-intents==2023.7.24
+home-assistant-intents==2023.7.25
 
 # homeassistant.components.home_connect
 homeconnect==0.7.2

--- a/tests/components/conversation/conftest.py
+++ b/tests/components/conversation/conftest.py
@@ -1,8 +1,10 @@
 """Conversation test helpers."""
+from unittest.mock import patch
 
 import pytest
 
 from homeassistant.components import conversation
+from homeassistant.components.shopping_list import intent as sl_intent
 from homeassistant.const import MATCH_ALL
 
 from . import MockAgent
@@ -28,3 +30,24 @@ def mock_agent_support_all(hass):
     agent = MockAgent(entry.entry_id, MATCH_ALL)
     conversation.async_set_agent(hass, entry, agent)
     return agent
+
+
+@pytest.fixture(autouse=True)
+def mock_shopping_list_io():
+    """Stub out the persistence."""
+    with patch("homeassistant.components.shopping_list.ShoppingData.save"), patch(
+        "homeassistant.components.shopping_list.ShoppingData.async_load"
+    ):
+        yield
+
+
+@pytest.fixture
+async def sl_setup(hass):
+    """Set up the shopping list."""
+
+    entry = MockConfigEntry(domain="shopping_list")
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+
+    await sl_intent.async_setup_intents(hass)

--- a/tests/components/conversation/test_default_agent.py
+++ b/tests/components/conversation/test_default_agent.py
@@ -265,3 +265,16 @@ async def test_trigger_sentences(hass: HomeAssistant, init_components) -> None:
         ), sentence
 
     assert len(callback.mock_calls) == 0
+
+
+async def test_shopping_list_add_item(
+    hass: HomeAssistant, init_components, sl_setup
+) -> None:
+    """Test adding an item to the shopping list through the default agent."""
+    result = await conversation.async_converse(
+        hass, "add apples to my shopping list", None, Context()
+    )
+    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.speech == {
+        "plain": {"speech": "Added apples", "extra_data": None}
+    }

--- a/tests/components/shopping_list/test_init.py
+++ b/tests/components/shopping_list/test_init.py
@@ -34,7 +34,8 @@ async def test_add_item(hass: HomeAssistant, sl_setup) -> None:
         hass, "test", "HassShoppingListAddItem", {"item": {"value": "beer"}}
     )
 
-    assert response.speech["plain"]["speech"] == "I've added beer to your shopping list"
+    # Response text is now handled by default conversation agent
+    assert response.response_type == intent.IntentResponseType.ACTION_DONE
 
 
 async def test_remove_item(hass: HomeAssistant, sl_setup) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The original `HassShoppingListAddItem` intent no longer returns hard-coded English text.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
* Bump hassil to 1.2.2 for bug fixes: https://github.com/home-assistant/hassil/compare/v1.2.1...v1.2.2
* Bump intents package for shopping list intent: https://github.com/home-assistant/intents-package/compare/2023.7.24...2023.7.25
* Ensure `HassShoppingListAddItem` works with default agent (English)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
