### PR TITLE
Fix color mode attribute for both official and non official Hue lights

### DIFF
--- a/homeassistant/components/hue/v2/light.py
+++ b/homeassistant/components/hue/v2/light.py
@@ -89,6 +89,7 @@ class HueLight(HueBaseEntity, LightEntity):
                 self._supported_color_modes.add(ColorMode.BRIGHTNESS)
             # support transition if brightness control
             self._attr_supported_features |= LightEntityFeature.TRANSITION
+        self._color_temp_active: bool = False
         # get list of supported effects (combine effects and timed_effects)
         self._attr_effect_list = []
         if effects := resource.effects:
@@ -121,16 +122,26 @@ class HueLight(HueBaseEntity, LightEntity):
     @property
     def color_mode(self) -> ColorMode:
         """Return the color mode of the light."""
-        if color_temp := self.resource.color_temperature:
-            # Hue lights return `mired_valid` to indicate CT is active
-            if color_temp.mirek is not None:
-                return ColorMode.COLOR_TEMP
+        if self.color_temp_active:
+            return ColorMode.COLOR_TEMP
         if self.resource.supports_color:
             return ColorMode.XY
         if self.resource.supports_dimming:
             return ColorMode.BRIGHTNESS
         # fallback to on_off
         return ColorMode.ONOFF
+
+    @property
+    def color_temp_active(self) -> bool:
+        """Return if the light is in Color Temperature mode."""
+        color_temp = self.resource.color_temperature
+        if color_temp is None or color_temp.mirek is None:
+            return False
+        # Official Hue lights return `mirek_valid` to indicate CT is active
+        # while non-official lights do not.
+        if self.device.product_data.certified:
+            return self.resource.color_temperature.mirek_valid
+        return self._color_temp_active
 
     @property
     def xy_color(self) -> tuple[float, float] | None:
@@ -193,6 +204,7 @@ class HueLight(HueBaseEntity, LightEntity):
         xy_color = kwargs.get(ATTR_XY_COLOR)
         color_temp = normalize_hue_colortemp(kwargs.get(ATTR_COLOR_TEMP))
         brightness = normalize_hue_brightness(kwargs.get(ATTR_BRIGHTNESS))
+        self._color_temp_active = color_temp is not None
         flash = kwargs.get(ATTR_FLASH)
         effect = effect_str = kwargs.get(ATTR_EFFECT)
         if effect_str in (EFFECT_NONE, EFFECT_NONE.lower()):


### PR DESCRIPTION
## Proposed change
Small bugfix for the colormode attribute of Philips Hue lights.
Recently we fixed a bug where non-official Hue lights did not set the colormode correctly but that bugfix introduced a side effect for official hue lights. After some testing it turns out that for non-official Hue lights there is no consequent, reliable way to detect if the light is in color temperature mode. 

This fix will use an optimistic boolean for non official Hue lights to determine if the light is in color temperature mode, based on the last command (from HA) while relying on the official way for certified lights. 


## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #97552
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
