### PR TITLE
Wrap most ZHA exceptions in `HomeAssistantError`

### DIFF
--- a/homeassistant/components/zha/button.py
+++ b/homeassistant/components/zha/button.py
@@ -6,9 +6,6 @@ import functools
 import logging
 from typing import TYPE_CHECKING, Any, Self
 
-import zigpy.exceptions
-from zigpy.zcl.foundation import Status
-
 from homeassistant.components.button import ButtonDeviceClass, ButtonEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory, Platform
@@ -134,17 +131,10 @@ class ZHAAttributeButton(ZhaEntity, ButtonEntity):
 
     async def async_press(self) -> None:
         """Write attribute with defined value."""
-        try:
-            result = await self._cluster_handler.cluster.write_attributes(
-                {self._attribute_name: self._attribute_value}
-            )
-        except zigpy.exceptions.ZigbeeException as ex:
-            self.error("Could not set value: %s", ex)
-            return
-        if not isinstance(result, Exception) and all(
-            record.status == Status.SUCCESS for record in result[0]
-        ):
-            self.async_write_ha_state()
+        await self._cluster_handler.write_attributes_safe(
+            {self._attribute_name: self._attribute_value}
+        )
+        self.async_write_ha_state()
 
 
 @CONFIG_DIAGNOSTIC_MATCH(

--- a/homeassistant/components/zha/core/cluster_handlers/__init__.py
+++ b/homeassistant/components/zha/core/cluster_handlers/__init__.py
@@ -49,6 +49,7 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 RETRYABLE_REQUEST_DECORATOR = zigpy.util.retryable_request(tries=3)
+UNPROXIED_CLUSTER_METHODS = {"general_command"}
 
 
 _P = ParamSpec("_P")
@@ -537,7 +538,11 @@ class ClusterHandler(LogMixin):
 
     def __getattr__(self, name):
         """Get attribute or a decorated cluster command."""
-        if hasattr(self._cluster, name) and callable(getattr(self._cluster, name)):
+        if (
+            hasattr(self._cluster, name)
+            and callable(getattr(self._cluster, name))
+            and name not in UNPROXIED_CLUSTER_METHODS
+        ):
             command = getattr(self._cluster, name)
             wrapped_command = retry_request(command)
             wrapped_command.__name__ = name

--- a/homeassistant/components/zha/core/cluster_handlers/general.py
+++ b/homeassistant/components/zha/core/cluster_handlers/general.py
@@ -11,6 +11,7 @@ from zigpy.zcl.clusters import general
 from zigpy.zcl.foundation import Status
 
 from homeassistant.core import callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.event import async_call_later
 
 from .. import registries
@@ -384,21 +385,19 @@ class OnOffClusterHandler(ClusterHandler):
         """Return cached value of on/off attribute."""
         return self.cluster.get("on_off")
 
-    async def turn_on(self) -> bool:
+    async def turn_on(self) -> None:
         """Turn the on off cluster on."""
         result = await self.on()
-        if isinstance(result, Exception) or result[1] is not Status.SUCCESS:
-            return False
+        if result[1] is not Status.SUCCESS:
+            raise HomeAssistantError(f"Failed to turn on: {result[1]}")
         self.cluster.update_attribute(self.ON_OFF, t.Bool.true)
-        return True
 
-    async def turn_off(self) -> bool:
+    async def turn_off(self) -> None:
         """Turn the on off cluster off."""
         result = await self.off()
-        if isinstance(result, Exception) or result[1] is not Status.SUCCESS:
-            return False
+        if result[1] is not Status.SUCCESS:
+            raise HomeAssistantError(f"Failed to turn off: {result[1]}")
         self.cluster.update_attribute(self.ON_OFF, t.Bool.false)
-        return True
 
     @callback
     def cluster_command(self, tsn, command_id, args):

--- a/homeassistant/components/zha/core/cluster_handlers/general.py
+++ b/homeassistant/components/zha/core/cluster_handlers/general.py
@@ -1,7 +1,6 @@
 """General cluster handlers module for Zigbee Home Automation."""
 from __future__ import annotations
 
-import asyncio
 from collections.abc import Coroutine
 from typing import TYPE_CHECKING, Any
 
@@ -111,18 +110,9 @@ class AnalogOutput(ClusterHandler):
         """Return cached value of application_type."""
         return self.cluster.get("application_type")
 
-    async def async_set_present_value(self, value: float) -> bool:
+    async def async_set_present_value(self, value: float) -> None:
         """Update present_value."""
-        try:
-            res = await self.cluster.write_attributes({"present_value": value})
-        except zigpy.exceptions.ZigbeeException as ex:
-            self.error("Could not set value: %s", ex)
-            return False
-        if not isinstance(res, Exception) and all(
-            record.status == Status.SUCCESS for record in res[0]
-        ):
-            return True
-        return False
+        await self.write_attributes_safe({"present_value": value})
 
 
 @registries.ZIGBEE_CLUSTER_HANDLER_REGISTRY.register(general.AnalogValue.cluster_id)
@@ -510,13 +500,7 @@ class PollControl(ClusterHandler):
 
     async def async_configure_cluster_handler_specific(self) -> None:
         """Configure cluster handler: set check-in interval."""
-        try:
-            res = await self.cluster.write_attributes(
-                {"checkin_interval": self.CHECKIN_INTERVAL}
-            )
-            self.debug("%ss check-in interval set: %s", self.CHECKIN_INTERVAL / 4, res)
-        except (asyncio.TimeoutError, zigpy.exceptions.ZigbeeException) as ex:
-            self.debug("Couldn't set check-in interval: %s", ex)
+        await self.write_attributes_safe({"checkin_interval": self.CHECKIN_INTERVAL})
 
     @callback
     def cluster_command(

--- a/homeassistant/components/zha/core/cluster_handlers/manufacturerspecific.py
+++ b/homeassistant/components/zha/core/cluster_handlers/manufacturerspecific.py
@@ -5,7 +5,6 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from zhaquirks.inovelli.types import AllLEDEffectType, SingleLEDEffectType
-from zigpy.exceptions import ZigbeeException
 import zigpy.zcl
 
 from homeassistant.core import callback
@@ -351,12 +350,7 @@ class IkeaAirPurifierClusterHandler(ClusterHandler):
 
     async def async_set_speed(self, value) -> None:
         """Set the speed of the fan."""
-
-        try:
-            await self.cluster.write_attributes({"fan_mode": value})
-        except ZigbeeException as ex:
-            self.error("Could not set speed: %s", ex)
-            return
+        await self.write_attributes_safe({"fan_mode": value})
 
     async def async_update(self) -> None:
         """Retrieve latest state."""

--- a/homeassistant/components/zha/cover.py
+++ b/homeassistant/components/zha/cover.py
@@ -140,30 +140,34 @@ class ZhaCover(ZhaEntity, CoverEntity):
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the window cover."""
         res = await self._cover_cluster_handler.up_open()
-        if res[1] is Status.SUCCESS:
-            self.async_update_state(STATE_OPENING)
+        if res[1] is not Status.SUCCESS:
+            raise HomeAssistantError(f"Failed to open cover: {res[1]}")
+        self.async_update_state(STATE_OPENING)
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the window cover."""
         res = await self._cover_cluster_handler.down_close()
-        if res[1] is Status.SUCCESS:
-            self.async_update_state(STATE_CLOSING)
+        if res[1] is not Status.SUCCESS:
+            raise HomeAssistantError(f"Failed to close cover: {res[1]}")
+        self.async_update_state(STATE_CLOSING)
 
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move the roller shutter to a specific position."""
         new_pos = kwargs[ATTR_POSITION]
         res = await self._cover_cluster_handler.go_to_lift_percentage(100 - new_pos)
-        if res[1] is Status.SUCCESS:
-            self.async_update_state(
-                STATE_CLOSING if new_pos < self._current_position else STATE_OPENING
-            )
+        if res[1] is not Status.SUCCESS:
+            raise HomeAssistantError(f"Failed to set cover position: {res[1]}")
+        self.async_update_state(
+            STATE_CLOSING if new_pos < self._current_position else STATE_OPENING
+        )
 
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the window cover."""
         res = await self._cover_cluster_handler.stop()
-        if res[1] is Status.SUCCESS:
-            self._state = STATE_OPEN if self._current_position > 0 else STATE_CLOSED
-            self.async_write_ha_state()
+        if res[1] is not Status.SUCCESS:
+            raise HomeAssistantError(f"Failed to stop cover: {res[1]}")
+        self._state = STATE_OPEN if self._current_position > 0 else STATE_CLOSED
+        self.async_write_ha_state()
 
     async def async_update(self) -> None:
         """Attempt to retrieve the open/close state of the cover."""
@@ -289,7 +293,7 @@ class Shade(ZhaEntity, CoverEntity):
         )
 
         if res[1] != Status.SUCCESS:
-            raise HomeAssistantError(f"Failed to set cover's position: {res[1]}")
+            raise HomeAssistantError(f"Failed to set cover position: {res[1]}")
 
         self._position = new_pos
         self.async_write_ha_state()

--- a/homeassistant/components/zha/cover.py
+++ b/homeassistant/components/zha/cover.py
@@ -23,6 +23,7 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -266,8 +267,7 @@ class Shade(ZhaEntity, CoverEntity):
         """Open the window cover."""
         res = await self._on_off_cluster_handler.on()
         if res[1] != Status.SUCCESS:
-            self.debug("couldn't open cover: %s", res)
-            return
+            raise HomeAssistantError(f"Failed to open cover: {res[1]}")
 
         self._is_open = True
         self.async_write_ha_state()
@@ -276,8 +276,7 @@ class Shade(ZhaEntity, CoverEntity):
         """Close the window cover."""
         res = await self._on_off_cluster_handler.off()
         if res[1] != Status.SUCCESS:
-            self.debug("couldn't open cover: %s", res)
-            return
+            raise HomeAssistantError(f"Failed to close cover: {res[1]}")
 
         self._is_open = False
         self.async_write_ha_state()
@@ -290,8 +289,7 @@ class Shade(ZhaEntity, CoverEntity):
         )
 
         if res[1] != Status.SUCCESS:
