### PR TITLE
Add option to disable MQTT Alarm Control Panel supported features

### DIFF
--- a/homeassistant/components/mqtt/alarm_control_panel.py
+++ b/homeassistant/components/mqtt/alarm_control_panel.py
@@ -91,9 +91,9 @@ REMOTE_CODE_TEXT = "REMOTE_CODE_TEXT"
 
 PLATFORM_SCHEMA_MODERN = MQTT_BASE_SCHEMA.extend(
     {
-        vol.Optional(
-            CONF_SUPPORTED_FEATURES, default=list(_SUPPORTED_FEATURES)
-        ): cv.multi_select(_SUPPORTED_FEATURES),
+        vol.Optional(CONF_SUPPORTED_FEATURES, default=list(_SUPPORTED_FEATURES)): [
+            vol.In(_SUPPORTED_FEATURES)
+        ],
         vol.Optional(CONF_CODE): cv.string,
         vol.Optional(CONF_CODE_ARM_REQUIRED, default=True): cv.boolean,
         vol.Optional(CONF_CODE_DISARM_REQUIRED, default=True): cv.boolean,
@@ -152,7 +152,6 @@ class MqttAlarm(MqttEntity, alarm.AlarmControlPanelEntity):
     _default_name = DEFAULT_NAME
     _entity_id_format = alarm.ENTITY_ID_FORMAT
     _attributes_extra_blocked = MQTT_ALARM_ATTRIBUTES_BLOCKED
-    _attr_supported_features: AlarmControlPanelEntityFeature
 
     def __init__(
         self,
@@ -181,7 +180,6 @@ class MqttAlarm(MqttEntity, alarm.AlarmControlPanelEntity):
             config[CONF_COMMAND_TEMPLATE], entity=self
         ).async_render
 
-        self._attr_supported_features = AlarmControlPanelEntityFeature(0)
         for feature in self._config[CONF_SUPPORTED_FEATURES]:
             self._attr_supported_features |= _SUPPORTED_FEATURES[feature]
 

--- a/homeassistant/components/mqtt/alarm_control_panel.py
+++ b/homeassistant/components/mqtt/alarm_control_panel.py
@@ -91,7 +91,7 @@ REMOTE_CODE_TEXT = "REMOTE_CODE_TEXT"
 
 PLATFORM_SCHEMA_MODERN = MQTT_BASE_SCHEMA.extend(
     {
-        vol.Required(
+        vol.Optional(
             CONF_SUPPORTED_FEATURES, default=list(_SUPPORTED_FEATURES)
         ): cv.multi_select(_SUPPORTED_FEATURES),
         vol.Optional(CONF_CODE): cv.string,
@@ -152,9 +152,7 @@ class MqttAlarm(MqttEntity, alarm.AlarmControlPanelEntity):
     _default_name = DEFAULT_NAME
     _entity_id_format = alarm.ENTITY_ID_FORMAT
     _attributes_extra_blocked = MQTT_ALARM_ATTRIBUTES_BLOCKED
-    _attr_supported_features: AlarmControlPanelEntityFeature = (
-        AlarmControlPanelEntityFeature(0)
-    )
+    _attr_supported_features: AlarmControlPanelEntityFeature
 
     def __init__(
         self,
@@ -183,6 +181,7 @@ class MqttAlarm(MqttEntity, alarm.AlarmControlPanelEntity):
             config[CONF_COMMAND_TEMPLATE], entity=self
         ).async_render
 
+        self._attr_supported_features = AlarmControlPanelEntityFeature(0)
         for feature in self._config[CONF_SUPPORTED_FEATURES]:
             self._attr_supported_features |= _SUPPORTED_FEATURES[feature]
 

--- a/homeassistant/components/mqtt/const.py
+++ b/homeassistant/components/mqtt/const.py
@@ -28,6 +28,7 @@ CONF_WS_PATH = "ws_path"
 CONF_WS_HEADERS = "ws_headers"
 CONF_WILL_MESSAGE = "will_message"
 CONF_PAYLOAD_RESET = "payload_reset"
+CONF_SUPPORTED_FEATURES = "supported_features"
 
 CONF_ACTION_TEMPLATE = "action_template"
 CONF_ACTION_TOPIC = "action_topic"

--- a/tests/components/mqtt/test_alarm_control_panel.py
+++ b/tests/components/mqtt/test_alarm_control_panel.py
@@ -275,8 +275,7 @@ async def test_ignore_update_state_if_unknown_via_state_topic(
                 DEFAULT_CONFIG,
                 ({"supported_features": "invalid"},),
             ),
-            AlarmControlPanelEntityFeature.ARM_HOME
-            | AlarmControlPanelEntityFeature.ARM_AWAY,
+            None,
             False,
         ),
         (

--- a/tests/components/mqtt/test_alarm_control_panel.py
+++ b/tests/components/mqtt/test_alarm_control_panel.py
@@ -285,8 +285,7 @@ async def test_ignore_update_state_if_unknown_via_state_topic(
                 DEFAULT_CONFIG,
                 ({"supported_features": ["invalid"]},),
             ),
-            AlarmControlPanelEntityFeature.ARM_HOME
-            | AlarmControlPanelEntityFeature.ARM_AWAY,
+            None,
             False,
         ),
         (
@@ -295,8 +294,7 @@ async def test_ignore_update_state_if_unknown_via_state_topic(
                 DEFAULT_CONFIG,
                 ({"supported_features": ["arm_home", "invalid"]},),
             ),
-            AlarmControlPanelEntityFeature.ARM_HOME
-            | AlarmControlPanelEntityFeature.ARM_AWAY,
+            None,
             False,
         ),
     ],
@@ -304,7 +302,7 @@ async def test_ignore_update_state_if_unknown_via_state_topic(
 async def test_supported_features(
     hass: HomeAssistant,
     mqtt_mock_entry: MqttMockHAClientGenerator,
-    expected_features: AlarmControlPanelEntityFeature,
+    expected_features: AlarmControlPanelEntityFeature | None,
     valid: bool,
 ) -> None:
     """Test conditional enablement of supported features."""


### PR DESCRIPTION
## Proposed change

The MQTT Alarm Control Panel currrently enables all features (arm home, arm away, arm night, arm vacation, arm custom bypass) unconditionally. This clutters the interface and can even be potentially dangerous, by enabling modes that the remote alarm may not support.

Make all the features conditional, similar to how other MQTT components (e.g. cover, light etc.) handle this, as well as how other Alarm Panels (e.g. template) do as well.

Keep the default payloads as configured, to **maintain backwards compatibility**. In other words, all modes are (still) enabled by default, but can now be disabled by setting the new `supported_features` option to the list of features supported.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

_(Arguably a bugfix)_

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # (none reported)
- This PR is related to issue: (none reported)
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/28599

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

~~If the code communicates with devices, web services, or third-party tools:~~

- [ ] ~~The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.~~
- [ ] ~~New or updated dependencies have been added to `requirements_all.txt`. 
      Updated by running `python3 -m script.gen_requirements_all`.~~
- [ ] ~~For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.~~
- [ ] ~~Untested files have been added to `.coveragerc`.~~

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
