### PR TITLE
Ignore ble name for gardena

### DIFF
--- a/homeassistant/components/gardena_bluetooth/config_flow.py
+++ b/homeassistant/components/gardena_bluetooth/config_flow.py
@@ -48,10 +48,7 @@ def _is_supported(discovery_info: BluetoothServiceInfo):
 
 
 def _get_name(discovery_info: BluetoothServiceInfo):
-    if not (data := discovery_info.manufacturer_data.get(ManufacturerData.company)):
-        _LOGGER.debug("Missing manufacturer data: %s", discovery_info)
-        return False
-
+    data = discovery_info.manufacturer_data[ManufacturerData.company]
     manufacturer_data = ManufacturerData.decode(data)
     product_type = ProductType.from_manufacturer_data(manufacturer_data)
 

--- a/homeassistant/components/gardena_bluetooth/manifest.json
+++ b/homeassistant/components/gardena_bluetooth/manifest.json
@@ -13,5 +13,5 @@
   "dependencies": ["bluetooth_adapters"],
   "documentation": "https://www.home-assistant.io/integrations/gardena_bluetooth",
   "iot_class": "local_polling",
-  "requirements": ["gardena_bluetooth==1.0.2"]
+  "requirements": ["gardena_bluetooth==1.2.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -826,7 +826,7 @@ fritzconnection[qr]==1.12.2
 gTTS==2.2.4
 
 # homeassistant.components.gardena_bluetooth
-gardena_bluetooth==1.0.2
+gardena_bluetooth==1.2.0
 
 # homeassistant.components.google_assistant_sdk
 gassist-text==0.0.10

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -648,7 +648,7 @@ fritzconnection[qr]==1.12.2
 gTTS==2.2.4
 
 # homeassistant.components.gardena_bluetooth
-gardena_bluetooth==1.0.2
+gardena_bluetooth==1.2.0
 
 # homeassistant.components.google_assistant_sdk
 gassist-text==0.0.10

--- a/tests/components/gardena_bluetooth/snapshots/test_config_flow.ambr
+++ b/tests/components/gardena_bluetooth/snapshots/test_config_flow.ambr
@@ -3,7 +3,7 @@
   FlowResultSnapshot({
     'data_schema': None,
     'description_placeholders': dict({
-      'name': 'Timer',
+      'name': 'Gardena Water Computer',
     }),
     'errors': None,
     'flow_id': <ANY>,
@@ -19,7 +19,7 @@
       'confirm_only': True,
       'source': 'bluetooth',
       'title_placeholders': dict({
-        'name': 'Timer',
+        'name': 'Gardena Water Computer',
       }),
       'unique_id': '00000000-0000-0000-0000-000000000001',
     }),
@@ -44,11 +44,11 @@
       'pref_disable_new_entities': False,
       'pref_disable_polling': False,
       'source': 'bluetooth',
-      'title': 'Timer',
+      'title': 'Gardena Water Computer',
       'unique_id': '00000000-0000-0000-0000-000000000001',
       'version': 1,
     }),
-    'title': 'Timer',
+    'title': 'Gardena Water Computer',
     'type': <FlowResultType.CREATE_ENTRY: 'create_entry'>,
     'version': 1,
   })
@@ -124,7 +124,7 @@
         'options': list([
           tuple(
             '00000000-0000-0000-0000-000000000001',
-            'Timer',
+            'Gardena Water Computer',
           ),
         ]),
         'required': True,
@@ -144,7 +144,7 @@
   FlowResultSnapshot({
     'data_schema': None,
     'description_placeholders': dict({
-      'name': 'Timer',
+      'name': 'Gardena Water Computer',
     }),
     'errors': None,
     'flow_id': <ANY>,
@@ -182,11 +182,11 @@
         'options': list([
           tuple(
             '00000000-0000-0000-0000-000000000001',
-            'Timer',
+            'Gardena Water Computer',
           ),
           tuple(
             '00000000-0000-0000-0000-000000000002',
-            'Gardena Device',
+            'Gardena Water Computer',
           ),
         ]),
         'required': True,
@@ -206,7 +206,7 @@
   FlowResultSnapshot({
     'data_schema': None,
     'description_placeholders': dict({
-      'name': 'Timer',
+      'name': 'Gardena Water Computer',
     }),
     'errors': None,
     'flow_id': <ANY>,
@@ -222,7 +222,7 @@
       'confirm_only': True,
       'source': 'user',
       'title_placeholders': dict({
-        'name': 'Timer',
+        'name': 'Gardena Water Computer',
       }),
       'unique_id': '00000000-0000-0000-0000-000000000001',
     }),
@@ -247,11 +247,11 @@
       'pref_disable_new_entities': False,
       'pref_disable_polling': False,
       'source': 'user',
-      'title': 'Timer',
+      'title': 'Gardena Water Computer',
       'unique_id': '00000000-0000-0000-0000-000000000001',
       'version': 1,
     }),
-    'title': 'Timer',
+    'title': 'Gardena Water Computer',
     'type': <FlowResultType.CREATE_ENTRY: 'create_entry'>,
     'version': 1,
   })


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Ignore BLE name for gardena addition since devices are mostly named invalidly

Updated dependency changes: https://github.com/elupus/gardena-bluetooth/compare/1.0.2...1.2.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: #97957

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
