### PR TITLE
Add account sensors to electric kiwi integration

### DIFF
--- a/homeassistant/components/electric_kiwi/const.py
+++ b/homeassistant/components/electric_kiwi/const.py
@@ -9,3 +9,6 @@ OAUTH2_TOKEN = "https://welcome.electrickiwi.co.nz/oauth/token"
 API_BASE_URL = "https://api.electrickiwi.co.nz"
 
 SCOPE_VALUES = "read_connection_detail read_billing_frequency read_account_running_balance read_consumption_summary read_consumption_averages read_hop_intervals_config read_hop_connection save_hop_connection read_session"
+
+HOP_COORDINATOR = "hop_coordinator"
+ACCOUNT_COORDINATOR = "account_coordinator"

--- a/homeassistant/components/electric_kiwi/coordinator.py
+++ b/homeassistant/components/electric_kiwi/coordinator.py
@@ -6,7 +6,7 @@ import logging
 
 from electrickiwi_api import ElectricKiwiApi
 from electrickiwi_api.exceptions import ApiException, AuthException
-from electrickiwi_api.model import Hop, HopIntervals
+from electrickiwi_api.model import AccountBalance, Hop, HopIntervals
 
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
@@ -14,11 +14,40 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 _LOGGER = logging.getLogger(__name__)
 
+ACCOUNT_SCAN_INTERVAL = timedelta(hours=6)
 HOP_SCAN_INTERVAL = timedelta(minutes=20)
 
 
+class ElectricKiwiAccountDataCoordinator(DataUpdateCoordinator):
+    """ElectricKiwi Account Data object."""
+
+    def __init__(self, hass: HomeAssistant, ek_api: ElectricKiwiApi) -> None:
+        """Initialize ElectricKiwiAccountDataCoordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            # Name of the data. For logging purposes.
+            name="Electric Kiwi Account Data",
+            # Polling interval. Will only be polled if there are subscribers.
+            update_interval=ACCOUNT_SCAN_INTERVAL,
+        )
+        self._ek_api = ek_api
+
+    async def _async_update_data(self) -> AccountBalance:
+        """Fetch data from Account balance API endpoint."""
+        try:
+            async with asyncio.timeout(60):
+                return await self._ek_api.get_account_balance()
+        except AuthException as auth_err:
+            raise ConfigEntryAuthFailed from auth_err
+        except ApiException as api_err:
+            raise UpdateFailed(
+                f"Error communicating with EK API: {api_err}"
+            ) from api_err
+
+
 class ElectricKiwiHOPDataCoordinator(DataUpdateCoordinator[Hop]):
-    """ElectricKiwi Data object."""
+    """ElectricKiwi HOP Data object."""
 
     def __init__(self, hass: HomeAssistant, ek_api: ElectricKiwiApi) -> None:
         """Initialize ElectricKiwiAccountDataCoordinator."""

--- a/homeassistant/components/electric_kiwi/coordinator.py
+++ b/homeassistant/components/electric_kiwi/coordinator.py
@@ -26,9 +26,7 @@ class ElectricKiwiAccountDataCoordinator(DataUpdateCoordinator):
         super().__init__(
             hass,
             _LOGGER,
-            # Name of the data. For logging purposes.
             name="Electric Kiwi Account Data",
-            # Polling interval. Will only be polled if there are subscribers.
             update_interval=ACCOUNT_SCAN_INTERVAL,
         )
         self._ek_api = ek_api

--- a/homeassistant/components/electric_kiwi/select.py
+++ b/homeassistant/components/electric_kiwi/select.py
@@ -10,7 +10,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import ATTRIBUTION, DOMAIN
+from .const import ATTRIBUTION, DOMAIN, HOP_COORDINATOR
 from .coordinator import ElectricKiwiHOPDataCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -27,7 +27,9 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Electric Kiwi select setup."""
