### PR TITLE
Add neato dismiss alert button

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -772,6 +772,7 @@ omit =
     homeassistant/components/neato/sensor.py
     homeassistant/components/neato/switch.py
     homeassistant/components/neato/vacuum.py
+    homeassistant/components/neato/button.py
     homeassistant/components/nederlandse_spoorwegen/sensor.py
     homeassistant/components/netdata/sensor.py
     homeassistant/components/netgear/__init__.py

--- a/homeassistant/components/neato/__init__.py
+++ b/homeassistant/components/neato/__init__.py
@@ -40,7 +40,13 @@ CONFIG_SCHEMA = vol.Schema(
     extra=vol.ALLOW_EXTRA,
 )
 
-PLATFORMS = [Platform.CAMERA, Platform.VACUUM, Platform.SWITCH, Platform.SENSOR]
+PLATFORMS = [
+    Platform.CAMERA,
+    Platform.VACUUM,
+    Platform.SWITCH,
+    Platform.SENSOR,
+    Platform.BUTTON,
+]
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:

--- a/homeassistant/components/neato/button.py
+++ b/homeassistant/components/neato/button.py
@@ -17,10 +17,7 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up Neato button from config entry."""
-    entities = [
-        NeatoDismissAlertButton(robot)
-        for robot in hass.data[NEATO_ROBOTS]
-    ]
+    entities = [NeatoDismissAlertButton(robot) for robot in hass.data[NEATO_ROBOTS]]
 
     async_add_entities(entities, True)
 
@@ -38,9 +35,7 @@ class NeatoDismissAlertButton(ButtonEntity):
         self.robot = robot
         self._attr_name = f"{robot.name} Dismiss Alert"
         self._attr_unique_id = f"{robot.serial}_dismiss_alert"
-        self._attr_device_info = DeviceInfo(
-            identifiers={(NEATO_DOMAIN, robot.serial)}
-        )
+        self._attr_device_info = DeviceInfo(identifiers={(NEATO_DOMAIN, robot.serial)})
 
     async def async_press(self) -> None:
         """Press the button."""

--- a/homeassistant/components/neato/button.py
+++ b/homeassistant/components/neato/button.py
@@ -1,0 +1,70 @@
+"""Support for Neato buttons."""
+from __future__ import annotations
+
+import logging
+
+from pybotvac import Robot
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import NEATO_DOMAIN, NEATO_ROBOTS
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up Neato button from config entry."""
+    dev = []
+
+    for robot in hass.data[NEATO_ROBOTS]:
+        dev.append(NeatoDismissAlertButton(robot))
+
+    if not dev:
+        return
+
+    _LOGGER.debug("Adding vacuum buttons %s", dev)
+    async_add_entities(dev, True)
+
+
+class NeatoDismissAlertButton(ButtonEntity):
+    """Representation of a dismiss_alert button entity."""
+
+    def __init__(
+        self,
+        robot: Robot,
+    ) -> None:
+        """Initialize a dismiss_alert Neato button entity."""
+        self.robot = robot
+        self._button_name = f"{self.robot.name} Dismiss Alert"
+        self._robot_serial: str = self.robot.serial
+
+    async def async_press(self) -> None:
+        """Press the button."""
+        await self.hass.async_add_executor_job(self.robot.dismiss_current_alert)
+
+    @property
+    def name(self) -> str:
+        """Return the name of this camera."""
+        return self._button_name
+
+    @property
+    def unique_id(self) -> str:
+        """Return unique ID."""
+        return self._robot_serial
+
+    @property
+    def entity_category(self) -> EntityCategory:
+        """Device entity category."""
+        return EntityCategory.CONFIG
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Device info for neato robot."""
+        return DeviceInfo(identifiers={(NEATO_DOMAIN, self._robot_serial)})

--- a/homeassistant/components/neato/button.py
+++ b/homeassistant/components/neato/button.py
@@ -21,16 +21,13 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up Neato button from config entry."""
-    dev = []
+    entities = [
+        NeatoDismissAlertButton(robot)
+        for robot in hass.data[NEATO_ROBOTS]
+    ]
 
-    for robot in hass.data[NEATO_ROBOTS]:
-        dev.append(NeatoDismissAlertButton(robot))
-
-    if not dev:
-        return
-
-    _LOGGER.debug("Adding vacuum buttons %s", dev)
-    async_add_entities(dev, True)
+    _LOGGER.debug("Adding vacuum buttons %s", entities)
+    async_add_entities(entities, True)
 
 
 class NeatoDismissAlertButton(ButtonEntity):

