### PR TITLE
Use asyncio.timeout [core]

### DIFF
--- a/homeassistant/components/bluetooth/scanner.py
+++ b/homeassistant/components/bluetooth/scanner.py
@@ -8,7 +8,6 @@ import logging
 import platform
 from typing import Any
 
-import async_timeout
 import bleak
 from bleak import BleakError
 from bleak.assigned_numbers import AdvertisementDataType
@@ -220,7 +219,7 @@ class HaScanner(BaseHaScanner):
                 START_ATTEMPTS,
             )
             try:
-                async with async_timeout.timeout(START_TIMEOUT):
+                async with asyncio.timeout(START_TIMEOUT):
                     await self.scanner.start()  # type: ignore[no-untyped-call]
             except InvalidMessageError as ex:
                 _LOGGER.debug(

--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -15,7 +15,6 @@ from random import SystemRandom
 from typing import Any, Final, cast, final
 
 from aiohttp import hdrs, web
-import async_timeout
 import attr
 import voluptuous as vol
 
@@ -168,7 +167,7 @@ async def _async_get_image(
     are handled.
     """
     with suppress(asyncio.CancelledError, asyncio.TimeoutError):
-        async with async_timeout.timeout(timeout):
+        async with asyncio.timeout(timeout):
             if image_bytes := await camera.async_camera_image(
                 width=width, height=height
             ):
@@ -525,7 +524,7 @@ class Camera(Entity):
             self._create_stream_lock = asyncio.Lock()
         async with self._create_stream_lock:
             if not self.stream:
-                async with async_timeout.timeout(CAMERA_STREAM_SOURCE_TIMEOUT):
+                async with asyncio.timeout(CAMERA_STREAM_SOURCE_TIMEOUT):
                     source = await self.stream_source()
                 if not source:
                     return None

--- a/homeassistant/components/cloud/alexa_config.py
+++ b/homeassistant/components/cloud/alexa_config.py
@@ -10,7 +10,6 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 import aiohttp
-import async_timeout
 from hass_nabucasa import Cloud, cloud_api
 from yarl import URL
 
@@ -501,7 +500,7 @@ class CloudAlexaConfig(alexa_config.AbstractConfig):
             )
 
         try:
-            async with async_timeout.timeout(10):
+            async with asyncio.timeout(10):
                 await asyncio.wait(tasks, return_when=asyncio.ALL_COMPLETED)
 
             return True

--- a/homeassistant/components/cloud/http_api.py
+++ b/homeassistant/components/cloud/http_api.py
@@ -10,7 +10,6 @@ from typing import Any, Concatenate, ParamSpec, TypeVar
 
 import aiohttp
 from aiohttp import web
-import async_timeout
 import attr
 from hass_nabucasa import Cloud, auth, thingtalk
 from hass_nabucasa.const import STATE_DISCONNECTED
@@ -252,7 +251,7 @@ class CloudLogoutView(HomeAssistantView):
         hass = request.app["hass"]
         cloud = hass.data[DOMAIN]
 
-        async with async_timeout.timeout(REQUEST_TIMEOUT):
+        async with asyncio.timeout(REQUEST_TIMEOUT):
             await cloud.logout()
 
         return self.json_message("ok")
@@ -292,7 +291,7 @@ class CloudRegisterView(HomeAssistantView):
             if location_info.zip_code is not None:
                 client_metadata["NC_ZIP_CODE"] = location_info.zip_code
 
-        async with async_timeout.timeout(REQUEST_TIMEOUT):
+        async with asyncio.timeout(REQUEST_TIMEOUT):
             await cloud.auth.async_register(
                 data["email"],
                 data["password"],
@@ -316,7 +315,7 @@ class CloudResendConfirmView(HomeAssistantView):
         hass = request.app["hass"]
         cloud = hass.data[DOMAIN]
 
-        async with async_timeout.timeout(REQUEST_TIMEOUT):
+        async with asyncio.timeout(REQUEST_TIMEOUT):
             await cloud.auth.async_resend_email_confirm(data["email"])
 
         return self.json_message("ok")
@@ -336,7 +335,7 @@ class CloudForgotPasswordView(HomeAssistantView):
         hass = request.app["hass"]
         cloud = hass.data[DOMAIN]
 
-        async with async_timeout.timeout(REQUEST_TIMEOUT):
+        async with asyncio.timeout(REQUEST_TIMEOUT):
             await cloud.auth.async_forgot_password(data["email"])
 
         return self.json_message("ok")
@@ -439,7 +438,7 @@ async def websocket_update_prefs(
     if changes.get(PREF_ALEXA_REPORT_STATE):
         alexa_config = await cloud.client.get_alexa_config()
         try:
-            async with async_timeout.timeout(10):
+            async with asyncio.timeout(10):
                 await alexa_config.async_get_access_token()
         except asyncio.TimeoutError:
             connection.send_error(
@@ -779,7 +778,7 @@ async def alexa_sync(
     cloud = hass.data[DOMAIN]
     alexa_config = await cloud.client.get_alexa_config()
 
-    async with async_timeout.timeout(10):
+    async with asyncio.timeout(10):
         try:
             success = await alexa_config.async_sync_entities()
         except alexa_errors.NoTokenAvailable:
@@ -808,7 +807,7 @@ async def thingtalk_convert(
     """Convert a query."""
     cloud = hass.data[DOMAIN]
 
-    async with async_timeout.timeout(10):
+    async with asyncio.timeout(10):
         try:
             connection.send_result(
                 msg["id"], await thingtalk.async_convert(cloud, msg["query"])

--- a/homeassistant/components/cloud/subscription.py
+++ b/homeassistant/components/cloud/subscription.py
@@ -6,7 +6,6 @@ import logging
 from typing import Any
 
 from aiohttp.client_exceptions import ClientError
-import async_timeout
 from hass_nabucasa import Cloud, cloud_api
 
 from .client import CloudClient
@@ -18,7 +17,7 @@ _LOGGER = logging.getLogger(__name__)
 async def async_subscription_info(cloud: Cloud[CloudClient]) -> dict[str, Any] | None:
     """Fetch the subscription info."""
     try:
-        async with async_timeout.timeout(REQUEST_TIMEOUT):
+        async with asyncio.timeout(REQUEST_TIMEOUT):
             return await cloud_api.async_subscription_info(cloud)
     except asyncio.TimeoutError:
         _LOGGER.error(
@@ -39,7 +38,7 @@ async def async_migrate_paypal_agreement(
 ) -> dict[str, Any] | None:
     """Migrate a paypal agreement from legacy."""
     try:
-        async with async_timeout.timeout(REQUEST_TIMEOUT):
+        async with asyncio.timeout(REQUEST_TIMEOUT):
             return await cloud_api.async_migrate_paypal_agreement(cloud)
     except asyncio.TimeoutError:
         _LOGGER.error(

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -12,7 +12,6 @@ import time
 from typing import TYPE_CHECKING, Any
 import uuid
 
-import async_timeout
 import attr
 import certifi
 
@@ -918,7 +917,7 @@ class MQTT:
         # may be executed first.
         await self._register_mid(mid)
         try:
-            async with async_timeout.timeout(TIMEOUT_ACK):
+            async with asyncio.timeout(TIMEOUT_ACK):
                 await self._pending_operations[mid].wait()
         except asyncio.TimeoutError:
             _LOGGER.warning(

--- a/homeassistant/components/mqtt/util.py
+++ b/homeassistant/components/mqtt/util.py
@@ -8,7 +8,6 @@ from pathlib import Path
 import tempfile
 from typing import Any
 
-import async_timeout
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntryState
@@ -71,7 +70,7 @@ async def async_wait_for_mqtt_client(hass: HomeAssistant) -> bool:
             return state_reached_future.result()
 
     try:
-        async with async_timeout.timeout(AVAILABILITY_TIMEOUT):
+        async with asyncio.timeout(AVAILABILITY_TIMEOUT):
             # Await the client setup or an error state was received
             return await state_reached_future
     except asyncio.TimeoutError:

--- a/homeassistant/components/recorder/core.py
+++ b/homeassistant/components/recorder/core.py
@@ -13,7 +13,6 @@ import threading
 import time
 from typing import Any, TypeVar, cast
 
-import async_timeout
 import psutil_home_assistant as ha_psutil
 from sqlalchemy import create_engine, event as sqlalchemy_event, exc, select
 from sqlalchemy.engine import Engine
@@ -1306,7 +1305,7 @@ class Recorder(threading.Thread):
         task = DatabaseLockTask(database_locked, threading.Event(), False)
         self.queue_task(task)
         try:
-            async with async_timeout.timeout(DB_LOCK_TIMEOUT):
+            async with asyncio.timeout(DB_LOCK_TIMEOUT):
                 await database_locked.wait()
         except asyncio.TimeoutError as err:
             task.database_unlock.set()

--- a/homeassistant/components/stream/core.py
+++ b/homeassistant/components/stream/core.py
@@ -10,7 +10,6 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from aiohttp import web
-import async_timeout
 import attr
 import numpy as np
 
@@ -332,7 +331,7 @@ class StreamOutput:
     async def part_recv(self, timeout: float | None = None) -> bool:
         """Wait for an event signalling the latest part segment."""
         try:
-            async with async_timeout.timeout(timeout):
+            async with asyncio.timeout(timeout):
                 await self._part_event.wait()
         except asyncio.TimeoutError:
             return False

--- a/homeassistant/components/system_health/__init__.py
+++ b/homeassistant/components/system_health/__init__.py
@@ -9,7 +9,6 @@ import logging
 from typing import Any
 
 import aiohttp
-import async_timeout
 import voluptuous as vol
 
 from homeassistant.components import websocket_api
@@ -73,7 +72,7 @@ async def get_integration_info(
     """Get integration system health."""
     try:
         assert registration.info_callback
-        async with async_timeout.timeout(INFO_CALLBACK_TIMEOUT):
+        async with asyncio.timeout(INFO_CALLBACK_TIMEOUT):
             data = await registration.info_callback(hass)
     except asyncio.TimeoutError:
         data = {"error": {"type": "failed", "error": "timeout"}}

--- a/homeassistant/components/websocket_api/http.py
+++ b/homeassistant/components/websocket_api/http.py
@@ -9,7 +9,6 @@ import logging
 from typing import TYPE_CHECKING, Any, Final
 
 from aiohttp import WSMsgType, web
-import async_timeout
 
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
@@ -273,7 +272,7 @@ class WebSocketHandler:
         logging_debug = logging.DEBUG
 
         try:
-            async with async_timeout.timeout(10):
+            async with asyncio.timeout(10):
                 await wsock.prepare(request)
         except asyncio.TimeoutError:
             self._logger.warning("Timeout preparing request from %s", request.remote)
@@ -302,7 +301,7 @@ class WebSocketHandler:
 
             # Auth Phase
             try:
-                async with async_timeout.timeout(10):
+                async with asyncio.timeout(10):
                     msg = await wsock.receive()
             except asyncio.TimeoutError as err:
                 disconnect_warn = "Did not receive auth message within 10 seconds"

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -29,7 +29,6 @@ from time import monotonic
 from typing import TYPE_CHECKING, Any, Generic, ParamSpec, Self, TypeVar, cast, overload
 from urllib.parse import urlparse
 
-import async_timeout
 import voluptuous as vol
 import yarl
 
@@ -806,7 +805,7 @@ class HomeAssistant:
             )
             task.cancel("Home Assistant stage 2 shutdown")
             try:
-                async with async_timeout.timeout(0.1):
+                async with asyncio.timeout(0.1):
                     await task
             except asyncio.CancelledError:
                 pass

--- a/homeassistant/helpers/aiohttp_client.py
+++ b/homeassistant/helpers/aiohttp_client.py
@@ -13,7 +13,6 @@ import aiohttp
 from aiohttp import web
 from aiohttp.hdrs import CONTENT_TYPE, USER_AGENT
 from aiohttp.web_exceptions import HTTPBadGateway, HTTPGatewayTimeout
-import async_timeout
 
 from homeassistant import config_entries
 from homeassistant.const import APPLICATION_NAME, EVENT_HOMEASSISTANT_CLOSE, __version__
@@ -170,7 +169,7 @@ async def async_aiohttp_proxy_web(
 ) -> web.StreamResponse | None:
     """Stream websession request to aiohttp web response."""
     try:
-        async with async_timeout.timeout(timeout):
+        async with asyncio.timeout(timeout):
             req = await web_coro
 
     except asyncio.CancelledError:
@@ -211,7 +210,7 @@ async def async_aiohttp_proxy_stream(
     # Suppressing something went wrong fetching data, closed connection
     with suppress(asyncio.TimeoutError, aiohttp.ClientError):
         while hass.is_running:
-            async with async_timeout.timeout(timeout):
+            async with asyncio.timeout(timeout):
                 data = await stream.read(buffer_size)
 
             if not data:

--- a/homeassistant/helpers/config_entry_oauth2_flow.py
+++ b/homeassistant/helpers/config_entry_oauth2_flow.py
@@ -16,7 +16,6 @@ import time
 from typing import Any, cast
 
 from aiohttp import client, web
-import async_timeout
 import jwt
 import voluptuous as vol
 from yarl import URL
@@ -287,7 +286,7 @@ class AbstractOAuth2FlowHandler(config_entries.ConfigFlow, metaclass=ABCMeta):
             return self.async_external_step_done(next_step_id=next_step)
 
         try:
-            async with async_timeout.timeout(OAUTH_AUTHORIZE_URL_TIMEOUT_SEC):
+            async with asyncio.timeout(OAUTH_AUTHORIZE_URL_TIMEOUT_SEC):
                 url = await self.async_generate_authorize_url()
         except asyncio.TimeoutError as err:
             _LOGGER.error("Timeout generating authorize url: %s", err)
@@ -311,7 +310,7 @@ class AbstractOAuth2FlowHandler(config_entries.ConfigFlow, metaclass=ABCMeta):
         _LOGGER.debug("Creating config entry from external data")
 
         try:
-            async with async_timeout.timeout(OAUTH_TOKEN_TIMEOUT_SEC):
+            async with asyncio.timeout(OAUTH_TOKEN_TIMEOUT_SEC):
                 token = await self.flow_impl.async_resolve_external_data(
                     self.external_data
                 )

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -601,9 +601,10 @@ class _ScriptRun:
         @callback
         def async_script_wait(entity_id, from_s, to_s):
             """Handle script after template condition is true."""
+            # pylint: disable=protected-access
             wait_var = self._variables["wait"]
-            if to_context and to_context.deadline:
-                wait_var["remaining"] = to_context.deadline - self._hass.loop.time()
+            if to_context and to_context._when:
+                wait_var["remaining"] = to_context._when - self._hass.loop.time()
             else:
                 wait_var["remaining"] = timeout
             wait_var["completed"] = True
@@ -970,9 +971,10 @@ class _ScriptRun:
         done = asyncio.Event()
 
         async def async_done(variables, context=None):
+            # pylint: disable=protected-access
             wait_var = self._variables["wait"]
-            if to_context and to_context.deadline:
-                wait_var["remaining"] = to_context.deadline - self._hass.loop.time()
+            if to_context and to_context._when:
+                wait_var["remaining"] = to_context._when - self._hass.loop.time()
             else:
                 wait_var["remaining"] = timeout
             wait_var["trigger"] = variables["trigger"]

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -13,7 +13,6 @@ import logging
 from types import MappingProxyType
 from typing import Any, TypedDict, TypeVar, cast
 
-import async_timeout
 import voluptuous as vol
 
 from homeassistant import exceptions
@@ -574,7 +573,7 @@ class _ScriptRun:
         self._changed()
         trace_set_result(delay=delay, done=False)
         try:
-            async with async_timeout.timeout(delay):
+            async with asyncio.timeout(delay):
                 await self._stop.wait()
         except asyncio.TimeoutError:
             trace_set_result(delay=delay, done=True)
@@ -621,7 +620,7 @@ class _ScriptRun:
             self._hass.async_create_task(flag.wait()) for flag in (self._stop, done)
         ]
         try:
-            async with async_timeout.timeout(timeout) as to_context:
+            async with asyncio.timeout(timeout) as to_context:
                 await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
         except asyncio.TimeoutError as ex:
             self._variables["wait"]["remaining"] = 0.0
@@ -1000,7 +999,7 @@ class _ScriptRun:
             self._hass.async_create_task(flag.wait()) for flag in (self._stop, done)
         ]
         try:
-            async with async_timeout.timeout(timeout) as to_context:
+            async with asyncio.timeout(timeout) as to_context:
                 await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
         except asyncio.TimeoutError as ex:
             self._variables["wait"]["remaining"] = 0.0

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -34,7 +34,6 @@ from typing import (
 from urllib.parse import urlencode as urllib_urlencode
 import weakref
 
-import async_timeout
 from awesomeversion import AwesomeVersion
 import jinja2
 from jinja2 import pass_context, pass_environment, pass_eval_context
@@ -651,7 +650,7 @@ class Template:
         try:
             template_render_thread = ThreadWithException(target=_render_template)
             template_render_thread.start()
-            async with async_timeout.timeout(timeout):
+            async with asyncio.timeout(timeout):
                 await finish_event.wait()
             if self._exc_info:
                 raise TemplateError(self._exc_info[1].with_traceback(self._exc_info[2]))

--- a/tests/components/group/test_cover.py
+++ b/tests/components/group/test_cover.py
@@ -1,7 +1,7 @@
 """The tests for the group cover platform."""
+import asyncio
 from datetime import timedelta
 
-import async_timeout
 import pytest
 
 from homeassistant.components.cover import (
@@ -828,7 +828,7 @@ async def test_nested_group(hass: HomeAssistant) -> None:
     assert state.attributes.get(ATTR_ENTITY_ID) == ["cover.bedroom_group"]
 
     # Test controlling the nested group
-    async with async_timeout.timeout(0.5):
+    async with asyncio.timeout(0.5):
         await hass.services.async_call(
             DOMAIN,
             SERVICE_CLOSE_COVER,

--- a/tests/components/group/test_fan.py
+++ b/tests/components/group/test_fan.py
@@ -1,7 +1,7 @@
 """The tests for the group fan platform."""
+import asyncio
 from unittest.mock import patch
 
-import async_timeout
 import pytest
 
 from homeassistant import config as hass_config
@@ -576,7 +576,7 @@ async def test_nested_group(hass: HomeAssistant) -> None:
     assert state.attributes.get(ATTR_ENTITY_ID) == ["fan.bedroom_group"]
 
     # Test controlling the nested group
-    async with async_timeout.timeout(0.5):
+    async with asyncio.timeout(0.5):
         await hass.services.async_call(
             DOMAIN,
             SERVICE_TURN_ON,

--- a/tests/components/group/test_light.py
+++ b/tests/components/group/test_light.py
@@ -1,7 +1,7 @@
 """The tests for the Group Light platform."""
+import asyncio
 from unittest.mock import MagicMock, patch
 
-import async_timeout
 import pytest
 
 from homeassistant import config as hass_config
@@ -1643,7 +1643,7 @@ async def test_nested_group(hass: HomeAssistant) -> None:
     assert state.attributes.get(ATTR_ENTITY_ID) == ["light.bedroom_group"]
 
     # Test controlling the nested group
-    async with async_timeout.timeout(0.5):
+    async with asyncio.timeout(0.5):
         await hass.services.async_call(
             LIGHT_DOMAIN,
             SERVICE_TOGGLE,

--- a/tests/components/group/test_media_player.py
+++ b/tests/components/group/test_media_player.py
@@ -1,7 +1,7 @@
 """The tests for the Media group platform."""
+import asyncio
 from unittest.mock import Mock, patch
 
-import async_timeout
 import pytest
 
 from homeassistant.components.group import DOMAIN
@@ -583,7 +583,7 @@ async def test_nested_group(hass: HomeAssistant) -> None:
     assert state.attributes.get(ATTR_ENTITY_ID) == ["media_player.group_1"]
 
     # Test controlling the nested group
-    async with async_timeout.timeout(0.5):
+    async with asyncio.timeout(0.5):
         await hass.services.async_call(
             MEDIA_DOMAIN,
             SERVICE_TURN_OFF,

--- a/tests/components/group/test_switch.py
+++ b/tests/components/group/test_switch.py
@@ -1,7 +1,6 @@
 """The tests for the Group Switch platform."""
+import asyncio
 from unittest.mock import patch
-
-import async_timeout
 
 from homeassistant import config as hass_config
 from homeassistant.components.group import DOMAIN, SERVICE_RELOAD
@@ -445,7 +444,7 @@ async def test_nested_group(hass: HomeAssistant) -> None:
     assert state.attributes.get(ATTR_ENTITY_ID) == ["switch.some_group"]
 
     # Test controlling the nested group
-    async with async_timeout.timeout(0.5):
+    async with asyncio.timeout(0.5):
         await hass.services.async_call(
             SWITCH_DOMAIN,
             SERVICE_TOGGLE,

--- a/tests/components/history/test_websocket_api.py
+++ b/tests/components/history/test_websocket_api.py
@@ -4,7 +4,6 @@ import asyncio
 from datetime import timedelta
 from unittest.mock import patch
 
-import async_timeout
 from freezegun import freeze_time
 import pytest
 
@@ -560,12 +559,12 @@ async def test_history_stream_significant_domain_historical_only(
             "no_attributes": True,
         }
     )
-    async with async_timeout.timeout(3):
+    async with asyncio.timeout(3):
         response = await client.receive_json()
     assert response["success"]
     assert response["id"] == 1
     assert response["type"] == "result"
-    async with async_timeout.timeout(3):
+    async with asyncio.timeout(3):
         response = await client.receive_json()
     assert response == {
         "event": {
@@ -591,13 +590,13 @@ async def test_history_stream_significant_domain_historical_only(
             "minimal_response": True,
         }
     )
-    async with async_timeout.timeout(3):
+    async with asyncio.timeout(3):
         response = await client.receive_json()
     assert response["success"]
     assert response["id"] == 2
     assert response["type"] == "result"
 
-    async with async_timeout.timeout(3):
+    async with asyncio.timeout(3):
         response = await client.receive_json()
     sensor_test_history = response["event"]["states"]["climate.test"]
     assert len(sensor_test_history) == 5
@@ -626,13 +625,13 @@ async def test_history_stream_significant_domain_historical_only(
             "no_attributes": False,
         }
     )
-    async with async_timeout.timeout(3):
+    async with asyncio.timeout(3):
         response = await client.receive_json()
     assert response["success"]
     assert response["id"] == 3
     assert response["type"] == "result"
 
-    async with async_timeout.timeout(3):
+    async with asyncio.timeout(3):
         response = await client.receive_json()
     sensor_test_history = response["event"]["states"]["climate.test"]
 
@@ -663,13 +662,13 @@ async def test_history_stream_significant_domain_historical_only(
             "no_attributes": False,
         }
     )
-    async with async_timeout.timeout(3):
+    async with asyncio.timeout(3):
         response = await client.receive_json()
     assert response["success"]
     assert response["id"] == 4
     assert response["type"] == "result"
 
-    async with async_timeout.timeout(3):
+    async with asyncio.timeout(3):
         response = await client.receive_json()
     sensor_test_history = response["event"]["states"]["climate.test"]
 
@@ -708,13 +707,13 @@ async def test_history_stream_significant_domain_historical_only(
             "no_attributes": False,
         }
     )
-    async with async_timeout.timeout(3):
+    async with asyncio.timeout(3):
         response = await client.receive_json()
     assert response["success"]
     assert response["id"] == 5
     assert response["type"] == "result"
 
-    async with async_timeout.timeout(3):
+    async with asyncio.timeout(3):
         response = await client.receive_json()
     sensor_test_history = response["event"]["states"]["climate.test"]
 

--- a/tests/components/websocket_api/test_commands.py
+++ b/tests/components/websocket_api/test_commands.py
@@ -1,9 +1,9 @@
 """Tests for WebSocket API commands."""
+import asyncio
 from copy import deepcopy
 import datetime
 from unittest.mock import ANY, AsyncMock, Mock, patch
 
-from async_timeout import timeout
 import pytest
 import voluptuous as vol
 
@@ -497,7 +497,7 @@ async def test_subscribe_unsubscribe_events(
     hass.bus.async_fire("test_event", {"hello": "world"})
     hass.bus.async_fire("ignore_event")
 
-    async with timeout(3):
+    async with asyncio.timeout(3):
         msg = await websocket_client.receive_json()
 
     assert msg["id"] == 5
@@ -712,7 +712,7 @@ async def test_subscribe_unsubscribe_events_whitelist(
 
     hass.bus.async_fire("themes_updated")
 
-    async with timeout(3):
+    async with asyncio.timeout(3):
         msg = await websocket_client.receive_json()
 
     assert msg["id"] == 6
@@ -1611,7 +1611,7 @@ async def test_subscribe_trigger(hass: HomeAssistant, websocket_client) -> None:
     hass.bus.async_fire("test_event", {"hello": "world"}, context=context)
     hass.bus.async_fire("ignore_event")
 
-    async with timeout(3):
+    async with asyncio.timeout(3):
         msg = await websocket_client.receive_json()
 
     assert msg["id"] == 5

--- a/tests/helpers/test_config_entry_oauth2_flow.py
+++ b/tests/helpers/test_config_entry_oauth2_flow.py
@@ -140,7 +140,7 @@ async def test_abort_if_authorization_timeout(
     flow.hass = hass
 
     with patch(
-        "homeassistant.helpers.config_entry_oauth2_flow.async_timeout.timeout",
+        "homeassistant.helpers.config_entry_oauth2_flow.asyncio.timeout",
         side_effect=asyncio.TimeoutError,
     ):
         result = await flow.async_step_user()
@@ -331,7 +331,7 @@ async def test_abort_on_oauth_timeout_error(
     assert resp.headers["content-type"] == "text/html; charset=utf-8"
 
     with patch(
-        "homeassistant.helpers.config_entry_oauth2_flow.async_timeout.timeout",
+        "homeassistant.helpers.config_entry_oauth2_flow.asyncio.timeout",
         side_effect=asyncio.TimeoutError,
     ):
         result = await hass.config_entries.flow.async_configure(result["flow_id"])

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -8,7 +8,6 @@ from unittest.mock import patch
 
 from astral import LocationInfo
 import astral.sun
-import async_timeout
 from freezegun import freeze_time
 from freezegun.api import FrozenDateTimeFactory
 import jinja2
@@ -4361,7 +4360,7 @@ async def test_call_later(hass: HomeAssistant) -> None:
 
     async_fire_time_changed_exact(hass, dt_util.utcnow() + timedelta(seconds=delay))
 
-    async with async_timeout.timeout(delay + delay_tolerance):
+    async with asyncio.timeout(delay + delay_tolerance):
         assert await future, "callback was called but the delay was wrong"
 
 
@@ -4381,7 +4380,7 @@ async def test_async_call_later(hass: HomeAssistant) -> None:
 
     async_fire_time_changed_exact(hass, dt_util.utcnow() + timedelta(seconds=delay))
 
-    async with async_timeout.timeout(delay + delay_tolerance):
+    async with asyncio.timeout(delay + delay_tolerance):
         assert await future, "callback was called but the delay was wrong"
     assert isinstance(remove, Callable)
     remove()
@@ -4403,7 +4402,7 @@ async def test_async_call_later_timedelta(hass: HomeAssistant) -> None:
 
     async_fire_time_changed_exact(hass, dt_util.utcnow() + timedelta(seconds=delay))
 
-    async with async_timeout.timeout(delay + delay_tolerance):
+    async with asyncio.timeout(delay + delay_tolerance):
         assert await future, "callback was called but the delay was wrong"
     assert isinstance(remove, Callable)
     remove()
@@ -4430,7 +4429,7 @@ async def test_async_call_later_cancel(hass: HomeAssistant) -> None:
     async_fire_time_changed_exact(hass, dt_util.utcnow() + timedelta(seconds=delay))
 
     with contextlib.suppress(asyncio.TimeoutError):
-        async with async_timeout.timeout(delay + delay_tolerance):
+        async with asyncio.timeout(delay + delay_tolerance):
             assert await future, "callback not canceled"
 
 

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -9,7 +9,6 @@ from types import MappingProxyType
 from unittest import mock
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from async_timeout import timeout
 import pytest
 import voluptuous as vol
 
@@ -1000,7 +999,7 @@ async def test_wait_basic_times_out(hass: HomeAssistant, action_type) -> None:
         assert script_obj.last_action == wait_alias
         hass.states.async_set("switch.test", "not_on")
 
-        async with timeout(0.1):
+        async with asyncio.timeout(0.1):
             await hass.async_block_till_done()
     except asyncio.TimeoutError:
         timed_out = True
@@ -1386,7 +1385,7 @@ async def test_wait_template_with_utcnow_no_match(hass: HomeAssistant) -> None:
         ):
             async_fire_time_changed(hass, second_non_matching_time)
 
-        async with timeout(0.1):
+        async with asyncio.timeout(0.1):
             await hass.async_block_till_done()
     except asyncio.TimeoutError:
         timed_out = True

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -14,7 +14,6 @@ import time
 from typing import Any
 from unittest.mock import MagicMock, Mock, PropertyMock, patch
 
-import async_timeout
 import pytest
 import voluptuous as vol
 
@@ -235,7 +234,7 @@ async def test_async_get_hass_can_be_called(hass: HomeAssistant) -> None:
         assert can_call_async_get_hass()
 
     hass.async_create_task(_async_create_task(), "create_task")
-    async with async_timeout.timeout(1):
+    async with asyncio.timeout(1):
         await task_finished.wait()
     task_finished.clear()
 
@@ -246,7 +245,7 @@ async def test_async_get_hass_can_be_called(hass: HomeAssistant) -> None:
         task_finished.set()
 
     hass.async_add_job(_add_job)
-    async with async_timeout.timeout(1):
+    async with asyncio.timeout(1):
         await task_finished.wait()
     task_finished.clear()
 
@@ -263,7 +262,7 @@ async def test_async_get_hass_can_be_called(hass: HomeAssistant) -> None:
         hass.async_add_job(_callback)
 
     _schedule_callback_from_callback()
-    async with async_timeout.timeout(1):
+    async with asyncio.timeout(1):
         await task_finished.wait()
     task_finished.clear()
 
@@ -279,7 +278,7 @@ async def test_async_get_hass_can_be_called(hass: HomeAssistant) -> None:
         hass.async_add_job(_coroutine())
 
     _schedule_coroutine_from_callback()
-    async with async_timeout.timeout(1):
+    async with asyncio.timeout(1):
         await task_finished.wait()
     task_finished.clear()
 
@@ -295,7 +294,7 @@ async def test_async_get_hass_can_be_called(hass: HomeAssistant) -> None:
         hass.async_add_job(_callback)
 
     await _schedule_callback_from_coroutine()
-    async with async_timeout.timeout(1):
+    async with asyncio.timeout(1):
         await task_finished.wait()
     task_finished.clear()
 
@@ -310,7 +309,7 @@ async def test_async_get_hass_can_be_called(hass: HomeAssistant) -> None:
         await hass.async_create_task(_coroutine())
 
     await _schedule_callback_from_coroutine()
-    async with async_timeout.timeout(1):
+    async with asyncio.timeout(1):
         await task_finished.wait()
     task_finished.clear()
 
@@ -326,7 +325,7 @@ async def test_async_get_hass_can_be_called(hass: HomeAssistant) -> None:
         hass.add_job(_async_add_job)
 
     await hass.async_add_executor_job(_async_add_executor_job_add_job)
-    async with async_timeout.timeout(1):
+    async with asyncio.timeout(1):
         await task_finished.wait()
     task_finished.clear()
 
@@ -341,7 +340,7 @@ async def test_async_get_hass_can_be_called(hass: HomeAssistant) -> None:
         hass.create_task(_async_create_task())
 
     await hass.async_add_executor_job(_async_add_executor_job_create_task)
-    async with async_timeout.timeout(1):
+    async with asyncio.timeout(1):
         await task_finished.wait()
     task_finished.clear()
 
@@ -359,7 +358,7 @@ async def test_async_get_hass_can_be_called(hass: HomeAssistant) -> None:
 
     my_job_add_job = MyJobAddJob()
     my_job_add_job.start()
-    async with async_timeout.timeout(1):
+    async with asyncio.timeout(1):
         await task_finished.wait()
     task_finished.clear()
     my_job_add_job.join()
@@ -377,7 +376,7 @@ async def test_async_get_hass_can_be_called(hass: HomeAssistant) -> None:
 
     my_job_create_task = MyJobCreateTask()
     my_job_create_task.start()
-    async with async_timeout.timeout(1):
+    async with asyncio.timeout(1):
         await task_finished.wait()
     task_finished.clear()
     my_job_create_task.join()


### PR DESCRIPTION
## Proposed change
Replace `async_timeout.timeout` with `asyncio.timeout`.
Based on #98415 by @bdraco

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
