### PR TITLE
Wallbox Integration Change Switch Availability

### DIFF
--- a/homeassistant/components/wallbox/switch.py
+++ b/homeassistant/components/wallbox/switch.py
@@ -54,11 +54,14 @@ class WallboxSwitch(WallboxEntity, SwitchEntity):
     @property
     def available(self) -> bool:
         """Return the availability of the switch."""
-        return self.coordinator.data[CHARGER_STATUS_DESCRIPTION_KEY] in {
-            ChargerStatus.CHARGING,
-            ChargerStatus.DISCHARGING,
-            ChargerStatus.PAUSED,
-            ChargerStatus.SCHEDULED,
+        return self.coordinator.data[CHARGER_STATUS_DESCRIPTION_KEY] not in {
+            ChargerStatus.UNKNOWN,
+            ChargerStatus.UPDATING,
+            ChargerStatus.ERROR,
+            ChargerStatus.LOCKED,
+            ChargerStatus.LOCKED_CAR_CONNECTED,
+            ChargerStatus.DISCONNECTED,
+            ChargerStatus.READY,
         }
 
     @property

--- a/homeassistant/components/wallbox/switch.py
+++ b/homeassistant/components/wallbox/switch.py
@@ -54,7 +54,9 @@ class WallboxSwitch(WallboxEntity, SwitchEntity):
     @property
     def available(self) -> bool:
         """Return the availability of the switch."""
-        return super().available and self.coordinator.data[CHARGER_STATUS_DESCRIPTION_KEY] not in {
+        return super().available and self.coordinator.data[
+            CHARGER_STATUS_DESCRIPTION_KEY
+        ] not in {
             ChargerStatus.UNKNOWN,
             ChargerStatus.UPDATING,
             ChargerStatus.ERROR,

--- a/homeassistant/components/wallbox/switch.py
+++ b/homeassistant/components/wallbox/switch.py
@@ -54,7 +54,7 @@ class WallboxSwitch(WallboxEntity, SwitchEntity):
     @property
     def available(self) -> bool:
         """Return the availability of the switch."""
-        return self.coordinator.data[CHARGER_STATUS_DESCRIPTION_KEY] not in {
+        return super().available and self.coordinator.data[CHARGER_STATUS_DESCRIPTION_KEY] not in {
             ChargerStatus.UNKNOWN,
             ChargerStatus.UPDATING,
             ChargerStatus.ERROR,

--- a/tests/components/wallbox/test_init.py
+++ b/tests/components/wallbox/test_init.py
@@ -70,34 +70,6 @@ async def test_wallbox_refresh_failed_invalid_auth(
     assert entry.state == ConfigEntryState.NOT_LOADED
 
 
-async def test_wallbox_refresh_failed_connection_error_auth(
-    hass: HomeAssistant, entry: MockConfigEntry
-) -> None:
-    """Test Wallbox setup with connection error."""
-
-    await setup_integration(hass, entry)
-    assert entry.state == ConfigEntryState.LOADED
-
-    with requests_mock.Mocker() as mock_request:
-        mock_request.get(
-            "https://user-api.wall-box.com/users/signin",
-            json=authorisation_response,
-            status_code=404,
-        )
-        mock_request.get(
-            "https://api.wall-box.com/chargers/status/12345",
-            json=test_response,
-            status_code=403,
-        )
-
-        wallbox = hass.data[DOMAIN][entry.entry_id]
-
-        await wallbox.async_refresh()
-
-    assert await hass.config_entries.async_unload(entry.entry_id)
-    assert entry.state == ConfigEntryState.NOT_LOADED
-
-
 async def test_wallbox_refresh_failed_connection_error(
     hass: HomeAssistant, entry: MockConfigEntry
 ) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
This PR changes the availability of the Wallbox Pause/Resume switch. Before it was only available when the wallbox was in a few  select statusses. As new statusses have been added by Wallbox this causes issues for users where the switch would be unavailable. This PR reverses the logic and makes it unavailable for a few select statusses and available in all other cases.
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #97587
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
