### PR TITLE
Ignore smartthings storage on fresh install

### DIFF
--- a/homeassistant/components/smartthings/__init__.py
+++ b/homeassistant/components/smartthings/__init__.py
@@ -58,7 +58,7 @@ CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Initialize the SmartThings platform."""
-    await setup_smartapp_endpoint(hass)
+    await setup_smartapp_endpoint(hass, False)
     return True
 
 

--- a/homeassistant/components/smartthings/config_flow.py
+++ b/homeassistant/components/smartthings/config_flow.py
@@ -57,7 +57,9 @@ class SmartThingsFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(self, user_input=None):
         """Validate and confirm webhook setup."""
-        await setup_smartapp_endpoint(self.hass)
+        await setup_smartapp_endpoint(
+            self.hass, len(self._async_current_entries()) == 0
+        )
         webhook_url = get_webhook_url(self.hass)
 
         # Abort if the webhook is invalid

--- a/homeassistant/components/smartthings/config_flow.py
+++ b/homeassistant/components/smartthings/config_flow.py
@@ -50,6 +50,7 @@ class SmartThingsFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self.installed_app_id = None
         self.refresh_token = None
         self.location_id = None
+        self.endpoints_initialized = False
 
     async def async_step_import(self, user_input=None):
         """Occurs when a previously entry setup fails and is re-initiated."""
@@ -57,9 +58,11 @@ class SmartThingsFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(self, user_input=None):
         """Validate and confirm webhook setup."""
-        await setup_smartapp_endpoint(
-            self.hass, len(self._async_current_entries()) == 0
-        )
+        if not self.endpoints_initialized:
+            self.endpoints_initialized = True
+            await setup_smartapp_endpoint(
+                self.hass, len(self._async_current_entries()) == 0
+            )
         webhook_url = get_webhook_url(self.hass)
 
         # Abort if the webhook is invalid

--- a/homeassistant/components/smartthings/smartapp.py
+++ b/homeassistant/components/smartthings/smartapp.py
@@ -197,7 +197,7 @@ def setup_smartapp(hass, app):
     return smartapp
 
 
-async def setup_smartapp_endpoint(hass: HomeAssistant, clean: bool):
+async def setup_smartapp_endpoint(hass: HomeAssistant, fresh_install: bool):
     """Configure the SmartApp webhook in hass.
 
     SmartApps are an extension point within the SmartThings ecosystem and
@@ -205,16 +205,16 @@ async def setup_smartapp_endpoint(hass: HomeAssistant, clean: bool):
     """
     if hass.data.get(DOMAIN):
         # already setup
-        if not clean:
+        if not fresh_install:
             return
 
-        # We're cleaning up, so unload it.
+        # We're doing a fresh install, clean up
         await unload_smartapp_endpoint(hass)
 
     # Get/create config to store a unique id for this hass instance.
     store = Store[dict[str, Any]](hass, STORAGE_VERSION, STORAGE_KEY)
 
-    if clean or not (config := await store.async_load()):
+    if fresh_install or not (config := await store.async_load()):
         # Create config
         config = {
             CONF_INSTANCE_ID: str(uuid4()),

--- a/homeassistant/components/smartthings/smartapp.py
+++ b/homeassistant/components/smartthings/smartapp.py
@@ -205,7 +205,11 @@ async def setup_smartapp_endpoint(hass: HomeAssistant, clean: bool):
     """
     if hass.data.get(DOMAIN):
         # already setup
-        return
+        if not clean:
+            return
+
+        # We're cleaning up, so unload it.
+        await unload_smartapp_endpoint(hass)
 
     # Get/create config to store a unique id for this hass instance.
     store = Store[dict[str, Any]](hass, STORAGE_VERSION, STORAGE_KEY)

--- a/homeassistant/components/smartthings/smartapp.py
+++ b/homeassistant/components/smartthings/smartapp.py
@@ -197,7 +197,7 @@ def setup_smartapp(hass, app):
     return smartapp
 
 
-async def setup_smartapp_endpoint(hass: HomeAssistant):
+async def setup_smartapp_endpoint(hass: HomeAssistant, clean: bool):
     """Configure the SmartApp webhook in hass.
 
     SmartApps are an extension point within the SmartThings ecosystem and
@@ -209,7 +209,8 @@ async def setup_smartapp_endpoint(hass: HomeAssistant):
 
     # Get/create config to store a unique id for this hass instance.
     store = Store[dict[str, Any]](hass, STORAGE_VERSION, STORAGE_KEY)
-    if not (config := await store.async_load()):
+
+    if clean or not (config := await store.async_load()):
         # Create config
         config = {
             CONF_INSTANCE_ID: str(uuid4()),

--- a/tests/components/smartthings/test_config_flow.py
+++ b/tests/components/smartthings/test_config_flow.py
@@ -187,6 +187,7 @@ async def test_entry_created_existing_app_new_oauth_client(
     smartthings_mock.apps.return_value = [app]
     smartthings_mock.generate_app_oauth.return_value = app_oauth_client
     smartthings_mock.locations.return_value = [location]
+    smartthings_mock.create_app = AsyncMock(return_value=(app, app_oauth_client))
     request = Mock()
     request.installed_app_id = installed_app_id
     request.auth_token = token
@@ -377,7 +378,8 @@ async def test_entry_created_with_cloudhook(
         assert result["description_placeholders"][
             "webhook_url"
         ] == smartapp.get_webhook_url(hass)
-        assert mock_create_cloudhook.call_count == 1
+        # One is done by app fixture, one done by new config entry
+        assert mock_create_cloudhook.call_count == 2
 
         # Advance to PAT screen
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})

--- a/tests/components/smartthings/test_config_flow.py
+++ b/tests/components/smartthings/test_config_flow.py
@@ -366,7 +366,7 @@ async def test_entry_created_with_cloudhook(
         "async_create_cloudhook",
         AsyncMock(return_value="http://cloud.test"),
     ) as mock_create_cloudhook:
-        await smartapp.setup_smartapp_endpoint(hass)
+        await smartapp.setup_smartapp_endpoint(hass, True)
 
         # Webhook confirmation shown
         result = await hass.config_entries.flow.async_init(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When creating a new config flow, ignore existing storage if there are no other config entries set up. This is equivalent to removing the storage manually which seems to be a leading issue that people experience when using the Smartthings integration.

Analysis of the Smartthings architecture https://docs.google.com/document/d/1DesFhAaLg_pNn4LJRY0bZQboV3uIknVbW_nlnMxP-44/edit?usp=sharing

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
