### PR TITLE
Tomorrow.io Polling Rate

### DIFF
--- a/homeassistant/components/tomorrowio/config_flow.py
+++ b/homeassistant/components/tomorrowio/config_flow.py
@@ -56,6 +56,10 @@ def _get_config_schema(
         vol.Required(CONF_API_KEY, default=input_dict.get(CONF_API_KEY)): str,
     }
 
+    api_polling_rate = {
+        vol.Required(450): int,
+    }
+
     default_location = (
         input_dict[CONF_LOCATION]
         if CONF_LOCATION in input_dict
@@ -67,6 +71,7 @@ def _get_config_schema(
     return vol.Schema(
         {
             **api_key_schema,
+            **api_polling_rate,
             vol.Required(
                 CONF_LOCATION,
                 default=default_location,

--- a/homeassistant/components/tomorrowio/config_flow.py
+++ b/homeassistant/components/tomorrowio/config_flow.py
@@ -29,7 +29,9 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.selector import LocationSelector, LocationSelectorConfig
 
 from .const import (
+    CONF_MAX_REQUESTS_PER_DAY,
     CONF_TIMESTEP,
+    DEFAULT_MAX_REQUESTS_PER_DAY,
     DEFAULT_NAME,
     DEFAULT_TIMESTEP,
     DOMAIN,
@@ -56,6 +58,12 @@ def _get_config_schema(
         vol.Required(CONF_API_KEY, default=input_dict.get(CONF_API_KEY)): str,
     }
 
+    api_polling_rate = {
+        vol.Required(
+            CONF_MAX_REQUESTS_PER_DAY, default=DEFAULT_MAX_REQUESTS_PER_DAY
+        ): vol.All(int, vol.Range(min=1)),
+    }
+
     default_location = (
         input_dict[CONF_LOCATION]
         if CONF_LOCATION in input_dict
@@ -67,6 +75,7 @@ def _get_config_schema(
     return vol.Schema(
         {
             **api_key_schema,
+            **api_polling_rate,
             vol.Required(
                 CONF_LOCATION,
                 default=default_location,
@@ -103,6 +112,10 @@ class TomorrowioOptionsConfigFlow(config_entries.OptionsFlow):
                 CONF_TIMESTEP,
                 default=self._config_entry.options[CONF_TIMESTEP],
             ): vol.In([1, 5, 15, 30]),
+            vol.Required(
+                CONF_MAX_REQUESTS_PER_DAY,
+                default=self._config_entry.options[CONF_MAX_REQUESTS_PER_DAY],
+            ): vol.All(int, vol.Range(min=1)),
         }
 
         return self.async_show_form(

--- a/homeassistant/components/tomorrowio/const.py
+++ b/homeassistant/components/tomorrowio/const.py
@@ -23,6 +23,7 @@ from homeassistant.components.weather import (
 LOGGER = logging.getLogger(__package__)
 
 CONF_TIMESTEP = "timestep"
+CONF_MAX_REQUESTS_PER_DAY = "max_api_requests"
 FORECAST_TYPES = [DAILY, HOURLY, NOWCAST]
 
 DEFAULT_TIMESTEP = 15
@@ -32,6 +33,7 @@ INTEGRATION_NAME = "Tomorrow.io"
 DEFAULT_NAME = INTEGRATION_NAME
 ATTRIBUTION = "Powered by Tomorrow.io"
 
+DEFAULT_MAX_REQUESTS_PER_DAY = 500
 MAX_REQUESTS_PER_DAY = 100
 
 CLEAR_CONDITIONS = {"night": ATTR_CONDITION_CLEAR_NIGHT, "day": ATTR_CONDITION_SUNNY}

--- a/homeassistant/components/tomorrowio/strings.json
+++ b/homeassistant/components/tomorrowio/strings.json
@@ -26,7 +26,8 @@
         "title": "Update Tomorrow.io Options",
         "description": "If you choose to enable the `nowcast` forecast entity, you can configure the number of minutes between each forecast. The number of forecasts provided depends on the number of minutes chosen between forecasts.",
         "data": {
-          "timestep": "Min. Between NowCast Forecasts"
+          "timestep": "Min. Between NowCast Forecasts",
+          "max_api_requests": "Maximum number of allowed API calls per day"
         }
       }
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
It *may* be breaking, depending on what is decided upon.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
At the moment the tomorrow.io integration has a hardcoded API call limit of 100 calls per day. I noticed that my own free API key allows up to 500 calls, so I figured it would be nice to be able to increase that number.

There's two options, as far as I can tell:

1. Change the magic number from 100 to 500 - bad practice imho, and might break existing installations if people with older API keys still have the older call limit also
2. Allow the configuration of the API call limit - I began to add that in this pull request - it's not done yet though, because I wanted to ask first if that'd be okay.

There *is* an HTTP header `X-RateLimit-Limit-day` to check the rate limit - but it is only available for enterprise customers. The http header is not sent when you use a free API key, I checked.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
