### PR TITLE
Update vacuum entity constants for Alexa tests

### DIFF
--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -3872,12 +3872,12 @@ async def test_vacuum_discovery(hass: HomeAssistant) -> None:
         "docked",
         {
             "friendly_name": "Test vacuum 1",
-            "supported_features": vacuum.SUPPORT_TURN_ON
-            | vacuum.SUPPORT_TURN_OFF
-            | vacuum.SUPPORT_START
-            | vacuum.SUPPORT_STOP
-            | vacuum.SUPPORT_RETURN_HOME
-            | vacuum.SUPPORT_PAUSE,
+            "supported_features": vacuum.VacuumEntityFeature.TURN_ON
+            | vacuum.VacuumEntityFeature.TURN_OFF
+            | vacuum.VacuumEntityFeature.START
+            | vacuum.VacuumEntityFeature.STOP
+            | vacuum.VacuumEntityFeature.RETURN_HOME
+            | vacuum.VacuumEntityFeature.PAUSE,
         },
     )
     appliance = await discovery_test(device, hass)
@@ -3913,12 +3913,12 @@ async def test_vacuum_fan_speed(hass: HomeAssistant) -> None:
         "cleaning",
         {
             "friendly_name": "Test vacuum 2",
-            "supported_features": vacuum.SUPPORT_TURN_ON
-            | vacuum.SUPPORT_TURN_OFF
-            | vacuum.SUPPORT_START
-            | vacuum.SUPPORT_STOP
-            | vacuum.SUPPORT_PAUSE
-            | vacuum.SUPPORT_FAN_SPEED,
+            "supported_features": vacuum.VacuumEntityFeature.TURN_ON
+            | vacuum.VacuumEntityFeature.TURN_OFF
+            | vacuum.VacuumEntityFeature.START
+            | vacuum.VacuumEntityFeature.STOP
+            | vacuum.VacuumEntityFeature.PAUSE
+            | vacuum.VacuumEntityFeature.FAN_SPEED,
             "fan_speed_list": ["off", "low", "medium", "high", "turbo", "super_sucker"],
             "fan_speed": "medium",
         },
@@ -4042,12 +4042,12 @@ async def test_vacuum_pause(hass: HomeAssistant) -> None:
         "cleaning",
         {
             "friendly_name": "Test vacuum 3",
-            "supported_features": vacuum.SUPPORT_TURN_ON
-            | vacuum.SUPPORT_TURN_OFF
-            | vacuum.SUPPORT_START
-            | vacuum.SUPPORT_STOP
-            | vacuum.SUPPORT_PAUSE
-            | vacuum.SUPPORT_FAN_SPEED,
+            "supported_features": vacuum.VacuumEntityFeature.TURN_ON
+            | vacuum.VacuumEntityFeature.TURN_OFF
+            | vacuum.VacuumEntityFeature.START
+            | vacuum.VacuumEntityFeature.STOP
+            | vacuum.VacuumEntityFeature.PAUSE
+            | vacuum.VacuumEntityFeature.FAN_SPEED,
             "fan_speed_list": ["off", "low", "medium", "high", "turbo", "super_sucker"],
             "fan_speed": "medium",
         },
@@ -4080,12 +4080,12 @@ async def test_vacuum_resume(hass: HomeAssistant) -> None:
         "docked",
         {
             "friendly_name": "Test vacuum 4",
-            "supported_features": vacuum.SUPPORT_TURN_ON
-            | vacuum.SUPPORT_TURN_OFF
-            | vacuum.SUPPORT_START
-            | vacuum.SUPPORT_STOP
-            | vacuum.SUPPORT_PAUSE
-            | vacuum.SUPPORT_FAN_SPEED,
+            "supported_features": vacuum.VacuumEntityFeature.TURN_ON
+            | vacuum.VacuumEntityFeature.TURN_OFF
+            | vacuum.VacuumEntityFeature.START
+            | vacuum.VacuumEntityFeature.STOP
+            | vacuum.VacuumEntityFeature.PAUSE
+            | vacuum.VacuumEntityFeature.FAN_SPEED,
             "fan_speed_list": ["off", "low", "medium", "high", "turbo", "super_sucker"],
             "fan_speed": "medium",
         },
