### PR TITLE
Delay creation of Reolink repair issues

### DIFF
--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -26,6 +26,7 @@ from .exceptions import ReolinkSetupException, ReolinkWebhookException, UserNotA
 
 DEFAULT_TIMEOUT = 60
 FIRST_ONVIF_TIMEOUT = 10
+FIRST_ONVIF_LONG_POLL_TIMEOUT = 90
 SUBSCRIPTION_RENEW_THRESHOLD = 300
 POLL_INTERVAL_NO_PUSH = 5
 LONG_POLL_COOLDOWN = 0.75
@@ -205,7 +206,7 @@ class ReolinkHost:
         # ONVIF push is not received, start long polling and schedule check
         await self._async_start_long_polling()
         self._cancel_long_poll_check = async_call_later(
-            self._hass, FIRST_ONVIF_TIMEOUT, self._async_check_onvif_long_poll
+            self._hass, FIRST_ONVIF_LONG_POLL_TIMEOUT, self._async_check_onvif_long_poll
         )
 
         self._cancel_onvif_check = None
@@ -215,7 +216,7 @@ class ReolinkHost:
         if not self._long_poll_received:
             _LOGGER.debug(
                 "Did not receive state through ONVIF long polling after %i seconds",
-                FIRST_ONVIF_TIMEOUT,
+                FIRST_ONVIF_LONG_POLL_TIMEOUT,
             )
             ir.async_create_issue(
                 self._hass,
@@ -230,8 +231,24 @@ class ReolinkHost:
                     "network_link": "https://my.home-assistant.io/redirect/network/",
                 },
             )
+            if self._base_url.startswith("https"):
+                ir.async_create_issue(
+                    self._hass,
+                    DOMAIN,
+                    "https_webhook",
+                    is_fixable=False,
+                    severity=ir.IssueSeverity.WARNING,
+                    translation_key="https_webhook",
+                    translation_placeholders={
+                        "base_url": self._base_url,
+                        "network_link": "https://my.home-assistant.io/redirect/network/",
+                    },
+                )
+            else:
+                ir.async_delete_issue(self._hass, DOMAIN, "https_webhook")
         else:
             ir.async_delete_issue(self._hass, DOMAIN, "webhook_url")
+            ir.async_delete_issue(self._hass, DOMAIN, "https_webhook")
 
         # If no ONVIF push or long polling state is received, start fast polling
         await self._async_poll_all_motion()
@@ -407,22 +424,6 @@ class ReolinkHost:
 
         webhook_path = webhook.async_generate_path(event_id)
         self._webhook_url = f"{self._base_url}{webhook_path}"
-
-        if self._base_url.startswith("https"):
-            ir.async_create_issue(
-                self._hass,
-                DOMAIN,
-                "https_webhook",
-                is_fixable=False,
-                severity=ir.IssueSeverity.WARNING,
-                translation_key="https_webhook",
-                translation_placeholders={
-                    "base_url": self._base_url,
-                    "network_link": "https://my.home-assistant.io/redirect/network/",
-                },
-            )
-        else:
-            ir.async_delete_issue(self._hass, DOMAIN, "https_webhook")
 
         _LOGGER.debug("Registered webhook: %s", event_id)
 

--- a/tests/components/reolink/test_init.py
+++ b/tests/components/reolink/test_init.py
@@ -116,7 +116,14 @@ async def test_https_repair_issue(
         hass, {"country": "GB", "internal_url": "https://test_homeassistant_address"}
     )
 
-    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    with patch(
+        "homeassistant.components.reolink.host.FIRST_ONVIF_TIMEOUT", new=0
+    ), patch(
+        "homeassistant.components.reolink.host.FIRST_ONVIF_LONG_POLL_TIMEOUT", new=0
+    ), patch(
+        "homeassistant.components.reolink.host.ReolinkHost._async_long_polling",
+    ):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
     issue_registry = ir.async_get(hass)
@@ -150,6 +157,8 @@ async def test_webhook_repair_issue(
     """Test repairs issue is raised when the webhook url is unreachable."""
     with patch(
         "homeassistant.components.reolink.host.FIRST_ONVIF_TIMEOUT", new=0
+    ), patch(
+        "homeassistant.components.reolink.host.FIRST_ONVIF_LONG_POLL_TIMEOUT", new=0
     ), patch(
         "homeassistant.components.reolink.host.ReolinkHost._async_long_polling",
     ):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Some older cameras like the E1 zoom IPC_566SD65MP do not imediatly return a first ONVIF long polling response, if there is no event at HA startup it will only respond with the first message after 60 seconds. Therefore delay the creation of the repair issue (and possible start of fast polling) from 10s to 90s.

Additionally do not create repair issues about a HTTPS local URL beeing used if ONVIF long polling works, since that is a decent enough backup for ONVIF push. No need to worry users about it if ONVIF long polling is working fine.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
