### PR TITLE
Add overkiz battery sensor level medium

### DIFF
--- a/homeassistant/components/overkiz/sensor.py
+++ b/homeassistant/components/overkiz/sensor.py
@@ -67,7 +67,7 @@ SENSOR_DESCRIPTIONS: list[OverkizSensorDescription] = [
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:battery",
         device_class=SensorDeviceClass.ENUM,
-        options=["full", "normal", "low", "verylow"],
+        options=["full", "normal", "medium", "low", "verylow"],
         translation_key="battery",
     ),
     OverkizSensorDescription(

--- a/homeassistant/components/overkiz/strings.json
+++ b/homeassistant/components/overkiz/strings.json
@@ -77,6 +77,7 @@
           "full": "Full",
           "low": "Low",
           "normal": "Normal",
+          "medium": "Medium",
           "verylow": "Very low"
         }
       },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
My setup using Overkiz (SOMFY) was returning error on one battery sensor.
```
2023-07-30 08:39:50 2023-07-30 08:39:50.386 ERROR (MainThread) [homeassistant] Error doing job: Task exception was never retrieved
2023-07-30 08:39:50 Traceback (most recent call last):
2023-07-30 08:39:50   File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 229, in _handle_refresh_interval
2023-07-30 08:39:50     await self._async_refresh(log_failures=True, scheduled=True)
2023-07-30 08:39:50   File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 374, in _async_refresh
2023-07-30 08:39:50     self.async_update_listeners()
2023-07-30 08:39:50   File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 164, in async_update_listeners
2023-07-30 08:39:50     update_callback()
2023-07-30 08:39:50   File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 431, in _handle_coordinator_update
2023-07-30 08:39:50     self.async_write_ha_state()
2023-07-30 08:39:50   File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 742, in async_write_ha_state
2023-07-30 08:39:50     self._async_write_ha_state()
2023-07-30 08:39:50   File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 810, in _async_write_ha_state
2023-07-30 08:39:50     state = self._stringify_state(available)
2023-07-30 08:39:50             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2023-07-30 08:39:50   File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 748, in _stringify_state
2023-07-30 08:39:50     if (state := self.state) is None:
2023-07-30 08:39:50                  ^^^^^^^^^^
2023-07-30 08:39:50   File "/usr/src/homeassistant/homeassistant/components/sensor/__init__.py", line 572, in state
2023-07-30 08:39:50     raise ValueError(
2023-07-30 08:39:50 ValueError: Sensor sensor.commande_sans_fil_battery_2 provides state value 'medium', which is not in the list of options provided
````

The PR is adding the level medium (between normal and low).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
