### PR TITLE
Add wildcards to sentence triggers

### DIFF
--- a/homeassistant/components/conversation/__init__.py
+++ b/homeassistant/components/conversation/__init__.py
@@ -322,6 +322,10 @@ async def websocket_hass_agent_debug(
                     "intent": {
                         "name": result.intent.name,
                     },
+                    "slots": {  # direct access to values
+                        entity_key: entity.value
+                        for entity_key, entity in result.entities.items()
+                    },
                     "entities": {
                         entity_key: {
                             "name": entity.name,

--- a/homeassistant/components/conversation/__init__.py
+++ b/homeassistant/components/conversation/__init__.py
@@ -326,7 +326,7 @@ async def websocket_hass_agent_debug(
                         entity_key: entity.value
                         for entity_key, entity in result.entities.items()
                     },
-                    "entities": {
+                    "details": {
                         entity_key: {
                             "name": entity.name,
                             "value": entity.value,

--- a/homeassistant/components/conversation/default_agent.py
+++ b/homeassistant/components/conversation/default_agent.py
@@ -11,7 +11,14 @@ from pathlib import Path
 import re
 from typing import IO, Any
 
-from hassil.intents import Intents, ResponseType, SlotList, TextSlotList
+from hassil.expression import Expression, ListReference, Sequence
+from hassil.intents import (
+    Intents,
+    ResponseType,
+    SlotList,
+    TextSlotList,
+    WildcardSlotList,
+)
 from hassil.recognize import RecognizeResult, recognize_all
 from hassil.util import merge_dict
 from home_assistant_intents import get_domains_and_languages, get_intents
@@ -48,7 +55,7 @@ _ENTITY_REGISTRY_UPDATE_FIELDS = ["aliases", "name", "original_name"]
 
 REGEX_TYPE = type(re.compile(""))
 TRIGGER_CALLBACK_TYPE = Callable[  # pylint: disable=invalid-name
-    [str], Awaitable[str | None]
+    [str, RecognizeResult], Awaitable[str | None]
 ]
 
 
@@ -657,6 +664,17 @@ class DefaultAgent(AbstractConversationAgent):
         }
 
         self._trigger_intents = Intents.from_dict(intents_dict)
+
+        # Assume slot list references are wildcards
+        wildcard_names: set[str] = set()
+        for trigger_intent in self._trigger_intents.intents.values():
+            for intent_data in trigger_intent.data:
+                for sentence in intent_data.sentences:
+                    _collect_list_references(sentence, wildcard_names)
+
+        for wildcard_name in wildcard_names:
+            self._trigger_intents.slot_lists[wildcard_name] = WildcardSlotList()
+
         _LOGGER.debug("Rebuilt trigger intents: %s", intents_dict)
 
     def _unregister_trigger(self, trigger_data: TriggerData) -> None:
@@ -682,14 +700,14 @@ class DefaultAgent(AbstractConversationAgent):
 
         assert self._trigger_intents is not None
 
-        matched_triggers: set[int] = set()
+        matched_triggers: dict[int, RecognizeResult] = {}
         for result in recognize_all(sentence, self._trigger_intents):
             trigger_id = int(result.intent.name)
             if trigger_id in matched_triggers:
                 # Already matched a sentence from this trigger
                 break
 
-            matched_triggers.add(trigger_id)
+            matched_triggers[trigger_id] = result
 
         if not matched_triggers:
             # Sentence did not match any trigger sentences
@@ -699,14 +717,14 @@ class DefaultAgent(AbstractConversationAgent):
             "'%s' matched %s trigger(s): %s",
             sentence,
             len(matched_triggers),
-            matched_triggers,
+            list(matched_triggers.keys()),
         )
 
         # Gather callback responses in parallel
         trigger_responses = await asyncio.gather(
             *(
-                self._trigger_sentences[trigger_id].callback(sentence)
-                for trigger_id in matched_triggers
+                self._trigger_sentences[trigger_id].callback(sentence, result)
+                for trigger_id, result in matched_triggers.items()
             )
         )
 
@@ -733,3 +751,15 @@ def _make_error_result(
     response.async_set_error(error_code, response_text)
 
     return ConversationResult(response, conversation_id)
+
+
+def _collect_list_references(expression: Expression, list_names: set[str]) -> None:
+    """Collect list reference names recursively."""
+    if isinstance(expression, Sequence):
+        seq: Sequence = expression
+        for item in seq.items:
+            _collect_list_references(item, list_names)
+    elif isinstance(expression, ListReference):
+        # {list}
+        list_ref: ListReference = expression
+        list_names.add(list_ref.slot_name)

--- a/homeassistant/components/conversation/default_agent.py
+++ b/homeassistant/components/conversation/default_agent.py
@@ -717,7 +717,7 @@ class DefaultAgent(AbstractConversationAgent):
             "'%s' matched %s trigger(s): %s",
             sentence,
             len(matched_triggers),
-            list(matched_triggers.keys()),
+            list(matched_triggers),
         )
 
         # Gather callback responses in parallel

--- a/homeassistant/components/conversation/manifest.json
+++ b/homeassistant/components/conversation/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "system",
   "iot_class": "local_push",
   "quality_scale": "internal",
-  "requirements": ["hassil==1.2.4", "home-assistant-intents==2023.7.25"]
+  "requirements": ["hassil==1.2.5", "home-assistant-intents==2023.7.25"]
 }

--- a/homeassistant/components/conversation/manifest.json
+++ b/homeassistant/components/conversation/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "system",
   "iot_class": "local_push",
   "quality_scale": "internal",
-  "requirements": ["hassil==1.2.2", "home-assistant-intents==2023.7.25"]
+  "requirements": ["hassil==1.2.3", "home-assistant-intents==2023.7.25"]
 }

--- a/homeassistant/components/conversation/manifest.json
+++ b/homeassistant/components/conversation/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "system",
   "iot_class": "local_push",
   "quality_scale": "internal",
-  "requirements": ["hassil==1.2.3", "home-assistant-intents==2023.7.25"]
+  "requirements": ["hassil==1.2.4", "home-assistant-intents==2023.7.25"]
 }

--- a/homeassistant/components/conversation/trigger.py
+++ b/homeassistant/components/conversation/trigger.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from hassil.recognize import PUNCTUATION
+from hassil.recognize import PUNCTUATION, RecognizeResult
 import voluptuous as vol
 
 from homeassistant.const import CONF_COMMAND, CONF_PLATFORM
@@ -49,12 +49,18 @@ async def async_attach_trigger(
     job = HassJob(action)
 
     @callback
-    async def call_action(sentence: str) -> str | None:
+    async def call_action(sentence: str, result: RecognizeResult) -> str | None:
         """Call action with right context."""
         trigger_input: dict[str, Any] = {  # Satisfy type checker
             **trigger_data,
             "platform": DOMAIN,
             "sentence": sentence,
+        }
+
+        # Add wildcard values as extra trigger data
+        trigger_input["wildcards"] = {
+            entity_name: entity.text.strip()
+            for entity_name, entity in result.entities.items()
         }
 
         # Wait for the automation to complete

--- a/homeassistant/components/conversation/trigger.py
+++ b/homeassistant/components/conversation/trigger.py
@@ -55,12 +55,10 @@ async def async_attach_trigger(
             **trigger_data,
             "platform": DOMAIN,
             "sentence": sentence,
-        }
-
-        # Add wildcard values as extra trigger data
-        trigger_input["wildcards"] = {
-            entity_name: entity.text.strip()
-            for entity_name, entity in result.entities.items()
+            "wildcards": {  # Add wildcard values as extra trigger data
+                entity_name: entity.text.strip()
+                for entity_name, entity in result.entities.items()
+            },
         }
 
         # Wait for the automation to complete

--- a/homeassistant/components/conversation/trigger.py
+++ b/homeassistant/components/conversation/trigger.py
@@ -55,8 +55,14 @@ async def async_attach_trigger(
             **trigger_data,
             "platform": DOMAIN,
             "sentence": sentence,
-            "wildcards": {  # Add wildcard values as extra trigger data
-                entity_name: entity.text.strip()
+            "entities": {  # Add slot values as extra trigger data
+                entity_name: {
+                    "name": entity_name,
+                    "text": entity.text.strip(),
+                    "value": entity.value.strip()
+                    if isinstance(entity.value, str)
+                    else entity.value,
+                }
                 for entity_name, entity in result.entities.items()
             },
         }

--- a/homeassistant/components/conversation/trigger.py
+++ b/homeassistant/components/conversation/trigger.py
@@ -51,19 +51,26 @@ async def async_attach_trigger(
     @callback
     async def call_action(sentence: str, result: RecognizeResult) -> str | None:
         """Call action with right context."""
+
+        # Add slot values as extra trigger data
+        entities = {
+            entity_name: {
+                "name": entity_name,
+                "text": entity.text.strip(),  # remove whitespace
+                "value": entity.value.strip()
+                if isinstance(entity.value, str)
+                else entity.value,
+            }
+            for entity_name, entity in result.entities.items()
+        }
+
         trigger_input: dict[str, Any] = {  # Satisfy type checker
             **trigger_data,
             "platform": DOMAIN,
             "sentence": sentence,
-            "entities": {  # Add slot values as extra trigger data
-                entity_name: {
-                    "name": entity_name,
-                    "text": entity.text.strip(),
-                    "value": entity.value.strip()
-                    if isinstance(entity.value, str)
-                    else entity.value,
-                }
-                for entity_name, entity in result.entities.items()
+            "entities": entities,
+            "slots": {  # direct access to values
+                entity_name: entity["value"] for entity_name, entity in entities.items()
             },
         }
 

--- a/homeassistant/components/conversation/trigger.py
+++ b/homeassistant/components/conversation/trigger.py
@@ -53,7 +53,7 @@ async def async_attach_trigger(
         """Call action with right context."""
 
         # Add slot values as extra trigger data
-        entities = {
+        details = {
             entity_name: {
                 "name": entity_name,
                 "text": entity.text.strip(),  # remove whitespace
@@ -68,9 +68,9 @@ async def async_attach_trigger(
             **trigger_data,
             "platform": DOMAIN,
             "sentence": sentence,
-            "entities": entities,
+            "details": details,
             "slots": {  # direct access to values
-                entity_name: entity["value"] for entity_name, entity in entities.items()
+                entity_name: entity["value"] for entity_name, entity in details.items()
             },
         }
 

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -20,7 +20,7 @@ dbus-fast==1.87.2
 fnv-hash-fast==0.4.0
 ha-av==10.1.0
 hass-nabucasa==0.69.0
-hassil==1.2.3
+hassil==1.2.4
 home-assistant-bluetooth==1.10.2
 home-assistant-frontend==20230725.0
 home-assistant-intents==2023.7.25

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -20,7 +20,7 @@ dbus-fast==1.87.2
 fnv-hash-fast==0.4.0
 ha-av==10.1.0
 hass-nabucasa==0.69.0
-hassil==1.2.4
+hassil==1.2.5
 home-assistant-bluetooth==1.10.2
 home-assistant-frontend==20230725.0
 home-assistant-intents==2023.7.25

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -20,7 +20,7 @@ dbus-fast==1.87.2
 fnv-hash-fast==0.4.0
 ha-av==10.1.0
 hass-nabucasa==0.69.0
-hassil==1.2.2
+hassil==1.2.3
 home-assistant-bluetooth==1.10.2
 home-assistant-frontend==20230725.0
 home-assistant-intents==2023.7.25

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -958,7 +958,7 @@ hass-nabucasa==0.69.0
 hass-splunk==0.1.1
 
 # homeassistant.components.conversation
-hassil==1.2.3
+hassil==1.2.4
 
 # homeassistant.components.jewish_calendar
 hdate==0.10.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -958,7 +958,7 @@ hass-nabucasa==0.69.0
 hass-splunk==0.1.1
 
 # homeassistant.components.conversation
-hassil==1.2.4
+hassil==1.2.5
 
 # homeassistant.components.jewish_calendar
 hdate==0.10.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -958,7 +958,7 @@ hass-nabucasa==0.69.0
 hass-splunk==0.1.1
 
 # homeassistant.components.conversation
-hassil==1.2.2
+hassil==1.2.3
 
 # homeassistant.components.jewish_calendar
 hdate==0.10.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -753,7 +753,7 @@ habitipy==0.2.0
 hass-nabucasa==0.69.0
 
 # homeassistant.components.conversation
-hassil==1.2.4
+hassil==1.2.5
 
 # homeassistant.components.jewish_calendar
 hdate==0.10.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -753,7 +753,7 @@ habitipy==0.2.0
 hass-nabucasa==0.69.0
 
 # homeassistant.components.conversation
-hassil==1.2.2
+hassil==1.2.3
 
 # homeassistant.components.jewish_calendar
 hdate==0.10.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -753,7 +753,7 @@ habitipy==0.2.0
 hass-nabucasa==0.69.0
 
 # homeassistant.components.conversation
-hassil==1.2.3
+hassil==1.2.4
 
 # homeassistant.components.jewish_calendar
 hdate==0.10.4

--- a/tests/components/conversation/snapshots/test_init.ambr
+++ b/tests/components/conversation/snapshots/test_init.ambr
@@ -372,7 +372,7 @@
   dict({
     'results': list([
       dict({
-        'entities': dict({
+        'details': dict({
           'name': dict({
             'name': 'name',
             'text': 'my cool light',
@@ -392,7 +392,7 @@
         }),
       }),
       dict({
-        'entities': dict({
+        'details': dict({
           'name': dict({
             'name': 'name',
             'text': 'my cool light',
@@ -412,7 +412,7 @@
         }),
       }),
       dict({
-        'entities': dict({
+        'details': dict({
           'area': dict({
             'name': 'area',
             'text': 'kitchen',
@@ -438,7 +438,7 @@
         }),
       }),
       dict({
-        'entities': dict({
+        'details': dict({
           'area': dict({
             'name': 'area',
             'text': 'kitchen',

--- a/tests/components/conversation/snapshots/test_init.ambr
+++ b/tests/components/conversation/snapshots/test_init.ambr
@@ -382,6 +382,9 @@
         'intent': dict({
           'name': 'HassTurnOn',
         }),
+        'slots': dict({
+          'name': 'my cool light',
+        }),
         'targets': dict({
           'light.kitchen': dict({
             'matched': True,
@@ -398,6 +401,9 @@
         }),
         'intent': dict({
           'name': 'HassTurnOff',
+        }),
+        'slots': dict({
+          'name': 'my cool light',
         }),
         'targets': dict({
           'light.kitchen': dict({
@@ -420,6 +426,10 @@
         }),
         'intent': dict({
           'name': 'HassTurnOn',
+        }),
+        'slots': dict({
+          'area': 'kitchen',
+          'domain': 'light',
         }),
         'targets': dict({
           'light.kitchen': dict({
@@ -447,6 +457,11 @@
         }),
         'intent': dict({
           'name': 'HassGetState',
+        }),
+        'slots': dict({
+          'area': 'kitchen',
+          'domain': 'light',
+          'state': 'on',
         }),
         'targets': dict({
           'light.kitchen': dict({

--- a/tests/components/conversation/test_default_agent.py
+++ b/tests/components/conversation/test_default_agent.py
@@ -246,7 +246,8 @@ async def test_trigger_sentences(hass: HomeAssistant, init_components) -> None:
     for sentence in test_sentences:
         callback.reset_mock()
         result = await conversation.async_converse(hass, sentence, None, Context())
-        callback.assert_called_once_with(sentence)
+        assert callback.call_count == 1
+        assert callback.call_args[0][0] == sentence
         assert (
             result.response.response_type == intent.IntentResponseType.ACTION_DONE
         ), sentence

--- a/tests/components/conversation/test_trigger.py
+++ b/tests/components/conversation/test_trigger.py
@@ -61,6 +61,7 @@ async def test_if_fires_on_event(hass: HomeAssistant, calls, setup_comp) -> None
         "idx": "0",
         "platform": "conversation",
         "sentence": "Ha ha ha",
+        "slots": {},
         "entities": {},
     }
 
@@ -104,6 +105,7 @@ async def test_same_trigger_multiple_sentences(
         "idx": "0",
         "platform": "conversation",
         "sentence": "hello",
+        "slots": {},
         "entities": {},
     }
 
@@ -230,6 +232,10 @@ async def test_wildcards(hass: HomeAssistant, calls, setup_comp) -> None:
         "idx": "0",
         "platform": "conversation",
         "sentence": "play the white album by the beatles",
+        "slots": {
+            "album": "the white album",
+            "artist": "the beatles",
+        },
         "entities": {
             "album": {
                 "name": "album",

--- a/tests/components/conversation/test_trigger.py
+++ b/tests/components/conversation/test_trigger.py
@@ -61,7 +61,7 @@ async def test_if_fires_on_event(hass: HomeAssistant, calls, setup_comp) -> None
         "idx": "0",
         "platform": "conversation",
         "sentence": "Ha ha ha",
-        "wildcards": {},
+        "entities": {},
     }
 
 
@@ -104,7 +104,7 @@ async def test_same_trigger_multiple_sentences(
         "idx": "0",
         "platform": "conversation",
         "sentence": "hello",
-        "wildcards": {},
+        "entities": {},
     }
 
 
@@ -230,8 +230,16 @@ async def test_wildcards(hass: HomeAssistant, calls, setup_comp) -> None:
         "idx": "0",
         "platform": "conversation",
         "sentence": "play the white album by the beatles",
-        "wildcards": {
-            "album": "the white album",
-            "artist": "the beatles",
+        "entities": {
+            "album": {
+                "name": "album",
+                "text": "the white album",
+                "value": "the white album",
+            },
+            "artist": {
+                "name": "artist",
+                "text": "the beatles",
+                "value": "the beatles",
+            },
         },
     }

--- a/tests/components/conversation/test_trigger.py
+++ b/tests/components/conversation/test_trigger.py
@@ -62,7 +62,7 @@ async def test_if_fires_on_event(hass: HomeAssistant, calls, setup_comp) -> None
         "platform": "conversation",
         "sentence": "Ha ha ha",
         "slots": {},
-        "entities": {},
+        "details": {},
     }
 
 
@@ -106,7 +106,7 @@ async def test_same_trigger_multiple_sentences(
         "platform": "conversation",
         "sentence": "hello",
         "slots": {},
-        "entities": {},
+        "details": {},
     }
 
 
@@ -236,7 +236,7 @@ async def test_wildcards(hass: HomeAssistant, calls, setup_comp) -> None:
             "album": "the white album",
             "artist": "the beatles",
         },
-        "entities": {
+        "details": {
             "album": {
                 "name": "album",
                 "text": "the white album",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Depends on PR: https://github.com/home-assistant/core/pull/97232

Adds wildcard support to sentence triggers. Any `{list}` in your triggers will capture text and copy it into `trigger.wildcards`.
For example: "play {album} by {artist}" will match "play the white album by the beatles" and have:

* `trigger.slots.album` = "the white album"
* `trigger.slots.artist` = "the beatles"

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/28332

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
