### PR TITLE
Add device_class to Renault charging remaining time

### DIFF
--- a/homeassistant/components/renault/sensor.py
+++ b/homeassistant/components/renault/sensor.py
@@ -190,6 +190,7 @@ SENSOR_TYPES: tuple[RenaultSensorEntityDescription[Any], ...] = (
         key="charging_remaining_time",
         coordinator="battery",
         data_key="chargingRemainingTime",
+        device_class=SensorDeviceClass.DURATION,
         entity_class=RenaultSensor[KamereonVehicleBatteryStatusData],
         icon="mdi:timer",
         native_unit_of_measurement=UnitOfTime.MINUTES,

--- a/tests/components/renault/const.py
+++ b/tests/components/renault/const.py
@@ -198,6 +198,7 @@ MOCK_VEHICLES = {
                 ATTR_UNIT_OF_MEASUREMENT: UnitOfPower.KILO_WATT,
             },
             {
+                ATTR_DEVICE_CLASS: SensorDeviceClass.DURATION,
                 ATTR_ENTITY_ID: "sensor.reg_number_charging_remaining_time",
                 ATTR_ICON: "mdi:timer",
                 ATTR_STATE: "145",

--- a/tests/components/renault/const.py
+++ b/tests/components/renault/const.py
@@ -434,6 +434,7 @@ MOCK_VEHICLES = {
                 ATTR_UNIT_OF_MEASUREMENT: UnitOfPower.KILO_WATT,
             },
             {
+                ATTR_DEVICE_CLASS: SensorDeviceClass.DURATION,
                 ATTR_ENTITY_ID: "sensor.reg_number_charging_remaining_time",
                 ATTR_ICON: "mdi:timer",
                 ATTR_STATE: STATE_UNKNOWN,
@@ -669,6 +670,7 @@ MOCK_VEHICLES = {
                 ATTR_UNIT_OF_MEASUREMENT: UnitOfPower.KILO_WATT,
             },
             {
+                ATTR_DEVICE_CLASS: SensorDeviceClass.DURATION,
                 ATTR_ENTITY_ID: "sensor.reg_number_charging_remaining_time",
                 ATTR_ICON: "mdi:timer",
                 ATTR_STATE: "145",

--- a/tests/components/renault/snapshots/test_sensor.ambr
+++ b/tests/components/renault/snapshots/test_sensor.ambr
@@ -404,7 +404,7 @@
       'name': None,
       'options': dict({
       }),
-      'original_device_class': None,
+      'original_device_class': <SensorDeviceClass.DURATION: 'duration'>,
       'original_icon': 'mdi:timer',
       'original_name': 'Charging remaining time',
       'platform': 'renault',
@@ -1100,7 +1100,7 @@
       'name': None,
       'options': dict({
       }),
-      'original_device_class': None,
+      'original_device_class': <SensorDeviceClass.DURATION: 'duration'>,
       'original_icon': 'mdi:timer',
       'original_name': 'Charging remaining time',
       'platform': 'renault',
@@ -1790,7 +1790,7 @@
       'name': None,
       'options': dict({
       }),
-      'original_device_class': None,
+      'original_device_class': <SensorDeviceClass.DURATION: 'duration'>,
       'original_icon': 'mdi:timer',
       'original_name': 'Charging remaining time',
       'platform': 'renault',
@@ -2803,7 +2803,7 @@
       'name': None,
       'options': dict({
       }),
-      'original_device_class': None,
+      'original_device_class': <SensorDeviceClass.DURATION: 'duration'>,
       'original_icon': 'mdi:timer',
       'original_name': 'Charging remaining time',
       'platform': 'renault',
@@ -3417,7 +3417,7 @@
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       }),
       'config_entry_id': <ANY>,
-      'device_class': None,
+      'device_class': <SensorDeviceClass.DURATION: 'duration'>,
       'device_id': <ANY>,
       'disabled_by': None,
       'domain': 'sensor',
@@ -3499,7 +3499,7 @@
       'name': None,
       'options': dict({
       }),
-      'original_device_class': None,
+      'original_device_class': <SensorDeviceClass.DURATION: 'duration'>,
       'original_icon': 'mdi:timer',
       'original_name': 'Charging remaining time',
       'platform': 'renault',
@@ -4107,7 +4107,7 @@
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       }),
       'config_entry_id': <ANY>,
-      'device_class': None,
+      'device_class': <SensorDeviceClass.DURATION: 'duration'>,
       'device_id': <ANY>,
       'disabled_by': None,
       'domain': 'sensor',
@@ -4189,7 +4189,7 @@
       'name': None,
       'options': dict({
       }),
-      'original_device_class': None,
+      'original_device_class': <SensorDeviceClass.DURATION: 'duration'>,
       'original_icon': 'mdi:timer',
       'original_name': 'Charging remaining time',
       'platform': 'renault',

--- a/tests/components/renault/snapshots/test_sensor.ambr
+++ b/tests/components/renault/snapshots/test_sensor.ambr
@@ -811,6 +811,7 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
+        'device_class': 'duration',
         'friendly_name': 'REG-NUMBER Charging remaining time',
         'icon': 'mdi:timer',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -1505,6 +1506,7 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
+        'device_class': 'duration',
         'friendly_name': 'REG-NUMBER Charging remaining time',
         'icon': 'mdi:timer',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -2223,6 +2225,7 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
+        'device_class': 'duration',
         'friendly_name': 'REG-NUMBER Charging remaining time',
         'icon': 'mdi:timer',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -3210,6 +3213,7 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
+        'device_class': 'duration',
         'friendly_name': 'REG-NUMBER Charging remaining time',
         'icon': 'mdi:timer',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -3417,7 +3421,7 @@
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       }),
       'config_entry_id': <ANY>,
-      'device_class': <SensorDeviceClass.DURATION: 'duration'>,
+      'device_class': None,
       'device_id': <ANY>,
       'disabled_by': None,
       'domain': 'sensor',
@@ -3904,6 +3908,7 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
+        'device_class': 'duration',
         'friendly_name': 'REG-NUMBER Charging remaining time',
         'icon': 'mdi:timer',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -4107,7 +4112,7 @@
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       }),
       'config_entry_id': <ANY>,
-      'device_class': <SensorDeviceClass.DURATION: 'duration'>,
+      'device_class': None,
       'device_id': <ANY>,
       'disabled_by': None,
       'domain': 'sensor',
@@ -4622,6 +4627,7 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
+        'device_class': 'duration',
         'friendly_name': 'REG-NUMBER Charging remaining time',
         'icon': 'mdi:timer',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,


### PR DESCRIPTION
## Proposed change

Set `device_class=duration` on the 'charging remaining time' entity in the Renault integration.

I had some issues showing this property on my dashboard, setting this attribute via developer tools fixed it locally - so I thought I'd contribute it back upstream. 

Example from my dashboard:
before | after
-|-
![before](https://github.com/home-assistant/core/assets/1143801/0d18c9a7-d648-4843-9760-dada2c3f2638)|![after](https://github.com/home-assistant/core/assets/1143801/04731126-aeee-4f10-953f-a4e195d9f838) 


<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
