### PR TITLE
Fix GoGoGate2 configuration URL when remote access is disabled

### DIFF
--- a/homeassistant/components/gogogate2/common.py
+++ b/homeassistant/components/gogogate2/common.py
@@ -114,7 +114,9 @@ class GoGoGate2Entity(CoordinatorEntity[DeviceDataUpdateCoordinator]):
         """Device info for the controller."""
         data = self.coordinator.data
         configuration_url = (
-            f"https://{data.remoteaccess}" if data.remoteaccess else None
+            f"https://{data.remoteaccess}"
+            if data.remoteaccessenabled
+            else f"http://{self._config_entry.data[CONF_IP_ADDRESS]}"
         )
         return DeviceInfo(
             configuration_url=configuration_url,

--- a/homeassistant/components/gogogate2/common.py
+++ b/homeassistant/components/gogogate2/common.py
@@ -113,11 +113,10 @@ class GoGoGate2Entity(CoordinatorEntity[DeviceDataUpdateCoordinator]):
     def device_info(self) -> DeviceInfo:
         """Device info for the controller."""
         data = self.coordinator.data
-        configuration_url = (
-            f"https://{data.remoteaccess}"
-            if data.remoteaccessenabled
-            else f"http://{self._config_entry.data[CONF_IP_ADDRESS]}"
-        )
+        if data.remoteaccessenabled:
+            configuration_url = f"https://{data.remoteaccess}"
+        else:
+            configuration_url = f"http://{self._config_entry.data[CONF_IP_ADDRESS]}"
         return DeviceInfo(
             configuration_url=configuration_url,
             identifiers={(DOMAIN, str(self._config_entry.unique_id))},

--- a/tests/components/gogogate2/__init__.py
+++ b/tests/components/gogogate2/__init__.py
@@ -77,7 +77,7 @@ def _mocked_ismartgate_closed_door_response():
         ismartgatename="ismartgatename0",
         model="ismartgatePRO",
         apiversion="",
-        remoteaccessenabled=False,
+        remoteaccessenabled=True,
         remoteaccess="abc321.blah.blah",
         firmwareversion="555",
         pin=123,

--- a/tests/components/gogogate2/test_cover.py
+++ b/tests/components/gogogate2/test_cover.py
@@ -340,6 +340,7 @@ async def test_device_info_ismartgate(
     assert device.name == "mycontroller"
     assert device.model == "ismartgatePRO"
     assert device.sw_version == "555"
+    assert device.configuration_url == "https://abc321.blah.blah"
 
 
 @patch("homeassistant.components.gogogate2.common.GogoGate2Api")
@@ -375,3 +376,4 @@ async def test_device_info_gogogate2(
     assert device.name == "mycontroller"
     assert device.model == "gogogate2"
     assert device.sw_version == "222"
+    assert device.configuration_url == "http://127.0.0.1"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fix the configuration URL for a GoGoGate2/iSmartGate device when remote access is disabled. Use local IP in configuration URL if remote access is disabled.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: Fixes the broken configration URL reported in https://github.com/home-assistant/core/issues/95587#issuecomment-1677171242
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
