### PR TITLE
Decrease event loop latency by binding time.monotonic to loop.time directly

### DIFF
--- a/homeassistant/runner.py
+++ b/homeassistant/runner.py
@@ -8,7 +8,7 @@ import logging
 import os
 import subprocess
 import threading
-import time
+from time import monotonic
 import traceback
 from typing import Any
 
@@ -118,7 +118,7 @@ class HassEventLoopPolicy(asyncio.DefaultEventLoopPolicy):
         # bind the built-in time.monotonic directly as loop.time to avoid the
         # overhead of the additional method call since its the most called loop
         # method and its roughly 10%+ of all the call time in base_events.py
-        loop.time = time.monotonic  # type: ignore[method-assign]
+        loop.time = monotonic  # type: ignore[method-assign]
         return loop
 
 

--- a/homeassistant/runner.py
+++ b/homeassistant/runner.py
@@ -115,6 +115,10 @@ class HassEventLoopPolicy(asyncio.DefaultEventLoopPolicy):
         loop.set_default_executor = warn_use(  # type: ignore[method-assign]
             loop.set_default_executor, "sets default executor on the event loop"
         )
+        # bind the built-in time.monotonic directly as loop.time to avoid the
+        # overhead of the additional method call since its the most called loop
+        # method and its roughly 10%+ of all the call time in base_events.py
+        loop.time = time.monotonic  # type: ignore[method-assign]
         return loop
 
 
@@ -177,10 +181,6 @@ def run(runtime_config: RuntimeConfig) -> int:
     asyncio.set_event_loop_policy(HassEventLoopPolicy(runtime_config.debug))
     # Backport of cpython 3.9 asyncio.run with a _cancel_all_tasks that times out
     loop = asyncio.new_event_loop()
-    # bind the built-in time.monotonic directly as loop.time to avoid the
-    # overhead of the additional method call since its the most called loop
-    # method and its roughly 10%+ of all the call time in base_events.py
-    loop.time = time.monotonic  # type: ignore[method-assign]
     try:
         asyncio.set_event_loop(loop)
         return loop.run_until_complete(setup_and_run_hass(runtime_config))

--- a/tests/common.py
+++ b/tests/common.py
@@ -420,6 +420,9 @@ def async_fire_time_changed(
     _async_fire_time_changed(hass, utc_datetime, fire_all)
 
 
+_MONOTONIC_RESOLUTION = time.get_clock_info("monotonic").resolution
+
+
 @callback
 def _async_fire_time_changed(
     hass: HomeAssistant, utc_datetime: datetime | None, fire_all: bool
@@ -432,7 +435,7 @@ def _async_fire_time_changed(
             continue
 
         mock_seconds_into_future = timestamp - time.time()
-        future_seconds = task.when() - hass.loop.time()
+        future_seconds = task.when() - (hass.loop.time() + _MONOTONIC_RESOLUTION)
 
         if fire_all or mock_seconds_into_future >= future_seconds:
             with patch(

--- a/tests/components/statistics/test_sensor.py
+++ b/tests/components/statistics/test_sensor.py
@@ -8,6 +8,7 @@ from typing import Any
 from unittest.mock import patch
 
 from freezegun import freeze_time
+import pytest
 
 from homeassistant import config as hass_config
 from homeassistant.components.recorder import Recorder
@@ -1286,12 +1287,14 @@ async def test_initialize_from_database(
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfTemperature.CELSIUS
 
 
+@pytest.mark.freeze_time(
+    datetime(dt_util.utcnow().year + 1, 8, 2, 12, 23, 42, tzinfo=dt_util.UTC)
+)
 async def test_initialize_from_database_with_maxage(
     recorder_mock: Recorder, hass: HomeAssistant
 ) -> None:
     """Test initializing the statistics from the database."""
-    now = dt_util.utcnow()
-    current_time = datetime(now.year + 1, 8, 2, 12, 23, 42, tzinfo=dt_util.UTC)
+    current_time = dt_util.utcnow()
 
     # Testing correct retrieval from recorder, thus we do not
     # want purging to occur within the class itself.

--- a/tests/patch_time.py
+++ b/tests/patch_time.py
@@ -2,8 +2,9 @@
 from __future__ import annotations
 
 import datetime
+import time
 
-from homeassistant import util
+from homeassistant import runner, util
 from homeassistant.util import dt as dt_util
 
 
@@ -12,5 +13,11 @@ def _utcnow() -> datetime.datetime:
     return datetime.datetime.now(datetime.UTC)
 
 
+def _monotonic() -> float:
+    """Make monotonic patchable by freezegun."""
+    return time.monotonic()
+
+
 dt_util.utcnow = _utcnow  # type: ignore[assignment]
 util.utcnow = _utcnow  # type: ignore[assignment]
+runner.monotonic = _monotonic  # type: ignore[assignment]


### PR DESCRIPTION
I've been running this for a while with good results. Not expecting an side effects since its calling the exact same path under the hood without the python method call wrapper.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is a small improvement to decrease event loop latency. While the original goal was to reduce Bluetooth connection time latency, everything using asyncio is a bit more responsive as a result. 

`base_events.py` is almost always the top file in profiles since `_run_once` is there. This change eliminated at least 10% of the run time in that file, ~13.8% in when profiling as the time call is made upwards of ~30000 times per minute on systems with 4 bluetooth remotes/local adapters. The python `time` method call that wrapped `time.monotonic`, is the most frequently called non `built-in` method on all my production systems, and it was more expensive than the actual call to `time.monotonic` since `time.monotonic` is implemented as a `built-in`/cext.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
