### PR TITLE
Add number platform & battery setpoint entities to Enphase integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -305,6 +305,7 @@ omit =
     homeassistant/components/enphase_envoy/binary_sensor.py
     homeassistant/components/enphase_envoy/coordinator.py
     homeassistant/components/enphase_envoy/entity.py
+    homeassistant/components/enphase_envoy/number.py
     homeassistant/components/enphase_envoy/select.py
     homeassistant/components/enphase_envoy/sensor.py
     homeassistant/components/enphase_envoy/switch.py

--- a/homeassistant/components/enphase_envoy/const.py
+++ b/homeassistant/components/enphase_envoy/const.py
@@ -5,6 +5,12 @@ from homeassistant.const import Platform
 
 DOMAIN = "enphase_envoy"
 
-PLATFORMS = [Platform.BINARY_SENSOR, Platform.SELECT, Platform.SENSOR, Platform.SWITCH]
+PLATFORMS = [
+    Platform.BINARY_SENSOR,
+    Platform.NUMBER,
+    Platform.SELECT,
+    Platform.SENSOR,
+    Platform.SWITCH,
+]
 
 INVALID_AUTH_ERRORS = (EnvoyAuthenticationError, EnvoyAuthenticationRequired)

--- a/homeassistant/components/enphase_envoy/number.py
+++ b/homeassistant/components/enphase_envoy/number.py
@@ -66,8 +66,6 @@ async def async_setup_entry(
     coordinator: EnphaseUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
     envoy_data = coordinator.envoy.data
     assert envoy_data is not None
-    envoy_serial_num = config_entry.unique_id
-    assert envoy_serial_num is not None
     entities: list[NumberEntity] = []
     if envoy_data.dry_contact_settings:
         entities.extend(

--- a/homeassistant/components/enphase_envoy/number.py
+++ b/homeassistant/components/enphase_envoy/number.py
@@ -90,22 +90,18 @@ class EnvoyRelayNumberEntity(EnvoyBaseEntity, NumberEntity):
         """Initialize the Enphase relay number entity."""
         super().__init__(coordinator, description)
         self.envoy = coordinator.envoy
-        assert self.envoy is not None
-        assert self.data is not None
-        self.enpower = self.data.enpower
-        assert self.enpower is not None
-        self._serial_number = self.enpower.serial_number
+        enpower = self.data.enpower
+        assert enpower is not None
+        self._serial_number = enpower.serial_number
         self.relay = self.data.dry_contact_settings[relay]
         self.relay_id = relay
-        self._attr_unique_id = (
-            f"{self._serial_number}_relay_{relay}_{self.entity_description.key}"
-        )
+        self._attr_unique_id = f"{self._serial_number}_relay_{relay}_{description.key}"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, relay)},
             manufacturer="Enphase",
             model="Dry contact relay",
             name=self.relay.load_name,
-            sw_version=str(self.enpower.firmware_version),
+            sw_version=str(enpower.firmware_version),
             via_device=(DOMAIN, self._serial_number),
         )
 

