### PR TITLE
Fix hassfest check for schema

### DIFF
--- a/script/hassfest/config_schema.py
+++ b/script/hassfest/config_schema.py
@@ -20,7 +20,7 @@ def _has_assignment(module: ast.Module, name: str) -> bool:
             continue
         if type(item) == ast.Assign:
             for target in item.targets:
-                if type(target) == ast.Name and target.id == name:
+                if getattr(target, "id", None) == name:
                     return True
             continue
         if item.target.id == name:

--- a/script/hassfest/config_schema.py
+++ b/script/hassfest/config_schema.py
@@ -20,7 +20,7 @@ def _has_assignment(module: ast.Module, name: str) -> bool:
             continue
         if type(item) == ast.Assign:
             for target in item.targets:
-                if target.id == name:
+                if type(target) == ast.Name and target.id == name:
                     return True
             continue
         if item.target.id == name:


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This needed a guard to make sure its the right node type

fixes
```
Validating config_schema...Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/Users/bdraco/home-assistant/script/hassfest/__main__.py", line 244, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/bdraco/home-assistant/script/hassfest/__main__.py", line 166, in main
    plugin.validate(integrations, config)
  File "/Users/bdraco/home-assistant/script/hassfest/config_schema.py", line 108, in validate
    _validate_integration(config, integration)
  File "/Users/bdraco/home-assistant/script/hassfest/config_schema.py", line 73, in _validate_integration
    _has_assignment(init, "CONFIG_SCHEMA")
  File "/Users/bdraco/home-assistant/script/hassfest/config_schema.py", line 23, in _has_assignment
    if target.id == name:
       ^^^^^^^^^
AttributeError: Attribute object has no attribute id
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