-            self.debug("couldn't set cover's position: %s", res)
-            return
+            raise HomeAssistantError(f"Failed to set cover's position: {res[1]}")
 
         self._position = new_pos
         self.async_write_ha_state()
@@ -300,8 +298,7 @@ class Shade(ZhaEntity, CoverEntity):
         """Stop the cover."""
         res = await self._level_cluster_handler.stop()
         if res[1] != Status.SUCCESS:
-            self.debug("couldn't stop cover: %s", res)
-            return
+            raise HomeAssistantError(f"Failed to stop cover: {res[1]}")
 
 
 @MULTI_MATCH(

--- a/homeassistant/components/zha/cover.py
+++ b/homeassistant/components/zha/cover.py
@@ -139,20 +139,20 @@ class ZhaCover(ZhaEntity, CoverEntity):
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the window cover."""
         res = await self._cover_cluster_handler.up_open()
-        if not isinstance(res, Exception) and res[1] is Status.SUCCESS:
+        if res[1] is Status.SUCCESS:
             self.async_update_state(STATE_OPENING)
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the window cover."""
         res = await self._cover_cluster_handler.down_close()
-        if not isinstance(res, Exception) and res[1] is Status.SUCCESS:
+        if res[1] is Status.SUCCESS:
             self.async_update_state(STATE_CLOSING)
 
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move the roller shutter to a specific position."""
         new_pos = kwargs[ATTR_POSITION]
         res = await self._cover_cluster_handler.go_to_lift_percentage(100 - new_pos)
-        if not isinstance(res, Exception) and res[1] is Status.SUCCESS:
+        if res[1] is Status.SUCCESS:
             self.async_update_state(
                 STATE_CLOSING if new_pos < self._current_position else STATE_OPENING
             )
@@ -160,7 +160,7 @@ class ZhaCover(ZhaEntity, CoverEntity):
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the window cover."""
         res = await self._cover_cluster_handler.stop()
-        if not isinstance(res, Exception) and res[1] is Status.SUCCESS:
+        if res[1] is Status.SUCCESS:
             self._state = STATE_OPEN if self._current_position > 0 else STATE_CLOSED
             self.async_write_ha_state()
 
@@ -265,7 +265,7 @@ class Shade(ZhaEntity, CoverEntity):
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the window cover."""
         res = await self._on_off_cluster_handler.on()
-        if isinstance(res, Exception) or res[1] != Status.SUCCESS:
+        if res[1] != Status.SUCCESS:
             self.debug("couldn't open cover: %s", res)
             return
 
@@ -275,7 +275,7 @@ class Shade(ZhaEntity, CoverEntity):
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the window cover."""
         res = await self._on_off_cluster_handler.off()
-        if isinstance(res, Exception) or res[1] != Status.SUCCESS:
+        if res[1] != Status.SUCCESS:
             self.debug("couldn't open cover: %s", res)
             return
 
@@ -289,7 +289,7 @@ class Shade(ZhaEntity, CoverEntity):
             new_pos * 255 / 100, 1
         )
 
