### PR TITLE
Restore govee_ble state when gateway device becomes available

### DIFF
--- a/homeassistant/components/govee_ble/sensor.py
+++ b/homeassistant/components/govee_ble/sensor.py
@@ -110,7 +110,9 @@ async def async_setup_entry(
             GoveeBluetoothSensorEntity, async_add_entities
         )
     )
-    entry.async_on_unload(coordinator.async_register_processor(processor))
+    entry.async_on_unload(
+        coordinator.async_register_processor(processor, SensorEntityDescription)
+    )
 
 
 class GoveeBluetoothSensorEntity(

--- a/tests/components/govee_ble/__init__.py
+++ b/tests/components/govee_ble/__init__.py
@@ -37,6 +37,31 @@ GVH5177_SERVICE_INFO = BluetoothServiceInfo(
     source="local",
 )
 
+GVH5178_REMOTE_SERVICE_INFO = BluetoothServiceInfo(
+    name="B51782BC8",
+    address="A4:C1:38:75:2B:C8",
+    rssi=-66,
+    manufacturer_data={
+        1: b"\x01\x01\x01\x00\x2a\xf7\x64\x00\x03",
+        76: b"\x02\x15INTELLI_ROCKS_HWPu\xf2\xff\xc2",
+    },
+    service_data={},
+    service_uuids=["0000ec88-0000-1000-8000-00805f9b34fb"],
+    source="local",
+)
+GVH5178_PRIMARY_SERVICE_INFO = BluetoothServiceInfo(
+    name="B51782BC8",
+    address="A4:C1:38:75:2B:C8",
+    rssi=-66,
+    manufacturer_data={
+        1: b"\x01\x01\x00\x00\x2a\xf7\x64\x00\x03",
+        76: b"\x02\x15INTELLI_ROCKS_HWPu\xf2\xff\xc2",
+    },
+    service_data={},
+    service_uuids=["0000ec88-0000-1000-8000-00805f9b34fb"],
+    source="local",
+)
+
 GVH5178_SERVICE_INFO_ERROR = BluetoothServiceInfo(
     name="B51782BC8",
     address="A4:C1:38:75:2B:C8",

--- a/tests/components/govee_ble/test_sensor.py
+++ b/tests/components/govee_ble/test_sensor.py
@@ -1,4 +1,11 @@
 """Test the Govee BLE sensors."""
+from datetime import timedelta
+import time
+from unittest.mock import patch
+
+from homeassistant.components.bluetooth import (
+    FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS,
+)
 from homeassistant.components.govee_ble.const import DOMAIN
 from homeassistant.components.sensor import ATTR_STATE_CLASS
 from homeassistant.const import (
@@ -7,11 +14,20 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
 
-from . import GVH5075_SERVICE_INFO, GVH5178_SERVICE_INFO_ERROR
+from . import (
+    GVH5075_SERVICE_INFO,
+    GVH5178_PRIMARY_SERVICE_INFO,
+    GVH5178_REMOTE_SERVICE_INFO,
+    GVH5178_SERVICE_INFO_ERROR,
+)
 
-from tests.common import MockConfigEntry
-from tests.components.bluetooth import inject_bluetooth_service_info
+from tests.common import MockConfigEntry, async_fire_time_changed
+from tests.components.bluetooth import (
+    inject_bluetooth_service_info,
+    patch_all_discovered_devices,
+)
 
 
 async def test_sensors(hass: HomeAssistant) -> None:
@@ -62,3 +78,80 @@ async def test_gvh5178_error(hass: HomeAssistant) -> None:
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
+
+
+async def test_gvh5178_multi_sensor(hass: HomeAssistant) -> None:
+    """Test H5178 with a primary and remote sensor.
+
+    The gateway sensor is responsible for broadcasting the state for
+    all sensors and it does so in many advertisements. We want
+    all the connected devices to stay available when the gateway
+    sensor is available.
+    """
+    start_monotonic = time.monotonic()
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="A4:C1:38:75:2B:C8",
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert len(hass.states.async_all()) == 0
+    inject_bluetooth_service_info(hass, GVH5178_REMOTE_SERVICE_INFO)
+    await hass.async_block_till_done()
+    assert len(hass.states.async_all()) == 3
+
+    temp_sensor = hass.states.get("sensor.b51782bc8_remote_temperature")
+    assert temp_sensor.state == "1.0"
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Fastforward time without BLE advertisements
+    monotonic_now = start_monotonic + FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS + 1
+
+    with patch(
+        "homeassistant.components.bluetooth.manager.MONOTONIC_TIME",
+        return_value=monotonic_now,
+    ), patch_all_discovered_devices([]):
+        async_fire_time_changed(
+            hass,
+            dt_util.utcnow()
+            + timedelta(seconds=FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS + 1),
+        )
+        await hass.async_block_till_done()
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    temp_sensor = hass.states.get("sensor.b51782bc8_remote_temperature")
+    assert temp_sensor.state == STATE_UNAVAILABLE
+
+    inject_bluetooth_service_info(hass, GVH5178_PRIMARY_SERVICE_INFO)
+    await hass.async_block_till_done()
+
+    temp_sensor = hass.states.get("sensor.b51782bc8_remote_temperature")
+    assert temp_sensor.state == "1.0"
+
+    primary_temp_sensor = hass.states.get("sensor.b51782bc8_primary_temperature")
+    assert primary_temp_sensor.state == "1.0"
+
+    # Fastforward time without BLE advertisements
+    with patch(
+        "homeassistant.components.bluetooth.manager.MONOTONIC_TIME",
+        return_value=monotonic_now,
+    ), patch_all_discovered_devices([]):
+        async_fire_time_changed(
+            hass,
+            dt_util.utcnow()
+            + timedelta(seconds=FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS + 1),
+        )
+        await hass.async_block_till_done()
+
+    temp_sensor = hass.states.get("sensor.b51782bc8_remote_temperature")
+    assert temp_sensor.state == STATE_UNAVAILABLE
+
+    primary_temp_sensor = hass.states.get("sensor.b51782bc8_primary_temperature")
+    assert primary_temp_sensor.state == STATE_UNAVAILABLE


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Some of the govee ble devices have multiple sensors that feed data through a primary / gateway device. When the gateway device goes out of range, all the sensors should become unavailable. When the gateway device returns to being in range, all the connected devices should also become available again. Currently we did not restore the state of connected devices and we only saw the one that we got advertisment for last.

uses the new restore method from https://github.com/home-assistant/core/pull/97462


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
