### PR TITLE
Update aioairzone to v0.6.6

### DIFF
--- a/homeassistant/components/airzone/manifest.json
+++ b/homeassistant/components/airzone/manifest.json
@@ -11,5 +11,5 @@
   "documentation": "https://www.home-assistant.io/integrations/airzone",
   "iot_class": "local_polling",
   "loggers": ["aioairzone"],
-  "requirements": ["aioairzone==0.6.5"]
+  "requirements": ["aioairzone==0.6.6"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -188,7 +188,7 @@ aioairq==0.2.4
 aioairzone-cloud==0.2.1
 
 # homeassistant.components.airzone
-aioairzone==0.6.5
+aioairzone==0.6.6
 
 # homeassistant.components.ambient_station
 aioambient==2023.04.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -169,7 +169,7 @@ aioairq==0.2.4
 aioairzone-cloud==0.2.1
 
 # homeassistant.components.airzone
-aioairzone==0.6.5
+aioairzone==0.6.6
 
 # homeassistant.components.ambient_station
 aioambient==2023.04.0

--- a/tests/components/airzone/test_climate.py
+++ b/tests/components/airzone/test_climate.py
@@ -54,6 +54,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.util.dt import utcnow
 
 from .util import (
+    HVAC_DHW_MOCK,
     HVAC_MOCK,
     HVAC_SYSTEMS_MOCK,
     HVAC_WEBSERVER_MOCK,
@@ -226,6 +227,9 @@ async def test_airzone_create_climates(hass: HomeAssistant) -> None:
     HVAC_MOCK_CHANGED[API_SYSTEMS][0][API_DATA][0][API_MIN_TEMP] = 10
 
     with patch(
+        "homeassistant.components.airzone.AirzoneLocalApi.get_dhw",
+        return_value=HVAC_DHW_MOCK,
+    ), patch(
         "homeassistant.components.airzone.AirzoneLocalApi.get_hvac",
         return_value=HVAC_MOCK_CHANGED,
     ), patch(
@@ -437,6 +441,9 @@ async def test_airzone_climate_set_hvac_mode(hass: HomeAssistant) -> None:
     del HVAC_MOCK_NO_SET_POINT[API_SYSTEMS][0][API_DATA][0][API_SET_POINT]
 
     with patch(
+        "homeassistant.components.airzone.AirzoneLocalApi.get_dhw",
+        return_value=HVAC_DHW_MOCK,
+    ), patch(
         "homeassistant.components.airzone.AirzoneLocalApi.get_hvac",
         return_value=HVAC_MOCK_NO_SET_POINT,
     ), patch(

--- a/tests/components/airzone/test_config_flow.py
+++ b/tests/components/airzone/test_config_flow.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 from aioairzone.const import API_MAC, API_SYSTEMS
 from aioairzone.exceptions import (
     AirzoneError,
+    HotWaterNotAvailable,
     InvalidMethod,
     InvalidSystem,
     SystemOutOfRange,
@@ -19,7 +20,14 @@ from homeassistant.const import CONF_HOST, CONF_ID, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
-from .util import CONFIG, CONFIG_ID1, HVAC_MOCK, HVAC_VERSION_MOCK, HVAC_WEBSERVER_MOCK
+from .util import (
+    CONFIG,
+    CONFIG_ID1,
+    HVAC_DHW_MOCK,
+    HVAC_MOCK,
+    HVAC_VERSION_MOCK,
+    HVAC_WEBSERVER_MOCK,
+)
 
 from tests.common import MockConfigEntry
 
@@ -41,6 +49,9 @@ async def test_form(hass: HomeAssistant) -> None:
         "homeassistant.components.airzone.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry, patch(
+        "homeassistant.components.airzone.AirzoneLocalApi.get_dhw",
+        return_value=HVAC_DHW_MOCK,
+    ), patch(
         "homeassistant.components.airzone.AirzoneLocalApi.get_hvac",
         return_value=HVAC_MOCK,
     ), patch(
@@ -87,6 +98,9 @@ async def test_form_invalid_system_id(hass: HomeAssistant) -> None:
         "homeassistant.components.airzone.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry, patch(
+        "homeassistant.components.airzone.AirzoneLocalApi.get_dhw",
+        side_effect=HotWaterNotAvailable,
+    ), patch(
         "homeassistant.components.airzone.AirzoneLocalApi.get_hvac",
         side_effect=InvalidSystem,
     ) as mock_hvac, patch(
@@ -186,6 +200,9 @@ async def test_dhcp_flow(hass: HomeAssistant) -> None:
         "homeassistant.components.airzone.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry, patch(
+        "homeassistant.components.airzone.AirzoneLocalApi.get_dhw",
+        return_value=HVAC_DHW_MOCK,
+    ), patch(
         "homeassistant.components.airzone.AirzoneLocalApi.get_hvac",
         return_value=HVAC_MOCK,
     ), patch(
@@ -264,6 +281,9 @@ async def test_dhcp_connection_error(hass: HomeAssistant) -> None:
         "homeassistant.components.airzone.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry, patch(
+        "homeassistant.components.airzone.AirzoneLocalApi.get_dhw",
+        return_value=HVAC_DHW_MOCK,
+    ), patch(
         "homeassistant.components.airzone.AirzoneLocalApi.get_hvac",
         return_value=HVAC_MOCK,
     ), patch(
@@ -317,6 +337,9 @@ async def test_dhcp_invalid_system_id(hass: HomeAssistant) -> None:
         "homeassistant.components.airzone.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry, patch(
+        "homeassistant.components.airzone.AirzoneLocalApi.get_dhw",
+        side_effect=HotWaterNotAvailable,
+    ), patch(
         "homeassistant.components.airzone.AirzoneLocalApi.get_hvac",
         side_effect=InvalidSystem,
     ) as mock_hvac, patch(

--- a/tests/components/airzone/test_coordinator.py
+++ b/tests/components/airzone/test_coordinator.py
@@ -2,7 +2,12 @@
 
 from unittest.mock import patch
 
-from aioairzone.exceptions import AirzoneError, InvalidMethod, SystemOutOfRange
+from aioairzone.exceptions import (
+    AirzoneError,
+    HotWaterNotAvailable,
+    InvalidMethod,
+    SystemOutOfRange,
+)
 
 from homeassistant.components.airzone.const import DOMAIN
 from homeassistant.components.airzone.coordinator import SCAN_INTERVAL
@@ -26,6 +31,9 @@ async def test_coordinator_client_connector_error(hass: HomeAssistant) -> None:
     config_entry.add_to_hass(hass)
 
     with patch(
+        "homeassistant.components.airzone.AirzoneLocalApi.get_dhw",
+        side_effect=HotWaterNotAvailable,
+    ), patch(
         "homeassistant.components.airzone.AirzoneLocalApi.get_hvac",
         return_value=HVAC_MOCK,
     ) as mock_hvac, patch(

--- a/tests/components/airzone/test_init.py
+++ b/tests/components/airzone/test_init.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import patch
 
-from aioairzone.exceptions import InvalidMethod, SystemOutOfRange
+from aioairzone.exceptions import HotWaterNotAvailable, InvalidMethod, SystemOutOfRange
 
 from homeassistant.components.airzone.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
@@ -23,6 +23,9 @@ async def test_unique_id_migrate(hass: HomeAssistant) -> None:
     config_entry.add_to_hass(hass)
 
     with patch(
+        "homeassistant.components.airzone.AirzoneLocalApi.get_dhw",
+        side_effect=HotWaterNotAvailable,
+    ), patch(
         "homeassistant.components.airzone.AirzoneLocalApi.get_hvac",
         return_value=HVAC_MOCK,
     ), patch(
@@ -45,6 +48,9 @@ async def test_unique_id_migrate(hass: HomeAssistant) -> None:
     )
 
     with patch(
+        "homeassistant.components.airzone.AirzoneLocalApi.get_dhw",
+        side_effect=HotWaterNotAvailable,
+    ), patch(
         "homeassistant.components.airzone.AirzoneLocalApi.get_hvac",
         return_value=HVAC_MOCK,
     ), patch(

--- a/tests/components/airzone/test_sensor.py
+++ b/tests/components/airzone/test_sensor.py
@@ -10,6 +10,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.util.dt import utcnow
 
 from .util import (
+    HVAC_DHW_MOCK,
     HVAC_MOCK,
     HVAC_SYSTEMS_MOCK,
     HVAC_VERSION_MOCK,
@@ -86,6 +87,9 @@ async def test_airzone_sensors_availability(
     del HVAC_MOCK_UNAVAILABLE_ZONE[API_SYSTEMS][0][API_DATA][1]
 
     with patch(
+        "homeassistant.components.airzone.AirzoneLocalApi.get_dhw",
+        return_value=HVAC_DHW_MOCK,
+    ), patch(
         "homeassistant.components.airzone.AirzoneLocalApi.get_hvac",
         return_value=HVAC_MOCK_UNAVAILABLE_ZONE,
     ), patch(

--- a/tests/components/airzone/util.py
+++ b/tests/components/airzone/util.py
@@ -3,6 +3,12 @@
 from unittest.mock import patch
 
 from aioairzone.const import (
+    API_ACS_MAX_TEMP,
+    API_ACS_MIN_TEMP,
+    API_ACS_ON,
+    API_ACS_POWER_MODE,
+    API_ACS_SET_POINT,
+    API_ACS_TEMP,
     API_AIR_DEMAND,
     API_COLD_ANGLE,
     API_COLD_STAGE,
@@ -266,6 +272,18 @@ HVAC_MOCK = {
     ]
 }
 
+HVAC_DHW_MOCK = {
+    API_DATA: {
+        API_SYSTEM_ID: 0,
+        API_ACS_TEMP: 43,
+        API_ACS_SET_POINT: 45,
+        API_ACS_MAX_TEMP: 75,
+        API_ACS_MIN_TEMP: 30,
+        API_ACS_ON: 1,
+        API_ACS_POWER_MODE: 0,
+    }
+}
+
 HVAC_SYSTEMS_MOCK = {
     API_SYSTEMS: [
         {
@@ -301,6 +319,9 @@ async def async_init_integration(
     config_entry.add_to_hass(hass)
 
     with patch(
+        "homeassistant.components.airzone.AirzoneLocalApi.get_dhw",
+        return_value=HVAC_DHW_MOCK,
+    ), patch(
         "homeassistant.components.airzone.AirzoneLocalApi.get_hvac",
         return_value=HVAC_MOCK,
     ), patch(


### PR DESCRIPTION
## Proposed change
Update aioairzone to [v0.6.6](https://github.com/Noltari/aioairzone/compare/0.6.5...0.6.6).
Introduces support for Water Heater entities.

Releases:
- https://github.com/Noltari/aioairzone/releases/tag/0.6.6

Git compare:
https://github.com/Noltari/aioairzone/compare/0.6.5...0.6.6

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
