### PR TITLE
Fix abode DeprecationWarnings

### DIFF
--- a/homeassistant/components/abode/__init__.py
+++ b/homeassistant/components/abode/__init__.py
@@ -287,14 +287,14 @@ class AbodeDevice(AbodeEntity):
         """Initialize Abode device."""
         super().__init__(data)
         self._device = device
-        self._attr_unique_id = device.device_uuid
+        self._attr_unique_id = device.uuid
 
     async def async_added_to_hass(self) -> None:
         """Subscribe to device events."""
         await super().async_added_to_hass()
         await self.hass.async_add_executor_job(
             self._data.abode.events.add_device_callback,
-            self._device.device_id,
+            self._device.id,
             self._update_callback,
         )
 
@@ -302,7 +302,7 @@ class AbodeDevice(AbodeEntity):
         """Unsubscribe from device events."""
         await super().async_will_remove_from_hass()
         await self.hass.async_add_executor_job(
-            self._data.abode.events.remove_all_device_callbacks, self._device.device_id
+            self._data.abode.events.remove_all_device_callbacks, self._device.id
         )
 
     def update(self) -> None:
@@ -313,7 +313,7 @@ class AbodeDevice(AbodeEntity):
     def extra_state_attributes(self) -> dict[str, str]:
         """Return the state attributes."""
         return {
-            "device_id": self._device.device_id,
+            "device_id": self._device.id,
             "battery_low": self._device.battery_low,
             "no_response": self._device.no_response,
             "device_type": self._device.type,
@@ -323,7 +323,7 @@ class AbodeDevice(AbodeEntity):
     def device_info(self) -> entity.DeviceInfo:
         """Return device registry information for this entity."""
         return entity.DeviceInfo(
-            identifiers={(DOMAIN, self._device.device_id)},
+            identifiers={(DOMAIN, self._device.id)},
             manufacturer="Abode",
             model=self._device.type,
             name=self._device.name,

--- a/homeassistant/components/abode/alarm_control_panel.py
+++ b/homeassistant/components/abode/alarm_control_panel.py
@@ -69,7 +69,7 @@ class AbodeAlarm(AbodeDevice, alarm.AlarmControlPanelEntity):
     def extra_state_attributes(self) -> dict[str, str]:
         """Return the state attributes."""
         return {
-            "device_id": self._device.device_id,
+            "device_id": self._device.id,
             "battery_backup": self._device.battery,
             "cellular_backup": self._device.is_cellular,
         }

--- a/homeassistant/components/abode/sensor.py
+++ b/homeassistant/components/abode/sensor.py
@@ -63,7 +63,7 @@ class AbodeSensor(AbodeDevice, SensorEntity):
         """Initialize a sensor for an Abode device."""
         super().__init__(data, device)
         self.entity_description = description
-        self._attr_unique_id = f"{device.device_uuid}-{description.key}"
+        self._attr_unique_id = f"{device.uuid}-{description.key}"
         if description.key == CONST.TEMP_STATUS_KEY:
             self._attr_native_unit_of_measurement = device.temp_unit
         elif description.key == CONST.HUMI_STATUS_KEY:


### PR DESCRIPTION
## Proposed change
_Let's fix some pytest warnings!_

```
  /.../venv/lib/python3.11/site-packages/jaraco/abode/devices/base.py:153:
    DeprecationWarning: Device.device_uuid is deprecated. Use .uuid.

  /.../venv/lib/python3.11/site-packages/jaraco/abode/devices/base.py:147:
    DeprecationWarning: Device.device_id is deprecated. Use .id.
```

From the changelog entry:
```
Removed unnecessary _device_id and _device_uuid accessors and deprecated
device_id and device_uuid accessors in favor of simply Device.id and Device.uuid accessors.
```

Version `3.3.0` (current `3.3.0`): https://github.com/jaraco/jaraco.abode/blob/main/NEWS.rst#v330


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