@@ -4108,9 +4108,9 @@ async def test_vacuum_discovery_no_turn_on(hass: HomeAssistant) -> None:
         "cleaning",
         {
             "friendly_name": "Test vacuum 5",
-            "supported_features": vacuum.SUPPORT_TURN_OFF
-            | vacuum.SUPPORT_START
-            | vacuum.SUPPORT_RETURN_HOME,
+            "supported_features": vacuum.VacuumEntityFeature.TURN_OFF
+            | vacuum.VacuumEntityFeature.START
+            | vacuum.VacuumEntityFeature.RETURN_HOME,
         },
     )
     appliance = await discovery_test(device, hass)
@@ -4138,9 +4138,9 @@ async def test_vacuum_discovery_no_turn_off(hass: HomeAssistant) -> None:
         "cleaning",
         {
             "friendly_name": "Test vacuum 6",
-            "supported_features": vacuum.SUPPORT_TURN_ON
-            | vacuum.SUPPORT_START
-            | vacuum.SUPPORT_RETURN_HOME,
+            "supported_features": vacuum.VacuumEntityFeature.TURN_ON
+            | vacuum.VacuumEntityFeature.START
+            | vacuum.VacuumEntityFeature.RETURN_HOME,
         },
     )
     appliance = await discovery_test(device, hass)
@@ -4169,7 +4169,8 @@ async def test_vacuum_discovery_no_turn_on_or_off(hass: HomeAssistant) -> None:
         "cleaning",
         {
             "friendly_name": "Test vacuum 7",
-            "supported_features": vacuum.SUPPORT_START | vacuum.SUPPORT_RETURN_HOME,
+            "supported_features": vacuum.VacuumEntityFeature.START
+            | vacuum.VacuumEntityFeature.RETURN_HOME,
         },
     )
     appliance = await discovery_test(device, hass)

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -8,7 +8,7 @@ from homeassistant.components.alexa import smart_home, state_report
 import homeassistant.components.camera as camera
 from homeassistant.components.cover import CoverDeviceClass
 from homeassistant.components.media_player import MediaPlayerEntityFeature
-import homeassistant.components.vacuum as vacuum
+from homeassistant.components.vacuum import VacuumEntityFeature
 from homeassistant.config import async_process_ha_core_config
 from homeassistant.const import STATE_UNKNOWN, UnitOfTemperature
 from homeassistant.core import Context, Event, HomeAssistant
@@ -3872,12 +3872,12 @@ async def test_vacuum_discovery(hass: HomeAssistant) -> None:
         "docked",
         {
             "friendly_name": "Test vacuum 1",
-            "supported_features": vacuum.VacuumEntityFeature.TURN_ON
-            | vacuum.VacuumEntityFeature.TURN_OFF
-            | vacuum.VacuumEntityFeature.START
-            | vacuum.VacuumEntityFeature.STOP
-            | vacuum.VacuumEntityFeature.RETURN_HOME
-            | vacuum.VacuumEntityFeature.PAUSE,
+            "supported_features": VacuumEntityFeature.TURN_ON
+            | VacuumEntityFeature.TURN_OFF
+            | VacuumEntityFeature.START
+            | VacuumEntityFeature.STOP
+            | VacuumEntityFeature.RETURN_HOME
+            | VacuumEntityFeature.PAUSE,
         },
     )
     appliance = await discovery_test(device, hass)
@@ -3913,12 +3913,12 @@ async def test_vacuum_fan_speed(hass: HomeAssistant) -> None:
         "cleaning",
         {
             "friendly_name": "Test vacuum 2",
-            "supported_features": vacuum.VacuumEntityFeature.TURN_ON
-            | vacuum.VacuumEntityFeature.TURN_OFF
-            | vacuum.VacuumEntityFeature.START
-            | vacuum.VacuumEntityFeature.STOP
-            | vacuum.VacuumEntityFeature.PAUSE
-            | vacuum.VacuumEntityFeature.FAN_SPEED,
+            "supported_features": VacuumEntityFeature.TURN_ON
+            | VacuumEntityFeature.TURN_OFF
+            | VacuumEntityFeature.START
+            | VacuumEntityFeature.STOP
+            | VacuumEntityFeature.PAUSE
+            | VacuumEntityFeature.FAN_SPEED,
             "fan_speed_list": ["off", "low", "medium", "high", "turbo", "super_sucker"],
             "fan_speed": "medium",
         },
