### PR TITLE
Ruff: isort don't split imports based on trailing comma

### DIFF
--- a/homeassistant/components/analytics/analytics.py
+++ b/homeassistant/components/analytics/analytics.py
@@ -22,9 +22,7 @@ from homeassistant.components.recorder import (
     get_instance as get_recorder_instance,
 )
 import homeassistant.config as conf_util
-from homeassistant.config_entries import (
-    SOURCE_IGNORE,
-)
+from homeassistant.config_entries import SOURCE_IGNORE
 from homeassistant.const import ATTR_DOMAIN, __version__ as HA_VERSION
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError

--- a/homeassistant/components/arcam_fmj/device_trigger.py
+++ b/homeassistant/components/arcam_fmj/device_trigger.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 
 import voluptuous as vol
 
-from homeassistant.components.device_automation import (
-    DEVICE_TRIGGER_BASE_SCHEMA,
-)
+from homeassistant.components.device_automation import DEVICE_TRIGGER_BASE_SCHEMA
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     CONF_DEVICE_ID,

--- a/homeassistant/components/august/activity.py
+++ b/homeassistant/components/august/activity.py
@@ -4,10 +4,7 @@ from datetime import datetime
 import logging
 
 from aiohttp import ClientError
-from yalexs.activity import (
-    Activity,
-    ActivityType,
-)
+from yalexs.activity import Activity, ActivityType
 from yalexs.api_async import ApiAsync
 from yalexs.pubnub_async import AugustPubNub
 from yalexs.util import get_latest_activity

--- a/homeassistant/components/aurora/coordinator.py
+++ b/homeassistant/components/aurora/coordinator.py
@@ -7,10 +7,7 @@ from aiohttp import ClientError
 from auroranoaa import AuroraForecast
 
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.update_coordinator import (
-    DataUpdateCoordinator,
-    UpdateFailed,
-)
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/aurora/entity.py
+++ b/homeassistant/components/aurora/entity.py
@@ -4,14 +4,9 @@ import logging
 
 from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo
-from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
-)
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import (
-    ATTRIBUTION,
-    DOMAIN,
-)
+from .const import ATTRIBUTION, DOMAIN
 from .coordinator import AuroraDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/awair/__init__.py
+++ b/homeassistant/components/awair/__init__.py
@@ -13,11 +13,7 @@ from python_awair.devices import AwairBaseDevice, AwairLocalDevice
 from python_awair.exceptions import AuthError, AwairError
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    CONF_ACCESS_TOKEN,
-    CONF_HOST,
-    Platform,
-)
+from homeassistant.const import CONF_ACCESS_TOKEN, CONF_HOST, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.aiohttp_client import async_get_clientsession

--- a/homeassistant/components/bluetooth/passive_update_processor.py
+++ b/homeassistant/components/bluetooth/passive_update_processor.py
@@ -16,14 +16,8 @@ from homeassistant.const import (
     EntityCategory,
 )
 from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant, callback
-from homeassistant.helpers.entity import (
-    DeviceInfo,
-    Entity,
-    EntityDescription,
-)
-from homeassistant.helpers.entity_platform import (
-    async_get_current_platform,
-)
+from homeassistant.helpers.entity import DeviceInfo, Entity, EntityDescription
+from homeassistant.helpers.entity_platform import async_get_current_platform
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.storage import Store
 from homeassistant.util.enum import try_parse_enum

--- a/homeassistant/components/bluetooth/update_coordinator.py
+++ b/homeassistant/components/bluetooth/update_coordinator.py
@@ -12,14 +12,8 @@ from .api import (
     async_register_callback,
     async_track_unavailable,
 )
-from .match import (
-    BluetoothCallbackMatcher,
-)
-from .models import (
-    BluetoothChange,
-    BluetoothScanningMode,
-    BluetoothServiceInfoBleak,
-)
+from .match import BluetoothCallbackMatcher
+from .models import BluetoothChange, BluetoothScanningMode, BluetoothServiceInfoBleak
 
 
 class BasePassiveBluetoothCoordinator(ABC):

--- a/homeassistant/components/bthome/logbook.py
+++ b/homeassistant/components/bthome/logbook.py
@@ -8,11 +8,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import async_get
 from homeassistant.helpers.typing import EventType
 
-from .const import (
-    BTHOME_BLE_EVENT,
-    DOMAIN,
-    BTHomeBleEvent,
-)
+from .const import BTHOME_BLE_EVENT, DOMAIN, BTHomeBleEvent
 
 
 @callback

--- a/homeassistant/components/cert_expiry/__init__.py
+++ b/homeassistant/components/cert_expiry/__init__.py
@@ -5,11 +5,7 @@ from datetime import datetime, timedelta
 import logging
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    CONF_HOST,
-    CONF_PORT,
-    Platform,
-)
+from homeassistant.const import CONF_HOST, CONF_PORT, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.start import async_at_started
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed

--- a/homeassistant/components/duotecno/cover.py
+++ b/homeassistant/components/duotecno/cover.py
@@ -5,10 +5,7 @@ from typing import Any
 
 from duotecno.unit import DuoswitchUnit
 
-from homeassistant.components.cover import (
-    CoverEntity,
-    CoverEntityFeature,
-)
+from homeassistant.components.cover import CoverEntity, CoverEntityFeature
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError

--- a/homeassistant/components/duotecno/light.py
+++ b/homeassistant/components/duotecno/light.py
@@ -3,11 +3,7 @@ from typing import Any
 
 from duotecno.unit import DimUnit
 
-from homeassistant.components.light import (
-    ATTR_BRIGHTNESS,
-    ColorMode,
-    LightEntity,
-)
+from homeassistant.components.light import ATTR_BRIGHTNESS, ColorMode, LightEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError

--- a/homeassistant/components/enphase_envoy/config_flow.py
+++ b/homeassistant/components/enphase_envoy/config_flow.py
@@ -6,11 +6,7 @@ import logging
 from typing import Any
 
 from awesomeversion import AwesomeVersion
-from pyenphase import (
-    AUTH_TOKEN_MIN_VERSION,
-    Envoy,
-    EnvoyError,
-)
+from pyenphase import AUTH_TOKEN_MIN_VERSION, Envoy, EnvoyError
 import voluptuous as vol
 
 from homeassistant import config_entries

--- a/homeassistant/components/enphase_envoy/const.py
+++ b/homeassistant/components/enphase_envoy/const.py
@@ -1,8 +1,5 @@
 """The enphase_envoy component."""
-from pyenphase import (
-    EnvoyAuthenticationError,
-    EnvoyAuthenticationRequired,
-)
+from pyenphase import EnvoyAuthenticationError, EnvoyAuthenticationRequired
 
 from homeassistant.const import Platform
 

--- a/homeassistant/components/enphase_envoy/coordinator.py
+++ b/homeassistant/components/enphase_envoy/coordinator.py
@@ -7,11 +7,7 @@ from datetime import timedelta
 import logging
 from typing import Any
 
-from pyenphase import (
-    Envoy,
-    EnvoyError,
-    EnvoyTokenAuth,
-)
+from pyenphase import Envoy, EnvoyError, EnvoyTokenAuth
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME, CONF_PASSWORD, CONF_TOKEN, CONF_USERNAME

--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -1,9 +1,7 @@
 """Support for esphome devices."""
 from __future__ import annotations
 
