### PR TITLE
Handle timestamp sensors in Prometheus integration

### DIFF
--- a/tests/components/prometheus/test_init.py
+++ b/tests/components/prometheus/test_init.py
@@ -232,6 +232,12 @@ async def test_sensor_device_class(client, sensor_entities) -> None:
         'friendly_name="Radio Energy"} 14.0' in body
     )
 
+    assert (
+        'sensor_timestamp_seconds{domain="sensor",'
+        'entity="sensor.timestamp",'
+        'friendly_name="Timestamp"} 1.691445808136036e+09' in body
+    )
+
 
 @pytest.mark.parametrize("namespace", [""])
 async def test_input_number(client, input_number_entities) -> None:
@@ -1049,6 +1055,16 @@ async def sensor_fixture(
     set_state_with_entry(hass, sensor_11, 50)
     data["sensor_11"] = sensor_11
 
+    sensor_12 = entity_registry.async_get_or_create(
+        domain=sensor.DOMAIN,
+        platform="test",
+        unique_id="sensor_12",
+        original_device_class=SensorDeviceClass.TIMESTAMP,
+        suggested_object_id="Timestamp",
+        original_name="Timestamp",
+    )
+    set_state_with_entry(hass, sensor_12, "2023-08-07T15:03:28.136036-0700")
+    data["sensor_12"] = sensor_12
     await hass.async_block_till_done()
     return data
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The Prometheus integration didn't properly handle sensors of device class timestamp:

```
homeassistant_sensor_timestamp_None{domain="sensor",entity="sensor.sun_next_dawn",friendly_name="Sun None"} 0.0
homeassistant_sensor_timestamp_None{domain="sensor",entity="sensor.sun_next_dusk",friendly_name="Sun None"} 0.0
homeassistant_sensor_timestamp_None{domain="sensor",entity="sensor.sun_next_midnight",friendly_name="Sun None"} 0.0
homeassistant_sensor_timestamp_None{domain="sensor",entity="sensor.sun_next_noon",friendly_name="Sun None"} 0.0
homeassistant_sensor_timestamp_None{domain="sensor",entity="sensor.sun_next_rising",friendly_name="Sun None"} 0.0
homeassistant_sensor_timestamp_None{domain="sensor",entity="sensor.sun_next_setting",friendly_name="Sun None"} 0.0
```

This fixes that:

```
homeassistant_sensor_timestamp_seconds{domain="sensor",entity="sensor.sun_next_dawn",friendly_name="Sun None"} 1.691498974e+09
homeassistant_sensor_timestamp_seconds{domain="sensor",entity="sensor.sun_next_dusk",friendly_name="Sun None"} 1.691465887e+09
homeassistant_sensor_timestamp_seconds{domain="sensor",entity="sensor.sun_next_midnight",friendly_name="Sun None"} 1.691482414e+09
homeassistant_sensor_timestamp_seconds{domain="sensor",entity="sensor.sun_next_noon",friendly_name="Sun None"} 1.691525621e+09
homeassistant_sensor_timestamp_seconds{domain="sensor",entity="sensor.sun_next_rising",friendly_name="Sun None"} 1.691500706e+09
homeassistant_sensor_timestamp_seconds{domain="sensor",entity="sensor.sun_next_setting",friendly_name="Sun None"} 1.691464155e+09
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
