### PR TITLE
Avoid firing update coordinator callbacks when nothing has changed

### DIFF
--- a/homeassistant/helpers/update_coordinator.py
+++ b/homeassistant/helpers/update_coordinator.py
@@ -54,7 +54,12 @@ class BaseDataUpdateCoordinatorProtocol(Protocol):
 
 
 class DataUpdateCoordinator(BaseDataUpdateCoordinatorProtocol, Generic[_DataT]):
-    """Class to manage fetching data from single endpoint."""
+    """Class to manage fetching data from single endpoint.
+
+    Setting :attr:`always_update` to ``False`` will cause coordinator to only
+    callback listeners when data has changed. This requires that the data
+    implements ``__eq__``.
+    """
 
     def __init__(
         self,

--- a/homeassistant/helpers/update_coordinator.py
+++ b/homeassistant/helpers/update_coordinator.py
@@ -374,11 +374,14 @@ class DataUpdateCoordinator(BaseDataUpdateCoordinatorProtocol, Generic[_DataT]):
             if not auth_failed and self._listeners and not self.hass.is_stopping:
                 self._schedule_refresh()
 
+        if not self.last_update_success and not previous_update_success:
+            return
+
         if (
             # If the data object is the same object we cannot tell if the data has
             # changed so we always notify listeners.
             previous_data is self.data
-            or previous_update_success != self.last_update_success
+            or self.last_update_success != previous_update_success
             or previous_data != self.data
         ):
             self.async_update_listeners()

--- a/homeassistant/helpers/update_coordinator.py
+++ b/homeassistant/helpers/update_coordinator.py
@@ -65,6 +65,7 @@ class DataUpdateCoordinator(BaseDataUpdateCoordinatorProtocol, Generic[_DataT]):
         update_interval: timedelta | None = None,
         update_method: Callable[[], Awaitable[_DataT]] | None = None,
         request_refresh_debouncer: Debouncer[Coroutine[Any, Any, None]] | None = None,
+        force_update: bool = True,
     ) -> None:
         """Initialize global data updater."""
         self.hass = hass
@@ -74,6 +75,7 @@ class DataUpdateCoordinator(BaseDataUpdateCoordinatorProtocol, Generic[_DataT]):
         self.update_interval = update_interval
         self._shutdown_requested = False
         self.config_entry = config_entries.current_entry.get()
+        self.force_update = force_update
 
         # It's None before the first successful update.
         # Components should call async_config_entry_first_refresh
@@ -378,9 +380,7 @@ class DataUpdateCoordinator(BaseDataUpdateCoordinatorProtocol, Generic[_DataT]):
             return
 
         if (
-            # If the data object is the same object we cannot tell if the data has
-            # changed so we always notify listeners.
-            previous_data is self.data
+            self.force_update
             or self.last_update_success != previous_update_success
             or previous_data != self.data
         ):

--- a/homeassistant/helpers/update_coordinator.py
+++ b/homeassistant/helpers/update_coordinator.py
@@ -65,7 +65,7 @@ class DataUpdateCoordinator(BaseDataUpdateCoordinatorProtocol, Generic[_DataT]):
         update_interval: timedelta | None = None,
         update_method: Callable[[], Awaitable[_DataT]] | None = None,
         request_refresh_debouncer: Debouncer[Coroutine[Any, Any, None]] | None = None,
-        force_update: bool = True,
+        always_update: bool = True,
     ) -> None:
         """Initialize global data updater."""
         self.hass = hass
@@ -75,7 +75,7 @@ class DataUpdateCoordinator(BaseDataUpdateCoordinatorProtocol, Generic[_DataT]):
         self.update_interval = update_interval
         self._shutdown_requested = False
         self.config_entry = config_entries.current_entry.get()
-        self.force_update = force_update
+        self.always_update = always_update
 
         # It's None before the first successful update.
         # Components should call async_config_entry_first_refresh
@@ -380,7 +380,7 @@ class DataUpdateCoordinator(BaseDataUpdateCoordinatorProtocol, Generic[_DataT]):
             return
 
         if (
-            self.force_update
+            self.always_update
             or self.last_update_success != previous_update_success
             or previous_data != self.data
         ):

