### PR TITLE
Cache envoy auth tokens to ensure integration works if cloud is offline

### DIFF
--- a/homeassistant/components/enphase_envoy/__init__.py
+++ b/homeassistant/components/enphase_envoy/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from pyenphase import Envoy
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.httpx_client import get_async_client
@@ -16,15 +16,9 @@ from .coordinator import EnphaseUpdateCoordinator
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Enphase Envoy from a config entry."""
 
-    config = entry.data
-    name = config[CONF_NAME]
-    host = config[CONF_HOST]
-    username = config[CONF_USERNAME]
-    password = config[CONF_PASSWORD]
-
+    host = entry.data[CONF_HOST]
     envoy = Envoy(host, get_async_client(hass, verify_ssl=False))
-
-    coordinator = EnphaseUpdateCoordinator(hass, envoy, name, username, password)
+    coordinator = EnphaseUpdateCoordinator(hass, envoy, entry)
 
     await coordinator.async_config_entry_first_refresh()
     if not entry.unique_id:

--- a/homeassistant/components/enphase_envoy/config_flow.py
+++ b/homeassistant/components/enphase_envoy/config_flow.py
@@ -9,8 +9,6 @@ from awesomeversion import AwesomeVersion
 from pyenphase import (
     AUTH_TOKEN_MIN_VERSION,
     Envoy,
-    EnvoyAuthenticationError,
-    EnvoyAuthenticationRequired,
     EnvoyError,
 )
 import voluptuous as vol
@@ -23,15 +21,13 @@ from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.httpx_client import get_async_client
 from homeassistant.util.network import is_ipv4_address
 
-from .const import DOMAIN
+from .const import DOMAIN, INVALID_AUTH_ERRORS
 
 _LOGGER = logging.getLogger(__name__)
 
 ENVOY = "Envoy"
 
 CONF_SERIAL = "serial"
-
-INVALID_AUTH_ERRORS = (EnvoyAuthenticationError, EnvoyAuthenticationRequired)
 
 INSTALLER_AUTH_USERNAME = "installer"
 

--- a/homeassistant/components/enphase_envoy/const.py
+++ b/homeassistant/components/enphase_envoy/const.py
@@ -1,6 +1,15 @@
 """The enphase_envoy component."""
+from pyenphase import (
+    EnvoyAuthenticationError,
+    EnvoyAuthenticationRequired,
+)
+
 from homeassistant.const import Platform
 
 DOMAIN = "enphase_envoy"
 
 PLATFORMS = [Platform.SENSOR]
+
+CONF_TOKEN = "token"
+
+INVALID_AUTH_ERRORS = (EnvoyAuthenticationError, EnvoyAuthenticationRequired)

--- a/homeassistant/components/enphase_envoy/coordinator.py
+++ b/homeassistant/components/enphase_envoy/coordinator.py
@@ -56,6 +56,7 @@ class EnphaseUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 await envoy.authenticate(token=token)
             except INVALID_AUTH_ERRORS:
                 # token likely expired or firmware changed
+                # so we fall through to authenticate with username/password
                 pass
             else:
                 self._setup_complete = True

--- a/homeassistant/components/enphase_envoy/diagnostics.py
+++ b/homeassistant/components/enphase_envoy/diagnostics.py
@@ -8,7 +8,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME, CONF_PASSWORD, CONF_UNIQUE_ID, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN
+from .const import CONF_TOKEN, DOMAIN
 from .coordinator import EnphaseUpdateCoordinator
 
 CONF_TITLE = "title"
@@ -20,6 +20,7 @@ TO_REDACT = {
     CONF_TITLE,
     CONF_UNIQUE_ID,
     CONF_USERNAME,
+    CONF_TOKEN,
 }
 
 

--- a/homeassistant/components/enphase_envoy/manifest.json
+++ b/homeassistant/components/enphase_envoy/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://www.home-assistant.io/integrations/enphase_envoy",
   "iot_class": "local_polling",
   "loggers": ["pyenphase"],
-  "requirements": ["pyenphase==0.8.0"],
+  "requirements": ["pyenphase==0.9.0"],
   "zeroconf": [
     {
       "type": "_enphase-envoy._tcp.local."

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1662,7 +1662,7 @@ pyedimax==0.2.1
 pyefergy==22.1.1
 
 # homeassistant.components.enphase_envoy
-pyenphase==0.8.0
+pyenphase==0.9.0
 
 # homeassistant.components.envisalink
 pyenvisalink==4.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1229,7 +1229,7 @@ pyeconet==0.1.20
 pyefergy==22.1.1
 
 # homeassistant.components.enphase_envoy
-pyenphase==0.8.0
+pyenphase==0.9.0
 
 # homeassistant.components.everlights
 pyeverlights==0.1.0

--- a/tests/components/enphase_envoy/conftest.py
+++ b/tests/components/enphase_envoy/conftest.py
@@ -7,6 +7,7 @@ from pyenphase import (
     EnvoyInverter,
     EnvoySystemConsumption,
     EnvoySystemProduction,
+    EnvoyTokenAuth,
 )
 import pytest
 
@@ -43,12 +44,13 @@ def config_fixture():
 
 
 @pytest.fixture(name="mock_envoy")
-def mock_envoy_fixture(serial_number, mock_authenticate, mock_setup):
+def mock_envoy_fixture(serial_number, mock_authenticate, mock_setup, mock_auth):
     """Define a mocked Envoy fixture."""
     mock_envoy = Mock(spec=Envoy)
     mock_envoy.serial_number = serial_number
     mock_envoy.authenticate = mock_authenticate
     mock_envoy.setup = mock_setup
+    mock_envoy.auth = mock_auth
     mock_envoy.data = EnvoyData(
         system_consumption=EnvoySystemConsumption(
             watt_hours_last_7_days=1234,
@@ -97,6 +99,12 @@ async def setup_enphase_envoy_fixture(hass, config, mock_envoy):
 def mock_authenticate():
     """Define a mocked Envoy.authenticate fixture."""
     return AsyncMock()
+
+
+@pytest.fixture(name="mock_auth")
+def mock_auth(serial_number):
+    """Define a mocked EnvoyAuth fixture."""
+    return EnvoyTokenAuth("127.0.0.1", token="abc", envoy_serial=serial_number)
 
 
 @pytest.fixture(name="mock_setup")

--- a/tests/components/enphase_envoy/test_diagnostics.py
+++ b/tests/components/enphase_envoy/test_diagnostics.py
@@ -24,6 +24,7 @@ async def test_entry_diagnostics(
                 "name": REDACTED,
                 "username": REDACTED,
                 "password": REDACTED,
+                "token": "abc",
             },
             "options": {},
             "pref_disable_new_entities": False,

--- a/tests/components/enphase_envoy/test_diagnostics.py
+++ b/tests/components/enphase_envoy/test_diagnostics.py
@@ -24,7 +24,7 @@ async def test_entry_diagnostics(
                 "name": REDACTED,
                 "username": REDACTED,
                 "password": REDACTED,
-                "token": "abc",
+                "token": REDACTED,
             },
             "options": {},
             "pref_disable_new_entities": False,


### PR DESCRIPTION
~~needs https://github.com/home-assistant/core/pull/97862~~

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Save the token so that we do not have to hit the cloud api at startup every time

I did not implement token only auth since tokens are only valid for 1 year anyways. support for providing only a token instead of a username and password will likely not happen since the tokens are only valid for a limited time unless they can be refreshed with the same token (needs to be investigated and done but that’s something for the future) edit: the docs don't contemplate renewing tokens the api docs don't contemplate refreshing the token so I don't think its possible <https://enphase.com/download/iq-gateway-access-using-local-apis-or-local-ui-token-based-authentication-tech-brief>

changelog: https://github.com/pyenphase/pyenphase/compare/v0.8.0...v0.9.0

For a future PR:
we should probably proactively refresh when it will expire in less than 30 days in case the cloud service breaks for a few days but that gets a bit complex since we need to do it at startup and once per day

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
