### PR TITLE
Refactor deprecated RESULT_TYPE_*

### DIFF
--- a/tests/components/airzone/test_config_flow.py
+++ b/tests/components/airzone/test_config_flow.py
@@ -10,13 +10,14 @@ from aioairzone.exceptions import (
     SystemOutOfRange,
 )
 
-from homeassistant import config_entries, data_entry_flow
+from homeassistant import config_entries
 from homeassistant.components import dhcp
 from homeassistant.components.airzone.config_flow import short_mac
 from homeassistant.components.airzone.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER, ConfigEntryState
 from homeassistant.const import CONF_HOST, CONF_ID, CONF_PORT
 from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
 
 from .util import CONFIG, CONFIG_ID1, HVAC_MOCK, HVAC_VERSION_MOCK, HVAC_WEBSERVER_MOCK
 
@@ -56,7 +57,7 @@ async def test_form(hass: HomeAssistant) -> None:
             DOMAIN, context={"source": SOURCE_USER}
         )
 
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] == FlowResultType.FORM
         assert result["step_id"] == "user"
         assert result["errors"] == {}
 
@@ -70,7 +71,7 @@ async def test_form(hass: HomeAssistant) -> None:
         entry = conf_entries[0]
         assert entry.state is ConfigEntryState.LOADED
 
-        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+        assert result["type"] == FlowResultType.CREATE_ENTRY
         assert result["title"] == f"Airzone {CONFIG[CONF_HOST]}:{CONFIG[CONF_PORT]}"
         assert result["data"][CONF_HOST] == CONFIG[CONF_HOST]
         assert result["data"][CONF_PORT] == CONFIG[CONF_PORT]
@@ -102,7 +103,7 @@ async def test_form_invalid_system_id(hass: HomeAssistant) -> None:
             DOMAIN, context={"source": SOURCE_USER}, data=CONFIG
         )
 
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] == FlowResultType.FORM
         assert result["step_id"] == "user"
         assert result["errors"] == {CONF_ID: "invalid_system_id"}
 
@@ -113,7 +114,7 @@ async def test_form_invalid_system_id(hass: HomeAssistant) -> None:
             result["flow_id"], CONFIG_ID1
         )
 
-        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+        assert result["type"] == FlowResultType.CREATE_ENTRY
 
         await hass.async_block_till_done()
 
@@ -121,7 +122,7 @@ async def test_form_invalid_system_id(hass: HomeAssistant) -> None:
         entry = conf_entries[0]
         assert entry.state is ConfigEntryState.LOADED
 
-        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+        assert result["type"] == FlowResultType.CREATE_ENTRY
         assert (
             result["title"]
             == f"Airzone {CONFIG_ID1[CONF_HOST]}:{CONFIG_ID1[CONF_PORT]}"
@@ -178,7 +179,7 @@ async def test_dhcp_flow(hass: HomeAssistant) -> None:
             context={"source": config_entries.SOURCE_DHCP},
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "discovered_connection"
 
     with patch(
@@ -204,7 +205,7 @@ async def test_dhcp_flow(hass: HomeAssistant) -> None:
             },
         )
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
     assert result2["data"] == {
         CONF_HOST: TEST_IP,
         CONF_PORT: TEST_PORT,
@@ -226,7 +227,7 @@ async def test_dhcp_flow_error(hass: HomeAssistant) -> None:
             context={"source": config_entries.SOURCE_DHCP},
         )
 
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "cannot_connect"
 
 
@@ -243,7 +244,7 @@ async def test_dhcp_connection_error(hass: HomeAssistant) -> None:
             context={"source": config_entries.SOURCE_DHCP},
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "discovered_connection"
 
     with patch(
@@ -288,7 +289,7 @@ async def test_dhcp_connection_error(hass: HomeAssistant) -> None:
         entry = conf_entries[0]
         assert entry.state is ConfigEntryState.LOADED
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == FlowResultType.CREATE_ENTRY
         assert result["title"] == f"Airzone {short_mac(HVAC_WEBSERVER_MOCK[API_MAC])}"
         assert result["data"][CONF_HOST] == TEST_IP
         assert result["data"][CONF_PORT] == TEST_PORT
@@ -309,7 +310,7 @@ async def test_dhcp_invalid_system_id(hass: HomeAssistant) -> None:
             context={"source": config_entries.SOURCE_DHCP},
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "discovered_connection"
 
     with patch(
@@ -335,7 +336,7 @@ async def test_dhcp_invalid_system_id(hass: HomeAssistant) -> None:
             },
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == FlowResultType.FORM
         assert result["step_id"] == "discovered_connection"
         assert result["errors"] == {CONF_ID: "invalid_system_id"}
 
@@ -356,7 +357,7 @@ async def test_dhcp_invalid_system_id(hass: HomeAssistant) -> None:
         entry = conf_entries[0]
         assert entry.state is ConfigEntryState.LOADED
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == FlowResultType.CREATE_ENTRY
         assert result["title"] == f"Airzone {short_mac(DHCP_SERVICE_INFO.macaddress)}"
         assert result["data"][CONF_HOST] == TEST_IP
         assert result["data"][CONF_PORT] == TEST_PORT

--- a/tests/components/bsblan/test_config_flow.py
+++ b/tests/components/bsblan/test_config_flow.py
@@ -3,17 +3,12 @@ from unittest.mock import AsyncMock, MagicMock
 
 from bsblan import BSBLANConnectionError
 
-from homeassistant import data_entry_flow
 from homeassistant.components.bsblan import config_flow
 from homeassistant.components.bsblan.const import CONF_PASSKEY, DOMAIN
 from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
 from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import (
-    RESULT_TYPE_ABORT,
-    RESULT_TYPE_CREATE_ENTRY,
-    RESULT_TYPE_FORM,
-)
+from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers.device_registry import format_mac
 
 from tests.common import MockConfigEntry
@@ -30,7 +25,7 @@ async def test_full_user_flow_implementation(
         context={"source": SOURCE_USER},
     )
 
-    assert result.get("type") == RESULT_TYPE_FORM
+    assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == "user"
 
     result2 = await hass.config_entries.flow.async_configure(
@@ -44,7 +39,7 @@ async def test_full_user_flow_implementation(
         },
     )
 
-    assert result2.get("type") == RESULT_TYPE_CREATE_ENTRY
+    assert result2.get("type") == FlowResultType.CREATE_ENTRY
     assert result2.get("title") == format_mac("00:80:41:19:69:90")
     assert result2.get("data") == {
         CONF_HOST: "127.0.0.1",
@@ -68,7 +63,7 @@ async def test_show_user_form(hass: HomeAssistant) -> None:
     )
 
     assert result["step_id"] == "user"
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
 
 
 async def test_connection_error(
@@ -90,7 +85,7 @@ async def test_connection_error(
         },
     )
 
-    assert result.get("type") == RESULT_TYPE_FORM
+    assert result.get("type") == FlowResultType.FORM
     assert result.get("errors") == {"base": "cannot_connect"}
     assert result.get("step_id") == "user"
 
@@ -114,5 +109,5 @@ async def test_user_device_exists_abort(
         },
     )
 
