### PR TITLE
Remove title config entry for Sun

### DIFF
--- a/homeassistant/components/sun/__init__.py
+++ b/homeassistant/components/sun/__init__.py
@@ -83,6 +83,21 @@ _PHASE_UPDATES = {
 CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
 
 
+async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    """Migrate old entry."""
+    _LOGGER.debug("Migrating from version %s", config_entry.version)
+
+    if config_entry.version == 1:
+        # Remove title from configuration entry
+        config_entry.title = ""
+        config_entry.version = 2
+        hass.config_entries.async_update_entry(config_entry, data={})
+
+    _LOGGER.info("Migration to version %s successful", config_entry.version)
+
+    return True
+
+
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Track the state of the sun."""
     hass.async_create_task(

--- a/homeassistant/components/sun/__init__.py
+++ b/homeassistant/components/sun/__init__.py
@@ -91,7 +91,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
         # Remove title from configuration entry
         config_entry.title = ""
         config_entry.version = 2
-        hass.config_entries.async_update_entry(config_entry, data={})
+        hass.config_entries.async_update_entry(config_entry)
 
     _LOGGER.info("Migration to version %s successful", config_entry.version)
 

--- a/homeassistant/components/sun/config_flow.py
+++ b/homeassistant/components/sun/config_flow.py
@@ -6,7 +6,7 @@ from typing import Any
 from homeassistant.config_entries import ConfigFlow
 from homeassistant.data_entry_flow import FlowResult
 
-from .const import DEFAULT_NAME, DOMAIN
+from .const import DOMAIN
 
 
 class SunConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -22,7 +22,7 @@ class SunConfigFlow(ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="single_instance_allowed")
 
         if user_input is not None:
-            return self.async_create_entry(title=DEFAULT_NAME, data={})
+            return self.async_create_entry(title="", data={})
 
         return self.async_show_form(step_id="user")
 

--- a/homeassistant/components/sun/config_flow.py
+++ b/homeassistant/components/sun/config_flow.py
@@ -12,7 +12,7 @@ from .const import DOMAIN
 class SunConfigFlow(ConfigFlow, domain=DOMAIN):
     """Config flow for Sun."""
 
-    VERSION = 1
+    VERSION = 2
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None

--- a/homeassistant/components/sun/const.py
+++ b/homeassistant/components/sun/const.py
@@ -2,5 +2,3 @@
 from typing import Final
 
 DOMAIN: Final = "sun"
-
-DEFAULT_NAME: Final = "Sun"

--- a/tests/components/sun/test_config_flow.py
+++ b/tests/components/sun/test_config_flow.py
@@ -30,7 +30,7 @@ async def test_full_user_flow(hass: HomeAssistant) -> None:
         )
 
     assert result.get("type") == FlowResultType.CREATE_ENTRY
-    assert result.get("title") == "Sun"
+    assert result.get("title") == ""
     assert result.get("data") == {}
     assert result.get("options") == {}
     assert len(mock_setup_entry.mock_calls) == 1
@@ -65,6 +65,6 @@ async def test_import_flow(
     )
 
     assert result.get("type") == FlowResultType.CREATE_ENTRY
-    assert result.get("title") == "Sun"
+    assert result.get("title") == ""
     assert result.get("data") == {}
     assert result.get("options") == {}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
None

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Removes the title of the Sun integration configuration entry to translate the name displayed on the frontend (in the absence of a configuration entry title, the displayed text will be the title of the integration, which is already translatable).

There is no impact as this integration allows only one configuration entry.

Added a migration for the configuration entry to remove the title of existing entry.

#### An example for a random language (in this case for French):

* Before:
  ![image](https://github.com/home-assistant/core/assets/31328123/546ec4cd-7776-407c-bf05-d1a312a498f8)

* After:
  ![image](https://github.com/home-assistant/core/assets/31328123/f2a45236-04b4-4534-a1f4-af2b97792dc9)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
