### PR TITLE
Simplify error handling in otbr async_setup_entry

### DIFF
--- a/homeassistant/components/otbr/__init__.py
+++ b/homeassistant/components/otbr/__init__.py
@@ -10,7 +10,7 @@ from homeassistant.components.thread import async_add_dataset
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
-from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import config_validation as cv, issue_registry as ir
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import ConfigType
 
@@ -44,6 +44,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         asyncio.TimeoutError,
     ) as err:
         raise ConfigEntryNotReady("Unable to connect") from err
+    if border_agent_id is None:
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            f"get_get_border_agent_id_unsupported_{otbrdata.entry_id}",
+            is_fixable=False,
+            is_persistent=False,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key="get_get_border_agent_id_unsupported",
+        )
+        return False
     if dataset_tlvs:
         await update_issues(hass, otbrdata, dataset_tlvs)
         await async_add_dataset(

--- a/homeassistant/components/otbr/__init__.py
+++ b/homeassistant/components/otbr/__init__.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 
 import aiohttp
 import python_otbr_api
@@ -37,6 +36,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     otbrdata = OTBRData(entry.data["url"], api, entry.entry_id)
     try:
+        border_agent_id = await otbrdata.get_border_agent_id()
         dataset_tlvs = await otbrdata.get_active_dataset_tlvs()
     except (
         HomeAssistantError,
@@ -45,19 +45,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     ) as err:
         raise ConfigEntryNotReady("Unable to connect") from err
     if dataset_tlvs:
-        border_agent_id: str | None = None
-        with contextlib.suppress(
-            HomeAssistantError, aiohttp.ClientError, asyncio.TimeoutError
-        ):
-            border_agent_bytes = await otbrdata.get_border_agent_id()
-            if border_agent_bytes:
-                border_agent_id = border_agent_bytes.hex()
         await update_issues(hass, otbrdata, dataset_tlvs)
         await async_add_dataset(
             hass,
             DOMAIN,
             dataset_tlvs.hex(),
-            preferred_border_agent_id=border_agent_id,
+            preferred_border_agent_id=border_agent_id.hex(),
         )
 
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))