@@ -4042,12 +4042,12 @@ async def test_vacuum_pause(hass: HomeAssistant) -> None:
         "cleaning",
         {
             "friendly_name": "Test vacuum 3",
-            "supported_features": vacuum.VacuumEntityFeature.TURN_ON
-            | vacuum.VacuumEntityFeature.TURN_OFF
-            | vacuum.VacuumEntityFeature.START
-            | vacuum.VacuumEntityFeature.STOP
-            | vacuum.VacuumEntityFeature.PAUSE
-            | vacuum.VacuumEntityFeature.FAN_SPEED,
+            "supported_features": VacuumEntityFeature.TURN_ON
+            | VacuumEntityFeature.TURN_OFF
+            | VacuumEntityFeature.START
+            | VacuumEntityFeature.STOP
+            | VacuumEntityFeature.PAUSE
+            | VacuumEntityFeature.FAN_SPEED,
             "fan_speed_list": ["off", "low", "medium", "high", "turbo", "super_sucker"],
             "fan_speed": "medium",
         },
@@ -4080,12 +4080,12 @@ async def test_vacuum_resume(hass: HomeAssistant) -> None:
         "docked",
         {
             "friendly_name": "Test vacuum 4",
-            "supported_features": vacuum.VacuumEntityFeature.TURN_ON
-            | vacuum.VacuumEntityFeature.TURN_OFF
-            | vacuum.VacuumEntityFeature.START
-            | vacuum.VacuumEntityFeature.STOP
-            | vacuum.VacuumEntityFeature.PAUSE
-            | vacuum.VacuumEntityFeature.FAN_SPEED,
+            "supported_features": VacuumEntityFeature.TURN_ON
+            | VacuumEntityFeature.TURN_OFF
+            | VacuumEntityFeature.START
+            | VacuumEntityFeature.STOP
+            | VacuumEntityFeature.PAUSE
+            | VacuumEntityFeature.FAN_SPEED,
             "fan_speed_list": ["off", "low", "medium", "high", "turbo", "super_sucker"],
             "fan_speed": "medium",
         },
@@ -4108,9 +4108,9 @@ async def test_vacuum_discovery_no_turn_on(hass: HomeAssistant) -> None:
         "cleaning",
         {
             "friendly_name": "Test vacuum 5",
-            "supported_features": vacuum.VacuumEntityFeature.TURN_OFF
-            | vacuum.VacuumEntityFeature.START
-            | vacuum.VacuumEntityFeature.RETURN_HOME,
+            "supported_features": VacuumEntityFeature.TURN_OFF
+            | VacuumEntityFeature.START
+            | VacuumEntityFeature.RETURN_HOME,
         },
     )
     appliance = await discovery_test(device, hass)
@@ -4138,9 +4138,9 @@ async def test_vacuum_discovery_no_turn_off(hass: HomeAssistant) -> None:
         "cleaning",
         {
             "friendly_name": "Test vacuum 6",
-            "supported_features": vacuum.VacuumEntityFeature.TURN_ON
-            | vacuum.VacuumEntityFeature.START
-            | vacuum.VacuumEntityFeature.RETURN_HOME,
+            "supported_features": VacuumEntityFeature.TURN_ON
+            | VacuumEntityFeature.START
+            | VacuumEntityFeature.RETURN_HOME,
         },
     )
     appliance = await discovery_test(device, hass)
@@ -4169,8 +4169,8 @@ async def test_vacuum_discovery_no_turn_on_or_off(hass: HomeAssistant) -> None:
         "cleaning",
         {
             "friendly_name": "Test vacuum 7",
-            "supported_features": vacuum.VacuumEntityFeature.START
-            | vacuum.VacuumEntityFeature.RETURN_HOME,
+            "supported_features": VacuumEntityFeature.START
+            | VacuumEntityFeature.RETURN_HOME,
         },
     )
     appliance = await discovery_test(device, hass)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update entity feature constants in Alexa tests

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
