### PR TITLE
Move KNX keyring validation and storage to helper module

### DIFF
--- a/homeassistant/components/knx/config_flow.py
+++ b/homeassistant/components/knx/config_flow.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import AsyncGenerator
-from pathlib import Path
-import shutil
 from typing import Any, Final
 
 import voluptuous as vol
@@ -18,15 +16,13 @@ from xknx.io import DEFAULT_MCAST_GRP, DEFAULT_MCAST_PORT
 from xknx.io.gateway_scanner import GatewayDescriptor, GatewayScanner
 from xknx.io.self_description import request_description
 from xknx.io.util import validate_ip as xknx_validate_ip
-from xknx.secure.keyring import Keyring, XMLInterface, sync_load_keyring
+from xknx.secure.keyring import Keyring, XMLInterface
 
-from homeassistant.components.file_upload import process_uploaded_file
 from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowHandler, FlowResult
 from homeassistant.helpers import selector
-from homeassistant.helpers.storage import STORAGE_DIR
 from homeassistant.helpers.typing import UNDEFINED
 
 from .const import (
@@ -60,6 +56,7 @@ from .const import (
     TELEGRAM_LOG_MAX,
     KNXConfigEntryData,
 )
+from .helpers.keyfile import DEFAULT_KNX_KEYRING_FILENAME, save_uploaded_knxkeys_file
 from .schema import ia_validator, ip_v4_validator
 
 CONF_KNX_GATEWAY: Final = "gateway"
@@ -77,7 +74,6 @@ DEFAULT_ENTRY_DATA = KNXConfigEntryData(
 )
 
 CONF_KEYRING_FILE: Final = "knxkeys_file"
-DEFAULT_KNX_KEYRING_FILENAME: Final = "keyring.knxkeys"
 
 CONF_KNX_TUNNELING_TYPE: Final = "tunneling_type"
 CONF_KNX_TUNNELING_TYPE_LABELS: Final = {
@@ -499,10 +495,15 @@ class KNXCommonFlow(ABC, FlowHandler):
 
         if user_input is not None:
             password = user_input[CONF_KNX_KNXKEY_PASSWORD]
-            errors = await self._save_uploaded_knxkeys_file(
-                uploaded_file_id=user_input[CONF_KEYRING_FILE],
-                password=password,
-            )
+            try:
+                self._keyring = await save_uploaded_knxkeys_file(
+                    self.hass,
+                    uploaded_file_id=user_input[CONF_KEYRING_FILE],
+                    password=password,
+                )
+            except InvalidSecureConfiguration:
+                errors[CONF_KNX_KNXKEY_PASSWORD] = "keyfile_invalid_signature"
+
             if not errors and self._keyring:
                 self.new_entry_data |= KNXConfigEntryData(
                     knxkeys_filename=f"{DOMAIN}/{DEFAULT_KNX_KEYRING_FILENAME}",
@@ -710,33 +711,6 @@ class KNXCommonFlow(ABC, FlowHandler):
         return self.async_show_form(
             step_id="routing", data_schema=vol.Schema(fields), errors=errors
         )
-
-    async def _save_uploaded_knxkeys_file(
-        self, uploaded_file_id: str, password: str
-    ) -> dict[str, str]:
-        """Validate the uploaded file and move it to the storage directory. Return errors."""
-
-        def _process_upload() -> tuple[Keyring | None, dict[str, str]]:
-            keyring: Keyring | None = None
-            errors = {}
-            with process_uploaded_file(self.hass, uploaded_file_id) as file_path:
-                try:
-                    keyring = sync_load_keyring(
-                        path=file_path,
-                        password=password,
-                    )
-                except InvalidSecureConfiguration:
-                    errors[CONF_KNX_KNXKEY_PASSWORD] = "keyfile_invalid_signature"
-                else:
-                    dest_path = Path(self.hass.config.path(STORAGE_DIR, DOMAIN))
-                    dest_path.mkdir(exist_ok=True)
-                    dest_file = dest_path / DEFAULT_KNX_KEYRING_FILENAME
-                    shutil.move(file_path, dest_file)
-            return keyring, errors
-
-        keyring, errors = await self.hass.async_add_executor_job(_process_upload)
-        self._keyring = keyring
-        return errors
 
 
 class KNXConfigFlow(KNXCommonFlow, ConfigFlow, domain=DOMAIN):

--- a/homeassistant/components/knx/config_flow.py
+++ b/homeassistant/components/knx/config_flow.py
@@ -56,7 +56,7 @@ from .const import (
     TELEGRAM_LOG_MAX,
     KNXConfigEntryData,
 )
-from .helpers.keyfile import DEFAULT_KNX_KEYRING_FILENAME, save_uploaded_knxkeys_file
+from .helpers.keyring import DEFAULT_KNX_KEYRING_FILENAME, save_uploaded_knxkeys_file
 from .schema import ia_validator, ip_v4_validator
 
 CONF_KNX_GATEWAY: Final = "gateway"

--- a/homeassistant/components/knx/helpers/keyfile.py
+++ b/homeassistant/components/knx/helpers/keyfile.py
@@ -1,0 +1,47 @@
+"""KNX Keyfile handler."""
+import logging
+from pathlib import Path
+import shutil
+from typing import Final
+
+from xknx.exceptions.exception import InvalidSecureConfiguration
+from xknx.secure.keyring import Keyring, sync_load_keyring
+
+from homeassistant.components.file_upload import process_uploaded_file
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.storage import STORAGE_DIR
+
+from ..const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+DEFAULT_KNX_KEYRING_FILENAME: Final = "keyring.knxkeys"
+
+
+async def save_uploaded_knxkeys_file(
+    hass: HomeAssistant, uploaded_file_id: str, password: str
+) -> Keyring:
+    """Validate the uploaded file and move it to the storage directory.
+
+    Return a Keyring object.
+    Raises InvalidSecureConfiguration if the file or password is invalid.
+    """
+
+    def _process_upload() -> Keyring:
+        with process_uploaded_file(hass, uploaded_file_id) as file_path:
+            try:
+                keyring = sync_load_keyring(
+                    path=file_path,
+                    password=password,
+                )
+            except InvalidSecureConfiguration as err:
+                _LOGGER.debug(err)
+                raise
+            dest_path = Path(hass.config.path(STORAGE_DIR, DOMAIN))
+            dest_path.mkdir(exist_ok=True)
+            dest_file = dest_path / DEFAULT_KNX_KEYRING_FILENAME
+            shutil.move(file_path, dest_file)
+        return keyring
+
+    return await hass.async_add_executor_job(_process_upload)

--- a/homeassistant/components/knx/helpers/keyring.py
+++ b/homeassistant/components/knx/helpers/keyring.py
@@ -1,4 +1,4 @@
-"""KNX Keyfile handler."""
+"""KNX Keyring handler."""
 import logging
 from pathlib import Path
 import shutil

--- a/tests/components/knx/test_config_flow.py
+++ b/tests/components/knx/test_config_flow.py
@@ -71,9 +71,9 @@ def fixture_knx_setup():
 def patch_file_upload(return_value=FIXTURE_KEYRING, side_effect=None):
     """Patch file upload. Yields the Keyring instance (return_value)."""
     with patch(
-        "homeassistant.components.knx.config_flow.process_uploaded_file"
+        "homeassistant.components.knx.helpers.keyring.process_uploaded_file"
     ) as file_upload_mock, patch(
-        "homeassistant.components.knx.config_flow.sync_load_keyring",
+        "homeassistant.components.knx.helpers.keyring.sync_load_keyring",
         return_value=return_value,
         side_effect=side_effect,
     ), patch(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Move KNX keyring validation and storage to helper module.
This shall be used not only by the ConfigFlow, but also by the frontend panel in the future, so I think it makes sense to move it to a dedicated module and refactor the storage method to a generic function.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
