### PR TITLE
Exchange WazeRouteCalculator with pywaze in waze_travel_time

### DIFF
--- a/homeassistant/components/waze_travel_time/config_flow.py
+++ b/homeassistant/components/waze_travel_time/config_flow.py
@@ -129,8 +129,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         if user_input:
             user_input[CONF_REGION] = user_input[CONF_REGION].upper()
-            if await self.hass.async_add_executor_job(
-                is_valid_config_entry,
+            if await is_valid_config_entry(
                 self.hass,
                 user_input[CONF_ORIGIN],
                 user_input[CONF_DESTINATION],

--- a/homeassistant/components/waze_travel_time/helpers.py
+++ b/homeassistant/components/waze_travel_time/helpers.py
@@ -17,9 +17,9 @@ async def is_valid_config_entry(
     resolved_origin = find_coordinates(hass, origin)
     resolved_destination = find_coordinates(hass, destination)
     httpx_client = get_async_client(hass)
+    client = WazeRouteCalculator(region=region, client=httpx_client)
     try:
-        async with WazeRouteCalculator(region=region, client=httpx_client) as client:
-            await client.calc_all_routes_info(resolved_origin, resolved_destination)
+        await client.calc_all_routes_info(resolved_origin, resolved_destination)
     except WRCError as error:
         _LOGGER.error("Error trying to validate entry: %s", error)
         return False

--- a/homeassistant/components/waze_travel_time/helpers.py
+++ b/homeassistant/components/waze_travel_time/helpers.py
@@ -3,17 +3,22 @@ import logging
 
 from pywaze.route_calculator import WazeRouteCalculator, WRCError
 
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.httpx_client import get_async_client
 from homeassistant.helpers.location import find_coordinates
 
 _LOGGER = logging.getLogger(__name__)
 
 
-async def is_valid_config_entry(hass, origin, destination, region):
+async def is_valid_config_entry(
+    hass: HomeAssistant, origin: str, destination: str, region: str
+) -> bool:
     """Return whether the config entry data is valid."""
     origin = find_coordinates(hass, origin)
     destination = find_coordinates(hass, destination)
+    httpx_client = get_async_client(hass)
     try:
-        async with WazeRouteCalculator(region=region) as client:
+        async with WazeRouteCalculator(region=region, client=httpx_client) as client:
             await client.calc_all_routes_info(origin, destination)
     except WRCError as error:
         _LOGGER.error("Error trying to validate entry: %s", error)

--- a/homeassistant/components/waze_travel_time/helpers.py
+++ b/homeassistant/components/waze_travel_time/helpers.py
@@ -1,19 +1,20 @@
 """Helpers for Waze Travel Time integration."""
 import logging
 
-from WazeRouteCalculator import WazeRouteCalculator, WRCError
+from pywaze.route_calculator import WazeRouteCalculator, WRCError
 
 from homeassistant.helpers.location import find_coordinates
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def is_valid_config_entry(hass, origin, destination, region):
+async def is_valid_config_entry(hass, origin, destination, region):
     """Return whether the config entry data is valid."""
     origin = find_coordinates(hass, origin)
     destination = find_coordinates(hass, destination)
     try:
-        WazeRouteCalculator(origin, destination, region).calc_all_routes_info()
+        async with WazeRouteCalculator(region=region) as client:
+            await client.calc_all_routes_info(origin, destination)
     except WRCError as error:
         _LOGGER.error("Error trying to validate entry: %s", error)
         return False

--- a/homeassistant/components/waze_travel_time/helpers.py
+++ b/homeassistant/components/waze_travel_time/helpers.py
@@ -14,12 +14,12 @@ async def is_valid_config_entry(
     hass: HomeAssistant, origin: str, destination: str, region: str
 ) -> bool:
     """Return whether the config entry data is valid."""
-    origin = find_coordinates(hass, origin)
-    destination = find_coordinates(hass, destination)
+    resolved_origin = find_coordinates(hass, origin)
+    resolved_destination = find_coordinates(hass, destination)
     httpx_client = get_async_client(hass)
     try:
         async with WazeRouteCalculator(region=region, client=httpx_client) as client:
-            await client.calc_all_routes_info(origin, destination)
+            await client.calc_all_routes_info(resolved_origin, resolved_destination)
     except WRCError as error:
         _LOGGER.error("Error trying to validate entry: %s", error)
         return False

--- a/homeassistant/components/waze_travel_time/manifest.json
+++ b/homeassistant/components/waze_travel_time/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/waze_travel_time",
   "iot_class": "cloud_polling",
   "loggers": ["pywaze", "homeassistant.helpers.location"],
-  "requirements": ["pywaze==0.1.3"]
+  "requirements": ["pywaze==0.2.0"]
 }

--- a/homeassistant/components/waze_travel_time/manifest.json
+++ b/homeassistant/components/waze_travel_time/manifest.json
@@ -5,6 +5,6 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/waze_travel_time",
   "iot_class": "cloud_polling",
-  "loggers": ["WazeRouteCalculator", "homeassistant.helpers.location"],
-  "requirements": ["WazeRouteCalculator==0.14"]
+  "loggers": ["pywaze", "homeassistant.helpers.location"],
+  "requirements": ["pywaze==0.1.3"]
 }

--- a/homeassistant/components/waze_travel_time/manifest.json
+++ b/homeassistant/components/waze_travel_time/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/waze_travel_time",
   "iot_class": "cloud_polling",
   "loggers": ["pywaze", "homeassistant.helpers.location"],
-  "requirements": ["pywaze==0.2.0"]
+  "requirements": ["pywaze==0.3.0"]
 }

