### PR TITLE
modbus: use pb not pymodbus consistently as name.

### DIFF
--- a/homeassistant/components/modbus/base_platform.py
+++ b/homeassistant/components/modbus/base_platform.py
@@ -73,10 +73,6 @@ class BasePlatform(Entity):
     def __init__(self, hub: ModbusHub, entry: dict[str, Any]) -> None:
         """Initialize the Modbus binary sensor."""
         self._hub = hub
-        # temporary fix,
-        # make sure slave is always defined to avoid an error in pymodbus
-        # attr(in_waiting) not defined.
-        # see issue #657 and PR #660 in riptideio/pymodbus
         self._slave = entry.get(CONF_SLAVE, 0)
         self._address = int(entry[CONF_ADDRESS])
         self._input_type = entry[CONF_INPUT_TYPE]
@@ -287,7 +283,7 @@ class BaseSwitch(BasePlatform, ToggleEntity, RestoreEntity):
 
     async def async_turn(self, command: int) -> None:
         """Evaluate switch result."""
-        result = await self._hub.async_pymodbus_call(
+        result = await self._hub.async_pb_call(
             self._slave, self._address, command, self._write_type
         )
         if result is None:
@@ -323,7 +319,7 @@ class BaseSwitch(BasePlatform, ToggleEntity, RestoreEntity):
         if self._call_active:
             return
         self._call_active = True
-        result = await self._hub.async_pymodbus_call(
+        result = await self._hub.async_pb_call(
             self._slave, self._verify_address, 1, self._verify_type
         )
         self._call_active = False

--- a/homeassistant/components/modbus/binary_sensor.py
+++ b/homeassistant/components/modbus/binary_sensor.py
@@ -97,7 +97,7 @@ class ModbusBinarySensor(BasePlatform, RestoreEntity, BinarySensorEntity):
         if self._call_active:
             return
         self._call_active = True
-        result = await self._hub.async_pymodbus_call(
+        result = await self._hub.async_pb_call(
             self._slave, self._address, self._count, self._input_type
         )
         self._call_active = False

--- a/homeassistant/components/modbus/climate.py
+++ b/homeassistant/components/modbus/climate.py
@@ -155,14 +155,14 @@ class ModbusThermostat(BaseStructPlatform, RestoreEntity, ClimateEntity):
         if self._hvac_onoff_register is not None:
             # Turn HVAC Off by writing 0 to the On/Off register, or 1 otherwise.
             if self._hvac_onoff_write_registers:
-                await self._hub.async_pymodbus_call(
+                await self._hub.async_pb_call(
                     self._slave,
                     self._hvac_onoff_register,
                     [0 if hvac_mode == HVACMode.OFF else 1],
                     CALL_TYPE_WRITE_REGISTERS,
                 )
             else:
-                await self._hub.async_pymodbus_call(
+                await self._hub.async_pb_call(
                     self._slave,
                     self._hvac_onoff_register,
                     0 if hvac_mode == HVACMode.OFF else 1,
@@ -174,14 +174,14 @@ class ModbusThermostat(BaseStructPlatform, RestoreEntity, ClimateEntity):
             for value, mode in self._hvac_mode_mapping:
                 if mode == hvac_mode:
                     if self._hvac_mode_write_registers:
-                        await self._hub.async_pymodbus_call(
+                        await self._hub.async_pb_call(
                             self._slave,
                             self._hvac_mode_register,
                             [value],
                             CALL_TYPE_WRITE_REGISTERS,
                         )
                     else:
-                        await self._hub.async_pymodbus_call(
+                        await self._hub.async_pb_call(
                             self._slave,
                             self._hvac_mode_register,
                             value,
@@ -217,21 +217,21 @@ class ModbusThermostat(BaseStructPlatform, RestoreEntity, ClimateEntity):
             DataType.UINT16,
         ):
             if self._target_temperature_write_registers:
-                result = await self._hub.async_pymodbus_call(
+                result = await self._hub.async_pb_call(
                     self._slave,
                     self._target_temperature_register,
                     [int(float(registers[0]))],
                     CALL_TYPE_WRITE_REGISTERS,
                 )
             else:
-                result = await self._hub.async_pymodbus_call(
+                result = await self._hub.async_pb_call(
                     self._slave,
                     self._target_temperature_register,
                     int(float(registers[0])),
                     CALL_TYPE_WRITE_REGISTER,
                 )
         else:
-            result = await self._hub.async_pymodbus_call(
+            result = await self._hub.async_pb_call(
                 self._slave,
                 self._target_temperature_register,
                 [int(float(i)) for i in registers],
@@ -287,7 +287,7 @@ class ModbusThermostat(BaseStructPlatform, RestoreEntity, ClimateEntity):
         self, register_type: str, register: int, raw: bool | None = False
     ) -> float | None:
         """Read register using the Modbus hub slave."""
-        result = await self._hub.async_pymodbus_call(
+        result = await self._hub.async_pb_call(
             self._slave, register, self._count, register_type
         )
         if result is None:

--- a/homeassistant/components/modbus/cover.py
+++ b/homeassistant/components/modbus/cover.py
@@ -120,7 +120,7 @@ class ModbusCover(BasePlatform, CoverEntity, RestoreEntity):
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open cover."""
-        result = await self._hub.async_pymodbus_call(
+        result = await self._hub.async_pb_call(
             self._slave, self._write_address, self._state_open, self._write_type
         )
         self._attr_available = result is not None
@@ -128,7 +128,7 @@ class ModbusCover(BasePlatform, CoverEntity, RestoreEntity):
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close cover."""
-        result = await self._hub.async_pymodbus_call(
+        result = await self._hub.async_pb_call(
             self._slave, self._write_address, self._state_closed, self._write_type
         )
         self._attr_available = result is not None
@@ -142,7 +142,7 @@ class ModbusCover(BasePlatform, CoverEntity, RestoreEntity):
         if self._call_active:
             return
         self._call_active = True
-        result = await self._hub.async_pymodbus_call(
+        result = await self._hub.async_pb_call(
             self._slave, self._address, 1, self._input_type
         )
         self._call_active = False

--- a/homeassistant/components/modbus/modbus.py
+++ b/homeassistant/components/modbus/modbus.py
@@ -79,7 +79,7 @@ _LOGGER = logging.getLogger(__name__)
 
 ConfEntry = namedtuple("ConfEntry", "call_type attr func_name")
 RunEntry = namedtuple("RunEntry", "attr func")
-PYMODBUS_CALL = [
+PB_CALL = [
     ConfEntry(
         CALL_TYPE_COIL,
         "bits",
@@ -178,11 +178,11 @@ async def async_modbus_setup(
             service.data[ATTR_HUB] if ATTR_HUB in service.data else DEFAULT_HUB
         ]
         if isinstance(value, list):
-            await hub.async_pymodbus_call(
+            await hub.async_pb_call(
                 unit, address, [int(float(i)) for i in value], CALL_TYPE_WRITE_REGISTERS
             )
         else:
-            await hub.async_pymodbus_call(
+            await hub.async_pb_call(
                 unit, address, int(float(value)), CALL_TYPE_WRITE_REGISTER
             )
 
@@ -199,9 +199,9 @@ async def async_modbus_setup(
             service.data[ATTR_HUB] if ATTR_HUB in service.data else DEFAULT_HUB
         ]
         if isinstance(state, list):
-            await hub.async_pymodbus_call(unit, address, state, CALL_TYPE_WRITE_COILS)
+            await hub.async_pb_call(unit, address, state, CALL_TYPE_WRITE_COILS)
         else:
-            await hub.async_pymodbus_call(unit, address, state, CALL_TYPE_WRITE_COIL)
+            await hub.async_pb_call(unit, address, state, CALL_TYPE_WRITE_COIL)
 
     for x_write in (
         (SERVICE_WRITE_REGISTER, async_write_register, ATTR_VALUE, cv.positive_int),
@@ -264,7 +264,7 @@ class ModbusHub:
         self.name = client_config[CONF_NAME]
         self._config_type = client_config[CONF_TYPE]
         self._config_delay = client_config[CONF_DELAY]
-        self._pb_call: dict[str, RunEntry] = {}
+        self._pb_request: dict[str, RunEntry] = {}
         self._pb_class = {
             SERIAL: ModbusSerialClient,
             TCP: ModbusTcpClient,
@@ -315,10 +315,10 @@ class ModbusHub:
             _LOGGER.error(log_text)
             self._in_error = error_state
 
-    async def async_pymodbus_connect(self) -> None:
+    async def async_pb_connect(self) -> None:
         """Connect to device, async."""
         async with self._lock:
-            if not await self.hass.async_add_executor_job(self._pymodbus_connect):
+            if not await self.hass.async_add_executor_job(self.pb_connect):
                 err = f"{self.name} connect failed, retry in pymodbus"
                 self._log_error(err, error_state=False)
 
@@ -330,12 +330,12 @@ class ModbusHub:
             self._log_error(str(exception_error), error_state=False)
             return False
 
-        for entry in PYMODBUS_CALL:
+        for entry in PB_CALL:
             func = getattr(self._client, entry.func_name)
-            self._pb_call[entry.call_type] = RunEntry(entry.attr, func)
+            self._pb_request[entry.call_type] = RunEntry(entry.attr, func)
 
         self.hass.async_create_background_task(
-            self.async_pymodbus_connect(), "modbus-connect"
+            self.async_pb_connect(), "modbus-connect"
         )
 
         # Start counting down to allow modbus requests.
@@ -374,7 +374,7 @@ class ModbusHub:
                 message = f"modbus {self.name} communication closed"
                 _LOGGER.warning(message)
 
-    def _pymodbus_connect(self) -> bool:
+    def pb_connect(self) -> bool:
         """Connect client."""
         try:
             self._client.connect()  # type: ignore[union-attr]
@@ -386,12 +386,12 @@ class ModbusHub:
         _LOGGER.info(message)
         return True
 
-    def _pymodbus_call(
+    def pb_call(
         self, unit: int | None, address: int, value: int | list[int], use_call: str
     ) -> ModbusResponse | None:
         """Call sync. pymodbus."""
         kwargs = {"slave": unit} if unit else {}
-        entry = self._pb_call[use_call]
+        entry = self._pb_request[use_call]
         try:
             result: ModbusResponse = entry.func(address, value, **kwargs)
         except ModbusException as exception_error:
@@ -403,7 +403,7 @@ class ModbusHub:
         self._in_error = False
         return result
 
-    async def async_pymodbus_call(
+    async def async_pb_call(
         self,
         unit: int | None,
         address: int,
@@ -417,7 +417,7 @@ class ModbusHub:
             if not self._client:
                 return None
             result = await self.hass.async_add_executor_job(
-                self._pymodbus_call, unit, address, value, use_call
+                self.pb_call, unit, address, value, use_call
             )
             if self._msg_wait:
                 # small delay until next request/response

--- a/homeassistant/components/modbus/sensor.py
+++ b/homeassistant/components/modbus/sensor.py
@@ -101,7 +101,7 @@ class ModbusRegisterSensor(BaseStructPlatform, RestoreSensor, SensorEntity):
         """Update the state of the sensor."""
         # remark "now" is a dummy parameter to avoid problems with
         # async_track_time_interval
-        raw_result = await self._hub.async_pymodbus_call(
+        raw_result = await self._hub.async_pb_call(
             self._slave, self._address, self._count, self._input_type
         )
         if raw_result is None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Variable / method names connecting to the pymodbus library was inconsistently named.

Changing pymodbus -> pb

Gives a consistent naming, and makes the external debugging easier (for me as code owner).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
