### PR TITLE
Fix recorder DeprecationWarnings

### DIFF
--- a/tests/components/recorder/db_schema_16.py
+++ b/tests/components/recorder/db_schema_16.py
@@ -23,8 +23,7 @@ from sqlalchemy import (
     distinct,
 )
 from sqlalchemy.dialects import mysql
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import declarative_base, relationship
 from sqlalchemy.orm.session import Session
 
 from homeassistant.const import (

--- a/tests/components/recorder/db_schema_18.py
+++ b/tests/components/recorder/db_schema_18.py
@@ -23,8 +23,7 @@ from sqlalchemy import (
     distinct,
 )
 from sqlalchemy.dialects import mysql
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import declarative_base, relationship
 from sqlalchemy.orm.session import Session
 
 from homeassistant.const import (

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -2224,7 +2224,7 @@ async def test_connect_args_priority(hass: HomeAssistant, config_url) -> None:
             return "mysql"
 
         @classmethod
-        def dbapi(cls):
+        def import_dbapi(cls):
             ...
 
         def engine_created(*args):

--- a/tests/components/recorder/test_pool.py
+++ b/tests/components/recorder/test_pool.py
@@ -26,14 +26,14 @@ def test_recorder_pool(caplog: pytest.LogCaptureFixture) -> None:
 
     def _get_connection_twice():
         session = get_session()
-        connections.append(session.connection().connection.connection)
+        connections.append(session.connection().connection.driver_connection)
         session.close()
 
         if shutdown:
             engine.pool.shutdown()
 
         session = get_session()
-        connections.append(session.connection().connection.connection)
+        connections.append(session.connection().connection.driver_connection)
         session.close()
 
     caplog.clear()


### PR DESCRIPTION
## Proposed change
_Let's fix some pytest warnings!_

```
 tests/components/recorder/test_migrate.py::test_schema_migrate[16-True]
   /home/runner/work/ha-core/ha-core/tests/components/recorder/db_schema_16.py:44:
       MovedIn20Warning: The ``declarative_base()`` function is now available as
       sqlalchemy.orm.declarative_base(). (deprecated since: 2.0) (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
     Base = declarative_base()

 tests/components/recorder/test_migrate.py::test_schema_migrate[18-True]
   /home/runner/work/ha-core/ha-core/tests/components/recorder/db_schema_18.py:44:
       MovedIn20Warning: The ``declarative_base()`` function is now available as
       sqlalchemy.orm.declarative_base(). (deprecated since: 2.0) (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
     Base = declarative_base()

 tests/components/recorder/test_init.py::test_connect_args_priority[***SERVER_IP/DB_NAME]
   /home/runner/work/ha-core/ha-core/homeassistant/components/recorder/core.py:1393:
       SADeprecationWarning: The dbapi() classmethod on dialect classes has been
       renamed to import_dbapi().  Implement an import_dbapi() classmethod directly on
       class <class 'tests.components.recorder.test_init.test_connect_args_priority.<locals>.MockDialect'>
       to remove this warning; the old .dbapi() classmethod may be maintained for backwards compatibility.
     self.engine = create_engine(self.db_url, **kwargs, future=True)

 tests/components/recorder/test_pool.py::test_recorder_pool
   /home/runner/work/ha-core/ha-core/tests/components/recorder/test_pool.py:29:
       SADeprecationWarning: The _ConnectionFairy.connection attribute is deprecated;
       please use 'driver_connection' (deprecated since: 2.0)
     connections.append(session.connection().connection.connection)

 tests/components/recorder/test_pool.py::test_recorder_pool
   /home/runner/work/ha-core/ha-core/tests/components/recorder/test_pool.py:36:
       SADeprecationWarning: The _ConnectionFairy.connection attribute is deprecated;
       please use 'driver_connection' (deprecated since: 2.0)
     connections.append(session.connection().connection.connection)
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
