### PR TITLE
Offer work- a-round for MQTT entity names that start with the device name

### DIFF
--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -36,6 +36,7 @@ from homeassistant.core import (
 )
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import dispatcher_send
+from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import bind_hass
 from homeassistant.util import dt as dt_util
@@ -64,6 +65,7 @@ from .const import (
     DEFAULT_WILL,
     DEFAULT_WS_HEADERS,
     DEFAULT_WS_PATH,
+    DOMAIN,
     MQTT_CONNECTED,
     MQTT_DISCONNECTED,
     PROTOCOL_5,
@@ -92,6 +94,10 @@ INITIAL_SUBSCRIBE_COOLDOWN = 1.0
 SUBSCRIBE_COOLDOWN = 0.1
 UNSUBSCRIBE_COOLDOWN = 0.1
 TIMEOUT_ACK = 10
+
+MQTT_ENTRIES_NAMING_BLOG_URL = (
+    "https://developers.home-assistant.io/blog/2023-057-21-change-naming-mqtt-entities/"
+)
 
 SubscribePayloadType = str | bytes  # Only bytes if encoding is None
 
@@ -404,6 +410,7 @@ class MQTT:
 
             @callback
             def ha_started(_: Event) -> None:
+                self.register_naming_issues()
                 self._ha_started.set()
 
             self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, ha_started)
@@ -415,6 +422,24 @@ class MQTT:
         self._cleanup_on_unload.append(
             hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, async_stop_mqtt)
         )