--- a/homeassistant/components/waze_travel_time/sensor.py
+++ b/homeassistant/components/waze_travel_time/sensor.py
@@ -179,8 +179,6 @@ class WazeTravelTimeData:
 
             routes = {}
             try:
-                _LOGGER.error(self.client)
-                _LOGGER.error(self.client.calc_all_routes_info)
                 routes = await self.client.calc_all_routes_info(
                     self.origin,
                     self.destination,
@@ -206,7 +204,6 @@ class WazeTravelTimeData:
                     }
 
                 if routes:
-                    _LOGGER.error(routes)
                     route = list(routes)[0]
                 else:
                     _LOGGER.warning("No routes found")

--- a/homeassistant/components/waze_travel_time/sensor.py
+++ b/homeassistant/components/waze_travel_time/sensor.py
@@ -179,6 +179,8 @@ class WazeTravelTimeData:
 
             routes = {}
             try:
+                _LOGGER.error(self.client)
+                _LOGGER.error(self.client.calc_all_routes_info)
                 routes = await self.client.calc_all_routes_info(
                     self.origin,
                     self.destination,
@@ -204,6 +206,7 @@ class WazeTravelTimeData:
                     }
 
                 if routes:
+                    _LOGGER.error(routes)
                     route = list(routes)[0]
                 else:
                     _LOGGER.warning("No routes found")

--- a/homeassistant/components/waze_travel_time/sensor.py
+++ b/homeassistant/components/waze_travel_time/sensor.py
@@ -154,9 +154,7 @@ class WazeTravelTimeData:
     ) -> None:
         """Set up WazeRouteCalculator."""
         self.config_entry = config_entry
-        self.client: WazeRouteCalculator = WazeRouteCalculator(
-            region=region, client=client
-        )
+        self.client = WazeRouteCalculator(region=region, client=client)
         self.origin: str | None = None
         self.destination: str | None = None
         self.duration = None

--- a/homeassistant/components/waze_travel_time/sensor.py
+++ b/homeassistant/components/waze_travel_time/sensor.py
@@ -148,8 +148,8 @@ class WazeTravelTimeData:
 
     def __init__(self, region: str, config_entry: ConfigEntry) -> None:
         """Set up WazeRouteCalculator."""
-        self.region = region
         self.config_entry = config_entry
+        self.client: WazeRouteCalculator = WazeRouteCalculator(region)
         self.origin: str | None = None
         self.destination: str | None = None
         self.duration = None
@@ -179,16 +179,15 @@ class WazeTravelTimeData:
 
             routes = {}
             try:
