### PR TITLE
Fix DeviceInfo configuration_url validation

### DIFF
--- a/homeassistant/components/tautulli/__init__.py
+++ b/homeassistant/components/tautulli/__init__.py
@@ -61,7 +61,7 @@ class TautulliEntity(CoordinatorEntity[TautulliDataUpdateCoordinator]):
         self.entity_description = description
         self.user = user
         self._attr_device_info = DeviceInfo(
-            configuration_url=coordinator.host_configuration.base_url,
+            configuration_url=str(coordinator.host_configuration.base_url),
             entry_type=DeviceEntryType.SERVICE,
             identifiers={(DOMAIN, user.user_id if user else entry_id)},
             manufacturer=DEFAULT_NAME,

--- a/homeassistant/components/tautulli/__init__.py
+++ b/homeassistant/components/tautulli/__init__.py
@@ -61,7 +61,7 @@ class TautulliEntity(CoordinatorEntity[TautulliDataUpdateCoordinator]):
         self.entity_description = description
         self.user = user
         self._attr_device_info = DeviceInfo(
-            configuration_url=str(coordinator.host_configuration.base_url),
+            configuration_url=coordinator.host_configuration.base_url,
             entry_type=DeviceEntryType.SERVICE,
             identifiers={(DOMAIN, user.user_id if user else entry_id)},
             manufacturer=DEFAULT_NAME,

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -15,6 +15,7 @@ from timeit import default_timer as timer
 from typing import TYPE_CHECKING, Any, Final, Literal, TypedDict, TypeVar, final
 
 import voluptuous as vol
+from yarl import URL
 
 from homeassistant.backports.functools import cached_property
 from homeassistant.config import DATA_CUSTOMIZE
@@ -177,7 +178,7 @@ def get_unit_of_measurement(hass: HomeAssistant, entity_id: str) -> str | None:
 class DeviceInfo(TypedDict, total=False):
     """Entity device information for device registry."""
 
-    configuration_url: str | None
+    configuration_url: str | URL | None
     connections: set[tuple[str, str]]
     default_manufacturer: str
     default_model: str

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -173,7 +173,7 @@ async def test_loading_from_storage(
                 {
                     "area_id": "12345A",
                     "config_entries": ["1234"],
-                    "configuration_url": "configuration_url",
+                    "configuration_url": "https://example.com/config",
                     "connections": [["Zigbee", "01.23.45.67.89"]],
                     "disabled_by": dr.DeviceEntryDisabler.USER,
                     "entry_type": dr.DeviceEntryType.SERVICE,
@@ -215,7 +215,7 @@ async def test_loading_from_storage(
     assert entry == dr.DeviceEntry(
         area_id="12345A",
         config_entries={"1234"},
-        configuration_url="configuration_url",
+        configuration_url="https://example.com/config",
         connections={("Zigbee", "01.23.45.67.89")},
         disabled_by=dr.DeviceEntryDisabler.USER,
         entry_type=dr.DeviceEntryType.SERVICE,
@@ -918,7 +918,7 @@ async def test_update(
         updated_entry = device_registry.async_update_device(
             entry.id,
             area_id="12345A",
-            configuration_url="configuration_url",
+            configuration_url="https://example.com/config",
             disabled_by=dr.DeviceEntryDisabler.USER,
             entry_type=dr.DeviceEntryType.SERVICE,
             hw_version="hw_version",
@@ -937,7 +937,7 @@ async def test_update(
     assert updated_entry == dr.DeviceEntry(
         area_id="12345A",
         config_entries={"1234"},
-        configuration_url="configuration_url",
+        configuration_url="https://example.com/config",
         connections={("mac", "12:34:56:ab:cd:ef")},
         disabled_by=dr.DeviceEntryDisabler.USER,
         entry_type=dr.DeviceEntryType.SERVICE,

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -1690,7 +1690,6 @@ async def test_only_disable_device_if_all_config_entries_are_disabled(
         (URL("http://localhost/config"), nullcontext()),
         (URL("http://localhost:8123/config"), nullcontext()),
         (URL("https://example.com/config"), nullcontext()),
-        ("homeassistant://config", nullcontext()),
         (URL("homeassistant://config"), nullcontext()),
         (None, nullcontext()),
         ("http://", pytest.raises(ValueError)),
@@ -1701,7 +1700,7 @@ async def test_only_disable_device_if_all_config_entries_are_disabled(
         (URL("https://"), pytest.raises(ValueError)),
         (URL("gopher://localhost"), pytest.raises(ValueError)),
         (URL("homeassistant://"), pytest.raises(ValueError)),
-        # Test any string castable objects
+        # Exception implements __str__
         (Exception("https://example.com"), nullcontext()),
         (Exception("https://"), pytest.raises(ValueError)),
         (Exception(), pytest.raises(ValueError)),

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -1701,6 +1701,10 @@ async def test_only_disable_device_if_all_config_entries_are_disabled(
         (URL("https://"), pytest.raises(ValueError)),
         (URL("gopher://localhost"), pytest.raises(ValueError)),
         (URL("homeassistant://"), pytest.raises(ValueError)),
+        # Test any string castable objects
+        (Exception("https://example.com"), nullcontext()),
+        (Exception("https://"), pytest.raises(ValueError)),
+        (Exception(), pytest.raises(ValueError)),
     ],
 )
 async def test_device_info_configuration_url_validation(

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -1722,8 +1722,8 @@ async def test_device_info_configuration_url_validation(
         )
 
     update_device = device_registry.async_get_or_create(
-        config_entry_id="1234",
-        identifiers={("something", "1234")},
+        config_entry_id="5678",
+        identifiers={("something", "5678")},
         name="name",
     )
     with expectation:

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -1857,11 +1857,6 @@ async def test_device_name_defaulting_config_entry(
             "name": "bla",
             "default_name": "yo",
         },
-        # Invalid configuration URL
-        {
-            "identifiers": {("hue", "1234")},
-            "configuration_url": "foo://192.168.0.100/config",
-        },
     ],
 )
 async def test_device_type_error_checking(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Tautulli sets an YARL URL as an `configuration_url`, which caused the report in #97302.

After comments below from Ludeeus, I've tried adding support for YARL to our device info (why parse an URL again?). Found out we had no tests for this validation, so added one...

While writing those test, I found out we don't test every case, nor do we validate when the config entry is updated. This means an invalid URL could be set by updating an device info :(

This PR adds validation and conversion handling of the configuration URL of `DeviceInfo` including tests.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #97302
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