--- a/homeassistant/components/enphase_envoy/number.py
+++ b/homeassistant/components/enphase_envoy/number.py
@@ -1,0 +1,123 @@
+"""Select platform for Enphase Envoy solar energy monitor."""
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+import logging
+
+from pyenphase import EnvoyDryContactSettings
+
+from homeassistant.components.number import (
+    NumberDeviceClass,
+    NumberEntity,
+    NumberEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import EnphaseUpdateCoordinator
+from .entity import EnvoyBaseEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class EnvoyRelayRequiredKeysMixin:
+    """Mixin for required keys."""
+
+    value_fn: Callable[[EnvoyDryContactSettings], float]
+
+
+@dataclass
+class EnvoyRelayNumberEntityDescription(
+    NumberEntityDescription, EnvoyRelayRequiredKeysMixin
+):
+    """Describes an Envoy Dry Contact Relay number entity."""
+
+
+RELAY_ENTITIES = (
+    EnvoyRelayNumberEntityDescription(
+        key="soc_low",
+        translation_key="cutoff_battery_level",
+        device_class=NumberDeviceClass.BATTERY,
+        value_fn=lambda relay: relay.soc_low,
+    ),
+    EnvoyRelayNumberEntityDescription(
+        key="soc_high",
+        translation_key="resume_battery_level",
+        device_class=NumberDeviceClass.BATTERY,
+        value_fn=lambda relay: relay.soc_high,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Enphase Envoy number platform."""
+    coordinator: EnphaseUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    envoy_data = coordinator.envoy.data
+    assert envoy_data is not None
+    envoy_serial_num = config_entry.unique_id
+    assert envoy_serial_num is not None
+    entities: list[NumberEntity] = []
+    if envoy_data.dry_contact_settings:
+        entities.extend(
+            EnvoyRelayNumberEntity(coordinator, entity, relay)
+            for entity in RELAY_ENTITIES
+            for relay in envoy_data.dry_contact_settings
+        )
+    async_add_entities(entities)
+
+
+class EnvoyRelayNumberEntity(EnvoyBaseEntity, NumberEntity):
+    """Representation of an Enphase Enpower number entity."""
+
+    entity_description: EnvoyRelayNumberEntityDescription
+
+    def __init__(
+        self,
+        coordinator: EnphaseUpdateCoordinator,
+        description: EnvoyRelayNumberEntityDescription,
+        relay: str,
+    ) -> None:
+        """Initialize the Enphase relay select entity."""
+        super().__init__(coordinator, description)
+        self.envoy = coordinator.envoy
+        assert self.envoy is not None
+        assert self.data is not None
+        self.enpower = self.data.enpower
+        assert self.enpower is not None
+        self._serial_number = self.enpower.serial_number
+        self.relay = self.data.dry_contact_settings[relay]
+        self.relay_id = relay
+        self._attr_unique_id = (
+            f"{self._serial_number}_relay_{relay}_{self.entity_description.key}"
+        )
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, relay)},
+            manufacturer="Enphase",
+            model="Dry contact relay",
+            name=self.relay.load_name,
+            sw_version=str(self.enpower.firmware_version),
+            via_device=(DOMAIN, self._serial_number),
+        )
+
+    @property
+    def native_value(self) -> float:
+        """Return the state of the relay entity."""
+        return self.entity_description.value_fn(
+            self.data.dry_contact_settings[self.relay_id]
+        )
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Update the relay."""
+        await self.envoy.update_dry_contact(
+            {"id": self.relay.id, self.entity_description.key: int(value)}
+        )
+        await self.coordinator.async_request_refresh()

--- a/homeassistant/components/enphase_envoy/number.py
+++ b/homeassistant/components/enphase_envoy/number.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-import logging
 
 from pyenphase import EnvoyDryContactSettings
 
@@ -21,8 +20,6 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import DOMAIN
 from .coordinator import EnphaseUpdateCoordinator
 from .entity import EnvoyBaseEntity
-
-_LOGGER = logging.getLogger(__name__)
 
 
 @dataclass
@@ -93,7 +90,6 @@ class EnvoyRelayNumberEntity(EnvoyBaseEntity, NumberEntity):
         enpower = self.data.enpower
         assert enpower is not None
         serial_number = enpower.serial_number
-        self._serial_number = serial_number
         self._relay_id = relay_id
         self._attr_unique_id = f"{serial_number}_relay_{relay_id}_{description.key}"
         self._attr_device_info = DeviceInfo(

--- a/homeassistant/components/enphase_envoy/number.py
+++ b/homeassistant/components/enphase_envoy/number.py
@@ -93,14 +93,14 @@ class EnvoyRelayNumberEntity(EnvoyBaseEntity, NumberEntity):
         enpower = self.data.enpower
         assert enpower is not None
         self._serial_number = enpower.serial_number
-        self.relay = self.data.dry_contact_settings[relay]
+        relay_data = self.data.dry_contact_settings[relay]
         self.relay_id = relay
         self._attr_unique_id = f"{self._serial_number}_relay_{relay}_{description.key}"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, relay)},
             manufacturer="Enphase",
             model="Dry contact relay",
-            name=self.relay.load_name,
+            name=relay_data.load_name,
             sw_version=str(enpower.firmware_version),
             via_device=(DOMAIN, self._serial_number),
         )
@@ -115,6 +115,6 @@ class EnvoyRelayNumberEntity(EnvoyBaseEntity, NumberEntity):
     async def async_set_native_value(self, value: float) -> None:
         """Update the relay."""
         await self.envoy.update_dry_contact(
-            {"id": self.relay.id, self.entity_description.key: int(value)}
+            {"id": self.relay_id, self.entity_description.key: int(value)}
         )
         await self.coordinator.async_request_refresh()

--- a/homeassistant/components/enphase_envoy/number.py
+++ b/homeassistant/components/enphase_envoy/number.py
@@ -92,18 +92,17 @@ class EnvoyRelayNumberEntity(EnvoyBaseEntity, NumberEntity):
         self.envoy = coordinator.envoy
         enpower = self.data.enpower
         assert enpower is not None
-        self._serial_number = enpower.serial_number
+        serial_number = enpower.serial_number
+        self._serial_number = serial_number
         self._relay_id = relay_id
-        self._attr_unique_id = (
-            f"{self._serial_number}_relay_{relay_id}_{description.key}"
-        )
+        self._attr_unique_id = f"{serial_number}_relay_{relay_id}_{description.key}"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, relay_id)},
             manufacturer="Enphase",
             model="Dry contact relay",
             name=self.data.dry_contact_settings[relay_id].load_name,
             sw_version=str(enpower.firmware_version),
