### PR TITLE
Add initial sensors for Enphase Encharge batteries

### DIFF
--- a/homeassistant/components/enphase_envoy/manifest.json
+++ b/homeassistant/components/enphase_envoy/manifest.json
@@ -1,12 +1,21 @@
 {
   "domain": "enphase_envoy",
   "name": "Enphase Envoy",
-  "codeowners": ["@bdraco", "@cgarwood", "@dgomes", "@joostlek"],
+  "codeowners": [
+    "@bdraco",
+    "@cgarwood",
+    "@dgomes",
+    "@joostlek"
+  ],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/enphase_envoy",
   "iot_class": "local_polling",
-  "loggers": ["pyenphase"],
-  "requirements": ["pyenphase==0.14.1"],
+  "loggers": [
+    "pyenphase"
+  ],
+  "requirements": [
+    "pyenphase==0.15.1"
+  ],
   "zeroconf": [
     {
       "type": "_enphase-envoy._tcp.local."

--- a/homeassistant/components/enphase_envoy/manifest.json
+++ b/homeassistant/components/enphase_envoy/manifest.json
@@ -1,21 +1,12 @@
 {
   "domain": "enphase_envoy",
   "name": "Enphase Envoy",
-  "codeowners": [
-    "@bdraco",
-    "@cgarwood",
-    "@dgomes",
-    "@joostlek"
-  ],
+  "codeowners": ["@bdraco", "@cgarwood", "@dgomes", "@joostlek"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/enphase_envoy",
   "iot_class": "local_polling",
-  "loggers": [
-    "pyenphase"
-  ],
-  "requirements": [
-    "pyenphase==0.15.1"
-  ],
+  "loggers": ["pyenphase"],
+  "requirements": ["pyenphase==0.15.1"],
   "zeroconf": [
     {
       "type": "_enphase-envoy._tcp.local."

--- a/homeassistant/components/enphase_envoy/sensor.py
+++ b/homeassistant/components/enphase_envoy/sensor.py
@@ -224,7 +224,6 @@ class EnvoyEnchargePowerSensorEntityDescription(
 ENCHARGE_INVENTORY_SENSORS = (
     EnvoyEnchargeSensorEntityDescription(
         key="temperature",
-        translation_key="current_temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         value_fn=lambda encharge: encharge.temperature,
@@ -240,21 +239,18 @@ ENCHARGE_INVENTORY_SENSORS = (
 ENCHARGE_POWER_SENSORS = (
     EnvoyEnchargePowerSensorEntityDescription(
         key="soc",
-        translation_key="state_of_charge",
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.BATTERY,
         value_fn=lambda encharge: encharge.soc,
     ),
     EnvoyEnchargePowerSensorEntityDescription(
         key="apparent_power_mva",
-        translation_key="apparent_power",
         native_unit_of_measurement=UnitOfApparentPower.VOLT_AMPERE,
         device_class=SensorDeviceClass.APPARENT_POWER,
         value_fn=lambda encharge: encharge.apparent_power_mva * 0.001,
     ),
     EnvoyEnchargePowerSensorEntityDescription(
         key="real_power_mw",
-        translation_key="real_power",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         value_fn=lambda encharge: encharge.real_power_mw * 0.001,

--- a/homeassistant/components/enphase_envoy/sensor.py
+++ b/homeassistant/components/enphase_envoy/sensor.py
@@ -414,7 +414,6 @@ class EnvoyEnchargeEntity(CoordinatorEntity[EnphaseUpdateCoordinator], SensorEnt
     """Envoy Encharge sensor entity."""
 
     entity_description: EnvoyEnchargeSensorEntityDescription
-    _attr_icon = ICON
     _attr_has_entity_name = True
 
     def __init__(
@@ -458,7 +457,6 @@ class EnvoyEnchargePowerEntity(
     """Envoy Encharge power sensor entity."""
 
     entity_description: EnvoyEnchargePowerSensorEntityDescription
-    _attr_icon = ICON
     _attr_has_entity_name = True
 
     def __init__(

--- a/homeassistant/components/enphase_envoy/sensor.py
+++ b/homeassistant/components/enphase_envoy/sensor.py
@@ -289,13 +289,13 @@ async def async_setup_entry(
 
     if envoy_data.encharge_inventory:
         entities.extend(
-            EnvoyEnchargeEntity(coordinator, description, encharge)
+            EnvoyEnchargeInventoryEntity(coordinator, description, encharge)
             for description in ENCHARGE_INVENTORY_SENSORS
             for encharge in envoy_data.encharge_inventory
         )
     if envoy_data.encharge_power:
         entities.extend(
-            EnvoyEnchargeEntity(coordinator, description, encharge)
+            EnvoyEnchargePowerEntity(coordinator, description, encharge)
             for description in ENCHARGE_POWER_SENSORS
             for encharge in envoy_data.encharge_power
         )
@@ -438,15 +438,32 @@ class EnvoyEnchargeEntity(CoordinatorEntity[EnphaseUpdateCoordinator], SensorEnt
         )
         super().__init__(coordinator)
 
+
+class EnvoyEnchargeInventoryEntity(EnvoyEnchargeEntity):
+    """Envoy Encharge inventory entity."""
+
+    entity_description: EnvoyEnchargeSensorEntityDescription
+
     @property
     def native_value(self) -> int | float | datetime.datetime | None:
-        """Return the state of the sensor."""
+        """Return the state of the inventory sensors."""
         envoy = self.coordinator.envoy
         assert envoy.data is not None
         assert envoy.data.encharge_inventory is not None
+        encharge = envoy.data.encharge_inventory[self._serial_number]
+        return self.entity_description.value_fn(encharge)
+
+
+class EnvoyEnchargePowerEntity(EnvoyEnchargeEntity):
+    """Envoy Encharge power entity."""
+
+    entity_description: EnvoyEnchargePowerSensorEntityDescription
+
+    @property
+    def native_value(self) -> int | float | None:
+        """Return the state of the power sensors."""
+        envoy = self.coordinator.envoy
+        assert envoy.data is not None
         assert envoy.data.encharge_power is not None
-        if self.entity_description in ENCHARGE_POWER_SENSORS:
-            encharge = envoy.data.encharge_power[self._serial_number]
-        else:
-            encharge = envoy.data.encharge_inventory[self._serial_number]
+        encharge = envoy.data.encharge_power[self._serial_number]
         return self.entity_description.value_fn(encharge)

--- a/homeassistant/components/enphase_envoy/sensor.py
+++ b/homeassistant/components/enphase_envoy/sensor.py
@@ -6,7 +6,13 @@ from dataclasses import dataclass
 import datetime
 import logging
 
-from pyenphase import EnvoyInverter, EnvoySystemConsumption, EnvoySystemProduction
+from pyenphase import (
+    EnvoyEncharge,
+    EnvoyEnchargePower,
+    EnvoyInverter,
+    EnvoySystemConsumption,
+    EnvoySystemProduction,
+)
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -15,7 +21,13 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import UnitOfEnergy, UnitOfPower
+from homeassistant.const import (
+    PERCENTAGE,
+    UnitOfApparentPower,
+    UnitOfEnergy,
+    UnitOfPower,
+    UnitOfTemperature,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo, Entity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -181,6 +193,75 @@ CONSUMPTION_SENSORS = (
 )
 
 
+@dataclass
+class EnvoyEnchargeRequiredKeysMixin:
+    """Mixin for required keys."""
+
+    value_fn: Callable[[EnvoyEncharge], datetime.datetime | int | float]
+
+
+@dataclass
+class EnvoyEnchargeSensorEntityDescription(
+    SensorEntityDescription, EnvoyEnchargeRequiredKeysMixin
+):
+    """Describes an Envoy Encharge sensor entity."""
+
+
+@dataclass
+class EnvoyEnchargePowerRequiredKeysMixin:
+    """Mixin for required keys."""
+
+    value_fn: Callable[[EnvoyEnchargePower], int | float]
+
+
+@dataclass
+class EnvoyEnchargePowerSensorEntityDescription(
+    SensorEntityDescription, EnvoyEnchargePowerRequiredKeysMixin
+):
+    """Describes an Envoy Encharge sensor entity."""
+
+
+ENCHARGE_INVENTORY_SENSORS = (
+    EnvoyEnchargeSensorEntityDescription(
+        key="temperature",
+        translation_key="current_temperature",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        value_fn=lambda encharge: encharge.temperature,
+    ),
+    EnvoyEnchargeSensorEntityDescription(
+        key=LAST_REPORTED_KEY,
+        translation_key=LAST_REPORTED_KEY,
+        native_unit_of_measurement=None,
+        device_class=SensorDeviceClass.TIMESTAMP,
+        value_fn=lambda encharge: dt_util.utc_from_timestamp(encharge.last_report_date),
+    ),
+)
+ENCHARGE_POWER_SENSORS = (
+    EnvoyEnchargePowerSensorEntityDescription(
+        key="soc",
+        translation_key="state_of_charge",
+        native_unit_of_measurement=PERCENTAGE,
+        device_class=SensorDeviceClass.BATTERY,
+        value_fn=lambda encharge: encharge.soc,
+    ),
+    EnvoyEnchargePowerSensorEntityDescription(
+        key="apparent_power_mva",
+        translation_key="apparent_power",
+        native_unit_of_measurement=UnitOfApparentPower.VOLT_AMPERE,
+        device_class=SensorDeviceClass.APPARENT_POWER,
+        value_fn=lambda encharge: encharge.apparent_power_mva * 0.001,
+    ),
+    EnvoyEnchargePowerSensorEntityDescription(
+        key="real_power_mw",
+        translation_key="real_power",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        value_fn=lambda encharge: encharge.real_power_mw * 0.001,
+    ),
+)
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -208,6 +289,19 @@ async def async_setup_entry(
             EnvoyInverterEntity(coordinator, description, inverter)
             for description in INVERTER_SENSORS
             for inverter in envoy_data.inverters
+        )
+
+    if envoy_data.encharge_inventory:
+        entities.extend(
+            EnvoyEnchargeEntity(coordinator, description, encharge)
+            for description in ENCHARGE_INVENTORY_SENSORS
+            for encharge in envoy_data.encharge_inventory
+        )
+    if envoy_data.encharge_power:
+        entities.extend(
+            EnvoyEnchargePowerEntity(coordinator, description, encharge)
+            for description in ENCHARGE_POWER_SENSORS
+            for encharge in envoy_data.encharge_power
         )
 
     async_add_entities(entities)
@@ -314,3 +408,89 @@ class EnvoyInverterEntity(CoordinatorEntity[EnphaseUpdateCoordinator], SensorEnt
         assert envoy.data.inverters is not None
         inverter = envoy.data.inverters[self._serial_number]
         return self.entity_description.value_fn(inverter)
+
+
+class EnvoyEnchargeEntity(CoordinatorEntity[EnphaseUpdateCoordinator], SensorEntity):
+    """Envoy Encharge sensor entity."""
+
+    entity_description: EnvoyEnchargeSensorEntityDescription
+    _attr_icon = ICON
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: EnphaseUpdateCoordinator,
+        description: EnvoyEnchargeSensorEntityDescription,
+        serial_number: str,
+    ) -> None:
+        """Initialize Encharge entity."""
+        self.entity_description = description
+        self._serial_number = serial_number
+        envoy_serial_num = coordinator.envoy.serial_number
+        assert envoy_serial_num is not None
+        self._attr_unique_id = f"{serial_number}_{description.key}"
+        assert coordinator.envoy.data is not None
+        assert coordinator.envoy.data.encharge_inventory is not None
+        encharge = coordinator.envoy.data.encharge_inventory[self._serial_number]
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, serial_number)},
+            manufacturer="Enphase",
+            model="Encharge",
+            name=f"Encharge {serial_number}",
+            sw_version=str(encharge.firmware_version),
+            via_device=(DOMAIN, envoy_serial_num),
+        )
+        super().__init__(coordinator)
+
+    @property
+    def native_value(self) -> int | float | datetime.datetime | None:
+        """Return the state of the sensor."""
+        envoy = self.coordinator.envoy
+        assert envoy.data is not None
+        assert envoy.data.encharge_inventory is not None
+        encharge = envoy.data.encharge_inventory[self._serial_number]
+        return self.entity_description.value_fn(encharge)
+
+
+class EnvoyEnchargePowerEntity(
+    CoordinatorEntity[EnphaseUpdateCoordinator], SensorEntity
+):
+    """Envoy Encharge power sensor entity."""
+
+    entity_description: EnvoyEnchargePowerSensorEntityDescription
+    _attr_icon = ICON
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: EnphaseUpdateCoordinator,
+        description: EnvoyEnchargePowerSensorEntityDescription,
+        serial_number: str,
+    ) -> None:
+        """Initialize Encharge entity."""
+        self.entity_description = description
+        self._serial_number = serial_number
+        envoy_serial_num = coordinator.envoy.serial_number
+        assert envoy_serial_num is not None
+        self._attr_unique_id = f"{serial_number}_{description.key}"
+        assert coordinator.envoy.data is not None
+        assert coordinator.envoy.data.encharge_inventory is not None
+        encharge = coordinator.envoy.data.encharge_inventory[self._serial_number]
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, serial_number)},
+            manufacturer="Enphase",
+            model="Encharge",
+            name=f"Encharge {serial_number}",
+            sw_version=str(encharge.firmware_version),
+            via_device=(DOMAIN, envoy_serial_num),
+        )
+        super().__init__(coordinator)
+
+    @property
+    def native_value(self) -> int | float | None:
+        """Return the state of the sensor."""
+        envoy = self.coordinator.envoy
+        assert envoy.data is not None
+        assert envoy.data.encharge_power is not None
+        encharge = envoy.data.encharge_power[self._serial_number]
+        return self.entity_description.value_fn(encharge)

--- a/homeassistant/components/enphase_envoy/strings.json
+++ b/homeassistant/components/enphase_envoy/strings.json
@@ -49,18 +49,6 @@
       },
       "lifetime_consumption": {
         "name": "Lifetime energy consumption"
-      },
-      "temperature": {
-        "name": "[%key:component::sensor::entity_component::temperature::name%]"
-      },
-      "state_of_charge": {
-        "name": "State of charge"
-      },
-      "apparent_power": {
-        "name": "Apparent power"
-      },
-      "real_power": {
-        "name": "Real power"
       }
     }
   }

--- a/homeassistant/components/enphase_envoy/strings.json
+++ b/homeassistant/components/enphase_envoy/strings.json
@@ -49,6 +49,18 @@
       },
       "lifetime_consumption": {
         "name": "Lifetime energy consumption"
+      },
+      "temperature": {
+        "name": "[%key:component::sensor::entity_component::temperature::name%]"
+      },
+      "state_of_charge": {
+        "name": "State of charge"
+      },
+      "apparent_power": {
+        "name": "Apparent power"
+      },
+      "real_power": {
+        "name": "Real power"
       }
     }
   }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1662,7 +1662,7 @@ pyedimax==0.2.1
 pyefergy==22.1.1
 
 # homeassistant.components.enphase_envoy
-pyenphase==0.14.1
+pyenphase==0.15.1
 
 # homeassistant.components.envisalink
 pyenvisalink==4.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1229,7 +1229,7 @@ pyeconet==0.1.20
 pyefergy==22.1.1
 
 # homeassistant.components.enphase_envoy
-pyenphase==0.14.1
+pyenphase==0.15.1
 
 # homeassistant.components.everlights
 pyeverlights==0.1.0


### PR DESCRIPTION
## Proposed change
Add some initial sensors for Enphase Encharge batteries to the `enphase_envoy` integration.

changelog: https://github.com/pyenphase/pyenphase/compare/v0.14.1...v0.15.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
