### PR TITLE
Fix pylint DeprecationWarnings

### DIFF
--- a/tests/pylint/test_enforce_type_hints.py
+++ b/tests/pylint/test_enforce_type_hints.py
@@ -108,7 +108,7 @@ def test_ignore_no_annotations(
 ) -> None:
     """Ensure that _is_valid_type is not run if there are no annotations."""
     # Set ignore option
-    type_hint_checker.config.ignore_missing_annotations = True
+    type_hint_checker.linter.config.ignore_missing_annotations = True
 
     func_node = astroid.extract_node(
         code,
@@ -143,7 +143,7 @@ def test_bypass_ignore_no_annotations(
     but `ignore-missing-annotations` option is forced to False.
     """
     # Set bypass option
-    type_hint_checker.config.ignore_missing_annotations = False
+    type_hint_checker.linter.config.ignore_missing_annotations = False
 
     func_node = astroid.extract_node(
         code,
@@ -485,7 +485,7 @@ def test_invalid_entity_properties(
 ) -> None:
     """Check missing entity properties when ignore_missing_annotations is False."""
     # Set bypass option
-    type_hint_checker.config.ignore_missing_annotations = False
+    type_hint_checker.linter.config.ignore_missing_annotations = False
 
     class_node, prop_node, func_node = astroid.extract_node(
         """
@@ -552,7 +552,7 @@ def test_ignore_invalid_entity_properties(
 ) -> None:
     """Check invalid entity properties are ignored by default."""
     # Set ignore option
-    type_hint_checker.config.ignore_missing_annotations = True
+    type_hint_checker.linter.config.ignore_missing_annotations = True
 
     class_node = astroid.extract_node(
         """
@@ -590,7 +590,7 @@ def test_named_arguments(
 ) -> None:
     """Check missing entity properties when ignore_missing_annotations is False."""
     # Set bypass option
-    type_hint_checker.config.ignore_missing_annotations = False
+    type_hint_checker.linter.config.ignore_missing_annotations = False
 
     class_node, func_node, percentage_node, preset_mode_node = astroid.extract_node(
         """
@@ -676,7 +676,7 @@ def test_invalid_mapping_return_type(
 ) -> None:
     """Check that Mapping[xxx, Any] doesn't accept invalid Mapping or dict."""
     # Set bypass option
-    type_hint_checker.config.ignore_missing_annotations = False
+    type_hint_checker.linter.config.ignore_missing_annotations = False
 
     class_node, property_node = astroid.extract_node(
         f"""
@@ -734,7 +734,7 @@ def test_valid_mapping_return_type(
 ) -> None:
     """Check that Mapping[xxx, Any] accepts both Mapping and dict."""
     # Set bypass option
-    type_hint_checker.config.ignore_missing_annotations = False
+    type_hint_checker.linter.config.ignore_missing_annotations = False
 
     class_node = astroid.extract_node(
         f"""
@@ -774,7 +774,7 @@ def test_valid_long_tuple(
 ) -> None:
     """Check invalid entity properties are ignored by default."""
     # Set ignore option
-    type_hint_checker.config.ignore_missing_annotations = False
+    type_hint_checker.linter.config.ignore_missing_annotations = False
 
     class_node, _, _, _ = astroid.extract_node(
         """
@@ -821,7 +821,7 @@ def test_invalid_long_tuple(
 ) -> None:
     """Check invalid entity properties are ignored by default."""
     # Set ignore option
-    type_hint_checker.config.ignore_missing_annotations = False
+    type_hint_checker.linter.config.ignore_missing_annotations = False
 
     class_node, rgbw_node, rgbww_node = astroid.extract_node(
         """
@@ -882,7 +882,7 @@ def test_invalid_device_class(
 ) -> None:
     """Ensure invalid hints are rejected for entity device_class."""
     # Set bypass option
-    type_hint_checker.config.ignore_missing_annotations = False
+    type_hint_checker.linter.config.ignore_missing_annotations = False
 
     class_node, prop_node = astroid.extract_node(
         """
@@ -925,7 +925,7 @@ def test_media_player_entity(
 ) -> None:
     """Ensure valid hints are accepted for media_player entity."""
     # Set bypass option
-    type_hint_checker.config.ignore_missing_annotations = False
+    type_hint_checker.linter.config.ignore_missing_annotations = False
 
     class_node = astroid.extract_node(
         """
@@ -952,7 +952,7 @@ def test_media_player_entity(
 def test_number_entity(linter: UnittestLinter, type_hint_checker: BaseChecker) -> None:
     """Ensure valid hints are accepted for number entity."""
     # Set bypass option
-    type_hint_checker.config.ignore_missing_annotations = False
+    type_hint_checker.linter.config.ignore_missing_annotations = False
 
     # Ensure that device class is valid despite Entity inheritance
     # Ensure that `int` is valid for `float` return type
@@ -989,7 +989,7 @@ def test_number_entity(linter: UnittestLinter, type_hint_checker: BaseChecker) -
 def test_vacuum_entity(linter: UnittestLinter, type_hint_checker: BaseChecker) -> None:
     """Ensure valid hints are accepted for vacuum entity."""
     # Set bypass option
-    type_hint_checker.config.ignore_missing_annotations = False
+    type_hint_checker.linter.config.ignore_missing_annotations = False
 
     # Ensure that `dict | list | None` is valid for params
     class_node = astroid.extract_node(


### PR DESCRIPTION
## Proposed change
_Let's fix some pytest warnings!_

```
  /.../tests/pylint/test_enforce_type_hints.py:111:
    DeprecationWarning: The checker-specific config attribute has been deprecated.
    Please use 'linter.config' to access the global configuration object.
```

From the changelog entry:

```
The config attribute of BaseChecker has been deprecated.
You can use checker.linter.config to access the global configuration
object instead of a checker-specific object.
Refs #5392
```

Version `2.14.0` (current `2.17.4`): https://pylint.readthedocs.io/en/stable/whatsnew/2/2.14/summary.html#deprecations


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
