### PR TITLE
Add support for energy price setting through `setEnergyCost`

### DIFF
--- a/homeassistant/components/wallbox/manifest.json
+++ b/homeassistant/components/wallbox/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/wallbox",
   "iot_class": "cloud_polling",
   "loggers": ["wallbox"],
-  "requirements": ["wallbox==0.4.12"]
+  "requirements": ["wallbox==0.4.14"]
 }

--- a/homeassistant/components/wallbox/number.py
+++ b/homeassistant/components/wallbox/number.py
@@ -91,6 +91,7 @@ class WallboxNumber(WallboxEntity, NumberEntity):
             coordinator.data[CHARGER_DATA_KEY][CHARGER_PART_NUMBER_KEY][0:3]
             in BIDIRECTIONAL_MODEL_PREFIXES
         )
+        self.native_step = 0.0001
 
     @property
     def native_max_value(self) -> float:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2670,7 +2670,7 @@ vultr==0.1.2
 wakeonlan==2.1.0
 
 # homeassistant.components.wallbox
-wallbox==0.4.12
+wallbox==0.4.14
 
 # homeassistant.components.folder_watcher
 watchdog==2.3.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1967,7 +1967,7 @@ vultr==0.1.2
 wakeonlan==2.1.0
 
 # homeassistant.components.wallbox
-wallbox==0.4.12
+wallbox==0.4.14
 
 # homeassistant.components.folder_watcher
 watchdog==2.3.1

--- a/tests/components/wallbox/__init__.py
+++ b/tests/components/wallbox/__init__.py
@@ -101,7 +101,14 @@ async def setup_integration(hass: HomeAssistant, entry: MockConfigEntry) -> None
         )
         mock_request.put(
             "https://api.wall-box.com/v2/charger/12345",
-            json=json.loads(json.dumps({CHARGER_MAX_CHARGING_CURRENT_KEY: 20})),
+            json=json.loads(
+                json.dumps(
+                    {
+                        CHARGER_MAX_CHARGING_CURRENT_KEY: 20,
+                        CHARGER_ENERGY_PRICE_KEY: 0.3,
+                    }
+                )
+            ),
             status_code=HTTPStatus.OK,
         )
 

--- a/tests/components/wallbox/test_config_flow.py
+++ b/tests/components/wallbox/test_config_flow.py
@@ -12,6 +12,7 @@ from homeassistant.components.wallbox.const import (
     CHARGER_CHARGING_POWER_KEY,
     CHARGER_CHARGING_SPEED_KEY,
     CHARGER_DATA_KEY,
+    CHARGER_ENERGY_PRICE_KEY,
     CHARGER_MAX_AVAILABLE_POWER_KEY,
     CHARGER_MAX_CHARGING_CURRENT_KEY,
     DOMAIN,
@@ -34,7 +35,10 @@ test_response = json.loads(
             CHARGER_CHARGING_SPEED_KEY: 0,
             CHARGER_ADDED_RANGE_KEY: "xx",
             CHARGER_ADDED_ENERGY_KEY: "44.697",
-            CHARGER_DATA_KEY: {CHARGER_MAX_CHARGING_CURRENT_KEY: 24},
+            CHARGER_DATA_KEY: {
+                CHARGER_MAX_CHARGING_CURRENT_KEY: 24,
+                CHARGER_ENERGY_PRICE_KEY: 0.4,
+            },
         }
     )
 )

--- a/tests/components/wallbox/test_init.py
+++ b/tests/components/wallbox/test_init.py
@@ -3,7 +3,11 @@ import json
 
 import requests_mock
 
-from homeassistant.components.wallbox import CHARGER_MAX_CHARGING_CURRENT_KEY, DOMAIN
+from homeassistant.components.wallbox import (
+    CHARGER_ENERGY_PRICE_KEY,
+    CHARGER_MAX_CHARGING_CURRENT_KEY,
+    DOMAIN,
+)
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
@@ -58,7 +62,14 @@ async def test_wallbox_refresh_failed_invalid_auth(
         )
         mock_request.put(
             "https://api.wall-box.com/v2/charger/12345",
-            json=json.loads(json.dumps({CHARGER_MAX_CHARGING_CURRENT_KEY: 20})),
+            json=json.loads(
+                json.dumps(
+                    {
+                        CHARGER_MAX_CHARGING_CURRENT_KEY: 20,
+                        CHARGER_ENERGY_PRICE_KEY: 0.3,
+                    }
+                )
+            ),
             status_code=403,
         )
 

--- a/tests/components/wallbox/test_number.py
+++ b/tests/components/wallbox/test_number.py
@@ -35,8 +35,8 @@ async def test_wallbox_number_class(
             json=authorisation_response,
             status_code=200,
         )
-        mock_request.put(
-            "https://api.wall-box.com/v2/charger/12345",
+        mock_request.post(
+            "https://api.wall-box.com/chargers/config/12345",
             json=json.loads(
                 json.dumps(
                     {
@@ -73,8 +73,8 @@ async def test_wallbox_number_class_connection_error(
             json=authorisation_response,
             status_code=200,
         )
-        mock_request.put(
-            "https://api.wall-box.com/v2/charger/12345",
+        mock_request.post(
+            "https://api.wall-box.com/chargers/config/12345",
             json=json.loads(
                 json.dumps(
                     {

--- a/tests/components/wallbox/test_number.py
+++ b/tests/components/wallbox/test_number.py
@@ -5,7 +5,10 @@ import pytest
 import requests_mock
 
 from homeassistant.components.input_number import ATTR_VALUE, SERVICE_SET_VALUE
-from homeassistant.components.wallbox import CHARGER_MAX_CHARGING_CURRENT_KEY
+from homeassistant.components.wallbox import (
+    CHARGER_ENERGY_PRICE_KEY,
+    CHARGER_MAX_CHARGING_CURRENT_KEY,
+)
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 
@@ -34,7 +37,14 @@ async def test_wallbox_number_class(
         )
         mock_request.put(
             "https://api.wall-box.com/v2/charger/12345",
-            json=json.loads(json.dumps({CHARGER_MAX_CHARGING_CURRENT_KEY: 20})),
+            json=json.loads(
+                json.dumps(
+                    {
+                        CHARGER_MAX_CHARGING_CURRENT_KEY: 20,
+                        CHARGER_ENERGY_PRICE_KEY: 0.3,
+                    }
+                )
+            ),
             status_code=200,
         )
 
@@ -65,7 +75,14 @@ async def test_wallbox_number_class_connection_error(
         )
         mock_request.put(
             "https://api.wall-box.com/v2/charger/12345",
-            json=json.loads(json.dumps({CHARGER_MAX_CHARGING_CURRENT_KEY: 20})),
+            json=json.loads(
+                json.dumps(
+                    {
+                        CHARGER_MAX_CHARGING_CURRENT_KEY: 20,
+                        CHARGER_ENERGY_PRICE_KEY: 0.3,
+                    }
+                )
+            ),
             status_code=404,
         )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Allow setting of the energy price to Wallbox.

Updated wallbox pypy package.
Changelog: https://github.com/cliviu74/wallbox/releases/tag/0.4.14 and https://github.com/cliviu74/wallbox/releases/tag/0.4.13


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes 
- This PR is related to issue: #93614
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
