### PR TITLE
Fix Enphase dry contact binary sensor state updates

### DIFF
--- a/homeassistant/components/enphase_envoy/binary_sensor.py
+++ b/homeassistant/components/enphase_envoy/binary_sensor.py
@@ -212,15 +212,15 @@ class EnvoyRelayBinarySensorEntity(EnvoyBaseBinarySensorEntity):
         self,
         coordinator: EnphaseUpdateCoordinator,
         description: BinarySensorEntityDescription,
-        relay: str,
+        relay_id: str,
     ) -> None:
         """Init the Enpower base entity."""
         super().__init__(coordinator, description)
         enpower = self.data.enpower
         assert enpower is not None
-        self.relay = self.data.dry_contact_status[relay]
+        self.relay_id = relay_id
         self._serial_number = enpower.serial_number
-        self._attr_unique_id = f"{self._serial_number}_relay_{self.relay.id}"
+        self._attr_unique_id = f"{self._serial_number}_relay_{relay_id}"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._serial_number)},
             manufacturer="Enphase",
@@ -229,11 +229,10 @@ class EnvoyRelayBinarySensorEntity(EnvoyBaseBinarySensorEntity):
             sw_version=str(enpower.firmware_version),
             via_device=(DOMAIN, self.envoy_serial_num),
         )
-        self._attr_name = (
-            f"{self.data.dry_contact_settings[self.relay.id].load_name} Relay"
-        )
+        self._attr_name = f"{self.data.dry_contact_settings[relay_id].load_name} Relay"
 
     @property
     def is_on(self) -> bool:
         """Return the state of the Enpower binary_sensor."""
-        return self.relay.status == DryContactStatus.CLOSED
+        relay = self.data.dry_contact_status[self.relay_id]
+        return relay.status == DryContactStatus.CLOSED


### PR DESCRIPTION
## Proposed change
This fixes a bug where the state of these sensors was only updating on an integration reload or HA restart.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
