### PR TITLE
Fix ZHA `turn_on` issues with `transition=0`, improve tests

### DIFF
--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -329,7 +329,7 @@ class BaseLight(LogMixin, light.LightEntity):
                 return
 
         if (
-            (brightness is not None or transition)
+            (brightness is not None or transition is not None)
             and not new_color_provided_while_off
             and brightness_supported(self._attr_supported_color_modes)
         ):

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -350,9 +350,9 @@ class BaseLight(LogMixin, light.LightEntity):
                 self._attr_brightness = level
 
         if (
-            brightness is None
+            (brightness is None and transition is None)
             and not new_color_provided_while_off
-            or (self._FORCE_ON and brightness)
+            or (self._FORCE_ON and brightness != 0)
         ):
             # since some lights don't always turn on with move_to_level_with_on_off,
             # we should call the on command on the on_off cluster

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -354,7 +354,7 @@ class BaseLight(LogMixin, light.LightEntity):
             and not new_color_provided_while_off
             or (self._FORCE_ON and brightness != 0)
         ):
-            # since some lights don't always turn on with move_to_level_with_on_off,
+            # since FORCE_ON lights don't turn on with move_to_level_with_on_off,
             # we should call the on command on the on_off cluster
             # if brightness is not 0.
             result = await self._on_off_cluster_handler.on()
@@ -385,7 +385,7 @@ class BaseLight(LogMixin, light.LightEntity):
                 return
 
         if new_color_provided_while_off:
-            # The light is has the correct color, so we can now transition
+            # The light has the correct color, so we can now transition
             # it to the correct brightness level.
             result = await self._level_cluster_handler.move_to_level(
                 level=level, transition_time=int(10 * duration)
@@ -1076,7 +1076,7 @@ class HueLight(Light):
     manufacturers={"Jasco", "Quotra-Vision", "eWeLight", "eWeLink"},
 )
 class ForceOnLight(Light):
-    """Representation of a light which does not respect move_to_level_with_on_off."""
+    """Representation of a light which does not respect on/off for move_to_level_with_on_off commands."""
 
     _attr_name: str = "Light"
     _FORCE_ON = True

--- a/tests/components/zha/test_light.py
+++ b/tests/components/zha/test_light.py
@@ -539,8 +539,8 @@ async def test_transitions(
         {"entity_id": device_1_entity_id, "transition": 0},
         blocking=True,
     )
-    assert dev1_cluster_on_off.request.call_count == 1
-    assert dev1_cluster_on_off.request.await_count == 1
+    assert dev1_cluster_on_off.request.call_count == 0
+    assert dev1_cluster_on_off.request.await_count == 0
     assert dev1_cluster_color.request.call_count == 0
     assert dev1_cluster_color.request.await_count == 0
     assert dev1_cluster_level.request.call_count == 1
@@ -1494,18 +1494,10 @@ async def async_test_level_on_off_from_hass(
         {"entity_id": entity_id, "transition": 10},
         blocking=True,
     )
-    assert on_off_cluster.request.call_count == 1
-    assert on_off_cluster.request.await_count == 1
+    assert on_off_cluster.request.call_count == 0
+    assert on_off_cluster.request.await_count == 0
     assert level_cluster.request.call_count == 1
     assert level_cluster.request.await_count == 1
-    assert on_off_cluster.request.call_args == call(
-        False,
-        on_off_cluster.commands_by_name["on"].id,
-        on_off_cluster.commands_by_name["on"].schema,
-        expect_reply=True,
-        manufacturer=None,
-        tsn=None,
-    )
     assert level_cluster.request.call_args == call(
         False,
         level_cluster.commands_by_name["move_to_level_with_on_off"].id,

--- a/tests/components/zha/test_light.py
+++ b/tests/components/zha/test_light.py
@@ -530,7 +530,37 @@ async def test_transitions(
     light2_state = hass.states.get(device_2_entity_id)
     assert light2_state.state == STATE_OFF
 
-    # first test 0 length transition with no color provided
+    # first test 0 length transition with no color and no brightness provided
+    dev1_cluster_on_off.request.reset_mock()
+    dev1_cluster_level.request.reset_mock()
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        "turn_on",
+        {"entity_id": device_1_entity_id, "transition": 0},
+        blocking=True,
+    )
+    assert dev1_cluster_on_off.request.call_count == 1
+    assert dev1_cluster_on_off.request.await_count == 1
+    assert dev1_cluster_color.request.call_count == 0
+    assert dev1_cluster_color.request.await_count == 0
+    assert dev1_cluster_level.request.call_count == 1
+    assert dev1_cluster_level.request.await_count == 1
+    assert dev1_cluster_level.request.call_args == call(
+        False,
+        dev1_cluster_level.commands_by_name["move_to_level_with_on_off"].id,
+        dev1_cluster_level.commands_by_name["move_to_level_with_on_off"].schema,
+        level=254,  # default "full on" brightness
+        transition_time=0,
+        expect_reply=True,
+        manufacturer=None,
+        tsn=None,
+    )
+
+    light1_state = hass.states.get(device_1_entity_id)
+    assert light1_state.state == STATE_ON
+    assert light1_state.attributes["brightness"] == 254
+
+    # test 0 length transition with brightness, but no color provided
     dev1_cluster_on_off.request.reset_mock()
     dev1_cluster_level.request.reset_mock()
     await hass.services.async_call(


### PR DESCRIPTION
## Proposed change

This PR fixes multiple small issues with the `light.turn_on` service for ZHA lights:
- fixes `light.turn_on` for ZHA lights ignoring `transition=0` when no brightness is given at the same time + add test case: https://github.com/home-assistant/core/pull/97539/commits/0437c55281949d94a8274b3c2233ccd0bdd2eb21
- add test that checks that "force on" lights also get an "on" command (in addition to the "move to level" command) when `turn_on` is called with only `transition=0`: https://github.com/home-assistant/core/pull/97539/commits/21be318dfd60dd073a2cb9a989e0c1bc2b6dc8ce
- fix unnecessary "on" command sent in addition to "move_to_level_with_on_off" for `transition=0` calls + adjust test cases to not expect unnecessary "on" command in those cases: https://github.com/home-assistant/core/pull/97539/commits/0c73dc1467b274b20dfa9c146067ec7a5533dde0
- improve comments: https://github.com/home-assistant/core/pull/97539/commits/93acd6f82c5dd4794276dd86238cdc905d31ea77

Note: The commits are split up and have added comments to easier see why the changes are needed.

(This also fixes #93265)

~~I'll also do some more extensive testing to verify this all works as expected, before marking this PR as "ready".~~
I've not noticed any unwanted behavior so far though.
EDIT: Didn't notice any issues.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #93265
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.


To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
