### PR TITLE
Add Encharge binary sensors to Enphase integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -302,6 +302,7 @@ omit =
     homeassistant/components/enocean/sensor.py
     homeassistant/components/enocean/switch.py
     homeassistant/components/enphase_envoy/__init__.py
+    homeassistant/components/enphase_envoy/binary_sensor.py
     homeassistant/components/enphase_envoy/coordinator.py
     homeassistant/components/enphase_envoy/sensor.py
     homeassistant/components/entur_public_transport/*

--- a/homeassistant/components/enphase_envoy/binary_sensor.py
+++ b/homeassistant/components/enphase_envoy/binary_sensor.py
@@ -18,7 +18,7 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo, Entity
+from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
@@ -41,7 +41,7 @@ class EnvoyEnchargeRequiredKeysMixin:
 class EnvoyEnchargeBinarySensorEntityDescription(
     BinarySensorEntityDescription, EnvoyEnchargeRequiredKeysMixin
 ):
-    """Describes an Envoy Encharge sensor entity."""
+    """Describes an Envoy Encharge binary sensor entity."""
 
 
 ENCHARGE_SENSORS = (
@@ -72,14 +72,13 @@ async def async_setup_entry(
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up envoy sensor platform."""
+    """Set up envoy binary sensor platform."""
     coordinator: EnphaseUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
     envoy_data = coordinator.envoy.data
     assert envoy_data is not None
     envoy_serial_num = config_entry.unique_id
     assert envoy_serial_num is not None
-    _LOGGER.debug("Envoy data: %s", envoy_data)
-    entities: list[Entity] = []
+    entities: list[BinarySensorEntity] = []
     if envoy_data.encharge_inventory:
         entities.extend(
             EnvoyEnchargeBinarySensorEntity(coordinator, description, encharge)
@@ -104,7 +103,7 @@ class EnvoyEnchargeBinarySensorEntity(
         description: EnvoyEnchargeBinarySensorEntityDescription,
         serial_number: str,
     ) -> None:
-        """Init the envoy base entity."""
+        """Init the Encharge base entity."""
         self.entity_description = description
         self.coordinator = coordinator
         assert serial_number is not None

--- a/homeassistant/components/enphase_envoy/binary_sensor.py
+++ b/homeassistant/components/enphase_envoy/binary_sensor.py
@@ -1,0 +1,142 @@
+"""Support for Enphase Envoy solar energy monitor."""
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+import logging
+
+from pyenphase import (
+    EnvoyData,
+    EnvoyEncharge,
+)
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo, Entity
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+)
+
+from .const import DOMAIN
+from .coordinator import EnphaseUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class EnvoyEnchargeRequiredKeysMixin:
+    """Mixin for required keys."""
+
+    value_fn: Callable[[EnvoyEncharge], bool]
+
+
+@dataclass
+class EnvoyEnchargeBinarySensorEntityDescription(
+    BinarySensorEntityDescription, EnvoyEnchargeRequiredKeysMixin
+):
+    """Describes an Envoy Encharge sensor entity."""
+
+
+ENCHARGE_SENSORS = (
+    EnvoyEnchargeBinarySensorEntityDescription(
+        key="communicating",
+        translation_key="communicating",
+        device_class=BinarySensorDeviceClass.CONNECTIVITY,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda encharge: encharge.communicating,
+    ),
+    EnvoyEnchargeBinarySensorEntityDescription(
+        key="dc_switch",
+        translation_key="dc_switch",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda encharge: not encharge.dc_switch_off,
+    ),
+    EnvoyEnchargeBinarySensorEntityDescription(
+        key="operating",
+        translation_key="operating",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda encharge: encharge.operating,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up envoy sensor platform."""
+    coordinator: EnphaseUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    envoy_data = coordinator.envoy.data
+    assert envoy_data is not None
+    envoy_serial_num = config_entry.unique_id
+    assert envoy_serial_num is not None
+    _LOGGER.debug("Envoy data: %s", envoy_data)
+    entities: list[Entity] = []
+    if envoy_data.encharge_inventory:
+        entities.extend(
+            EnvoyEnchargeBinarySensorEntity(coordinator, description, encharge)
+            for description in ENCHARGE_SENSORS
+            for encharge in envoy_data.encharge_inventory
+        )
+
+    async_add_entities(entities)
+
+
+class EnvoyEnchargeBinarySensorEntity(
+    CoordinatorEntity[EnphaseUpdateCoordinator], BinarySensorEntity
+):
+    """Defines a base envoy binary_sensor entity."""
+
+    _attr_has_entity_name = True
+    entity_description: EnvoyEnchargeBinarySensorEntityDescription
+
+    def __init__(
+        self,
+        coordinator: EnphaseUpdateCoordinator,
+        description: EnvoyEnchargeBinarySensorEntityDescription,
+        serial_number: str,
+    ) -> None:
+        """Init the envoy base entity."""
+        self.entity_description = description
+        self.coordinator = coordinator
+        assert serial_number is not None
+
+        self.envoy_serial_num = coordinator.envoy.serial_number
+        assert self.envoy_serial_num is not None
+
+        self._serial_number = serial_number
+        self._attr_unique_id = f"{serial_number}_{description.key}"
+        encharge_inventory = self.data.encharge_inventory
+        assert encharge_inventory is not None
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, serial_number)},
+            manufacturer="Enphase",
+            model="Encharge",
+            name=f"Encharge {serial_number}",
+            sw_version=str(encharge_inventory[self._serial_number].firmware_version),
+            via_device=(DOMAIN, self.envoy_serial_num),
+        )
+
+        super().__init__(coordinator)
+
+    @property
+    def data(self) -> EnvoyData:
+        """Return envoy data."""
+        data = self.coordinator.envoy.data
+        assert data is not None
+        return data
+
+    @property
+    def is_on(self) -> bool:
+        """Return the state of the Encharge binary_sensor."""
+        encharge_inventory = self.data.encharge_inventory
+        assert encharge_inventory is not None
+        return self.entity_description.value_fn(encharge_inventory[self._serial_number])

--- a/homeassistant/components/enphase_envoy/const.py
+++ b/homeassistant/components/enphase_envoy/const.py
@@ -8,6 +8,6 @@ from homeassistant.const import Platform
 
 DOMAIN = "enphase_envoy"
 
-PLATFORMS = [Platform.SENSOR]
+PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR]
 
 INVALID_AUTH_ERRORS = (EnvoyAuthenticationError, EnvoyAuthenticationRequired)

--- a/homeassistant/components/enphase_envoy/strings.json
+++ b/homeassistant/components/enphase_envoy/strings.json
@@ -22,6 +22,17 @@
     }
   },
   "entity": {
+    "binary_sensor": {
+      "communicating": {
+        "name": "Communicating"
+      },
+      "dc_switch": {
+        "name": "DC Switch"
+      },
+      "operating": {
+        "name": "Operating"
+      }
+    },
     "sensor": {
       "last_reported": {
         "name": "Last reported"


### PR DESCRIPTION
## Proposed change
Add a binary_sensor platform to the `enphase_envoy` component with 3 binary sensors for systems with Encharge batteries.
`Communicating`: Battery is communicating with the controller
`DC Switch`: State of the physical DC disconnect switch on the battery
`Operating`: Battery is operating


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/28507

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
