### PR TITLE
Add select platform to Enphase integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -305,6 +305,7 @@ omit =
     homeassistant/components/enphase_envoy/binary_sensor.py
     homeassistant/components/enphase_envoy/coordinator.py
     homeassistant/components/enphase_envoy/entity.py
+    homeassistant/components/enphase_envoy/select.py
     homeassistant/components/enphase_envoy/sensor.py
     homeassistant/components/enphase_envoy/switch.py
     homeassistant/components/entur_public_transport/*

--- a/homeassistant/components/enphase_envoy/const.py
+++ b/homeassistant/components/enphase_envoy/const.py
@@ -5,6 +5,6 @@ from homeassistant.const import Platform
 
 DOMAIN = "enphase_envoy"
 
-PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR, Platform.SWITCH]
+PLATFORMS = [Platform.BINARY_SENSOR, Platform.SELECT, Platform.SENSOR, Platform.SWITCH]
 
 INVALID_AUTH_ERRORS = (EnvoyAuthenticationError, EnvoyAuthenticationRequired)

--- a/homeassistant/components/enphase_envoy/manifest.json
+++ b/homeassistant/components/enphase_envoy/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://www.home-assistant.io/integrations/enphase_envoy",
   "iot_class": "local_polling",
   "loggers": ["pyenphase"],
-  "requirements": ["pyenphase==1.5.2"],
+  "requirements": ["pyenphase==1.6.0"],
   "zeroconf": [
     {
       "type": "_enphase-envoy._tcp.local."

--- a/homeassistant/components/enphase_envoy/select.py
+++ b/homeassistant/components/enphase_envoy/select.py
@@ -136,10 +136,9 @@ async def async_setup_entry(
 
 
 class EnvoyRelaySelectEntity(EnvoyBaseEntity, SelectEntity):
-    """Representation of an Enphase Enpower switch entity."""
+    """Representation of an Enphase Enpower select entity."""
 
     entity_description: EnvoyRelaySelectEntityDescription
-    _attr_has_entity_name = True
 
     def __init__(
         self,

--- a/homeassistant/components/enphase_envoy/select.py
+++ b/homeassistant/components/enphase_envoy/select.py
@@ -1,0 +1,179 @@
+"""Select platform for Enphase Envoy solar energy monitor."""
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+import logging
+from typing import Any
+
+from pyenphase import EnvoyDryContactSettings
+from pyenphase.models.dry_contacts import DryContactAction, DryContactMode
+
+from homeassistant.components.select import SelectEntity, SelectEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import EnphaseUpdateCoordinator
+from .entity import EnvoyBaseEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class EnvoyRelayRequiredKeysMixin:
+    """Mixin for required keys."""
+
+    value_fn: Callable[[EnvoyDryContactSettings], str]
+    update_fn: Callable[[Any, Any, Any], Any]
+
+
+@dataclass
+class EnvoyRelaySelectEntityDescription(
+    SelectEntityDescription, EnvoyRelayRequiredKeysMixin
+):
+    """Describes an Envoy Dry Contact Relay select entity."""
+
+
+RELAY_MODE_MAP = {
+    DryContactMode.MANUAL: "standard",
+    DryContactMode.STATE_OF_CHARGE: "battery",
+}
+RELAY_ACTION_MAP = {
+    DryContactAction.APPLY: "powered",
+    DryContactAction.SHED: "not_powered",
+    DryContactAction.SCHEDULE: "schedule",
+    DryContactAction.NONE: "none",
+}
+
+RELAY_ENTITIES = (
+    EnvoyRelaySelectEntityDescription(
+        key="mode",
+        name="Mode",
+        translation_key="relay_mode",
+        options=list(RELAY_MODE_MAP.values()),
+        value_fn=lambda relay: RELAY_MODE_MAP[relay.mode],
+        update_fn=lambda envoy, relay, value: envoy.update_dry_contact(
+            {
+                "id": relay.id,
+                "mode": next(
+                    key for key, val in RELAY_MODE_MAP.items() if val == value
+                ),
+            }
+        ),
+    ),
+    EnvoyRelaySelectEntityDescription(
+        key="grid_action",
+        name="Grid action",
+        translation_key="relay_grid_action",
+        options=list(RELAY_ACTION_MAP.values()),
+        value_fn=lambda relay: RELAY_ACTION_MAP[relay.grid_action],
+        update_fn=lambda envoy, relay, value: envoy.update_dry_contact(
+            {
+                "id": relay.id,
+                "grid_action": next(
+                    key for key, val in RELAY_ACTION_MAP.items() if val == value
+                ),
+            }
+        ),
+    ),
+    EnvoyRelaySelectEntityDescription(
+        key="microgrid_action",
+        name="Microgrid action",
+        translation_key="relay_microgrid_action",
+        options=list(RELAY_ACTION_MAP.values()),
+        value_fn=lambda relay: RELAY_ACTION_MAP[relay.micro_grid_action],
+        update_fn=lambda envoy, relay, value: envoy.update_dry_contact(
+            {
+                "id": relay.id,
+                "micro_grid_action": next(
+                    key for key, val in RELAY_ACTION_MAP.items() if val == value
+                ),
+            }
+        ),
+    ),
+    EnvoyRelaySelectEntityDescription(
+        key="generator_action",
+        name="Generator action",
+        translation_key="relay_generator_action",
+        options=list(RELAY_ACTION_MAP.values()),
+        value_fn=lambda relay: RELAY_ACTION_MAP[relay.generator_action],
+        update_fn=lambda envoy, relay, value: envoy.update_dry_contact(
+            {
+                "id": relay.id,
+                "generator_action": next(
+                    key for key, val in RELAY_ACTION_MAP.items() if val == value
+                ),
+            }
+        ),
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Enphase Envoy select platform."""
+    coordinator: EnphaseUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    envoy_data = coordinator.envoy.data
+    assert envoy_data is not None
+    envoy_serial_num = config_entry.unique_id
+    assert envoy_serial_num is not None
+    entities: list[SelectEntity] = []
+    if envoy_data.dry_contact_settings:
+        entities.extend(
+            [
+                EnvoyRelaySelectEntity(coordinator, entity, relay)
+                for entity in RELAY_ENTITIES
+                for relay in envoy_data.dry_contact_settings
+            ]
+        )
+    async_add_entities(entities)
+
+
+class EnvoyRelaySelectEntity(EnvoyBaseEntity, SelectEntity):
+    """Representation of an Enphase Enpower switch entity."""
+
+    entity_description: EnvoyRelaySelectEntityDescription
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: EnphaseUpdateCoordinator,
+        description: EnvoyRelaySelectEntityDescription,
+        relay: str,
+    ) -> None:
+        """Initialize the Enphase relay select entity."""
+        super().__init__(coordinator, description)
+        self.envoy = coordinator.envoy
+        assert self.envoy is not None
+        assert self.data is not None
+        self.enpower = self.data.enpower
+        assert self.enpower is not None
+        self._serial_number = self.enpower.serial_number
+        self.relay = self.data.dry_contact_settings[relay]
+        self._attr_unique_id = (
+            f"{self._serial_number}_relay_{relay}_{self.entity_description.key}"
+        )
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, relay)},
+            manufacturer="Enphase",
+            model="Dry Contact Relay",
+            name=self.relay.load_name,
+            sw_version=str(self.enpower.firmware_version),
+            via_device=(DOMAIN, self._serial_number),
+        )
+
+    @property
+    def current_option(self) -> str:
+        """Return the state of the Enpower switch."""
+        return self.entity_description.value_fn(self.relay)
+
+    async def async_select_option(self, option: str) -> None:
+        """Update the relay."""
+        await self.entity_description.update_fn(self.envoy, self.relay, option)
+        await self.coordinator.async_request_refresh()

--- a/homeassistant/components/enphase_envoy/select.py
+++ b/homeassistant/components/enphase_envoy/select.py
@@ -41,28 +41,22 @@ RELAY_MODE_MAP = {
     DryContactMode.MANUAL: "standard",
     DryContactMode.STATE_OF_CHARGE: "battery",
 }
-REVERSE_RELAY_MODE_MAP = {
-    "standard": DryContactMode.MANUAL,
-    "battery": DryContactMode.STATE_OF_CHARGE,
-}
+REVERSE_RELAY_MODE_MAP = {v: k for k, v in RELAY_MODE_MAP.items()}
 RELAY_ACTION_MAP = {
     DryContactAction.APPLY: "powered",
     DryContactAction.SHED: "not_powered",
     DryContactAction.SCHEDULE: "schedule",
     DryContactAction.NONE: "none",
 }
-REVERSE_RELAY_ACTION_MAP = {
-    "powered": DryContactAction.APPLY,
-    "not_powered": DryContactAction.SHED,
-    "schedule": DryContactAction.SCHEDULE,
-    "none": DryContactAction.NONE,
-}
+REVERSE_RELAY_ACTION_MAP = {v: k for k, v in RELAY_ACTION_MAP.items()}
+MODE_OPTIONS = list(REVERSE_RELAY_MODE_MAP)
+ACTION_OPTIONS = list(REVERSE_RELAY_ACTION_MAP)
 
 RELAY_ENTITIES = (
     EnvoyRelaySelectEntityDescription(
         key="mode",
         translation_key="relay_mode",
-        options=list(RELAY_MODE_MAP.values()),
+        options=MODE_OPTIONS,
         value_fn=lambda relay: RELAY_MODE_MAP[relay.mode],
         update_fn=lambda envoy, relay, value: envoy.update_dry_contact(
             {
@@ -74,7 +68,7 @@ RELAY_ENTITIES = (
     EnvoyRelaySelectEntityDescription(
         key="grid_action",
         translation_key="relay_grid_action",
-        options=list(RELAY_ACTION_MAP.values()),
+        options=ACTION_OPTIONS,
         value_fn=lambda relay: RELAY_ACTION_MAP[relay.grid_action],
         update_fn=lambda envoy, relay, value: envoy.update_dry_contact(
             {
@@ -86,7 +80,7 @@ RELAY_ENTITIES = (
     EnvoyRelaySelectEntityDescription(
         key="microgrid_action",
         translation_key="relay_microgrid_action",
-        options=list(RELAY_ACTION_MAP.values()),
+        options=ACTION_OPTIONS,
         value_fn=lambda relay: RELAY_ACTION_MAP[relay.micro_grid_action],
         update_fn=lambda envoy, relay, value: envoy.update_dry_contact(
             {
@@ -98,7 +92,7 @@ RELAY_ENTITIES = (
     EnvoyRelaySelectEntityDescription(
         key="generator_action",
         translation_key="relay_generator_action",
-        options=list(RELAY_ACTION_MAP.values()),
+        options=ACTION_OPTIONS,
         value_fn=lambda relay: RELAY_ACTION_MAP[relay.generator_action],
         update_fn=lambda envoy, relay, value: envoy.update_dry_contact(
             {
@@ -124,11 +118,9 @@ async def async_setup_entry(
     entities: list[SelectEntity] = []
     if envoy_data.dry_contact_settings:
         entities.extend(
-            [
-                EnvoyRelaySelectEntity(coordinator, entity, relay)
-                for entity in RELAY_ENTITIES
-                for relay in envoy_data.dry_contact_settings
-            ]
+            EnvoyRelaySelectEntity(coordinator, entity, relay)
+            for entity in RELAY_ENTITIES
+            for relay in envoy_data.dry_contact_settings
         )
     async_add_entities(entities)
 

--- a/homeassistant/components/enphase_envoy/select.py
+++ b/homeassistant/components/enphase_envoy/select.py
@@ -61,7 +61,6 @@ REVERSE_RELAY_ACTION_MAP = {
 RELAY_ENTITIES = (
     EnvoyRelaySelectEntityDescription(
         key="mode",
-        name="Mode",
         translation_key="relay_mode",
         options=list(RELAY_MODE_MAP.values()),
         value_fn=lambda relay: RELAY_MODE_MAP[relay.mode],
@@ -74,7 +73,6 @@ RELAY_ENTITIES = (
     ),
     EnvoyRelaySelectEntityDescription(
         key="grid_action",
-        name="Grid action",
         translation_key="relay_grid_action",
         options=list(RELAY_ACTION_MAP.values()),
         value_fn=lambda relay: RELAY_ACTION_MAP[relay.grid_action],
@@ -87,7 +85,6 @@ RELAY_ENTITIES = (
     ),
     EnvoyRelaySelectEntityDescription(
         key="microgrid_action",
-        name="Microgrid action",
         translation_key="relay_microgrid_action",
         options=list(RELAY_ACTION_MAP.values()),
         value_fn=lambda relay: RELAY_ACTION_MAP[relay.micro_grid_action],
@@ -100,7 +97,6 @@ RELAY_ENTITIES = (
     ),
     EnvoyRelaySelectEntityDescription(
         key="generator_action",
-        name="Generator action",
         translation_key="relay_generator_action",
         options=list(RELAY_ACTION_MAP.values()),
         value_fn=lambda relay: RELAY_ACTION_MAP[relay.generator_action],
@@ -164,7 +160,7 @@ class EnvoyRelaySelectEntity(EnvoyBaseEntity, SelectEntity):
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, relay)},
             manufacturer="Enphase",
-            model="Dry Contact Relay",
+            model="Dry contact relay",
             name=self.relay.load_name,
             sw_version=str(self.enpower.firmware_version),
             via_device=(DOMAIN, self._serial_number),

--- a/homeassistant/components/enphase_envoy/strings.json
+++ b/homeassistant/components/enphase_envoy/strings.json
@@ -36,6 +36,38 @@
         "name": "Grid status"
       }
     },
+    "select": {
+      "relay_mode": {
+        "state": {
+          "standard": "Standard",
+          "battery": "Battery Level"
+        }
+      },
+      "relay_grid_action": {
+        "state": {
+          "powered": "Powered",
+          "not_powered": "Not Powered",
+          "schedule": "Follow Schedule",
+          "none": "None"
+        }
+      },
+      "relay_microgrid_action": {
+        "state": {
+          "powered": "Powered",
+          "not_powered": "Not Powered",
+          "schedule": "Follow Schedule",
+          "none": "None"
+        }
+      },
+      "relay_generator_action": {
+        "state": {
+          "powered": "Powered",
+          "not_powered": "Not Powered",
+          "schedule": "Follow Schedule",
+          "none": "None"
+        }
+      }
+    },
     "sensor": {
       "last_reported": {
         "name": "Last reported"

--- a/homeassistant/components/enphase_envoy/strings.json
+++ b/homeassistant/components/enphase_envoy/strings.json
@@ -38,33 +38,37 @@
     },
     "select": {
       "relay_mode": {
+        "name": "Mode",
         "state": {
           "standard": "Standard",
-          "battery": "Battery Level"
+          "battery": "Battery level"
         }
       },
       "relay_grid_action": {
+        "name": "Grid action",
         "state": {
           "powered": "Powered",
-          "not_powered": "Not Powered",
-          "schedule": "Follow Schedule",
+          "not_powered": "Not powered",
+          "schedule": "Follow schedule",
           "none": "None"
         }
       },
       "relay_microgrid_action": {
+        "name": "Microgrid action",
         "state": {
-          "powered": "Powered",
-          "not_powered": "Not Powered",
-          "schedule": "Follow Schedule",
-          "none": "None"
+          "powered": "[%key:component::enphase_envoy::entity::select::relay_grid_action::state::powered%]",
+          "not_powered": "[%key:component::enphase_envoy::entity::select::relay_grid_action::state::not_powered%]",
+          "schedule": "[%key:component::enphase_envoy::entity::select::relay_grid_action::state::schedule%]",
+          "none": "[%key:component::enphase_envoy::entity::select::relay_grid_action::state::none%]"
         }
       },
       "relay_generator_action": {
+        "name": "Generator action",
         "state": {
-          "powered": "Powered",
-          "not_powered": "Not Powered",
-          "schedule": "Follow Schedule",
-          "none": "None"
+          "powered": "[%key:component::enphase_envoy::entity::select::relay_grid_action::state::powered%]",
+          "not_powered": "[%key:component::enphase_envoy::entity::select::relay_grid_action::state::not_powered%]",
+          "schedule": "[%key:component::enphase_envoy::entity::select::relay_grid_action::state::schedule%]",
+          "none": "[%key:component::enphase_envoy::entity::select::relay_grid_action::state::none%]"
         }
       }
     },

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1665,7 +1665,7 @@ pyedimax==0.2.1
 pyefergy==22.1.1
 
 # homeassistant.components.enphase_envoy
-pyenphase==1.5.2
+pyenphase==1.6.0
 
 # homeassistant.components.envisalink
 pyenvisalink==4.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1229,7 +1229,7 @@ pyeconet==0.1.20
 pyefergy==22.1.1
 
 # homeassistant.components.enphase_envoy
-pyenphase==1.5.2
+pyenphase==1.6.0
 
 # homeassistant.components.everlights
 pyeverlights==0.1.0


### PR DESCRIPTION
## Proposed change
Adds a `select` platform to the Enphase integration with options to control load shedding relays (if installed with their Enphase solar system)

https://github.com/pyenphase/pyenphase/compare/v1.5.2...v1.6.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/28583

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