--- a/homeassistant/components/otbr/strings.json
+++ b/homeassistant/components/otbr/strings.json
@@ -16,6 +16,10 @@
     }
   },
   "issues": {
+    "get_get_border_agent_id_unsupported": {
+      "title": "The OTBR does not support border agent ID",
+      "description": "Your OTBR does not support border agent ID.\n\nTo fix this issue, update the OTBR to the latest version and restart Home Assistant.\nTo update the OTBR, update the Open Thread Border Router or Silicon Labs Multiprotocol add-on if you use the OTBR from the add-on, otherwise update your self managed OTBR."
+    },
     "insecure_thread_network": {
       "title": "Insecure Thread network settings detected",
       "description": "Your Thread network is using a default network key or pass phrase.\n\nThis is a security risk, please create a new Thread network."

--- a/homeassistant/components/otbr/util.py
+++ b/homeassistant/components/otbr/util.py
@@ -87,7 +87,7 @@ class OTBRData:
         """Get the border agent ID or None if not supported by the router."""
         try:
             return await self.api.get_border_agent_id()
-        except python_otbr_api.FactoryResetNotSupportedError:
+        except python_otbr_api.GetBorderAgentIdNotSupportedError:
             return None
 
     @_handle_otbr_error

--- a/homeassistant/components/otbr/util.py
+++ b/homeassistant/components/otbr/util.py
@@ -83,9 +83,12 @@ class OTBRData:
             await self.delete_active_dataset()
 
     @_handle_otbr_error
-    async def get_border_agent_id(self) -> bytes:
-        """Get the border agent ID."""
-        return await self.api.get_border_agent_id()
+    async def get_border_agent_id(self) -> bytes | None:
+        """Get the border agent ID or None if not supported by the router."""
+        try:
+            return await self.api.get_border_agent_id()
+        except python_otbr_api.FactoryResetNotSupportedError:
+            return None
 
     @_handle_otbr_error
     async def set_enabled(self, enabled: bool) -> None:

--- a/tests/components/otbr/test_init.py
+++ b/tests/components/otbr/test_init.py
@@ -209,7 +209,7 @@ async def test_config_entry_update(hass: HomeAssistant) -> None:
     config_entry.add_to_hass(hass)
     mock_api = MagicMock()
     mock_api.get_active_dataset_tlvs = AsyncMock(return_value=None)
-    mock_api.get_border_agent_id = AsyncMock(return_value=None)
+    mock_api.get_border_agent_id = AsyncMock(return_value=TEST_BORDER_AGENT_ID)
     with patch("python_otbr_api.OTBR", return_value=mock_api) as mock_otrb_api:
         assert await hass.config_entries.async_setup(config_entry.entry_id)
 

--- a/tests/components/otbr/test_init.py
+++ b/tests/components/otbr/test_init.py
@@ -198,6 +198,22 @@ async def test_config_entry_not_ready(hass: HomeAssistant, error) -> None:
         assert not await hass.config_entries.async_setup(config_entry.entry_id)
 
 
+async def test_border_agent_id_not_supported(hass: HomeAssistant) -> None:
+    """Test border router does not support border agent ID."""
+
+    config_entry = MockConfigEntry(
+        data=CONFIG_ENTRY_DATA_MULTIPAN,
+        domain=otbr.DOMAIN,
+        options={},
+        title="My OTBR",
+    )
+    config_entry.add_to_hass(hass)
+    with patch(
+        "python_otbr_api.OTBR.get_active_dataset_tlvs", return_value=DATASET_CH16
+    ), patch("python_otbr_api.OTBR.get_border_agent_id", return_value=None):
+        assert not await hass.config_entries.async_setup(config_entry.entry_id)
+
+
 async def test_config_entry_update(hass: HomeAssistant) -> None:
     """Test update config entry settings."""
     config_entry = MockConfigEntry(

--- a/tests/components/otbr/test_init.py
+++ b/tests/components/otbr/test_init.py
@@ -210,7 +210,10 @@ async def test_border_agent_id_not_supported(hass: HomeAssistant) -> None:
     config_entry.add_to_hass(hass)
     with patch(
         "python_otbr_api.OTBR.get_active_dataset_tlvs", return_value=DATASET_CH16
-    ), patch("python_otbr_api.OTBR.get_border_agent_id", return_value=None):
+    ), patch(
+        "python_otbr_api.OTBR.get_border_agent_id",
+        side_effect=python_otbr_api.GetBorderAgentIdNotSupportedError,
+    ):
         assert not await hass.config_entries.async_setup(config_entry.entry_id)
 
 

--- a/tests/components/otbr/test_init.py
+++ b/tests/components/otbr/test_init.py
@@ -90,11 +90,15 @@ async def test_import_share_radio_channel_collision(
     with patch(
         "python_otbr_api.OTBR.get_active_dataset_tlvs", return_value=DATASET_CH16
     ), patch(
+        "python_otbr_api.OTBR.get_border_agent_id", return_value=TEST_BORDER_AGENT_ID
+    ), patch(
         "homeassistant.components.thread.dataset_store.DatasetStore.async_add"
     ) as mock_add:
         assert await hass.config_entries.async_setup(config_entry.entry_id)
 
-    mock_add.assert_called_once_with(otbr.DOMAIN, DATASET_CH16.hex(), None)
+    mock_add.assert_called_once_with(
+        otbr.DOMAIN, DATASET_CH16.hex(), TEST_BORDER_AGENT_ID.hex()
+    )
     assert issue_registry.async_get_issue(
         domain=otbr.DOMAIN,
         issue_id=f"otbr_zha_channel_collision_{config_entry.entry_id}",
@@ -123,11 +127,15 @@ async def test_import_share_radio_no_channel_collision(
     with patch(
         "python_otbr_api.OTBR.get_active_dataset_tlvs", return_value=dataset
     ), patch(
+        "python_otbr_api.OTBR.get_border_agent_id", return_value=TEST_BORDER_AGENT_ID
+    ), patch(
         "homeassistant.components.thread.dataset_store.DatasetStore.async_add"
     ) as mock_add:
         assert await hass.config_entries.async_setup(config_entry.entry_id)
 
-    mock_add.assert_called_once_with(otbr.DOMAIN, dataset.hex(), None)
+    mock_add.assert_called_once_with(
+        otbr.DOMAIN, dataset.hex(), TEST_BORDER_AGENT_ID.hex()
+    )
     assert not issue_registry.async_get_issue(
         domain=otbr.DOMAIN,
         issue_id=f"otbr_zha_channel_collision_{config_entry.entry_id}",
@@ -154,11 +162,15 @@ async def test_import_insecure_dataset(hass: HomeAssistant, dataset: bytes) -> N
     with patch(
         "python_otbr_api.OTBR.get_active_dataset_tlvs", return_value=dataset
     ), patch(
+        "python_otbr_api.OTBR.get_border_agent_id", return_value=TEST_BORDER_AGENT_ID
+    ), patch(
         "homeassistant.components.thread.dataset_store.DatasetStore.async_add"
     ) as mock_add:
         assert await hass.config_entries.async_setup(config_entry.entry_id)
 
-    mock_add.assert_called_once_with(otbr.DOMAIN, dataset.hex(), None)
+    mock_add.assert_called_once_with(
+        otbr.DOMAIN, dataset.hex(), TEST_BORDER_AGENT_ID.hex()
+    )
     assert issue_registry.async_get_issue(
         domain=otbr.DOMAIN, issue_id=f"insecure_thread_network_{config_entry.entry_id}"
     )
@@ -197,6 +209,7 @@ async def test_config_entry_update(hass: HomeAssistant) -> None:
     config_entry.add_to_hass(hass)
     mock_api = MagicMock()
     mock_api.get_active_dataset_tlvs = AsyncMock(return_value=None)
+    mock_api.get_border_agent_id = AsyncMock(return_value=None)
     with patch("python_otbr_api.OTBR", return_value=mock_api) as mock_otrb_api:
         assert await hass.config_entries.async_setup(config_entry.entry_id)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Simplify error handling in otbr async_setup_entry
Raise an issue if the OTBR does not support border agent ID

Needs https://github.com/home-assistant/core/pull/98403

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