--- a/homeassistant/helpers/update_coordinator.py
+++ b/homeassistant/helpers/update_coordinator.py
@@ -58,7 +58,7 @@ class DataUpdateCoordinator(BaseDataUpdateCoordinatorProtocol, Generic[_DataT]):
 
     Setting :attr:`always_update` to ``False`` will cause coordinator to only
     callback listeners when data has changed. This requires that the data
-    implements ``__eq__``.
+    implements ``__eq__`` or uses a python object that already does.
     """
 
     def __init__(

--- a/homeassistant/helpers/update_coordinator.py
+++ b/homeassistant/helpers/update_coordinator.py
@@ -375,11 +375,9 @@ class DataUpdateCoordinator(BaseDataUpdateCoordinatorProtocol, Generic[_DataT]):
                 self._schedule_refresh()
 
         if (
-            # some integrations use the coordinator
-            # to poll for data but don't use the data
-            # in the entity so we always want to update
-            # listeners in that case
-            self.data is None
+            # If the data object is the same object we cannot tell if the data has
+            # changed so we always notify listeners.
+            previous_data is self.data
             or previous_update_success != self.last_update_success
             or previous_data != self.data
         ):

--- a/tests/helpers/test_update_coordinator.py
+++ b/tests/helpers/test_update_coordinator.py
@@ -596,12 +596,12 @@ async def test_async_set_update_error(
     remove_callbacks()
 
 
-async def test_only_callback_on_change_when_force_update_is_false(
+async def test_only_callback_on_change_when_always_update_is_false(
     crd: update_coordinator.DataUpdateCoordinator[int], caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Test we do not callback listeners unless something has actually changed when force_update is false."""
+    """Test we do not callback listeners unless something has actually changed when always_update is false."""
     update_callback = Mock()
-    crd.force_update = False
+    crd.always_update = False
     remove_callbacks = crd.async_add_listener(update_callback)
     mocked_data = None
     mocked_exception = None
