### PR TITLE
Update homekit entity feature constants

### DIFF
--- a/tests/components/homekit/test_get_accessories.py
+++ b/tests/components/homekit/test_get_accessories.py
@@ -3,8 +3,8 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-import homeassistant.components.climate as climate
-import homeassistant.components.cover as cover
+from homeassistant.components.climate import ClimateEntityFeature
+from homeassistant.components.cover import CoverEntityFeature
 from homeassistant.components.homekit.accessories import TYPES, get_accessory
 from homeassistant.components.homekit.const import (
     ATTR_INTEGRATION,
@@ -17,9 +17,9 @@ from homeassistant.components.homekit.const import (
     TYPE_SWITCH,
     TYPE_VALVE,
 )
-import homeassistant.components.media_player.const as media_player_c
+from homeassistant.components.media_player import MediaPlayerEntityFeature
 from homeassistant.components.sensor import SensorDeviceClass
-import homeassistant.components.vacuum as vacuum
+from homeassistant.components.vacuum import VacuumEntityFeature
 from homeassistant.const import (
     ATTR_CODE,
     ATTR_DEVICE_CLASS,
@@ -90,7 +90,7 @@ def test_customize_options(config, name) -> None:
             "Thermostat",
             "climate.test",
             "auto",
-            {ATTR_SUPPORTED_FEATURES: climate.SUPPORT_TARGET_TEMPERATURE_RANGE},
+            {ATTR_SUPPORTED_FEATURES: ClimateEntityFeature.TARGET_TEMPERATURE_RANGE},
             {},
         ),
         ("HumidifierDehumidifier", "humidifier.test", "auto", {}, {}),
@@ -118,7 +118,8 @@ def test_types(type_name, entity_id, state, attrs, config) -> None:
             "open",
             {
                 ATTR_DEVICE_CLASS: "garage",
-                ATTR_SUPPORTED_FEATURES: cover.SUPPORT_OPEN | cover.SUPPORT_CLOSE,
+                ATTR_SUPPORTED_FEATURES: CoverEntityFeature.OPEN
+                | CoverEntityFeature.CLOSE,
             },
         ),
         (
@@ -127,26 +128,20 @@ def test_types(type_name, entity_id, state, attrs, config) -> None:
             "open",
             {
                 ATTR_DEVICE_CLASS: "window",
-                ATTR_SUPPORTED_FEATURES: cover.SUPPORT_SET_POSITION,
+                ATTR_SUPPORTED_FEATURES: CoverEntityFeature.SET_POSITION,
             },
         ),
         (
             "WindowCovering",
             "cover.set_position",
             "open",
-            {ATTR_SUPPORTED_FEATURES: cover.SUPPORT_SET_POSITION},
+            {ATTR_SUPPORTED_FEATURES: CoverEntityFeature.SET_POSITION},
         ),
         (
             "WindowCovering",
             "cover.tilt",
             "open",
-            {ATTR_SUPPORTED_FEATURES: cover.SUPPORT_SET_TILT_POSITION},
-        ),
-        (
-            "WindowCoveringBasic",
-            "cover.open_window",
-            "open",
-            {ATTR_SUPPORTED_FEATURES: (cover.SUPPORT_OPEN | cover.SUPPORT_CLOSE)},
+            {ATTR_SUPPORTED_FEATURES: CoverEntityFeature.SET_TILT_POSITION},
         ),
         (
             "WindowCoveringBasic",
@@ -154,9 +149,19 @@ def test_types(type_name, entity_id, state, attrs, config) -> None:
             "open",
             {
                 ATTR_SUPPORTED_FEATURES: (
-                    cover.SUPPORT_OPEN
-                    | cover.SUPPORT_CLOSE
-                    | cover.SUPPORT_SET_TILT_POSITION
+                    CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
+                )
+            },
+        ),
+        (
+            "WindowCoveringBasic",
+            "cover.open_window",
+            "open",
+            {
+                ATTR_SUPPORTED_FEATURES: (
+                    CoverEntityFeature.OPEN
+                    | CoverEntityFeature.CLOSE
+                    | CoverEntityFeature.SET_TILT_POSITION
                 )
             },
         ),
@@ -166,7 +171,7 @@ def test_types(type_name, entity_id, state, attrs, config) -> None:
             "open",
             {
                 ATTR_DEVICE_CLASS: "door",
-                ATTR_SUPPORTED_FEATURES: cover.SUPPORT_SET_POSITION,
+                ATTR_SUPPORTED_FEATURES: CoverEntityFeature.SET_POSITION,
             },
         ),
     ],
@@ -188,8 +193,8 @@ def test_type_covers(type_name, entity_id, state, attrs) -> None:
             "media_player.test",
             "on",
             {
-                ATTR_SUPPORTED_FEATURES: media_player_c.MediaPlayerEntityFeature.TURN_ON
-                | media_player_c.MediaPlayerEntityFeature.TURN_OFF
+                ATTR_SUPPORTED_FEATURES: MediaPlayerEntityFeature.TURN_ON
+                | MediaPlayerEntityFeature.TURN_OFF
             },
             {CONF_FEATURE_LIST: {FEATURE_ON_OFF: None}},
         ),
@@ -334,8 +339,8 @@ def test_type_switches(type_name, entity_id, state, attrs, config) -> None:
             "vacuum.dock_vacuum",
             "docked",
             {
-                ATTR_SUPPORTED_FEATURES: vacuum.SUPPORT_START
-                | vacuum.SUPPORT_RETURN_HOME
+                ATTR_SUPPORTED_FEATURES: VacuumEntityFeature.START
+                | VacuumEntityFeature.RETURN_HOME
             },
         ),
         ("Vacuum", "vacuum.basic_vacuum", "off", {}),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update homekit entity feature constants

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