+
+    def register_naming_issues(self) -> None:
+        """Register issues with MQTT entity naming."""
+        mqtt_data = get_mqtt_data(self.hass)
+        for issue_key, items in mqtt_data.issues.items():
+            async_create_issue(
+                self.hass,
+                DOMAIN,
+                issue_key,
+                breaks_in_ha_version="2024.2.0",
+                is_fixable=False,
+                translation_key=issue_key,
+                translation_placeholders={
+                    "config": str(list(items)),
+                },
+                learn_more_url=MQTT_ENTRIES_NAMING_BLOG_URL,
+                severity=IssueSeverity.WARNING,
+            )
 
     def start(
         self,

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -427,9 +427,7 @@ class MQTT:
         """Register issues with MQTT entity naming."""
         mqtt_data = get_mqtt_data(self.hass)
         for issue_key, items in mqtt_data.issues.items():
-            config_list = ""
-            for item in items:
-                config_list = config_list.join(f"- {item}\n")
+            config_list = "\n".join([f"- {item}" for item in items])
             async_create_issue(
                 self.hass,
                 DOMAIN,

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -429,7 +429,7 @@ class MQTT:
         for issue_key, items in mqtt_data.issues.items():
             config_list = ""
             for item in items:
-                config_list.join(f"- {item}\n")
+                config_list = config_list.join(f"- {item}\n")
             async_create_issue(
                 self.hass,
                 DOMAIN,

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -427,6 +427,9 @@ class MQTT:
         """Register issues with MQTT entity naming."""
         mqtt_data = get_mqtt_data(self.hass)
         for issue_key, items in mqtt_data.issues.items():
+            config_list = ""
+            for item in items:
+                config_list.join(f"- {item}\n")
             async_create_issue(
                 self.hass,
                 DOMAIN,
@@ -435,7 +438,7 @@ class MQTT:
                 is_fixable=False,
                 translation_key=issue_key,
                 translation_placeholders={
-                    "config": str(list(items)),
+                    "config": config_list,
                 },
                 learn_more_url=MQTT_ENTRIES_NAMING_BLOG_URL,
                 severity=IssueSeverity.WARNING,

--- a/homeassistant/components/mqtt/mixins.py
+++ b/homeassistant/components/mqtt/mixins.py
@@ -1130,6 +1130,7 @@ class MqttEntity(
             # Assign the default name
             self._attr_name = self._default_name
         if CONF_DEVICE in config:
+            device_name: str
             if CONF_NAME not in config[CONF_DEVICE]:
                 _LOGGER.info(
                     "MQTT device information always needs to include a name, got %s, "
@@ -1137,7 +1138,7 @@ class MqttEntity(
                     "name must be included in each entity's device configuration",
                     config,
                 )
-            elif config[CONF_DEVICE][CONF_NAME] == entity_name:
+            elif (device_name := config[CONF_DEVICE][CONF_NAME]) == entity_name:
                 _LOGGER.warning(
                     "MQTT device name is equal to entity name in your config %s, "
                     "this is not expected. Please correct your configuration. "
@@ -1145,6 +1146,17 @@ class MqttEntity(
                     config,
                 )
                 self._attr_name = None
+            elif isinstance(entity_name, str) and entity_name.startswith(device_name):
+                new_entity_name = entity_name[len(device_name) :].lstrip()
+                _LOGGER.warning(
+                    "MQTT entity name starts with the device name in your config %s, "
+                    "this is not expected. Please correct your configuration. "
+                    "The device name prefix will be stripped off the entity name "
+                    "and becomes '%s'",
+                    config,
+                    new_entity_name,
+                )
+                self._attr_name = new_entity_name
 
     def _setup_common_attributes_from_config(self, config: ConfigType) -> None:
         """(Re)Setup the common attributes for the entity."""

--- a/homeassistant/components/mqtt/mixins.py
+++ b/homeassistant/components/mqtt/mixins.py
@@ -1028,6 +1028,7 @@ class MqttEntity(
         self._config: ConfigType = config
         self._attr_unique_id = config.get(CONF_UNIQUE_ID)
         self._sub_state: dict[str, EntitySubscription] = {}
+        self._discovery = discovery_data is not None
 
         # Load config
         self._setup_from_config(self._config)
@@ -1143,7 +1144,11 @@ class MqttEntity(
                 )
             elif (device_name := config[CONF_DEVICE][CONF_NAME]) == entity_name:
                 self._attr_name = None
-                self._issue_key = "entity_name_is_device_name"
+                self._issue_key = (
+                    "entity_name_is_device_name_discovery"
+                    if self._discovery
+                    else "entity_name_is_device_name_yaml"
+                )
                 _LOGGER.warning(
                     "MQTT device name is equal to entity name in your config %s, "
                     "this is not expected. Please correct your configuration. "
@@ -1157,7 +1162,11 @@ class MqttEntity(
                 if device_name[:1].isupper():
                     # Ensure a capital if the device name first char is a capital
                     new_entity_name = new_entity_name[:1].upper() + new_entity_name[1:]
-                self._issue_key = "entity_name_startswith_device_name"
+                self._issue_key = (
+                    "entity_name_startswith_device_name_discovery"
+                    if self._discovery
+                    else "entity_name_startswith_device_name_yaml"
+                )
                 _LOGGER.warning(
                     "MQTT entity name starts with the device name in your config %s, "
                     "this is not expected. Please correct your configuration. "

--- a/homeassistant/components/mqtt/models.py
+++ b/homeassistant/components/mqtt/models.py
@@ -305,6 +305,7 @@ class MqttData:
     )
     discovery_unsubscribe: list[CALLBACK_TYPE] = field(default_factory=list)
     integration_unsubscribe: dict[str, CALLBACK_TYPE] = field(default_factory=dict)
+    issues: dict[str, set[str]] = field(default_factory=dict)
     last_discovery: float = 0.0
     reload_dispatchers: list[CALLBACK_TYPE] = field(default_factory=list)
     reload_handlers: dict[str, Callable[[], Coroutine[Any, Any, None]]] = field(

--- a/homeassistant/components/mqtt/strings.json
+++ b/homeassistant/components/mqtt/strings.json
@@ -10,11 +10,11 @@
     },
     "entity_name_is_device_name": {
       "title": "MQTT entities with a name is equal to device name",
-      "description": "Some MQTT entities have an entity name that is equal to the device name. This is not expected. To avoid a duplicate names the entity name is set to `null` as a work-a-round. Please update your configuration, or inform the maintainer of the integration that supplies the entity, and restart Home Assistant to fix this issue.\n\nList of effected entities:\n\n`{config}`"
+      "description": "Some MQTT entities have an entity name that is equal to the device name. This is not expected. To avoid a duplicate names the entity name is set to `null` as a work-a-round. Please update your configuration, or inform the maintainer of the integration that supplies the entity, and restart Home Assistant to fix this issue.\n\nList of effected entities:\n\n{config}"
     },
     "entity_name_startswith_device_name": {
       "title": "MQTT entities with a that name starts with the device name",
-      "description": "Some MQTT entities have an entity name that starts with the device name. This is not expected. To avoid a duplicate names the device name prefix is stripped of the entity name as a work-a-round. Please update your configuration, or inform the maintainer of the integration that supplies the entity, and restart Home Assistant to fix this issue. \n\nList of effected entities:\n\n`{config}`"
+      "description": "Some MQTT entities have an entity name that starts with the device name. This is not expected. To avoid a duplicate names the device name prefix is stripped of the entity name as a work-a-round. Please update your configuration, or inform the maintainer of the integration that supplies the entity, and restart Home Assistant to fix this issue. \n\nList of effected entities:\n\n{config}"
     }
   },
   "config": {

--- a/homeassistant/components/mqtt/strings.json
+++ b/homeassistant/components/mqtt/strings.json
@@ -10,11 +10,11 @@
     },
     "entity_name_is_device_name": {
       "title": "MQTT entity name of {entity_id} is equal to device name",
-      "description": "MQTT entity with entity_id `{entity_id}` has an entity name that is equal to the device name. This is not expected. To avoid a duplicate names the entity name is set to `null` as a work-a-round. Please update your configuration, or inform the maintainer of the integration that supplies the entity, and restart Home Assistant to fix this issue.\n\nConfiguration found:\n```yaml\n{config}\n```"
+      "description": "MQTT entity with entity_id `{entity_id}` has an entity name that is equal to the device name. This is not expected. To avoid a duplicate names the entity name is set to `null` as a work-a-round. Please update your configuration, or inform the maintainer of the integration that supplies the entity, and restart Home Assistant to fix this issue.\n\nNames found in configuration:\n```yaml\n{config}\n```"
     },
     "entity_name_startswith_device_name": {
       "title": "MQTT entity name of {entity_id} starts with the device name",
-      "description": "MQTT entity with entity_id `{entity_id}` has an entity name that starts with the device name. This is not expected. To avoid a duplicate names the device name prefix is stripped of the entity name as a work-a-round. Please update your configuration, or inform the maintainer of the integration that supplies the entity, and restart Home Assistant to fix this issue. \n\nConfiguration found:\n```yaml\n{config}\n```"
+      "description": "MQTT entity with entity_id `{entity_id}` has an entity name that starts with the device name. This is not expected. To avoid a duplicate names the device name prefix is stripped of the entity name as a work-a-round. Please update your configuration, or inform the maintainer of the integration that supplies the entity, and restart Home Assistant to fix this issue. \n\nNames found in configuration:\n```yaml\n{config}\n```"
     }
   },
   "config": {

--- a/homeassistant/components/mqtt/strings.json
+++ b/homeassistant/components/mqtt/strings.json
@@ -10,7 +10,7 @@
     },
     "entity_name_is_device_name": {
       "title": "MQTT entities with a name is equal to device name",
-      "description": "Some MQTT entities have an entity name that is equal to the device name. This is not expected. To avoid a duplicate name the entity name is set to `null` as a work-a-round. Please update your configuration, or inform the maintainer of the integration that supplies the entity, and restart Home Assistant to fix this issue.\n\nList of effected entities:\n\n{config}"
+      "description": "Some MQTT entities have an entity name equal to the device name. This is not expected. The entity name is set to `null` as a work-a-round to avoid a duplicate name. Please update your configuration, or inform the maintainer of the software application that supplies the entity, and restart Home Assistant to fix this issue.\n\nList of effected entities:\n\n{config}"
     },
     "entity_name_startswith_device_name": {
       "title": "MQTT entities with a name that starts with the device name",

--- a/homeassistant/components/mqtt/strings.json
+++ b/homeassistant/components/mqtt/strings.json
@@ -7,6 +7,14 @@
     "deprecation_mqtt_legacy_vacuum_discovery": {
       "title": "MQTT vacuum entities with legacy schema added through MQTT discovery",
       "description": "MQTT vacuum entities that use the legacy schema are deprecated, please adjust your devices to use the correct schema and restart Home Assistant to fix this issue."
+    },
+    "entity_name_is_device_name": {
+      "title": "MQTT entity name of {entity_id} is equal to device name",
+      "description": "MQTT entity with entity_id `{entity_id}` has an entity name that is equal to the device name, this is not expected. To avoid a duplicate names the entity name is set to `null` as a work-a-round. Please update your configuration, or inform the maintainer of the integration that supplies the entity, and restart Home Assistant to fix this issue.\n\nConfiguration found:\n```yaml\n{config}\n```"
+    },
+    "entity_name_startswith_device_name": {
+      "title": "MQTT entity name of {entity_id} starts with the device name",
+      "description": "MQTT entity with entity_id `{entity_id}` has an entity name that starts with the device name, this is not expected. To avoid a duplicate names the device name prefix is stripped of the entity name as a work-a-round. Please update your configuration, or inform the maintainer of the integration that supplies the entity, and restart Home Assistant to fix this issue. \n\nConfiguration found:\n```yaml\n{config}\n```"
     }
   },
   "config": {

--- a/homeassistant/components/mqtt/strings.json
+++ b/homeassistant/components/mqtt/strings.json
@@ -9,12 +9,12 @@
       "description": "MQTT vacuum entities that use the legacy schema are deprecated, please adjust your devices to use the correct schema and restart Home Assistant to fix this issue."
     },
     "entity_name_is_device_name": {
-      "title": "MQTT entity name of {entity_id} is equal to device name",
-      "description": "MQTT entity with entity_id `{entity_id}` has an entity name that is equal to the device name. This is not expected. To avoid a duplicate names the entity name is set to `null` as a work-a-round. Please update your configuration, or inform the maintainer of the integration that supplies the entity, and restart Home Assistant to fix this issue.\n\nNames found in configuration:\n```yaml\n{config}\n```"
+      "title": "MQTT entities with a name is equal to device name",
+      "description": "Some MQTT entities have an entity name that is equal to the device name. This is not expected. To avoid a duplicate names the entity name is set to `null` as a work-a-round. Please update your configuration, or inform the maintainer of the integration that supplies the entity, and restart Home Assistant to fix this issue.\n\nList of effected entities:\n\n`{config}`"
     },
     "entity_name_startswith_device_name": {
-      "title": "MQTT entity name of {entity_id} starts with the device name",
-      "description": "MQTT entity with entity_id `{entity_id}` has an entity name that starts with the device name. This is not expected. To avoid a duplicate names the device name prefix is stripped of the entity name as a work-a-round. Please update your configuration, or inform the maintainer of the integration that supplies the entity, and restart Home Assistant to fix this issue. \n\nNames found in configuration:\n```yaml\n{config}\n```"
+      "title": "MQTT entities with a that name starts with the device name",
+      "description": "Some MQTT entities have an entity name that starts with the device name. This is not expected. To avoid a duplicate names the device name prefix is stripped of the entity name as a work-a-round. Please update your configuration, or inform the maintainer of the integration that supplies the entity, and restart Home Assistant to fix this issue. \n\nList of effected entities:\n\n`{config}`"
     }
   },
   "config": {

--- a/homeassistant/components/mqtt/strings.json
+++ b/homeassistant/components/mqtt/strings.json
@@ -8,13 +8,21 @@
       "title": "MQTT vacuum entities with legacy schema added through MQTT discovery",
       "description": "MQTT vacuum entities that use the legacy schema are deprecated, please adjust your devices to use the correct schema and restart Home Assistant to fix this issue."
     },
-    "entity_name_is_device_name": {
+    "entity_name_is_device_name_yaml": {
       "title": "MQTT entities with a name is equal to device name",
-      "description": "Some MQTT entities have an entity name equal to the device name. This is not expected. The entity name is set to `null` as a work-a-round to avoid a duplicate name. Please update your configuration, or inform the maintainer of the software application that supplies the entity, and restart Home Assistant to fix this issue.\n\nList of effected entities:\n\n{config}"
+      "description": "Some MQTT entities have an entity name equal to the device name. This is not expected. The entity name is set to `null` as a work-a-round to avoid a duplicate name. Please update your configuration and restart Home Assistant to fix this issue.\n\nList of affected entities:\n\n{config}"
     },
-    "entity_name_startswith_device_name": {
+    "entity_name_startswith_device_name_yaml": {
       "title": "MQTT entities with a name that starts with the device name",
-      "description": "Some MQTT entities have an entity name that starts with the device name. This is not expected. To avoid a duplicate name the device name prefix is stripped of the entity name as a work-a-round. Please update your configuration, or inform the maintainer of the integration that supplies the entity, and restart Home Assistant to fix this issue. \n\nList of effected entities:\n\n{config}"
+      "description": "Some MQTT entities have an entity name that starts with the device name. This is not expected. To avoid a duplicate name the device name prefix is stripped of the entity name as a work-a-round. Please update your configuration and restart Home Assistant to fix this issue. \n\nList of affected entities:\n\n{config}"
+    },
+    "entity_name_is_device_name_discovery": {
+      "title": "MQTT entities with a name is equal to device name",
+      "description": "Some MQTT entities have an entity name equal to the device name. This is not expected. The entity name is set to `null` as a work-a-round to avoid a duplicate name. Please inform the maintainer of the software application that supplies the affected entities to fix this issue.\n\nList of affected entities:\n\n{config}"
+    },
+    "entity_name_startswith_device_name_discovery": {
+      "title": "MQTT entities with a name that starts with the device name",
+      "description": "Some MQTT entities have an entity name that starts with the device name. This is not expected. To avoid a duplicate name the device name prefix is stripped of the entity name as a work-a-round. Please inform the maintainer of the software application that supplies the affected entities to fix this issue. \n\nList of affected entities:\n\n{config}"
     }
   },
   "config": {

--- a/homeassistant/components/mqtt/strings.json
+++ b/homeassistant/components/mqtt/strings.json
@@ -13,7 +13,7 @@
       "description": "Some MQTT entities have an entity name that is equal to the device name. This is not expected. To avoid a duplicate name the entity name is set to `null` as a work-a-round. Please update your configuration, or inform the maintainer of the integration that supplies the entity, and restart Home Assistant to fix this issue.\n\nList of effected entities:\n\n{config}"
     },
     "entity_name_startswith_device_name": {
-      "title": "MQTT entities with a that name starts with the device name",
+      "title": "MQTT entities with a name that starts with the device name",
       "description": "Some MQTT entities have an entity name that starts with the device name. This is not expected. To avoid a duplicate name the device name prefix is stripped of the entity name as a work-a-round. Please update your configuration, or inform the maintainer of the integration that supplies the entity, and restart Home Assistant to fix this issue. \n\nList of effected entities:\n\n{config}"
     }
   },

--- a/homeassistant/components/mqtt/strings.json
+++ b/homeassistant/components/mqtt/strings.json
@@ -9,19 +9,19 @@
       "description": "MQTT vacuum entities that use the legacy schema are deprecated, please adjust your devices to use the correct schema and restart Home Assistant to fix this issue."
     },
     "entity_name_is_device_name_yaml": {
-      "title": "MQTT entities with a name is equal to device name",
+      "title": "Manual configured MQTT entities with a name that is equal to the device name",
       "description": "Some MQTT entities have an entity name equal to the device name. This is not expected. The entity name is set to `null` as a work-a-round to avoid a duplicate name. Please update your configuration and restart Home Assistant to fix this issue.\n\nList of affected entities:\n\n{config}"
     },
     "entity_name_startswith_device_name_yaml": {
-      "title": "MQTT entities with a name that starts with the device name",
+      "title": "Manual configured MQTT entities with a name that starts with the device name",
       "description": "Some MQTT entities have an entity name that starts with the device name. This is not expected. To avoid a duplicate name the device name prefix is stripped of the entity name as a work-a-round. Please update your configuration and restart Home Assistant to fix this issue. \n\nList of affected entities:\n\n{config}"
     },
     "entity_name_is_device_name_discovery": {
-      "title": "MQTT entities with a name is equal to device name",
+      "title": "Discovered MQTT entities with a name that is equal to the device name",
       "description": "Some MQTT entities have an entity name equal to the device name. This is not expected. The entity name is set to `null` as a work-a-round to avoid a duplicate name. Please inform the maintainer of the software application that supplies the affected entities to fix this issue.\n\nList of affected entities:\n\n{config}"
     },
     "entity_name_startswith_device_name_discovery": {
-      "title": "MQTT entities with a name that starts with the device name",
+      "title": "Discovered entities with a name that starts with the device name",
       "description": "Some MQTT entities have an entity name that starts with the device name. This is not expected. To avoid a duplicate name the device name prefix is stripped of the entity name as a work-a-round. Please inform the maintainer of the software application that supplies the affected entities to fix this issue. \n\nList of affected entities:\n\n{config}"
     }
   },

--- a/homeassistant/components/mqtt/strings.json
+++ b/homeassistant/components/mqtt/strings.json
@@ -14,7 +14,7 @@
     },
     "entity_name_startswith_device_name": {
       "title": "MQTT entities with a that name starts with the device name",
-      "description": "Some MQTT entities have an entity name that starts with the device name. This is not expected. To avoid a duplicate names the device name prefix is stripped of the entity name as a work-a-round. Please update your configuration, or inform the maintainer of the integration that supplies the entity, and restart Home Assistant to fix this issue. \n\nList of effected entities:\n\n{config}"
+      "description": "Some MQTT entities have an entity name that starts with the device name. This is not expected. To avoid a duplicate name the device name prefix is stripped of the entity name as a work-a-round. Please update your configuration, or inform the maintainer of the integration that supplies the entity, and restart Home Assistant to fix this issue. \n\nList of effected entities:\n\n{config}"
     }
   },
   "config": {

--- a/homeassistant/components/mqtt/strings.json
+++ b/homeassistant/components/mqtt/strings.json
@@ -10,7 +10,7 @@
     },
     "entity_name_is_device_name": {
       "title": "MQTT entities with a name is equal to device name",
-      "description": "Some MQTT entities have an entity name that is equal to the device name. This is not expected. To avoid a duplicate names the entity name is set to `null` as a work-a-round. Please update your configuration, or inform the maintainer of the integration that supplies the entity, and restart Home Assistant to fix this issue.\n\nList of effected entities:\n\n{config}"
+      "description": "Some MQTT entities have an entity name that is equal to the device name. This is not expected. To avoid a duplicate name the entity name is set to `null` as a work-a-round. Please update your configuration, or inform the maintainer of the integration that supplies the entity, and restart Home Assistant to fix this issue.\n\nList of effected entities:\n\n{config}"
     },
     "entity_name_startswith_device_name": {
       "title": "MQTT entities with a that name starts with the device name",

--- a/homeassistant/components/mqtt/strings.json
+++ b/homeassistant/components/mqtt/strings.json
@@ -10,11 +10,11 @@
     },
     "entity_name_is_device_name": {
       "title": "MQTT entity name of {entity_id} is equal to device name",
-      "description": "MQTT entity with entity_id `{entity_id}` has an entity name that is equal to the device name, this is not expected. To avoid a duplicate names the entity name is set to `null` as a work-a-round. Please update your configuration, or inform the maintainer of the integration that supplies the entity, and restart Home Assistant to fix this issue.\n\nConfiguration found:\n```yaml\n{config}\n```"
+      "description": "MQTT entity with entity_id `{entity_id}` has an entity name that is equal to the device name. This is not expected. To avoid a duplicate names the entity name is set to `null` as a work-a-round. Please update your configuration, or inform the maintainer of the integration that supplies the entity, and restart Home Assistant to fix this issue.\n\nConfiguration found:\n```yaml\n{config}\n```"
     },
     "entity_name_startswith_device_name": {
       "title": "MQTT entity name of {entity_id} starts with the device name",
-      "description": "MQTT entity with entity_id `{entity_id}` has an entity name that starts with the device name, this is not expected. To avoid a duplicate names the device name prefix is stripped of the entity name as a work-a-round. Please update your configuration, or inform the maintainer of the integration that supplies the entity, and restart Home Assistant to fix this issue. \n\nConfiguration found:\n```yaml\n{config}\n```"
+      "description": "MQTT entity with entity_id `{entity_id}` has an entity name that starts with the device name. This is not expected. To avoid a duplicate names the device name prefix is stripped of the entity name as a work-a-round. Please update your configuration, or inform the maintainer of the integration that supplies the entity, and restart Home Assistant to fix this issue. \n\nConfiguration found:\n```yaml\n{config}\n```"
     }
   },
   "config": {

--- a/tests/components/mqtt/test_mixins.py
+++ b/tests/components/mqtt/test_mixins.py
@@ -232,11 +232,11 @@ async def test_availability_with_shared_state_topic(
             "Hello world",
             False,
         ),
-        (  # entity_name_startswith_device_name
+        (  # entity_name_startswith_device_name1
             {
                 mqtt.DOMAIN: {
                     sensor.DOMAIN: {
-                        "name": "World Home Assistant",
+                        "name": "World automation",
                         "state_topic": "test-topic",
                         "unique_id": "veryunique",
                         "device_class": "humidity",
@@ -247,9 +247,29 @@ async def test_availability_with_shared_state_topic(
                     }
                 }
             },
-            "sensor.world_home_assistant",
-            "World Home Assistant",
+            "sensor.world_automation",
+            "World automation",
             "World",
+            False,
+        ),
+        (  # entity_name_startswith_device_name2
+            {
+                mqtt.DOMAIN: {
+                    sensor.DOMAIN: {
+                        "name": "world automation",
+                        "state_topic": "test-topic",
+                        "unique_id": "veryunique",
+                        "device_class": "humidity",
+                        "device": {
+                            "identifiers": ["helloworld"],
+                            "name": "world",
+                        },
+                    }
+                }
+            },
+            "sensor.world_automation",
+            "world automation",
+            "world",
             False,
         ),
     ],
@@ -263,7 +283,8 @@ async def test_availability_with_shared_state_topic(
         "none_entity_name_with_device_name",
         "none_entity_name_without_device_name",
         "entity_name_and_device_name_the_same",
-        "entity_name_startswith_device_name",
+        "entity_name_startswith_device_name1",
+        "entity_name_startswith_device_name2",
     ],
 )
 @patch("homeassistant.components.mqtt.PLATFORMS", [Platform.SENSOR])

--- a/tests/components/mqtt/test_mixins.py
+++ b/tests/components/mqtt/test_mixins.py
@@ -6,14 +6,19 @@ import pytest
 
 from homeassistant.components import mqtt, sensor
 from homeassistant.components.mqtt.sensor import DEFAULT_NAME as DEFAULT_SENSOR_NAME
-from homeassistant.const import EVENT_STATE_CHANGED, Platform
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.const import (
+    EVENT_HOMEASSISTANT_STARTED,
+    EVENT_STATE_CHANGED,
+    Platform,
+)
+from homeassistant.core import CoreState, HomeAssistant, callback
 from homeassistant.helpers import (
     device_registry as dr,
+    issue_registry as ir,
 )
 
-from tests.common import async_fire_mqtt_message
-from tests.typing import MqttMockHAClientGenerator
+from tests.common import MockConfigEntry, async_capture_events, async_fire_mqtt_message
+from tests.typing import MqttMockHAClientGenerator, MqttMockPahoClient
 
 
 @pytest.mark.parametrize(
@@ -80,7 +85,14 @@ async def test_availability_with_shared_state_topic(
 
 
 @pytest.mark.parametrize(
-    ("hass_config", "entity_id", "friendly_name", "device_name", "assert_log"),
+    (
+        "hass_config",
+        "entity_id",
+        "friendly_name",
+        "device_name",
+        "assert_log",
+        "issue_events",
+    ),
     [
         (  # default_entity_name_without_device_name
             {
@@ -96,6 +108,7 @@ async def test_availability_with_shared_state_topic(
             DEFAULT_SENSOR_NAME,
             None,
             True,
+            0,
         ),
         (  # default_entity_name_with_device_name
             {
@@ -111,6 +124,7 @@ async def test_availability_with_shared_state_topic(
             "Test MQTT Sensor",
             "Test",
             False,
+            0,
         ),
         (  # name_follows_device_class
             {
@@ -127,6 +141,7 @@ async def test_availability_with_shared_state_topic(
             "Test Humidity",
             "Test",
             False,
+            0,
         ),
         (  # name_follows_device_class_without_device_name
             {
@@ -143,6 +158,7 @@ async def test_availability_with_shared_state_topic(
             "Humidity",
             None,
             True,
+            0,
         ),
         (  # name_overrides_device_class
             {
@@ -160,6 +176,7 @@ async def test_availability_with_shared_state_topic(
             "Test MySensor",
             "Test",
             False,
+            0,
         ),
         (  # name_set_no_device_name_set
             {
@@ -177,6 +194,7 @@ async def test_availability_with_shared_state_topic(
             "MySensor",
             None,
             True,
+            0,
         ),
         (  # none_entity_name_with_device_name
             {
@@ -194,6 +212,7 @@ async def test_availability_with_shared_state_topic(
             "Test",
             "Test",
             False,
+            0,
         ),
         (  # none_entity_name_without_device_name
             {
@@ -211,6 +230,7 @@ async def test_availability_with_shared_state_topic(
             "mqtt veryunique",
             None,
             True,
+            0,
         ),
         (  # entity_name_and_device_name_the_same
             {
@@ -231,6 +251,7 @@ async def test_availability_with_shared_state_topic(
             "Hello world",
             "Hello world",
             False,
+            1,
         ),
         (  # entity_name_startswith_device_name1
             {
@@ -251,6 +272,7 @@ async def test_availability_with_shared_state_topic(
             "World automation",
             "World",
             False,
+            1,
         ),
         (  # entity_name_startswith_device_name2
             {
@@ -271,6 +293,7 @@ async def test_availability_with_shared_state_topic(
             "world automation",
             "world",
             False,
+            1,
         ),
     ],
     ids=[
@@ -287,21 +310,48 @@ async def test_availability_with_shared_state_topic(
         "entity_name_startswith_device_name2",
     ],
 )
+@pytest.mark.parametrize(
+    "mqtt_config_entry_data",
+    [
+        {
+            mqtt.CONF_BROKER: "mock-broker",
+            mqtt.CONF_BIRTH_MESSAGE: {
+                mqtt.ATTR_TOPIC: "homeassistant/status",
+                mqtt.ATTR_PAYLOAD: "online",
+                mqtt.ATTR_QOS: 0,
+                mqtt.ATTR_RETAIN: False,
+            },
+        }
+    ],
+)
 @patch("homeassistant.components.mqtt.PLATFORMS", [Platform.SENSOR])
+@patch("homeassistant.components.mqtt.client.DISCOVERY_COOLDOWN", 0.0)
 async def test_default_entity_and_device_name(
     hass: HomeAssistant,
-    mqtt_mock_entry: MqttMockHAClientGenerator,
+    mqtt_client_mock: MqttMockPahoClient,
+    mqtt_config_entry_data,
     caplog: pytest.LogCaptureFixture,
     entity_id: str,
     friendly_name: str,
     device_name: str | None,
     assert_log: bool,
+    issue_events: int,
 ) -> None:
     """Test device name setup with and without a device_class set.
 
     This is a test helper for the _setup_common_attributes_from_config mixin.
     """
-    await mqtt_mock_entry()
+    # mqtt_mock = await mqtt_mock_entry()
+
+    events = async_capture_events(hass, ir.EVENT_REPAIRS_ISSUE_REGISTRY_UPDATED)
+    hass.state = CoreState.starting
+    await hass.async_block_till_done()
+
+    entry = MockConfigEntry(domain=mqtt.DOMAIN, data=mqtt_config_entry_data)
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+    await hass.async_block_till_done()
 
     registry = dr.async_get(hass)
 
@@ -316,3 +366,6 @@ async def test_default_entity_and_device_name(
     assert (
         "MQTT device information always needs to include a name" in caplog.text
     ) is assert_log
+
+    # Assert that an issues ware registered
+    assert len(events) == issue_events

--- a/tests/components/mqtt/test_mixins.py
+++ b/tests/components/mqtt/test_mixins.py
@@ -212,7 +212,7 @@ async def test_availability_with_shared_state_topic(
             None,
             True,
         ),
-        (  # entity_name_and_device_name_the_sane
+        (  # entity_name_and_device_name_the_same
             {
                 mqtt.DOMAIN: {
                     sensor.DOMAIN: {
@@ -232,6 +232,26 @@ async def test_availability_with_shared_state_topic(
             "Hello world",
             False,
         ),
+        (  # entity_name_startswith_device_name
+            {
+                mqtt.DOMAIN: {
+                    sensor.DOMAIN: {
+                        "name": "World Home Assistant",
+                        "state_topic": "test-topic",
+                        "unique_id": "veryunique",
+                        "device_class": "humidity",
+                        "device": {
+                            "identifiers": ["helloworld"],
+                            "name": "World",
+                        },
+                    }
+                }
+            },
+            "sensor.world_home_assistant",
+            "World Home Assistant",
+            "World",
+            False,
+        ),
     ],
     ids=[
         "default_entity_name_without_device_name",
@@ -242,7 +262,8 @@ async def test_availability_with_shared_state_topic(
         "name_set_no_device_name_set",
         "none_entity_name_with_device_name",
         "none_entity_name_without_device_name",
-        "entity_name_and_device_name_the_sane",
+        "entity_name_and_device_name_the_same",
+        "entity_name_startswith_device_name",
     ],
 )
 @patch("homeassistant.components.mqtt.PLATFORMS", [Platform.SENSOR])

--- a/tests/components/mqtt/test_mixins.py
+++ b/tests/components/mqtt/test_mixins.py
@@ -310,20 +310,6 @@ async def test_availability_with_shared_state_topic(
         "entity_name_startswith_device_name2",
     ],
 )
-@pytest.mark.parametrize(
-    "mqtt_config_entry_data",
-    [
-        {
-            mqtt.CONF_BROKER: "mock-broker",
-            mqtt.CONF_BIRTH_MESSAGE: {
-                mqtt.ATTR_TOPIC: "homeassistant/status",
-                mqtt.ATTR_PAYLOAD: "online",
-                mqtt.ATTR_QOS: 0,
-                mqtt.ATTR_RETAIN: False,
-            },
-        }
-    ],
-)
 @patch("homeassistant.components.mqtt.PLATFORMS", [Platform.SENSOR])
 @patch("homeassistant.components.mqtt.client.DISCOVERY_COOLDOWN", 0.0)
 async def test_default_entity_and_device_name(
@@ -347,7 +333,7 @@ async def test_default_entity_and_device_name(
     hass.state = CoreState.starting
     await hass.async_block_till_done()
 
-    entry = MockConfigEntry(domain=mqtt.DOMAIN, data=mqtt_config_entry_data)
+    entry = MockConfigEntry(domain=mqtt.DOMAIN, data={mqtt.CONF_BROKER: "mock-broker"})
     entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(entry.entry_id)
     hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Offer a work around for MQTT items that have entity names that start with the device name. Due to the new naming introduced, this causes duplicate names for devices that have not yet an updated config. This PR will simply strip off the device name part of the entity name if it is detected that the entity name starts with the device name. This should be an exact match.
If the device name starts with a capital, it will be ensured the entity name also starts with a capital.

The PR also registers an issue for entities that became a naming warning and work-a-round.

Issue when the entity name is the device name.
![afbeelding](https://github.com/home-assistant/core/assets/7188918/f80d386f-6189-4064-80e6-1dc68844aebd)

Issue when the entity name starts with the device name.
![afbeelding](https://github.com/home-assistant/core/assets/7188918/8b0160a6-3012-451a-b1db-e8693432fec8)

Issues are registered during startup only.
Note that issues for discovered items are shown if the discovery payload is retained.
A warning is always logged.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #97483 #97450
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