-                async with WazeRouteCalculator(
-                    region=self.region,
+                routes = await self.client.calc_all_routes_info(
+                    self.origin,
+                    self.destination,
                     vehicle_type=vehicle_type,
                     avoid_toll_roads=avoid_toll_roads,
                     avoid_subscription_roads=avoid_subscription_roads,
                     avoid_ferries=avoid_ferries,
-                ) as client:
-                    routes = await client.calc_all_routes_info(
-                        self.origin, self.destination, real_time=realtime
-                    )
+                    real_time=realtime,
+                )
 
                 if incl_filter not in {None, ""}:
                     routes = {

--- a/homeassistant/components/waze_travel_time/sensor.py
+++ b/homeassistant/components/waze_travel_time/sensor.py
@@ -5,6 +5,7 @@ from datetime import timedelta
 import logging
 from typing import Any
 
+import httpx
 from pywaze.route_calculator import WazeRouteCalculator, WRCError
 
 from homeassistant.components.sensor import (
@@ -23,6 +24,7 @@ from homeassistant.const import (
 from homeassistant.core import CoreState, HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.httpx_client import get_async_client
 from homeassistant.helpers.location import find_coordinates
 from homeassistant.util.unit_conversion import DistanceConverter
 
@@ -60,6 +62,7 @@ async def async_setup_entry(
 
     data = WazeTravelTimeData(
         region,
+        get_async_client(hass),
         config_entry,
     )
 
@@ -146,10 +149,14 @@ class WazeTravelTime(SensorEntity):
 class WazeTravelTimeData:
     """WazeTravelTime Data object."""
 
-    def __init__(self, region: str, config_entry: ConfigEntry) -> None:
+    def __init__(
+        self, region: str, client: httpx.AsyncClient, config_entry: ConfigEntry
+    ) -> None:
         """Set up WazeRouteCalculator."""
         self.config_entry = config_entry
-        self.client: WazeRouteCalculator = WazeRouteCalculator(region)
+        self.client: WazeRouteCalculator = WazeRouteCalculator(
+            region=region, client=client
+        )
         self.origin: str | None = None
         self.destination: str | None = None
         self.duration = None

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -139,9 +139,6 @@ TwitterAPI==2.7.12
 # homeassistant.components.onvif
 WSDiscovery==2.0.0
 
-# homeassistant.components.waze_travel_time
-WazeRouteCalculator==0.14
-
 # homeassistant.components.accuweather
 accuweather==1.0.0
 
@@ -2225,6 +2222,9 @@ pyvlx==0.2.20
 
 # homeassistant.components.volumio
 pyvolumio==0.1.5
+
+# homeassistant.components.waze_travel_time
+pywaze==0.1.3
 
 # homeassistant.components.html5
 pywebpush==1.9.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2224,7 +2224,7 @@ pyvlx==0.2.20
 pyvolumio==0.1.5
 
 # homeassistant.components.waze_travel_time
-pywaze==0.2.0
+pywaze==0.3.0
 
 # homeassistant.components.html5
 pywebpush==1.9.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2224,7 +2224,7 @@ pyvlx==0.2.20
 pyvolumio==0.1.5
 
 # homeassistant.components.waze_travel_time
-pywaze==0.1.3
+pywaze==0.2.0
 
 # homeassistant.components.html5
 pywebpush==1.9.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1632,7 +1632,7 @@ pyvizio==0.1.61
 pyvolumio==0.1.5
 
 # homeassistant.components.waze_travel_time
-pywaze==0.1.3
+pywaze==0.2.0
 
 # homeassistant.components.html5
 pywebpush==1.9.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -120,9 +120,6 @@ SQLAlchemy==2.0.15
 # homeassistant.components.onvif
 WSDiscovery==2.0.0
 
-# homeassistant.components.waze_travel_time
-WazeRouteCalculator==0.14
-
 # homeassistant.components.accuweather
 accuweather==1.0.0
 
@@ -1633,6 +1630,9 @@ pyvizio==0.1.61
 
 # homeassistant.components.volumio
 pyvolumio==0.1.5
+
+# homeassistant.components.waze_travel_time
+pywaze==0.1.3
 
 # homeassistant.components.html5
 pywebpush==1.9.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1632,7 +1632,7 @@ pyvizio==0.1.61
 pyvolumio==0.1.5
 
 # homeassistant.components.waze_travel_time
-pywaze==0.2.0
+pywaze==0.3.0
 
 # homeassistant.components.html5
 pywebpush==1.9.2

--- a/tests/components/waze_travel_time/conftest.py
+++ b/tests/components/waze_travel_time/conftest.py
@@ -2,42 +2,31 @@
 from unittest.mock import patch
 
 import pytest
-from WazeRouteCalculator import WRCError
-
-
-@pytest.fixture(name="mock_wrc", autouse=True)
-def mock_wrc_fixture():
-    """Mock out WazeRouteCalculator."""
-    with patch(
-        "homeassistant.components.waze_travel_time.sensor.WazeRouteCalculator"
-    ) as mock_wrc:
-        yield mock_wrc
+from pywaze.route_calculator import WRCError
 
 
 @pytest.fixture(name="mock_update")
-def mock_update_fixture(mock_wrc):
+def mock_update_fixture():
     """Mock an update to the sensor."""
-    obj = mock_wrc.return_value
-    obj.calc_all_routes_info.return_value = {"My route": (150, 300)}
+    with patch(
+        "pywaze.route_calculator.WazeRouteCalculator.calc_all_routes_info",
+        return_value={"My route": (150, 300)},
+    ) as mock_wrc:
+        yield mock_wrc
 
 
 @pytest.fixture(name="validate_config_entry")
-def validate_config_entry_fixture():
+def validate_config_entry_fixture(mock_update):
     """Return valid config entry."""
-    with patch(
-        "homeassistant.components.waze_travel_time.helpers.WazeRouteCalculator"
-    ) as mock_wrc:
-        obj = mock_wrc.return_value
-        obj.calc_all_routes_info.return_value = None
-        yield mock_wrc
+    mock_update.return_value = None
+    return mock_update
 
 
 @pytest.fixture(name="invalidate_config_entry")
 def invalidate_config_entry_fixture(validate_config_entry):
     """Return invalid config entry."""
-    obj = validate_config_entry.return_value
-    obj.calc_all_routes_info.return_value = {}
-    obj.calc_all_routes_info.side_effect = WRCError("test")
+    validate_config_entry.side_effect = WRCError("test")
+    return validate_config_entry
 
 
 @pytest.fixture(name="bypass_platform_setup")

--- a/tests/components/waze_travel_time/test_sensor.py
+++ b/tests/components/waze_travel_time/test_sensor.py
@@ -1,6 +1,6 @@
 """Test Waze Travel Time sensors."""
 import pytest
-from WazeRouteCalculator import WRCError
+from pywaze.route_calculator import WRCError
 
 from homeassistant.components.waze_travel_time.const import (
     CONF_AVOID_FERRIES,
@@ -35,17 +35,17 @@ async def mock_config_fixture(hass, data, options):
 
 
 @pytest.fixture(name="mock_update_wrcerror")
-def mock_update_wrcerror_fixture(mock_wrc):
+def mock_update_wrcerror_fixture(mock_update):
     """Mock an update to the sensor failed with WRCError."""
-    obj = mock_wrc.return_value
-    obj.calc_all_routes_info.side_effect = WRCError("test")
+    mock_update.side_effect = WRCError("test")
+    return mock_update
 
 
 @pytest.fixture(name="mock_update_keyerror")
-def mock_update_keyerror_fixture(mock_wrc):
+def mock_update_keyerror_fixture(mock_update):
     """Mock an update to the sensor failed with KeyError."""
-    obj = mock_wrc.return_value
-    obj.calc_all_routes_info.side_effect = KeyError("test")
+    mock_update.side_effect = KeyError("test")
+    return mock_update
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR changes the 3rd party library used to connect to the Waze API from [WazeRouteCalculator](https://github.com/kovacsbalu/WazeRouteCalculator) to [pywaze](https://github.com/eifinger/pywaze)
I tried to keep the changes between the libraries as small as possible for now:

* Different package layout
* Same behavior in regards to input and output
* Uses httpx instead of requests to support async

**Background**

The `waze_travel_time` integration is powered by [WazeRouteCalculator](https://github.com/kovacsbalu/WazeRouteCalculator) but the author is unresponsive in the last year. Especially [the request](https://github.com/kovacsbalu/WazeRouteCalculator/issues/71) to release bug fixes to PyPI so we can use them is ignored.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #93240, fixes #84568
- This PR is related to issue: #92664
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
