### PR TITLE
Fix xiaomi_ble not remembering a device is a sleepy device

### DIFF
--- a/homeassistant/components/xiaomi_ble/__init__.py
+++ b/homeassistant/components/xiaomi_ble/__init__.py
@@ -19,6 +19,7 @@ from homeassistant.helpers.device_registry import DeviceRegistry, async_get
 
 from .const import (
     CONF_DISCOVERED_EVENT_CLASSES,
+    CONF_SLEEPY_DEVICE,
     DOMAIN,
     XIAOMI_BLE_EVENT,
     XiaomiBleEvent,
@@ -43,6 +44,11 @@ def process_service_info(
         entry.entry_id
     ]
     discovered_device_classes = coordinator.discovered_device_classes
+    if entry.data.get(CONF_SLEEPY_DEVICE, False) != data.sleepy_device:
+        hass.config_entries.async_update_entry(
+            entry,
+            data=entry.data | {CONF_SLEEPY_DEVICE: data.sleepy_device},
+        )
     if update.events:
         address = service_info.device.address
         for device_key, event in update.events.items():
@@ -157,6 +163,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # since we will trade the BLEDevice for a connectable one
         # if we need to poll it
         connectable=False,
+        entry=entry,
     )
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(

--- a/homeassistant/components/xiaomi_ble/binary_sensor.py
+++ b/homeassistant/components/xiaomi_ble/binary_sensor.py
@@ -136,7 +136,4 @@ class XiaomiBluetoothSensorEntity(
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
-        coordinator: XiaomiActiveBluetoothProcessorCoordinator = (
-            self.processor.coordinator
-        )
-        return coordinator.device_data.sleepy_device or super().available
+        return self.processor.coordinator.sleepy_device or super().available

--- a/homeassistant/components/xiaomi_ble/const.py
+++ b/homeassistant/components/xiaomi_ble/const.py
@@ -7,6 +7,7 @@ DOMAIN = "xiaomi_ble"
 
 
 CONF_DISCOVERED_EVENT_CLASSES: Final = "known_events"
+CONF_SLEEPY_DEVICE: Final = "sleepy_device"
 CONF_EVENT_PROPERTIES: Final = "event_properties"
 EVENT_PROPERTIES: Final = "event_properties"
 EVENT_TYPE: Final = "event_type"

--- a/homeassistant/components/xiaomi_ble/coordinator.py
+++ b/homeassistant/components/xiaomi_ble/coordinator.py
@@ -15,8 +15,11 @@ from homeassistant.components.bluetooth.active_update_processor import (
 from homeassistant.components.bluetooth.passive_update_processor import (
     PassiveBluetoothDataProcessor,
 )
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.debounce import Debouncer
+
+from .const import CONF_SLEEPY_DEVICE
 
 
 class XiaomiActiveBluetoothProcessorCoordinator(ActiveBluetoothProcessorCoordinator):
@@ -39,6 +42,7 @@ class XiaomiActiveBluetoothProcessorCoordinator(ActiveBluetoothProcessorCoordina
         ]
         | None = None,
         poll_debouncer: Debouncer[Coroutine[Any, Any, None]] | None = None,
+        entry: ConfigEntry,
         connectable: bool = True,
     ) -> None:
         """Initialize the Xiaomi Bluetooth Active Update Processor Coordinator."""
@@ -55,6 +59,12 @@ class XiaomiActiveBluetoothProcessorCoordinator(ActiveBluetoothProcessorCoordina
         )
         self.discovered_device_classes = discovered_device_classes
         self.device_data = device_data
+        self.entry = entry
+
+    @property
+    def sleepy_device(self) -> bool:
+        """Return True if the device is a sleepy device."""
+        return self.entry.data.get(CONF_SLEEPY_DEVICE, self.device_data.sleepy_device)
 
 
 class XiaomiPassiveBluetoothDataProcessor(PassiveBluetoothDataProcessor):

--- a/homeassistant/components/xiaomi_ble/sensor.py
+++ b/homeassistant/components/xiaomi_ble/sensor.py
@@ -200,7 +200,4 @@ class XiaomiBluetoothSensorEntity(
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
-        coordinator: XiaomiActiveBluetoothProcessorCoordinator = (
-            self.processor.coordinator
-        )
-        return coordinator.device_data.sleepy_device or super().available
+        return self.processor.coordinator.sleepy_device or super().available

--- a/tests/components/xiaomi_ble/test_binary_sensor.py
+++ b/tests/components/xiaomi_ble/test_binary_sensor.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 from homeassistant.components.bluetooth import (
     FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS,
 )
-from homeassistant.components.xiaomi_ble.const import DOMAIN
+from homeassistant.components.xiaomi_ble.const import CONF_SLEEPY_DEVICE, DOMAIN
 from homeassistant.const import (
     ATTR_FRIENDLY_NAME,
     STATE_OFF,
@@ -313,6 +313,8 @@ async def test_unavailable(hass: HomeAssistant) -> None:
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
 
+    assert CONF_SLEEPY_DEVICE not in entry.data
+
 
 async def test_sleepy_device(hass: HomeAssistant) -> None:
     """Test sleepy device does not go to unavailable after 60 minutes."""
@@ -363,3 +365,5 @@ async def test_sleepy_device(hass: HomeAssistant) -> None:
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
+
+    assert entry.data[CONF_SLEEPY_DEVICE] is True


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
We did not store if the device was sleepy which meant as soon as HA was restarted, the integration would forget that the device was sleepy.

This is not very useful yet, but will be once https://github.com/home-assistant/core/pull/97462 is done

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
