### PR TITLE
Improve rainbird error handling

### DIFF
--- a/homeassistant/components/rainbird/coordinator.py
+++ b/homeassistant/components/rainbird/coordinator.py
@@ -8,7 +8,11 @@ import logging
 from typing import TypeVar
 
 import async_timeout
-from pyrainbird.async_client import AsyncRainbirdController, RainbirdApiException
+from pyrainbird.async_client import (
+    AsyncRainbirdController,
+    RainbirdApiException,
+    RainbirdDeviceBusyException,
+)
 from pyrainbird.data import ModelAndVersion
 
 from homeassistant.core import HomeAssistant
@@ -84,8 +88,10 @@ class RainbirdUpdateCoordinator(DataUpdateCoordinator[RainbirdDeviceState]):
         try:
             async with async_timeout.timeout(TIMEOUT_SECONDS):
                 return await self._fetch_data()
+        except RainbirdDeviceBusyException as err:
+            raise UpdateFailed("Rain Bird device is busy") from err
         except RainbirdApiException as err:
-            raise UpdateFailed(f"Error communicating with Device: {err}") from err
+            raise UpdateFailed("Rain Bird device failure") from err
 
     async def _fetch_data(self) -> RainbirdDeviceState:
         """Fetch data from the Rain Bird device.

--- a/homeassistant/components/rainbird/number.py
+++ b/homeassistant/components/rainbird/number.py
@@ -3,10 +3,13 @@ from __future__ import annotations
 
 import logging
 
+from pyrainbird.exceptions import RainbirdApiException
+
 from homeassistant.components.number import NumberEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfTime
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -58,4 +61,7 @@ class RainDelayNumber(CoordinatorEntity[RainbirdUpdateCoordinator], NumberEntity
 
     async def async_set_native_value(self, value: float) -> None:
         """Update the current value."""
-        await self.coordinator.controller.set_rain_delay(value)
+        try:
+            await self.coordinator.controller.set_rain_delay(value)
+        except RainbirdApiException as err:
+            raise HomeAssistantError() from err

--- a/homeassistant/components/rainbird/number.py
+++ b/homeassistant/components/rainbird/number.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import logging
 
-from pyrainbird.exceptions import RainbirdApiException
+from pyrainbird.exceptions import RainbirdApiException, RainbirdDeviceBusyException
 
 from homeassistant.components.number import NumberEntity
 from homeassistant.config_entries import ConfigEntry
@@ -63,5 +63,9 @@ class RainDelayNumber(CoordinatorEntity[RainbirdUpdateCoordinator], NumberEntity
         """Update the current value."""
         try:
             await self.coordinator.controller.set_rain_delay(value)
+        except RainbirdDeviceBusyException as err:
+            raise HomeAssistantError(
+                "Rain Bird device is busy; Wait and try again"
+            ) from err
         except RainbirdApiException as err:
-            raise HomeAssistantError() from err
+            raise HomeAssistantError("Rain Bird device failure") from err

--- a/tests/components/rainbird/conftest.py
+++ b/tests/components/rainbird/conftest.py
@@ -150,6 +150,11 @@ def mock_response(data: str) -> AiohttpClientMockResponse:
     return AiohttpClientMockResponse("POST", URL, response=rainbird_response(data))
 
 
+def mock_response_error() -> AiohttpClientMockResponse:
+    """Create a fake AiohttpClientMockResponse."""
+    return AiohttpClientMockResponse("POST", URL, status=HTTPStatus.SERVICE_UNAVAILABLE)
+
+
 @pytest.fixture(name="stations_response")
 def mock_station_response() -> str:
     """Mock response to return available stations."""

--- a/tests/components/rainbird/conftest.py
+++ b/tests/components/rainbird/conftest.py
@@ -72,11 +72,6 @@ CONFIG_ENTRY_DATA = {
 }
 
 
-UNAVAILABLE_RESPONSE = AiohttpClientMockResponse(
-    "POST", URL, status=HTTPStatus.SERVICE_UNAVAILABLE
-)
-
-
 @pytest.fixture
 def platforms() -> list[Platform]:
     """Fixture to specify platforms to test."""
@@ -150,9 +145,11 @@ def mock_response(data: str) -> AiohttpClientMockResponse:
     return AiohttpClientMockResponse("POST", URL, response=rainbird_response(data))
 
 
-def mock_response_error() -> AiohttpClientMockResponse:
+def mock_response_error(
+    status: HTTPStatus = HTTPStatus.SERVICE_UNAVAILABLE,
+) -> AiohttpClientMockResponse:
     """Create a fake AiohttpClientMockResponse."""
-    return AiohttpClientMockResponse("POST", URL, status=HTTPStatus.SERVICE_UNAVAILABLE)
+    return AiohttpClientMockResponse("POST", URL, status=status)
 
 
 @pytest.fixture(name="stations_response")

--- a/tests/components/rainbird/test_init.py
+++ b/tests/components/rainbird/test_init.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
+from http import HTTPStatus
+
 import pytest
 
 from homeassistant.components.rainbird import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
-from .conftest import CONFIG_ENTRY_DATA, UNAVAILABLE_RESPONSE, ComponentSetup
+from .conftest import CONFIG_ENTRY_DATA, ComponentSetup, mock_response_error
 
 from tests.test_util.aiohttp import AiohttpClientMockResponse
 
@@ -44,16 +46,34 @@ async def test_init_success(
 @pytest.mark.parametrize(
     ("yaml_config", "config_entry_data", "responses", "config_entry_states"),
     [
-        ({}, CONFIG_ENTRY_DATA, [UNAVAILABLE_RESPONSE], [ConfigEntryState.SETUP_RETRY]),
+        (
+            {},
+            CONFIG_ENTRY_DATA,
+            [mock_response_error(HTTPStatus.SERVICE_UNAVAILABLE)],
+            [ConfigEntryState.SETUP_RETRY],
+        ),
+        # Note: This should be improved to support reauth when the password is incorrect
+        (
+            {},
+            CONFIG_ENTRY_DATA,
+            [mock_response_error(HTTPStatus.FORBIDDEN)],
+            [ConfigEntryState.SETUP_RETRY],
+        ),
+        (
+            {},
+            CONFIG_ENTRY_DATA,
+            [mock_response_error(HTTPStatus.INTERNAL_SERVER_ERROR)],
+            [ConfigEntryState.SETUP_RETRY],
+        ),
     ],
-    ids=["config_entry_failure"],
+    ids=["unavailable", "forbidden", "server_error"],
 )
 async def test_communication_failure(
     hass: HomeAssistant,
     setup_integration: ComponentSetup,
     config_entry_states: list[ConfigEntryState],
 ) -> None:
-    """Test unable to talk to server on startup, which permanently fails setup."""
+    """Test unable to talk to device on startup, which fails setup."""
 
     assert await setup_integration()
 

--- a/tests/components/rainbird/test_init.py
+++ b/tests/components/rainbird/test_init.py
@@ -10,7 +10,13 @@ from homeassistant.components.rainbird import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
-from .conftest import CONFIG_ENTRY_DATA, ComponentSetup, mock_response_error
+from .conftest import (
+    CONFIG_ENTRY_DATA,
+    MODEL_AND_VERSION_RESPONSE,
+    ComponentSetup,
+    mock_response,
+    mock_response_error,
+)
 
 from tests.test_util.aiohttp import AiohttpClientMockResponse
 
@@ -52,21 +58,37 @@ async def test_init_success(
             [mock_response_error(HTTPStatus.SERVICE_UNAVAILABLE)],
             [ConfigEntryState.SETUP_RETRY],
         ),
-        # Note: This should be improved to support reauth when the password is incorrect
-        (
-            {},
-            CONFIG_ENTRY_DATA,
-            [mock_response_error(HTTPStatus.FORBIDDEN)],
-            [ConfigEntryState.SETUP_RETRY],
-        ),
         (
             {},
             CONFIG_ENTRY_DATA,
             [mock_response_error(HTTPStatus.INTERNAL_SERVER_ERROR)],
             [ConfigEntryState.SETUP_RETRY],
         ),
+        (
+            {},
+            CONFIG_ENTRY_DATA,
+            [
+                mock_response(MODEL_AND_VERSION_RESPONSE),
+                mock_response_error(HTTPStatus.SERVICE_UNAVAILABLE),
+            ],
+            [ConfigEntryState.SETUP_RETRY],
+        ),
+        (
+            {},
+            CONFIG_ENTRY_DATA,
+            [
+                mock_response(MODEL_AND_VERSION_RESPONSE),
+                mock_response_error(HTTPStatus.INTERNAL_SERVER_ERROR),
+            ],
+            [ConfigEntryState.SETUP_RETRY],
+        ),
     ],
-    ids=["unavailable", "forbidden", "server_error"],
+    ids=[
+        "unavailable",
+        "server-error",
+        "coordinator-unavailable",
+        "coordinator-server-error",
+    ],
 )
 async def test_communication_failure(
     hass: HomeAssistant,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve rainbird error handling to include more user friendly error messages. (Aside: This does not currently treat password failure or support reauth yet since it needs config flow support.)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: #92857
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
