### PR TITLE
Fix RootFolder not iterable in Radarr

### DIFF
--- a/homeassistant/components/radarr/coordinator.py
+++ b/homeassistant/components/radarr/coordinator.py
@@ -92,5 +92,5 @@ class MoviesDataUpdateCoordinator(RadarrDataUpdateCoordinator[int]):
         """Fetch the movies data."""
         movies = await self.api_client.async_get_movies()
         if isinstance(movies, RadarrMovie):
-            movies = [movies]
+            return 1
         return len(movies)

--- a/homeassistant/components/radarr/coordinator.py
+++ b/homeassistant/components/radarr/coordinator.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from datetime import timedelta
-from typing import Generic, TypeVar, cast
+from typing import Generic, TypeVar
 
 from aiopyarr import Health, RadarrMovie, RootFolder, SystemStatus, exceptions
 from aiopyarr.models.host_configuration import PyArrHostConfiguration
@@ -71,7 +71,10 @@ class DiskSpaceDataUpdateCoordinator(RadarrDataUpdateCoordinator[list[RootFolder
 
     async def _fetch_data(self) -> list[RootFolder]:
         """Fetch the data."""
-        return cast(list[RootFolder], await self.api_client.async_get_root_folders())
+        root_folders = await self.api_client.async_get_root_folders()
+        if isinstance(root_folders, RootFolder):
+            root_folders = [root_folders]
+        return root_folders
 
 
 class HealthDataUpdateCoordinator(RadarrDataUpdateCoordinator[list[Health]]):
@@ -87,4 +90,7 @@ class MoviesDataUpdateCoordinator(RadarrDataUpdateCoordinator[int]):
 
     async def _fetch_data(self) -> int:
         """Fetch the movies data."""
-        return len(cast(list[RadarrMovie], await self.api_client.async_get_movies()))
+        movies = await self.api_client.async_get_movies()
+        if isinstance(movies, RadarrMovie):
+            movies = [movies]
+        return len(movies)

--- a/tests/components/radarr/__init__.py
+++ b/tests/components/radarr/__init__.py
@@ -41,6 +41,7 @@ def mock_connection(
     error: bool = False,
     invalid_auth: bool = False,
     windows: bool = False,
+    single_return: bool = False,
 ) -> None:
     """Mock radarr connection."""
     if error:
@@ -75,22 +76,27 @@ def mock_connection(
         headers={"Content-Type": CONTENT_TYPE_JSON},
     )
 
+    root_folder_fixture = "rootfolder-linux"
+
     if windows:
-        aioclient_mock.get(
-            f"{url}/api/v3/rootfolder",
-            text=load_fixture("radarr/rootfolder-windows.json"),
-            headers={"Content-Type": CONTENT_TYPE_JSON},
-        )
-    else:
-        aioclient_mock.get(
-            f"{url}/api/v3/rootfolder",
-            text=load_fixture("radarr/rootfolder-linux.json"),
-            headers={"Content-Type": CONTENT_TYPE_JSON},
-        )
+        root_folder_fixture = "rootfolder-windows"
+
+    if single_return:
+        root_folder_fixture = f"single-{root_folder_fixture}"
+
+    aioclient_mock.get(
+        f"{url}/api/v3/rootfolder",
+        text=load_fixture(f"radarr/{root_folder_fixture}.json"),
+        headers={"Content-Type": CONTENT_TYPE_JSON},
+    )
+
+    movie_fixture = "movie"
+    if single_return:
+        movie_fixture = f"single-{movie_fixture}"
 
     aioclient_mock.get(
         f"{url}/api/v3/movie",
-        text=load_fixture("radarr/movie.json"),
+        text=load_fixture(f"radarr/{movie_fixture}.json"),
         headers={"Content-Type": CONTENT_TYPE_JSON},
     )
 
@@ -139,6 +145,7 @@ async def setup_integration(
     connection_error: bool = False,
     invalid_auth: bool = False,
     windows: bool = False,
+    single_return: bool = False,
 ) -> MockConfigEntry:
     """Set up the radarr integration in Home Assistant."""
     entry = MockConfigEntry(
@@ -159,6 +166,7 @@ async def setup_integration(
         error=connection_error,
         invalid_auth=invalid_auth,
         windows=windows,
+        single_return=single_return,
     )
 
     if not skip_entry_setup:
@@ -183,7 +191,7 @@ def patch_radarr():
 
 
 def create_entry(hass: HomeAssistant) -> MockConfigEntry:
-    """Create Efergy entry in Home Assistant."""
+    """Create Radarr entry in Home Assistant."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={

--- a/tests/components/radarr/fixtures/single-movie.json
+++ b/tests/components/radarr/fixtures/single-movie.json
@@ -1,0 +1,118 @@
+[
+  {
+    "id": 0,
+    "title": "string",
+    "originalTitle": "string",
+    "alternateTitles": [
+      {
+        "sourceType": "tmdb",
+        "movieId": 1,
+        "title": "string",
+        "sourceId": 0,
+        "votes": 0,
+        "voteCount": 0,
+        "language": {
+          "id": 1,
+          "name": "English"
+        },
+        "id": 1
+      }
+    ],
+    "sortTitle": "string",
+    "sizeOnDisk": 0,
+    "overview": "string",
+    "inCinemas": "2020-11-06T00:00:00Z",
+    "physicalRelease": "2019-03-19T00:00:00Z",
+    "images": [
+      {
+        "coverType": "poster",
+        "url": "string",
+        "remoteUrl": "string"
+      }
+    ],
+    "website": "string",
+    "year": 0,
+    "hasFile": true,
+    "youTubeTrailerId": "string",
+    "studio": "string",
+    "path": "string",
+    "rootFolderPath": "string",
+    "qualityProfileId": 0,
+    "monitored": true,
+    "minimumAvailability": "announced",
+    "isAvailable": true,
+    "folderName": "string",
+    "runtime": 0,
+    "cleanTitle": "string",
+    "imdbId": "string",
+    "tmdbId": 0,
+    "titleSlug": "string",
+    "certification": "string",
+    "genres": ["string"],
+    "tags": [0],
+    "added": "2018-12-28T05:56:49Z",
+    "ratings": {
+      "votes": 0,
+      "value": 0
+    },
+    "movieFile": {
+      "movieId": 0,
+      "relativePath": "string",
+      "path": "string",
+      "size": 916662234,
+      "dateAdded": "2020-11-26T02:00:35Z",
+      "indexerFlags": 1,
+      "quality": {
+        "quality": {
+          "id": 14,
+          "name": "WEBRip-720p",
+          "source": "webrip",
+          "resolution": 720,
+          "modifier": "none"
+        },
+        "revision": {
+          "version": 1,
+          "real": 0,
+          "isRepack": false
+        }
+      },
+      "mediaInfo": {
+        "audioBitrate": 0,
+        "audioChannels": 2,
+        "audioCodec": "AAC",
+        "audioLanguages": "",
+        "audioStreamCount": 1,
+        "videoBitDepth": 8,
+        "videoBitrate": 1000000,
+        "videoCodec": "x264",
+        "videoFps": 25.0,
+        "resolution": "1280x534",
+        "runTime": "1:49:06",
+        "scanType": "Progressive",
+        "subtitles": ""
+      },
+      "originalFilePath": "string",
+      "qualityCutoffNotMet": true,
+      "languages": [
+        {
+          "id": 26,
+          "name": "Hindi"
+        }
+      ],
+      "edition": "",
+      "id": 35361
+    },
+    "collection": {
+      "name": "string",
+      "tmdbId": 0,
+      "images": [
+        {
+          "coverType": "poster",
+          "url": "string",
+          "remoteUrl": "string"
+        }
+      ]
+    },
+    "status": "deleted"
+  }
+]

--- a/tests/components/radarr/fixtures/single-movie.json
+++ b/tests/components/radarr/fixtures/single-movie.json
@@ -1,118 +1,116 @@
-[
-  {
-    "id": 0,
-    "title": "string",
-    "originalTitle": "string",
-    "alternateTitles": [
+{
+  "id": 0,
+  "title": "string",
+  "originalTitle": "string",
+  "alternateTitles": [
+    {
+      "sourceType": "tmdb",
+      "movieId": 1,
+      "title": "string",
+      "sourceId": 0,
+      "votes": 0,
+      "voteCount": 0,
+      "language": {
+        "id": 1,
+        "name": "English"
+      },
+      "id": 1
+    }
+  ],
+  "sortTitle": "string",
+  "sizeOnDisk": 0,
+  "overview": "string",
+  "inCinemas": "2020-11-06T00:00:00Z",
+  "physicalRelease": "2019-03-19T00:00:00Z",
+  "images": [
+    {
+      "coverType": "poster",
+      "url": "string",
+      "remoteUrl": "string"
+    }
+  ],
+  "website": "string",
+  "year": 0,
+  "hasFile": true,
+  "youTubeTrailerId": "string",
+  "studio": "string",
+  "path": "string",
+  "rootFolderPath": "string",
+  "qualityProfileId": 0,
+  "monitored": true,
+  "minimumAvailability": "announced",
+  "isAvailable": true,
+  "folderName": "string",
+  "runtime": 0,
+  "cleanTitle": "string",
+  "imdbId": "string",
+  "tmdbId": 0,
+  "titleSlug": "string",
+  "certification": "string",
+  "genres": ["string"],
+  "tags": [0],
+  "added": "2018-12-28T05:56:49Z",
+  "ratings": {
+    "votes": 0,
+    "value": 0
+  },
+  "movieFile": {
+    "movieId": 0,
+    "relativePath": "string",
+    "path": "string",
+    "size": 916662234,
+    "dateAdded": "2020-11-26T02:00:35Z",
+    "indexerFlags": 1,
+    "quality": {
+      "quality": {
+        "id": 14,
+        "name": "WEBRip-720p",
+        "source": "webrip",
+        "resolution": 720,
+        "modifier": "none"
+      },
+      "revision": {
+        "version": 1,
+        "real": 0,
+        "isRepack": false
+      }
+    },
+    "mediaInfo": {
+      "audioBitrate": 0,
+      "audioChannels": 2,
+      "audioCodec": "AAC",
+      "audioLanguages": "",
+      "audioStreamCount": 1,
+      "videoBitDepth": 8,
+      "videoBitrate": 1000000,
+      "videoCodec": "x264",
+      "videoFps": 25.0,
+      "resolution": "1280x534",
+      "runTime": "1:49:06",
+      "scanType": "Progressive",
+      "subtitles": ""
+    },
+    "originalFilePath": "string",
+    "qualityCutoffNotMet": true,
+    "languages": [
       {
-        "sourceType": "tmdb",
-        "movieId": 1,
-        "title": "string",
-        "sourceId": 0,
-        "votes": 0,
-        "voteCount": 0,
-        "language": {
-          "id": 1,
-          "name": "English"
-        },
-        "id": 1
+        "id": 26,
+        "name": "Hindi"
       }
     ],
-    "sortTitle": "string",
-    "sizeOnDisk": 0,
-    "overview": "string",
-    "inCinemas": "2020-11-06T00:00:00Z",
-    "physicalRelease": "2019-03-19T00:00:00Z",
+    "edition": "",
+    "id": 35361
+  },
+  "collection": {
+    "name": "string",
+    "tmdbId": 0,
     "images": [
       {
         "coverType": "poster",
         "url": "string",
         "remoteUrl": "string"
       }
-    ],
-    "website": "string",
-    "year": 0,
-    "hasFile": true,
-    "youTubeTrailerId": "string",
-    "studio": "string",
-    "path": "string",
-    "rootFolderPath": "string",
-    "qualityProfileId": 0,
-    "monitored": true,
-    "minimumAvailability": "announced",
-    "isAvailable": true,
-    "folderName": "string",
-    "runtime": 0,
-    "cleanTitle": "string",
-    "imdbId": "string",
-    "tmdbId": 0,
-    "titleSlug": "string",
-    "certification": "string",
-    "genres": ["string"],
-    "tags": [0],
-    "added": "2018-12-28T05:56:49Z",
-    "ratings": {
-      "votes": 0,
-      "value": 0
-    },
-    "movieFile": {
-      "movieId": 0,
-      "relativePath": "string",
-      "path": "string",
-      "size": 916662234,
-      "dateAdded": "2020-11-26T02:00:35Z",
-      "indexerFlags": 1,
-      "quality": {
-        "quality": {
-          "id": 14,
-          "name": "WEBRip-720p",
-          "source": "webrip",
-          "resolution": 720,
-          "modifier": "none"
-        },
-        "revision": {
-          "version": 1,
-          "real": 0,
-          "isRepack": false
-        }
-      },
-      "mediaInfo": {
-        "audioBitrate": 0,
-        "audioChannels": 2,
-        "audioCodec": "AAC",
-        "audioLanguages": "",
-        "audioStreamCount": 1,
-        "videoBitDepth": 8,
-        "videoBitrate": 1000000,
-        "videoCodec": "x264",
-        "videoFps": 25.0,
-        "resolution": "1280x534",
-        "runTime": "1:49:06",
-        "scanType": "Progressive",
-        "subtitles": ""
-      },
-      "originalFilePath": "string",
-      "qualityCutoffNotMet": true,
-      "languages": [
-        {
-          "id": 26,
-          "name": "Hindi"
-        }
-      ],
-      "edition": "",
-      "id": 35361
-    },
-    "collection": {
-      "name": "string",
-      "tmdbId": 0,
-      "images": [
-        {
-          "coverType": "poster",
-          "url": "string",
-          "remoteUrl": "string"
-        }
-      ]
-    },
-    "status": "deleted"
-  }
-]
+    ]
+  },
+  "status": "deleted"
+}

--- a/tests/components/radarr/fixtures/single-rootfolder-linux.json
+++ b/tests/components/radarr/fixtures/single-rootfolder-linux.json
@@ -1,0 +1,6 @@
+{
+  "path": "/downloads",
+  "freeSpace": 282500064232,
+  "unmappedFolders": [],
+  "id": 1
+}

--- a/tests/components/radarr/fixtures/single-rootfolder-windows.json
+++ b/tests/components/radarr/fixtures/single-rootfolder-windows.json
@@ -1,0 +1,6 @@
+{
+  "path": "D:\\Downloads\\TV",
+  "freeSpace": 282500064232,
+  "unmappedFolders": [],
+  "id": 1
+}

--- a/tests/components/radarr/test_sensor.py
+++ b/tests/components/radarr/test_sensor.py
@@ -1,4 +1,5 @@
 """The tests for Radarr sensor platform."""
+import pytest
 
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.const import ATTR_DEVICE_CLASS, ATTR_UNIT_OF_MEASUREMENT
@@ -9,15 +10,43 @@ from . import setup_integration
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 
+@pytest.mark.parametrize(
+    ("windows", "single", "root_folder"),
+    [
+        (
+            False,
+            False,
+            "downloads",
+        ),
+        (
+            False,
+            True,
+            "downloads",
+        ),
+        (
+            True,
+            False,
+            "tv",
+        ),
+        (
+            True,
+            True,
+            "tv",
+        ),
+    ],
+)
 async def test_sensors(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
     entity_registry_enabled_by_default: None,
+    windows: bool,
+    single: bool,
+    root_folder: str,
 ) -> None:
     """Test for successfully setting up the Radarr platform."""
-    await setup_integration(hass, aioclient_mock)
+    await setup_integration(hass, aioclient_mock, windows=windows, single_return=single)
 
-    state = hass.states.get("sensor.mock_title_disk_space_downloads")
+    state = hass.states.get(f"sensor.mock_title_disk_space_{root_folder}")
     assert state.state == "263.10"
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == "GB"
     state = hass.states.get("sensor.mock_title_movies")
@@ -26,13 +55,3 @@ async def test_sensors(
     state = hass.states.get("sensor.mock_title_start_time")
     assert state.state == "2020-09-01T23:50:20+00:00"
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.TIMESTAMP
-
-
-async def test_windows(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
-) -> None:
-    """Test for successfully setting up the Radarr platform on Windows."""
-    await setup_integration(hass, aioclient_mock, windows=True)
-
-    state = hass.states.get("sensor.mock_title_disk_space_tv")
-    assert state.state == "263.10"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Regularly, Radarr logs the following in my logs (also at a friend):
```
2023-07-16 17:35:38.421 ERROR (MainThread) [homeassistant.components.sensor] Error while setting up radarr platform for sensor
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 353, in _async_setup_platform
    await asyncio.shield(task)
  File "/usr/src/homeassistant/homeassistant/components/radarr/sensor.py", line 120, in async_setup_entry
    entities.extend(
                   ^
TypeError: 'RootFolder' object is not iterable
```
Apparently, aiopyarr can return both a list of RootFolders, or a RootFolder. Currently it uses cast to make it a list, but it doesn't do it well, otherwise we wouldn't get this error.

This change will create a list from the RootFolder if it's a single object

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
