### PR TITLE
Bump reolink_aio to 0.7.6 + Timeout

### DIFF
--- a/homeassistant/components/reolink/__init__.py
+++ b/homeassistant/components/reolink/__init__.py
@@ -10,6 +10,7 @@ from typing import Literal
 
 import async_timeout
 from reolink_aio.exceptions import CredentialsInvalidError, ReolinkError
+from reolink_aio.api import RETRY_ATTEMPTS
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP, Platform
@@ -77,15 +78,13 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     async def async_device_config_update() -> None:
         """Update the host state cache and renew the ONVIF-subscription."""
-        async with async_timeout.timeout(host.api.timeout):
+        async with async_timeout.timeout(host.api.timeout*(RETRY_ATTEMPTS + 2)):
             try:
                 await host.update_states()
             except ReolinkError as err:
-                raise UpdateFailed(
-                    f"Error updating Reolink {host.api.nvr_name}"
-                ) from err
+                raise UpdateFailed(str(err)) from err
 
-        async with async_timeout.timeout(host.api.timeout):
+        async with async_timeout.timeout(host.api.timeout*(RETRY_ATTEMPTS + 2)):
             await host.renew()
 
     async def async_check_firmware_update() -> str | Literal[False]:
@@ -93,7 +92,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         if not host.api.supported(None, "update"):
             return False
 
-        async with async_timeout.timeout(host.api.timeout):
+        async with async_timeout.timeout(host.api.timeout*(RETRY_ATTEMPTS + 2)):
             try:
                 return await host.api.check_new_firmware()
             except (ReolinkError, asyncio.exceptions.CancelledError) as err:

--- a/homeassistant/components/reolink/__init__.py
+++ b/homeassistant/components/reolink/__init__.py
@@ -9,8 +9,8 @@ import logging
 from typing import Literal
 
 import async_timeout
-from reolink_aio.exceptions import CredentialsInvalidError, ReolinkError
 from reolink_aio.api import RETRY_ATTEMPTS
+from reolink_aio.exceptions import CredentialsInvalidError, ReolinkError
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP, Platform
@@ -78,13 +78,13 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     async def async_device_config_update() -> None:
         """Update the host state cache and renew the ONVIF-subscription."""
-        async with async_timeout.timeout(host.api.timeout*(RETRY_ATTEMPTS + 2)):
+        async with async_timeout.timeout(host.api.timeout * (RETRY_ATTEMPTS + 2)):
             try:
                 await host.update_states()
             except ReolinkError as err:
                 raise UpdateFailed(str(err)) from err
 
-        async with async_timeout.timeout(host.api.timeout*(RETRY_ATTEMPTS + 2)):
+        async with async_timeout.timeout(host.api.timeout * (RETRY_ATTEMPTS + 2)):
             await host.renew()
 
     async def async_check_firmware_update() -> str | Literal[False]:
@@ -92,7 +92,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         if not host.api.supported(None, "update"):
             return False
 
-        async with async_timeout.timeout(host.api.timeout*(RETRY_ATTEMPTS + 2)):
+        async with async_timeout.timeout(host.api.timeout * (RETRY_ATTEMPTS + 2)):
             try:
                 return await host.api.check_new_firmware()
             except (ReolinkError, asyncio.exceptions.CancelledError) as err:

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -24,7 +24,7 @@ from homeassistant.helpers.network import NoURLAvailableError, get_url
 from .const import CONF_PROTOCOL, CONF_USE_HTTPS, DOMAIN
 from .exceptions import ReolinkSetupException, ReolinkWebhookException, UserNotAdmin
 
-DEFAULT_TIMEOUT = 60
+DEFAULT_TIMEOUT = 30
 FIRST_ONVIF_TIMEOUT = 10
 SUBSCRIPTION_RENEW_THRESHOLD = 300
 POLL_INTERVAL_NO_PUSH = 5
@@ -451,7 +451,7 @@ class ReolinkHost:
                 await asyncio.sleep(LONG_POLL_ERROR_COOLDOWN)
                 continue
             except Exception as ex:
-                _LOGGER.exception("Error while requesting ONVIF pull point: %s", ex)
+                _LOGGER.exception("Unexpected exception while requesting ONVIF pull point: %s", ex)
                 await self._api.unsubscribe(sub_type=SubType.long_poll)
                 raise ex
 

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -451,7 +451,9 @@ class ReolinkHost:
                 await asyncio.sleep(LONG_POLL_ERROR_COOLDOWN)
                 continue
             except Exception as ex:
-                _LOGGER.exception("Unexpected exception while requesting ONVIF pull point: %s", ex)
+                _LOGGER.exception(
+                    "Unexpected exception while requesting ONVIF pull point: %s", ex
+                )
                 await self._api.unsubscribe(sub_type=SubType.long_poll)
                 raise ex
 

--- a/homeassistant/components/reolink/manifest.json
+++ b/homeassistant/components/reolink/manifest.json
@@ -18,5 +18,5 @@
   "documentation": "https://www.home-assistant.io/integrations/reolink",
   "iot_class": "local_push",
   "loggers": ["reolink_aio"],
-  "requirements": ["reolink-aio==0.7.5"]
+  "requirements": ["reolink-aio==0.7.6"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2281,7 +2281,7 @@ renault-api==0.1.13
 renson-endura-delta==1.5.0
 
 # homeassistant.components.reolink
-reolink-aio==0.7.5
+reolink-aio==0.7.6
 
 # homeassistant.components.idteck_prox
 rfk101py==0.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1677,7 +1677,7 @@ renault-api==0.1.13
 renson-endura-delta==1.5.0
 
 # homeassistant.components.reolink
-reolink-aio==0.7.5
+reolink-aio==0.7.6
 
 # homeassistant.components.rflink
 rflink==0.0.65


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump reolink_aio to 0.7.6:
**Bug fixes:**
- [Fix long_polling blocking send_mutex for 5 minutes](https://github.com/starkillerOG/reolink_aio/commit/87100bea42874eb5868f09f6f1e09ea374fe0e0b)
- [Catch aiohttp.ServerConnectionError](https://github.com/starkillerOG/reolink_aio/commit/c943cba6672625558e9eeb0983ff38b656059cf5)

**Optimizations:**
- [Reduce default timeout from 60s to 30s](https://github.com/starkillerOG/reolink_aio/commit/41a186c667030d035144164d1f03db4c0e02c3ff)
- [Restore 60s timeout for getting reolink.com](https://github.com/starkillerOG/reolink_aio/commit/fa4a940b4180cb798b03ed9e94dd6edde7196608)
- [Reduce timeout/connection logging to debug](https://github.com/starkillerOG/reolink_aio/commit/8ebc0a50db1ca6be5004be685c983319c341d3bf)
- [First log error, then expire_session and unsubscribe](https://github.com/starkillerOG/reolink_aio/commit/d012ddb73fdccf02bf1552309ecd979b7fa82464)

**Full Changelog**: https://github.com/starkillerOG/reolink_aio/compare/0.7.5...0.7.6

Additionally:
- Reduce timeout from 60s to 30s since the upstream library bump to 0.7.4 introduced 3 retries
- Let the timeouts be handeled in the upstream lib by properly setting the async_timeout values in HA
- Fix some small logging problems

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/97384
- This PR is related to issue: https://github.com/home-assistant/core/issues/97458 https://github.com/home-assistant/core/issues/96222 https://github.com/home-assistant/core/issues/92047
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
