### PR TITLE
Add hour of free power select to Electric Kiwi

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -270,6 +270,7 @@ omit =
     homeassistant/components/electric_kiwi/oauth2.py
     homeassistant/components/electric_kiwi/sensor.py
     homeassistant/components/electric_kiwi/coordinator.py
+    homeassistant/components/electric_kiwi/select.py
     homeassistant/components/eliqonline/sensor.py
     homeassistant/components/elkm1/__init__.py
     homeassistant/components/elkm1/alarm_control_panel.py

--- a/homeassistant/components/electric_kiwi/__init__.py
+++ b/homeassistant/components/electric_kiwi/__init__.py
@@ -15,9 +15,7 @@ from . import api
 from .const import DOMAIN
 from .coordinator import ElectricKiwiHOPDataCoordinator
 
-PLATFORMS: list[Platform] = [
-    Platform.SENSOR,
-]
+PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.SELECT]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/electric_kiwi/select.py
+++ b/homeassistant/components/electric_kiwi/select.py
@@ -1,0 +1,99 @@
+"""Support for Electric Kiwi hour of free power."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+from typing import Final
+
+from homeassistant.components.select import SelectEntity, SelectEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import ATTRIBUTION, DOMAIN
+from .coordinator import ElectricKiwiHOPDataCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+ATTR_EK_HOP_SELECT = "hop_select"
+
+
+@dataclass
+class ElectricKiwiHOPSelectDescriptionMixin:
+    """Define an entity description mixin for select entities."""
+
+    options_dict: dict[str, int] | None
+
+
+@dataclass
+class ElectricKiwiHOPSelectDescription(
+    SelectEntityDescription, ElectricKiwiHOPSelectDescriptionMixin
+):
+    """Class to describe an Electric Kiwi select entity."""
+
+
+HOP_SELECT_TYPE: Final[tuple[ElectricKiwiHOPSelectDescription, ...]] = (
+    ElectricKiwiHOPSelectDescription(
+        entity_category=EntityCategory.CONFIG,
+        key=ATTR_EK_HOP_SELECT,
+        translation_key="hopselector",
+        options_dict=None,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Electric Kiwi Sensor Setup."""
+    hop_coordinator: ElectricKiwiHOPDataCoordinator = hass.data[DOMAIN][entry.entry_id][
+        "hop_coordinator"
+    ]
+
+    _LOGGER.debug("Setting up HOP entity")
+    entities = [
+        ElectricKiwiSelectHOPEntity(hop_coordinator, description)
+        for description in HOP_SELECT_TYPE
+    ]
+    async_add_entities(entities)
+
+
+class ElectricKiwiSelectHOPEntity(
+    CoordinatorEntity[ElectricKiwiHOPDataCoordinator], SelectEntity
+):
+    """Entity object for seeing and setting the hour of free power."""
+
+    entity_description: ElectricKiwiHOPSelectDescription
+    _attr_has_entity_name = True
+    _attr_attribution = ATTRIBUTION
+    values_dict: dict[str, int]
+
+    def __init__(
+        self,
+        hop_coordinator: ElectricKiwiHOPDataCoordinator,
+        description: ElectricKiwiHOPSelectDescription,
+    ) -> None:
+        """Initialise the HOP selection entity."""
+        super().__init__(hop_coordinator)
+        self._attr_unique_id = f"{self.coordinator._ek_api.customer_number}_{self.coordinator._ek_api.connection_id}_{description.key}"
+        self.entity_description = description
+        self._state = None
+        self.values_dict = self.coordinator.get_hop_options()
+        self._attr_options = list(self.values_dict.keys())
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Update attributes when the coordinator updates."""
+        super()._handle_coordinator_update()
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the currently selected option."""
+        return f"{self.coordinator.data.start.start_time} - {self.coordinator.data.end.end_time}"
+
+    async def async_select_option(self, option: str) -> None:
+        """Change the selected option."""
+        value = self.values_dict[option]
+        await self.coordinator.async_update_hop(value)
+        self.async_write_ha_state()