-    assert result.get("type") == RESULT_TYPE_ABORT
+    assert result.get("type") == FlowResultType.ABORT
     assert result.get("reason") == "already_configured"

--- a/tests/components/devolo_home_network/test_config_flow.py
+++ b/tests/components/devolo_home_network/test_config_flow.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 from devolo_plc_api.exceptions.device import DeviceNotFound
 import pytest
 
-from homeassistant import config_entries, data_entry_flow
+from homeassistant import config_entries
 from homeassistant.components.devolo_home_network import config_flow
 from homeassistant.components.devolo_home_network.const import (
     DOMAIN,
@@ -191,7 +191,7 @@ async def test_form_reauth(hass: HomeAssistant) -> None:
     )
 
     assert result["step_id"] == "reauth_confirm"
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
 
     with patch(
         "homeassistant.components.devolo_home_network.async_setup_entry",
@@ -203,7 +203,7 @@ async def test_form_reauth(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result2["type"] == FlowResultType.ABORT
     assert result2["reason"] == "reauth_successful"
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/dlna_dmr/test_config_flow.py
+++ b/tests/components/dlna_dmr/test_config_flow.py
@@ -10,7 +10,7 @@ from async_upnp_client.client import UpnpDevice
 from async_upnp_client.exceptions import UpnpError
 import pytest
 
-from homeassistant import config_entries, data_entry_flow
+from homeassistant import config_entries
 from homeassistant.components import ssdp
 from homeassistant.components.dlna_dmr.const import (
     CONF_BROWSE_UNFILTERED,
@@ -21,6 +21,7 @@ from homeassistant.components.dlna_dmr.const import (
 )
 from homeassistant.const import CONF_DEVICE_ID, CONF_HOST, CONF_MAC, CONF_TYPE, CONF_URL
 from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
 
 from .conftest import (
     MOCK_DEVICE_HOST_ADDR,
@@ -101,7 +102,7 @@ async def test_user_flow_undiscovered_manual(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DLNA_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["errors"] == {}
     assert result["step_id"] == "manual"
 
@@ -109,7 +110,7 @@ async def test_user_flow_undiscovered_manual(hass: HomeAssistant) -> None:
         result["flow_id"], user_input={CONF_URL: MOCK_DEVICE_LOCATION}
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["title"] == MOCK_DEVICE_NAME
     assert result["data"] == {
         CONF_URL: MOCK_DEVICE_LOCATION,
@@ -136,7 +137,7 @@ async def test_user_flow_discovered_manual(
     result = await hass.config_entries.flow.async_init(
         DLNA_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["errors"] is None
     assert result["step_id"] == "user"
 
@@ -144,7 +145,7 @@ async def test_user_flow_discovered_manual(
         result["flow_id"], user_input={}
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["errors"] == {}
     assert result["step_id"] == "manual"
 
@@ -152,7 +153,7 @@ async def test_user_flow_discovered_manual(
         result["flow_id"], user_input={CONF_URL: MOCK_DEVICE_LOCATION}
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["title"] == MOCK_DEVICE_NAME
     assert result["data"] == {
         CONF_URL: MOCK_DEVICE_LOCATION,
@@ -177,7 +178,7 @@ async def test_user_flow_selected(hass: HomeAssistant, ssdp_scanner_mock: Mock) 
     result = await hass.config_entries.flow.async_init(
         DLNA_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["errors"] is None
     assert result["step_id"] == "user"
 
@@ -185,7 +186,7 @@ async def test_user_flow_selected(hass: HomeAssistant, ssdp_scanner_mock: Mock) 
         result["flow_id"], user_input={CONF_HOST: MOCK_DEVICE_NAME}
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["title"] == MOCK_DEVICE_NAME
     assert result["data"] == {
         CONF_URL: MOCK_DEVICE_LOCATION,
@@ -208,7 +209,7 @@ async def test_user_flow_uncontactable(
     result = await hass.config_entries.flow.async_init(
         DLNA_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["errors"] == {}
     assert result["step_id"] == "manual"
 
@@ -216,7 +217,7 @@ async def test_user_flow_uncontactable(
         result["flow_id"], user_input={CONF_URL: MOCK_DEVICE_LOCATION}
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["errors"] == {"base": "cannot_connect"}
     assert result["step_id"] == "manual"
 
@@ -241,7 +242,7 @@ async def test_user_flow_embedded_st(
     result = await hass.config_entries.flow.async_init(
         DLNA_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["errors"] == {}
     assert result["step_id"] == "manual"
 
@@ -249,7 +250,7 @@ async def test_user_flow_embedded_st(
         result["flow_id"], user_input={CONF_URL: MOCK_DEVICE_LOCATION}
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["title"] == MOCK_DEVICE_NAME
     assert result["data"] == {
         CONF_URL: MOCK_DEVICE_LOCATION,
@@ -272,7 +273,7 @@ async def test_user_flow_wrong_st(hass: HomeAssistant, domain_data_mock: Mock) -
     result = await hass.config_entries.flow.async_init(
         DLNA_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["errors"] == {}
     assert result["step_id"] == "manual"
 
@@ -280,7 +281,7 @@ async def test_user_flow_wrong_st(hass: HomeAssistant, domain_data_mock: Mock) -
         result["flow_id"], user_input={CONF_URL: MOCK_DEVICE_LOCATION}
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["errors"] == {"base": "not_dmr"}
     assert result["step_id"] == "manual"
 
@@ -295,7 +296,7 @@ async def test_ssdp_flow_success(hass: HomeAssistant) -> None:
         context={"source": config_entries.SOURCE_SSDP},
         data=MOCK_DISCOVERY,
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "confirm"
 
     result = await hass.config_entries.flow.async_configure(
@@ -303,7 +304,7 @@ async def test_ssdp_flow_success(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["title"] == MOCK_DEVICE_NAME
     assert result["data"] == {
         CONF_URL: MOCK_DEVICE_LOCATION,
@@ -327,7 +328,7 @@ async def test_ssdp_flow_unavailable(
         context={"source": config_entries.SOURCE_SSDP},
         data=MOCK_DISCOVERY,
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "confirm"
 
     domain_data_mock.upnp_factory.async_create_device.side_effect = UpnpError
@@ -337,7 +338,7 @@ async def test_ssdp_flow_unavailable(
     )
     await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["title"] == MOCK_DEVICE_NAME
     assert result["data"] == {
         CONF_URL: MOCK_DEVICE_LOCATION,
@@ -368,7 +369,7 @@ async def test_ssdp_flow_existing(
             },
         ),
     )
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert config_entry_mock.data[CONF_URL] == NEW_DEVICE_LOCATION
 
@@ -388,7 +389,7 @@ async def test_ssdp_flow_duplicate_location(
         context={"source": config_entries.SOURCE_SSDP},
         data=discovery,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert config_entry_mock.data[CONF_URL] == MOCK_DEVICE_LOCATION
 
@@ -414,7 +415,7 @@ async def test_ssdp_duplicate_mac_ignored_entry(
         context={"source": config_entries.SOURCE_SSDP},
         data=discovery,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -437,7 +438,7 @@ async def test_ssdp_duplicate_mac_configured_entry(
         context={"source": config_entries.SOURCE_SSDP},
         data=discovery,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -453,7 +454,7 @@ async def test_ssdp_add_mac(
         context={"source": config_entries.SOURCE_SSDP},
         data=MOCK_DISCOVERY,
     )
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     await hass.async_block_till_done()
 
@@ -474,7 +475,7 @@ async def test_ssdp_dont_remove_mac(
         context={"source": config_entries.SOURCE_SSDP},
         data=MOCK_DISCOVERY,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     await hass.async_block_till_done()
 
@@ -502,7 +503,7 @@ async def test_ssdp_flow_upnp_udn(
             },
         ),
     )
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert config_entry_mock.data[CONF_URL] == NEW_DEVICE_LOCATION
 
@@ -518,7 +519,7 @@ async def test_ssdp_missing_services(hass: HomeAssistant) -> None:
         context={"source": config_entries.SOURCE_SSDP},
         data=discovery,
     )
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "not_dmr"
 
     # Service list does not contain services
@@ -530,7 +531,7 @@ async def test_ssdp_missing_services(hass: HomeAssistant) -> None:
         context={"source": config_entries.SOURCE_SSDP},
         data=discovery,
     )
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "not_dmr"
 
     # AVTransport service is missing
@@ -546,7 +547,7 @@ async def test_ssdp_missing_services(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DLNA_DOMAIN, context={"source": config_entries.SOURCE_SSDP}, data=discovery
     )
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "not_dmr"
 
 
@@ -568,7 +569,7 @@ async def test_ssdp_single_service(hass: HomeAssistant) -> None:
         context={"source": config_entries.SOURCE_SSDP},
         data=discovery,
     )
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "not_dmr"
 
 
@@ -582,7 +583,7 @@ async def test_ssdp_ignore_device(hass: HomeAssistant) -> None:
         context={"source": config_entries.SOURCE_SSDP},
         data=discovery,
     )
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "alternative_integration"
 
     discovery = dataclasses.replace(MOCK_DISCOVERY)
@@ -595,7 +596,7 @@ async def test_ssdp_ignore_device(hass: HomeAssistant) -> None:
         context={"source": config_entries.SOURCE_SSDP},
         data=discovery,
     )
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "alternative_integration"
 
     for manufacturer, model in [
@@ -613,7 +614,7 @@ async def test_ssdp_ignore_device(hass: HomeAssistant) -> None:
             context={"source": config_entries.SOURCE_SSDP},
             data=discovery,
         )
-        assert result["type"] == data_entry_flow.FlowResultType.ABORT
+        assert result["type"] == FlowResultType.ABORT
         assert result["reason"] == "alternative_integration"
 
 
@@ -635,7 +636,7 @@ async def test_ignore_flow(hass: HomeAssistant, ssdp_scanner_mock: Mock) -> None
     )
     await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["title"] == MOCK_DEVICE_NAME
     assert result["data"] == {
         CONF_URL: MOCK_DEVICE_LOCATION,
@@ -659,7 +660,7 @@ async def test_ignore_flow_no_ssdp(
     )
     await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["title"] == MOCK_DEVICE_NAME
     assert result["data"] == {
         CONF_URL: None,
@@ -680,7 +681,7 @@ async def test_unignore_flow(hass: HomeAssistant, ssdp_scanner_mock: Mock) -> No
     )
     await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["title"] == MOCK_DEVICE_NAME
 
     # Device was found via SSDP, matching the 2nd device type tried
@@ -698,7 +699,7 @@ async def test_unignore_flow(hass: HomeAssistant, ssdp_scanner_mock: Mock) -> No
         context={"source": config_entries.SOURCE_UNIGNORE},
         data={"unique_id": MOCK_DEVICE_UDN},
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "confirm"
 
     result = await hass.config_entries.flow.async_configure(
@@ -706,7 +707,7 @@ async def test_unignore_flow(hass: HomeAssistant, ssdp_scanner_mock: Mock) -> No
     )
     await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["title"] == MOCK_DEVICE_NAME
     assert result["data"] == {
         CONF_URL: MOCK_DEVICE_LOCATION,
@@ -733,7 +734,7 @@ async def test_unignore_flow_offline(
     )
     await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["title"] == MOCK_DEVICE_NAME
 
     # Device is not in the SSDP discoveries (perhaps HA restarted between ignore and unignore)
@@ -745,7 +746,7 @@ async def test_unignore_flow_offline(
         context={"source": config_entries.SOURCE_UNIGNORE},
         data={"unique_id": MOCK_DEVICE_UDN},
     )
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "discovery_error"
 
 
@@ -759,7 +760,7 @@ async def test_get_mac_address_ipv4(
         context={"source": config_entries.SOURCE_SSDP},
         data=MOCK_DISCOVERY,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "confirm"
 
     mock_get_mac_address.assert_called_once_with(ip=MOCK_DEVICE_HOST_ADDR)
@@ -783,7 +784,7 @@ async def test_get_mac_address_ipv6(
         context={"source": config_entries.SOURCE_SSDP},
         data=discovery,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "confirm"
 
     # The scope must be removed for get_mac_address to work correctly
@@ -824,7 +825,7 @@ async def test_options_flow(
     config_entry_mock.add_to_hass(hass)
     result = await hass.config_entries.options.async_init(config_entry_mock.entry_id)
 
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "init"
     assert result["errors"] == {}
 
@@ -838,7 +839,7 @@ async def test_options_flow(
         },
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "init"
     assert result["errors"] == {"base": "invalid_url"}
 
@@ -853,7 +854,7 @@ async def test_options_flow(
         },
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["data"] == {
         CONF_LISTEN_PORT: 2222,
         CONF_CALLBACK_URL_OVERRIDE: "http://override/callback",

--- a/tests/components/dremel_3d_printer/test_config_flow.py
+++ b/tests/components/dremel_3d_printer/test_config_flow.py
@@ -3,11 +3,11 @@ from unittest.mock import patch
 
 from requests.exceptions import ConnectTimeout
 
-from homeassistant import data_entry_flow
 from homeassistant.components.dremel_3d_printer.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import CONF_SOURCE
 from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
 
 from .conftest import CONF_DATA, patch_async_setup_entry
 
@@ -22,7 +22,7 @@ async def test_full_user_flow_implementation(hass: HomeAssistant, connection) ->
         DOMAIN, context={CONF_SOURCE: SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
 
     with patch_async_setup_entry():
@@ -30,7 +30,7 @@ async def test_full_user_flow_implementation(hass: HomeAssistant, connection) ->
             result["flow_id"], user_input=CONF_DATA
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["title"] == "DREMEL 3D45"
     assert result["data"] == CONF_DATA
 
@@ -42,7 +42,7 @@ async def test_already_configured(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={CONF_SOURCE: SOURCE_USER}, data=CONF_DATA
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -53,7 +53,7 @@ async def test_cannot_connect(hass: HomeAssistant, connection) -> None:
             DOMAIN, context={CONF_SOURCE: SOURCE_USER}, data=CONF_DATA
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {"base": "cannot_connect"}
 
@@ -62,7 +62,7 @@ async def test_cannot_connect(hass: HomeAssistant, connection) -> None:
             result["flow_id"], user_input=CONF_DATA
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["data"] == CONF_DATA
 
 
@@ -73,7 +73,7 @@ async def test_unknown_error(hass: HomeAssistant, connection) -> None:
             DOMAIN, context={CONF_SOURCE: SOURCE_USER}, data=CONF_DATA
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {"base": "unknown"}
 
@@ -82,6 +82,6 @@ async def test_unknown_error(hass: HomeAssistant, connection) -> None:
             result["flow_id"], user_input=CONF_DATA
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["title"] == "DREMEL 3D45"
     assert result["data"] == CONF_DATA

--- a/tests/components/generic/test_config_flow.py
+++ b/tests/components/generic/test_config_flow.py
@@ -9,7 +9,7 @@ import httpx
 import pytest
 import respx
 
-from homeassistant import config_entries, data_entry_flow
+from homeassistant import config_entries
 from homeassistant.components.camera import async_get_image
 from homeassistant.components.generic.config_flow import slug
 from homeassistant.components.generic.const import (
@@ -35,6 +35,7 @@ from homeassistant.const import (
     HTTP_BASIC_AUTHENTICATION,
 )
 from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import entity_registry as er, issue_registry as ir
 
 from tests.common import MockConfigEntry
@@ -79,7 +80,7 @@ async def test_form(
             user_flow["flow_id"],
             TESTDATA,
         )
-        assert result1["type"] == data_entry_flow.FlowResultType.FORM
+        assert result1["type"] == FlowResultType.FORM
         assert result1["step_id"] == "user_confirm_still"
         client = await hass_client()
         preview_id = result1["flow_id"]
@@ -92,7 +93,7 @@ async def test_form(
             user_input={CONF_CONFIRMED_OK: True},
         )
         await hass.async_block_till_done()
-    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
     assert result2["title"] == "127_0_0_1"
     assert result2["options"] == {
         CONF_STILL_IMAGE_URL: "http://127.0.0.1/testurl/1",
@@ -133,13 +134,13 @@ async def test_form_only_stillimage(
             data,
         )
         await hass.async_block_till_done()
-        assert result1["type"] == data_entry_flow.FlowResultType.FORM
+        assert result1["type"] == FlowResultType.FORM
         assert result1["step_id"] == "user_confirm_still"
         result2 = await hass.config_entries.flow.async_configure(
             result1["flow_id"],
             user_input={CONF_CONFIRMED_OK: True},
         )
-    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
     assert result2["title"] == "127_0_0_1"
     assert result2["options"] == {
         CONF_STILL_IMAGE_URL: "http://127.0.0.1/testurl/1",
@@ -166,13 +167,13 @@ async def test_form_reject_still_preview(
             user_flow["flow_id"],
             TESTDATA,
         )
-    assert result1["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result1["type"] == FlowResultType.FORM
     assert result1["step_id"] == "user_confirm_still"
     result2 = await hass.config_entries.flow.async_configure(
         result1["flow_id"],
         user_input={CONF_CONFIRMED_OK: False},
     )
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["type"] == FlowResultType.FORM
     assert result2["step_id"] == "user"
 
 
@@ -193,7 +194,7 @@ async def test_form_still_preview_cam_off(
             user_flow["flow_id"],
             TESTDATA,
         )
-        assert result1["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result1["type"] == FlowResultType.FORM
         assert result1["step_id"] == "user_confirm_still"
         preview_id = result1["flow_id"]
         # Try to view the image, should be unavailable.
@@ -214,14 +215,14 @@ async def test_form_only_stillimage_gif(
             user_flow["flow_id"],
             data,
         )
-        assert result1["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result1["type"] == FlowResultType.FORM
         assert result1["step_id"] == "user_confirm_still"
         result2 = await hass.config_entries.flow.async_configure(
             result1["flow_id"],
             user_input={CONF_CONFIRMED_OK: True},
         )
         await hass.async_block_till_done()
-    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
     assert result2["options"][CONF_CONTENT_TYPE] == "image/gif"
 
 
@@ -239,14 +240,14 @@ async def test_form_only_svg_whitespace(
             user_flow["flow_id"],
             data,
         )
-        assert result1["type"] == data_entry_flow.FlowResultType.FORM
+        assert result1["type"] == FlowResultType.FORM
         assert result1["step_id"] == "user_confirm_still"
         result2 = await hass.config_entries.flow.async_configure(
             result1["flow_id"],
             user_input={CONF_CONFIRMED_OK: True},
         )
     await hass.async_block_till_done()
-    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
 
 
 @respx.mock
@@ -274,14 +275,14 @@ async def test_form_only_still_sample(
             user_flow["flow_id"],
             data,
         )
-        assert result1["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result1["type"] == FlowResultType.FORM
         assert result1["step_id"] == "user_confirm_still"
         result2 = await hass.config_entries.flow.async_configure(
             result1["flow_id"],
             user_input={CONF_CONFIRMED_OK: True},
         )
         await hass.async_block_till_done()
-    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
 
 
 @respx.mock
@@ -362,13 +363,13 @@ async def test_form_rtsp_mode(
         result1 = await hass.config_entries.flow.async_configure(
             user_flow["flow_id"], data
         )
-        assert result1["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result1["type"] == FlowResultType.FORM
         assert result1["step_id"] == "user_confirm_still"
         result2 = await hass.config_entries.flow.async_configure(
             result1["flow_id"],
             user_input={CONF_CONFIRMED_OK: True},
         )
-    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
     assert result2["title"] == "127_0_0_1"
     assert result2["options"] == {
         CONF_STILL_IMAGE_URL: "http://127.0.0.1/testurl/1",
@@ -399,14 +400,14 @@ async def test_form_only_stream(
             user_flow["flow_id"],
             data,
         )
-        assert result1["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result1["type"] == FlowResultType.FORM
         assert result1["step_id"] == "user_confirm_still"
         result3 = await hass.config_entries.flow.async_configure(
             result1["flow_id"],
             user_input={CONF_CONFIRMED_OK: True},
         )
         await hass.async_block_till_done()
-    assert result3["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result3["type"] == FlowResultType.CREATE_ENTRY
     assert result3["title"] == "127_0_0_1"
     assert result3["options"] == {
         CONF_AUTHENTICATION: HTTP_BASIC_AUTHENTICATION,
@@ -442,7 +443,7 @@ async def test_form_still_and_stream_not_provided(
             CONF_VERIFY_SSL: False,
         },
     )
-    assert result2["type"] == data_entry_flow.FlowResultType.FORM
+    assert result2["type"] == FlowResultType.FORM
     assert result2["errors"] == {"base": "no_still_image_or_stream_url"}
 
 
@@ -638,7 +639,7 @@ async def test_options_template_error(
     await hass.async_block_till_done()
 
     result = await hass.config_entries.options.async_init(mock_entry.entry_id)
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "init"
 
     # try updating the still image url
@@ -649,16 +650,16 @@ async def test_options_template_error(
             result["flow_id"],
             user_input=data,
         )
-        assert result2["type"] == data_entry_flow.FlowResultType.FORM
+        assert result2["type"] == FlowResultType.FORM
         assert result2["step_id"] == "confirm_still"
 
         result2a = await hass.config_entries.options.async_configure(
             result2["flow_id"], user_input={CONF_CONFIRMED_OK: True}
         )
-        assert result2a["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+        assert result2a["type"] == FlowResultType.CREATE_ENTRY
 
         result3 = await hass.config_entries.options.async_init(mock_entry.entry_id)
-        assert result3["type"] == data_entry_flow.FlowResultType.FORM
+        assert result3["type"] == FlowResultType.FORM
         assert result3["step_id"] == "init"
 
         # verify that an invalid template reports the correct UI error.
@@ -667,7 +668,7 @@ async def test_options_template_error(
             result3["flow_id"],
             user_input=data,
         )
-        assert result4.get("type") == data_entry_flow.FlowResultType.FORM
+        assert result4.get("type") == FlowResultType.FORM
         assert result4["errors"] == {"still_image_url": "template_error"}
 
         # verify that an invalid template reports the correct UI error.
@@ -678,7 +679,7 @@ async def test_options_template_error(
             user_input=data,
         )
 
-        assert result5.get("type") == data_entry_flow.FlowResultType.FORM
+        assert result5.get("type") == FlowResultType.FORM
         assert result5["errors"] == {"stream_source": "template_error"}
 
         # verify that an relative stream url is rejected.
@@ -688,7 +689,7 @@ async def test_options_template_error(
             result5["flow_id"],
             user_input=data,
         )
-        assert result6.get("type") == data_entry_flow.FlowResultType.FORM
+        assert result6.get("type") == FlowResultType.FORM
         assert result6["errors"] == {"stream_source": "relative_url"}
 
         # verify that an malformed stream url is rejected.
@@ -698,7 +699,7 @@ async def test_options_template_error(
             result6["flow_id"],
             user_input=data,
         )
-    assert result7.get("type") == data_entry_flow.FlowResultType.FORM
+    assert result7.get("type") == FlowResultType.FORM
     assert result7["errors"] == {"stream_source": "malformed_url"}
 
 
@@ -736,7 +737,7 @@ async def test_options_only_stream(
     await hass.async_block_till_done()
 
     result = await hass.config_entries.options.async_init(mock_entry.entry_id)
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "init"
 
     # try updating the config options
@@ -745,13 +746,13 @@ async def test_options_only_stream(
             result["flow_id"],
             user_input=data,
         )
-    assert result2["type"] == data_entry_flow.FlowResultType.FORM
+    assert result2["type"] == FlowResultType.FORM
     assert result2["step_id"] == "confirm_still"
 
     result3 = await hass.config_entries.options.async_configure(
         result2["flow_id"], user_input={CONF_CONFIRMED_OK: True}
     )
-    assert result3["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result3["type"] == FlowResultType.CREATE_ENTRY
     assert result3["data"][CONF_CONTENT_TYPE] == "image/jpeg"
 
 
@@ -766,7 +767,7 @@ async def test_import(hass: HomeAssistant, fakeimg_png) -> None:
     result2 = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data=TESTDATA_YAML
     )
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["title"] == "Yaml Defined Name"
     await hass.async_block_till_done()
 
@@ -778,7 +779,7 @@ async def test_import(hass: HomeAssistant, fakeimg_png) -> None:
 
     # Any name defined in yaml should end up as the entity id.
     assert hass.states.get("camera.yaml_defined_name")
-    assert result2["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result2["type"] == FlowResultType.ABORT
 
 
 # These above can be deleted after deprecation period is finished.
@@ -873,7 +874,7 @@ async def test_use_wallclock_as_timestamps_option(
     result = await hass.config_entries.options.async_init(
         mock_entry.entry_id, context={"show_advanced_options": True}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "init"
     with patch(
         "homeassistant.components.generic.async_setup_entry", return_value=True
@@ -882,12 +883,12 @@ async def test_use_wallclock_as_timestamps_option(
             result["flow_id"],
             user_input={CONF_USE_WALLCLOCK_AS_TIMESTAMPS: True, **TESTDATA},
         )
-    assert result2["type"] == data_entry_flow.FlowResultType.FORM
+    assert result2["type"] == FlowResultType.FORM
     # Test what happens if user rejects the preview
     result3 = await hass.config_entries.options.async_configure(
         result2["flow_id"], user_input={CONF_CONFIRMED_OK: False}
     )
-    assert result3["type"] == data_entry_flow.FlowResultType.FORM
+    assert result3["type"] == FlowResultType.FORM
     assert result3["step_id"] == "init"
     with patch(
         "homeassistant.components.generic.async_setup_entry", return_value=True
@@ -896,10 +897,10 @@ async def test_use_wallclock_as_timestamps_option(
             result3["flow_id"],
             user_input={CONF_USE_WALLCLOCK_AS_TIMESTAMPS: True, **TESTDATA},
         )
-    assert result4["type"] == data_entry_flow.FlowResultType.FORM
+    assert result4["type"] == FlowResultType.FORM
     assert result4["step_id"] == "confirm_still"
     result5 = await hass.config_entries.options.async_configure(
         result4["flow_id"],
         user_input={CONF_CONFIRMED_OK: True},
     )
-    assert result5["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result5["type"] == FlowResultType.CREATE_ENTRY

--- a/tests/components/geo_json_events/test_config_flow.py
+++ b/tests/components/geo_json_events/test_config_flow.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 
 import pytest
 
-from homeassistant import config_entries, data_entry_flow
+from homeassistant import config_entries
 from homeassistant.components.geo_json_events import DOMAIN
 from homeassistant.const import (
     CONF_LATITUDE,
@@ -14,6 +14,7 @@ from homeassistant.const import (
     CONF_URL,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
 
 from tests.common import MockConfigEntry
 from tests.components.geo_json_events.conftest import URL
@@ -31,7 +32,7 @@ async def test_duplicate_error_user(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result["step_id"] == "user"
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -44,7 +45,7 @@ async def test_duplicate_error_user(
             },
         },
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -64,7 +65,7 @@ async def test_duplicate_error_import(
             CONF_RADIUS: 25,
         },
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -82,7 +83,7 @@ async def test_step_import(hass: HomeAssistant) -> None:
             CONF_SCAN_INTERVAL: timedelta(minutes=4),
         },
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == FlowResultType.CREATE_ENTRY
     assert (
         result["title"] == "http://geo.json.local/geo_json_events.json (-41.2, 174.7)"
     )
@@ -100,7 +101,7 @@ async def test_step_user(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result["step_id"] == "user"
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -113,7 +114,7 @@ async def test_step_user(hass: HomeAssistant) -> None:
             },
         },
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == FlowResultType.CREATE_ENTRY
     assert (
         result["title"] == "http://geo.json.local/geo_json_events.json (-41.2, 174.7)"
     )

--- a/tests/components/lidarr/test_config_flow.py
+++ b/tests/components/lidarr/test_config_flow.py
@@ -1,9 +1,9 @@
 """Test Lidarr config flow."""
-from homeassistant import data_entry_flow
 from homeassistant.components.lidarr.const import DEFAULT_NAME, DOMAIN
 from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER
 from homeassistant.const import CONF_API_KEY, CONF_SOURCE
 from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
 
 from .conftest import CONF_DATA, MOCK_INPUT, ComponentSetup
 
@@ -15,14 +15,14 @@ async def test_flow_user_form(hass: HomeAssistant, connection) -> None:
         context={CONF_SOURCE: SOURCE_USER},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input=MOCK_INPUT,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["title"] == DEFAULT_NAME
     assert result["data"] == CONF_DATA
 
@@ -34,7 +34,7 @@ async def test_flow_user_invalid_auth(hass: HomeAssistant, invalid_auth) -> None
         context={CONF_SOURCE: SOURCE_USER},
         data=CONF_DATA,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"]["base"] == "invalid_auth"
 
@@ -47,7 +47,7 @@ async def test_flow_user_cannot_connect(hass: HomeAssistant, cannot_connect) -> 
         data=CONF_DATA,
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"]["base"] == "cannot_connect"
 
@@ -60,7 +60,7 @@ async def test_wrong_app(hass: HomeAssistant, wrong_app) -> None:
         data=MOCK_INPUT,
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"]["base"] == "wrong_app"
 
@@ -73,7 +73,7 @@ async def test_zeroconf_failed(hass: HomeAssistant, zeroconf_failed) -> None:
         data=MOCK_INPUT,
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"]["base"] == "zeroconf_failed"
 
@@ -88,7 +88,7 @@ async def test_flow_user_unknown_error(hass: HomeAssistant, unknown) -> None:
         result["flow_id"],
         user_input=CONF_DATA,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"]["base"] == "unknown"
 
@@ -108,18 +108,18 @@ async def test_flow_reauth(
         },
         data=CONF_DATA,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={CONF_API_KEY: "abc123"},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
     assert entry.data[CONF_API_KEY] == "abc123"

--- a/tests/components/pushbullet/test_config_flow.py
+++ b/tests/components/pushbullet/test_config_flow.py
@@ -4,10 +4,11 @@ from unittest.mock import patch
 from pushbullet import InvalidKeyError, PushbulletError
 import pytest
 
-from homeassistant import config_entries, data_entry_flow
+from homeassistant import config_entries
 from homeassistant.components.pushbullet.const import DOMAIN
 from homeassistant.const import CONF_API_KEY
 from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
 
 from . import MOCK_CONFIG
 
@@ -33,7 +34,7 @@ async def test_flow_user(hass: HomeAssistant, requests_mock_fixture) -> None:
         result["flow_id"],
         user_input=MOCK_CONFIG,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["title"] == "pushbullet"
     assert result["data"] == MOCK_CONFIG
 
@@ -58,7 +59,7 @@ async def test_flow_user_already_configured(
         result["flow_id"],
         user_input=MOCK_CONFIG,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -83,7 +84,7 @@ async def test_flow_name_already_configured(hass: HomeAssistant) -> None:
         result["flow_id"],
         user_input=new_config,
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -99,7 +100,7 @@ async def test_flow_invalid_key(hass: HomeAssistant) -> None:
             context={"source": config_entries.SOURCE_USER},
             data=MOCK_CONFIG,
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {CONF_API_KEY: "invalid_api_key"}
 
@@ -116,6 +117,6 @@ async def test_flow_conn_error(hass: HomeAssistant) -> None:
             context={"source": config_entries.SOURCE_USER},
             data=MOCK_CONFIG,
         )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {"base": "cannot_connect"}

--- a/tests/components/radarr/test_config_flow.py
+++ b/tests/components/radarr/test_config_flow.py
@@ -3,11 +3,11 @@ from unittest.mock import patch
 
 from aiopyarr import exceptions
 
-from homeassistant import data_entry_flow
 from homeassistant.components.radarr.const import DEFAULT_NAME, DOMAIN
 from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER
 from homeassistant.const import CONF_API_KEY, CONF_SOURCE, CONF_URL, CONF_VERIFY_SSL
 from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
 
 from . import (
     API_KEY,
@@ -33,7 +33,7 @@ async def test_show_user_form(hass: HomeAssistant) -> None:
     )
 
     assert result["step_id"] == "user"
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
 
 
 async def test_cannot_connect(
@@ -48,7 +48,7 @@ async def test_cannot_connect(
         data=MOCK_USER_INPUT,
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {"base": "cannot_connect"}
 
@@ -62,7 +62,7 @@ async def test_invalid_auth(
         DOMAIN, context={CONF_SOURCE: SOURCE_USER}, data=MOCK_USER_INPUT
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {"base": "invalid_auth"}
 
@@ -79,7 +79,7 @@ async def test_wrong_app(hass: HomeAssistant) -> None:
             data={CONF_URL: URL, CONF_VERIFY_SSL: False},
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"]["base"] == "wrong_app"
 
@@ -96,7 +96,7 @@ async def test_zero_conf_failure(hass: HomeAssistant) -> None:
             data={CONF_URL: URL, CONF_VERIFY_SSL: False},
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"]["base"] == "zeroconf_failed"
 
@@ -113,7 +113,7 @@ async def test_unknown_error(hass: HomeAssistant) -> None:
             data=MOCK_USER_INPUT,
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {"base": "unknown"}
 
@@ -130,7 +130,7 @@ async def test_zero_conf(hass: HomeAssistant) -> None:
             data={CONF_URL: URL, CONF_VERIFY_SSL: False},
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["title"] == DEFAULT_NAME
     assert result["data"] == CONF_DATA
 
@@ -150,14 +150,14 @@ async def test_full_reauth_flow_implementation(
         data=entry.data,
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
 
     with patch_async_setup_entry() as mock_setup_entry:
@@ -166,7 +166,7 @@ async def test_full_reauth_flow_implementation(
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
 
     assert entry.data == CONF_DATA | {CONF_API_KEY: "test-api-key-reauth"}
@@ -185,7 +185,7 @@ async def test_full_user_flow_implementation(
         context={CONF_SOURCE: SOURCE_USER},
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
 
     with patch_async_setup_entry():
@@ -194,7 +194,7 @@ async def test_full_user_flow_implementation(
             user_input=MOCK_USER_INPUT,
         )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["title"] == DEFAULT_NAME
     assert result["data"] == CONF_DATA
     assert result["data"][CONF_URL] == "http://192.168.1.189:7887/test"

--- a/tests/components/renson/test_config_flow.py
+++ b/tests/components/renson/test_config_flow.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 from homeassistant import config_entries
 from homeassistant.components.renson.const import DOMAIN
 from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import RESULT_TYPE_CREATE_ENTRY, RESULT_TYPE_FORM
+from homeassistant.data_entry_flow import FlowResultType
 
 
 async def test_form(hass: HomeAssistant) -> None:
@@ -12,7 +12,7 @@ async def test_form(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["errors"] is None
 
     with patch(
@@ -30,7 +30,7 @@ async def test_form(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
     assert result2["title"] == "Renson"
     assert result2["data"] == {
         "host": "1.1.1.1",
@@ -55,7 +55,7 @@ async def test_form_cannot_connect(hass: HomeAssistant) -> None:
             },
         )
 
-    assert result2["type"] == RESULT_TYPE_FORM
+    assert result2["type"] == FlowResultType.FORM
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
@@ -76,5 +76,5 @@ async def test_form_unknown(hass: HomeAssistant) -> None:
             },
         )
 
-    assert result2["type"] == RESULT_TYPE_FORM
+    assert result2["type"] == FlowResultType.FORM
     assert result2["errors"] == {"base": "unknown"}

--- a/tests/components/roborock/test_config_flow.py
+++ b/tests/components/roborock/test_config_flow.py
@@ -10,9 +10,10 @@ from roborock.exceptions import (
     RoborockUrlException,
 )
 
-from homeassistant import config_entries, data_entry_flow
+from homeassistant import config_entries
 from homeassistant.components.roborock.const import CONF_ENTRY_CODE, DOMAIN
 from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
 
 from .mock_data import MOCK_CONFIG, USER_DATA, USER_EMAIL
 
@@ -28,7 +29,7 @@ async def test_config_flow_success(
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == FlowResultType.FORM
         assert result["step_id"] == "user"
         with patch(
             "homeassistant.components.roborock.config_flow.RoborockApiClient.request_code"
@@ -37,7 +38,7 @@ async def test_config_flow_success(
                 result["flow_id"], {"username": USER_EMAIL}
             )
 
-            assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+            assert result["type"] == FlowResultType.FORM
             assert result["step_id"] == "code"
             assert result["errors"] == {}
         with patch(
@@ -48,7 +49,7 @@ async def test_config_flow_success(
                 result["flow_id"], user_input={CONF_ENTRY_CODE: "123456"}
             )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["title"] == USER_EMAIL
     assert result["data"] == MOCK_CONFIG
     assert result["result"]
@@ -81,7 +82,7 @@ async def test_config_flow_failures_request_code(
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == FlowResultType.FORM
         assert result["step_id"] == "user"
         with patch(
             "homeassistant.components.roborock.config_flow.RoborockApiClient.request_code",
@@ -90,7 +91,7 @@ async def test_config_flow_failures_request_code(
             result = await hass.config_entries.flow.async_configure(
                 result["flow_id"], {"username": USER_EMAIL}
             )
-            assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+            assert result["type"] == FlowResultType.FORM
             assert result["errors"] == request_code_errors
         # Recover from error
         with patch(
@@ -100,7 +101,7 @@ async def test_config_flow_failures_request_code(
                 result["flow_id"], {"username": USER_EMAIL}
             )
 
-            assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+            assert result["type"] == FlowResultType.FORM
             assert result["step_id"] == "code"
             assert result["errors"] == {}
         with patch(
@@ -111,7 +112,7 @@ async def test_config_flow_failures_request_code(
                 result["flow_id"], user_input={CONF_ENTRY_CODE: "123456"}
             )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["title"] == USER_EMAIL
     assert result["data"] == MOCK_CONFIG
     assert result["result"]
@@ -142,7 +143,7 @@ async def test_config_flow_failures_code_login(
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == FlowResultType.FORM
         assert result["step_id"] == "user"
         with patch(
             "homeassistant.components.roborock.config_flow.RoborockApiClient.request_code"
@@ -151,7 +152,7 @@ async def test_config_flow_failures_code_login(
                 result["flow_id"], {"username": USER_EMAIL}
             )
 
-            assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+            assert result["type"] == FlowResultType.FORM
             assert result["step_id"] == "code"
             assert result["errors"] == {}
         # Raise exception for invalid code
@@ -162,7 +163,7 @@ async def test_config_flow_failures_code_login(
             result = await hass.config_entries.flow.async_configure(
                 result["flow_id"], user_input={CONF_ENTRY_CODE: "123456"}
             )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["type"] == FlowResultType.FORM
         assert result["errors"] == code_login_errors
         with patch(
             "homeassistant.components.roborock.config_flow.RoborockApiClient.code_login",
@@ -172,7 +173,7 @@ async def test_config_flow_failures_code_login(
                 result["flow_id"], user_input={CONF_ENTRY_CODE: "123456"}
             )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["title"] == USER_EMAIL
     assert result["data"] == MOCK_CONFIG
     assert result["result"]

--- a/tests/components/tautulli/test_config_flow.py
+++ b/tests/components/tautulli/test_config_flow.py
@@ -3,11 +3,11 @@ from unittest.mock import AsyncMock, patch
 
 from pytautulli import exceptions
 
-from homeassistant import data_entry_flow
 from homeassistant.components.tautulli.const import DOMAIN
 from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER
 from homeassistant.const import CONF_API_KEY, CONF_SOURCE, CONF_URL, CONF_VERIFY_SSL
 from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
 
 from . import CONF_DATA, NAME, patch_config_flow_tautulli, setup_integration
 
@@ -20,7 +20,7 @@ async def test_flow_user(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={CONF_SOURCE: SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {}
 
@@ -31,7 +31,7 @@ async def test_flow_user(hass: HomeAssistant) -> None:
         )
     await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
     assert result2["title"] == NAME
     assert result2["data"] == CONF_DATA
 
@@ -43,7 +43,7 @@ async def test_flow_user_cannot_connect(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={CONF_SOURCE: SOURCE_USER}, data=CONF_DATA
         )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"]["base"] == "cannot_connect"
 
@@ -54,7 +54,7 @@ async def test_flow_user_cannot_connect(hass: HomeAssistant) -> None:
         )
     await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
     assert result2["title"] == NAME
     assert result2["data"] == CONF_DATA
 
@@ -66,7 +66,7 @@ async def test_flow_user_invalid_auth(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}, data=CONF_DATA
         )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"]["base"] == "invalid_auth"
 
@@ -77,7 +77,7 @@ async def test_flow_user_invalid_auth(hass: HomeAssistant) -> None:
         )
     await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
     assert result2["title"] == NAME
     assert result2["data"] == CONF_DATA
 
@@ -89,7 +89,7 @@ async def test_flow_user_unknown_error(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={CONF_SOURCE: SOURCE_USER}, data=CONF_DATA
         )
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] == FlowResultType.FORM
         assert result["step_id"] == "user"
         assert result["errors"]["base"] == "unknown"
 
@@ -100,7 +100,7 @@ async def test_flow_user_unknown_error(hass: HomeAssistant) -> None:
         )
     await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
     assert result2["title"] == NAME
     assert result2["data"] == CONF_DATA
 
@@ -116,7 +116,7 @@ async def test_flow_user_already_configured(hass: HomeAssistant) -> None:
             context={"source": SOURCE_USER},
             data=CONF_DATA,
         )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == FlowResultType.ABORT
         assert result["reason"] == "already_configured"
 
 
@@ -128,7 +128,7 @@ async def test_flow_user_multiple_entries_allowed(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={CONF_SOURCE: SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {}
 
@@ -144,7 +144,7 @@ async def test_flow_user_multiple_entries_allowed(hass: HomeAssistant) -> None:
         )
     await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
     assert result2["title"] == NAME
     assert result2["data"] == input
 
@@ -164,7 +164,7 @@ async def test_flow_reauth(
         },
         data=CONF_DATA,
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
     assert result["errors"] == {}
 
@@ -179,7 +179,7 @@ async def test_flow_reauth(
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result2["type"] == FlowResultType.ABORT
     assert result2["reason"] == "reauth_successful"
     assert entry.data == CONF_DATA
     assert len(mock_entry.mock_calls) == 1
@@ -205,7 +205,7 @@ async def test_flow_reauth_error(
             result["flow_id"],
             user_input={CONF_API_KEY: "efgh"},
         )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
     assert result["errors"]["base"] == "invalid_auth"
 
@@ -214,5 +214,5 @@ async def test_flow_reauth_error(
             result["flow_id"],
             user_input={CONF_API_KEY: "efgh"},
         )
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"

--- a/tests/components/upcloud/test_config_flow.py
+++ b/tests/components/upcloud/test_config_flow.py
@@ -6,10 +6,11 @@ import requests_mock
 from requests_mock import ANY
 from upcloud_api import UpCloudAPIError
 
-from homeassistant import config_entries, data_entry_flow
+from homeassistant import config_entries
 from homeassistant.components.upcloud.const import DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_SCAN_INTERVAL, CONF_USERNAME
 from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
 
 from tests.common import MockConfigEntry
 
@@ -29,7 +30,7 @@ async def test_show_set_form(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": config_entries.SOURCE_USER}, data=None
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
 
 
@@ -42,7 +43,7 @@ async def test_connection_error(
         DOMAIN, context={"source": config_entries.SOURCE_USER}, data=FIXTURE_USER_INPUT
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {"base": "cannot_connect"}
 
@@ -63,7 +64,7 @@ async def test_login_error(
         DOMAIN, context={"source": config_entries.SOURCE_USER}, data=FIXTURE_USER_INPUT
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {"base": "invalid_auth"}
 
@@ -78,7 +79,7 @@ async def test_success(
         DOMAIN, context={"source": config_entries.SOURCE_USER}, data=FIXTURE_USER_INPUT
     )
 
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_USERNAME] == FIXTURE_USER_INPUT[CONF_USERNAME]
     assert result["data"][CONF_PASSWORD] == FIXTURE_USER_INPUT[CONF_PASSWORD]
 
@@ -96,7 +97,7 @@ async def test_options(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
@@ -108,7 +109,7 @@ async def test_options(hass: HomeAssistant) -> None:
     )
 
 
-async def test_already_configured(hass, requests_mock):
+async def test_already_configured(hass: HomeAssistant, requests_mock) -> None:
     """Test duplicate entry aborts and updates data."""
 
     config_entry = MockConfigEntry(
@@ -127,7 +128,7 @@ async def test_already_configured(hass, requests_mock):
         DOMAIN, context={"source": config_entries.SOURCE_USER}, data=new_user_input
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert config_entry.data[CONF_USERNAME] == new_user_input[CONF_USERNAME]
     assert config_entry.data[CONF_PASSWORD] == new_user_input[CONF_PASSWORD]

--- a/tests/components/wemo/test_config_flow.py
+++ b/tests/components/wemo/test_config_flow.py
@@ -2,11 +2,11 @@
 
 from dataclasses import asdict
 
-from homeassistant import data_entry_flow
 from homeassistant.components.wemo.const import DOMAIN
 from homeassistant.components.wemo.wemo_device import Options
 from homeassistant.config_entries import SOURCE_USER
 from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
 
 from tests.common import MockConfigEntry, patch
 
@@ -21,7 +21,7 @@ async def test_not_discovered(hass: HomeAssistant) -> None:
     with patch("homeassistant.components.wemo.config_flow.pywemo") as mock_pywemo:
         mock_pywemo.discover_devices.return_value = []
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "no_devices_found"
 
 
@@ -33,14 +33,14 @@ async def test_options(hass: HomeAssistant) -> None:
 
     result = await hass.config_entries.options.async_init(entry.entry_id)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], user_input=asdict(options)
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == FlowResultType.CREATE_ENTRY
     assert Options(**result["data"]) == options
 
 
@@ -51,7 +51,7 @@ async def test_invalid_options(hass: HomeAssistant) -> None:
 
     result = await hass.config_entries.options.async_init(entry.entry_id)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "init"
 
     # enable_subscription must be True if enable_long_press is True (default).


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I propose with this PR to refactor the deprecated RESULT_TYPE_* to FlowResultType-enum. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x I have followed the [development checklist][dev-checklist]
- [xI have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
