### PR TITLE
Add packaging as default requirement

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -31,6 +31,7 @@ Jinja2==3.1.2
 lru-dict==1.2.0
 mutagen==1.46.0
 orjson==3.9.2
+packaging>=23.1
 paho-mqtt==1.6.1
 Pillow==10.0.0
 pip>=21.3.1

--- a/homeassistant/runner.py
+++ b/homeassistant/runner.py
@@ -11,6 +11,8 @@ import threading
 import traceback
 from typing import Any
 
+import packaging.tags
+
 from . import bootstrap
 from .core import callback
 from .helpers.frame import warn_use
@@ -165,7 +167,8 @@ def _enable_posix_spawn() -> None:
     # and will use fork() instead of posix_spawn() which significantly
     # less efficient. This is a workaround to force posix_spawn()
     # on Alpine Linux which is supported by musl.
-    subprocess._USE_POSIX_SPAWN = os.path.exists(ALPINE_RELEASE_FILE)
+    tag = next(packaging.tags.sys_tags())
+    subprocess._USE_POSIX_SPAWN = "musllinux" in tag.platform
 
 
 def run(runtime_config: RuntimeConfig) -> int:

--- a/homeassistant/runner.py
+++ b/homeassistant/runner.py
@@ -31,7 +31,6 @@ from .util.thread import deadlock_safe_shutdown
 #
 MAX_EXECUTOR_WORKERS = 64
 TASK_CANCELATION_TIMEOUT = 5
-ALPINE_RELEASE_FILE = "/etc/alpine-release"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -166,7 +165,7 @@ def _enable_posix_spawn() -> None:
     # The subprocess module does not know about Alpine Linux/musl
     # and will use fork() instead of posix_spawn() which significantly
     # less efficient. This is a workaround to force posix_spawn()
-    # on Alpine Linux which is supported by musl.
+    # when using musl since cpython is not aware its supported.
     tag = next(packaging.tags.sys_tags())
     subprocess._USE_POSIX_SPAWN = "musllinux" in tag.platform
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dependencies    = [
     # pyOpenSSL 23.2.0 is required to work with cryptography 41+
     "pyOpenSSL==23.2.0",
     "orjson==3.9.2",
+    "packaging>=23.1",
     "pip>=21.3.1",
     "python-slugify==4.0.1",
     "PyYAML==6.0.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ PyJWT==2.8.0
 cryptography==41.0.2
 pyOpenSSL==23.2.0
 orjson==3.9.2
+packaging>=23.1
 pip>=21.3.1
 python-slugify==4.0.1
 PyYAML==6.0.1


### PR DESCRIPTION
## Proposed change
Followup to #97628

At the time I didn't realize that we don't install `packaging` by default. 
It's used in many other packages already, so it was installed as a transitive dependency in our test environment.

https://packaging.pypa.io/en/stable/changelog.html

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
