### PR TITLE
Add python_script response

### DIFF
--- a/homeassistant/components/python_script/__init__.py
+++ b/homeassistant/components/python_script/__init__.py
@@ -238,8 +238,13 @@ def execute(hass, filename, source, data=None):
             filename,
             restricted_globals["output"],
         )
+        # Ensure that we're always returning a dictionary
         if not isinstance(restricted_globals["output"], dict):
-            raise ScriptError("Expected 'output' to be a dictionary")
+            output_type = type(restricted_globals["output"])
+            restricted_globals["output"] = {}
+            raise ScriptError(
+                f"Expected `output` to be a dictionary, was {output_type}"
+            )
     except ScriptError as err:
         logger.error("Error executing script: %s", err)
     except Exception as err:  # pylint: disable=broad-except

--- a/homeassistant/components/python_script/__init__.py
+++ b/homeassistant/components/python_script/__init__.py
@@ -27,7 +27,6 @@ from homeassistant.core import (
     SupportsResponse,
 )
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
-from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.service import async_set_service_schema
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import bind_hass
@@ -250,16 +249,6 @@ def execute(hass, filename, source, data=None, return_response=False):
         if return_response:
             raise ServiceValidationError(f"Error executing script: {err}") from err
         logger.error("Error executing script: %s", err)
-        ir.create_issue(
-            hass,
-            DOMAIN,
-            filename,
-            breaks_in_ha_version="2024.4.0",
-            is_fixable=False,
-            severity=ir.IssueSeverity.ERROR,
-            translation_key="script_continue_on_error",
-            translation_placeholders={"script_name": filename.replace(".py", "")},
-        )
         return None
     except Exception as err:  # pylint: disable=broad-except
         if return_response:
@@ -267,16 +256,6 @@ def execute(hass, filename, source, data=None, return_response=False):
                 f"Error executing script ({type(err).__name__}): {err}"
             ) from err
         logger.exception("Error executing script: %s", err)
-        ir.create_issue(
-            hass,
-            DOMAIN,
-            filename,
-            breaks_in_ha_version="2024.4.0",
-            is_fixable=False,
-            severity=ir.IssueSeverity.ERROR,
-            translation_key="script_continue_on_error",
-            translation_placeholders={"script_name": filename.replace(".py", "")},
-        )
         return None
 
     return restricted_globals["output"]

--- a/homeassistant/components/python_script/__init__.py
+++ b/homeassistant/components/python_script/__init__.py
@@ -248,7 +248,9 @@ def execute(hass, filename, source, data=None):
     except ScriptError as err:
         raise ValueError(f"Error executing script: {err}") from err
     except Exception as err:  # pylint: disable=broad-except
-        raise HomeAssistantError(f"Error executing script: {err}") from err
+        raise HomeAssistantError(
+            f"Error executing script ({type(err).__name__}): {err}"
+        ) from err
 
     return restricted_globals["output"]
 

--- a/homeassistant/components/python_script/__init__.py
+++ b/homeassistant/components/python_script/__init__.py
@@ -27,6 +27,7 @@ from homeassistant.core import (
     SupportsResponse,
 )
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.service import async_set_service_schema
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import bind_hass
@@ -249,6 +250,16 @@ def execute(hass, filename, source, data=None, return_response=False):
         if return_response:
             raise ServiceValidationError(f"Error executing script: {err}") from err
         logger.error("Error executing script: %s", err)
+        ir.create_issue(
+            hass,
+            DOMAIN,
+            filename,
+            breaks_in_ha_version="2024.4.0",
+            is_fixable=False,
+            severity=ir.IssueSeverity.ERROR,
+            translation_key="script_continue_on_error",
+            translation_placeholders={"script_name": filename.replace(".py", "")},
+        )
         return None
     except Exception as err:  # pylint: disable=broad-except
         if return_response:
@@ -256,6 +267,16 @@ def execute(hass, filename, source, data=None, return_response=False):
                 f"Error executing script ({type(err).__name__}): {err}"
             ) from err
         logger.exception("Error executing script: %s", err)
+        ir.create_issue(
+            hass,
+            DOMAIN,
+            filename,
+            breaks_in_ha_version="2024.4.0",
+            is_fixable=False,
+            severity=ir.IssueSeverity.ERROR,
+            translation_key="script_continue_on_error",
+            translation_placeholders={"script_name": filename.replace(".py", "")},
+        )
         return None
 
     return restricted_globals["output"]

--- a/homeassistant/components/python_script/__init__.py
+++ b/homeassistant/components/python_script/__init__.py
@@ -26,7 +26,7 @@ from homeassistant.core import (
     ServiceResponse,
     SupportsResponse,
 )
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers.service import async_set_service_schema
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import bind_hass
@@ -246,7 +246,7 @@ def execute(hass, filename, source, data=None):
                 f"Expected `output` to be a dictionary, was {output_type}"
             )
     except ScriptError as err:
