### PR TITLE
Add Enphase Encharge aggregate sensors

### DIFF
--- a/homeassistant/components/enphase_envoy/manifest.json
+++ b/homeassistant/components/enphase_envoy/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://www.home-assistant.io/integrations/enphase_envoy",
   "iot_class": "local_polling",
   "loggers": ["pyenphase"],
-  "requirements": ["pyenphase==1.4.0"],
+  "requirements": ["pyenphase==1.5.2"],
   "zeroconf": [
     {
       "type": "_enphase-envoy._tcp.local."

--- a/homeassistant/components/enphase_envoy/sensor.py
+++ b/homeassistant/components/enphase_envoy/sensor.py
@@ -8,6 +8,7 @@ import logging
 
 from pyenphase import (
     EnvoyEncharge,
+    EnvoyEnchargeAggregate,
     EnvoyEnchargePower,
     EnvoyEnpower,
     EnvoyInverter,
@@ -288,6 +289,58 @@ ENPOWER_SENSORS = (
 )
 
 
+@dataclass
+class EnvoyEnchargeAggregateRequiredKeysMixin:
+    """Mixin for required keys."""
+
+    value_fn: Callable[[EnvoyEnchargeAggregate], int]
+
+
+@dataclass
+class EnvoyEnchargeAggregateSensorEntityDescription(
+    SensorEntityDescription, EnvoyEnchargeAggregateRequiredKeysMixin
+):
+    """Describes an Envoy Encharge sensor entity."""
+
+
+ENCHARGE_AGGREGATE_SENSORS = (
+    EnvoyEnchargeAggregateSensorEntityDescription(
+        key="battery_level",
+        native_unit_of_measurement=PERCENTAGE,
+        device_class=SensorDeviceClass.BATTERY,
+        value_fn=lambda encharge: encharge.state_of_charge,
+    ),
+    EnvoyEnchargeAggregateSensorEntityDescription(
+        key="reserve_soc",
+        translation_key="reserve_soc",
+        native_unit_of_measurement=PERCENTAGE,
+        device_class=SensorDeviceClass.BATTERY,
+        value_fn=lambda encharge: encharge.reserve_state_of_charge,
+    ),
+    EnvoyEnchargeAggregateSensorEntityDescription(
+        key="available_energy",
+        translation_key="available_energy",
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        value_fn=lambda encharge: encharge.available_energy,
+    ),
+    EnvoyEnchargeAggregateSensorEntityDescription(
+        key="reserve_energy",
+        translation_key="reserve_energy",
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        value_fn=lambda encharge: encharge.backup_reserve,
+    ),
+    EnvoyEnchargeAggregateSensorEntityDescription(
+        key="max_capacity",
+        translation_key="max_capacity",
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        value_fn=lambda encharge: encharge.max_available_capacity,
+    ),
+)
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -328,6 +381,11 @@ async def async_setup_entry(
             EnvoyEnchargePowerEntity(coordinator, description, encharge)
             for description in ENCHARGE_POWER_SENSORS
             for encharge in envoy_data.encharge_power
+        )
+    if envoy_data.encharge_aggregate:
+        entities.extend(
+            EnvoyEnchargeAggregateEntity(coordinator, description)
+            for description in ENCHARGE_AGGREGATE_SENSORS
         )
     if envoy_data.enpower:
         entities.extend(
@@ -480,6 +538,19 @@ class EnvoyEnchargePowerEntity(EnvoyEnchargeEntity):
         encharge_power = self.data.encharge_power
         assert encharge_power is not None
         return self.entity_description.value_fn(encharge_power[self._serial_number])
+
+
+class EnvoyEnchargeAggregateEntity(EnvoySystemSensorEntity):
+    """Envoy Encharge Aggregate sensor entity."""
+
+    entity_description: EnvoyEnchargeAggregateSensorEntityDescription
+
+    @property
+    def native_value(self) -> int:
+        """Return the state of the aggregate sensors."""
+        encharge_aggregate = self.data.encharge_aggregate
+        assert encharge_aggregate is not None
+        return self.entity_description.value_fn(encharge_aggregate)
 
 
 class EnvoyEnpowerEntity(EnvoySensorBaseEntity):

--- a/homeassistant/components/enphase_envoy/strings.json
+++ b/homeassistant/components/enphase_envoy/strings.json
@@ -63,6 +63,21 @@
       },
       "lifetime_consumption": {
         "name": "Lifetime energy consumption"
+      },
+      "reserve_soc": {
+        "name": "Reserve battery level"
+      },
+      "available_energy": {
+        "name": "Available battery energy"
+      },
+      "reserve_energy": {
+        "name": "Reserve battery energy"
+      },
+      "max_capacity": {
+        "name": "Battery capacity"
+      },
+      "configured_reserve_soc": {
+        "name": "Configured reserve battery level"
       }
     },
     "switch": {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1665,7 +1665,7 @@ pyedimax==0.2.1
 pyefergy==22.1.1
 
 # homeassistant.components.enphase_envoy
-pyenphase==1.4.0
+pyenphase==1.5.2
 
 # homeassistant.components.envisalink
 pyenvisalink==4.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1229,7 +1229,7 @@ pyeconet==0.1.20
 pyefergy==22.1.1
 
 # homeassistant.components.enphase_envoy
-pyenphase==1.4.0
+pyenphase==1.5.2
 
 # homeassistant.components.everlights
 pyeverlights==0.1.0


### PR DESCRIPTION
## Proposed change
Adds sensors with aggregate data for all Enphase Encharge batteries connected to an Envoy:
- Aggregate state of charge
- Reserve state of charge
- Available energy (watt-hours)
- Backup energy (watt-hours)
- Total capacity (watt-hours)

https://github.com/pyenphase/pyenphase/compare/v1.4.0...v1.5.2

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
