### PR TITLE
Modernize ipma weather

### DIFF
--- a/homeassistant/components/ipma/config_flow.py
+++ b/homeassistant/components/ipma/config_flow.py
@@ -2,10 +2,10 @@
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_MODE, CONF_NAME
+from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME
 import homeassistant.helpers.config_validation as cv
 
-from .const import DOMAIN, FORECAST_MODE, HOME_LOCATION_NAME
+from .const import DOMAIN, HOME_LOCATION_NAME
 
 
 class IpmaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
@@ -47,7 +47,6 @@ class IpmaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     vol.Required(CONF_NAME, default=name): str,
                     vol.Required(CONF_LATITUDE, default=latitude): cv.latitude,
                     vol.Required(CONF_LONGITUDE, default=longitude): cv.longitude,
-                    vol.Required(CONF_MODE, default="daily"): vol.In(FORECAST_MODE),
                 }
             ),
             errors=self._errors,

--- a/homeassistant/components/ipma/const.py
+++ b/homeassistant/components/ipma/const.py
@@ -49,6 +49,4 @@ CONDITION_CLASSES = {
     ATTR_CONDITION_CLEAR_NIGHT: [-1],
 }
 
-FORECAST_MODE = ["hourly", "daily"]
-
 ATTRIBUTION = "Instituto Português do Mar e Atmosfera"

--- a/homeassistant/components/ipma/weather.py
+++ b/homeassistant/components/ipma/weather.py
@@ -31,8 +31,7 @@ from homeassistant.const import (
     UnitOfSpeed,
     UnitOfTemperature,
 )
-from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import entity_registry as er
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.sun import is_up
 from homeassistant.util import Throttle
