### PR TITLE
Update zwave_js entity naming logic

### DIFF
--- a/homeassistant/components/zwave_js/entity.py
+++ b/homeassistant/components/zwave_js/entity.py
@@ -189,7 +189,7 @@ class ZWaveBaseEntity(Entity):
         if additional_info := [item for item in (additional_info or []) if item]:
             name = f"{name} {' '.join(additional_info)}"
 
-        # Only append endpoint to name if there are no equivalent values on a lower
+        # Only append endpoint to name if there are equivalent values on a lower
         # endpoint
         if self.info.primary_value.endpoint is not None and any(
             get_value_id_str(

--- a/homeassistant/components/zwave_js/entity.py
+++ b/homeassistant/components/zwave_js/entity.py
@@ -161,6 +161,7 @@ class ZWaveBaseEntity(Entity):
         name_prefix: str | None = None,
     ) -> str:
         """Generate entity name."""
+        primary_value = self.info.primary_value
         name = ""
         if (
             hasattr(self, "entity_description")
@@ -178,9 +179,9 @@ class ZWaveBaseEntity(Entity):
             value_name = alternate_value_name
         elif include_value_name:
             value_name = (
-                self.info.primary_value.metadata.label
-                or self.info.primary_value.property_key_name
-                or self.info.primary_value.property_name
+                primary_value.metadata.label
+                or primary_value.property_key_name
+                or primary_value.property_name
                 or ""
             )
 
@@ -191,18 +192,18 @@ class ZWaveBaseEntity(Entity):
 
         # Only append endpoint to name if there are equivalent values on a lower
         # endpoint
-        if self.info.primary_value.endpoint is not None and any(
+        if primary_value.endpoint is not None and any(
             get_value_id_str(
                 self.info.node,
-                self.info.primary_value.command_class,
-                self.info.primary_value.property_,
+                primary_value.command_class,
+                primary_value.property_,
                 endpoint=endpoint_idx,
-                property_key=self.info.primary_value.property_key,
+                property_key=primary_value.property_key,
             )
             in self.info.node.values
-            for endpoint_idx in range(0, self.info.primary_value.endpoint)
+            for endpoint_idx in range(0, primary_value.endpoint)
         ):
-            name += f" ({self.info.primary_value.endpoint})"
+            name += f" ({primary_value.endpoint})"
 
         return name
 

--- a/homeassistant/components/zwave_js/entity.py
+++ b/homeassistant/components/zwave_js/entity.py
@@ -188,10 +188,19 @@ class ZWaveBaseEntity(Entity):
         # Only include non empty additional info
         if additional_info := [item for item in (additional_info or []) if item]:
             name = f"{name} {' '.join(additional_info)}"
-        # append endpoint if > 1
-        if (
-            self.info.primary_value.endpoint is not None
-            and self.info.primary_value.endpoint > 1
+
+        # Only append endpoint to name if there are no equivalent values on a lower
+        # endpoint
+        if self.info.primary_value.endpoint is not None and any(
+            get_value_id_str(
+                self.info.node,
+                self.info.primary_value.command_class,
+                self.info.primary_value.property_,
+                endpoint=endpoint_idx,
+                property_key=self.info.primary_value.property_key,
+            )
+            in self.info.node.values
+            for endpoint_idx in range(0, self.info.primary_value.endpoint)
         ):
             name += f" ({self.info.primary_value.endpoint})"
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
The entity naming logic has been updated to be less brittle. As a result, some `zwave_js` entities that you haven't given a custom name to may be renamed. Since they are registered in the entity registry, the entity IDs will not change and your automations should therefore not be impacted by the change.


## Proposed change
Per https://github.com/home-assistant-libs/zwave-js-server-python/pull/713 the order in which we were discovering values was impacting entity naming which shouldn't be the case. As a result I've made the entity naming logic smarter, which should result in a repeatable set of names, regardless of the order that the values are parsed.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
