### PR TITLE
Reolink long poll recover

### DIFF
--- a/homeassistant/components/reolink/__init__.py
+++ b/homeassistant/components/reolink/__init__.py
@@ -78,13 +78,13 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     async def async_device_config_update() -> None:
         """Update the host state cache and renew the ONVIF-subscription."""
-        async with async_timeout.timeout(host.api.timeout*(RETRY_ATTEMPTS + 2)):
+        async with async_timeout.timeout(host.api.timeout*RETRY_ATTEMPTS + 20):
             try:
                 await host.update_states()
             except ReolinkError as err:
                 raise UpdateFailed(str(err)) from err
 
-        async with async_timeout.timeout(host.api.timeout*(RETRY_ATTEMPTS + 2)):
+        async with async_timeout.timeout(host.api.timeout*RETRY_ATTEMPTS + 20):
             await host.renew()
 
     async def async_check_firmware_update() -> str | Literal[False]:
@@ -92,7 +92,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         if not host.api.supported(None, "update"):
             return False
 
-        async with async_timeout.timeout(host.api.timeout*(RETRY_ATTEMPTS + 2)):
+        async with async_timeout.timeout(host.api.timeout*(RETRY_ATTEMPTS+2) + 20):
             try:
                 return await host.api.check_new_firmware()
             except (ReolinkError, asyncio.exceptions.CancelledError) as err:

--- a/homeassistant/components/reolink/__init__.py
+++ b/homeassistant/components/reolink/__init__.py
@@ -10,7 +10,6 @@ from typing import Literal
 
 import async_timeout
 from reolink_aio.exceptions import CredentialsInvalidError, ReolinkError
-from reolink_aio.api import RETRY_ATTEMPTS
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP, Platform
@@ -78,7 +77,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     async def async_device_config_update() -> None:
         """Update the host state cache and renew the ONVIF-subscription."""
-        async with async_timeout.timeout(host.api.timeout*RETRY_ATTEMPTS + 20):
+        async with async_timeout.timeout(host.api.timeout):
             try:
                 await host.update_states()
             except ReolinkError as err:
@@ -86,7 +85,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
                     f"Error updating Reolink {host.api.nvr_name}"
                 ) from err
 
-        async with async_timeout.timeout(host.api.timeout*RETRY_ATTEMPTS + 20):
+        async with async_timeout.timeout(host.api.timeout):
             await host.renew()
 
     async def async_check_firmware_update() -> str | Literal[False]:
@@ -94,7 +93,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         if not host.api.supported(None, "update"):
             return False
 
-        async with async_timeout.timeout(host.api.timeout*(RETRY_ATTEMPTS+2) + 20):
+        async with async_timeout.timeout(host.api.timeout):
             try:
                 return await host.api.check_new_firmware()
             except (ReolinkError, asyncio.exceptions.CancelledError) as err:

--- a/homeassistant/components/reolink/__init__.py
+++ b/homeassistant/components/reolink/__init__.py
@@ -78,13 +78,13 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     async def async_device_config_update() -> None:
         """Update the host state cache and renew the ONVIF-subscription."""
-        async with async_timeout.timeout(host.api.timeout*RETRY_ATTEMPTS + 20):
+        async with async_timeout.timeout(host.api.timeout*(RETRY_ATTEMPTS + 2)):
             try:
                 await host.update_states()
             except ReolinkError as err:
                 raise UpdateFailed(str(err)) from err
 
-        async with async_timeout.timeout(host.api.timeout*RETRY_ATTEMPTS + 20):
+        async with async_timeout.timeout(host.api.timeout*(RETRY_ATTEMPTS + 2)):
             await host.renew()
 
     async def async_check_firmware_update() -> str | Literal[False]:
@@ -92,7 +92,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         if not host.api.supported(None, "update"):
             return False
 
-        async with async_timeout.timeout(host.api.timeout*(RETRY_ATTEMPTS+2) + 20):
+        async with async_timeout.timeout(host.api.timeout*(RETRY_ATTEMPTS + 2)):
             try:
                 return await host.api.check_new_firmware()
             except (ReolinkError, asyncio.exceptions.CancelledError) as err:

--- a/homeassistant/components/reolink/__init__.py
+++ b/homeassistant/components/reolink/__init__.py
@@ -82,7 +82,9 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
             try:
                 await host.update_states()
             except ReolinkError as err:
-                raise UpdateFailed(str(err)) from err
+                raise UpdateFailed(
+                    f"Error updating Reolink {host.api.nvr_name}"
+                ) from err
 
         async with async_timeout.timeout(host.api.timeout*RETRY_ATTEMPTS + 20):
             await host.renew()

--- a/homeassistant/components/reolink/__init__.py
+++ b/homeassistant/components/reolink/__init__.py
@@ -10,6 +10,7 @@ from typing import Literal
 
 import async_timeout
 from reolink_aio.exceptions import CredentialsInvalidError, ReolinkError
+from reolink_aio.api import RETRY_ATTEMPTS
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP, Platform
@@ -77,7 +78,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     async def async_device_config_update() -> None:
         """Update the host state cache and renew the ONVIF-subscription."""
-        async with async_timeout.timeout(host.api.timeout):
+        async with async_timeout.timeout(host.api.timeout*RETRY_ATTEMPTS + 20):
             try:
                 await host.update_states()
             except ReolinkError as err:
@@ -85,7 +86,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
                     f"Error updating Reolink {host.api.nvr_name}"
                 ) from err
 
