### PR TITLE
Fix keymitt_ble RuntimeWarning

### DIFF
--- a/homeassistant/components/keymitt_ble/config_flow.py
+++ b/homeassistant/components/keymitt_ble/config_flow.py
@@ -138,7 +138,7 @@ class MicroBotConfigFlow(ConfigFlow, domain=DOMAIN):
             await self._client.connect(init=True)
             return self.async_show_form(step_id="link")
 
-        if not self._client.is_connected():
+        if not await self._client.is_connected():
             errors["base"] = "linking"
         else:
             await self._client.disconnect()

--- a/tests/components/keymitt_ble/__init__.py
+++ b/tests/components/keymitt_ble/__init__.py
@@ -77,6 +77,6 @@ class MockMicroBotApiClientFail:
     async def disconnect(self):
         """Mock disconnect."""
 
-    def is_connected(self):
+    async def is_connected(self):
         """Mock disconnected."""
         return False


### PR DESCRIPTION
## Proposed change
_Let's fix some pytest warnings!_

```
 tests/components/keymitt_ble/test_config_flow.py::test_user_setup
   /home/runner/work/ha-core/ha-core/homeassistant/components/keymitt_ble/config_flow.py:141:
       RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
   Coroutine created at (most recent call last)
     ...
     File "/opt/hostedtoolcache/Python/3.11.4/x64/lib/python3.11/unittest/mock.py", line 1128, in _mock_call
       return self._execute_mock_call(*args, **kwargs)
     if not self._client.is_connected():
```

`client.is_connected` is an async function and should be awaited.
https://github.com/spycle/pyMicroBot/blob/v0.0.9/microbot/__init__.py#L202

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
