### PR TITLE
Allow deleting config entry devices in jellyfin

### DIFF
--- a/homeassistant/components/jellyfin/__init__.py
+++ b/homeassistant/components/jellyfin/__init__.py
@@ -67,4 +67,7 @@ async def async_remove_config_entry_device(
     hass: HomeAssistant, config_entry: ConfigEntry, device_entry: dr.DeviceEntry
 ) -> bool:
     """Remove device from a config entry."""
-    return True
+    data: JellyfinData = hass.data[DOMAIN][config_entry.entry_id]
+    device_ids = data.get_device_ids()
+
+    return not device_entry.identifiers.intersection((DOMAIN, id) for id in device_ids)

--- a/homeassistant/components/jellyfin/__init__.py
+++ b/homeassistant/components/jellyfin/__init__.py
@@ -67,7 +67,9 @@ async def async_remove_config_entry_device(
     hass: HomeAssistant, config_entry: ConfigEntry, device_entry: dr.DeviceEntry
 ) -> bool:
     """Remove device from a config entry."""
-    data: JellyfinData = hass.data[DOMAIN][config_entry.entry_id]
-    device_ids = data.get_device_ids()
+    data = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator = data.coordinators["sessions"]
 
-    return not device_entry.identifiers.intersection((DOMAIN, id) for id in device_ids)
+    return not device_entry.identifiers.intersection(
+        (DOMAIN, id) for id in coordinator.device_ids
+    )

--- a/homeassistant/components/jellyfin/__init__.py
+++ b/homeassistant/components/jellyfin/__init__.py
@@ -71,5 +71,8 @@ async def async_remove_config_entry_device(
     coordinator = data.coordinators["sessions"]
 
     return not device_entry.identifiers.intersection(
-        (DOMAIN, id) for id in coordinator.device_ids
+        (
+            (DOMAIN, coordinator.server_id),
+            *((DOMAIN, id) for id in coordinator.device_ids),
+        )
     )

--- a/homeassistant/components/jellyfin/__init__.py
+++ b/homeassistant/components/jellyfin/__init__.py
@@ -4,6 +4,7 @@ from typing import Any
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import device_registry as dr
 
 from .client_wrapper import CannotConnect, InvalidAuth, create_client, validate_input
 from .const import CONF_CLIENT_DEVICE_ID, DOMAIN, LOGGER, PLATFORMS
@@ -59,4 +60,11 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     hass.data[DOMAIN].pop(entry.entry_id)
 
+    return True
+
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant, config_entry: ConfigEntry, device_entry: dr.DeviceEntry
+) -> bool:
+    """Remove device from a config entry."""
     return True

--- a/homeassistant/components/jellyfin/coordinator.py
+++ b/homeassistant/components/jellyfin/coordinator.py
@@ -47,6 +47,7 @@ class JellyfinDataUpdateCoordinator(DataUpdateCoordinator[JellyfinDataT], ABC):
         self.user_id: str = user_id
 
         self.session_ids: set[str] = set()
+        self.device_ids: set[str] = set()
 
     async def _async_update_data(self) -> JellyfinDataT:
         """Get the latest data from Jellyfin."""
@@ -74,5 +75,7 @@ class SessionsDataUpdateCoordinator(
             if session["DeviceId"] != self.client_device_id
             and session["Client"] != USER_APP_NAME
         }
+
+        self.device_ids = {session["DeviceId"] for session in sessions_by_id.values()}
 
         return sessions_by_id

--- a/homeassistant/components/jellyfin/models.py
+++ b/homeassistant/components/jellyfin/models.py
@@ -15,16 +15,3 @@ class JellyfinData:
     client_device_id: str
     jellyfin_client: JellyfinClient
     coordinators: dict[str, JellyfinDataUpdateCoordinator]
-
-    def get_device_ids(self) -> list[str]:
-        """Fetch known device ids using session coordinator data."""
-        if "sessions" not in self.coordinators:
-            return []
-
-        if self.coordinators["sessions"].data is None:
-            return []
-
-        return [
-            session["DeviceId"]
-            for session in self.coordinators["sessions"].data.values()
-        ]

--- a/homeassistant/components/jellyfin/models.py
+++ b/homeassistant/components/jellyfin/models.py
@@ -15,3 +15,16 @@ class JellyfinData:
     client_device_id: str
     jellyfin_client: JellyfinClient
     coordinators: dict[str, JellyfinDataUpdateCoordinator]
+
+    def get_device_ids(self) -> list[str]:
+        """Fetch known device ids using session coordinator data."""
+        if "sessions" not in self.coordinators:
+            return []
+
+        if self.coordinators["sessions"].data is None:
+            return []
+
+        return [
+            session["DeviceId"]
+            for session in self.coordinators["sessions"].data.values()
+        ]

--- a/tests/components/jellyfin/test_init.py
+++ b/tests/components/jellyfin/test_init.py
@@ -8,6 +8,25 @@ from homeassistant.core import HomeAssistant
 from . import async_load_json_fixture
 
 from tests.common import MockConfigEntry
+from tests.typing import WebSocketGenerator
+
+
+async def remove_device(
+    ws_client: aiohttp.ClientWebSocketResponse,
+    device_id: str,
+    config_entry_id: str
+) -> bool:
+    """Remove config entry from a device."""
+    await ws_client.send_json(
+        {
+            "id": 1,
+            "type": "config/device_registry/remove_config_entry",
+            "config_entry_id": config_entry_id,
+            "device_id": device_id,
+        }
+    )
+    response = await ws_client.receive_json()
+    return response["success"]
 
 
 async def test_config_entry_not_ready(
@@ -66,3 +85,42 @@ async def test_load_unload_config_entry(
     await hass.async_block_till_done()
     assert mock_config_entry.entry_id not in hass.data[DOMAIN]
     assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
+
+
+async def test_device_remove_devices(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    mock_config_entry: MockConfigEntry,
+    mock_jellyfin: MagicMock,
+) -> None:
+    """Test we can only remove a device that no longer exists."""
+    assert await async_setup_component(hass, "config", {})
+
+    mock_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    device_registry = dr.async_get(hass)
+
+    device_entry = device_registry.async_get_device(
+        identifiers={
+            (
+                DOMAIN,
+                "TEST-UUID",
+            )
+        },
+    )
+    assert (
+        await remove_device(await hass_ws_client(hass), device_entry.id, mock_config_entry.entry_id)
+        is False
+    )
+    old_device_entry = device_registry.async_get_or_create(
+        config_entry_id=mock_config_entry.entry_id,
+        identifiers={(DOMAIN, "OLD-DEVICE-UUID")},
+    )
+    assert (
+        await remove_device(
+            await hass_ws_client(hass), old_device_entry.id, mock_config_entry.entry_id
+        )
+        is True
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Due to how certain jellyfin client implementations rely on device identification methods that can get reset on app updates/certain data cleared or changing of login details. It's best to allow users to cleanup some of the old device entries that can build up.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
