### PR TITLE
Restore bthome state at startup if device is in range but has not yet broadcast

### DIFF
--- a/homeassistant/components/bluetooth/passive_update_processor.py
+++ b/homeassistant/components/bluetooth/passive_update_processor.py
@@ -203,9 +203,11 @@ class PassiveBluetoothDataProcessor(Generic[_T]):
         self,
         entity_class: type[PassiveBluetoothProcessorEntity],
         async_add_entites: AddEntitiesCallback,
+        created: set[PassiveBluetoothEntityKey] | None = None,
     ) -> Callable[[], None]:
         """Add a listener for new entities."""
-        created: set[PassiveBluetoothEntityKey] = set()
+        if not created:
+            created = set()
 
         @callback
         def _async_add_or_update_entities(
@@ -301,6 +303,18 @@ class PassiveBluetoothDataProcessor(Generic[_T]):
         self.entity_data.update(new_data.entity_data)
         self.entity_names.update(new_data.entity_names)
         self.async_update_listeners(new_data)
+
+
+def passive_bluetooth_entity_key_from_unique_id(
+    unique_id: str,
+) -> PassiveBluetoothEntityKey:
+    """Create a PassiveBluetoothEntityKey from a unique_id."""
+    device_id = None
+    unique_parts = unique_id.split("-", 1)
+    key = unique_parts[1]
+    if len(unique_parts) == 3:
+        device_id = unique_parts[2]
+    return PassiveBluetoothEntityKey(key, device_id)
 
 
 class PassiveBluetoothProcessorEntity(Entity, Generic[_PassiveBluetoothDataProcessorT]):

--- a/homeassistant/components/bthome/binary_sensor.py
+++ b/homeassistant/components/bthome/binary_sensor.py
@@ -196,6 +196,7 @@ async def async_setup_entry(
     processor = BTHomePassiveBluetoothDataProcessor(
         sensor_update_to_bluetooth_data_update
     )
+    entry.async_on_unload(coordinator.async_register_processor(processor))
 
     restore_entities: list[BTHomeBluetoothBinarySensorEntity] = []
     ent_reg = er.async_get(hass)
@@ -206,7 +207,7 @@ async def async_setup_entry(
             continue
         entity_key = passive_bluetooth_entity_key_from_unique_id(entity_entry.unique_id)
         device_class_enum = try_parse_enum(
-            BinarySensorDeviceClass, entity_entry.device_class
+            BinarySensorDeviceClass, entity_entry.original_device_class
         )
         if not (
             bthome_device_class := HASS_DEVICE_CLASS_TO_BTHOME.get(device_class_enum)
@@ -227,7 +228,6 @@ async def async_setup_entry(
             BTHomeBluetoothBinarySensorEntity, async_add_entities
         )
     )
-    entry.async_on_unload(coordinator.async_register_processor(processor))
 
 
 class BTHomeBluetoothBinarySensorEntity(

--- a/tests/components/bthome/test_binary_sensor.py
+++ b/tests/components/bthome/test_binary_sensor.py
@@ -308,3 +308,65 @@ async def test_sleepy_device(hass: HomeAssistant) -> None:
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
+
+
+async def test_sleepy_device_restores_state(hass: HomeAssistant) -> None:
+    """Test sleepy device does not go to unavailable after 60 minutes."""
+    start_monotonic = time.monotonic()
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="A4:C1:38:8D:18:B2",
+        data={},
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert len(hass.states.async_all()) == 0
+
+    inject_bluetooth_service_info(
+        hass,
+        make_bthome_v2_adv(
+            "A4:C1:38:8D:18:B2",
+            b"\x44\x11\x01",
+        ),
+    )
+    await hass.async_block_till_done()
+
+    assert len(hass.states.async_all()) == 1
+
+    opening_sensor = hass.states.get("binary_sensor.test_device_18b2_opening")
+
+    assert opening_sensor.state == STATE_ON
+
+    # Fastforward time without BLE advertisements
+    monotonic_now = start_monotonic + FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS + 1
+
+    with patch(
+        "homeassistant.components.bluetooth.manager.MONOTONIC_TIME",
+        return_value=monotonic_now,
+    ), patch_all_discovered_devices([]):
+        async_fire_time_changed(
+            hass,
+            dt_util.utcnow()
+            + timedelta(seconds=FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS + 1),
+        )
+        await hass.async_block_till_done()
+
+    opening_sensor = hass.states.get("binary_sensor.test_device_18b2_opening")
+
+    # Sleepy devices should keep their state over time
+    assert opening_sensor.state == STATE_ON
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    opening_sensor = hass.states.get("binary_sensor.test_device_18b2_opening")
+
+    # Sleepy devices should keep their state on restore
+    assert opening_sensor.state == STATE_ON

--- a/tests/components/bthome/test_sensor.py
+++ b/tests/components/bthome/test_sensor.py
@@ -1191,3 +1191,65 @@ async def test_sleepy_device(hass: HomeAssistant) -> None:
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
+
+
+async def test_sleepy_device_restore_state(hass: HomeAssistant) -> None:
+    """Test sleepy device does not go to unavailable after 60 minutes and restores state."""
+    start_monotonic = time.monotonic()
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="A4:C1:38:8D:18:B2",
+        data={},
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert len(hass.states.async_all()) == 0
+
+    inject_bluetooth_service_info(
+        hass,
+        make_bthome_v2_adv(
+            "A4:C1:38:8D:18:B2",
+            b"\x44\x04\x13\x8a\x01",
+        ),
+    )
+    await hass.async_block_till_done()
+
+    assert len(hass.states.async_all()) == 1
+
+    pressure_sensor = hass.states.get("sensor.test_device_18b2_pressure")
+
+    assert pressure_sensor.state == "1008.83"
+
+    # Fastforward time without BLE advertisements
+    monotonic_now = start_monotonic + FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS + 1
+
+    with patch(
+        "homeassistant.components.bluetooth.manager.MONOTONIC_TIME",
+        return_value=monotonic_now,
+    ), patch_all_discovered_devices([]):
+        async_fire_time_changed(
+            hass,
+            dt_util.utcnow()
+            + timedelta(seconds=FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS + 1),
+        )
+        await hass.async_block_till_done()
+
+    pressure_sensor = hass.states.get("sensor.test_device_18b2_pressure")
+
+    # Sleepy devices should keep their state over time
+    assert pressure_sensor.state == "1008.83"
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    pressure_sensor = hass.states.get("sensor.test_device_18b2_pressure")
+
+    # Sleepy devices should keep their state over time and restore it
+    assert pressure_sensor.state == "1008.83"


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If the device is not in range, the state will continue to be unavailable

fixes #97454

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
