### PR TITLE
Add missing transmit power to ESPHome Bluetooth scanners

### DIFF
--- a/homeassistant/components/bluetooth/manifest.json
+++ b/homeassistant/components/bluetooth/manifest.json
@@ -18,7 +18,7 @@
     "bleak-retry-connector==3.1.1",
     "bluetooth-adapters==0.16.0",
     "bluetooth-auto-recovery==1.2.1",
-    "bluetooth-data-tools==1.7.0",
+    "bluetooth-data-tools==1.8.0",
     "dbus-fast==1.91.2"
   ]
 }

--- a/homeassistant/components/esphome/bluetooth/scanner.py
+++ b/homeassistant/components/esphome/bluetooth/scanner.py
@@ -2,7 +2,10 @@
 from __future__ import annotations
 
 from aioesphomeapi import BluetoothLEAdvertisement, BluetoothLERawAdvertisement
-from bluetooth_data_tools import int_to_bluetooth_address, parse_advertisement_data
+from bluetooth_data_tools import (
+    int_to_bluetooth_address,
+    parse_advertisement_data_tuple,
+)
 
 from homeassistant.components.bluetooth import MONOTONIC_TIME, BaseHaRemoteScanner
 from homeassistant.core import callback
@@ -10,6 +13,8 @@ from homeassistant.core import callback
 
 class ESPHomeScanner(BaseHaRemoteScanner):
     """Scanner for esphome."""
+
+    __slots__ = ()
 
     @callback
     def async_on_advertisement(self, adv: BluetoothLEAdvertisement) -> None:
@@ -34,15 +39,10 @@ class ESPHomeScanner(BaseHaRemoteScanner):
         """Call the registered callback."""
         now = MONOTONIC_TIME()
         for adv in advertisements:
-            parsed = parse_advertisement_data((adv.data,))
             self._async_on_advertisement(
                 int_to_bluetooth_address(adv.address),
                 adv.rssi,
-                parsed.local_name,
-                parsed.service_uuids,
-                parsed.service_data,
-                parsed.manufacturer_data,
-                None,
+                *parse_advertisement_data_tuple((adv.data,)),
                 {"address_type": adv.address_type},
                 now,
             )

--- a/homeassistant/components/esphome/manifest.json
+++ b/homeassistant/components/esphome/manifest.json
@@ -17,7 +17,7 @@
   "requirements": [
     "async_interrupt==1.1.1",
     "aioesphomeapi==15.1.15",
-    "bluetooth-data-tools==1.7.0",
+    "bluetooth-data-tools==1.8.0",
     "esphome-dashboard-api==1.2.3"
   ],
   "zeroconf": ["_esphomelib._tcp.local."]

--- a/homeassistant/components/ld2410_ble/manifest.json
+++ b/homeassistant/components/ld2410_ble/manifest.json
@@ -20,5 +20,5 @@
   "documentation": "https://www.home-assistant.io/integrations/ld2410_ble",
   "integration_type": "device",
   "iot_class": "local_push",
-  "requirements": ["bluetooth-data-tools==1.7.0", "ld2410-ble==0.1.1"]
+  "requirements": ["bluetooth-data-tools==1.8.0", "ld2410-ble==0.1.1"]
 }

--- a/homeassistant/components/led_ble/manifest.json
+++ b/homeassistant/components/led_ble/manifest.json
@@ -32,5 +32,5 @@
   "dependencies": ["bluetooth_adapters"],
   "documentation": "https://www.home-assistant.io/integrations/led_ble",
   "iot_class": "local_polling",
-  "requirements": ["bluetooth-data-tools==1.7.0", "led-ble==1.0.0"]
+  "requirements": ["bluetooth-data-tools==1.8.0", "led-ble==1.0.0"]
 }

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -12,7 +12,7 @@ bleak-retry-connector==3.1.1
 bleak==0.20.2
 bluetooth-adapters==0.16.0
 bluetooth-auto-recovery==1.2.1
-bluetooth-data-tools==1.7.0
+bluetooth-data-tools==1.8.0
 certifi>=2021.5.30
 ciso8601==2.3.0
 cryptography==41.0.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -540,7 +540,7 @@ bluetooth-auto-recovery==1.2.1
 # homeassistant.components.esphome
 # homeassistant.components.ld2410_ble
 # homeassistant.components.led_ble
-bluetooth-data-tools==1.7.0
+bluetooth-data-tools==1.8.0
 
 # homeassistant.components.bond
 bond-async==0.2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -454,7 +454,7 @@ bluetooth-auto-recovery==1.2.1
 # homeassistant.components.esphome
 # homeassistant.components.ld2410_ble
 # homeassistant.components.led_ble
-bluetooth-data-tools==1.7.0
+bluetooth-data-tools==1.8.0
 
 # homeassistant.components.bond
 bond-async==0.2.1


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
We did not previously have a way to get the transmit power value when using ESPHome scanners. bluetooth-data-tools 1.8.0 includes it in the advertisement tuple to fully align with the bleak implementation.  Note: this only works with ESPHome 2023.7.x and later

While this is technically a bug fix but I did not tag it for a patch release since transmit is not yet used in the HA codebase. It is likely only expected by upstream libraries that calculate estimated distance (and useful for troubleshooting)

ESPHome is the last remote to add support for this as `shelly` and `ruuvi_gateway` could already fill the transmit power field which opens up the door for integrations to use this data for improving Bluetooth troubleshooting and presence detection

changelog: https://github.com/Bluetooth-Devices/bluetooth-data-tools/compare/v1.7.0...v1.8.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
