### PR TITLE
Log entity_id payload and template on MQTT value template error

### DIFF
--- a/homeassistant/components/mqtt/models.py
+++ b/homeassistant/components/mqtt/models.py
@@ -239,8 +239,7 @@ class MqttValueTemplate:
                 )
             except Exception as ex:  # pylint: disable=broad-except
                 _LOGGER.error(
-                    "%s: %s rendering template for entity '%s', template: "
-                    "'%s'",
+                    "%s: %s rendering template for entity '%s', template: '%s'",
                     type(ex).__name__,
                     ex,
                     self._entity.entity_id if self._entity else "n/a",

--- a/homeassistant/components/mqtt/models.py
+++ b/homeassistant/components/mqtt/models.py
@@ -231,11 +231,23 @@ class MqttValueTemplate:
                 values,
                 self._value_template,
             )
-            rendered_payload = (
-                self._value_template.async_render_with_possible_json_value(
-                    payload, variables=values
+            try:
+                rendered_payload = (
+                    self._value_template.async_render_with_possible_json_value(
+                        payload, variables=values
+                    )
                 )
-            )
+            except Exception as ex:  # pylint: disable=broad-except
+                _LOGGER.error(
+                    "%s: %s when rendering template for entity '%s', template: "
+                    "'%s' with payload: %s",
+                    type(ex).__name__,
+                    ex,
+                    self._entity.entity_id if self._entity else "n/a",
+                    self._value_template.template,
+                    payload,
+                )
+                raise ex
             return rendered_payload
 
         _LOGGER.debug(

--- a/homeassistant/components/mqtt/models.py
+++ b/homeassistant/components/mqtt/models.py
@@ -240,12 +240,11 @@ class MqttValueTemplate:
             except Exception as ex:  # pylint: disable=broad-except
                 _LOGGER.error(
                     "%s: %s rendering template for entity '%s', template: "
-                    "'%s' with payload: %s",
+                    "'%s'",
                     type(ex).__name__,
                     ex,
                     self._entity.entity_id if self._entity else "n/a",
                     self._value_template.template,
-                    payload,
                 )
                 raise ex
             return rendered_payload

--- a/homeassistant/components/mqtt/models.py
+++ b/homeassistant/components/mqtt/models.py
@@ -239,7 +239,7 @@ class MqttValueTemplate:
                 )
             except Exception as ex:  # pylint: disable=broad-except
                 _LOGGER.error(
-                    "%s: %s when rendering template for entity '%s', template: "
+                    "%s: %s rendering template for entity '%s', template: "
                     "'%s' with payload: %s",
                     type(ex).__name__,
                     ex,
@@ -260,9 +260,24 @@ class MqttValueTemplate:
             default,
             self._value_template,
         )
-        rendered_payload = self._value_template.async_render_with_possible_json_value(
-            payload, default, variables=values
-        )
+        try:
+            rendered_payload = (
+                self._value_template.async_render_with_possible_json_value(
+                    payload, default, variables=values
+                )
+            )
+        except Exception as ex:  # pylint: disable=broad-except
+            _LOGGER.error(
+                "%s: %s rendering template for entity '%s', template: "
+                "'%s', default value: %s and payload: %s",
+                type(ex).__name__,
+                ex,
+                self._entity.entity_id if self._entity else "n/a",
+                self._value_template.template,
+                default,
+                payload,
+            )
+            raise ex
         return rendered_payload
 
 

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -433,8 +433,19 @@ async def test_value_template_fails(
     await hass.async_block_till_done()
     assert (
         "TypeError: unsupported operand type(s) for *: 'NoneType' and 'int' "
-        "when rendering template for entity 'sensor.test', "
+        "rendering template for entity 'sensor.test', "
         "template: '{{ value_json.some_var * 2 }}' with payload: "
+        '{"some_var": null }'
+    ) in caplog.text
+    caplog.clear()
+    with pytest.raises(TypeError):
+        val_tpl.async_render_with_possible_json_value(
+            '{"some_var": null }', default=100
+        )
+    assert (
+        "TypeError: unsupported operand type(s) for *: 'NoneType' and 'int' "
+        "rendering template for entity 'sensor.test', "
+        "template: '{{ value_json.some_var * 2 }}', default value: 100 and payload: "
         '{"some_var": null }'
     ) in caplog.text
 

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -434,8 +434,7 @@ async def test_value_template_fails(
     assert (
         "TypeError: unsupported operand type(s) for *: 'NoneType' and 'int' "
         "rendering template for entity 'sensor.test', "
-        "template: '{{ value_json.some_var * 2 }}' with payload: "
-        '{"some_var": null }'
+        "template: '{{ value_json.some_var * 2 }}'"
     ) in caplog.text
     caplog.clear()
     with pytest.raises(TypeError):

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -41,6 +41,7 @@ from .test_common import help_all_subscribe_calls
 
 from tests.common import (
     MockConfigEntry,
+    MockEntity,
     async_fire_mqtt_message,
     async_fire_time_changed,
     mock_restore_cache,
@@ -415,6 +416,27 @@ async def test_value_template_value(hass: HomeAssistant) -> None:
         val_tpl3.async_render_with_possible_json_value("call1")
         val_tpl3.async_render_with_possible_json_value("call2")
         assert template_state_calls.call_count == 1
+
+
+async def test_value_template_fails(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test the rendering of MQTT value template fails."""
+
+    # test rendering a value fails
+    entity = MockEntity(entity_id="sensor.test")
+    entity.hass = hass
+    tpl = template.Template("{{ value_json.some_var * 2 }}")
+    val_tpl = mqtt.MqttValueTemplate(tpl, hass=hass, entity=entity)
+    with pytest.raises(TypeError):
+        val_tpl.async_render_with_possible_json_value('{"some_var": null }')
+    await hass.async_block_till_done()
+    assert (
+        "TypeError: unsupported operand type(s) for *: 'NoneType' and 'int' "
+        "when rendering template for entity 'sensor.test', "
+        "template: '{{ value_json.some_var * 2 }}' with payload: "
+        '{"some_var": null }'
+    ) in caplog.text
 
 
 async def test_service_call_without_topic_does_not_publish(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve logging of MQTT payload and template when an error occurs when rendering a template.

Without this PR, debug logging is needed to see what is happening when a template error occurs.
The original exception is still raised to supply a stack trace.

An example is issue #98344 where a template causes a `TypeError`. The error trace does not tell what template and payload was causing the error. A message telling the the topic and state is logged though`, triggered by the same exception.

Log trace starting with the additional log line added by this PR:

```log
2023-08-16 08:03:38.806 ERROR (MainThread) [homeassistant.components.mqtt.models] TypeError: object of type 'NoneType' has no len() rendering template for entity 'sensor.bedroom_temperature_mqtt_sensor', template: '{{ value_json.program|default(\"\") | truncate(254, True, '', 0) }}', default value: default and payload: {
  "child_lock": null,
  "current_heating_setpoint": 23,
  "deadzone_temperature": null,
  "heat": "OFF",
  "last_seen": "2023-08-13T19:53:40+03:00",
  "linkquality": 51,
  "local_temperature": 26,
  "local_temperature_calibration": null,
  "max_temperature_limit": null,
  "min_temperature_limit": null,
  "preset": "hold",
  "preset_mode": "hold",
  "program": null,
  "running_state": "idle",
  "sensor": null,
  "system_mode": "off"
}
2023-08-16 08:03:38.860 ERROR (MainThread) [homeassistant.util.logging] Exception in message_received when handling msg on 'home/bedroom/temperature': '{
  "child_lock": null,
  "current_heating_setpoint": 23,
  "deadzone_temperature": null,
  "heat": "OFF",
  "last_seen": "2023-08-13T19:53:40+03:00",
  "linkquality": 51,
  "local_temperature": 26,
  "local_temperature_calibration": null,
  "max_temperature_limit": null,
  "min_temperature_limit": null,
  "preset": "hold",
  "preset_mode": "hold",
  "program": null,
  "running_state": "idle",
  "sensor": null,
  "system_mode": "off"
}'
Traceback (most recent call last):
  File "/workspaces/core/homeassistant/components/mqtt/debug_info.py", line 44, in wrapper
    msg_callback(msg)
  File "/workspaces/core/homeassistant/components/mqtt/sensor.py", line 293, in message_received
    _update_state(msg)
  File "/workspaces/core/homeassistant/components/mqtt/sensor.py", line 244, in _update_state
    payload = self._template(msg.payload, PayloadSentinel.DEFAULT)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/core/homeassistant/components/mqtt/models.py", line 280, in async_render_with_possible_json_value
    raise ex
  File "/workspaces/core/homeassistant/components/mqtt/models.py", line 265, in async_render_with_possible_json_value
    self._value_template.async_render_with_possible_json_value(
  File "/workspaces/core/homeassistant/helpers/template.py", line 735, in async_render_with_possible_json_value
    return _render_with_context(self.template, compiled, **variables).strip()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/core/homeassistant/helpers/template.py", line 2179, in _render_with_context
    return template.render(**kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/jinja2/environment.py", line 1301, in render
    self.environment.handle_exception()
  File "/usr/local/lib/python3.11/site-packages/jinja2/environment.py", line 936, in handle_exception
    raise rewrite_traceback_stack(source=source)
  File "<template>", line 1, in top-level template code
  File "/usr/local/lib/python3.11/site-packages/jinja2/filters.py", line 870, in do_truncate
    if len(s) <= length + leeway:
       ^^^^^^
TypeError: object of type 'NoneType' has no len()
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/98344
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
