### PR TITLE
Fix command_line tests RuntimeWarnings

### DIFF
--- a/tests/components/command_line/test_binary_sensor.py
+++ b/tests/components/command_line/test_binary_sensor.py
@@ -246,7 +246,7 @@ async def test_updating_to_often(
     assert called
     async_fire_time_changed(hass, dt_util.now() + timedelta(seconds=15))
     wait_till_event.set()
-    asyncio.wait(0)
+    await asyncio.sleep(0)
     assert (
         "Updating Command Line Binary Sensor Test took longer than the scheduled update interval"
         not in caplog.text
@@ -258,6 +258,7 @@ async def test_updating_to_often(
     await asyncio.sleep(0)
     async_fire_time_changed(hass, dt_util.now() + timedelta(seconds=10))
     wait_till_event.set()
+    await asyncio.sleep(0)
 
     assert (
         "Updating Command Line Binary Sensor Test took longer than the scheduled update interval"

--- a/tests/components/command_line/test_sensor.py
+++ b/tests/components/command_line/test_sensor.py
@@ -580,7 +580,7 @@ async def test_updating_to_often(
     assert called
     async_fire_time_changed(hass, dt_util.now() + timedelta(seconds=15))
     wait_till_event.set()
-    asyncio.wait(0)
+    await asyncio.sleep(0)
 
     assert (
         "Updating Command Line Sensor Test took longer than the scheduled update interval"
@@ -593,6 +593,7 @@ async def test_updating_to_often(
     await asyncio.sleep(0)
     async_fire_time_changed(hass, dt_util.now() + timedelta(seconds=10))
     wait_till_event.set()
+    await asyncio.sleep(0)
 
     assert (
         "Updating Command Line Sensor Test took longer than the scheduled update interval"


### PR DESCRIPTION
## Proposed change
_Let's fix some pytest warnings!_

```
 tests/components/command_line/test_binary_sensor.py::test_updating_to_often
   /home/runner/work/ha-core/ha-core/tests/components/command_line/test_binary_sensor.py:249:
       RuntimeWarning: coroutine 'wait' was never awaited
   Coroutine created at (most recent call last)
     ...
     File "/home/runner/work/ha-core/ha-core/tests/components/command_line/test_binary_sensor.py", line 249, in test_updating_to_often
       asyncio.wait(0)
     asyncio.wait(0)

 tests/components/command_line/test_sensor.py::test_updating_to_often
   /home/runner/work/ha-core/ha-core/tests/components/command_line/test_sensor.py:583:
       RuntimeWarning: coroutine 'wait' was never awaited
   Coroutine created at (most recent call last)
     ...
     File "/home/runner/work/ha-core/ha-core/tests/components/command_line/test_sensor.py", line 583, in test_updating_to_often
       asyncio.wait(0)
     asyncio.wait(0)
```

Use `await asyncio.sleep(0)` instead of `asyncio.wait(0)`.
https://docs.python.org/3/library/asyncio-task.html#asyncio.sleep

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
