### PR TITLE
Do not fire homekit_controller events from IP polling

### DIFF
--- a/homeassistant/components/homekit_controller/device_trigger.py
+++ b/homeassistant/components/homekit_controller/device_trigger.py
@@ -80,11 +80,11 @@ class TriggerSource:
             self._iid_trigger_keys.setdefault(iid, set()).add(trigger_key)
             await connection.add_watchable_characteristics([(aid, iid)])
 
-    def fire(self, iid: int, value: dict[str, Any]) -> None:
+    def fire(self, iid: int, ev: dict[str, Any]) -> None:
         """Process events that have been received from a HomeKit accessory."""
         for trigger_key in self._iid_trigger_keys.get(iid, set()):
             for event_handler in self._callbacks.get(trigger_key, []):
-                event_handler(value)
+                event_handler(ev)
 
     def async_get_triggers(self) -> Generator[tuple[str, str], None, None]:
         """List device triggers for HomeKit devices."""
@@ -107,8 +107,8 @@ class TriggerSource:
         hass = self._hass
 
         @callback
-        def event_handler(char: dict[str, Any]) -> None:
-            if sub_type != HK_TO_HA_INPUT_EVENT_VALUES.get(char["value"]):
+        def event_handler(ev: dict[str, Any]) -> None:
+            if sub_type != HK_TO_HA_INPUT_EVENT_VALUES[ev["value"]]:
                 return
             hass.async_run_hass_job(job, {"trigger": {**trigger_data, **config}})
 
@@ -262,6 +262,10 @@ def async_fire_triggers(conn: HKDevice, events: dict[tuple[int, int], dict[str, 
     if not trigger_sources:
         return
     for (aid, iid), ev in events.items():
+        # If the value is None, we received the event via polling
+        # and we don't want to trigger on that
+        if ev["value"] is None:
+            continue
         if aid in conn.devices:
             device_id = conn.devices[aid]
             if source := trigger_sources.get(device_id):

--- a/tests/components/homekit_controller/test_device_trigger.py
+++ b/tests/components/homekit_controller/test_device_trigger.py
@@ -425,6 +425,14 @@ async def test_handle_events_late_setup(hass: HomeAssistant, utcnow, calls) -> N
     assert len(calls) == 1
     assert calls[0].data["some"] == "device - button1 - single_press - 0"
 
+    # Make sure automation doesn't trigger for a polled None
+    helper.pairing.testing.update_named_service(
+        "Button 1", {CharacteristicsTypes.INPUT_EVENT: None}
+    )
+
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+
     # Make sure automation doesn't trigger for long press
     helper.pairing.testing.update_named_service(
         "Button 1", {CharacteristicsTypes.INPUT_EVENT: 1}


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

If we poll an `ev` char for a programmable switch, we will get a value of `None` back.

We should not fire events for `None`

Rename a few places were the event data was confusing since it was called `char` and `value`

Verified this didn't break BLE as well
<img width="861" alt="Screenshot 2023-08-05 at 12 10 26 PM" src="https://github.com/home-assistant/core/assets/663432/f80b75a3-df25-4f34-98f1-dbb6a32d61ab">


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #97654
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