-        raise ValueError(f"Error executing script: {err}") from err
+        raise ServiceValidationError(f"Error executing script: {err}") from err
     except Exception as err:  # pylint: disable=broad-except
         raise HomeAssistantError(
             f"Error executing script ({type(err).__name__}): {err}"

--- a/homeassistant/components/python_script/__init__.py
+++ b/homeassistant/components/python_script/__init__.py
@@ -246,9 +246,9 @@ def execute(hass, filename, source, data=None):
                 f"Expected `output` to be a dictionary, was {output_type}"
             )
     except ScriptError as err:
-        logger.error("Error executing script: %s", err)
+        raise ValueError(f"Error executing script: {err}") from err
     except Exception as err:  # pylint: disable=broad-except
-        logger.exception("Error executing script: %s", err)
+        raise HomeAssistantError(f"Error executing script: {err}") from err
 
     return restricted_globals["output"]
 

--- a/homeassistant/components/python_script/__init__.py
+++ b/homeassistant/components/python_script/__init__.py
@@ -255,7 +255,7 @@ def execute(hass, filename, source, data=None, return_response=False):
             raise HomeAssistantError(
                 f"Error executing script ({type(err).__name__}): {err}"
             ) from err
-        logger.error("Error executing script: %s", err)
+        logger.exception("Error executing script: %s", err)
         return None
 
     return restricted_globals["output"]

--- a/homeassistant/components/python_script/strings.json
+++ b/homeassistant/components/python_script/strings.json
@@ -4,5 +4,11 @@
       "name": "[%key:common::action::reload%]",
       "description": "Reloads all available Python scripts."
     }
+  },
+  "issues": {
+    "script_continue_on_error": {
+      "title": "'python_script.{script_name}' logs errors and continues",
+      "description": "The `python_script` integration will change to raise script errors instead of logging them.\n\nThis will **stop** automations/scripts if `continue_on_error` is not set ([docs](https://www.home-assistant.io/docs/scripts/#continuing-on-error)).\n\nTo enable the new behavior, add a `response_variable` ([docs](https://www.home-assistant.io/docs/scripts/service-calls/#use-templates-to-handle-response-data)) to your service call."
+    }
   }
 }

--- a/homeassistant/components/python_script/strings.json
+++ b/homeassistant/components/python_script/strings.json
@@ -4,11 +4,5 @@
       "name": "[%key:common::action::reload%]",
       "description": "Reloads all available Python scripts."
     }
-  },
-  "issues": {
-    "script_continue_on_error": {
-      "title": "'python_script.{script_name}' logs errors and continues",
-      "description": "The `python_script` integration will change to raise script errors instead of logging them.\n\nThis will **stop** automations/scripts if `continue_on_error` is not set ([docs](https://www.home-assistant.io/docs/scripts/#continuing-on-error)).\n\nTo enable the new behavior, add a `response_variable` ([docs](https://www.home-assistant.io/docs/scripts/service-calls/#use-templates-to-handle-response-data)) to your service call."
-    }
   }
 }

--- a/tests/components/python_script/test_init.py
+++ b/tests/components/python_script/test_init.py
@@ -132,7 +132,7 @@ raise Exception('boom')
     await hass.async_block_till_done()
 
     assert type(task.exception()) == HomeAssistantError
-    assert "Error executing script: boom" in str(task.exception())
+    assert "Error executing script (Exception): boom" in str(task.exception())
 
 
 async def test_accessing_async_methods(hass: HomeAssistant) -> None:

--- a/tests/components/python_script/test_init.py
+++ b/tests/components/python_script/test_init.py
@@ -6,7 +6,7 @@ import pytest
 
 from homeassistant.components.python_script import DOMAIN, FOLDER, execute
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers.service import async_get_all_descriptions
 from homeassistant.setup import async_setup_component
 
@@ -144,7 +144,7 @@ hass.async_stop()
     task = hass.async_add_executor_job(execute, hass, "test.py", source, {})
     await hass.async_block_till_done()
 
-    assert type(task.exception()) == ValueError
+    assert type(task.exception()) == ServiceValidationError
     assert "Not allowed to access async methods" in str(task.exception())
 
 
@@ -176,7 +176,7 @@ async def test_accessing_forbidden_methods(hass: HomeAssistant) -> None:
         task = hass.async_add_executor_job(execute, hass, "test.py", source, {})
         await hass.async_block_till_done()
 
