### PR TITLE
Add Event platform/entity to Hue integration

### DIFF
--- a/homeassistant/components/hue/bridge.py
+++ b/homeassistant/components/hue/bridge.py
@@ -29,6 +29,7 @@ HUB_BUSY_SLEEP = 0.5
 PLATFORMS_v1 = [Platform.BINARY_SENSOR, Platform.LIGHT, Platform.SENSOR]
 PLATFORMS_v2 = [
     Platform.BINARY_SENSOR,
+    Platform.EVENT,
     Platform.LIGHT,
     Platform.SCENE,
     Platform.SENSOR,

--- a/homeassistant/components/hue/const.py
+++ b/homeassistant/components/hue/const.py
@@ -47,7 +47,6 @@ DEFAULT_BUTTON_EVENT_TYPES = (
     ButtonEvent.INITIAL_PRESS,
     ButtonEvent.REPEAT,
     ButtonEvent.SHORT_RELEASE,
-    ButtonEvent.LONG_PRESS,
     ButtonEvent.LONG_RELEASE,
 )
 

--- a/homeassistant/components/hue/const.py
+++ b/homeassistant/components/hue/const.py
@@ -1,4 +1,9 @@
 """Constants for the Hue component."""
+from aiohue.v2.models.button import ButtonEvent
+from aiohue.v2.models.relative_rotary import (
+    RelativeRotaryAction,
+    RelativeRotaryDirection,
+)
 
 DOMAIN = "hue"
 
@@ -33,3 +38,26 @@ DEFAULT_ALLOW_UNREACHABLE = False
 # How long to wait to actually do the refresh after requesting it.
 # We wait some time so if we control multiple lights, we batch requests.
 REQUEST_REFRESH_DELAY = 0.3
+
+
+# V2 API SPECIFIC CONSTANTS ##################
+
+DEFAULT_BUTTON_EVENT_TYPES = (
+    # all except `DOUBLE_SHORT_RELEASE`
+    ButtonEvent.INITIAL_PRESS,
+    ButtonEvent.REPEAT,
+    ButtonEvent.SHORT_RELEASE,
+    ButtonEvent.LONG_PRESS,
+    ButtonEvent.LONG_RELEASE,
+)
+
+DEFAULT_ROTARY_EVENT_TYPES = (RelativeRotaryAction.START, RelativeRotaryAction.REPEAT)
+DEFAULT_ROTARY_EVENT_SUBTYPES = (
+    RelativeRotaryDirection.CLOCK_WISE,
+    RelativeRotaryDirection.COUNTER_CLOCK_WISE,
+)
+
+DEVICE_SPECIFIC_EVENT_TYPES = {
+    # device specific overrides of specific supported button events
+    "Hue tap switch": (ButtonEvent.INITIAL_PRESS,),
+}

--- a/homeassistant/components/hue/const.py
+++ b/homeassistant/components/hue/const.py
@@ -43,7 +43,8 @@ REQUEST_REFRESH_DELAY = 0.3
 # V2 API SPECIFIC CONSTANTS ##################
 
 DEFAULT_BUTTON_EVENT_TYPES = (
-    # all except `DOUBLE_SHORT_RELEASE`
+    # I have never ever seen the `DOUBLE_SHORT_RELEASE`
+    # or `DOUBLE_SHORT_RELEASE` events so leave them out here
     ButtonEvent.INITIAL_PRESS,
     ButtonEvent.REPEAT,
     ButtonEvent.SHORT_RELEASE,

--- a/homeassistant/components/hue/event.py
+++ b/homeassistant/components/hue/event.py
@@ -1,0 +1,134 @@
+"""Hue event entities from Button resources."""
+from __future__ import annotations
+
+from typing import Any
+
+from aiohue.v2 import HueBridgeV2
+from aiohue.v2.controllers.events import EventType
+from aiohue.v2.models.button import Button
+from aiohue.v2.models.relative_rotary import (
+    RelativeRotary,
+    RelativeRotaryDirection,
+)
+
+from homeassistant.components.event import (
+    EventDeviceClass,
+    EventEntity,
+    EventEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .bridge import HueBridge
+from .const import DEFAULT_BUTTON_EVENT_TYPES, DEVICE_SPECIFIC_EVENT_TYPES, DOMAIN
+from .v2.entity import HueBaseEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up scene platform from Hue group scenes."""
+    bridge: HueBridge = hass.data[DOMAIN][config_entry.entry_id]
+    api: HueBridgeV2 = bridge.api
+
+    if bridge.api_version == 1:
+        # should not happen, but just in case
+        raise NotImplementedError("Scene support is only available for V2 bridges")
+
+    # add entities for all button and relative rotary resources
+    @callback
+    def async_add_entity(
+        event_type: EventType,
+        resource: Button | RelativeRotary,
+    ) -> None:
+        """Add entity from Hue resource."""
+        if isinstance(resource, RelativeRotary):
+            async_add_entities(
+                [HueRotaryEventEntity(bridge, api.sensors.relative_rotary, resource)]
+            )
+        else:
+            async_add_entities(
+                [HueButtonEventEntity(bridge, api.sensors.button, resource)]
+            )
+
+    for controller in (api.sensors.button, api.sensors.relative_rotary):
+        # add all current items in controller
+        for item in controller:
+            async_add_entity(EventType.RESOURCE_ADDED, item)
+
+        # register listener for new items only
+        config_entry.async_on_unload(
+            controller.subscribe(
+                async_add_entity, event_filter=EventType.RESOURCE_ADDED
+            )
+        )
+
+
+class HueButtonEventEntity(HueBaseEntity, EventEntity):
+    """Representation of a Hue Event entity from a button resource."""
+
+    entity_description = EventEntityDescription(
+        key="button",
+        device_class=EventDeviceClass.BUTTON,
+        has_entity_name=True,
+        translation_key="button",
+    )
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initialize the entity."""
+        super().__init__(*args, **kwargs)
+        # fill the event types based on the features the switch supports
+        hue_dev_id = self.controller.get_device(self.resource.id).id
+        model_id = self.bridge.api.devices[hue_dev_id].product_data.product_name
+        event_types: list[str] = []
+        for event_type in DEVICE_SPECIFIC_EVENT_TYPES.get(
+            model_id, DEFAULT_BUTTON_EVENT_TYPES
+        ):
+            event_types.append(event_type.value)
+        self._attr_event_types = event_types
+
+    @property
+    def name(self) -> str:
+        """Return name for the entity."""
+        return f"Button {self.resource.metadata.control_id}"
+
+    @callback
+    def _handle_event(self, event_type: EventType, resource: Button) -> None:
+        """Handle status event for this resource (or it's parent)."""
+        if event_type == EventType.RESOURCE_UPDATED and resource.id == self.resource.id:
+            self._trigger_event(resource.button.last_event.value)
+            self.async_write_ha_state()
+            return
+        super()._handle_event(event_type, resource)
+
+
+class HueRotaryEventEntity(HueBaseEntity, EventEntity):
+    """Representation of a Hue Event entity from a RelativeRotary resource."""
+
+    entity_description = EventEntityDescription(
+        key="rotary",
+        device_class=EventDeviceClass.BUTTON,
+        translation_key="rotary",
+        event_types=[
+            RelativeRotaryDirection.CLOCK_WISE.value,
+            RelativeRotaryDirection.COUNTER_CLOCK_WISE.value,
+        ],
+    )
+
+    @callback
+    def _handle_event(self, event_type: EventType, resource: RelativeRotary) -> None:
+        """Handle status event for this resource (or it's parent)."""
+        if event_type == EventType.RESOURCE_UPDATED and resource.id == self.resource.id:
+            event_key = resource.relative_rotary.last_event.rotation.direction.value
+            event_data = {
+                "duration": resource.relative_rotary.last_event.rotation.duration,
+                "steps": resource.relative_rotary.last_event.rotation.steps,
+                "action": resource.relative_rotary.last_event.action.value,
+            }
+            self._trigger_event(event_key, event_data)
+            self.async_write_ha_state()
+            return
+        super()._handle_event(event_type, resource)

--- a/homeassistant/components/hue/event.py
+++ b/homeassistant/components/hue/event.py
@@ -73,7 +73,6 @@ class HueButtonEventEntity(HueBaseEntity, EventEntity):
     entity_description = EventEntityDescription(
         key="button",
         device_class=EventDeviceClass.BUTTON,
-        has_entity_name=False,
         translation_key="button",
     )
 

--- a/homeassistant/components/hue/event.py
+++ b/homeassistant/components/hue/event.py
@@ -30,7 +30,7 @@ async def async_setup_entry(
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up scene platform from Hue group scenes."""
+    """Set up event platform from Hue button resources."""
     bridge: HueBridge = hass.data[DOMAIN][config_entry.entry_id]
     api: HueBridgeV2 = bridge.api
 

--- a/homeassistant/components/hue/event.py
+++ b/homeassistant/components/hue/event.py
@@ -73,7 +73,7 @@ class HueButtonEventEntity(HueBaseEntity, EventEntity):
     entity_description = EventEntityDescription(
         key="button",
         device_class=EventDeviceClass.BUTTON,
-        has_entity_name=True,
+        has_entity_name=False,
         translation_key="button",
     )
 
@@ -93,7 +93,7 @@ class HueButtonEventEntity(HueBaseEntity, EventEntity):
     @property
     def name(self) -> str:
         """Return name for the entity."""
-        return f"Button {self.resource.metadata.control_id}"
+        return f"{super().name} {self.resource.metadata.control_id}"
 
     @callback
     def _handle_event(self, event_type: EventType, resource: Button) -> None:

--- a/homeassistant/components/hue/event.py
+++ b/homeassistant/components/hue/event.py
@@ -36,7 +36,7 @@ async def async_setup_entry(
 
     if bridge.api_version == 1:
         # should not happen, but just in case
-        raise NotImplementedError("Scene support is only available for V2 bridges")
+        raise NotImplementedError("Event support is only available for V2 bridges")
 
     # add entities for all button and relative rotary resources
     @callback

--- a/homeassistant/components/hue/strings.json
+++ b/homeassistant/components/hue/strings.json
@@ -75,8 +75,9 @@
             "state": {
               "initial_press": "Initial press",
               "repeat": "Repeat",
-              "short_release": "Short release",
-              "long_release": "Long release",
+              "short_release": "Short press",
+              "long_release": "Long press",
+              "double_short_release": "Double press",
               "long_press": "Long press"
             }
           }

--- a/homeassistant/components/hue/strings.json
+++ b/homeassistant/components/hue/strings.json
@@ -77,8 +77,7 @@
               "repeat": "Repeat",
               "short_release": "Short press",
               "long_release": "Long press",
-              "double_short_release": "Double press",
-              "long_press": "Long press"
+              "double_short_release": "Double press"
             }
           }
         }

--- a/homeassistant/components/hue/strings.json
+++ b/homeassistant/components/hue/strings.json
@@ -67,6 +67,34 @@
       "start": "[%key:component::hue::device_automation::trigger_type::initial_press%]"
     }
   },
+  "entity": {
+    "event": {
+      "button": {
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "initial_press": "Initial press",
+              "repeat": "Repeat",
+              "short_release": "Short release",
+              "long_release": "Long release",
+              "long_press": "Long press"
+            }
+          }
+        }
+      },
+      "rotary": {
+        "name": "Rotary",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "clock_wise": "Clockwise",
+              "counter_clock_wise": "Counter clockwise"
+            }
+          }
+        }
+      }
+    }
+  },
   "options": {
     "step": {
       "init": {

--- a/homeassistant/components/hue/v2/device_trigger.py
+++ b/homeassistant/components/hue/v2/device_trigger.py
@@ -3,11 +3,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from aiohue.v2.models.button import ButtonEvent
-from aiohue.v2.models.relative_rotary import (
-    RelativeRotaryAction,
-    RelativeRotaryDirection,
-)
 from aiohue.v2.models.resource import ResourceTypes
 import voluptuous as vol
 
@@ -24,7 +19,15 @@ from homeassistant.core import CALLBACK_TYPE, callback
 from homeassistant.helpers.device_registry import DeviceEntry
 from homeassistant.helpers.typing import ConfigType
 
-from ..const import ATTR_HUE_EVENT, CONF_SUBTYPE, DOMAIN
+from ..const import (
+    ATTR_HUE_EVENT,
+    CONF_SUBTYPE,
+    DEFAULT_BUTTON_EVENT_TYPES,
+    DEFAULT_ROTARY_EVENT_SUBTYPES,
+    DEFAULT_ROTARY_EVENT_TYPES,
+    DEVICE_SPECIFIC_EVENT_TYPES,
+    DOMAIN,
+)
 
 if TYPE_CHECKING:
     from aiohue.v2 import HueBridgeV2
@@ -40,26 +43,6 @@ TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
         vol.Optional(CONF_UNIQUE_ID): str,
     }
 )
-
-DEFAULT_BUTTON_EVENT_TYPES = (
-    # all except `DOUBLE_SHORT_RELEASE`
-    ButtonEvent.INITIAL_PRESS,
-    ButtonEvent.REPEAT,
-    ButtonEvent.SHORT_RELEASE,
-    ButtonEvent.LONG_PRESS,
-    ButtonEvent.LONG_RELEASE,
-)
-
-DEFAULT_ROTARY_EVENT_TYPES = (RelativeRotaryAction.START, RelativeRotaryAction.REPEAT)
-DEFAULT_ROTARY_EVENT_SUBTYPES = (
-    RelativeRotaryDirection.CLOCK_WISE,
-    RelativeRotaryDirection.COUNTER_CLOCK_WISE,
-)
-
-DEVICE_SPECIFIC_EVENT_TYPES = {
-    # device specific overrides of specific supported button events
-    "Hue tap switch": (ButtonEvent.INITIAL_PRESS,),
-}
 
 
 async def async_validate_trigger_config(

--- a/tests/components/hue/const.py
+++ b/tests/components/hue/const.py
@@ -18,6 +18,7 @@ FAKE_DEVICE = {
         {"rid": "fake_zigbee_connectivity_id_1", "rtype": "zigbee_connectivity"},
         {"rid": "fake_temperature_sensor_id_1", "rtype": "temperature"},
         {"rid": "fake_motion_sensor_id_1", "rtype": "motion"},
+        {"rid": "fake_relative_rotary", "rtype": "relative_rotary"},
     ],
     "type": "device",
 }
@@ -94,4 +95,21 @@ FAKE_SCENE = {
     "speed": 0.5,
     "auto_dynamic": False,
     "type": "scene",
+}
+
+FAKE_ROTARY = {
+    "id": "fake_relative_rotary",
+    "id_v1": "/sensors/1",
+    "owner": {"rid": "fake_device_id_1", "rtype": "device"},
+    "relative_rotary": {
+        "last_event": {
+            "action": "start",
+            "rotation": {
+                "direction": "clock_wise",
+                "steps": 0,
+                "duration": 0,
+            },
+        }
+    },
+    "type": "relative_rotary",
 }

--- a/tests/components/hue/fixtures/v2_resources.json
+++ b/tests/components/hue/fixtures/v2_resources.json
@@ -475,6 +475,10 @@
       {
         "rid": "db50a5d9-8cc7-486f-be06-c0b8f0d26c69",
         "rtype": "zigbee_connectivity"
+      },
+      {
+        "rid": "2f029c7b-868b-49e9-aa01-a0bbc595990d",
+        "rtype": "relative_rotary"
       }
     ],
     "type": "device"

--- a/tests/components/hue/test_bridge.py
+++ b/tests/components/hue/test_bridge.py
@@ -51,9 +51,16 @@ async def test_bridge_setup_v2(hass: HomeAssistant, mock_api_v2) -> None:
     assert hue_bridge.api is mock_api_v2
     assert isinstance(hue_bridge.api, HueBridgeV2)
     assert hue_bridge.api_version == 2
-    assert len(mock_forward.mock_calls) == 5
+    assert len(mock_forward.mock_calls) == 6
     forward_entries = {c[1][1] for c in mock_forward.mock_calls}
-    assert forward_entries == {"light", "binary_sensor", "sensor", "switch", "scene"}
+    assert forward_entries == {
+        "light",
+        "binary_sensor",
+        "event",
+        "sensor",
+        "switch",
+        "scene",
+    }
 
 
 async def test_bridge_setup_invalid_api_key(hass: HomeAssistant) -> None:

--- a/tests/components/hue/test_device_trigger_v2.py
+++ b/tests/components/hue/test_device_trigger_v2.py
@@ -92,7 +92,6 @@ async def test_get_triggers(
             }
             for event_type in (
                 ButtonEvent.INITIAL_PRESS,
-                ButtonEvent.LONG_PRESS,
                 ButtonEvent.LONG_RELEASE,
                 ButtonEvent.REPEAT,
                 ButtonEvent.SHORT_RELEASE,

--- a/tests/components/hue/test_event.py
+++ b/tests/components/hue/test_event.py
@@ -28,7 +28,6 @@ async def test_event(
         "initial_press",
         "repeat",
         "short_release",
-        "long_press",
         "long_release",
     ]
     # trigger firing 'initial_press' event from the device

--- a/tests/components/hue/test_event.py
+++ b/tests/components/hue/test_event.py
@@ -1,0 +1,56 @@
+"""Philips Hue Event platform tests for V2 bridge/api."""
+from homeassistant.components.event import (
+    ATTR_EVENT_TYPE,
+    ATTR_EVENT_TYPES,
+)
+from homeassistant.core import HomeAssistant
+
+from .conftest import setup_platform
+
+
+async def test_event(
+    hass: HomeAssistant, mock_bridge_v2, v2_resources_test_data
+) -> None:
+    """Test event entity for Hue integration."""
+    await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
+    await setup_platform(hass, mock_bridge_v2, "event")
+    # 7 entities should be created from test data
+    assert len(hass.states.async_all()) == 7
+
+    # pick one of the remote buttons
+    state = hass.states.get("event.hue_dimmer_switch_with_4_controls_button_1")
+    assert state
+    assert state.state == "unknown"
+    # the switch endpoint has no label so the entity name should be the device itself
+    assert state.name == "Hue Dimmer switch with 4 controls Button 1"
+    # check event_types
+    assert state.attributes[ATTR_EVENT_TYPES] == [
+        "initial_press",
+        "repeat",
+        "short_release",
+        "long_press",
+        "long_release",
+    ]
+    # trigger firing 'initial_press' event from the device
+    btn_event = {
+        "button": {"last_event": "initial_press"},
+        "id": "f92aa267-1387-4f02-9950-210fb7ca1f5a",
+        "metadata": {"control_id": 1},
+        "type": "button",
+    }
+    mock_bridge_v2.api.emit_event("update", btn_event)
+    await hass.async_block_till_done()
+    state = hass.states.get("event.hue_dimmer_switch_with_4_controls_button_1")
+    assert state.attributes[ATTR_EVENT_TYPE] == "initial_press"
+
+    # trigger firing 'long_release' event from the device
+    btn_event = {
+        "button": {"last_event": "long_release"},
+        "id": "f92aa267-1387-4f02-9950-210fb7ca1f5a",
+        "metadata": {"control_id": 1},
+        "type": "button",
+    }
+    mock_bridge_v2.api.emit_event("update", btn_event)
+    await hass.async_block_till_done()
+    state = hass.states.get("event.hue_dimmer_switch_with_4_controls_button_1")
+    assert state.attributes[ATTR_EVENT_TYPE] == "long_release"


### PR DESCRIPTION
## Proposed change
Add the new Event platform/entity to the Hue integration, meaning that you will now get a nice entity for your remote button(s) instead of manual fiddling with events.

**Future optimizations:**
- switch to translation keys for the whole (v2) integration.
- phase out device triggers
- phase out forwarding the raw event on the HA eventbus.


![Scherm­afbeelding 2023-07-26 om 13 18 32](https://github.com/home-assistant/core/assets/6389780/13de1b88-19d2-4654-aafa-70b56d36808d)


Marked as draft due to the tests still in the making.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