-            via_device=(DOMAIN, self._serial_number),
+            via_device=(DOMAIN, serial_number),
         )
 
     @property

--- a/homeassistant/components/enphase_envoy/number.py
+++ b/homeassistant/components/enphase_envoy/number.py
@@ -49,7 +49,7 @@ RELAY_ENTITIES = (
     ),
     EnvoyRelayNumberEntityDescription(
         key="soc_high",
-        translation_key="resume_battery_level",
+        translation_key="restore_battery_level",
         device_class=NumberDeviceClass.BATTERY,
         entity_category=EntityCategory.CONFIG,
         value_fn=lambda relay: relay.soc_high,

--- a/homeassistant/components/enphase_envoy/number.py
+++ b/homeassistant/components/enphase_envoy/number.py
@@ -13,6 +13,7 @@ from homeassistant.components.number import (
     NumberEntityDescription,
 )
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -43,12 +44,14 @@ RELAY_ENTITIES = (
         key="soc_low",
         translation_key="cutoff_battery_level",
         device_class=NumberDeviceClass.BATTERY,
+        entity_category=EntityCategory.CONFIG,
         value_fn=lambda relay: relay.soc_low,
     ),
     EnvoyRelayNumberEntityDescription(
         key="soc_high",
         translation_key="resume_battery_level",
         device_class=NumberDeviceClass.BATTERY,
+        entity_category=EntityCategory.CONFIG,
         value_fn=lambda relay: relay.soc_high,
     ),
 )

--- a/homeassistant/components/enphase_envoy/number.py
+++ b/homeassistant/components/enphase_envoy/number.py
@@ -1,4 +1,4 @@
-"""Select platform for Enphase Envoy solar energy monitor."""
+"""Number platform for Enphase Envoy solar energy monitor."""
 from __future__ import annotations
 
 from collections.abc import Callable
@@ -89,7 +89,7 @@ class EnvoyRelayNumberEntity(EnvoyBaseEntity, NumberEntity):
         description: EnvoyRelayNumberEntityDescription,
         relay: str,
     ) -> None:
-        """Initialize the Enphase relay select entity."""
+        """Initialize the Enphase relay number entity."""
         super().__init__(coordinator, description)
         self.envoy = coordinator.envoy
         assert self.envoy is not None

--- a/homeassistant/components/enphase_envoy/strings.json
+++ b/homeassistant/components/enphase_envoy/strings.json
@@ -40,8 +40,8 @@
       "cutoff_battery_level": {
         "name": "Cutoff battery level"
       },
-      "resume_battery_level": {
-        "name": "Resume battery level"
+      "restore_battery_level": {
+        "name": "Restore battery level"
       }
     },
     "select": {

--- a/homeassistant/components/enphase_envoy/strings.json
+++ b/homeassistant/components/enphase_envoy/strings.json
@@ -36,6 +36,14 @@
         "name": "Grid status"
       }
     },
+    "number": {
+      "cutoff_battery_level": {
+        "name": "Cutoff battery level"
+      },
+      "resume_battery_level": {
+        "name": "Resume battery level"
+      }
+    },
     "select": {
       "relay_mode": {
         "name": "Mode",


### PR DESCRIPTION
## Proposed change
Adds a `number` platform to the Enphase Envoy integration, and includes two number entities for configuring the battery levels where a load shedding relay will shed the load and restore the load

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # 
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/28587

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
