### PR TITLE
Move Wake on Lan YAML configuration to integration key

### DIFF
--- a/homeassistant/components/wake_on_lan/const.py
+++ b/homeassistant/components/wake_on_lan/const.py
@@ -1,2 +1,6 @@
 """Constants for the Wake-On-LAN component."""
 DOMAIN = "wake_on_lan"
+
+CONF_OFF_ACTION = "turn_off"
+DEFAULT_NAME = "Wake on LAN"
+DEFAULT_PING_TIMEOUT = 1

--- a/homeassistant/components/wake_on_lan/switch.py
+++ b/homeassistant/components/wake_on_lan/switch.py
@@ -63,7 +63,7 @@ async def async_setup_platform(
             translation_key="deprecated_yaml",
             translation_placeholders={
                 "domain": DOMAIN,
-                "integration_title": "Ping",
+                "integration_title": "Wake on Lan",
             },
         )
     if discovery_info:

--- a/tests/components/wake_on_lan/conftest.py
+++ b/tests/components/wake_on_lan/conftest.py
@@ -1,9 +1,14 @@
 """Test fixtures for Wake on Lan."""
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
+
+from homeassistant import setup
+from homeassistant.components.wake_on_lan.const import DOMAIN
+from homeassistant.core import HomeAssistant
 
 
 @pytest.fixture
@@ -11,3 +16,43 @@ def mock_send_magic_packet() -> AsyncMock:
     """Mock magic packet."""
     with patch("wakeonlan.send_magic_packet") as mock_send:
         yield mock_send
+
+
+@pytest.fixture(name="get_config")
+async def get_config_to_integration_load() -> dict[str, Any]:
+    """Return default configuration.
+
+    To override the config, tests can be marked with:
+    @pytest.mark.parametrize("get_config", [{...}]).
+    """
+
+    return {
+        "wake_on_lan": [
+            {
+                "switch": {
+                    "mac": "00:01:02:03:04:05",
+                    "name": "Test WOL 1",
+                    "host": "127.0.0.1",
+                }
+            },
+            {
+                "switch": {
+                    "mac": "00:01:02:03:04:06",
+                    "name": "Test WOL 2",
+                }
+            },
+        ]
+    }
+
+
+@pytest.fixture(name="load_yaml_integration")
+async def load_int(
+    hass: HomeAssistant, get_config: dict[str, Any], mock_send_magic_packet: AsyncMock
+) -> None:
+    """Set up the WOL integration in Home Assistant."""
+    await setup.async_setup_component(
+        hass,
+        DOMAIN,
+        get_config,
+    )
+    await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Move WOL YAML configuration to integration key

```YAML
wake_on_lan:
  - switch:
      mac: 00:01:02:03:04:05
      name: "Test WOL switch"
  - switch:
      mac: 00:01:02:03:04:06
      name: "Test WOL switch 2"
```

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/28352

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
