### PR TITLE
Add default headers to webserver responses

### DIFF
--- a/homeassistant/components/http/headers.py
+++ b/homeassistant/components/http/headers.py
@@ -1,0 +1,29 @@
+"""Middleware that helps with the control of headers in our responses."""
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+
+from aiohttp.web import Application, Request, StreamResponse, middleware
+
+from homeassistant.core import callback
+
+
+@callback
+def setup_headers(app: Application, use_x_frame_options: bool) -> None:
+    """Create headers middleware for the app."""
+
+    @middleware
+    async def headers_middleware(
+        request: Request, handler: Callable[[Request], Awaitable[StreamResponse]]
+    ) -> StreamResponse:
+        """Process request and add headers to the responses."""
+        response = await handler(request)
+        response.headers["Referrer-Policy"] = "no-referrer"
+        response.headers["X-Content-Type-Options"] = "nosniff"
+
+        if use_x_frame_options:
+            response.headers["X-Frame-Options"] = "SAMEORIGIN"
+
+        return response
+
+    app.middlewares.append(headers_middleware)

--- a/homeassistant/components/http/headers.py
+++ b/homeassistant/components/http/headers.py
@@ -21,6 +21,9 @@ def setup_headers(app: Application, use_x_frame_options: bool) -> None:
         response.headers["Referrer-Policy"] = "no-referrer"
         response.headers["X-Content-Type-Options"] = "nosniff"
 
+        # Set an empty server header, to prevent aiohttp of setting one.
+        response.headers["Server"] = ""
+
         if use_x_frame_options:
             response.headers["X-Frame-Options"] = "SAMEORIGIN"
 

--- a/tests/components/http/test_headers.py
+++ b/tests/components/http/test_headers.py
@@ -25,6 +25,7 @@ async def test_headers_added(aiohttp_client: ClientSessionGenerator) -> None:
 
     assert resp.status == HTTPStatus.OK
     assert resp.headers["Referrer-Policy"] == "no-referrer"
+    assert resp.headers["Server"] == ""
     assert resp.headers["X-Content-Type-Options"] == "nosniff"
     assert resp.headers["X-Frame-Options"] == "SAMEORIGIN"
 

--- a/tests/components/http/test_headers.py
+++ b/tests/components/http/test_headers.py
@@ -1,0 +1,43 @@
+"""Test headers middleware."""
+from http import HTTPStatus
+
+from aiohttp import web
+
+from homeassistant.components.http.headers import setup_headers
+
+from tests.typing import ClientSessionGenerator
+
+
+async def mock_handler(request):
+    """Return OK."""
+    return web.Response(text="OK")
+
+
+async def test_headers_added(aiohttp_client: ClientSessionGenerator) -> None:
+    """Test that headers are being added on each request."""
+    app = web.Application()
+    app.router.add_get("/", mock_handler)
+
+    setup_headers(app, use_x_frame_options=True)
+
+    mock_api_client = await aiohttp_client(app)
+    resp = await mock_api_client.get("/")
+
+    assert resp.status == HTTPStatus.OK
+    assert resp.headers["Referrer-Policy"] == "no-referrer"
+    assert resp.headers["X-Content-Type-Options"] == "nosniff"
+    assert resp.headers["X-Frame-Options"] == "SAMEORIGIN"
+
+
+async def test_allow_framing(aiohttp_client: ClientSessionGenerator) -> None:
+    """Test that we allow framing when disabled."""
+    app = web.Application()
+    app.router.add_get("/", mock_handler)
+
+    setup_headers(app, use_x_frame_options=False)
+
+    mock_api_client = await aiohttp_client(app)
+    resp = await mock_api_client.get("/")
+
+    assert resp.status == HTTPStatus.OK
+    assert "X-Frame-Options" not in resp.headers

--- a/tests/scripts/test_check_config.py
+++ b/tests/scripts/test_check_config.py
@@ -117,6 +117,7 @@ def test_secrets(mock_is_file, event_loop, mock_hass_config_yaml: None) -> None:
         "login_attempts_threshold": -1,
         "server_port": 8123,
         "ssl_profile": "modern",
+        "use_x_frame_options": True,
     }
     assert res["secret_cache"] == {
         get_test_config_dir("secrets.yaml"): {"http_pw": "http://google.com"}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

Home Assistant can't be put in an iframe anymore by default. If you still want to embed the Home Assistant interface in a frame, you can do so by disabling `use_x_frame_options` by setting it to `false` in the `http` configuration.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds a little bit of middleware, that sets some useful headers by default. To improve both security and privacy.

- Sets `Referrer-Policy` to disable any referrer to be sent out. This prevents leaking your instance URL when navigating away.
- Sets `X-Frame-Options` which helps to prevent clickjacking.
- Sets `X-Content-Type-Options` to avoid MIME type sniffing.
- Sets `Server` to an empty string. This prevents `aiohttp` adding its version + Python version; leaking unneeded information.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/28453

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
