### PR TITLE
Add Enphase switch platform and grid enable switch

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -306,6 +306,7 @@ omit =
     homeassistant/components/enphase_envoy/coordinator.py
     homeassistant/components/enphase_envoy/entity.py
     homeassistant/components/enphase_envoy/sensor.py
+    homeassistant/components/enphase_envoy/switch.py
     homeassistant/components/entur_public_transport/*
     homeassistant/components/environment_canada/__init__.py
     homeassistant/components/environment_canada/camera.py

--- a/homeassistant/components/enphase_envoy/const.py
+++ b/homeassistant/components/enphase_envoy/const.py
@@ -5,6 +5,6 @@ from homeassistant.const import Platform
 
 DOMAIN = "enphase_envoy"
 
-PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR]
+PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR, Platform.SWITCH]
 
 INVALID_AUTH_ERRORS = (EnvoyAuthenticationError, EnvoyAuthenticationRequired)

--- a/homeassistant/components/enphase_envoy/manifest.json
+++ b/homeassistant/components/enphase_envoy/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://www.home-assistant.io/integrations/enphase_envoy",
   "iot_class": "local_polling",
   "loggers": ["pyenphase"],
-  "requirements": ["pyenphase==1.3.0"],
+  "requirements": ["pyenphase==1.4.0"],
   "zeroconf": [
     {
       "type": "_enphase-envoy._tcp.local."

--- a/homeassistant/components/enphase_envoy/strings.json
+++ b/homeassistant/components/enphase_envoy/strings.json
@@ -64,6 +64,11 @@
       "lifetime_consumption": {
         "name": "Lifetime energy consumption"
       }
+    },
+    "switch": {
+      "grid_enabled": {
+        "name": "Grid enabled"
+      }
     }
   }
 }

--- a/homeassistant/components/enphase_envoy/switch.py
+++ b/homeassistant/components/enphase_envoy/switch.py
@@ -1,0 +1,113 @@
+"""Switch platform for Enphase Envoy solar energy monitor."""
+from __future__ import annotations
+
+from collections.abc import Callable, Coroutine
+from dataclasses import dataclass
+import logging
+from typing import Any
+
+from pyenphase import Envoy, EnvoyEnpower
+
+from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import EnphaseUpdateCoordinator
+from .entity import EnvoyBaseEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class EnvoyEnpowerRequiredKeysMixin:
+    """Mixin for required keys."""
+
+    value_fn: Callable[[EnvoyEnpower], bool]
+    turn_on_fn: Callable[[Envoy], Coroutine[Any, Any, dict[str, Any]]]
+    turn_off_fn: Callable[[Envoy], Coroutine[Any, Any, dict[str, Any]]]
+
+
+@dataclass
+class EnvoyEnpowerSwitchEntityDescription(
+    SwitchEntityDescription, EnvoyEnpowerRequiredKeysMixin
+):
+    """Describes an Envoy Enpower binary sensor entity."""
+
+
+ENPOWER_GRID_SWITCH = EnvoyEnpowerSwitchEntityDescription(
+    key="mains_admin_state",
+    translation_key="grid_enabled",
+    value_fn=lambda enpower: enpower.mains_admin_state == "closed",
+    turn_on_fn=lambda envoy: envoy.go_on_grid(),
+    turn_off_fn=lambda envoy: envoy.go_off_grid(),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up envoy binary sensor platform."""
+    coordinator: EnphaseUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    envoy_data = coordinator.envoy.data
+    assert envoy_data is not None
+    envoy_serial_num = config_entry.unique_id
+    assert envoy_serial_num is not None
+    entities: list[SwitchEntity] = []
+    if envoy_data.enpower:
+        entities.extend(
+            [
+                EnvoyEnpowerSwitchEntity(
+                    coordinator, ENPOWER_GRID_SWITCH, envoy_data.enpower
+                )
+            ]
+        )
+    async_add_entities(entities)
+
+
+class EnvoyEnpowerSwitchEntity(EnvoyBaseEntity, SwitchEntity):
+    """Representation of an Enphase Enpower switch entity."""
+
+    entity_description: EnvoyEnpowerSwitchEntityDescription
+
+    def __init__(
+        self,
+        coordinator: EnphaseUpdateCoordinator,
+        description: EnvoyEnpowerSwitchEntityDescription,
+        enpower: EnvoyEnpower,
+    ) -> None:
+        """Initialize the Enphase Enpower switch entity."""
+        super().__init__(coordinator, description)
+        self.envoy = coordinator.envoy
+        self.enpower = enpower
+        self._serial_number = enpower.serial_number
+        self._attr_unique_id = f"{self._serial_number}_{description.key}"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, self._serial_number)},
+            manufacturer="Enphase",
+            model="Enpower",
+            name=f"Enpower {self._serial_number}",
+            sw_version=str(enpower.firmware_version),
+            via_device=(DOMAIN, self.envoy_serial_num),
+        )
+
+    @property
+    def is_on(self) -> bool:
+        """Return the state of the Enpower switch."""
+        enpower = self.data.enpower
+        assert enpower is not None
+        return self.entity_description.value_fn(enpower)
+
+    async def async_turn_on(self):
+        """Turn on the Enpower switch."""
+        await self.entity_description.turn_on_fn(self.envoy)
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_off(self):
+        """Turn off the Enpower switch."""
+        await self.entity_description.turn_off_fn(self.envoy)
+        await self.coordinator.async_request_refresh()

--- a/homeassistant/components/enphase_envoy/switch.py
+++ b/homeassistant/components/enphase_envoy/switch.py
@@ -34,7 +34,7 @@ class EnvoyEnpowerRequiredKeysMixin:
 class EnvoyEnpowerSwitchEntityDescription(
     SwitchEntityDescription, EnvoyEnpowerRequiredKeysMixin
 ):
-    """Describes an Envoy Enpower binary sensor entity."""
+    """Describes an Envoy Enpower switch entity."""
 
 
 ENPOWER_GRID_SWITCH = EnvoyEnpowerSwitchEntityDescription(
@@ -51,7 +51,7 @@ async def async_setup_entry(
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up envoy binary sensor platform."""
+    """Set up Enphase Envoy switch platform."""
     coordinator: EnphaseUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
     envoy_data = coordinator.envoy.data
     assert envoy_data is not None

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1665,7 +1665,7 @@ pyedimax==0.2.1
 pyefergy==22.1.1
 
 # homeassistant.components.enphase_envoy
-pyenphase==1.3.0
+pyenphase==1.4.0
 
 # homeassistant.components.envisalink
 pyenvisalink==4.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1229,7 +1229,7 @@ pyeconet==0.1.20
 pyefergy==22.1.1
 
 # homeassistant.components.enphase_envoy
-pyenphase==1.3.0
+pyenphase==1.4.0
 
 # homeassistant.components.everlights
 pyeverlights==0.1.0


### PR DESCRIPTION
## Proposed change
Adds a `switch` platform to the `enphase_envoy` integration, and a switch to toggle grid power on/off for Enphase Ensemble systems that support going off-grid.

https://github.com/pyenphase/pyenphase/compare/v1.3.0...v1.4.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/28542

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