--- a/homeassistant/components/electric_kiwi/select.py
+++ b/homeassistant/components/electric_kiwi/select.py
@@ -6,7 +6,7 @@ import logging
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -56,11 +56,6 @@ class ElectricKiwiSelectHOPEntity(
         self._state = None
         self.values_dict = self.coordinator.get_hop_options()
         self._attr_options = list(self.values_dict.keys())
-
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        """Update attributes when the coordinator updates."""
-        super()._handle_coordinator_update()
 
     @property
     def current_option(self) -> str | None:

--- a/homeassistant/components/electric_kiwi/select.py
+++ b/homeassistant/components/electric_kiwi/select.py
@@ -46,7 +46,7 @@ HOP_SELECT_TYPE: Final[tuple[ElectricKiwiHOPSelectDescription, ...]] = (
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
-    """Electric Kiwi Sensor Setup."""
+    """Electric Kiwi select setup."""
     hop_coordinator: ElectricKiwiHOPDataCoordinator = hass.data[DOMAIN][entry.entry_id][
         "hop_coordinator"
     ]

--- a/homeassistant/components/electric_kiwi/select.py
+++ b/homeassistant/components/electric_kiwi/select.py
@@ -1,9 +1,7 @@
 """Support for Electric Kiwi hour of free power."""
 from __future__ import annotations
 
-from dataclasses import dataclass
 import logging
-from typing import Final
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.config_entries import ConfigEntry
@@ -18,28 +16,10 @@ from .coordinator import ElectricKiwiHOPDataCoordinator
 _LOGGER = logging.getLogger(__name__)
 ATTR_EK_HOP_SELECT = "hop_select"
 
-
-@dataclass
-class ElectricKiwiHOPSelectDescriptionMixin:
-    """Define an entity description mixin for select entities."""
-
-    options_dict: dict[str, int] | None
-
-
-@dataclass
-class ElectricKiwiHOPSelectDescription(
-    SelectEntityDescription, ElectricKiwiHOPSelectDescriptionMixin
-):
-    """Class to describe an Electric Kiwi select entity."""
-
-
-HOP_SELECT_TYPE: Final[tuple[ElectricKiwiHOPSelectDescription, ...]] = (
-    ElectricKiwiHOPSelectDescription(
-        entity_category=EntityCategory.CONFIG,
-        key=ATTR_EK_HOP_SELECT,
-        translation_key="hopselector",
-        options_dict=None,
-    ),
+HOP_SELECT = SelectEntityDescription(
+    entity_category=EntityCategory.CONFIG,
+    key=ATTR_EK_HOP_SELECT,
+    translation_key="hopselector",
 )
 
 
@@ -47,15 +27,10 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Electric Kiwi select setup."""
-    hop_coordinator: ElectricKiwiHOPDataCoordinator = hass.data[DOMAIN][entry.entry_id][
-        "hop_coordinator"
-    ]
+    hop_coordinator: ElectricKiwiHOPDataCoordinator = hass.data[DOMAIN][entry.entry_id]
 
     _LOGGER.debug("Setting up HOP entity")
-    entities = [
-        ElectricKiwiSelectHOPEntity(hop_coordinator, description)
-        for description in HOP_SELECT_TYPE
-    ]
+    entities = [ElectricKiwiSelectHOPEntity(hop_coordinator, HOP_SELECT)]
     async_add_entities(entities)
 
 
@@ -64,7 +39,7 @@ class ElectricKiwiSelectHOPEntity(
 ):
     """Entity object for seeing and setting the hour of free power."""
 
-    entity_description: ElectricKiwiHOPSelectDescription
+    entity_description: SelectEntityDescription
     _attr_has_entity_name = True
     _attr_attribution = ATTRIBUTION
     values_dict: dict[str, int]
@@ -72,7 +47,7 @@ class ElectricKiwiSelectHOPEntity(
     def __init__(
         self,
         hop_coordinator: ElectricKiwiHOPDataCoordinator,
-        description: ElectricKiwiHOPSelectDescription,
+        description: SelectEntityDescription,
     ) -> None:
         """Initialise the HOP selection entity."""
         super().__init__(hop_coordinator)

--- a/homeassistant/components/electric_kiwi/strings.json
+++ b/homeassistant/components/electric_kiwi/strings.json
@@ -31,6 +31,11 @@
       "hopfreepowerend": {
         "name": "Hour of free power end"
       }
+    },
+    "select": {
+      "hopselector": {
+        "name": "Hour of free power"
+      }
     }
   }
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add select entity for choosing hour of free power, this allows users to select their hour of free power from home assistant instead of their app and or create automations around it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/28426

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