--- a/homeassistant/components/neato/button.py
+++ b/homeassistant/components/neato/button.py
@@ -36,6 +36,8 @@ async def async_setup_entry(
 class NeatoDismissAlertButton(ButtonEntity):
     """Representation of a dismiss_alert button entity."""
 
+    _attr_entity_category = EntityCategory.CONFIG
+
     def __init__(
         self,
         robot: Robot,
@@ -44,7 +46,6 @@ class NeatoDismissAlertButton(ButtonEntity):
         self.robot = robot
         self._attr_name = f"{self.robot.name} Dismiss Alert"
         self._attr_unique_id = f"{self.robot.serial}_dismiss_alert"
-        self._attr_entity_category = EntityCategory.CONFIG
         self._attr_device_info = DeviceInfo(identifiers={(NEATO_DOMAIN, self.robot.serial)})
 
     async def async_press(self) -> None:

--- a/homeassistant/components/neato/button.py
+++ b/homeassistant/components/neato/button.py
@@ -46,7 +46,9 @@ class NeatoDismissAlertButton(ButtonEntity):
         self.robot = robot
         self._attr_name = f"{self.robot.name} Dismiss Alert"
         self._attr_unique_id = f"{self.robot.serial}_dismiss_alert"
-        self._attr_device_info = DeviceInfo(identifiers={(NEATO_DOMAIN, self.robot.serial)})
+        self._attr_device_info = DeviceInfo(
+            identifiers={(NEATO_DOMAIN, self.robot.serial)}
+        )
 
     async def async_press(self) -> None:
         """Press the button."""

--- a/homeassistant/components/neato/button.py
+++ b/homeassistant/components/neato/button.py
@@ -42,29 +42,11 @@ class NeatoDismissAlertButton(ButtonEntity):
     ) -> None:
         """Initialize a dismiss_alert Neato button entity."""
         self.robot = robot
-        self._button_name = f"{self.robot.name} Dismiss Alert"
-        self._robot_serial: str = self.robot.serial
+        self._attr_name = f"{self.robot.name} Dismiss Alert"
+        self._attr_unique_id = self.robot.serial
+        self._attr_entity_category = EntityCategory.CONFIG
+        self._attr_device_info = DeviceInfo(identifiers={(NEATO_DOMAIN, self._robot_serial)})
 
     async def async_press(self) -> None:
         """Press the button."""
         await self.hass.async_add_executor_job(self.robot.dismiss_current_alert)
-
-    @property
-    def name(self) -> str:
-        """Return the name of this camera."""
-        return self._button_name
-
-    @property
-    def unique_id(self) -> str:
-        """Return unique ID."""
-        return self._robot_serial
-
-    @property
-    def entity_category(self) -> EntityCategory:
-        """Device entity category."""
-        return EntityCategory.CONFIG
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Device info for neato robot."""
-        return DeviceInfo(identifiers={(NEATO_DOMAIN, self._robot_serial)})

--- a/homeassistant/components/neato/button.py
+++ b/homeassistant/components/neato/button.py
@@ -43,7 +43,7 @@ class NeatoDismissAlertButton(ButtonEntity):
         """Initialize a dismiss_alert Neato button entity."""
         self.robot = robot
         self._attr_name = f"{self.robot.name} Dismiss Alert"
-        self._attr_unique_id = self.robot.serial
+        self._attr_unique_id = f"{self.robot.serial}_dismiss_alert"
         self._attr_entity_category = EntityCategory.CONFIG
         self._attr_device_info = DeviceInfo(identifiers={(NEATO_DOMAIN, self._robot_serial)})
 

--- a/homeassistant/components/neato/button.py
+++ b/homeassistant/components/neato/button.py
@@ -41,10 +41,10 @@ class NeatoDismissAlertButton(ButtonEntity):
     ) -> None:
         """Initialize a dismiss_alert Neato button entity."""
         self.robot = robot
-        self._attr_name = f"{self.robot.name} Dismiss Alert"
-        self._attr_unique_id = f"{self.robot.serial}_dismiss_alert"
+        self._attr_name = f"{robot.name} Dismiss Alert"
+        self._attr_unique_id = f"{robot.serial}_dismiss_alert"
         self._attr_device_info = DeviceInfo(
-            identifiers={(NEATO_DOMAIN, self.robot.serial)}
+            identifiers={(NEATO_DOMAIN, robot.serial)}
         )
 
     async def async_press(self) -> None:

--- a/homeassistant/components/neato/button.py
+++ b/homeassistant/components/neato/button.py
@@ -45,7 +45,7 @@ class NeatoDismissAlertButton(ButtonEntity):
         self._attr_name = f"{self.robot.name} Dismiss Alert"
         self._attr_unique_id = f"{self.robot.serial}_dismiss_alert"
         self._attr_entity_category = EntityCategory.CONFIG
-        self._attr_device_info = DeviceInfo(identifiers={(NEATO_DOMAIN, self._robot_serial)})
+        self._attr_device_info = DeviceInfo(identifiers={(NEATO_DOMAIN, self.robot.serial)})
 
     async def async_press(self) -> None:
         """Press the button."""

--- a/homeassistant/components/neato/button.py
+++ b/homeassistant/components/neato/button.py
@@ -1,8 +1,6 @@
 """Support for Neato buttons."""
 from __future__ import annotations
 
-import logging
-
 from pybotvac import Robot
 
 from homeassistant.components.button import ButtonEntity
@@ -14,8 +12,6 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import NEATO_DOMAIN, NEATO_ROBOTS
 
-_LOGGER = logging.getLogger(__name__)
-
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
@@ -26,7 +22,6 @@ async def async_setup_entry(
         for robot in hass.data[NEATO_ROBOTS]
     ]
 
-    _LOGGER.debug("Adding vacuum buttons %s", entities)
     async_add_entities(entities, True)
 
 

--- a/homeassistant/components/neato/manifest.json
+++ b/homeassistant/components/neato/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://www.home-assistant.io/integrations/neato",
   "iot_class": "cloud_polling",
   "loggers": ["pybotvac"],
-  "requirements": ["pybotvac==0.0.23"]
+  "requirements": ["pybotvac==0.0.24"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1584,7 +1584,7 @@ pybbox==0.0.5-alpha
 pyblackbird==0.6
 
 # homeassistant.components.neato
-pybotvac==0.0.23
+pybotvac==0.0.24
 
 # homeassistant.components.braviatv
 pybravia==0.3.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1187,7 +1187,7 @@ pybalboa==1.0.1
 pyblackbird==0.6
 
 # homeassistant.components.neato
-pybotvac==0.0.23
+pybotvac==0.0.24
 
 # homeassistant.components.braviatv
 pybravia==0.3.3


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adding a _Dismiss Alert_ button to `neato` integration to be able to dismiss alerts preventing cleaning from start

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade https://github.com/stianaske/pybotvac/releases/tag/v0.0.24
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/28395

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