-from aioesphomeapi import (
-    APIClient,
-)
+from aioesphomeapi import APIClient
 
 from homeassistant.components import zeroconf
 from homeassistant.config_entries import ConfigEntry
@@ -17,10 +15,7 @@ from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
-from .const import (
-    CONF_NOISE_PSK,
-    DOMAIN,
-)
+from .const import CONF_NOISE_PSK, DOMAIN
 from .dashboard import async_setup as async_setup_dashboard
 from .domain_data import DomainData
 

--- a/homeassistant/components/esphome/alarm_control_panel.py
+++ b/homeassistant/components/esphome/alarm_control_panel.py
@@ -31,11 +31,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .entity import (
-    EsphomeEntity,
-    esphome_state_property,
-    platform_async_setup_entry,
-)
+from .entity import EsphomeEntity, esphome_state_property, platform_async_setup_entry
 from .enum_mapper import EsphomeEnumMapper
 
 _ESPHOME_ACP_STATE_TO_HASS_STATE: EsphomeEnumMapper[

--- a/homeassistant/components/esphome/binary_sensor.py
+++ b/homeassistant/components/esphome/binary_sensor.py
@@ -14,11 +14,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util.enum import try_parse_enum
 
 from .domain_data import DomainData
-from .entity import (
-    EsphomeAssistEntity,
-    EsphomeEntity,
-    platform_async_setup_entry,
-)
+from .entity import EsphomeAssistEntity, EsphomeEntity, platform_async_setup_entry
 
 
 async def async_setup_entry(

--- a/homeassistant/components/esphome/bluetooth/__init__.py
+++ b/homeassistant/components/esphome/bluetooth/__init__.py
@@ -16,10 +16,7 @@ from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback as hass_ca
 
 from ..entry_data import RuntimeEntryData
 from .cache import ESPHomeBluetoothCache
-from .client import (
-    ESPHomeClient,
-    ESPHomeClientData,
-)
+from .client import ESPHomeClient, ESPHomeClientData
 from .device import ESPHomeBluetoothDevice
 from .scanner import ESPHomeScanner
 

--- a/homeassistant/components/esphome/button.py
+++ b/homeassistant/components/esphome/button.py
@@ -9,10 +9,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util.enum import try_parse_enum
 
-from .entity import (
-    EsphomeEntity,
-    platform_async_setup_entry,
-)
+from .entity import EsphomeEntity, platform_async_setup_entry
 
 
 async def async_setup_entry(

--- a/homeassistant/components/esphome/camera.py
+++ b/homeassistant/components/esphome/camera.py
@@ -15,10 +15,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .entity import (
-    EsphomeEntity,
-    platform_async_setup_entry,
-)
+from .entity import EsphomeEntity, platform_async_setup_entry
 
 
 async def async_setup_entry(

--- a/homeassistant/components/esphome/climate.py
+++ b/homeassistant/components/esphome/climate.py
@@ -55,11 +55,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .entity import (
-    EsphomeEntity,
-    esphome_state_property,
-    platform_async_setup_entry,
-)
+from .entity import EsphomeEntity, esphome_state_property, platform_async_setup_entry
 from .enum_mapper import EsphomeEnumMapper
 
 FAN_QUIET = "quiet"

--- a/homeassistant/components/esphome/cover.py
+++ b/homeassistant/components/esphome/cover.py
@@ -17,11 +17,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util.enum import try_parse_enum
 
-from .entity import (
-    EsphomeEntity,
-    esphome_state_property,
-    platform_async_setup_entry,
-)
+from .entity import EsphomeEntity, esphome_state_property, platform_async_setup_entry
 
 
 async def async_setup_entry(

--- a/homeassistant/components/esphome/entity.py
+++ b/homeassistant/components/esphome/entity.py
@@ -4,12 +4,7 @@ from __future__ import annotations
 from collections.abc import Callable
 import functools
 import math
-from typing import (  # pylint: disable=unused-import
-    Any,
-    Generic,
-    TypeVar,
-    cast,
-)
+from typing import Any, Generic, TypeVar, cast  # pylint: disable=unused-import
 
 from aioesphomeapi import (
     EntityCategory as EsphomeEntityCategory,
@@ -19,16 +14,12 @@ from aioesphomeapi import (
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    EntityCategory,
-)
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_platform
 import homeassistant.helpers.config_validation as cv
 import homeassistant.helpers.device_registry as dr
-from homeassistant.helpers.dispatcher import (
-    async_dispatcher_connect,
-)
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import DeviceInfo, Entity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 

--- a/homeassistant/components/esphome/fan.py
+++ b/homeassistant/components/esphome/fan.py
@@ -22,11 +22,7 @@ from homeassistant.util.percentage import (
     ranged_value_to_percentage,
 )
 
-from .entity import (
-    EsphomeEntity,
-    esphome_state_property,
-    platform_async_setup_entry,
-)
+from .entity import EsphomeEntity, esphome_state_property, platform_async_setup_entry
 from .enum_mapper import EsphomeEnumMapper
 
 ORDERED_NAMED_FAN_SPEEDS = [FanSpeed.LOW, FanSpeed.MEDIUM, FanSpeed.HIGH]

--- a/homeassistant/components/esphome/light.py
+++ b/homeassistant/components/esphome/light.py
@@ -31,11 +31,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .entity import (
-    EsphomeEntity,
-    esphome_state_property,
-    platform_async_setup_entry,
-)
+from .entity import EsphomeEntity, esphome_state_property, platform_async_setup_entry
 
 FLASH_LENGTHS = {FLASH_SHORT: 2, FLASH_LONG: 10}
 

--- a/homeassistant/components/esphome/lock.py
+++ b/homeassistant/components/esphome/lock.py
@@ -11,11 +11,7 @@ from homeassistant.const import ATTR_CODE
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .entity import (
-    EsphomeEntity,
-    esphome_state_property,
-    platform_async_setup_entry,
-)
+from .entity import EsphomeEntity, esphome_state_property, platform_async_setup_entry
 
 
 async def async_setup_entry(

--- a/homeassistant/components/esphome/manager.py
+++ b/homeassistant/components/esphome/manager.py
@@ -23,11 +23,7 @@ import voluptuous as vol
 
 from homeassistant.components import tag, zeroconf
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    ATTR_DEVICE_ID,
-    CONF_MODE,
-    EVENT_HOMEASSISTANT_STOP,
-)
+from homeassistant.const import ATTR_DEVICE_ID, CONF_MODE, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import Event, HomeAssistant, ServiceCall, State, callback
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers import template

--- a/homeassistant/components/esphome/media_player.py
+++ b/homeassistant/components/esphome/media_player.py
@@ -25,11 +25,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .entity import (
-    EsphomeEntity,
-    esphome_state_property,
-    platform_async_setup_entry,
-)
+from .entity import EsphomeEntity, esphome_state_property, platform_async_setup_entry
 from .enum_mapper import EsphomeEnumMapper
 
 

--- a/homeassistant/components/esphome/number.py
+++ b/homeassistant/components/esphome/number.py
@@ -16,11 +16,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util.enum import try_parse_enum
 
-from .entity import (
-    EsphomeEntity,
-    esphome_state_property,
-    platform_async_setup_entry,
-)
+from .entity import EsphomeEntity, esphome_state_property, platform_async_setup_entry
 from .enum_mapper import EsphomeEnumMapper
 
 

--- a/homeassistant/components/esphome/sensor.py
+++ b/homeassistant/components/esphome/sensor.py
@@ -25,11 +25,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util import dt as dt_util
 from homeassistant.util.enum import try_parse_enum
 
-from .entity import (
-    EsphomeEntity,
-    esphome_state_property,
-    platform_async_setup_entry,
-)
+from .entity import EsphomeEntity, esphome_state_property, platform_async_setup_entry
 from .enum_mapper import EsphomeEnumMapper
 
 

--- a/homeassistant/components/esphome/switch.py
+++ b/homeassistant/components/esphome/switch.py
@@ -11,11 +11,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util.enum import try_parse_enum
 
-from .entity import (
-    EsphomeEntity,
-    esphome_state_property,
-    platform_async_setup_entry,
-)
+from .entity import EsphomeEntity, esphome_state_property, platform_async_setup_entry
 
 
 async def async_setup_entry(

--- a/homeassistant/components/ezviz/alarm_control_panel.py
+++ b/homeassistant/components/ezviz/alarm_control_panel.py
@@ -24,11 +24,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import (
-    DATA_COORDINATOR,
-    DOMAIN,
-    MANUFACTURER,
-)
+from .const import DATA_COORDINATOR, DOMAIN, MANUFACTURER
 from .coordinator import EzvizDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/ezviz/image.py
+++ b/homeassistant/components/ezviz/image.py
@@ -4,19 +4,12 @@ from __future__ import annotations
 import logging
 
 from homeassistant.components.image import Image, ImageEntity, ImageEntityDescription
-from homeassistant.config_entries import (
-    ConfigEntry,
-)
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.entity_platform import (
-    AddEntitiesCallback,
-)
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util import dt as dt_util
 
-from .const import (
-    DATA_COORDINATOR,
-    DOMAIN,
-)
+from .const import DATA_COORDINATOR, DOMAIN
 from .coordinator import EzvizDataUpdateCoordinator
 from .entity import EzvizEntity
 

--- a/homeassistant/components/fivem/__init__.py
+++ b/homeassistant/components/fivem/__init__.py
@@ -10,9 +10,7 @@ from homeassistant.const import CONF_HOST, CONF_PORT, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
-from .const import (
-    DOMAIN,
-)
+from .const import DOMAIN
 from .coordinator import FiveMDataUpdateCoordinator
 
 PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.SENSOR]

--- a/homeassistant/components/fivem/coordinator.py
+++ b/homeassistant/components/fivem/coordinator.py
@@ -10,10 +10,7 @@ from fivem import FiveM, FiveMServerOfflineError
 
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.update_coordinator import (
-    DataUpdateCoordinator,
-    UpdateFailed,
-)
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
     ATTR_PLAYERS_LIST,

--- a/homeassistant/components/fivem/entity.py
+++ b/homeassistant/components/fivem/entity.py
@@ -7,14 +7,9 @@ import logging
 from typing import Any
 
 from homeassistant.helpers.entity import DeviceInfo, EntityDescription
-from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
-)
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import (
-    DOMAIN,
-    MANUFACTURER,
-)
+from .const import DOMAIN, MANUFACTURER
 from .coordinator import FiveMDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/freebox/binary_sensor.py
+++ b/homeassistant/components/freebox/binary_sensor.py
@@ -10,9 +10,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntityDescription,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    EntityCategory,
-)
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback

--- a/homeassistant/components/gardena_bluetooth/button.py
+++ b/homeassistant/components/gardena_bluetooth/button.py
@@ -6,10 +6,7 @@ from dataclasses import dataclass, field
 from gardena_bluetooth.const import Reset
 from gardena_bluetooth.parse import CharacteristicBool
 
-from homeassistant.components.button import (
-    ButtonEntity,
-    ButtonEntityDescription,
-)
+from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant

--- a/homeassistant/components/geo_location/trigger.py
+++ b/homeassistant/components/geo_location/trigger.py
@@ -7,13 +7,7 @@ from typing import Final
 import voluptuous as vol
 
 from homeassistant.const import CONF_EVENT, CONF_PLATFORM, CONF_SOURCE, CONF_ZONE
-from homeassistant.core import (
-    CALLBACK_TYPE,
-    HassJob,
-    HomeAssistant,
-    State,
-    callback,
-)
+from homeassistant.core import CALLBACK_TYPE, HassJob, HomeAssistant, State, callback
 from homeassistant.helpers import condition, config_validation as cv
 from homeassistant.helpers.config_validation import entity_domain
 from homeassistant.helpers.event import (

--- a/homeassistant/components/homeassistant/triggers/state.py
+++ b/homeassistant/components/homeassistant/triggers/state.py
@@ -8,13 +8,7 @@ import voluptuous as vol
 
 from homeassistant import exceptions
 from homeassistant.const import CONF_ATTRIBUTE, CONF_FOR, CONF_PLATFORM, MATCH_ALL
-from homeassistant.core import (
-    CALLBACK_TYPE,
-    HassJob,
-    HomeAssistant,
-    State,
-    callback,
-)
+from homeassistant.core import CALLBACK_TYPE, HassJob, HomeAssistant, State, callback
 from homeassistant.helpers import (
     config_validation as cv,
     entity_registry as er,

--- a/homeassistant/components/hue/event.py
+++ b/homeassistant/components/hue/event.py
@@ -6,10 +6,7 @@ from typing import Any
 from aiohue.v2 import HueBridgeV2
 from aiohue.v2.controllers.events import EventType
 from aiohue.v2.models.button import Button
-from aiohue.v2.models.relative_rotary import (
-    RelativeRotary,
-    RelativeRotaryDirection,
-)
+from aiohue.v2.models.relative_rotary import RelativeRotary, RelativeRotaryDirection
 
 from homeassistant.components.event import (
     EventDeviceClass,

--- a/homeassistant/components/knx/light.py
+++ b/homeassistant/components/knx/light.py
@@ -4,11 +4,7 @@ from __future__ import annotations
 from typing import Any, cast
 
 from xknx import XKNX
-from xknx.devices.light import (
-    ColorTemperatureType,
-    Light as XknxLight,
-    XYYColor,
-)
+from xknx.devices.light import ColorTemperatureType, Light as XknxLight, XYYColor
 
 from homeassistant import config_entries
 from homeassistant.components.light import (

--- a/homeassistant/components/lastfm/coordinator.py
+++ b/homeassistant/components/lastfm/coordinator.py
@@ -11,11 +11,7 @@ from homeassistant.const import CONF_API_KEY
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import (
-    CONF_USERS,
-    DOMAIN,
-    LOGGER,
-)
+from .const import CONF_USERS, DOMAIN, LOGGER
 
 
 def format_track(track: Track | None) -> str | None:

--- a/homeassistant/components/lastfm/sensor.py
+++ b/homeassistant/components/lastfm/sensor.py
@@ -16,9 +16,7 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
-from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
-)
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
     ATTR_LAST_PLAYED,

--- a/homeassistant/components/mqtt/event.py
+++ b/homeassistant/components/mqtt/event.py
@@ -15,11 +15,7 @@ from homeassistant.components.event import (
     EventEntity,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    CONF_DEVICE_CLASS,
-    CONF_NAME,
-    CONF_VALUE_TEMPLATE,
-)
+from homeassistant.const import CONF_DEVICE_CLASS, CONF_NAME, CONF_VALUE_TEMPLATE
 from homeassistant.core import HomeAssistant, callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -36,11 +32,7 @@ from .const import (
     PAYLOAD_NONE,
 )
 from .debug_info import log_messages
-from .mixins import (
-    MQTT_ENTITY_COMMON_SCHEMA,
-    MqttEntity,
-    async_setup_entry_helper,
-)
+from .mixins import MQTT_ENTITY_COMMON_SCHEMA, MqttEntity, async_setup_entry_helper
 from .models import (
     MqttValueTemplate,
     PayloadSentinel,

--- a/homeassistant/components/mqtt/image.py
+++ b/homeassistant/components/mqtt/image.py
@@ -12,10 +12,7 @@ import httpx
 import voluptuous as vol
 
 from homeassistant.components import image
-from homeassistant.components.image import (
-    DEFAULT_CONTENT_TYPE,
-    ImageEntity,
-)
+from homeassistant.components.image import DEFAULT_CONTENT_TYPE, ImageEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant, callback

--- a/homeassistant/components/mqtt/scene.py
+++ b/homeassistant/components/mqtt/scene.py
@@ -17,11 +17,7 @@ from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from .config import MQTT_BASE_SCHEMA
 from .const import CONF_COMMAND_TOPIC, CONF_ENCODING, CONF_QOS, CONF_RETAIN
-from .mixins import (
-    MQTT_ENTITY_COMMON_SCHEMA,
-    MqttEntity,
-    async_setup_entry_helper,
-)
+from .mixins import MQTT_ENTITY_COMMON_SCHEMA, MqttEntity, async_setup_entry_helper
 from .util import valid_publish_topic
 
 DEFAULT_NAME = "MQTT Scene"

--- a/homeassistant/components/nobo_hub/climate.py
+++ b/homeassistant/components/nobo_hub/climate.py
@@ -17,11 +17,7 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    ATTR_NAME,
-    PRECISION_TENTHS,
-    UnitOfTemperature,
-)
+from homeassistant.const import ATTR_NAME, PRECISION_TENTHS, UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback

--- a/homeassistant/components/nobo_hub/sensor.py
+++ b/homeassistant/components/nobo_hub/sensor.py
@@ -9,11 +9,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    ATTR_MODEL,
-    ATTR_NAME,
-    UnitOfTemperature,
-)
+from homeassistant.const import ATTR_MODEL, ATTR_NAME, UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback

--- a/homeassistant/components/opensky/config_flow.py
+++ b/homeassistant/components/opensky/config_flow.py
@@ -6,12 +6,7 @@ from typing import Any
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow
-from homeassistant.const import (
-    CONF_LATITUDE,
-    CONF_LONGITUDE,
-    CONF_NAME,
-    CONF_RADIUS,
-)
+from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME, CONF_RADIUS
 from homeassistant.data_entry_flow import FlowResult
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import ConfigType

--- a/homeassistant/components/pegel_online/__init__.py
+++ b/homeassistant/components/pegel_online/__init__.py
@@ -10,10 +10,7 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import (
-    CONF_STATION,
-    DOMAIN,
-)
+from .const import CONF_STATION, DOMAIN
 from .coordinator import PegelOnlineDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/rova/sensor.py
+++ b/homeassistant/components/rova/sensor.py
@@ -21,12 +21,7 @@ from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util import Throttle
 from homeassistant.util.dt import get_time_zone
 
-from .const import (
-    CONF_HOUSE_NUMBER,
-    CONF_HOUSE_NUMBER_SUFFIX,
-    CONF_ZIP_CODE,
-    LOGGER,
-)
+from .const import CONF_HOUSE_NUMBER, CONF_HOUSE_NUMBER_SUFFIX, CONF_ZIP_CODE, LOGGER
 
 UPDATE_DELAY = timedelta(hours=12)
 SCAN_INTERVAL = timedelta(hours=12)

--- a/homeassistant/components/smhi/weather.py
+++ b/homeassistant/components/smhi/weather.py
@@ -62,11 +62,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_call_later
 from homeassistant.util import Throttle, slugify
 
-from .const import (
-    ATTR_SMHI_THUNDER_PROBABILITY,
-    DOMAIN,
-    ENTITY_ID_SENSOR_FORMAT,
-)
+from .const import ATTR_SMHI_THUNDER_PROBABILITY, DOMAIN, ENTITY_ID_SENSOR_FORMAT
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/template/image.py
+++ b/homeassistant/components/template/image.py
@@ -6,10 +6,7 @@ from typing import Any
 
 import voluptuous as vol
 
-from homeassistant.components.image import (
-    DOMAIN as IMAGE_DOMAIN,
-    ImageEntity,
-)
+from homeassistant.components.image import DOMAIN as IMAGE_DOMAIN, ImageEntity
 from homeassistant.const import CONF_UNIQUE_ID, CONF_URL, CONF_VERIFY_SSL
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import TemplateError
@@ -20,10 +17,7 @@ from homeassistant.util import dt as dt_util
 
 from . import TriggerUpdateCoordinator
 from .const import CONF_PICTURE
-from .template_entity import (
-    TemplateEntity,
-    make_template_entity_common_schema,
-)
+from .template_entity import TemplateEntity, make_template_entity_common_schema
 from .trigger_entity import TriggerEntity
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/unifi/switch.py
+++ b/homeassistant/components/unifi/switch.py
@@ -41,9 +41,7 @@ from homeassistant.components.switch import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.device_registry import (
-    DeviceEntryType,
-)
+from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 

--- a/homeassistant/components/utility_meter/select.py
+++ b/homeassistant/components/utility_meter/select.py
@@ -7,10 +7,7 @@ from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_UNIQUE_ID
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import (
-    device_registry as dr,
-    entity_registry as er,
-)
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity

--- a/homeassistant/components/voip/voip.py
+++ b/homeassistant/components/voip/voip.py
@@ -37,13 +37,7 @@ from homeassistant.const import __version__
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.util.ulid import ulid
 
-from .const import (
-    CHANNELS,
-    DOMAIN,
-    RATE,
-    RTP_AUDIO_SETTINGS,
-    WIDTH,
-)
+from .const import CHANNELS, DOMAIN, RATE, RTP_AUDIO_SETTINGS, WIDTH
 
 if TYPE_CHECKING:
     from .devices import VoIPDevice, VoIPDevices

--- a/homeassistant/components/wemo/fan.py
+++ b/homeassistant/components/wemo/fan.py
@@ -20,10 +20,7 @@ from homeassistant.util.percentage import (
 )
 
 from . import async_wemo_dispatcher_connect
-from .const import (
-    SERVICE_RESET_FILTER_LIFE,
-    SERVICE_SET_HUMIDITY,
-)
+from .const import SERVICE_RESET_FILTER_LIFE, SERVICE_SET_HUMIDITY
 from .entity import WemoBinaryStateEntity
 from .wemo_device import DeviceCoordinator
 

--- a/homeassistant/components/zone/trigger.py
+++ b/homeassistant/components/zone/trigger.py
@@ -12,12 +12,7 @@ from homeassistant.const import (
     CONF_PLATFORM,
     CONF_ZONE,
 )
-from homeassistant.core import (
-    CALLBACK_TYPE,
-    HassJob,
-    HomeAssistant,
-    callback,
-)
+from homeassistant.core import CALLBACK_TYPE, HassJob, HomeAssistant, callback
 from homeassistant.helpers import (
     condition,
     config_validation as cv,

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -26,16 +26,7 @@ import re
 import threading
 import time
 from time import monotonic
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Generic,
-    ParamSpec,
-    Self,
-    TypeVar,
-    cast,
-    overload,
-)
+from typing import TYPE_CHECKING, Any, Generic, ParamSpec, Self, TypeVar, cast, overload
 from urllib.parse import urlparse
 
 import async_timeout

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -26,10 +26,7 @@ from homeassistant.core import (
     split_entity_id,
     valid_entity_id,
 )
-from homeassistant.exceptions import (
-    HomeAssistantError,
-    PlatformNotReady,
-)
+from homeassistant.exceptions import HomeAssistantError, PlatformNotReady
 from homeassistant.generated import languages
 from homeassistant.setup import async_start_setup
 from homeassistant.util.async_ import run_callback_threadsafe

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -537,6 +537,7 @@ known-first-party = [
     "homeassistant",
 ]
 combine-as-imports = true
+split-on-trailing-comma = false
 
 [tool.ruff.per-file-ignores]
 

--- a/tests/components/advantage_air/test_diagnostics.py
+++ b/tests/components/advantage_air/test_diagnostics.py
@@ -3,11 +3,7 @@ from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.core import HomeAssistant
 
-from . import (
-    TEST_SYSTEM_DATA,
-    TEST_SYSTEM_URL,
-    add_mock_config,
-)
+from . import TEST_SYSTEM_DATA, TEST_SYSTEM_URL, add_mock_config
 
 from tests.components.diagnostics import get_diagnostics_for_config_entry
 from tests.test_util.aiohttp import AiohttpClientMocker

--- a/tests/components/climate/test_device_action.py
+++ b/tests/components/climate/test_device_action.py
@@ -5,9 +5,7 @@ import voluptuous_serialize
 
 import homeassistant.components.automation as automation
 from homeassistant.components.climate import DOMAIN, HVACMode, const, device_action
-from homeassistant.components.device_automation import (
-    DeviceAutomationType,
-)
+from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import (

--- a/tests/components/datadog/test_init.py
+++ b/tests/components/datadog/test_init.py
@@ -3,11 +3,7 @@ from unittest import mock
 from unittest.mock import patch
 
 import homeassistant.components.datadog as datadog
-from homeassistant.const import (
-    EVENT_LOGBOOK_ENTRY,
-    STATE_OFF,
-    STATE_ON,
-)
+from homeassistant.const import EVENT_LOGBOOK_ENTRY, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 

--- a/tests/components/deconz/test_device_trigger.py
+++ b/tests/components/deconz/test_device_trigger.py
@@ -33,10 +33,7 @@ from homeassistant.setup import async_setup_component
 
 from .test_gateway import DECONZ_WEB_REQUEST, setup_deconz_integration
 
-from tests.common import (
-    async_get_device_automations,
-    async_mock_service,
-)
+from tests.common import async_get_device_automations, async_mock_service
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 

--- a/tests/components/devolo_home_network/test_button.py
+++ b/tests/components/devolo_home_network/test_button.py
@@ -5,10 +5,7 @@ from devolo_plc_api.exceptions.device import DevicePasswordProtected, DeviceUnav
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.button import (
-    DOMAIN as PLATFORM,
-    SERVICE_PRESS,
-)
+from homeassistant.components.button import DOMAIN as PLATFORM, SERVICE_PRESS
 from homeassistant.components.devolo_home_network.const import DOMAIN
 from homeassistant.config_entries import SOURCE_REAUTH
 from homeassistant.const import ATTR_ENTITY_ID

--- a/tests/components/esphome/conftest.py
+++ b/tests/components/esphome/conftest.py
@@ -19,9 +19,7 @@ import async_timeout
 import pytest
 from zeroconf import Zeroconf
 
-from homeassistant.components.esphome import (
-    dashboard,
-)
+from homeassistant.components.esphome import dashboard
 from homeassistant.components.esphome.const import (
     CONF_ALLOW_SERVICE_CALLS,
     CONF_DEVICE_NAME,

--- a/tests/components/esphome/test_alarm_control_panel.py
+++ b/tests/components/esphome/test_alarm_control_panel.py
@@ -21,11 +21,7 @@ from homeassistant.components.alarm_control_panel import (
     SERVICE_ALARM_TRIGGER,
 )
 from homeassistant.components.esphome.alarm_control_panel import EspHomeACPFeatures
-from homeassistant.const import (
-    ATTR_ENTITY_ID,
-    STATE_ALARM_ARMED_AWAY,
-    STATE_UNKNOWN,
-)
+from homeassistant.const import ATTR_ENTITY_ID, STATE_ALARM_ARMED_AWAY, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 
 

--- a/tests/components/esphome/test_button.py
+++ b/tests/components/esphome/test_button.py
@@ -5,10 +5,7 @@ from unittest.mock import call
 
 from aioesphomeapi import APIClient, ButtonInfo
 
-from homeassistant.components.button import (
-    DOMAIN as BUTTON_DOMAIN,
-    SERVICE_PRESS,
-)
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
 from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 

--- a/tests/components/esphome/test_camera.py
+++ b/tests/components/esphome/test_camera.py
@@ -10,9 +10,7 @@ from aioesphomeapi import (
     UserService,
 )
 
-from homeassistant.components.camera import (
-    STATE_IDLE,
-)
+from homeassistant.components.camera import STATE_IDLE
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 

--- a/tests/components/esphome/test_config_flow.py
+++ b/tests/components/esphome/test_config_flow.py
@@ -17,10 +17,7 @@ import pytest
 
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components import dhcp, zeroconf
-from homeassistant.components.esphome import (
-    DomainData,
-    dashboard,
-)
+from homeassistant.components.esphome import DomainData, dashboard
 from homeassistant.components.esphome.const import (
     CONF_ALLOW_SERVICE_CALLS,
     CONF_DEVICE_NAME,

--- a/tests/components/esphome/test_diagnostics.py
+++ b/tests/components/esphome/test_diagnostics.py
@@ -1,10 +1,7 @@
 """Tests for the diagnostics data provided by the ESPHome integration."""
 
 
-from homeassistant.components.esphome.const import (
-    CONF_DEVICE_NAME,
-    CONF_NOISE_PSK,
-)
+from homeassistant.components.esphome.const import CONF_DEVICE_NAME, CONF_NOISE_PSK
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT
 from homeassistant.core import HomeAssistant
 

--- a/tests/components/esphome/test_manager.py
+++ b/tests/components/esphome/test_manager.py
@@ -1,12 +1,7 @@
 """Test ESPHome manager."""
 from collections.abc import Awaitable, Callable
 
-from aioesphomeapi import (
-    APIClient,
-    EntityInfo,
-    EntityState,
-    UserService,
-)
+from aioesphomeapi import APIClient, EntityInfo, EntityState, UserService
 
 from homeassistant.components.esphome.const import DOMAIN, STABLE_BLE_VERSION_STR
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT

--- a/tests/components/esphome/test_media_player.py
+++ b/tests/components/esphome/test_media_player.py
@@ -32,9 +32,7 @@ from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
-from tests.common import (
-    mock_platform,
-)
+from tests.common import mock_platform
 from tests.typing import WebSocketGenerator
 
 

--- a/tests/components/esphome/test_sensor.py
+++ b/tests/components/esphome/test_sensor.py
@@ -18,11 +18,7 @@ from aioesphomeapi import (
 )
 
 from homeassistant.components.sensor import ATTR_STATE_CLASS, SensorStateClass
-from homeassistant.const import (
-    ATTR_ICON,
-    ATTR_UNIT_OF_MEASUREMENT,
-    STATE_UNKNOWN,
-)
+from homeassistant.const import ATTR_ICON, ATTR_UNIT_OF_MEASUREMENT, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity import EntityCategory

--- a/tests/components/esphome/test_update.py
+++ b/tests/components/esphome/test_update.py
@@ -4,24 +4,12 @@ from collections.abc import Awaitable, Callable
 import dataclasses
 from unittest.mock import Mock, patch
 
-from aioesphomeapi import (
-    APIClient,
-    EntityInfo,
-    EntityState,
-    UserService,
-)
+from aioesphomeapi import APIClient, EntityInfo, EntityState, UserService
 import pytest
 
-from homeassistant.components.esphome.dashboard import (
-    async_get_dashboard,
-)
+from homeassistant.components.esphome.dashboard import async_get_dashboard
 from homeassistant.components.update import UpdateEntityFeature
-from homeassistant.const import (
-    STATE_OFF,
-    STATE_ON,
-    STATE_UNAVAILABLE,
-    STATE_UNKNOWN,
-)
+from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import async_dispatcher_send

--- a/tests/components/fritz/test_update.py
+++ b/tests/components/fritz/test_update.py
@@ -8,11 +8,7 @@ from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
-from .const import (
-    MOCK_FIRMWARE_AVAILABLE,
-    MOCK_FIRMWARE_RELEASE_URL,
-    MOCK_USER_DATA,
-)
+from .const import MOCK_FIRMWARE_AVAILABLE, MOCK_FIRMWARE_RELEASE_URL, MOCK_USER_DATA
 
 from tests.common import MockConfigEntry
 from tests.typing import ClientSessionGenerator

--- a/tests/components/gardena_bluetooth/__init__.py
+++ b/tests/components/gardena_bluetooth/__init__.py
@@ -7,9 +7,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.service_info.bluetooth import BluetoothServiceInfo
 
 from tests.common import MockConfigEntry
-from tests.components.bluetooth import (
-    inject_bluetooth_service_info,
-)
+from tests.components.bluetooth import inject_bluetooth_service_info
 
 WATER_TIMER_SERVICE_INFO = BluetoothServiceInfo(
     name="Timer",

--- a/tests/components/gardena_bluetooth/test_button.py
+++ b/tests/components/gardena_bluetooth/test_button.py
@@ -9,10 +9,7 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
-from homeassistant.const import (
-    ATTR_ENTITY_ID,
-    Platform,
-)
+from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 
 from . import setup_entry

--- a/tests/components/gardena_bluetooth/test_config_flow.py
+++ b/tests/components/gardena_bluetooth/test_config_flow.py
@@ -17,9 +17,7 @@ from . import (
     WATER_TIMER_UNNAMED_SERVICE_INFO,
 )
 
-from tests.components.bluetooth import (
-    inject_bluetooth_service_info,
-)
+from tests.components.bluetooth import inject_bluetooth_service_info
 
 pytestmark = pytest.mark.usefixtures("mock_setup_entry")
 

--- a/tests/components/gardena_bluetooth/test_number.py
+++ b/tests/components/gardena_bluetooth/test_number.py
@@ -19,10 +19,7 @@ from homeassistant.components.number import (
     DOMAIN as NUMBER_DOMAIN,
     SERVICE_SET_VALUE,
 )
-from homeassistant.const import (
-    ATTR_ENTITY_ID,
-    Platform,
-)
+from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 
 from . import setup_entry

--- a/tests/components/homekit_controller/test_device_trigger.py
+++ b/tests/components/homekit_controller/test_device_trigger.py
@@ -14,10 +14,7 @@ from homeassistant.setup import async_setup_component
 
 from .common import setup_test_component
 
-from tests.common import (
-    async_get_device_automations,
-    async_mock_service,
-)
+from tests.common import async_get_device_automations, async_mock_service
 
 
 @pytest.fixture(autouse=True, name="stub_blueprint_populate")

--- a/tests/components/hue/test_device_trigger_v2.py
+++ b/tests/components/hue/test_device_trigger_v2.py
@@ -11,10 +11,7 @@ from homeassistant.helpers import entity_registry as er
 
 from .conftest import setup_platform
 
-from tests.common import (
-    async_capture_events,
-    async_get_device_automations,
-)
+from tests.common import async_capture_events, async_get_device_automations
 
 
 async def test_hue_event(

--- a/tests/components/hue/test_event.py
+++ b/tests/components/hue/test_event.py
@@ -1,8 +1,5 @@
 """Philips Hue Event platform tests for V2 bridge/api."""
-from homeassistant.components.event import (
-    ATTR_EVENT_TYPE,
-    ATTR_EVENT_TYPES,
-)
+from homeassistant.components.event import ATTR_EVENT_TYPE, ATTR_EVENT_TYPES
 from homeassistant.core import HomeAssistant
 
 from .conftest import setup_platform

--- a/tests/components/influxdb/test_init.py
+++ b/tests/components/influxdb/test_init.py
@@ -8,12 +8,7 @@ import pytest
 
 import homeassistant.components.influxdb as influxdb
 from homeassistant.components.influxdb.const import DEFAULT_BUCKET
-from homeassistant.const import (
-    PERCENTAGE,
-    STATE_OFF,
-    STATE_ON,
-    STATE_STANDBY,
-)
+from homeassistant.const import PERCENTAGE, STATE_OFF, STATE_ON, STATE_STANDBY
 from homeassistant.core import HomeAssistant, split_entity_id
 from homeassistant.setup import async_setup_component
 

--- a/tests/components/lastfm/test_sensor.py
+++ b/tests/components/lastfm/test_sensor.py
@@ -4,10 +4,7 @@ from unittest.mock import patch
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.lastfm.const import (
-    CONF_USERS,
-    DOMAIN,
-)
+from homeassistant.components.lastfm.const import CONF_USERS, DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_API_KEY, CONF_PLATFORM, Platform
 from homeassistant.core import HomeAssistant

--- a/tests/components/light/test_device_action.py
+++ b/tests/components/light/test_device_action.py
@@ -14,10 +14,7 @@ from homeassistant.components.light import (
 )
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import (
-    device_registry as dr,
-    entity_registry as er,
-)
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 

--- a/tests/components/matter/test_door_lock.py
+++ b/tests/components/matter/test_door_lock.py
@@ -14,10 +14,7 @@ from homeassistant.components.lock import (
 from homeassistant.const import ATTR_CODE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 
-from .common import (
-    set_node_attribute,
-    trigger_subscription_callback,
-)
+from .common import set_node_attribute, trigger_subscription_callback
 
 
 # This tests needs to be adjusted to remove lingering tasks

--- a/tests/components/matter/test_event.py
+++ b/tests/components/matter/test_event.py
@@ -5,16 +5,10 @@ from matter_server.client.models.node import MatterNode
 from matter_server.common.models import EventType, MatterNodeEvent
 import pytest
 
-from homeassistant.components.event import (
-    ATTR_EVENT_TYPE,
-    ATTR_EVENT_TYPES,
-)
+from homeassistant.components.event import ATTR_EVENT_TYPE, ATTR_EVENT_TYPES
 from homeassistant.core import HomeAssistant
 
-from .common import (
-    setup_integration_with_node_fixture,
-    trigger_subscription_callback,
-)
+from .common import setup_integration_with_node_fixture, trigger_subscription_callback
 
 
 @pytest.fixture(name="generic_switch_node")

--- a/tests/components/mqtt/test_common.py
+++ b/tests/components/mqtt/test_common.py
@@ -26,10 +26,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.generated.mqtt import MQTT
-from homeassistant.helpers import (
-    device_registry as dr,
-    entity_registry as er,
-)
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 

--- a/tests/components/mqtt/test_event.py
+++ b/tests/components/mqtt/test_event.py
@@ -8,10 +8,7 @@ import pytest
 
 from homeassistant.components import event, mqtt
 from homeassistant.components.mqtt.event import MQTT_EVENT_ATTRIBUTES_BLOCKED
-from homeassistant.const import (
-    STATE_UNKNOWN,
-    Platform,
-)
+from homeassistant.const import STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
@@ -51,9 +48,7 @@ from .test_common import (
     help_test_update_with_json_attrs_not_dict,
 )
 
-from tests.common import (
-    async_fire_mqtt_message,
-)
+from tests.common import async_fire_mqtt_message
 from tests.typing import MqttMockHAClientGenerator, MqttMockPahoClient
 
 DEFAULT_CONFIG = {

--- a/tests/components/mqtt/test_mixins.py
+++ b/tests/components/mqtt/test_mixins.py
@@ -12,10 +12,7 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import CoreState, HomeAssistant, callback
-from homeassistant.helpers import (
-    device_registry as dr,
-    issue_registry as ir,
-)
+from homeassistant.helpers import device_registry as dr, issue_registry as ir
 
 from tests.common import MockConfigEntry, async_capture_events, async_fire_mqtt_message
 from tests.typing import MqttMockHAClientGenerator, MqttMockPahoClient

--- a/tests/components/nest/test_device_trigger.py
+++ b/tests/components/nest/test_device_trigger.py
@@ -17,10 +17,7 @@ from homeassistant.util.dt import utcnow
 
 from .common import DEVICE_ID, CreateDevice, FakeSubscriber, PlatformSetup
 
-from tests.common import (
-    async_get_device_automations,
-    async_mock_service,
-)
+from tests.common import async_get_device_automations, async_mock_service
 
 DEVICE_NAME = "My Camera"
 DATA_MESSAGE = {"message": "service-called"}

--- a/tests/components/opensky/test_config_flow.py
+++ b/tests/components/opensky/test_config_flow.py
@@ -3,11 +3,7 @@ from typing import Any
 
 import pytest
 
-from homeassistant.components.opensky.const import (
-    CONF_ALTITUDE,
-    DEFAULT_NAME,
-    DOMAIN,
-)
+from homeassistant.components.opensky.const import CONF_ALTITUDE, DEFAULT_NAME, DOMAIN
 from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME, CONF_RADIUS
 from homeassistant.core import HomeAssistant

--- a/tests/components/oralb/test_sensor.py
+++ b/tests/components/oralb/test_sensor.py
@@ -9,10 +9,7 @@ from homeassistant.components.bluetooth import (
     async_address_present,
 )
 from homeassistant.components.oralb.const import DOMAIN
-from homeassistant.const import (
-    ATTR_ASSUMED_STATE,
-    ATTR_FRIENDLY_NAME,
-)
+from homeassistant.const import ATTR_ASSUMED_STATE, ATTR_FRIENDLY_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 

--- a/tests/components/pegel_online/test_config_flow.py
+++ b/tests/components/pegel_online/test_config_flow.py
@@ -3,10 +3,7 @@ from unittest.mock import patch
 
 from aiohttp.client_exceptions import ClientError
 
-from homeassistant.components.pegel_online.const import (
-    CONF_STATION,
-    DOMAIN,
-)
+from homeassistant.components.pegel_online.const import CONF_STATION, DOMAIN
 from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import (
     CONF_LATITUDE,

--- a/tests/components/philips_js/test_device_trigger.py
+++ b/tests/components/philips_js/test_device_trigger.py
@@ -8,10 +8,7 @@ from homeassistant.components.philips_js.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
-from tests.common import (
-    async_get_device_automations,
-    async_mock_service,
-)
+from tests.common import async_get_device_automations, async_mock_service
 
 
 @pytest.fixture(autouse=True, name="stub_blueprint_populate")

--- a/tests/components/qingping/test_binary_sensor.py
+++ b/tests/components/qingping/test_binary_sensor.py
@@ -7,11 +7,7 @@ from homeassistant.components.bluetooth import (
     FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS,
 )
 from homeassistant.components.qingping.const import DOMAIN
-from homeassistant.const import (
-    ATTR_FRIENDLY_NAME,
-    STATE_OFF,
-    STATE_UNAVAILABLE,
-)
+from homeassistant.const import ATTR_FRIENDLY_NAME, STATE_OFF, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 

--- a/tests/components/rfxtrx/test_device_action.py
+++ b/tests/components/rfxtrx/test_device_action.py
@@ -16,10 +16,7 @@ from homeassistant.setup import async_setup_component
 
 from .conftest import create_rfx_test_cfg
 
-from tests.common import (
-    MockConfigEntry,
-    async_get_device_automations,
-)
+from tests.common import MockConfigEntry, async_get_device_automations
 
 
 class DeviceTestData(NamedTuple):

--- a/tests/components/shelly/test_device_trigger.py
+++ b/tests/components/shelly/test_device_trigger.py
@@ -25,10 +25,7 @@ from homeassistant.setup import async_setup_component
 
 from . import init_integration
 
-from tests.common import (
-    MockConfigEntry,
-    async_get_device_automations,
-)
+from tests.common import MockConfigEntry, async_get_device_automations
 
 
 @pytest.mark.parametrize(

--- a/tests/components/smhi/test_weather.py
+++ b/tests/components/smhi/test_weather.py
@@ -8,10 +8,7 @@ from smhi.smhi_lib import APIURL_TEMPLATE, SmhiForecast, SmhiForecastException
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.smhi.const import ATTR_SMHI_THUNDER_PROBABILITY
-from homeassistant.components.smhi.weather import (
-    CONDITION_CLASSES,
-    RETRY_TIMEOUT,
-)
+from homeassistant.components.smhi.weather import CONDITION_CLASSES, RETRY_TIMEOUT
 from homeassistant.components.weather import (
     ATTR_FORECAST,
     ATTR_FORECAST_CONDITION,

--- a/tests/components/subaru/test_device_tracker.py
+++ b/tests/components/subaru/test_device_tracker.py
@@ -9,11 +9,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from .api_responses import EXPECTED_STATE_EV_IMPERIAL, VEHICLE_STATUS_EV
-from .conftest import (
-    MOCK_API_FETCH,
-    MOCK_API_GET_DATA,
-    advance_time_to_next_fetch,
-)
+from .conftest import MOCK_API_FETCH, MOCK_API_GET_DATA, advance_time_to_next_fetch
 
 DEVICE_ID = "device_tracker.test_vehicle_2"
 

--- a/tests/components/tasmota/test_device_trigger.py
+++ b/tests/components/tasmota/test_device_trigger.py
@@ -18,10 +18,7 @@ from homeassistant.setup import async_setup_component
 
 from .test_common import DEFAULT_CONFIG, remove_device
 
-from tests.common import (
-    async_fire_mqtt_message,
-    async_get_device_automations,
-)
+from tests.common import async_fire_mqtt_message, async_get_device_automations
 from tests.typing import MqttMockHAClient, WebSocketGenerator
 
 

--- a/tests/components/template/test_image.py
+++ b/tests/components/template/test_image.py
@@ -14,11 +14,7 @@ from homeassistant.components.input_text import (
     DOMAIN as INPUT_TEXT_DOMAIN,
     SERVICE_SET_VALUE as INPUT_TEXT_SERVICE_SET_VALUE,
 )
-from homeassistant.const import (
-    ATTR_ENTITY_PICTURE,
-    CONF_ENTITY_ID,
-    STATE_UNKNOWN,
-)
+from homeassistant.const import ATTR_ENTITY_PICTURE, CONF_ENTITY_ID, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_registry import async_get
 from homeassistant.util import dt as dt_util

--- a/tests/components/transport_nsw/test_sensor.py
+++ b/tests/components/transport_nsw/test_sensor.py
@@ -1,10 +1,7 @@
 """The tests for the Transport NSW (AU) sensor platform."""
 from unittest.mock import patch
 
-from homeassistant.components.sensor import (
-    SensorDeviceClass,
-    SensorStateClass,
-)
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 

--- a/tests/components/unifi/test_button.py
+++ b/tests/components/unifi/test_button.py
@@ -2,24 +2,13 @@
 
 from aiounifi.websocket import WebsocketState
 
-from homeassistant.components.button import (
-    DOMAIN as BUTTON_DOMAIN,
-    ButtonDeviceClass,
-)
-from homeassistant.components.unifi.const import (
-    DOMAIN as UNIFI_DOMAIN,
-)
-from homeassistant.const import (
-    ATTR_DEVICE_CLASS,
-    STATE_UNAVAILABLE,
-    EntityCategory,
-)
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, ButtonDeviceClass
+from homeassistant.components.unifi.const import DOMAIN as UNIFI_DOMAIN
+from homeassistant.const import ATTR_DEVICE_CLASS, STATE_UNAVAILABLE, EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from .test_controller import (
-    setup_unifi_integration,
-)
+from .test_controller import setup_unifi_integration
 
 from tests.test_util.aiohttp import AiohttpClientMocker
 

--- a/tests/components/unifi/test_image.py
+++ b/tests/components/unifi/test_image.py
@@ -16,9 +16,7 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryDisabler
 from homeassistant.util import dt as dt_util
 
-from .test_controller import (
-    setup_unifi_integration,
-)
+from .test_controller import setup_unifi_integration
 
 from tests.common import async_fire_time_changed
 from tests.test_util.aiohttp import AiohttpClientMocker

--- a/tests/components/weather/test_recorder.py
+++ b/tests/components/weather/test_recorder.py
@@ -5,10 +5,7 @@ from datetime import timedelta
 
 from homeassistant.components.recorder import Recorder
 from homeassistant.components.recorder.history import get_significant_states
-from homeassistant.components.weather import (
-    ATTR_CONDITION_SUNNY,
-    ATTR_FORECAST,
-)
+from homeassistant.components.weather import ATTR_CONDITION_SUNNY, ATTR_FORECAST
 from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component

--- a/tests/components/websocket_api/conftest.py
+++ b/tests/components/websocket_api/conftest.py
@@ -6,10 +6,7 @@ from homeassistant.components.websocket_api.http import URL
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
-from tests.typing import (
-    MockHAClientWebSocket,
-    WebSocketGenerator,
-)
+from tests.typing import MockHAClientWebSocket, WebSocketGenerator
 
 
 @pytest.fixture

--- a/tests/components/websocket_api/test_commands.py
+++ b/tests/components/websocket_api/test_commands.py
@@ -33,10 +33,7 @@ from tests.common import (
     async_mock_service,
     mock_platform,
 )
-from tests.typing import (
-    ClientSessionGenerator,
-    WebSocketGenerator,
-)
+from tests.typing import ClientSessionGenerator, WebSocketGenerator
 
 STATE_KEY_SHORT_NAMES = {
     "entity_id": "e",

--- a/tests/components/websocket_api/test_http.py
+++ b/tests/components/websocket_api/test_http.py
@@ -18,10 +18,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.util.dt import utcnow
 
 from tests.common import async_fire_time_changed
-from tests.typing import (
-    MockHAClientWebSocket,
-    WebSocketGenerator,
-)
+from tests.typing import MockHAClientWebSocket, WebSocketGenerator
 
 
 @pytest.fixture

--- a/tests/components/wemo/test_device_trigger.py
+++ b/tests/components/wemo/test_device_trigger.py
@@ -17,10 +17,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
-from tests.common import (
-    async_get_device_automations,
-    async_mock_service,
-)
+from tests.common import async_get_device_automations, async_mock_service
 
 MOCK_DEVICE_ID = "some-device-id"
 DATA_MESSAGE = {"message": "service-called"}

--- a/tests/components/zha/test_device_action.py
+++ b/tests/components/zha/test_device_action.py
@@ -19,11 +19,7 @@ from homeassistant.setup import async_setup_component
 
 from .conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_TYPE
 
-from tests.common import (
-    async_get_device_automations,
-    async_mock_service,
-    mock_coro,
-)
+from tests.common import async_get_device_automations, async_mock_service, mock_coro
 
 
 @pytest.fixture(autouse=True, name="stub_blueprint_populate")

--- a/tests/components/zwave_js/test_device_trigger.py
+++ b/tests/components/zwave_js/test_device_trigger.py
@@ -25,10 +25,7 @@ from homeassistant.helpers.device_registry import async_get as async_get_dev_reg
 from homeassistant.helpers.entity_registry import async_get as async_get_ent_reg
 from homeassistant.setup import async_setup_component
 
-from tests.common import (
-    async_get_device_automations,
-    async_mock_service,
-)
+from tests.common import async_get_device_automations, async_mock_service
 
 
 @pytest.fixture

--- a/tests/util/test_distance.py
+++ b/tests/util/test_distance.py
@@ -2,9 +2,7 @@
 
 import pytest
 
-from homeassistant.const import (
-    UnitOfLength,
-)
+from homeassistant.const import UnitOfLength
 from homeassistant.exceptions import HomeAssistantError
 import homeassistant.util.distance as distance_util
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When we switched from isort to ruff for sorting imports, a slight difference occurred (as noticed by @emontnemery).

Split on trailing command by default is `false` in isort, but `true` in ruff.
<https://pycqa.github.io/isort/docs/configuration/options.html#split-on-trailing-comma>
<https://beta.ruff.rs/docs/settings/#isort-split-on-trailing-comma>

This PR brings back or old behavior and adjusts the existing imports.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
