### PR TITLE
Add restart device to UniFi button platform

### DIFF
--- a/homeassistant/components/unifi/button.py
+++ b/homeassistant/components/unifi/button.py
@@ -1,0 +1,108 @@
+"""Button platform for UniFi Network integration.
+
+Support for restarting UniFi devices.
+"""
+from __future__ import annotations
+
+from collections.abc import Callable, Coroutine
+from dataclasses import dataclass
+from typing import Any, Generic
+
+import aiounifi
+from aiounifi.interfaces.api_handlers import ItemEvent
+from aiounifi.interfaces.devices import Devices
+from aiounifi.models.api import ApiItemT
+from aiounifi.models.device import Device, DeviceRestartRequest
+
+from homeassistant.components.button import (
+    ButtonDeviceClass,
+    ButtonEntity,
+    ButtonEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN as UNIFI_DOMAIN
+from .controller import UniFiController
+from .entity import (
+    HandlerT,
+    UnifiEntity,
+    UnifiEntityDescription,
+    async_device_available_fn,
+    async_device_device_info_fn,
+)
+
+
+@callback
+async def async_restart_device_control_fn(
+    api: aiounifi.Controller, obj_id: str
+) -> None:
+    """Restart device."""
+    await api.request(DeviceRestartRequest.create(obj_id))
+
+
+@dataclass
+class UnifiButtonEntityDescriptionMixin(Generic[HandlerT, ApiItemT]):
+    """Validate and load entities from different UniFi handlers."""
+
+    control_fn: Callable[[aiounifi.Controller, str], Coroutine[Any, Any, None]]
+
+
+@dataclass
+class UnifiButtonEntityDescription(
+    ButtonEntityDescription,
+    UnifiEntityDescription[HandlerT, ApiItemT],
+    UnifiButtonEntityDescriptionMixin[HandlerT, ApiItemT],
+):
+    """Class describing UniFi button entity."""
+
+
+ENTITY_DESCRIPTIONS: tuple[UnifiButtonEntityDescription, ...] = (
+    UnifiButtonEntityDescription[Devices, Device](
+        key="Device restart",
+        entity_category=EntityCategory.CONFIG,
+        has_entity_name=True,
+        entity_registry_enabled_default=False,
+        device_class=ButtonDeviceClass.RESTART,
+        allowed_fn=lambda controller, obj_id: True,
+        api_handler_fn=lambda api: api.devices,
+        available_fn=async_device_available_fn,
+        control_fn=async_restart_device_control_fn,
+        device_info_fn=async_device_device_info_fn,
+        event_is_on=None,
+        event_to_subscribe=None,
+        name_fn=lambda _: "Restart",
+        object_fn=lambda api, obj_id: api.devices[obj_id],
+        should_poll=False,
+        supported_fn=lambda controller, obj_id: True,
+        unique_id_fn=lambda controller, obj_id: f"device_restart-{obj_id}",
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up button platform for UniFi Network integration."""
+    controller: UniFiController = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
+    controller.register_platform_add_entities(
+        UnifiButtonEntity, ENTITY_DESCRIPTIONS, async_add_entities
+    )
+
+
+class UnifiButtonEntity(UnifiEntity[HandlerT, ApiItemT], ButtonEntity):
+    """Base representation of a UniFi image."""
+
+    entity_description: UnifiButtonEntityDescription[HandlerT, ApiItemT]
+
+    async def async_press(self) -> None:
+        """Store reset presence state."""
+        await self.entity_description.control_fn(self.controller.api, self._obj_id)
+
+    @callback
+    def async_update_state(self, event: ItemEvent, obj_id: str) -> None:
+        """Update entity state."""

--- a/homeassistant/components/unifi/button.py
+++ b/homeassistant/components/unifi/button.py
@@ -64,7 +64,6 @@ ENTITY_DESCRIPTIONS: tuple[UnifiButtonEntityDescription, ...] = (
         key="Device restart",
         entity_category=EntityCategory.CONFIG,
         has_entity_name=True,
-        entity_registry_enabled_default=False,
         device_class=ButtonDeviceClass.RESTART,
         allowed_fn=lambda controller, obj_id: True,
         api_handler_fn=lambda api: api.devices,
@@ -89,6 +88,10 @@ async def async_setup_entry(
 ) -> None:
     """Set up button platform for UniFi Network integration."""
     controller: UniFiController = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
+
+    if controller.site_role != "admin":
+        return
+
     controller.register_platform_add_entities(
         UnifiButtonEntity, ENTITY_DESCRIPTIONS, async_add_entities
     )

--- a/homeassistant/components/unifi/button.py
+++ b/homeassistant/components/unifi/button.py
@@ -103,7 +103,7 @@ class UnifiButtonEntity(UnifiEntity[HandlerT, ApiItemT], ButtonEntity):
     entity_description: UnifiButtonEntityDescription[HandlerT, ApiItemT]
 
     async def async_press(self) -> None:
-        """Store reset presence state."""
+        """Press the button."""
         await self.entity_description.control_fn(self.controller.api, self._obj_id)
 
     @callback

--- a/homeassistant/components/unifi/const.py
+++ b/homeassistant/components/unifi/const.py
@@ -8,6 +8,7 @@ LOGGER = logging.getLogger(__package__)
 DOMAIN = "unifi"
 
 PLATFORMS = [
+    Platform.BUTTON,
     Platform.DEVICE_TRACKER,
     Platform.IMAGE,
     Platform.SENSOR,

--- a/tests/components/unifi/test_button.py
+++ b/tests/components/unifi/test_button.py
@@ -24,10 +24,10 @@ from .test_controller import (
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 
-async def test_wlan_switches(
+async def test_restart_device_button(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_unifi_websocket
 ) -> None:
-    """Test control of UniFi WLAN availability."""
+    """Test restarting device button."""
     config_entry = await setup_unifi_integration(
         hass,
         aioclient_mock,
@@ -35,7 +35,7 @@ async def test_wlan_switches(
             {
                 "board_rev": 3,
                 "device_id": "mock-id",
-                "ip": "10.0.1.1",
+                "ip": "10.0.0.1",
                 "last_seen": 1562600145,
                 "mac": "00:00:00:00:01:01",
                 "model": "US16P150",
@@ -60,7 +60,7 @@ async def test_wlan_switches(
     assert button is not None
     assert button.attributes.get(ATTR_DEVICE_CLASS) == ButtonDeviceClass.RESTART
 
-    # Restart device
+    # Send restart device command
     aioclient_mock.clear_requests()
     aioclient_mock.post(
         f"https://{controller.host}:1234/api/s/{controller.site}/cmd/devmgr",

--- a/tests/components/unifi/test_button.py
+++ b/tests/components/unifi/test_button.py
@@ -1,0 +1,1 @@
+"""UniFi Network button platform tests."""

--- a/tests/components/unifi/test_button.py
+++ b/tests/components/unifi/test_button.py
@@ -1,1 +1,92 @@
 """UniFi Network button platform tests."""
+
+from aiounifi.websocket import WebsocketState
+
+from homeassistant.components.button import (
+    DOMAIN as BUTTON_DOMAIN,
+    ButtonDeviceClass,
+)
+from homeassistant.components.unifi.const import (
+    DOMAIN as UNIFI_DOMAIN,
+)
+from homeassistant.const import (
+    ATTR_DEVICE_CLASS,
+    STATE_UNAVAILABLE,
+    EntityCategory,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from .test_controller import (
+    setup_unifi_integration,
+)
+
+from tests.test_util.aiohttp import AiohttpClientMocker
+
+
+async def test_wlan_switches(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_unifi_websocket
+) -> None:
+    """Test control of UniFi WLAN availability."""
+    config_entry = await setup_unifi_integration(
+        hass,
+        aioclient_mock,
+        devices_response=[
+            {
+                "board_rev": 3,
+                "device_id": "mock-id",
+                "ip": "10.0.1.1",
+                "last_seen": 1562600145,
+                "mac": "00:00:00:00:01:01",
+                "model": "US16P150",
+                "name": "switch",
+                "state": 1,
+                "type": "usw",
+                "version": "4.0.42.10433",
+            }
+        ],
+    )
+    controller = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
+
+    assert len(hass.states.async_entity_ids(BUTTON_DOMAIN)) == 1
+
+    ent_reg = er.async_get(hass)
+    ent_reg_entry = ent_reg.async_get("button.switch_restart")
+    assert ent_reg_entry.unique_id == "device_restart-00:00:00:00:01:01"
+    assert ent_reg_entry.entity_category is EntityCategory.CONFIG
+
+    # Validate state object
+    button = hass.states.get("button.switch_restart")
+    assert button is not None
+    assert button.attributes.get(ATTR_DEVICE_CLASS) == ButtonDeviceClass.RESTART
+
+    # Restart device
+    aioclient_mock.clear_requests()
+    aioclient_mock.post(
+        f"https://{controller.host}:1234/api/s/{controller.site}/cmd/devmgr",
+    )
+
+    await hass.services.async_call(
+        BUTTON_DOMAIN,
+        "press",
+        {"entity_id": "button.switch_restart"},
+        blocking=True,
+    )
+    assert aioclient_mock.call_count == 1
+    assert aioclient_mock.mock_calls[0][2] == {
+        "cmd": "restart",
+        "mac": "00:00:00:00:01:01",
+        "reboot_type": "soft",
+    }
+
+    # Availability signalling
+
+    # Controller disconnects
+    mock_unifi_websocket(state=WebsocketState.DISCONNECTED)
+    await hass.async_block_till_done()
+    assert hass.states.get("button.switch_restart").state == STATE_UNAVAILABLE
+
+    # Controller reconnects
+    mock_unifi_websocket(state=WebsocketState.RUNNING)
+    await hass.async_block_till_done()
+    assert hass.states.get("button.switch_restart").state != STATE_UNAVAILABLE

--- a/tests/components/unifi/test_controller.py
+++ b/tests/components/unifi/test_controller.py
@@ -9,6 +9,7 @@ import aiounifi
 from aiounifi.websocket import WebsocketState
 import pytest
 
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN
 from homeassistant.components.device_tracker import DOMAIN as TRACKER_DOMAIN
 from homeassistant.components.image import DOMAIN as IMAGE_DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
@@ -222,10 +223,11 @@ async def test_controller_setup(
 
     entry = controller.config_entry
     assert len(forward_entry_setup.mock_calls) == len(PLATFORMS)
-    assert forward_entry_setup.mock_calls[0][1] == (entry, TRACKER_DOMAIN)
-    assert forward_entry_setup.mock_calls[1][1] == (entry, IMAGE_DOMAIN)
-    assert forward_entry_setup.mock_calls[2][1] == (entry, SENSOR_DOMAIN)
-    assert forward_entry_setup.mock_calls[3][1] == (entry, SWITCH_DOMAIN)
+    assert forward_entry_setup.mock_calls[0][1] == (entry, BUTTON_DOMAIN)
+    assert forward_entry_setup.mock_calls[1][1] == (entry, TRACKER_DOMAIN)
+    assert forward_entry_setup.mock_calls[2][1] == (entry, IMAGE_DOMAIN)
+    assert forward_entry_setup.mock_calls[3][1] == (entry, SENSOR_DOMAIN)
+    assert forward_entry_setup.mock_calls[4][1] == (entry, SWITCH_DOMAIN)
 
     assert controller.host == ENTRY_CONFIG[CONF_HOST]
     assert controller.site == ENTRY_CONFIG[CONF_SITE_ID]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Button entity that allows restarting a device.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/28419

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
