### PR TITLE
Add option to preserve relative brightness in light groups

### DIFF
--- a/homeassistant/components/group/config_flow.py
+++ b/homeassistant/components/group/config_flow.py
@@ -22,6 +22,7 @@ from homeassistant.helpers.schema_config_entry_flow import (
 from . import DOMAIN
 from .binary_sensor import CONF_ALL
 from .const import CONF_HIDE_MEMBERS, CONF_IGNORE_NON_NUMERIC
+from .light import CONF_PRESERVE_RELATIVE_BRIGHTNESS
 
 _STATISTIC_MEASURES = [
     "min",
@@ -78,6 +79,15 @@ BINARY_SENSOR_CONFIG_SCHEMA = basic_group_config_schema("binary_sensor").extend(
     }
 )
 
+LIGHT_CONFIG_SCHEMA = basic_group_config_schema("light").extend(
+    {
+        vol.Required(CONF_ALL, default=False): selector.BooleanSelector(),
+        vol.Required(
+            CONF_PRESERVE_RELATIVE_BRIGHTNESS, default=False
+        ): selector.BooleanSelector(),
+    }
+)
+
 SENSOR_CONFIG_EXTENDS = {
     vol.Required(CONF_TYPE): selector.SelectSelector(
         selector.SelectSelectorConfig(
@@ -109,14 +119,35 @@ SENSOR_CONFIG_SCHEMA = basic_group_config_schema(
 ).extend(SENSOR_CONFIG_EXTENDS)
 
 
-async def light_switch_options_schema(
+async def light_options_schema(
     domain: str, handler: SchemaCommonFlowHandler
 ) -> vol.Schema:
     """Generate options schema."""
     return (await basic_group_options_schema(domain, handler)).extend(
         {
             vol.Required(
-                CONF_ALL, default=False, description={"advanced": True}
+                CONF_PRESERVE_RELATIVE_BRIGHTNESS,
+                default=False,
+            ): selector.BooleanSelector(),
+            vol.Required(
+                CONF_ALL,
+                default=False,
+                description={"advanced": True},
+            ): selector.BooleanSelector(),
+        }
+    )
+
+
+async def switch_options_schema(
+    domain: str, handler: SchemaCommonFlowHandler
+) -> vol.Schema:
+    """Generate options schema."""
+    return (await basic_group_options_schema(domain, handler)).extend(
+        {
+            vol.Required(
+                CONF_ALL,
+                default=False,
+                description={"advanced": True},
             ): selector.BooleanSelector(),
         }
     )
@@ -170,7 +201,7 @@ CONFIG_FLOW = {
         validate_user_input=set_group_type("fan"),
     ),
     "light": SchemaFlowFormStep(
-        basic_group_config_schema("light"),
+        LIGHT_CONFIG_SCHEMA,
         validate_user_input=set_group_type("light"),
     ),
     "lock": SchemaFlowFormStep(
@@ -197,13 +228,13 @@ OPTIONS_FLOW = {
     "binary_sensor": SchemaFlowFormStep(binary_sensor_options_schema),
     "cover": SchemaFlowFormStep(partial(basic_group_options_schema, "cover")),
     "fan": SchemaFlowFormStep(partial(basic_group_options_schema, "fan")),
-    "light": SchemaFlowFormStep(partial(light_switch_options_schema, "light")),
+    "light": SchemaFlowFormStep(partial(light_options_schema, "light")),
     "lock": SchemaFlowFormStep(partial(basic_group_options_schema, "lock")),
     "media_player": SchemaFlowFormStep(
         partial(basic_group_options_schema, "media_player")
     ),
     "sensor": SchemaFlowFormStep(partial(sensor_options_schema, "sensor")),
-    "switch": SchemaFlowFormStep(partial(light_switch_options_schema, "switch")),
+    "switch": SchemaFlowFormStep(partial(switch_options_schema, "switch")),
 }
 
 

--- a/homeassistant/components/group/strings.json
+++ b/homeassistant/components/group/strings.json
@@ -44,9 +44,11 @@
       },
       "light": {
         "title": "[%key:component::group::config::step::user::title%]",
+        "description": "[%key:component::group::config::step::binary_sensor::description%]\n\nIf \"preserve relative brightness\" is enabled, then the group's brightness is the brightness of the brightest member of the group, and adjusting the brightness of the group will scale each member's brightness relative to that maximum. If \"preserve relative brightness\" is disabled, the group's brightness is the average of all entities, and adjusting the brightness of the group will set all members to that brightness level.",
         "data": {
           "entities": "[%key:component::group::config::step::binary_sensor::data::entities%]",
           "hide_members": "[%key:component::group::config::step::binary_sensor::data::hide_members%]",
+          "preserve_relative_brightness": "Preserve relative brightness",
           "name": "[%key:component::group::config::step::binary_sensor::data::name%]"
         }
       },
@@ -113,11 +115,12 @@
         }
       },
       "light": {
-        "description": "[%key:component::group::config::step::binary_sensor::description%]",
+        "description": "[%key:component::group::config::step::light::description%]",
         "data": {
           "all": "[%key:component::group::config::step::binary_sensor::data::all%]",
           "entities": "[%key:component::group::config::step::binary_sensor::data::entities%]",
-          "hide_members": "[%key:component::group::config::step::binary_sensor::data::hide_members%]"
+          "hide_members": "[%key:component::group::config::step::binary_sensor::data::hide_members%]",
+          "preserve_relative_brightness": "[%key:component::group::config::step::light::data::preserve_relative_brightness%]"
         }
       },
       "lock": {

--- a/tests/components/group/test_config_flow.py
+++ b/tests/components/group/test_config_flow.py
@@ -27,7 +27,15 @@ from tests.common import MockConfigEntry
         ("binary_sensor", "on", "on", {}, {"all": True}, {"all": True}, {}),
         ("cover", "open", "open", {}, {}, {}, {}),
         ("fan", "on", "on", {}, {}, {}, {}),
-        ("light", "on", "on", {}, {}, {}, {}),
+        (
+            "light",
+            "on",
+            "on",
+            {},
+            {},
+            {"all": False, "preserve_relative_brightness": False},
+            {},
+        ),
         ("lock", "locked", "locked", {}, {}, {}, {}),
         ("media_player", "on", "on", {}, {}, {}, {}),
         (
@@ -193,7 +201,7 @@ def get_suggested(schema, key):
         ("binary_sensor", "on", {"all": False}, {}),
         ("cover", "open", {}, {}),
         ("fan", "on", {}, {}),
-        ("light", "on", {"all": False}, {}),
+        ("light", "on", {"all": False, "preserve_relative_brightness": False}, {}),
         ("lock", "locked", {}, {}),
         ("media_player", "on", {}, {}),
         (
@@ -295,10 +303,30 @@ async def test_options(
 @pytest.mark.parametrize(
     ("group_type", "extra_options", "extra_options_after", "advanced"),
     (
-        ("light", {"all": False}, {"all": False}, False),
-        ("light", {"all": True}, {"all": True}, False),
-        ("light", {"all": False}, {"all": False}, True),
-        ("light", {"all": True}, {"all": False}, True),
+        (
+            "light",
+            {"all": False, "preserve_relative_brightness": False},
+            {"all": False, "preserve_relative_brightness": False},
+            False,
+        ),
+        (
+            "light",
+            {"all": True, "preserve_relative_brightness": False},
+            {"all": True, "preserve_relative_brightness": False},
+            False,
+        ),
+        (
+            "light",
+            {"all": False, "preserve_relative_brightness": False},
+            {"all": False, "preserve_relative_brightness": False},
+            True,
+        ),
+        (
+            "light",
+            {"all": True, "preserve_relative_brightness": False},
+            {"all": False, "preserve_relative_brightness": False},
+            True,
+        ),
         ("switch", {"all": False}, {"all": False}, False),
         ("switch", {"all": True}, {"all": True}, False),
         ("switch", {"all": False}, {"all": False}, True),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->



## Proposed change

This introduces a new option on light groups: `preserve_relative_brightness`. When enabled, the brightness of the group is the brightness of the brightest member entity (rather than the average), and adjusting the brightness of the group scales the brightness of each entity relative to that maximum. This is, of course, rough and potentially subject to rounding errors. You can see the new behavior here:

https://github.com/home-assistant/core/assets/28167/5ef0b1d3-263c-4e7f-a00b-3afa79c6978d

If `preserve_relative_brightness` is disabled (the default), the old behavior is preserved: brightness of the group is the average brightness of its members, and setting the brightness of the group sets all members of that group to that brightness level. This is also the behavior if the group is off.

I wasn't able to find a feature request topic that exactly matches this, but I think that https://community.home-assistant.io/t/light-group-different-brightness-levels/357420, https://community.home-assistant.io/t/scene-dimmer/105702, and https://community.home-assistant.io/t/only-change-brightness-for-powered-on-in-group/302576 could all be addressed using a combination of this behavior and scenes.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/28457

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
