### PR TITLE
Load homekit_controller test data using its json loader

### DIFF
--- a/tests/components/homekit_controller/common.py
+++ b/tests/components/homekit_controller/common.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import timedelta
-import json
 import logging
 import os
 from typing import Any, Final
 from unittest import mock
 
+from aiohomekit.hkjson import loads as hkloads
 from aiohomekit.model import (
     Accessories,
     AccessoriesState,
@@ -185,7 +185,7 @@ async def setup_accessories_from_file(hass, path):
     accessories_fixture = await hass.async_add_executor_job(
         load_fixture, os.path.join("homekit_controller", path)
     )
-    accessories_json = json.loads(accessories_fixture)
+    accessories_json = hkloads(accessories_fixture)
     accessories = Accessories.from_list(accessories_json)
     return accessories
 

--- a/tests/components/homekit_controller/specific_devices/test_connectsense.py
+++ b/tests/components/homekit_controller/specific_devices/test_connectsense.py
@@ -20,7 +20,86 @@ from ..common import (
 async def test_connectsense_setup(hass: HomeAssistant) -> None:
     """Test that the accessory can be correctly setup in HA."""
     accessories = await setup_accessories_from_file(hass, "connectsense.json")
-    await setup_test_accessories(hass, accessories)
+    config_entry, pairing = await setup_test_accessories(hass, accessories)
+
+    await assert_devices_and_entities_created(
+        hass,
+        DeviceTestInfo(
+            unique_id=HUB_TEST_ACCESSORY_ID,
+            name="InWall Outlet-0394DE",
+            model="CS-IWO",
+            manufacturer="ConnectSense",
+            sw_version="1.0.0",
+            hw_version="",
+            serial_number="1020301376",
+            devices=[],
+            entities=[
+                EntityTestInfo(
+                    entity_id="sensor.inwall_outlet_0394de_current",
+                    friendly_name="InWall Outlet-0394DE Current",
+                    unique_id="00:00:00:00:00:00_1_13_18",
+                    capabilities={"state_class": SensorStateClass.MEASUREMENT},
+                    unit_of_measurement=ELECTRIC_CURRENT_AMPERE,
+                    state="0.03",
+                ),
+                EntityTestInfo(
+                    entity_id="sensor.inwall_outlet_0394de_power",
+                    friendly_name="InWall Outlet-0394DE Power",
+                    unique_id="00:00:00:00:00:00_1_13_19",
+                    capabilities={"state_class": SensorStateClass.MEASUREMENT},
+                    unit_of_measurement=POWER_WATT,
+                    state="0.8",
+                ),
+                EntityTestInfo(
+                    entity_id="sensor.inwall_outlet_0394de_energy_kwh",
+                    friendly_name="InWall Outlet-0394DE Energy kWh",
+                    unique_id="00:00:00:00:00:00_1_13_20",
+                    capabilities={"state_class": SensorStateClass.MEASUREMENT},
+                    unit_of_measurement=ENERGY_KILO_WATT_HOUR,
+                    state="379.69299",
+                ),
+                EntityTestInfo(
+                    entity_id="switch.inwall_outlet_0394de_outlet_a",
+                    friendly_name="InWall Outlet-0394DE Outlet A",
+                    unique_id="00:00:00:00:00:00_1_13",
+                    state="on",
+                ),
+                EntityTestInfo(
+                    entity_id="sensor.inwall_outlet_0394de_current_2",
+                    friendly_name="InWall Outlet-0394DE Current",
+                    unique_id="00:00:00:00:00:00_1_25_30",
+                    capabilities={"state_class": SensorStateClass.MEASUREMENT},
+                    unit_of_measurement=ELECTRIC_CURRENT_AMPERE,
+                    state="0.05",
+                ),
+                EntityTestInfo(
+                    entity_id="sensor.inwall_outlet_0394de_power_2",
+                    friendly_name="InWall Outlet-0394DE Power",
+                    unique_id="00:00:00:00:00:00_1_25_31",
+                    capabilities={"state_class": SensorStateClass.MEASUREMENT},
+                    unit_of_measurement=POWER_WATT,
+                    state="0.8",
+                ),
+                EntityTestInfo(
+                    entity_id="sensor.inwall_outlet_0394de_energy_kwh_2",
+                    friendly_name="InWall Outlet-0394DE Energy kWh",
+                    unique_id="00:00:00:00:00:00_1_25_32",
+                    capabilities={"state_class": SensorStateClass.MEASUREMENT},
+                    unit_of_measurement=ENERGY_KILO_WATT_HOUR,
+                    state="175.85001",
+                ),
+                EntityTestInfo(
+                    entity_id="switch.inwall_outlet_0394de_outlet_b",
+                    friendly_name="InWall Outlet-0394DE Outlet B",
+                    unique_id="00:00:00:00:00:00_1_25",
+                    state="on",
+                ),
+            ],
+        ),
+    )
+
+    await hass.config_entries.async_reload(config_entry.entry_id)
+    await hass.async_block_till_done()
 
     await assert_devices_and_entities_created(
         hass,


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Since HomeKit devices send lots of junk data and we have a special json loader to handle the bad data since we can do nothing about it. In #97502 we will switch the test mocking to use what we actually do in production to load json data, but since the homekit controller fixtures are being loaded with that loader it will fail. We need to load them with the homekit controller loader since its simulating data from a test device

replaces and closes #97507

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
