### PR TITLE
Replace deprecated pkg_resources with importlib.metadata

### DIFF
--- a/homeassistant/requirements.py
+++ b/homeassistant/requirements.py
@@ -7,7 +7,7 @@ import logging
 import os
 from typing import Any, cast
 
-import pkg_resources
+from packaging.requirements import Requirement
 
 from .core import HomeAssistant, callback
 from .exceptions import HomeAssistantError
@@ -232,8 +232,7 @@ class RequirementsManager:
             skipped_requirements = [
                 req
                 for req in requirements
-                if pkg_resources.Requirement.parse(req).project_name
-                in self.hass.config.skip_pip_packages
+                if Requirement(req).name in self.hass.config.skip_pip_packages
             ]
 
             for req in skipped_requirements:

--- a/tests/util/test_package.py
+++ b/tests/util/test_package.py
@@ -1,12 +1,12 @@
 """Test Home Assistant package util methods."""
 import asyncio
+from importlib.metadata import PackageNotFoundError, metadata
 import logging
 import os
 from subprocess import PIPE
 import sys
 from unittest.mock import MagicMock, call, patch
 
-import pkg_resources
 import pytest
 
 import homeassistant.util.package as package
@@ -246,9 +246,9 @@ async def test_async_get_user_site(mock_env_copy) -> None:
 
 def test_check_package_global() -> None:
     """Test for an installed package."""
-    first_package = list(pkg_resources.working_set)[0]
-    installed_package = first_package.project_name
-    installed_version = first_package.version
+    pkg = metadata("homeassistant")
+    installed_package = pkg["name"]
+    installed_version = pkg["version"]
 
     assert package.is_installed(installed_package)
     assert package.is_installed(f"{installed_package}=={installed_version}")
@@ -264,13 +264,13 @@ def test_check_package_zip() -> None:
 
 def test_get_distribution_falls_back_to_version() -> None:
     """Test for get_distribution failing and fallback to version."""
-    first_package = list(pkg_resources.working_set)[0]
-    installed_package = first_package.project_name
-    installed_version = first_package.version
+    pkg = metadata("homeassistant")
+    installed_package = pkg["name"]
+    installed_version = pkg["version"]
 
     with patch(
-        "homeassistant.util.package.pkg_resources.get_distribution",
-        side_effect=pkg_resources.ExtractionError,
+        "homeassistant.util.package.distribution",
+        side_effect=PackageNotFoundError,
     ):
         assert package.is_installed(installed_package)
         assert package.is_installed(f"{installed_package}=={installed_version}")
@@ -281,13 +281,13 @@ def test_get_distribution_falls_back_to_version() -> None:
 
 def test_check_package_previous_failed_install() -> None:
     """Test for when a previously install package failed and left cruft behind."""
-    first_package = list(pkg_resources.working_set)[0]
-    installed_package = first_package.project_name
-    installed_version = first_package.version
+    pkg = metadata("homeassistant")
+    installed_package = pkg["name"]
+    installed_version = pkg["version"]
 
     with patch(
-        "homeassistant.util.package.pkg_resources.get_distribution",
-        side_effect=pkg_resources.ExtractionError,
+        "homeassistant.util.package.distribution",
+        side_effect=PackageNotFoundError,
     ), patch("homeassistant.util.package.version", return_value=None):
         assert not package.is_installed(installed_package)
         assert not package.is_installed(f"{installed_package}=={installed_version}")


### PR DESCRIPTION
## Proposed change
_Let's fix some pytest warnings!_

```
  /.../homeassistant/requirements.py:10:
    DeprecationWarning: pkg_resources is deprecated as an API.
    See https://setuptools.pypa.io/en/latest/pkg_resources.html
```

From the documentation entry:

```md
Use of pkg_resources is deprecated in favor of
[importlib.resources](https://docs.python.org/3/library/importlib.resources.html#module-importlib.resources),
and [importlib.metadata](https://docs.python.org/3/library/importlib.metadata.html#module-importlib.metadata)
```

https://setuptools.pypa.io/en/latest/pkg_resources.html

Version `2.14.0` (current `2.17.4`): https://pylint.readthedocs.io/en/stable/whatsnew/2/2.14/summary.html#deprecations


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
