### PR TITLE
Add support for Bosch 2nd Gen Shutter Contact

### DIFF
--- a/homeassistant/components/bosch_shc/binary_sensor.py
+++ b/homeassistant/components/bosch_shc/binary_sensor.py
@@ -25,7 +25,9 @@ async def async_setup_entry(
     entities: list[BinarySensorEntity] = []
     session: SHCSession = hass.data[DOMAIN][config_entry.entry_id][DATA_SESSION]
 
-    for binary_sensor in session.device_helper.shutter_contacts:
+    for binary_sensor in (
+        session.device_helper.shutter_contacts + session.device_helper.shutter_contacts2
+    ):
         entities.append(
             ShutterContactSensor(
                 device=binary_sensor,
@@ -37,6 +39,7 @@ async def async_setup_entry(
     for binary_sensor in (
         session.device_helper.motion_detectors
         + session.device_helper.shutter_contacts
+        + session.device_helper.shutter_contacts2
         + session.device_helper.smoke_detectors
         + session.device_helper.thermostats
         + session.device_helper.twinguards


### PR DESCRIPTION
The new shutter contact has its own class in the boschshcpy module, thus requiring a new class in the binary_sensor.py file.

Resolves: #86295

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

This PR resolves #86295 by adding a new class supporting the Bosch 2nd gen. shutter contact.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR closes issue: #86295
- docs https://github.com/home-assistant/home-assistant.io/pull/28564
## Checklist

- [x] The code change is tested and works locally.
- [ ] Local tests pass.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
