### PR TITLE
Update aioairzone to v0.6.5

### DIFF
--- a/homeassistant/components/airzone/manifest.json
+++ b/homeassistant/components/airzone/manifest.json
@@ -11,5 +11,5 @@
   "documentation": "https://www.home-assistant.io/integrations/airzone",
   "iot_class": "local_polling",
   "loggers": ["aioairzone"],
-  "requirements": ["aioairzone==0.6.4"]
+  "requirements": ["aioairzone==0.6.5"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -191,7 +191,7 @@ aioairq==0.2.4
 aioairzone-cloud==0.2.1
 
 # homeassistant.components.airzone
-aioairzone==0.6.4
+aioairzone==0.6.5
 
 # homeassistant.components.ambient_station
 aioambient==2023.04.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -172,7 +172,7 @@ aioairq==0.2.4
 aioairzone-cloud==0.2.1
 
 # homeassistant.components.airzone
-aioairzone==0.6.4
+aioairzone==0.6.5
 
 # homeassistant.components.ambient_station
 aioambient==2023.04.0

--- a/tests/components/airzone/test_climate.py
+++ b/tests/components/airzone/test_climate.py
@@ -329,7 +329,7 @@ async def test_airzone_climate_set_hvac_mode(hass: HomeAssistant) -> None:
 
     await async_init_integration(hass)
 
-    HVAC_MOCK = {
+    HVAC_MOCK_1 = {
         API_DATA: [
             {
                 API_SYSTEM_ID: 1,
@@ -340,7 +340,7 @@ async def test_airzone_climate_set_hvac_mode(hass: HomeAssistant) -> None:
     }
     with patch(
         "homeassistant.components.airzone.AirzoneLocalApi.put_hvac",
-        return_value=HVAC_MOCK,
+        return_value=HVAC_MOCK_1,
     ):
         await hass.services.async_call(
             CLIMATE_DOMAIN,
@@ -406,6 +406,51 @@ async def test_airzone_climate_set_hvac_mode(hass: HomeAssistant) -> None:
 
     state = hass.states.get("climate.airzone_2_1")
     assert state.state == HVACMode.HEAT_COOL
+
+    HVAC_MOCK_4 = {
+        API_DATA: [
+            {
+                API_SYSTEM_ID: 1,
+                API_ZONE_ID: 1,
+                API_ON: 1,
+            }
+        ]
+    }
+    with patch(
+        "homeassistant.components.airzone.AirzoneLocalApi.put_hvac",
+        return_value=HVAC_MOCK_4,
+    ):
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_SET_HVAC_MODE,
+            {
+                ATTR_ENTITY_ID: "climate.salon",
+                ATTR_HVAC_MODE: HVACMode.FAN_ONLY,
+            },
+            blocking=True,
+        )
+
+    state = hass.states.get("climate.salon")
+    assert state.state == HVACMode.FAN_ONLY
+
+    HVAC_MOCK_NO_SET_POINT = {**HVAC_MOCK}
+    del HVAC_MOCK_NO_SET_POINT[API_SYSTEMS][0][API_DATA][0][API_SET_POINT]
+
+    with patch(
+        "homeassistant.components.airzone.AirzoneLocalApi.get_hvac",
+        return_value=HVAC_MOCK_NO_SET_POINT,
+    ), patch(
+        "homeassistant.components.airzone.AirzoneLocalApi.get_hvac_systems",
+        return_value=HVAC_SYSTEMS_MOCK,
+    ), patch(
+        "homeassistant.components.airzone.AirzoneLocalApi.get_webserver",
+        return_value=HVAC_WEBSERVER_MOCK,
+    ):
+        async_fire_time_changed(hass, utcnow() + SCAN_INTERVAL)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("climate.salon")
+    assert state.attributes.get(ATTR_TEMPERATURE) == 19.1
 
 
 async def test_airzone_climate_set_hvac_slave_error(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Proposed change
Update aioairzone to [v0.6.5](https://github.com/Noltari/aioairzone/compare/0.6.4...0.6.5).

Releases:
- https://github.com/Noltari/aioairzone/releases/tag/0.6.5

Git compare: https://github.com/Noltari/aioairzone/compare/0.6.4...0.6.5

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #96994
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
