### PR TITLE
Set script execution as cancelled when stopped

### DIFF
--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -482,6 +482,7 @@ class _ScriptRun:
         """Stop script run."""
         self._stop.set()
         await self._stopped.wait()
+        script_execution_set("cancelled")
 
     def _handle_exception(
         self, exception: Exception, continue_on_error: bool, log_exceptions: bool

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -1012,13 +1012,15 @@ async def test_wait_basic_times_out(hass: HomeAssistant, action_type) -> None:
         assert_action_trace(
             {
                 "0": [{"result": {"wait": {"completed": False, "remaining": None}}}],
-            }
+            },
+            expected_script_execution="cancelled",
         )
     else:
         assert_action_trace(
             {
                 "0": [{"result": {"wait": {"trigger": None, "remaining": None}}}],
-            }
+            },
+            expected_script_execution="cancelled",
         )
 
 
@@ -1166,7 +1168,8 @@ async def test_wait_template_not_schedule(hass: HomeAssistant) -> None:
                     "variables": {"wait": {"completed": True, "remaining": None}},
                 }
             ],
-        }
+        },
+        expected_script_execution="cancelled",
     )
 
 
@@ -4321,10 +4324,12 @@ async def test_shutdown_at(
         assert not script_obj.is_running
         assert "Stopping scripts running at shutdown: test script" in caplog.text
 
-    expected_trace = {
-        "0": [{"result": {"delay": 120.0, "done": False}}],
-    }
-    assert_action_trace(expected_trace)
+    assert_action_trace(
+        {
+            "0": [{"result": {"delay": 120.0, "done": False}}],
+        },
+        expected_script_execution="cancelled",
+    )
 
 
 @pytest.mark.parametrize("wait_for_stop_scripts_after_shutdown", [True])
@@ -4360,10 +4365,12 @@ async def test_shutdown_after(
             in caplog.text
         )
 
-    expected_trace = {
-        "0": [{"result": {"delay": 120.0, "done": False}}],
-    }
-    assert_action_trace(expected_trace)
+    assert_action_trace(
+        {
+            "0": [{"result": {"delay": 120.0, "done": False}}],
+        },
+        expected_script_execution="cancelled",
+    )
 
 
 @pytest.mark.parametrize("wait_for_stop_scripts_after_shutdown", [True])

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -1169,7 +1169,6 @@ async def test_wait_template_not_schedule(hass: HomeAssistant) -> None:
                 }
             ],
         },
-        expected_script_execution="cancelled",
     )
 
 
@@ -1400,7 +1399,8 @@ async def test_wait_template_with_utcnow_no_match(hass: HomeAssistant) -> None:
     assert_action_trace(
         {
             "0": [{"result": {"wait": {"completed": False, "remaining": None}}}],
-        }
+        },
+        expected_script_execution="cancelled",
     )
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently when an automation is running and is stopped by the UI (always stops the current actions) or via a service call (stop actions is optional), the error message is very unclear:
![image](https://github.com/home-assistant/core/assets/7083755/707babe4-40be-497b-9ac1-e224d6f5e848)
To make it clearer what is happening, I propose to set the script execution status to cancelled when the automation is stopped. This makes a clearer error message, thus giving a better indication on why it exactly failed (for example disabling the automation in a scene which is activated by that same automation, or disabling the automation in the same automation without setting stop actions to false).
![image](https://github.com/home-assistant/core/assets/7083755/7fe292b0-9669-4206-9c22-0e598e5dfb4a)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #97828
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