@@ -58,28 +57,6 @@ async def async_setup_entry(
     """Add a weather entity from a config_entry."""
     api = hass.data[DOMAIN][config_entry.entry_id][DATA_API]
     location = hass.data[DOMAIN][config_entry.entry_id][DATA_LOCATION]
-    mode = config_entry.data[CONF_MODE]
-
-    # Migrate old unique_id
-    @callback
-    def _async_migrator(entity_entry: er.RegistryEntry):
-        # Reject if new unique_id
-        if entity_entry.unique_id.count(",") == 2:
-            return None
-
-        new_unique_id = (
-            f"{location.station_latitude}, {location.station_longitude}, {mode}"
-        )
-
-        _LOGGER.info(
-            "Migrating unique_id from [%s] to [%s]",
-            entity_entry.unique_id,
-            new_unique_id,
-        )
-        return {"new_unique_id": new_unique_id}
-
-    await er.async_migrate_entries(hass, config_entry.entry_id, _async_migrator)
-
     async_add_entities([IPMAWeather(location, api, config_entry.data)], True)
 
 

--- a/homeassistant/components/ipma/weather.py
+++ b/homeassistant/components/ipma/weather.py
@@ -104,7 +104,12 @@ class IPMAWeather(WeatherEntity, IPMADevice):
         self._observation = None
         self._daily_forecast: list[IPMAForecast] | None = None
         self._hourly_forecast: list[IPMAForecast] | None = None
-        self._attr_unique_id = f"{self._location.station_latitude}, {self._location.station_longitude}, {self._mode}"
+        if self._mode is not None:
+            self._attr_unique_id = f"{self._location.station_latitude}, {self._location.station_longitude}, {self._mode}"
+        else:
+            self._attr_unique_id = (
+                f"{self._location.station_latitude}, {self._location.station_longitude}"
+            )
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     async def async_update(self) -> None:

--- a/tests/components/ipma/snapshots/test_weather.ambr
+++ b/tests/components/ipma/snapshots/test_weather.ambr
@@ -1,0 +1,104 @@
+# serializer version: 1
+# name: test_forecast_service
+  dict({
+    'forecast': list([
+      dict({
+        'condition': 'rainy',
+        'datetime': datetime.datetime(2020, 1, 16, 0, 0),
+        'precipitation_probability': '100.0',
+        'temperature': 16.2,
+        'templow': 10.6,
+        'wind_bearing': 'S',
+        'wind_speed': 10.0,
+      }),
+    ]),
+  })
+# ---
+# name: test_forecast_service.1
+  dict({
+    'forecast': list([
+      dict({
+        'condition': 'rainy',
+        'datetime': datetime.datetime(2020, 1, 15, 1, 0, tzinfo=datetime.timezone.utc),
+        'precipitation_probability': 80.0,
+        'temperature': 12.0,
+        'wind_bearing': 'S',
+        'wind_speed': 32.7,
+      }),
+      dict({
+        'condition': 'clear-night',
+        'datetime': datetime.datetime(2020, 1, 15, 2, 0, tzinfo=datetime.timezone.utc),
+        'precipitation_probability': 80.0,
+        'temperature': 12.0,
+        'wind_bearing': 'S',
+        'wind_speed': 32.7,
+      }),
+    ]),
+  })
+# ---
+# name: test_forecast_subscription[daily]
+  list([
+    dict({
+      'condition': 'rainy',
+      'datetime': '2020-01-16T00:00:00',
+      'precipitation_probability': '100.0',
+      'temperature': 16.2,
+      'templow': 10.6,
+      'wind_bearing': 'S',
+      'wind_speed': 10.0,
+    }),
+  ])
+# ---
+# name: test_forecast_subscription[daily].1
+  list([
+    dict({
+      'condition': 'rainy',
+      'datetime': '2020-01-16T00:00:00',
+      'precipitation_probability': '100.0',
+      'temperature': 16.2,
+      'templow': 10.6,
+      'wind_bearing': 'S',
+      'wind_speed': 10.0,
+    }),
+  ])
+# ---
+# name: test_forecast_subscription[hourly]
+  list([
+    dict({
+      'condition': 'rainy',
+      'datetime': '2020-01-15T01:00:00+00:00',
+      'precipitation_probability': 80.0,
+      'temperature': 12.0,
+      'wind_bearing': 'S',
+      'wind_speed': 32.7,
+    }),
+    dict({
+      'condition': 'clear-night',
+      'datetime': '2020-01-15T02:00:00+00:00',
+      'precipitation_probability': 80.0,
+      'temperature': 12.0,
+      'wind_bearing': 'S',
+      'wind_speed': 32.7,
+    }),
+  ])
+# ---
+# name: test_forecast_subscription[hourly].1
+  list([
+    dict({
+      'condition': 'rainy',
+      'datetime': '2020-01-15T01:00:00+00:00',
+      'precipitation_probability': 80.0,
+      'temperature': 12.0,
+      'wind_bearing': 'S',
+      'wind_speed': 32.7,
+    }),
+    dict({
+      'condition': 'clear-night',
+      'datetime': '2020-01-15T02:00:00+00:00',
+      'precipitation_probability': 80.0,
+      'temperature': 12.0,
+      'wind_bearing': 'S',
+      'wind_speed': 32.7,
+    }),
+  ])
+# ---

--- a/tests/components/ipma/test_weather.py
+++ b/tests/components/ipma/test_weather.py
@@ -1,9 +1,12 @@
 """The tests for the IPMA weather component."""
-from datetime import datetime
+import datetime
 from unittest.mock import patch
 
+from freezegun.api import FrozenDateTimeFactory
 import pytest
+from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.ipma.const import MIN_TIME_BETWEEN_UPDATES
 from homeassistant.components.weather import (
     ATTR_FORECAST,
     ATTR_FORECAST_CONDITION,
@@ -18,6 +21,8 @@ from homeassistant.components.weather import (
     ATTR_WEATHER_TEMPERATURE,
     ATTR_WEATHER_WIND_BEARING,
     ATTR_WEATHER_WIND_SPEED,
+    DOMAIN as WEATHER_DOMAIN,
+    SERVICE_GET_FORECAST,
 )
 from homeassistant.const import STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
@@ -25,6 +30,7 @@ from homeassistant.core import HomeAssistant
 from . import MockLocation
 
 from tests.common import MockConfigEntry
+from tests.typing import WebSocketGenerator
 
 TEST_CONFIG = {
     "name": "HomeTown",
@@ -91,7 +97,7 @@ async def test_daily_forecast(hass: HomeAssistant) -> None:
     assert state.state == "rainy"
 
     forecast = state.attributes.get(ATTR_FORECAST)[0]
-    assert forecast.get(ATTR_FORECAST_TIME) == datetime(2020, 1, 16, 0, 0, 0)
+    assert forecast.get(ATTR_FORECAST_TIME) == datetime.datetime(2020, 1, 16, 0, 0, 0)
     assert forecast.get(ATTR_FORECAST_CONDITION) == "rainy"
     assert forecast.get(ATTR_FORECAST_TEMP) == 16.2
     assert forecast.get(ATTR_FORECAST_TEMP_LOW) == 10.6
@@ -144,3 +150,93 @@ async def test_failed_get_observation_forecast(hass: HomeAssistant) -> None:
     assert data.get(ATTR_WEATHER_WIND_SPEED) is None
     assert data.get(ATTR_WEATHER_WIND_BEARING) is None
     assert state.attributes.get("friendly_name") == "HomeTown"
+
+
+async def test_forecast_service(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test multiple forecast."""
+
+    with patch(
+        "pyipma.location.Location.get",
+        return_value=MockLocation(),
+    ):
+        entry = MockConfigEntry(domain="ipma", data=TEST_CONFIG)
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    response = await hass.services.async_call(
+        WEATHER_DOMAIN,
+        SERVICE_GET_FORECAST,
+        {
+            "entity_id": "weather.hometown",
+            "type": "daily",
+        },
+        blocking=True,
+        return_response=True,
+    )
+    assert response == snapshot
+
+    response = await hass.services.async_call(
+        WEATHER_DOMAIN,
+        SERVICE_GET_FORECAST,
+        {
+            "entity_id": "weather.hometown",
+            "type": "hourly",
+        },
+        blocking=True,
+        return_response=True,
+    )
+    assert response == snapshot
+
+
+@pytest.mark.parametrize("forecast_type", ["daily", "hourly"])
+async def test_forecast_subscription(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    freezer: FrozenDateTimeFactory,
+    snapshot: SnapshotAssertion,
+    forecast_type: str,
+) -> None:
+    """Test multiple forecast."""
+    client = await hass_ws_client(hass)
+
+    with patch(
+        "pyipma.location.Location.get",
+        return_value=MockLocation(),
+    ):
+        entry = MockConfigEntry(domain="ipma", data=TEST_CONFIG)
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    await client.send_json_auto_id(
+        {
+            "type": "weather/subscribe_forecast",
+            "forecast_type": forecast_type,
+            "entity_id": "weather.hometown",
+        }
+    )
+    msg = await client.receive_json()
+    assert msg["success"]
+    assert msg["result"] is None
+    subscription_id = msg["id"]
+
+    msg = await client.receive_json()
+    assert msg["id"] == subscription_id
+    assert msg["type"] == "event"
+    forecast1 = msg["event"]["forecast"]
+
+    assert forecast1 == snapshot
+
+    freezer.tick(MIN_TIME_BETWEEN_UPDATES + datetime.timedelta(seconds=1))
+    await hass.async_block_till_done()
+    msg = await client.receive_json()
+
+    assert msg["id"] == subscription_id
+    assert msg["type"] == "event"
+    forecast2 = msg["event"]["forecast"]
+
+    assert forecast2 == snapshot


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Deprecation
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The IPMA weather entities have been updated:
- The `forecast` state attribute is deprecated and will be removed in Home Assistant Core 2024.3, users should instead call the service `weather.get_forecast`

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Modernize IPMA  weather:
- Add support for the `weather.get_forecast` service
- Add support for daily and hourly weather forecasts
- Remove config flow option which allowed selecting hourly or daily weather forecasts

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