-        if isinstance(res, Exception) or res[1] != Status.SUCCESS:
+        if res[1] != Status.SUCCESS:
             self.debug("couldn't set cover's position: %s", res)
             return
 
@@ -299,7 +299,7 @@ class Shade(ZhaEntity, CoverEntity):
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover."""
         res = await self._level_cluster_handler.stop()
-        if isinstance(res, Exception) or res[1] != Status.SUCCESS:
+        if res[1] != Status.SUCCESS:
             self.debug("couldn't stop cover: %s", res)
             return
 

--- a/homeassistant/components/zha/fan.py
+++ b/homeassistant/components/zha/fan.py
@@ -27,6 +27,7 @@ from homeassistant.util.percentage import (
 )
 
 from .core import discovery
+from .core.cluster_handlers import wrap_zigpy_exceptions
 from .core.const import (
     CLUSTER_HANDLER_FAN,
     DATA_ZHA,
@@ -206,7 +207,10 @@ class FanGroup(BaseFan, ZhaGroupEntity):
 
     async def _async_set_fan_mode(self, fan_mode: int) -> None:
         """Set the fan mode for the group."""
-        await self._fan_cluster_handler.write_attributes_safe({"fan_mode": fan_mode})
+
+        with wrap_zigpy_exceptions():
+            await self._fan_cluster_handler.write_attributes({"fan_mode": fan_mode})
+
         self.async_set_state(0, "fan_mode", fan_mode)
 
     async def async_update(self) -> None:

--- a/homeassistant/components/zha/fan.py
+++ b/homeassistant/components/zha/fan.py
@@ -6,7 +6,6 @@ import functools
 import math
 from typing import Any
 
-from zigpy.exceptions import ZigbeeException
 from zigpy.zcl.clusters import hvac
 
 from homeassistant.components.fan import (
@@ -207,10 +206,7 @@ class FanGroup(BaseFan, ZhaGroupEntity):
 
     async def _async_set_fan_mode(self, fan_mode: int) -> None:
         """Set the fan mode for the group."""
-        try:
-            await self._fan_cluster_handler.write_attributes({"fan_mode": fan_mode})
-        except ZigbeeException as ex:
-            self.error("Could not set fan mode: %s", ex)
+        await self._fan_cluster_handler.write_attributes_safe({"fan_mode": fan_mode})
         self.async_set_state(0, "fan_mode", fan_mode)
 
     async def async_update(self) -> None:

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -298,7 +298,7 @@ class BaseLight(LogMixin, light.LightEntity):
                 transition_time=int(10 * self._DEFAULT_MIN_TRANSITION_TIME),
             )
             t_log["move_to_level_with_on_off"] = result
-            if isinstance(result, Exception) or result[1] is not Status.SUCCESS:
+            if result[1] is not Status.SUCCESS:
                 # First 'move to level' call failed, so if the transitioning delay
                 # isn't running from a previous call,
                 # the flag can be unset immediately
@@ -338,7 +338,7 @@ class BaseLight(LogMixin, light.LightEntity):
                 transition_time=int(10 * duration),
             )
             t_log["move_to_level_with_on_off"] = result
-            if isinstance(result, Exception) or result[1] is not Status.SUCCESS:
+            if result[1] is not Status.SUCCESS:
                 # First 'move to level' call failed, so if the transitioning delay
                 # isn't running from a previous call, the flag can be unset immediately
                 if set_transition_flag and not self._transition_listener:
@@ -359,7 +359,7 @@ class BaseLight(LogMixin, light.LightEntity):
             # if brightness is not 0.
             result = await self._on_off_cluster_handler.on()
             t_log["on_off"] = result
-            if isinstance(result, Exception) or result[1] is not Status.SUCCESS:
+            if result[1] is not Status.SUCCESS:
                 # 'On' call failed, but as brightness may still transition
                 # (for FORCE_ON lights), we start the timer to unset the flag after
                 # the transition_time if necessary.
@@ -391,7 +391,7 @@ class BaseLight(LogMixin, light.LightEntity):
                 level=level, transition_time=int(10 * duration)
             )
             t_log["move_to_level_if_color"] = result
-            if isinstance(result, Exception) or result[1] is not Status.SUCCESS:
+            if result[1] is not Status.SUCCESS:
                 self.debug("turned on: %s", t_log)
                 return
             self._attr_state = bool(level)
@@ -474,7 +474,7 @@ class BaseLight(LogMixin, light.LightEntity):
         if self._zha_config_enable_light_transitioning_flag:
             self.async_transition_start_timer(transition_time)
         self.debug("turned off: %s", result)
-        if isinstance(result, Exception) or result[1] is not Status.SUCCESS:
+        if result[1] is not Status.SUCCESS:
             return
         self._attr_state = False
 
@@ -514,7 +514,7 @@ class BaseLight(LogMixin, light.LightEntity):
                 transition_time=int(10 * transition_time),
             )
             t_log["move_to_color_temp"] = result
-            if isinstance(result, Exception) or result[1] is not Status.SUCCESS:
+            if result[1] is not Status.SUCCESS:
                 return False
             self._attr_color_mode = ColorMode.COLOR_TEMP
             self._attr_color_temp = temperature
@@ -539,7 +539,7 @@ class BaseLight(LogMixin, light.LightEntity):
                     transition_time=int(10 * transition_time),
                 )
                 t_log["move_to_hue_and_saturation"] = result
-            if isinstance(result, Exception) or result[1] is not Status.SUCCESS:
+            if result[1] is not Status.SUCCESS:
                 return False
             self._attr_color_mode = ColorMode.HS
             self._attr_hs_color = hs_color
@@ -554,7 +554,7 @@ class BaseLight(LogMixin, light.LightEntity):
                 transition_time=int(10 * transition_time),
             )
             t_log["move_to_color"] = result
-            if isinstance(result, Exception) or result[1] is not Status.SUCCESS:
+            if result[1] is not Status.SUCCESS:
                 return False
             self._attr_color_mode = ColorMode.XY
             self._attr_xy_color = xy_color

--- a/homeassistant/components/zha/lock.py
+++ b/homeassistant/components/zha/lock.py
@@ -132,7 +132,7 @@ class ZhaDoorLock(ZhaEntity, LockEntity):
     async def async_lock(self, **kwargs: Any) -> None:
         """Lock the lock."""
         result = await self._doorlock_cluster_handler.lock_door()
-        if isinstance(result, Exception) or result[0] is not Status.SUCCESS:
+        if result[0] is not Status.SUCCESS:
             self.error("Error with lock_door: %s", result)
             return
         self.async_write_ha_state()
@@ -140,7 +140,7 @@ class ZhaDoorLock(ZhaEntity, LockEntity):
     async def async_unlock(self, **kwargs: Any) -> None:
         """Unlock the lock."""
         result = await self._doorlock_cluster_handler.unlock_door()
-        if isinstance(result, Exception) or result[0] is not Status.SUCCESS:
+        if result[0] is not Status.SUCCESS:
             self.error("Error with unlock_door: %s", result)
             return
         self.async_write_ha_state()

--- a/homeassistant/components/zha/number.py
+++ b/homeassistant/components/zha/number.py
@@ -5,9 +5,6 @@ import functools
 import logging
 from typing import TYPE_CHECKING, Any, Self
 
-import zigpy.exceptions
-from zigpy.zcl.foundation import Status
-
 from homeassistant.components.number import NumberEntity, NumberMode
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory, Platform, UnitOfMass, UnitOfTemperature
@@ -434,17 +431,10 @@ class ZHANumberConfigurationEntity(ZhaEntity, NumberEntity):
 
     async def async_set_native_value(self, value: float) -> None:
         """Update the current value from HA."""
-        try:
-            res = await self._cluster_handler.cluster.write_attributes(
-                {self._zcl_attribute: int(value / self._attr_multiplier)}
-            )
-        except zigpy.exceptions.ZigbeeException as ex:
-            self.error("Could not set value: %s", ex)
-            return
-        if not isinstance(res, Exception) and all(
-            record.status == Status.SUCCESS for record in res[0]
-        ):
-            self.async_write_ha_state()
+        await self._cluster_handler.write_attributes_safe(
+            {self._zcl_attribute: int(value / self._attr_multiplier)}
+        )
+        self.async_write_ha_state()
 
     async def async_update(self) -> None:
         """Attempt to retrieve the state of the entity."""

--- a/homeassistant/components/zha/number.py
+++ b/homeassistant/components/zha/number.py
@@ -359,9 +359,8 @@ class ZhaNumber(ZhaEntity, NumberEntity):
 
     async def async_set_native_value(self, value: float) -> None:
         """Update the current value from HA."""
-        num_value = float(value)
-        if await self._analog_output_cluster_handler.async_set_present_value(num_value):
-            self.async_write_ha_state()
+        await self._analog_output_cluster_handler.async_set_present_value(float(value))
+        self.async_write_ha_state()
 
     async def async_update(self) -> None:
         """Attempt to retrieve the state of the entity."""

--- a/homeassistant/components/zha/select.py
+++ b/homeassistant/components/zha/select.py
@@ -210,7 +210,7 @@ class ZCLEnumSelectEntity(ZhaEntity, SelectEntity):
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
-        await self._cluster_handler.cluster.write_attributes(
+        await self._cluster_handler.write_attributes_safe(
             {self._select_attr: self._enum[option.replace(" ", "_")]}
         )
         self.async_write_ha_state()

--- a/homeassistant/components/zha/switch.py
+++ b/homeassistant/components/zha/switch.py
@@ -84,16 +84,12 @@ class Switch(ZhaEntity, SwitchEntity):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
-        result = await self._on_off_cluster_handler.turn_on()
-        if not result:
-            return
+        await self._on_off_cluster_handler.turn_on()
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
-        result = await self._on_off_cluster_handler.turn_off()
-        if not result:
-            return
+        await self._on_off_cluster_handler.turn_off()
         self.async_write_ha_state()
 
     @callback
@@ -144,7 +140,7 @@ class SwitchGroup(ZhaGroupEntity, SwitchEntity):
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
         result = await self._on_off_cluster_handler.on()
-        if isinstance(result, Exception) or result[1] is not Status.SUCCESS:
+        if result[1] is not Status.SUCCESS:
             return
         self._state = True
         self.async_write_ha_state()
@@ -152,7 +148,7 @@ class SwitchGroup(ZhaGroupEntity, SwitchEntity):
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
         result = await self._on_off_cluster_handler.off()
-        if isinstance(result, Exception) or result[1] is not Status.SUCCESS:
+        if result[1] is not Status.SUCCESS:
             return
         self._state = False
         self.async_write_ha_state()

--- a/tests/components/zha/common.py
+++ b/tests/components/zha/common.py
@@ -173,9 +173,8 @@ def async_find_group_entity_id(hass, domain, group):
 
     entity_ids = hass.states.async_entity_ids(domain)
 
-    if entity_id in entity_ids:
-        return entity_id
-    return None
+    assert entity_id in entity_ids
+    return entity_id
 
 
 async def async_enable_traffic(hass, zha_devices, enabled=True):

--- a/tests/components/zha/conftest.py
+++ b/tests/components/zha/conftest.py
@@ -15,6 +15,7 @@ import zigpy.group
 import zigpy.profiles
 import zigpy.quirks
 import zigpy.types
+import zigpy.util
 import zigpy.zdo.types as zdo_t
 
 import homeassistant.components.zha.core.const as zha_const
@@ -28,6 +29,17 @@ from tests.components.light.conftest import mock_light_profiles  # noqa: F401
 
 FIXTURE_GRP_ID = 0x1001
 FIXTURE_GRP_NAME = "fixture group"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def disable_request_retry_delay():
+    """Disable ZHA request retrying delay to speed up failures."""
+
+    with patch(
+        "homeassistant.components.zha.core.cluster_handlers.RETRYABLE_REQUEST_DECORATOR",
+        zigpy.util.retryable_request(tries=3, delay=0),
+    ):
+        yield
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/components/zha/test_cover.py
+++ b/tests/components/zha/test_cover.py
@@ -39,6 +39,8 @@ from .conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
 
 from tests.common import async_capture_events, mock_restore_cache
 
+Default_Response = zcl_f.GENERAL_COMMANDS[zcl_f.GeneralCommand.Default_Response].schema
+
 
 @pytest.fixture(autouse=True)
 def cover_platform_only():
@@ -204,6 +206,121 @@ async def test_cover(
     cluster.PLUGGED_ATTR_READS = {"current_position_lift_percentage": 0}
     await async_test_rejoin(hass, zigpy_cover_device, [cluster], (1,))
     assert hass.states.get(entity_id).state == STATE_OPEN
+
+
+async def test_cover_failures(
+    hass: HomeAssistant, zha_device_joined_restored, zigpy_cover_device
+) -> None:
+    """Test ZHA cover platform failure cases."""
+
+    # load up cover domain
+    cluster = zigpy_cover_device.endpoints.get(1).window_covering
+    cluster.PLUGGED_ATTR_READS = {"current_position_lift_percentage": 100}
+    zha_device = await zha_device_joined_restored(zigpy_cover_device)
+
+    entity_id = find_entity_id(Platform.COVER, zha_device, hass)
+    assert entity_id is not None
+
+    await async_enable_traffic(hass, [zha_device], enabled=False)
+    # test that the cover was created and that it is unavailable
+    assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
+
+    # allow traffic to flow through the gateway and device
+    await async_enable_traffic(hass, [zha_device])
+    await hass.async_block_till_done()
+
+    # test that the state has changed from unavailable to off
+    await send_attributes_report(hass, cluster, {0: 0, 8: 100, 1: 1})
+    assert hass.states.get(entity_id).state == STATE_CLOSED
+
+    # test to see if it opens
+    await send_attributes_report(hass, cluster, {0: 1, 8: 0, 1: 100})
+    assert hass.states.get(entity_id).state == STATE_OPEN
+
+    # close from UI
+    with patch(
+        "zigpy.zcl.Cluster.request",
+        return_value=Default_Response(
+            command_id=closures.WindowCovering.ServerCommandDefs.down_close.id,
+            status=zcl_f.Status.UNSUP_CLUSTER_COMMAND,
+        ),
+    ):
+        with pytest.raises(HomeAssistantError, match=r"Failed to close cover"):
+            await hass.services.async_call(
+                COVER_DOMAIN,
+                SERVICE_CLOSE_COVER,
+                {"entity_id": entity_id},
+                blocking=True,
+            )
+        assert cluster.request.call_count == 1
+        assert (
+            cluster.request.call_args[0][1]
+            == closures.WindowCovering.ServerCommandDefs.down_close.id
+        )
+
+    # open from UI
+    with patch(
+        "zigpy.zcl.Cluster.request",
+        return_value=Default_Response(
+            command_id=closures.WindowCovering.ServerCommandDefs.up_open.id,
+            status=zcl_f.Status.UNSUP_CLUSTER_COMMAND,
+        ),
+    ):
+        with pytest.raises(HomeAssistantError, match=r"Failed to open cover"):
+            await hass.services.async_call(
+                COVER_DOMAIN,
+                SERVICE_OPEN_COVER,
+                {"entity_id": entity_id},
+                blocking=True,
+            )
+        assert cluster.request.call_count == 1
+        assert (
+            cluster.request.call_args[0][1]
+            == closures.WindowCovering.ServerCommandDefs.up_open.id
+        )
+
+    # set position UI
+    with patch(
+        "zigpy.zcl.Cluster.request",
+        return_value=Default_Response(
+            command_id=closures.WindowCovering.ServerCommandDefs.go_to_lift_percentage.id,
+            status=zcl_f.Status.UNSUP_CLUSTER_COMMAND,
+        ),
+    ):
+        with pytest.raises(HomeAssistantError, match=r"Failed to set cover position"):
+            await hass.services.async_call(
+                COVER_DOMAIN,
+                SERVICE_SET_COVER_POSITION,
+                {"entity_id": entity_id, "position": 47},
+                blocking=True,
+            )
+
+        assert cluster.request.call_count == 1
+        assert (
+            cluster.request.call_args[0][1]
+            == closures.WindowCovering.ServerCommandDefs.go_to_lift_percentage.id
+        )
+
+    # stop from UI
+    with patch(
+        "zigpy.zcl.Cluster.request",
+        return_value=Default_Response(
+            command_id=closures.WindowCovering.ServerCommandDefs.stop.id,
+            status=zcl_f.Status.UNSUP_CLUSTER_COMMAND,
+        ),
+    ):
+        with pytest.raises(HomeAssistantError, match=r"Failed to stop cover"):
+            await hass.services.async_call(
+                COVER_DOMAIN,
+                SERVICE_STOP_COVER,
+                {"entity_id": entity_id},
+                blocking=True,
+            )
+        assert cluster.request.call_count == 1
+        assert (
+            cluster.request.call_args[0][1]
+            == closures.WindowCovering.ServerCommandDefs.stop.id
+        )
 
 
 async def test_shade(

--- a/tests/components/zha/test_number.py
+++ b/tests/components/zha/test_number.py
@@ -9,8 +9,10 @@ import zigpy.zcl.clusters.lighting as lighting
 import zigpy.zcl.foundation as zcl_f
 
 from homeassistant.components.number import DOMAIN as NUMBER_DOMAIN
+from homeassistant.components.zha.core.device import ZHADevice
 from homeassistant.const import STATE_UNAVAILABLE, EntityCategory, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
@@ -162,8 +164,9 @@ async def test_number(
             {"entity_id": entity_id, "value": 30.0},
             blocking=True,
         )
-        assert len(cluster.write_attributes.mock_calls) == 1
-        assert cluster.write_attributes.call_args == call({"present_value": 30.0})
+        assert cluster.write_attributes.mock_calls == [
+            call({"present_value": 30.0}, manufacturer=None)
+        ]
         cluster.PLUGGED_ATTR_READS["present_value"] = 30.0
 
     # test rejoin
@@ -200,7 +203,12 @@ async def test_number(
     ),
 )
 async def test_level_control_number(
-    hass: HomeAssistant, light, zha_device_joined, attr, initial_value, new_value
+    hass: HomeAssistant,
+    light: ZHADevice,
+    zha_device_joined,
+    attr: str,
+    initial_value: int,
+    new_value: int,
 ) -> None:
     """Test ZHA level control number entities - new join."""
 
@@ -219,8 +227,7 @@ async def test_level_control_number(
     )
     assert entity_id is not None
 
-    assert level_control_cluster.read_attributes.call_count == 3
-    assert (
+    assert level_control_cluster.read_attributes.mock_calls == [
         call(
             [
                 "on_off_transition_time",
@@ -232,21 +239,13 @@ async def test_level_control_number(
             allow_cache=True,
             only_cache=False,
             manufacturer=None,
-        )
-        in level_control_cluster.read_attributes.call_args_list
-    )
-
-    assert (
+        ),
         call(
             ["start_up_current_level"],
             allow_cache=True,
             only_cache=False,
             manufacturer=None,
-        )
-        in level_control_cluster.read_attributes.call_args_list
-    )
-
-    assert (
+        ),
         call(
             [
                 "current_level",
@@ -254,9 +253,8 @@ async def test_level_control_number(
             allow_cache=False,
             only_cache=False,
             manufacturer=None,
-        )
-        in level_control_cluster.read_attributes.call_args_list
-    )
+        ),
+    ]
 
     state = hass.states.get(entity_id)
     assert state
@@ -277,10 +275,9 @@ async def test_level_control_number(
         blocking=True,
     )
 
-    assert level_control_cluster.write_attributes.call_count == 1
-    assert level_control_cluster.write_attributes.call_args[0][0] == {
-        attr: new_value,
-    }
+    assert level_control_cluster.write_attributes.mock_calls == [
+        call({attr: new_value}, manufacturer=None)
+    ]
 
     state = hass.states.get(entity_id)
     assert state
@@ -295,36 +292,34 @@ async def test_level_control_number(
     )
     # the mocking doesn't update the attr cache so this flips back to initial value
     assert hass.states.get(entity_id).state == str(initial_value)
-    assert level_control_cluster.read_attributes.call_count == 1
-    assert (
+    assert level_control_cluster.read_attributes.mock_calls == [
         call(
-            [
-                attr,
-            ],
+            [attr],
             allow_cache=False,
             only_cache=False,
             manufacturer=None,
         )
-        in level_control_cluster.read_attributes.call_args_list
-    )
+    ]
 
     level_control_cluster.write_attributes.reset_mock()
     level_control_cluster.write_attributes.side_effect = ZigbeeException
 
-    await hass.services.async_call(
-        "number",
-        "set_value",
-        {
-            "entity_id": entity_id,
-            "value": new_value,
-        },
-        blocking=True,
-    )
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            "number",
+            "set_value",
+            {
+                "entity_id": entity_id,
+                "value": new_value,
+            },
+            blocking=True,
+        )
 
-    assert level_control_cluster.write_attributes.call_count == 1
-    assert level_control_cluster.write_attributes.call_args[0][0] == {
-        attr: new_value,
-    }
+    assert level_control_cluster.write_attributes.mock_calls == [
+        call({attr: new_value}, manufacturer=None),
+        call({attr: new_value}, manufacturer=None),
+        call({attr: new_value}, manufacturer=None),
+    ]
     assert hass.states.get(entity_id).state == str(initial_value)
 
 
@@ -333,7 +328,12 @@ async def test_level_control_number(
     (("start_up_color_temperature", 500, 350),),
 )
 async def test_color_number(
-    hass: HomeAssistant, light, zha_device_joined, attr, initial_value, new_value
+    hass: HomeAssistant,
+    light: ZHADevice,
+    zha_device_joined,
+    attr: str,
+    initial_value: int,
+    new_value: int,
 ) -> None:
     """Test ZHA color number entities - new join."""
 
@@ -409,9 +409,7 @@ async def test_color_number(
     assert color_cluster.read_attributes.call_count == 1
     assert (
         call(
-            [
-                attr,
-            ],
+            [attr],
             allow_cache=False,
             only_cache=False,
             manufacturer=None,
@@ -422,18 +420,20 @@ async def test_color_number(
     color_cluster.write_attributes.reset_mock()
     color_cluster.write_attributes.side_effect = ZigbeeException
 
-    await hass.services.async_call(
-        "number",
-        "set_value",
-        {
-            "entity_id": entity_id,
-            "value": new_value,
-        },
-        blocking=True,
-    )
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            "number",
+            "set_value",
+            {
+                "entity_id": entity_id,
+                "value": new_value,
+            },
+            blocking=True,
+        )
 
-    assert color_cluster.write_attributes.call_count == 1
-    assert color_cluster.write_attributes.call_args[0][0] == {
-        attr: new_value,
-    }
+    assert color_cluster.write_attributes.mock_calls == [
+        call({attr: new_value}, manufacturer=None),
+        call({attr: new_value}, manufacturer=None),
+        call({attr: new_value}, manufacturer=None),
+    ]
     assert hass.states.get(entity_id).state == str(initial_value)

--- a/tests/components/zha/test_switch.py
+++ b/tests/components/zha/test_switch.py
@@ -21,6 +21,7 @@ from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.components.zha.core.group import GroupMember
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import async_setup_component
 
 from .common import (
@@ -411,10 +412,11 @@ async def test_switch_configurable(
         await hass.services.async_call(
             SWITCH_DOMAIN, "turn_on", {"entity_id": entity_id}, blocking=True
         )
-        assert len(cluster.write_attributes.mock_calls) == 1
-        assert cluster.write_attributes.call_args == call(
-            {"window_detection_function": True}
-        )
+        assert cluster.write_attributes.mock_calls == [
+            call({"window_detection_function": True}, manufacturer=None)
+        ]
+
+    cluster.write_attributes.reset_mock()
 
     # turn off from HA
     with patch(
@@ -425,10 +427,9 @@ async def test_switch_configurable(
         await hass.services.async_call(
             SWITCH_DOMAIN, "turn_off", {"entity_id": entity_id}, blocking=True
         )
-        assert len(cluster.write_attributes.mock_calls) == 2
-        assert cluster.write_attributes.call_args == call(
-            {"window_detection_function": False}
-        )
+        assert cluster.write_attributes.mock_calls == [
+            call({"window_detection_function": False}, manufacturer=None)
+        ]
 
     cluster.read_attributes.reset_mock()
     await async_setup_component(hass, "homeassistant", {})
@@ -461,14 +462,18 @@ async def test_switch_configurable(
     cluster.write_attributes.reset_mock()
     cluster.write_attributes.side_effect = ZigbeeException
 
-    await hass.services.async_call(
-        SWITCH_DOMAIN, "turn_off", {"entity_id": entity_id}, blocking=True
-    )
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            SWITCH_DOMAIN, "turn_off", {"entity_id": entity_id}, blocking=True
+        )
 
-    assert len(cluster.write_attributes.mock_calls) == 1
-    assert cluster.write_attributes.call_args == call(
-        {"window_detection_function": False}
-    )
+    assert cluster.write_attributes.mock_calls == [
+        call({"window_detection_function": False}, manufacturer=None),
+        call({"window_detection_function": False}, manufacturer=None),
+        call({"window_detection_function": False}, manufacturer=None),
+    ]
+
+    cluster.write_attributes.side_effect = None
 
     # test inverter
     cluster.write_attributes.reset_mock()
@@ -477,18 +482,17 @@ async def test_switch_configurable(
     await hass.services.async_call(
         SWITCH_DOMAIN, "turn_off", {"entity_id": entity_id}, blocking=True
     )
-    assert len(cluster.write_attributes.mock_calls) == 1
-    assert cluster.write_attributes.call_args == call(
-        {"window_detection_function": True}
-    )
+    assert cluster.write_attributes.mock_calls == [
+        call({"window_detection_function": True}, manufacturer=None)
+    ]
 
+    cluster.write_attributes.reset_mock()
     await hass.services.async_call(
         SWITCH_DOMAIN, "turn_on", {"entity_id": entity_id}, blocking=True
     )
-    assert len(cluster.write_attributes.mock_calls) == 2
-    assert cluster.write_attributes.call_args == call(
-        {"window_detection_function": False}
-    )
+    assert cluster.write_attributes.mock_calls == [
+        call({"window_detection_function": False}, manufacturer=None)
+    ]
 
     # test joining a new switch to the network and HA
     await async_test_rejoin(hass, zigpy_device_tuya, [cluster], (0,))


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR aims to allow more intentional `HomeAssistantError`s with readable error messages to be raised:

 - Reduce explicit handling of errors, instead opting to allow wrapped `HomeAssistantError`s to propagate.
 - Use a helper function to write attributes, which validates write statuses automatically and similarly raises a `HomeAssistantError` when a failure is encountered.
 - This PR also removes stale `isinstance...Exception` checks, since codepaths to return exceptions as objects are no longer present in ZHA.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #98495
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