-        assert type(task.exception()) == ValueError
+        assert type(task.exception()) == ServiceValidationError
         assert f"Not allowed to access {name}" in str(task.exception())
 
 
@@ -540,7 +540,7 @@ output = f"hello {data.get('name', 'World')}"
         "homeassistant.components.python_script.open",
         mock_open(read_data=source),
         create=True,
-    ), pytest.raises(ValueError):
+    ), pytest.raises(ServiceValidationError):
         await hass.services.async_call(
             "python_script",
             "hello",

--- a/tests/components/python_script/test_init.py
+++ b/tests/components/python_script/test_init.py
@@ -7,6 +7,7 @@ import pytest
 from homeassistant.components.python_script import DOMAIN, FOLDER, execute
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.service import async_get_all_descriptions
 from homeassistant.setup import async_setup_component
 
@@ -123,7 +124,9 @@ this is not valid Python
 
 
 async def test_execute_runtime_error(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    issue_registry: ir.IssueRegistry,
 ) -> None:
     """Test compile error logs error."""
     caplog.set_level(logging.ERROR)
@@ -135,9 +138,12 @@ raise Exception('boom')
     await hass.async_block_till_done()
 
     assert "Error executing script: boom" in caplog.text
+    assert len(issue_registry.issues) == 1
 
 
-async def test_execute_runtime_error_with_response(hass: HomeAssistant) -> None:
+async def test_execute_runtime_error_with_response(
+    hass: HomeAssistant, issue_registry: ir.IssueRegistry
+) -> None:
     """Test compile error logs error."""
     source = """
 raise Exception('boom')
@@ -148,10 +154,13 @@ raise Exception('boom')
 
     assert type(task.exception()) == HomeAssistantError
     assert "Error executing script (Exception): boom" in str(task.exception())
+    assert len(issue_registry.issues) == 0
 
 
 async def test_accessing_async_methods(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    issue_registry: ir.IssueRegistry,
 ) -> None:
     """Test compile error logs error."""
     caplog.set_level(logging.ERROR)
@@ -163,9 +172,12 @@ hass.async_stop()
     await hass.async_block_till_done()
 
     assert "Not allowed to access async methods" in caplog.text
+    assert len(issue_registry.issues) == 1
 
 
-async def test_accessing_async_methods_with_response(hass: HomeAssistant) -> None:
+async def test_accessing_async_methods_with_response(
+    hass: HomeAssistant, issue_registry: ir.IssueRegistry
+) -> None:
     """Test compile error logs error."""
     source = """
 hass.async_stop()
@@ -176,6 +188,7 @@ hass.async_stop()
 
     assert type(task.exception()) == ServiceValidationError
     assert "Not allowed to access async methods" in str(task.exception())
+    assert len(issue_registry.issues) == 0
 
 
 async def test_using_complex_structures(
@@ -196,7 +209,9 @@ logger.info('Logging from inside script: %s %s' % (mydict["a"], mylist[2]))
 
 
 async def test_accessing_forbidden_methods(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    issue_registry: ir.IssueRegistry,
 ) -> None:
     """Test compile error logs error."""
     caplog.set_level(logging.ERROR)
@@ -208,12 +223,16 @@ async def test_accessing_forbidden_methods(
         "time.tzset()": "TimeWrapper.tzset",
     }.items():
         caplog.records.clear()
+        issue_registry.async_delete("python_script", "test.py")
         hass.async_add_executor_job(execute, hass, "test.py", source, {})
         await hass.async_block_till_done()
         assert f"Not allowed to access {name}" in caplog.text
+        assert len(issue_registry.issues) == 1
 
 
-async def test_accessing_forbidden_methods_with_response(hass: HomeAssistant) -> None:
+async def test_accessing_forbidden_methods_with_response(
+    hass: HomeAssistant, issue_registry: ir.IssueRegistry
+) -> None:
     """Test compile error logs error."""
     for source, name in {
         "hass.stop()": "HomeAssistant.stop",
@@ -226,6 +245,7 @@ async def test_accessing_forbidden_methods_with_response(hass: HomeAssistant) ->
 
         assert type(task.exception()) == ServiceValidationError
         assert f"Not allowed to access {name}" in str(task.exception())
+        assert len(issue_registry.issues) == 0
 
 
 async def test_iterating(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Service calls to `python_script` no longer silently fail and will raise an exception instead of being logged. This will stop scripts or automations instead of ignoring the error. `continue_on_error` must be set for scripts and automations using `python_script` that may fail.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds the new `ServiceResponse` to `python_script` services to allow for cases where we don't need to persist data from a python script.

The changes in `core.ServiceRegistry.register` where required as `python_script` discovers the files and registers the services in a non-async function.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/28477

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
