### PR TITLE
Fix Hydrawise zone addressing

### DIFF
--- a/homeassistant/components/hydrawise/binary_sensor.py
+++ b/homeassistant/components/hydrawise/binary_sensor.py
@@ -92,6 +92,6 @@ class HydrawiseBinarySensor(HydrawiseEntity, BinarySensorEntity):
         if self.entity_description.key == "status":
             self._attr_is_on = self.coordinator.api.status == "All good!"
         elif self.entity_description.key == "is_watering":
-            relay_data = self.coordinator.api.relays[self.data["relay"] - 1]
+            relay_data = self.coordinator.api.relays_by_zone_number[self.data["relay"]]
             self._attr_is_on = relay_data["timestr"] == "Now"
         super()._handle_coordinator_update()

--- a/homeassistant/components/hydrawise/sensor.py
+++ b/homeassistant/components/hydrawise/sensor.py
@@ -77,7 +77,7 @@ class HydrawiseSensor(HydrawiseEntity, SensorEntity):
     def _handle_coordinator_update(self) -> None:
         """Get the latest data and updates the states."""
         LOGGER.debug("Updating Hydrawise sensor: %s", self.name)
-        relay_data = self.coordinator.api.relays[self.data["relay"] - 1]
+        relay_data = self.coordinator.api.relays_by_zone_number[self.data["relay"]]
         if self.entity_description.key == "watering_time":
             if relay_data["timestr"] == "Now":
                 self._attr_native_value = int(relay_data["run"] / 60)

--- a/homeassistant/components/hydrawise/switch.py
+++ b/homeassistant/components/hydrawise/switch.py
@@ -99,26 +99,26 @@ class HydrawiseSwitch(HydrawiseEntity, SwitchEntity):
 
     def turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""
-        relay_data = self.data["relay"] - 1
+        zone_number = self.data["relay"]
         if self.entity_description.key == "manual_watering":
-            self.coordinator.api.run_zone(self._default_watering_timer, relay_data)
+            self.coordinator.api.run_zone(self._default_watering_timer, zone_number)
         elif self.entity_description.key == "auto_watering":
-            self.coordinator.api.suspend_zone(0, relay_data)
+            self.coordinator.api.suspend_zone(0, zone_number)
 
     def turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
-        relay_data = self.data["relay"] - 1
+        zone_number = self.data["relay"]
         if self.entity_description.key == "manual_watering":
-            self.coordinator.api.run_zone(0, relay_data)
+            self.coordinator.api.run_zone(0, zone_number)
         elif self.entity_description.key == "auto_watering":
-            self.coordinator.api.suspend_zone(365, relay_data)
+            self.coordinator.api.suspend_zone(365, zone_number)
 
     @callback
     def _handle_coordinator_update(self) -> None:
         """Update device state."""
-        relay_data = self.data["relay"] - 1
+        zone_number = self.data["relay"]
         LOGGER.debug("Updating Hydrawise switch: %s", self.name)
-        timestr = self.coordinator.api.relays[relay_data]["timestr"]
+        timestr = self.coordinator.api.relays_by_zone_number[zone_number]["timestr"]
         if self.entity_description.key == "manual_watering":
             self._attr_is_on = timestr == "Now"
         elif self.entity_description.key == "auto_watering":


### PR DESCRIPTION
## Proposed change
Use the more reliable `relays_by_zone_number` attribute in the Hydrawise API. This is a dictionary indexed by the zone number instead of a list of zones in unknown order.

This also makes it more clear that the attribute we're looking at is the zone number.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #97317
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