-        async with async_timeout.timeout(host.api.timeout):
+        async with async_timeout.timeout(host.api.timeout*RETRY_ATTEMPTS + 20):
             await host.renew()
 
     async def async_check_firmware_update() -> str | Literal[False]:
@@ -93,7 +94,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         if not host.api.supported(None, "update"):
             return False
 
-        async with async_timeout.timeout(host.api.timeout):
+        async with async_timeout.timeout(host.api.timeout*(RETRY_ATTEMPTS+2) + 20):
             try:
                 return await host.api.check_new_firmware()
             except (ReolinkError, asyncio.exceptions.CancelledError) as err:

--- a/homeassistant/components/reolink/__init__.py
+++ b/homeassistant/components/reolink/__init__.py
@@ -82,9 +82,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
             try:
                 await host.update_states()
             except ReolinkError as err:
-                raise UpdateFailed(
-                    f"Error updating Reolink {host.api.nvr_name}"
-                ) from err
+                raise UpdateFailed(str(err)) from err
 
         async with async_timeout.timeout(host.api.timeout*RETRY_ATTEMPTS + 20):
             await host.renew()

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -467,7 +467,7 @@ class ReolinkHost:
                 await asyncio.sleep(LONG_POLL_ERROR_COOLDOWN)
                 continue
             except Exception as ex:
-                _LOGGER.exception("Error while requesting ONVIF pull point: %s", ex)
+                _LOGGER.exception("Unexpected exception while requesting ONVIF pull point: %s", ex)
                 await self._api.unsubscribe(sub_type=SubType.long_poll)
                 raise ex
 

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -336,7 +336,8 @@ class ReolinkHost:
                     # To prevent 5 minute request timeout
                     await self._async_stop_long_polling()
                     await self._async_start_long_polling()
-                await self._renew(SubType.long_poll)
+                else:
+                    await self._renew(SubType.long_poll)
         except SubscriptionError as err:
             if not self._lost_subscription:
                 self._lost_subscription = True

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -469,7 +469,7 @@ class ReolinkHost:
                 await asyncio.sleep(LONG_POLL_ERROR_COOLDOWN)
                 continue
             except Exception as ex:
-                _LOGGER.exception("Unexpected exception while requesting ONVIF pull point: %s", ex)
+                _LOGGER.exception("Error while requesting ONVIF pull point: %s", ex)
                 await self._api.unsubscribe(sub_type=SubType.long_poll)
                 raise ex
 

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -267,7 +267,19 @@ class ReolinkHost:
     async def _async_start_long_polling(self):
         """Start ONVIF long polling task."""
         if self._long_poll_task is None:
-            await self._api.subscribe(sub_type=SubType.long_poll)
+            try:
+                await self._api.subscribe(sub_type=SubType.long_poll)
+            except ReolinkError as err:
+                # make sure the long_poll_task is always created to try again later
+                if not self._lost_subscription:
+                    self._lost_subscription = True
+                    _LOGGER.error(
+                        "Reolink %s event long polling subscription lost: %s",
+                        self._api.nvr_name,
+                        str(err),
+                    )
+            else:
+                self._lost_subscription = False
             self._long_poll_task = asyncio.create_task(self._async_long_polling())
 
     async def _async_stop_long_polling(self):
@@ -319,6 +331,10 @@ class ReolinkHost:
         try:
             await self._renew(SubType.push)
             if self._long_poll_task is not None:
+                if not self._api.subscribed(SubType.long_poll):
+                    # restart long_polling to prevent 5 minute request timeout
+                    await self._async_stop_long_polling()
+                    await self._async_start_long_polling()
                 await self._renew(SubType.long_poll)
         except SubscriptionError as err:
             if not self._lost_subscription:

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -332,7 +332,8 @@ class ReolinkHost:
             await self._renew(SubType.push)
             if self._long_poll_task is not None:
                 if not self._api.subscribed(SubType.long_poll):
-                    # restart long_polling to prevent 5 minute request timeout
+                    _LOGGER.debug("restarting long polling task")
+                    # To prevent 5 minute request timeout
                     await self._async_stop_long_polling()
                     await self._async_start_long_polling()
                 await self._renew(SubType.long_poll)

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -24,7 +24,7 @@ from homeassistant.helpers.network import NoURLAvailableError, get_url
 from .const import CONF_PROTOCOL, CONF_USE_HTTPS, DOMAIN
 from .exceptions import ReolinkSetupException, ReolinkWebhookException, UserNotAdmin
 
-DEFAULT_TIMEOUT = 30
+DEFAULT_TIMEOUT = 60
 FIRST_ONVIF_TIMEOUT = 10
 SUBSCRIPTION_RENEW_THRESHOLD = 300
 POLL_INTERVAL_NO_PUSH = 5

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -24,7 +24,7 @@ from homeassistant.helpers.network import NoURLAvailableError, get_url
 from .const import CONF_PROTOCOL, CONF_USE_HTTPS, DOMAIN
 from .exceptions import ReolinkSetupException, ReolinkWebhookException, UserNotAdmin
 
-DEFAULT_TIMEOUT = 60
+DEFAULT_TIMEOUT = 30
 FIRST_ONVIF_TIMEOUT = 10
 SUBSCRIPTION_RENEW_THRESHOLD = 300
 POLL_INTERVAL_NO_PUSH = 5


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve recovery of long polling after a network connection loss/timeout.
This makes sure you do not have to wait 5 minutes for the long polling request to timeout.
It also ensures the long_polling task is always beeing created, even if the subscription had an error, such that the renew every 1 minute has another change to revive the long polling.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/97384
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