@@ -666,10 +666,10 @@ async def test_only_callback_on_change_when_force_update_is_false(
     remove_callbacks()
 
 
-async def test_always_callback_when_force_update_is_true(
+async def test_always_callback_when_always_update_is_true(
     crd: update_coordinator.DataUpdateCoordinator[int], caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Test we callback listeners even though the data is the same when force_update is True."""
+    """Test we callback listeners even though the data is the same when always_update is True."""
     update_callback = Mock()
     remove_callbacks = crd.async_add_listener(update_callback)
     mocked_data = None

--- a/tests/helpers/test_update_coordinator.py
+++ b/tests/helpers/test_update_coordinator.py
@@ -602,7 +602,7 @@ async def test_only_callback_on_change(
     """Test we do not callback listeners unless something has actually changed."""
     update_callback = Mock()
     remove_callbacks = crd.async_add_listener(update_callback)
-    mocked_data = 1
+    mocked_data = None
     mocked_exception = None
 
     async def _update_method() -> int:
@@ -614,37 +614,45 @@ async def test_only_callback_on_change(
 
     crd.update_method = _update_method
 
+    mocked_data = {"a": 1}
     await crd.async_refresh()
     update_callback.assert_called_once()
     update_callback.reset_mock()
 
+    mocked_data = {"a": 1}
     await crd.async_refresh()
     update_callback.assert_not_called()
     update_callback.reset_mock()
 
+    mocked_data = None
     mocked_exception = aiohttp.ClientError("Client Failure #1")
     await crd.async_refresh()
     update_callback.assert_called_once()
     update_callback.reset_mock()
 
+    mocked_data = None
+    mocked_exception = aiohttp.ClientError("Client Failure #1")
     await crd.async_refresh()
     update_callback.assert_not_called()
     update_callback.reset_mock()
 
     mocked_exception = None
+    mocked_data = {"a": 1}
     await crd.async_refresh()
     update_callback.assert_called_once()
     update_callback.reset_mock()
 
+    mocked_data = {"a": 1}
     await crd.async_refresh()
     update_callback.assert_not_called()
     update_callback.reset_mock()
 
-    mocked_data = 2
+    mocked_data = {"a": 2}
     await crd.async_refresh()
     update_callback.assert_called_once()
     update_callback.reset_mock()
 
+    mocked_data = {"a": 2}
     await crd.async_refresh()
     update_callback.assert_not_called()
     update_callback.reset_mock()

--- a/tests/helpers/test_update_coordinator.py
+++ b/tests/helpers/test_update_coordinator.py
@@ -657,4 +657,15 @@ async def test_only_callback_on_change(
     update_callback.assert_not_called()
     update_callback.reset_mock()
 
+    mocked_data = {"a": 2, "b": 3}
+    await crd.async_refresh()
+    update_callback.assert_called_once()
+    update_callback.reset_mock()
+
+    # Object is the same so we have no way to check if it changed
+    # so we always callback
+    await crd.async_refresh()
+    update_callback.assert_called_once()
+    update_callback.reset_mock()
+
     remove_callbacks()

--- a/tests/helpers/test_update_coordinator.py
+++ b/tests/helpers/test_update_coordinator.py
@@ -649,30 +649,4 @@ async def test_only_callback_on_change(
     update_callback.assert_not_called()
     update_callback.reset_mock()
 
-    # Make sure adding new listeners results in the next update being called
-    # even if the data hasn't changed
-    update_callback2 = Mock()
-    remove_callbacks2 = crd.async_add_listener(update_callback2)
-    await crd.async_refresh()
-    update_callback.assert_called_once()
-    update_callback.reset_mock()
-    update_callback2.assert_called_once()
-    update_callback2.reset_mock()
-
-    await crd.async_refresh()
-    update_callback.assert_not_called()
-    update_callback.reset_mock()
-    update_callback2.assert_not_called()
-    update_callback2.reset_mock()
-
-    # Remove callbacks to avoid lingering timers
     remove_callbacks()
-    await crd.async_refresh()
-    update_callback2.assert_called_once()
-    update_callback2.reset_mock()
-
-    await crd.async_refresh()
-    update_callback2.assert_not_called()
-    update_callback2.reset_mock()
-
-    remove_callbacks2()

--- a/tests/helpers/test_update_coordinator.py
+++ b/tests/helpers/test_update_coordinator.py
@@ -694,4 +694,18 @@ async def test_always_callback_when_force_update_is_true(
     update_callback.assert_called_once()
     update_callback.reset_mock()
 
+    # But still don't fire it if we are only getting
+    # failure over and over
+    mocked_data = None
+    mocked_exception = aiohttp.ClientError("Client Failure #1")
+    await crd.async_refresh()
+    update_callback.assert_called_once()
+    update_callback.reset_mock()
+
+    mocked_data = None
+    mocked_exception = aiohttp.ClientError("Client Failure #1")
+    await crd.async_refresh()
+    update_callback.assert_not_called()
+    update_callback.reset_mock()
+
     remove_callbacks()


### PR DESCRIPTION
Blog post and docs update https://github.com/home-assistant/developers.home-assistant/pull/1863

The `DataUpdateCoordinator` can now reduce unnecessary updates when API data can be compared.

When using the `DataUpdateCoordinator`, the data being polled is often expected to stay mostly the same. For example, if you are polling a light that is only turned on once a week, that data may be the same nearly all the time. The default behavior is always calling back listeners when the data is updated, even if it does not change. If the data returned from the API can be compared for changes with the Python `__eq__` method, set `always_update=False` when creating the `DataUpdateCoordinator` to avoid unnecessary callbacks and writes to the state machine.

## Proposed change

Most of the time the coordinator is polling the same data over and over again and nothing changes (ie waiting for a light to turn on that may never turn on that day). 

Avoid firing callbacks when nothing has changed when `always_update=False` is set since it results in many calls to `async_write_ha_state` that build the whole state and than throw it away.  This has the potential to remove 1000s of state writes per minute for integrations that update data every time.

This only works if the integration is updating based on the data the coordinator returns. The this does not help designs where the coordinator is causing an another object to get updated.

The default behavior remains the same and integrations must specifically opt-out of forced updates to avoid a breaking change. If we like this idea, I can put together a blog post for it.

Integrations I'm using that can immediately benefit by flipping the flag
- rainmachine
- steamist
- flux_led
- nut
- emonitor
- lookin
- powerwall
- cert_expiry
- filesize
- esphome (dashboard)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
