### PR TITLE
Upgrade Verisure to 2.6.4

### DIFF
--- a/homeassistant/components/verisure/coordinator.py
+++ b/homeassistant/components/verisure/coordinator.py
@@ -7,7 +7,6 @@ from time import sleep
 from verisure import (
     Error as VerisureError,
     LoginError as VerisureLoginError,
-    ResponseError as VerisureResponseError,
     Session as Verisure,
 )
 
@@ -50,7 +49,7 @@ class VerisureDataUpdateCoordinator(DataUpdateCoordinator):
         except VerisureLoginError as ex:
             LOGGER.error("Could not log in to verisure, %s", ex)
             raise ConfigEntryAuthFailed("Credentials expired for Verisure") from ex
-        except VerisureResponseError as ex:
+        except VerisureError as ex:
             LOGGER.error("Could not log in to verisure, %s", ex)
             return False
 
@@ -64,12 +63,8 @@ class VerisureDataUpdateCoordinator(DataUpdateCoordinator):
         """Fetch data from Verisure."""
         try:
             await self.hass.async_add_executor_job(self.verisure.update_cookie)
-        except VerisureLoginError as ex:
-            LOGGER.error("Credentials expired for Verisure, %s", ex)
-            raise ConfigEntryAuthFailed("Credentials expired for Verisure") from ex
-        except VerisureResponseError as ex:
-            LOGGER.error("Could not log in to verisure, %s", ex)
-            raise ConfigEntryAuthFailed("Could not log in to verisure") from ex
+        except VerisureError as ex:
+            raise UpdateFailed("Unable to update cookie") from ex
         try:
             overview = await self.hass.async_add_executor_job(
                 self.verisure.request,
@@ -81,13 +76,6 @@ class VerisureDataUpdateCoordinator(DataUpdateCoordinator):
                 self.verisure.smart_lock(),
                 self.verisure.smartplugs(),
             )
-        except VerisureResponseError as err:
-            LOGGER.debug("Cookie expired or service unavailable, %s", err)
-            overview = self._overview
-            try:
-                await self.hass.async_add_executor_job(self.verisure.update_cookie)
-            except VerisureResponseError as ex:
-                raise ConfigEntryAuthFailed("Credentials for Verisure expired.") from ex
         except VerisureError as err:
             LOGGER.error("Could not read overview, %s", err)
             raise UpdateFailed("Could not read overview") from err

--- a/homeassistant/components/verisure/coordinator.py
+++ b/homeassistant/components/verisure/coordinator.py
@@ -63,6 +63,8 @@ class VerisureDataUpdateCoordinator(DataUpdateCoordinator):
         """Fetch data from Verisure."""
         try:
             await self.hass.async_add_executor_job(self.verisure.update_cookie)
+        except VerisureLoginError as ex:
+            raise ConfigEntryAuthFailed("Credentials expired for Verisure") from ex
         except VerisureError as ex:
             raise UpdateFailed("Unable to update cookie") from ex
         try:

--- a/homeassistant/components/verisure/manifest.json
+++ b/homeassistant/components/verisure/manifest.json
@@ -12,5 +12,5 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "loggers": ["verisure"],
-  "requirements": ["vsure==2.6.1"]
+  "requirements": ["vsure==2.6.2"]
 }

--- a/homeassistant/components/verisure/manifest.json
+++ b/homeassistant/components/verisure/manifest.json
@@ -12,5 +12,5 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "loggers": ["verisure"],
-  "requirements": ["vsure==2.6.2"]
+  "requirements": ["vsure==2.6.3"]
 }

--- a/homeassistant/components/verisure/manifest.json
+++ b/homeassistant/components/verisure/manifest.json
@@ -12,5 +12,5 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "loggers": ["verisure"],
-  "requirements": ["vsure==2.6.3"]
+  "requirements": ["vsure==2.6.4"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2637,7 +2637,7 @@ volkszaehler==0.4.0
 volvooncall==0.10.3
 
 # homeassistant.components.verisure
-vsure==2.6.3
+vsure==2.6.4
 
 # homeassistant.components.vasttrafik
 vtjp==0.1.14

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2637,7 +2637,7 @@ volkszaehler==0.4.0
 volvooncall==0.10.3
 
 # homeassistant.components.verisure
-vsure==2.6.1
+vsure==2.6.2
 
 # homeassistant.components.vasttrafik
 vtjp==0.1.14

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2637,7 +2637,7 @@ volkszaehler==0.4.0
 volvooncall==0.10.3
 
 # homeassistant.components.verisure
-vsure==2.6.2
+vsure==2.6.3
 
 # homeassistant.components.vasttrafik
 vtjp==0.1.14

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1937,7 +1937,7 @@ voip-utils==0.1.0
 volvooncall==0.10.3
 
 # homeassistant.components.verisure
-vsure==2.6.3
+vsure==2.6.4
 
 # homeassistant.components.vulcan
 vulcan-api==2.3.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1937,7 +1937,7 @@ voip-utils==0.1.0
 volvooncall==0.10.3
 
 # homeassistant.components.verisure
-vsure==2.6.1
+vsure==2.6.2
 
 # homeassistant.components.vulcan
 vulcan-api==2.3.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1937,7 +1937,7 @@ voip-utils==0.1.0
 volvooncall==0.10.3
 
 # homeassistant.components.verisure
-vsure==2.6.2
+vsure==2.6.3
 
 # homeassistant.components.vulcan
 vulcan-api==2.3.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Update requirements
- Update manifest
- Update coordinator
  - Replace VerisureResponseError for VerisureError
  - raise UpdateFailed instead of ConfigEntryAuthFailed to fix #94028


Changelog: <https://github.com/persandstrom/python-verisure#version-history>

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #94028
- Dependency upgrade: https://github.com/persandstrom/python-verisure/pull/169

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