-    hop_coordinator: ElectricKiwiHOPDataCoordinator = hass.data[DOMAIN][entry.entry_id]
+    hop_coordinator: ElectricKiwiHOPDataCoordinator = hass.data[DOMAIN][entry.entry_id][
+        HOP_COORDINATOR
+    ]
 
     _LOGGER.debug("Setting up select entity")
     async_add_entities([ElectricKiwiSelectHOPEntity(hop_coordinator, HOP_SELECT)])

--- a/homeassistant/components/electric_kiwi/select.py
+++ b/homeassistant/components/electric_kiwi/select.py
@@ -19,7 +19,7 @@ ATTR_EK_HOP_SELECT = "hop_select"
 HOP_SELECT = SelectEntityDescription(
     entity_category=EntityCategory.CONFIG,
     key=ATTR_EK_HOP_SELECT,
-    translation_key="hopselector",
+    translation_key="hop_selector",
 )
 
 

--- a/homeassistant/components/electric_kiwi/sensor.py
+++ b/homeassistant/components/electric_kiwi/sensor.py
@@ -146,13 +146,13 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Electric Kiwi Sensors Setup."""
-    account_coordinator: ElectricKiwiAccountDataCoordinator = hass.data[DOMAIN][
-        entry.entry_id
-    ][ACCOUNT_COORDINATOR]
+    coordinator: ElectricKiwiAccountDataCoordinator = hass.data[DOMAIN][entry.entry_id][
+        ACCOUNT_COORDINATOR
+    ]
 
     account_entities = [
         ElectricKiwiAccountEntity(
-            account_coordinator,
+            coordinator,
             description,
         )
         for description in ACCOUNT_SENSOR_TYPES
@@ -180,13 +180,13 @@ class ElectricKiwiAccountEntity(
 
     def __init__(
         self,
-        account_coordinator: ElectricKiwiAccountDataCoordinator,
+        coordinator: ElectricKiwiAccountDataCoordinator,
         description: ElectricKiwiAccountSensorEntityDescription,
     ) -> None:
         """Entity object for Electric Kiwi sensor."""
-        super().__init__(account_coordinator)
+        super().__init__(coordinator)
 
-        self._attr_unique_id = f"{self.coordinator._ek_api.customer_number}_{self.coordinator._ek_api.connection_id}_{description.key}"
+        self._attr_unique_id = f"{coordinator._ek_api.customer_number}_{coordinator._ek_api.connection_id}_{description.key}"
         self.entity_description = description
 
     @property

--- a/homeassistant/components/electric_kiwi/sensor.py
+++ b/homeassistant/components/electric_kiwi/sensor.py
@@ -37,14 +37,14 @@ ATTR_NEXT_BILLING_DATE = "next_billing_date"
 ATTR_HOP_PERCENTAGE = "hop_percentage"
 
 
-@dataclass
+@dataclass(frozen=True)
 class ElectricKiwiAccountRequiredKeysMixin:
     """Mixin for required keys."""
 
     value_func: Callable[[AccountBalance], str | datetime]
 
 
-@dataclass
+@dataclass(frozen=True)
 class ElectricKiwiAccountSensorEntityDescription(
     SensorEntityDescription, ElectricKiwiAccountRequiredKeysMixin
 ):

--- a/homeassistant/components/electric_kiwi/sensor.py
+++ b/homeassistant/components/electric_kiwi/sensor.py
@@ -6,26 +6,90 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 import logging
 
-from electrickiwi_api.model import Hop
+from electrickiwi_api.model import AccountBalance, Hop
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
+    SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CURRENCY_DOLLAR, PERCENTAGE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
 
-from .const import ATTRIBUTION, DOMAIN
-from .coordinator import ElectricKiwiHOPDataCoordinator
+from .const import ACCOUNT_COORDINATOR, ATTRIBUTION, DOMAIN, HOP_COORDINATOR
+from .coordinator import (
+    ElectricKiwiAccountDataCoordinator,
+    ElectricKiwiHOPDataCoordinator,
+)
 
 _LOGGER = logging.getLogger(DOMAIN)
 
 ATTR_EK_HOP_START = "hop_sensor_start"
 ATTR_EK_HOP_END = "hop_sensor_end"
+ATTR_TOTAL_RUNNING_BALANCE = "total_running_balance"
+ATTR_TOTAL_CURRENT_BALANCE = "total_account_balance"
+ATTR_NEXT_BILLING_DATE = "next_billing_date"
+ATTR_HOP_PERCENTAGE = "hop_percentage"
+
+
+@dataclass
+class ElectricKiwiAccountRequiredKeysMixin:
+    """Mixin for required keys."""
+
+    value_func: Callable[[AccountBalance], str | datetime]
+
+
+@dataclass
+class ElectricKiwiAccountSensorEntityDescription(
+    SensorEntityDescription, ElectricKiwiAccountRequiredKeysMixin
+):
+    """Describes Electric Kiwi sensor entity."""
+
+
+ACCOUNT_SENSOR_TYPES: tuple[ElectricKiwiAccountSensorEntityDescription, ...] = (
+    ElectricKiwiAccountSensorEntityDescription(
+        key=ATTR_TOTAL_RUNNING_BALANCE,
+        translation_key="totalrunningbalance",
+        icon="mdi:currency-usd",
+        device_class=SensorDeviceClass.MONETARY,
+        state_class=SensorStateClass.TOTAL,
+        native_unit_of_measurement=CURRENCY_DOLLAR,
+        value_func=lambda account_balance: str(account_balance.total_running_balance),
+    ),
+    ElectricKiwiAccountSensorEntityDescription(
+        key=ATTR_TOTAL_CURRENT_BALANCE,
+        translation_key="totalcurrentbalance",
+        icon="mdi:currency-usd",
+        device_class=SensorDeviceClass.MONETARY,
+        state_class=SensorStateClass.TOTAL,
+        native_unit_of_measurement=CURRENCY_DOLLAR,
+        value_func=lambda account_balance: str(account_balance.total_account_balance),
+    ),
+    ElectricKiwiAccountSensorEntityDescription(
+        key=ATTR_NEXT_BILLING_DATE,
+        translation_key="nextbillingdate",
+        icon="mdi:calendar",
+        device_class=SensorDeviceClass.DATE,
+        value_func=lambda account_balance: datetime.strptime(
+            account_balance.next_billing_date, "%Y-%m-%d"
+        ),
+    ),
+    ElectricKiwiAccountSensorEntityDescription(
+        key=ATTR_HOP_PERCENTAGE,
+        translation_key="hoppowersavings",
+        icon="mdi:percent",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_func=lambda account_balance: str(
+            account_balance.connections[0].hop_percentage
+        ),
+    ),
+)
 
 
 @dataclass(frozen=True)
@@ -81,13 +145,54 @@ HOP_SENSOR_TYPES: tuple[ElectricKiwiHOPSensorEntityDescription, ...] = (
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
-    """Electric Kiwi Sensor Setup."""
-    hop_coordinator: ElectricKiwiHOPDataCoordinator = hass.data[DOMAIN][entry.entry_id]
+    """Electric Kiwi Sensors Setup."""
+    account_coordinator: ElectricKiwiAccountDataCoordinator = hass.data[DOMAIN][
+        entry.entry_id
+    ][ACCOUNT_COORDINATOR]
+
+    account_entities = [
+        ElectricKiwiAccountEntity(
+            account_coordinator,
+            description,
+        )
+        for description in ACCOUNT_SENSOR_TYPES
+    ]
+    async_add_entities(account_entities)
+
+    hop_coordinator: ElectricKiwiHOPDataCoordinator = hass.data[DOMAIN][entry.entry_id][
+        HOP_COORDINATOR
+    ]
     hop_entities = [
         ElectricKiwiHOPEntity(hop_coordinator, description)
         for description in HOP_SENSOR_TYPES
     ]
     async_add_entities(hop_entities)
+
+
+class ElectricKiwiAccountEntity(
+    CoordinatorEntity[ElectricKiwiAccountDataCoordinator], SensorEntity
+):
+    """Entity object for Electric Kiwi sensor."""
+
+    entity_description: ElectricKiwiAccountSensorEntityDescription
+    _attr_has_entity_name = True
+    _attr_attribution = ATTRIBUTION
+
+    def __init__(
+        self,
+        account_coordinator: ElectricKiwiAccountDataCoordinator,
+        description: ElectricKiwiAccountSensorEntityDescription,
+    ) -> None:
+        """Entity object for Electric Kiwi sensor."""
+        super().__init__(account_coordinator)
+
+        self._attr_unique_id = f"{self.coordinator._ek_api.customer_number}_{self.coordinator._ek_api.connection_id}_{description.key}"
+        self.entity_description = description
+
+    @property
+    def native_value(self) -> datetime | str:
+        """Return the state of the sensor."""
+        return self.entity_description.value_func(self.coordinator.data)
 
 
 class ElectricKiwiHOPEntity(

--- a/homeassistant/components/electric_kiwi/sensor.py
+++ b/homeassistant/components/electric_kiwi/sensor.py
@@ -186,7 +186,10 @@ class ElectricKiwiAccountEntity(
         """Entity object for Electric Kiwi sensor."""
         super().__init__(coordinator)
 
-        self._attr_unique_id = f"{coordinator._ek_api.customer_number}_{coordinator._ek_api.connection_id}_{description.key}"
+        self._attr_unique_id = (
+            f"{coordinator._ek_api.customer_number}"
+            f"_{coordinator._ek_api.connection_id}_{description.key}"
+        )
         self.entity_description = description
 
     @property

--- a/homeassistant/components/electric_kiwi/sensor.py
+++ b/homeassistant/components/electric_kiwi/sensor.py
@@ -41,7 +41,7 @@ ATTR_HOP_PERCENTAGE = "hop_percentage"
 class ElectricKiwiAccountRequiredKeysMixin:
     """Mixin for required keys."""
 
-    value_func: Callable[[AccountBalance], str | datetime]
+    value_func: Callable[[AccountBalance], float | int | datetime]
 
 
 @dataclass(frozen=True)

--- a/homeassistant/components/electric_kiwi/sensor.py
+++ b/homeassistant/components/electric_kiwi/sensor.py
@@ -146,7 +146,7 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Electric Kiwi Sensors Setup."""
-    coordinator: ElectricKiwiAccountDataCoordinator = hass.data[DOMAIN][entry.entry_id][
+    account_coordinator: ElectricKiwiAccountDataCoordinator = hass.data[DOMAIN][entry.entry_id][
         ACCOUNT_COORDINATOR
     ]
 

--- a/homeassistant/components/electric_kiwi/sensor.py
+++ b/homeassistant/components/electric_kiwi/sensor.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-import logging
 
 from electrickiwi_api.model import AccountBalance, Hop
 
@@ -27,10 +26,8 @@ from .coordinator import (
     ElectricKiwiHOPDataCoordinator,
 )
 
-_LOGGER = logging.getLogger(DOMAIN)
-
-ATTR_EK_HOP_START = "hop_sensor_start"
-ATTR_EK_HOP_END = "hop_sensor_end"
+ATTR_EK_HOP_START = "hop_power_start"
+ATTR_EK_HOP_END = "hop_power_end"
 ATTR_TOTAL_RUNNING_BALANCE = "total_running_balance"
 ATTR_TOTAL_CURRENT_BALANCE = "total_account_balance"
 ATTR_NEXT_BILLING_DATE = "next_billing_date"
@@ -54,7 +51,7 @@ class ElectricKiwiAccountSensorEntityDescription(
 ACCOUNT_SENSOR_TYPES: tuple[ElectricKiwiAccountSensorEntityDescription, ...] = (
     ElectricKiwiAccountSensorEntityDescription(
         key=ATTR_TOTAL_RUNNING_BALANCE,
-        translation_key="totalrunningbalance",
+        translation_key="total_running_balance",
         icon="mdi:currency-usd",
         device_class=SensorDeviceClass.MONETARY,
         state_class=SensorStateClass.TOTAL,
@@ -63,7 +60,7 @@ ACCOUNT_SENSOR_TYPES: tuple[ElectricKiwiAccountSensorEntityDescription, ...] = (
     ),
     ElectricKiwiAccountSensorEntityDescription(
         key=ATTR_TOTAL_CURRENT_BALANCE,
-        translation_key="totalcurrentbalance",
+        translation_key="total_current_balance",
         icon="mdi:currency-usd",
         device_class=SensorDeviceClass.MONETARY,
         state_class=SensorStateClass.TOTAL,
@@ -72,7 +69,7 @@ ACCOUNT_SENSOR_TYPES: tuple[ElectricKiwiAccountSensorEntityDescription, ...] = (
     ),
     ElectricKiwiAccountSensorEntityDescription(
         key=ATTR_NEXT_BILLING_DATE,
-        translation_key="nextbillingdate",
+        translation_key="next_billing_date",
         icon="mdi:calendar",
         device_class=SensorDeviceClass.DATE,
         value_func=lambda account_balance: datetime.strptime(
@@ -81,7 +78,7 @@ ACCOUNT_SENSOR_TYPES: tuple[ElectricKiwiAccountSensorEntityDescription, ...] = (
     ),
     ElectricKiwiAccountSensorEntityDescription(
         key=ATTR_HOP_PERCENTAGE,
-        translation_key="hoppowersavings",
+        translation_key="hop_power_savings",
         icon="mdi:percent",
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
@@ -129,13 +126,13 @@ def _check_and_move_time(hop: Hop, time: str) -> datetime:
 HOP_SENSOR_TYPES: tuple[ElectricKiwiHOPSensorEntityDescription, ...] = (
     ElectricKiwiHOPSensorEntityDescription(
         key=ATTR_EK_HOP_START,
-        translation_key="hopfreepowerstart",
+        translation_key="hop_free_power_start",
         device_class=SensorDeviceClass.TIMESTAMP,
         value_func=lambda hop: _check_and_move_time(hop, hop.start.start_time),
     ),
     ElectricKiwiHOPSensorEntityDescription(
         key=ATTR_EK_HOP_END,
-        translation_key="hopfreepowerend",
+        translation_key="hop_free_power_end",
         device_class=SensorDeviceClass.TIMESTAMP,
         value_func=lambda hop: _check_and_move_time(hop, hop.end.end_time),
     ),
@@ -146,13 +143,13 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Electric Kiwi Sensors Setup."""
-    account_coordinator: ElectricKiwiAccountDataCoordinator = hass.data[DOMAIN][entry.entry_id][
-        ACCOUNT_COORDINATOR
-    ]
+    account_coordinator: ElectricKiwiAccountDataCoordinator = hass.data[DOMAIN][
+        entry.entry_id
+    ][ACCOUNT_COORDINATOR]
 
     entities: list[SensorEntity] = [
         ElectricKiwiAccountEntity(
-            coordinator,
+            account_coordinator,
             description,
         )
         for description in ACCOUNT_SENSOR_TYPES

--- a/homeassistant/components/electric_kiwi/strings.json
+++ b/homeassistant/components/electric_kiwi/strings.json
@@ -28,8 +28,24 @@
   },
   "entity": {
     "sensor": {
-      "hopfreepowerstart": { "name": "Hour of free power start" },
-      "hopfreepowerend": { "name": "Hour of free power end" }
+      "hopfreepowerstart": {
+        "name": "Hour of free power start"
+      },
+      "hopfreepowerend": {
+        "name": "Hour of free power end"
+      },
+      "totalrunningbalance": {
+        "name": "Total running balance"
+      },
+      "totalcurrentbalance": {
+        "name": "Total current balance"
+      },
+      "nextbillingdate": {
+        "name": "Next billing date"
+      },
+      "hoppowersavings": {
+        "name": "Hour of power savings"
+      }
     },
     "select": { "hopselector": { "name": "Hour of free power" } }
   }

--- a/homeassistant/components/electric_kiwi/strings.json
+++ b/homeassistant/components/electric_kiwi/strings.json
@@ -28,25 +28,25 @@
   },
   "entity": {
     "sensor": {
-      "hopfreepowerstart": {
+      "hop_free_power_start": {
         "name": "Hour of free power start"
       },
-      "hopfreepowerend": {
+      "hop_free_power_end": {
         "name": "Hour of free power end"
       },
-      "totalrunningbalance": {
+      "total_running_balance": {
         "name": "Total running balance"
       },
-      "totalcurrentbalance": {
+      "total_current_balance": {
         "name": "Total current balance"
       },
-      "nextbillingdate": {
+      "next_billing_date": {
         "name": "Next billing date"
       },
-      "hoppowersavings": {
+      "hop_power_savings": {
         "name": "Hour of power savings"
       }
     },
-    "select": { "hopselector": { "name": "Hour of free power" } }
+    "select": { "hop_selector": { "name": "Hour of free power" } }
   }
 }

--- a/tests/components/electric_kiwi/conftest.py
+++ b/tests/components/electric_kiwi/conftest.py
@@ -43,14 +43,17 @@ def component_setup(
 
     async def _setup_func() -> bool:
         assert await async_setup_component(hass, "application_credentials", {})
+        await hass.async_block_till_done()
         await async_import_client_credential(
             hass,
             DOMAIN,
             ClientCredential(CLIENT_ID, CLIENT_SECRET),
             DOMAIN,
         )
+        await hass.async_block_till_done()
         config_entry.add_to_hass(hass)
-        return await hass.config_entries.async_setup(config_entry.entry_id)
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
 
     return _setup_func
 

--- a/tests/components/electric_kiwi/conftest.py
+++ b/tests/components/electric_kiwi/conftest.py
@@ -6,7 +6,7 @@ from time import time
 from unittest.mock import AsyncMock, patch
 import zoneinfo
 
-from electrickiwi_api.model import Hop, HopIntervals
+from electrickiwi_api.model import AccountBalance, Hop, HopIntervals
 import pytest
 
 from homeassistant.components.application_credentials import (
@@ -112,5 +112,10 @@ def ek_api() -> YieldFixture:
         )
         mock_ek_api.return_value.get_hop.return_value = Hop.from_dict(
             load_json_value_fixture("get_hop.json", DOMAIN)
+        )
+        mock_ek_api.return_value.get_account_balance.return_value = (
+            AccountBalance.from_dict(
+                load_json_value_fixture("account_balance.json", DOMAIN)
+            )
         )
         yield mock_ek_api

--- a/tests/components/electric_kiwi/conftest.py
+++ b/tests/components/electric_kiwi/conftest.py
@@ -52,8 +52,9 @@ def component_setup(
         )
         await hass.async_block_till_done()
         config_entry.add_to_hass(hass)
-        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        result = await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
+        return result
 
     return _setup_func
 

--- a/tests/components/electric_kiwi/fixtures/account_balance.json
+++ b/tests/components/electric_kiwi/fixtures/account_balance.json
@@ -1,0 +1,28 @@
+{
+  "data": {
+    "connections": [
+      {
+        "hop_percentage": "3.5",
+        "id": 3,
+        "running_balance": "184.09",
+        "start_date": "2020-10-04",
+        "unbilled_days": 15
+      }
+    ],
+    "last_billed_amount": "-66.31",
+    "last_billed_date": "2020-10-03",
+    "next_billing_date": "2020-11-03",
+    "is_prepay": "N",
+    "summary": {
+      "credits": "0.0",
+      "electricity_used": "184.09",
+      "other_charges": "0.00",
+      "payments": "-220.0"
+    },
+    "total_account_balance": "-102.22",
+    "total_billing_days": 30,
+    "total_running_balance": "184.09",
+    "type": "account_running_balance"
+  },
+  "status": 1
+}

--- a/tests/components/electric_kiwi/test_sensor.py
+++ b/tests/components/electric_kiwi/test_sensor.py
@@ -49,7 +49,7 @@ async def test_hop_sensors(
     sensor state should be set to today at 4pm or if now is past 4pm,
     then tomorrow at 4pm.
     """
-    assert await component_setup()
+    await component_setup()
     assert config_entry.state is ConfigEntryState.LOADED
 
     entity = entity_registry.async_get(sensor)
@@ -90,7 +90,7 @@ async def test_account_sensors(
 ) -> None:
     """Test Account sensors for the Electric Kiwi integration."""
 
-    assert await component_setup()
+    await component_setup()
     assert config_entry.state is ConfigEntryState.LOADED
 
     entity = entity_registry.async_get(sensor)

--- a/tests/components/electric_kiwi/test_sensor.py
+++ b/tests/components/electric_kiwi/test_sensor.py
@@ -73,9 +73,9 @@ async def test_hop_sensors(
     ("sensor", "sensor_state"),
     [
         ("sensor.total_running_balance", "184.09"),
-        ("sensor.total_account_balance", "-102.22"),
+        ("sensor.total_current_balance", "-102.22"),
         ("sensor.next_billing_date", "2020-11-03T00:00:00"),
-        ("sensor.hop_percentage", "3.5"),
+        ("sensor.hour_of_power_savings", "3.5"),
     ],
 )
 async def test_account_sensors(

--- a/tests/components/electric_kiwi/test_sensor.py
+++ b/tests/components/electric_kiwi/test_sensor.py
@@ -90,7 +90,7 @@ async def test_account_sensors(
 ) -> None:
     """Test Account sensors for the Electric Kiwi integration."""
 
-    await component_setup()
+    assert await component_setup()
     assert config_entry.state is ConfigEntryState.LOADED
 
     entity = entity_registry.async_get(sensor)

--- a/tests/components/electric_kiwi/test_sensor.py
+++ b/tests/components/electric_kiwi/test_sensor.py
@@ -70,7 +70,7 @@ async def test_hop_sensors(
 
 
 @pytest.mark.parametrize(
-    ("sensor", "sensor_state"),
+    ("sensor", "sensor_state", "device_class", "state_class"),
     [
         ("sensor.total_running_balance", "184.09"),
         ("sensor.total_current_balance", "-102.22"),

--- a/tests/components/electric_kiwi/test_sensor.py
+++ b/tests/components/electric_kiwi/test_sensor.py
@@ -100,10 +100,6 @@ async def test_account_sensors(
     account_data = await api.get_account_balance()
     assert account_data
 
-    AccountSensors = list(
-        filter(lambda x: entity.unique_id.endswith(x.key), ACCOUNT_SENSOR_TYPES)
-    )
-    AccountSensor: ElectricKiwiAccountSensorEntityDescription = AccountSensors[0]
 
     state = hass.states.get(sensor)
     assert state

--- a/tests/components/electric_kiwi/test_sensor.py
+++ b/tests/components/electric_kiwi/test_sensor.py
@@ -49,7 +49,7 @@ async def test_hop_sensors(
     sensor state should be set to today at 4pm or if now is past 4pm,
     then tomorrow at 4pm.
     """
-    await component_setup()
+    assert await component_setup()
     assert config_entry.state is ConfigEntryState.LOADED
 
     entity = entity_registry.async_get(sensor)

--- a/tests/components/electric_kiwi/test_sensor.py
+++ b/tests/components/electric_kiwi/test_sensor.py
@@ -105,8 +105,8 @@ async def test_account_sensors(
     assert state
     assert state.state == sensor_state
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
-    assert state.attributes.get(ATTR_DEVICE_CLASS) == AccountSensor.device_class
-    assert state.attributes.get(ATTR_STATE_CLASS) == AccountSensor.state_class
+    assert state.attributes.get(ATTR_DEVICE_CLASS) == .device_class
+    assert state.attributes.get(ATTR_STATE_CLASS) == state_class
 
 
 async def test_check_and_move_time(ek_api: AsyncMock) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add additional Account sensor entities for balance and expenses as well as hour of free power savings percentage.

total running balance
total account balance
next billing date
hop (how much power you've saved) percentage

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/28429

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
