### PR TITLE
Replace deprecated aiohttp_unused_port fixture

### DIFF
--- a/tests/components/http/test_init.py
+++ b/tests/components/http/test_init.py
@@ -85,11 +85,13 @@ class TestView(http.HomeAssistantView):
 
 
 async def test_registering_view_while_running(
-    hass: HomeAssistant, aiohttp_client: ClientSessionGenerator, aiohttp_unused_port
+    hass: HomeAssistant, aiohttp_client: ClientSessionGenerator, unused_tcp_port_factory
 ) -> None:
     """Test that we can register a view while the server is running."""
     await async_setup_component(
-        hass, http.DOMAIN, {http.DOMAIN: {http.CONF_SERVER_PORT: aiohttp_unused_port()}}
+        hass,
+        http.DOMAIN,
+        {http.DOMAIN: {http.CONF_SERVER_PORT: unused_tcp_port_factory()}},
     )
 
     await hass.async_start()
@@ -443,11 +445,11 @@ async def test_cors_defaults(hass: HomeAssistant) -> None:
 
 
 async def test_storing_config(
-    hass: HomeAssistant, aiohttp_client: ClientSessionGenerator, aiohttp_unused_port
+    hass: HomeAssistant, aiohttp_client: ClientSessionGenerator, unused_tcp_port_factory
 ) -> None:
     """Test that we store last working config."""
     config = {
-        http.CONF_SERVER_PORT: aiohttp_unused_port(),
+        http.CONF_SERVER_PORT: unused_tcp_port_factory(),
         "use_x_forwarded_for": True,
         "trusted_proxies": ["192.168.1.100"],
     }

--- a/tests/components/image_processing/test_init.py
+++ b/tests/components/image_processing/test_init.py
@@ -23,9 +23,9 @@ async def setup_homeassistant(hass: HomeAssistant):
 
 
 @pytest.fixture
-def aiohttp_unused_port(event_loop, aiohttp_unused_port, socket_enabled):
+def aiohttp_unused_port_factory(event_loop, unused_tcp_port_factory, socket_enabled):
     """Return aiohttp_unused_port and allow opening sockets."""
-    return aiohttp_unused_port
+    return unused_tcp_port_factory
 
 
 def get_url(hass):
@@ -34,12 +34,12 @@ def get_url(hass):
     return f"{hass.config.internal_url}{state.attributes.get(ATTR_ENTITY_PICTURE)}"
 
 
-async def setup_image_processing(hass, aiohttp_unused_port):
+async def setup_image_processing(hass, aiohttp_unused_port_factory):
     """Set up things to be run when tests are started."""
     await async_setup_component(
         hass,
         http.DOMAIN,
-        {http.DOMAIN: {http.CONF_SERVER_PORT: aiohttp_unused_port()}},
+        {http.DOMAIN: {http.CONF_SERVER_PORT: aiohttp_unused_port_factory()}},
     )
 
     config = {ip.DOMAIN: {"platform": "test"}, "camera": {"platform": "demo"}}
@@ -85,11 +85,11 @@ async def test_setup_component_with_service(hass: HomeAssistant) -> None:
 async def test_get_image_from_camera(
     mock_camera_read,
     hass: HomeAssistant,
-    aiohttp_unused_port,
+    aiohttp_unused_port_factory,
     enable_custom_integrations: None,
 ) -> None:
     """Grab an image from camera entity."""
-    await setup_image_processing(hass, aiohttp_unused_port)
+    await setup_image_processing(hass, aiohttp_unused_port_factory)
 
     common.async_scan(hass, entity_id="image_processing.test")
     await hass.async_block_till_done()
@@ -108,11 +108,11 @@ async def test_get_image_from_camera(
 async def test_get_image_without_exists_camera(
     mock_image,
     hass: HomeAssistant,
-    aiohttp_unused_port,
+    aiohttp_unused_port_factory,
     enable_custom_integrations: None,
 ) -> None:
     """Try to get image without exists camera."""
-    await setup_image_processing(hass, aiohttp_unused_port)
+    await setup_image_processing(hass, aiohttp_unused_port_factory)
 
     hass.states.async_remove("camera.demo_camera")
 


### PR DESCRIPTION
## Proposed change
_Let's fix some pytest warnings!_

```
DeprecationWarning: 'aiohttp_unused_port' fixture is deprecated and
scheduled for removal, please use 'unused_tcp_port_factory' instead
```

From the changelog entry:
```
The plugin is compatible with pytest-asyncio now. It uses pytest-asyncio for async tests running
and async fixtures support, providing by itself only fixtures for creating aiohttp test server and client.
```

Version `1.0.0` (current `1.0.4`): https://github.com/aio-libs/pytest-aiohttp/blob/master/CHANGES.rst#100-2022-1-20



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
