### PR TITLE
Fix tplink child plug state reporting

### DIFF
--- a/homeassistant/components/tplink/switch.py
+++ b/homeassistant/components/tplink/switch.py
@@ -116,7 +116,7 @@ class SmartPlugSwitchChild(SmartPlugSwitch):
         coordinator: TPLinkDataUpdateCoordinator,
         plug: SmartDevice,
     ) -> None:
-        """Initialize the switch."""
+        """Initialize the child switch."""
         super().__init__(device, coordinator)
         self._plug = plug
         self._attr_unique_id = legacy_device_id(plug)
@@ -124,10 +124,15 @@ class SmartPlugSwitchChild(SmartPlugSwitch):
 
     @async_refresh_after
     async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn the switch on."""
+        """Turn the child switch on."""
         await self._plug.turn_on()
 
     @async_refresh_after
     async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn the switch off."""
+        """Turn the child switch off."""
         await self._plug.turn_off()
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if child switch is on."""
+        return bool(self._plug.is_on)

--- a/tests/components/tplink/__init__.py
+++ b/tests/components/tplink/__init__.py
@@ -180,12 +180,14 @@ def _mocked_strip() -> SmartStrip:
     plug0.alias = "Plug0"
     plug0.device_id = "bb:bb:cc:dd:ee:ff_PLUG0DEVICEID"
     plug0.mac = "bb:bb:cc:dd:ee:ff"
+    plug0.is_on = True
     plug0.protocol = _mock_protocol()
     plug1 = _mocked_plug()
     plug1.device_id = "cc:bb:cc:dd:ee:ff_PLUG1DEVICEID"
     plug1.mac = "cc:bb:cc:dd:ee:ff"
     plug1.alias = "Plug1"
     plug1.protocol = _mock_protocol()
+    plug1.is_on = False
     strip.children = [plug0, plug1]
     return strip
 

--- a/tests/components/tplink/test_switch.py
+++ b/tests/components/tplink/test_switch.py
@@ -9,7 +9,7 @@ import pytest
 from homeassistant.components import tplink
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.components.tplink.const import DOMAIN
-from homeassistant.const import ATTR_ENTITY_ID, STATE_ON, STATE_UNAVAILABLE
+from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
@@ -146,22 +146,37 @@ async def test_strip(hass: HomeAssistant) -> None:
     # since this is what the previous version did
     assert hass.states.get("switch.my_strip") is None
 
-    for plug_id in range(2):
-        entity_id = f"switch.my_strip_plug{plug_id}"
-        state = hass.states.get(entity_id)
-        assert state.state == STATE_ON
+    entity_id = "switch.my_strip_plug0"
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ON
 
-        await hass.services.async_call(
-            SWITCH_DOMAIN, "turn_off", {ATTR_ENTITY_ID: entity_id}, blocking=True
-        )
-        strip.children[plug_id].turn_off.assert_called_once()
-        strip.children[plug_id].turn_off.reset_mock()
+    await hass.services.async_call(
+        SWITCH_DOMAIN, "turn_off", {ATTR_ENTITY_ID: entity_id}, blocking=True
+    )
+    strip.children[0].turn_off.assert_called_once()
+    strip.children[0].turn_off.reset_mock()
 
-        await hass.services.async_call(
-            SWITCH_DOMAIN, "turn_on", {ATTR_ENTITY_ID: entity_id}, blocking=True
-        )
-        strip.children[plug_id].turn_on.assert_called_once()
-        strip.children[plug_id].turn_on.reset_mock()
+    await hass.services.async_call(
+        SWITCH_DOMAIN, "turn_on", {ATTR_ENTITY_ID: entity_id}, blocking=True
+    )
+    strip.children[0].turn_on.assert_called_once()
+    strip.children[0].turn_on.reset_mock()
+
+    entity_id = "switch.my_strip_plug1"
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_OFF
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN, "turn_off", {ATTR_ENTITY_ID: entity_id}, blocking=True
+    )
+    strip.children[1].turn_off.assert_called_once()
+    strip.children[1].turn_off.reset_mock()
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN, "turn_on", {ATTR_ENTITY_ID: entity_id}, blocking=True
+    )
+    strip.children[1].turn_on.assert_called_once()
+    strip.children[1].turn_on.reset_mock()
 
 
 async def test_strip_unique_ids(hass: HomeAssistant) -> None:


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
regressed in https://github.com/home-assistant/core/pull/96246

fixes #97487 fixes #97653
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
