### PR TITLE
Modernize template weather

### DIFF
--- a/homeassistant/components/template/weather.py
+++ b/homeassistant/components/template/weather.py
@@ -30,7 +30,11 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.config_validation import PLATFORM_SCHEMA
 from homeassistant.helpers.entity import async_generate_entity_id
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.helpers.event import (
+    EventStateChangedData,
+    async_track_state_change_event,
+)
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType, EventType
 from homeassistant.util.unit_conversion import (
     DistanceConverter,
     PressureConverter,
@@ -259,14 +263,6 @@ class WeatherTemplate(TemplateEntity, WeatherEntity):
             return "Powered by Home Assistant"
         return self._attribution
 
-    @callback
-    def _update_state(self, result):
-        super()._update_state(result)
-        assert self.platform.config_entry
-        self.platform.config_entry.async_create_task(
-            self.hass, self.async_update_listeners("daily")
-        )
-
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""
 
@@ -336,9 +332,23 @@ class WeatherTemplate(TemplateEntity, WeatherEntity):
                 "_apparent_temperature",
                 self._apparent_temperature_template,
             )
+
         if self._forecast_template:
             self.add_template_attribute(
                 "_forecast",
                 self._forecast_template,
             )
+            self.async_on_remove(
+                async_track_state_change_event(
+                    self.hass, self.entity_id, self.async_state_changed_listener
+                )
+            )
         await super().async_added_to_hass()
+
+    @callback
+    async def async_state_changed_listener(
+        self,
+        event: EventType[EventStateChangedData],
+    ) -> None:
+        """Call to update forecast listener."""
+        await self.async_update_listeners(["daily"])

--- a/homeassistant/components/template/weather.py
+++ b/homeassistant/components/template/weather.py
@@ -421,11 +421,10 @@ class WeatherTemplate(TemplateEntity, WeatherEntity):
         if result is None or isinstance(result, TemplateError):
             return None
 
-        set().union()
         if isinstance(result, list):
             for forecast in result:
                 diff_result = (
-                    set().union(forecast.items()).difference(CHECK_FORECAST_KEYS)
+                    set().union(forecast.keys()).difference(CHECK_FORECAST_KEYS)
                 )
                 if diff_result:
                     raise vol.Invalid(

--- a/homeassistant/components/template/weather.py
+++ b/homeassistant/components/template/weather.py
@@ -435,11 +435,11 @@ class WeatherTemplate(TemplateEntity, WeatherEntity):
                 raise vol.Invalid(
                     "Only valid keys in Forecast are allowed, see Weather documentation https://www.home-assistant.io/integrations/weather/"
                 )
-            if forecast_type == "twice_daily" and "is_daytime" not in forecast.keys():
+            if forecast_type == "twice_daily" and "is_daytime" not in forecast:
                 raise vol.Invalid(
                     "`is_daytime` is missing in twice_daily forecast, see Weather documentation https://www.home-assistant.io/integrations/weather/"
                 )
-            if "datetime" not in forecast.keys():
+            if "datetime" not in forecast:
                 raise vol.Invalid(
                     "`datetime` is required in forecasts, see Weather documentation https://www.home-assistant.io/integrations/weather/"
                 )

--- a/tests/components/template/test_weather.py
+++ b/tests/components/template/test_weather.py
@@ -228,3 +228,77 @@ async def test_forecasts(hass: HomeAssistant, start_ha) -> None:
             }
         ]
     }
+
+
+@pytest.mark.parametrize(("count", "domain"), [(1, WEATHER_DOMAIN)])
+@pytest.mark.parametrize(
+    "config",
+    [
+        {
+            "weather": [
+                {
+                    "platform": "template",
+                    "name": "forecast",
+                    "condition_template": "sunny",
+                    "forecast_template": "{{ states.weather.forecast.attributes.forecast }}",
+                    "forecast_daily_template": "{{ states.weather.forecast.attributes.forecast }}",
+                    "forecast_hourly_template": "{{ states.weather.forecast_hourly.attributes.forecast }}",
+                    "temperature_template": "{{ states('sensor.temperature') | float }}",
+                    "humidity_template": "{{ states('sensor.humidity') | int }}",
+                },
+            ]
+        },
+    ],
+)
+async def test_forecast_invalid(
+    hass: HomeAssistant, start_ha, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test forecast service."""
+    for attr, _v_attr, value in [
+        ("sensor.temperature", ATTR_WEATHER_TEMPERATURE, 22.3),
+        ("sensor.humidity", ATTR_WEATHER_HUMIDITY, 60),
+    ]:
+        hass.states.async_set(attr, value)
+        await hass.async_block_till_done()
+
+    hass.states.async_set(
+        "weather.forecast",
+        "sunny",
+        {
+            ATTR_FORECAST: [
+                Forecast(
+                    condition="cloudy",
+                    datetime="2023-02-17T14:00:00+00:00",
+                    temperature=14.2,
+                    not_correct=1,
+                )
+            ]
+        },
+    )
+    hass.states.async_set(
+        "weather.forecast_hourly",
+        "sunny",
+        {ATTR_FORECAST: None},
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("weather.forecast_hourly")
+    assert state is not None
+    assert state.state == "sunny"
+
+    response = await hass.services.async_call(
+        WEATHER_DOMAIN,
+        SERVICE_GET_FORECAST,
+        {"entity_id": "weather.forecast", "type": "daily"},
+        blocking=True,
+        return_response=True,
+    )
+    assert response == {"forecast": []}
+    response = await hass.services.async_call(
+        WEATHER_DOMAIN,
+        SERVICE_GET_FORECAST,
+        {"entity_id": "weather.forecast", "type": "hourly"},
+        blocking=True,
+        return_response=True,
+    )
+    assert response == {"forecast": []}
+    assert "Only valid keys in Forecast are allowed" in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Deprecation
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The `template` weather entity have been updated:
- The `forecast` state attribute is deprecated and will be removed in Home Assistant Core 2024.3, users should instead call the service `weather.get_forecast`

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Modernize SMHI weather:
- Add support for the `weather.get_forecast` service
- Add support for daily weather forecasts ( as it's a template I had to choose one )

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/28532

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
