### PR TITLE
Use asyncio.timeout [i-n]

### DIFF
--- a/homeassistant/components/ialarm/__init__.py
+++ b/homeassistant/components/ialarm/__init__.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import asyncio
 import logging
 
-from async_timeout import timeout
 from pyialarm import IAlarm
 
 from homeassistant.components.alarm_control_panel import SCAN_INTERVAL
@@ -27,7 +26,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     ialarm = IAlarm(host, port)
 
     try:
-        async with timeout(10):
+        async with asyncio.timeout(10):
             mac = await hass.async_add_executor_job(ialarm.get_mac)
     except (asyncio.TimeoutError, ConnectionError) as ex:
         raise ConfigEntryNotReady from ex
@@ -81,7 +80,7 @@ class IAlarmDataUpdateCoordinator(DataUpdateCoordinator[None]):
     async def _async_update_data(self) -> None:
         """Fetch data from iAlarm."""
         try:
-            async with timeout(10):
+            async with asyncio.timeout(10):
                 await self.hass.async_add_executor_job(self._update_data)
         except ConnectionError as error:
             raise UpdateFailed(error) from error

--- a/homeassistant/components/iammeter/sensor.py
+++ b/homeassistant/components/iammeter/sensor.py
@@ -5,7 +5,6 @@ import asyncio
 from datetime import timedelta
 import logging
 
-import async_timeout
 from iammeter import real_time_api
 from iammeter.power_meter import IamMeterError
 import voluptuous as vol
@@ -52,7 +51,7 @@ async def async_setup_platform(
     config_port = config[CONF_PORT]
     config_name = config[CONF_NAME]
     try:
-        async with async_timeout.timeout(PLATFORM_TIMEOUT):
+        async with asyncio.timeout(PLATFORM_TIMEOUT):
             api = await real_time_api(config_host, config_port)
     except (IamMeterError, asyncio.TimeoutError) as err:
         _LOGGER.error("Device is not ready")
@@ -60,7 +59,7 @@ async def async_setup_platform(
 
     async def async_update_data():
         try:
-            async with async_timeout.timeout(PLATFORM_TIMEOUT):
+            async with asyncio.timeout(PLATFORM_TIMEOUT):
                 return await api.get_data()
         except (IamMeterError, asyncio.TimeoutError) as err:
             raise UpdateFailed from err

--- a/homeassistant/components/image/__init__.py
+++ b/homeassistant/components/image/__init__.py
@@ -11,7 +11,6 @@ from random import SystemRandom
 from typing import Final, final
 
 from aiohttp import hdrs, web
-import async_timeout
 import httpx
 
 from homeassistant.components.http import KEY_AUTHENTICATED, HomeAssistantView
@@ -72,7 +71,7 @@ def valid_image_content_type(content_type: str | None) -> str:
 async def _async_get_image(image_entity: ImageEntity, timeout: int) -> Image:
     """Fetch image from an image entity."""
     with suppress(asyncio.CancelledError, asyncio.TimeoutError, ImageContentTypeError):
-        async with async_timeout.timeout(timeout):
+        async with asyncio.timeout(timeout):
             if image_bytes := await image_entity.async_image():
                 content_type = valid_image_content_type(image_entity.content_type)
                 image = Image(content_type, image_bytes)

--- a/homeassistant/components/imap/coordinator.py
+++ b/homeassistant/components/imap/coordinator.py
@@ -11,7 +11,6 @@ import logging
 from typing import Any
 
 from aioimaplib import AUTH, IMAP4_SSL, NONAUTH, SELECTED, AioImapException
-import async_timeout
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -408,7 +407,7 @@ class ImapPushDataUpdateCoordinator(ImapDataUpdateCoordinator):
                 idle: asyncio.Future = await self.imap_client.idle_start()
                 await self.imap_client.wait_server_push()
                 self.imap_client.idle_done()
-                async with async_timeout.timeout(10):
+                async with asyncio.timeout(10):
                     await idle
 
             # From python 3.11 asyncio.TimeoutError is an alias of TimeoutError

--- a/homeassistant/components/intellifire/coordinator.py
+++ b/homeassistant/components/intellifire/coordinator.py
@@ -1,10 +1,10 @@
 """The IntelliFire integration."""
 from __future__ import annotations
 
+import asyncio
 from datetime import timedelta
 
 from aiohttp import ClientConnectionError
-from async_timeout import timeout
 from intellifire4py import IntellifirePollData
 from intellifire4py.intellifire import IntellifireAPILocal
 
@@ -38,7 +38,7 @@ class IntellifireDataUpdateCoordinator(DataUpdateCoordinator[IntellifirePollData
             await self._api.start_background_polling()
 
             # Don't return uninitialized poll data
-            async with timeout(15):
+            async with asyncio.timeout(15):
                 try:
                     await self._api.poll()
                 except (ConnectionError, ClientConnectionError) as exception:

--- a/homeassistant/components/ipma/__init__.py
+++ b/homeassistant/components/ipma/__init__.py
@@ -2,7 +2,6 @@
 import asyncio
 import logging
 
-import async_timeout
 from pyipma import IPMAException
 from pyipma.api import IPMA_API
 from pyipma.location import Location
@@ -32,7 +31,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     api = IPMA_API(async_get_clientsession(hass))
 
     try:
-        async with async_timeout.timeout(30):
+        async with asyncio.timeout(30):
             location = await Location.get(api, float(latitude), float(longitude))
     except (IPMAException, asyncio.TimeoutError) as err:
         raise ConfigEntryNotReady(

--- a/homeassistant/components/ipma/sensor.py
+++ b/homeassistant/components/ipma/sensor.py
@@ -1,11 +1,11 @@
 """Support for IPMA sensors."""
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 import logging
 
-import async_timeout
 from pyipma.api import IPMA_API
 from pyipma.location import Location
 
@@ -83,7 +83,7 @@ class IPMASensor(SensorEntity, IPMADevice):
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     async def async_update(self) -> None:
         """Update Fire risk."""
-        async with async_timeout.timeout(10):
+        async with asyncio.timeout(10):
             self._attr_native_value = await self.entity_description.value_fn(
                 self._location, self._api
             )

--- a/homeassistant/components/ipma/weather.py
+++ b/homeassistant/components/ipma/weather.py
@@ -6,7 +6,6 @@ import contextlib
 import logging
 from typing import Literal
 
-import async_timeout
 from pyipma.api import IPMA_API
 from pyipma.forecast import Forecast as IPMAForecast
 from pyipma.location import Location
@@ -91,7 +90,7 @@ class IPMAWeather(WeatherEntity, IPMADevice):
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     async def async_update(self) -> None:
         """Update Condition and Forecast."""
-        async with async_timeout.timeout(10):
+        async with asyncio.timeout(10):
             new_observation = await self._location.observation(self._api)
 
             if new_observation:
@@ -225,7 +224,7 @@ class IPMAWeather(WeatherEntity, IPMADevice):
     ) -> None:
         """Try to update weather forecast."""
         with contextlib.suppress(asyncio.TimeoutError):
-            async with async_timeout.timeout(10):
+            async with asyncio.timeout(10):
                 await self._update_forecast(forecast_type, period, False)
 
     async def async_forecast_daily(self) -> list[Forecast]:

--- a/homeassistant/components/isy994/__init__.py
+++ b/homeassistant/components/isy994/__init__.py
@@ -5,7 +5,6 @@ import asyncio
 from urllib.parse import urlparse
 
 from aiohttp import CookieJar
-import async_timeout
 from pyisy import ISY, ISYConnectionError, ISYInvalidAuthError, ISYResponseParseError
 from pyisy.constants import CONFIG_NETWORKING, CONFIG_PORTAL
 import voluptuous as vol
@@ -101,7 +100,7 @@ async def async_setup_entry(
     )
 
     try:
-        async with async_timeout.timeout(60):
+        async with asyncio.timeout(60):
             await isy.initialize()
     except asyncio.TimeoutError as err:
         raise ConfigEntryNotReady(

--- a/homeassistant/components/isy994/config_flow.py
+++ b/homeassistant/components/isy994/config_flow.py
@@ -1,13 +1,13 @@
 """Config flow for Universal Devices ISY/IoX integration."""
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Mapping
 import logging
 from typing import Any
 from urllib.parse import urlparse, urlunparse
 
 from aiohttp import CookieJar
-import async_timeout
 from pyisy import ISYConnectionError, ISYInvalidAuthError, ISYResponseParseError
 from pyisy.configuration import Configuration
 from pyisy.connection import Connection
@@ -97,7 +97,7 @@ async def validate_input(
     )
 
     try:
-        async with async_timeout.timeout(30):
+        async with asyncio.timeout(30):
             isy_conf_xml = await isy_conn.test_connection()
     except ISYInvalidAuthError as error:
         raise InvalidAuth from error

--- a/homeassistant/components/izone/config_flow.py
+++ b/homeassistant/components/izone/config_flow.py
@@ -4,8 +4,6 @@ import asyncio
 from contextlib import suppress
 import logging
 
-from async_timeout import timeout
-
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_entry_flow
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -28,7 +26,7 @@ async def _async_has_devices(hass: HomeAssistant) -> bool:
     disco = await async_start_discovery_service(hass)
 
     with suppress(asyncio.TimeoutError):
-        async with timeout(TIMEOUT_DISCOVERY):
+        async with asyncio.timeout(TIMEOUT_DISCOVERY):
             await controller_ready.wait()
 
     if not disco.pi_disco.controllers:

--- a/homeassistant/components/kaiterra/api_data.py
+++ b/homeassistant/components/kaiterra/api_data.py
@@ -3,7 +3,6 @@ import asyncio
 from logging import getLogger
 
 from aiohttp.client_exceptions import ClientConnectorError, ClientResponseError
-import async_timeout
 from kaiterra_async_client import AQIStandard, KaiterraAPIClient, Units
 
 from homeassistant.const import CONF_API_KEY, CONF_DEVICE_ID, CONF_DEVICES, CONF_TYPE
@@ -53,7 +52,7 @@ class KaiterraApiData:
         """Get the data from Kaiterra API."""
 
         try:
-            async with async_timeout.timeout(10):
+            async with asyncio.timeout(10):
                 data = await self._api.get_latest_sensor_readings(self._devices)
         except (ClientResponseError, ClientConnectorError, asyncio.TimeoutError) as err:
             _LOGGER.debug("Couldn't fetch data from Kaiterra API: %s", err)

--- a/homeassistant/components/kmtronic/__init__.py
+++ b/homeassistant/components/kmtronic/__init__.py
@@ -1,9 +1,9 @@
 """The kmtronic integration."""
+import asyncio
 from datetime import timedelta
 import logging
 
 import aiohttp
-import async_timeout
 from pykmtronic.auth import Auth
 from pykmtronic.hub import KMTronicHubAPI
 
@@ -33,7 +33,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     async def async_update_data():
         try:
-            async with async_timeout.timeout(10):
+            async with asyncio.timeout(10):
                 await hub.async_update_relays()
         except aiohttp.client_exceptions.ClientResponseError as err:
             raise UpdateFailed(f"Wrong credentials: {err}") from err

--- a/homeassistant/components/kraken/__init__.py
+++ b/homeassistant/components/kraken/__init__.py
@@ -5,7 +5,6 @@ import asyncio
 from datetime import timedelta
 import logging
 
-import async_timeout
 import krakenex
 import pykrakenapi
 
@@ -73,7 +72,7 @@ class KrakenData:
         once.
         """
         try:
-            async with async_timeout.timeout(10):
+            async with asyncio.timeout(10):
                 return await self._hass.async_add_executor_job(self._get_kraken_data)
         except pykrakenapi.pykrakenapi.KrakenAPIError as error:
             if "Unknown asset pair" in str(error):

--- a/homeassistant/components/landisgyr_heat_meter/config_flow.py
+++ b/homeassistant/components/landisgyr_heat_meter/config_flow.py
@@ -5,7 +5,6 @@ import asyncio
 import logging
 from typing import Any
 
-import async_timeout
 import serial
 from serial.tools import list_ports
 import ultraheat_api
@@ -105,7 +104,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         reader = ultraheat_api.UltraheatReader(port)
         heat_meter = ultraheat_api.HeatMeterService(reader)
         try:
-            async with async_timeout.timeout(ULTRAHEAT_TIMEOUT):
+            async with asyncio.timeout(ULTRAHEAT_TIMEOUT):
                 # validate and retrieve the model and device number for a unique id
                 data = await self.hass.async_add_executor_job(heat_meter.read)
 

--- a/homeassistant/components/landisgyr_heat_meter/coordinator.py
+++ b/homeassistant/components/landisgyr_heat_meter/coordinator.py
@@ -1,8 +1,8 @@
 """Data update coordinator for the ultraheat api."""
 
+import asyncio
 import logging
 
-import async_timeout
 import serial
 from ultraheat_api.response import HeatMeterResponse
 from ultraheat_api.service import HeatMeterService
@@ -31,7 +31,7 @@ class UltraheatCoordinator(DataUpdateCoordinator[HeatMeterResponse]):
     async def _async_update_data(self) -> HeatMeterResponse:
         """Fetch data from API endpoint."""
         try:
-            async with async_timeout.timeout(ULTRAHEAT_TIMEOUT):
+            async with asyncio.timeout(ULTRAHEAT_TIMEOUT):
                 return await self.hass.async_add_executor_job(self.api.read)
         except (FileNotFoundError, serial.serialutil.SerialException) as err:
             raise UpdateFailed(f"Error communicating with API: {err}") from err

--- a/homeassistant/components/laundrify/coordinator.py
+++ b/homeassistant/components/laundrify/coordinator.py
@@ -1,8 +1,8 @@
 """Custom DataUpdateCoordinator for the laundrify integration."""
+import asyncio
 from datetime import timedelta
 import logging
 
-import async_timeout
 from laundrify_aio import LaundrifyAPI
 from laundrify_aio.exceptions import ApiConnectionException, UnauthorizedException
 
@@ -36,7 +36,7 @@ class LaundrifyUpdateCoordinator(DataUpdateCoordinator[dict[str, LaundrifyDevice
         try:
             # Note: asyncio.TimeoutError and aiohttp.ClientError are already
             # handled by the data update coordinator.
-            async with async_timeout.timeout(REQUEST_TIMEOUT):
+            async with asyncio.timeout(REQUEST_TIMEOUT):
                 return {m["_id"]: m for m in await self.laundrify_api.get_machines()}
         except UnauthorizedException as err:
             # Raising ConfigEntryAuthFailed will cancel future updates

--- a/homeassistant/components/led_ble/__init__.py
+++ b/homeassistant/components/led_ble/__init__.py
@@ -5,7 +5,6 @@ import asyncio
 from datetime import timedelta
 import logging
 
-import async_timeout
 from led_ble import BLEAK_EXCEPTIONS, LEDBLE
 
 from homeassistant.components import bluetooth
@@ -78,7 +77,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         raise
 
     try:
-        async with async_timeout.timeout(DEVICE_TIMEOUT):
+        async with asyncio.timeout(DEVICE_TIMEOUT):
             await startup_event.wait()
     except asyncio.TimeoutError as ex:
         raise ConfigEntryNotReady(

--- a/homeassistant/components/lifx_cloud/scene.py
+++ b/homeassistant/components/lifx_cloud/scene.py
@@ -8,7 +8,6 @@ from typing import Any
 
 import aiohttp
 from aiohttp.hdrs import AUTHORIZATION
-import async_timeout
 import voluptuous as vol
 
 from homeassistant.components.scene import Scene
@@ -48,7 +47,7 @@ async def async_setup_platform(
 
     try:
         httpsession = async_get_clientsession(hass)
-        async with async_timeout.timeout(timeout):
+        async with asyncio.timeout(timeout):
             scenes_resp = await httpsession.get(url, headers=headers)
 
     except (asyncio.TimeoutError, aiohttp.ClientError):
@@ -90,7 +89,7 @@ class LifxCloudScene(Scene):
 
         try:
             httpsession = async_get_clientsession(self.hass)
-            async with async_timeout.timeout(self._timeout):
+            async with asyncio.timeout(self._timeout):
                 await httpsession.put(url, headers=self._headers)
 
         except (asyncio.TimeoutError, aiohttp.ClientError):

--- a/homeassistant/components/logi_circle/__init__.py
+++ b/homeassistant/components/logi_circle/__init__.py
@@ -2,7 +2,6 @@
 import asyncio
 
 from aiohttp.client_exceptions import ClientResponseError
-import async_timeout
 from logi_circle import LogiCircle
 from logi_circle.exception import AuthorizationFailed
 import voluptuous as vol
@@ -154,7 +153,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         return False
 
     try:
-        async with async_timeout.timeout(_TIMEOUT):
+        async with asyncio.timeout(_TIMEOUT):
             # Ensure the cameras property returns the same Camera objects for
             # all devices. Performs implicit login and session validation.
             await logi_circle.synchronize_cameras()

--- a/homeassistant/components/logi_circle/config_flow.py
+++ b/homeassistant/components/logi_circle/config_flow.py
@@ -3,7 +3,6 @@ import asyncio
 from collections import OrderedDict
 from http import HTTPStatus
 
-import async_timeout
 from logi_circle import LogiCircle
 from logi_circle.exception import AuthorizationFailed
 import voluptuous as vol
@@ -158,7 +157,7 @@ class LogiCircleFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
         try:
-            async with async_timeout.timeout(_TIMEOUT):
+            async with asyncio.timeout(_TIMEOUT):
                 await logi_session.authorize(code)
         except AuthorizationFailed:
             (self.hass.data[DATA_FLOW_IMPL][DOMAIN][EXTERNAL_ERRORS]) = "invalid_auth"

--- a/homeassistant/components/london_underground/sensor.py
+++ b/homeassistant/components/london_underground/sensor.py
@@ -1,10 +1,10 @@
 """Sensor for checking the status of London Underground tube lines."""
 from __future__ import annotations
 
+import asyncio
 from datetime import timedelta
 import logging
 
-import async_timeout
 from london_tube_status import TubeData
 import voluptuous as vol
 
@@ -90,7 +90,7 @@ class LondonTubeCoordinator(DataUpdateCoordinator):
         self._data = data
 
     async def _async_update_data(self):
-        async with async_timeout.timeout(10):
+        async with asyncio.timeout(10):
             await self._data.update()
             return self._data.data
 

--- a/homeassistant/components/loqed/coordinator.py
+++ b/homeassistant/components/loqed/coordinator.py
@@ -1,9 +1,9 @@
 """Provides the coordinator for a LOQED lock."""
+import asyncio
 import logging
 from typing import TypedDict
 
 from aiohttp.web import Request
-import async_timeout
 from loqedAPI import loqed
 
 from homeassistant.components import cloud, webhook
@@ -86,7 +86,7 @@ class LoqedDataCoordinator(DataUpdateCoordinator[StatusMessage]):
 
     async def _async_update_data(self) -> StatusMessage:
         """Fetch data from API endpoint."""
-        async with async_timeout.timeout(10):
+        async with asyncio.timeout(10):
             return await self._api.async_get_lock_details()
 
     async def _handle_webhook(

--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -8,7 +8,6 @@ import logging
 import ssl
 from typing import Any, cast
 
-import async_timeout
 from pylutron_caseta import BUTTON_STATUS_PRESSED
 from pylutron_caseta.smartbridge import Smartbridge
 import voluptuous as vol
@@ -173,7 +172,7 @@ async def async_setup_entry(
 
     timed_out = True
     with contextlib.suppress(asyncio.TimeoutError):
-        async with async_timeout.timeout(BRIDGE_TIMEOUT):
+        async with asyncio.timeout(BRIDGE_TIMEOUT):
             await bridge.connect()
             timed_out = False
 

--- a/homeassistant/components/lutron_caseta/config_flow.py
+++ b/homeassistant/components/lutron_caseta/config_flow.py
@@ -6,7 +6,6 @@ import logging
 import os
 import ssl
 
-import async_timeout
 from pylutron_caseta.pairing import PAIR_CA, PAIR_CERT, PAIR_KEY, async_pair
 from pylutron_caseta.smartbridge import Smartbridge
 import voluptuous as vol
@@ -226,7 +225,7 @@ class LutronCasetaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             return None
 
         try:
-            async with async_timeout.timeout(BRIDGE_TIMEOUT):
+            async with asyncio.timeout(BRIDGE_TIMEOUT):
                 await bridge.connect()
         except asyncio.TimeoutError:
             _LOGGER.error(

--- a/homeassistant/components/lyric/__init__.py
+++ b/homeassistant/components/lyric/__init__.py
@@ -1,6 +1,7 @@
 """The Honeywell Lyric integration."""
 from __future__ import annotations
 
+import asyncio
 from datetime import timedelta
 from http import HTTPStatus
 import logging
@@ -10,7 +11,6 @@ from aiolyric import Lyric
 from aiolyric.exceptions import LyricAuthenticationException, LyricException
 from aiolyric.objects.device import LyricDevice
 from aiolyric.objects.location import LyricLocation
-import async_timeout
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
@@ -74,7 +74,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             raise UpdateFailed(exception) from exception
 
         try:
-            async with async_timeout.timeout(60):
+            async with asyncio.timeout(60):
                 await lyric.get_locations()
             return lyric
         except LyricAuthenticationException as exception:

--- a/homeassistant/components/mailbox/__init__.py
+++ b/homeassistant/components/mailbox/__init__.py
@@ -10,7 +10,6 @@ from typing import Any, Final
 
 from aiohttp import web
 from aiohttp.web_exceptions import HTTPNotFound
-import async_timeout
 
 from homeassistant.components import frontend
 from homeassistant.components.http import HomeAssistantView
@@ -267,7 +266,7 @@ class MailboxMediaView(MailboxView):
         mailbox = self.get_mailbox(platform)
 
         with suppress(asyncio.CancelledError, asyncio.TimeoutError):
-            async with async_timeout.timeout(10):
+            async with asyncio.timeout(10):
                 try:
                     stream = await mailbox.async_get_media(msgid)
                 except StreamError as err:

--- a/homeassistant/components/matter/__init__.py
+++ b/homeassistant/components/matter/__init__.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import asyncio
 from contextlib import suppress
 
-import async_timeout
 from matter_server.client import MatterClient
 from matter_server.client.exceptions import CannotConnect, InvalidServerVersion
 from matter_server.common.errors import MatterError, NodeCommissionFailed, NodeNotExists
@@ -42,7 +41,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     matter_client = MatterClient(entry.data[CONF_URL], async_get_clientsession(hass))
     try:
-        async with async_timeout.timeout(CONNECT_TIMEOUT):
+        async with asyncio.timeout(CONNECT_TIMEOUT):
             await matter_client.connect()
     except (CannotConnect, asyncio.TimeoutError) as err:
         raise ConfigEntryNotReady("Failed to connect to matter server") from err
@@ -87,7 +86,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
 
     try:
-        async with async_timeout.timeout(LISTEN_READY_TIMEOUT):
+        async with asyncio.timeout(LISTEN_READY_TIMEOUT):
             await init_ready.wait()
     except asyncio.TimeoutError as err:
         listen_task.cancel()

--- a/homeassistant/components/mazda/__init__.py
+++ b/homeassistant/components/mazda/__init__.py
@@ -1,11 +1,11 @@
 """The Mazda Connected Services integration."""
 from __future__ import annotations
 
+import asyncio
 from datetime import timedelta
 import logging
 from typing import TYPE_CHECKING
 
-import async_timeout
 from pymazda import (
     Client as MazdaAPI,
     MazdaAccountLockedException,
@@ -53,7 +53,7 @@ PLATFORMS = [
 
 async def with_timeout(task, timeout_seconds=30):
     """Run an async task with a timeout."""
-    async with async_timeout.timeout(timeout_seconds):
+    async with asyncio.timeout(timeout_seconds):
         return await task
 
 

--- a/homeassistant/components/meater/__init__.py
+++ b/homeassistant/components/meater/__init__.py
@@ -1,8 +1,8 @@
 """The Meater Temperature Probe integration."""
+import asyncio
 from datetime import timedelta
 import logging
 
-import async_timeout
 from meater import (
     AuthenticationError,
     MeaterApi,
@@ -49,7 +49,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         try:
             # Note: asyncio.TimeoutError and aiohttp.ClientError are already
             # handled by the data update coordinator.
-            async with async_timeout.timeout(10):
+            async with asyncio.timeout(10):
                 devices: list[MeaterProbe] = await meater_api.get_all_devices()
         except AuthenticationError as err:
             raise ConfigEntryAuthFailed("The API call wasn't authenticated") from err

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -19,7 +19,6 @@ from urllib.parse import quote, urlparse
 from aiohttp import web
 from aiohttp.hdrs import CACHE_CONTROL, CONTENT_TYPE
 from aiohttp.typedefs import LooseHeaders
-import async_timeout
 import voluptuous as vol
 from yarl import URL
 
@@ -1259,7 +1258,7 @@ async def async_fetch_image(
     content, content_type = (None, None)
     websession = async_get_clientsession(hass)
     with suppress(asyncio.TimeoutError):
-        async with async_timeout.timeout(10):
+        async with asyncio.timeout(10):
             response = await websession.get(url)
             if response.status == HTTPStatus.OK:
                 content = await response.read()

--- a/homeassistant/components/melcloud/__init__.py
+++ b/homeassistant/components/melcloud/__init__.py
@@ -7,7 +7,6 @@ import logging
 from typing import Any
 
 from aiohttp import ClientConnectionError
-from async_timeout import timeout
 from pymelcloud import Device, get_devices
 import voluptuous as vol
 
@@ -152,7 +151,7 @@ async def mel_devices_setup(
     """Query connected devices from MELCloud."""
     session = async_get_clientsession(hass)
     try:
-        async with timeout(10):
+        async with asyncio.timeout(10):
             all_devices = await get_devices(
                 token,
                 session,

--- a/homeassistant/components/melcloud/config_flow.py
+++ b/homeassistant/components/melcloud/config_flow.py
@@ -5,7 +5,6 @@ import asyncio
 from http import HTTPStatus
 
 from aiohttp import ClientError, ClientResponseError
-from async_timeout import timeout
 import pymelcloud
 import voluptuous as vol
 
@@ -78,7 +77,7 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     ):
         """Create client."""
         try:
-            async with timeout(10):
+            async with asyncio.timeout(10):
                 if (acquired_token := token) is None:
                     acquired_token = await pymelcloud.login(
                         username,

--- a/homeassistant/components/microsoft_face/__init__.py
+++ b/homeassistant/components/microsoft_face/__init__.py
@@ -7,7 +7,6 @@ import logging
 
 import aiohttp
 from aiohttp.hdrs import CONTENT_TYPE
-import async_timeout
 import voluptuous as vol
 
 from homeassistant.components import camera
@@ -314,7 +313,7 @@ class MicrosoftFace:
                 payload = None
 
         try:
-            async with async_timeout.timeout(self.timeout):
+            async with asyncio.timeout(self.timeout):
                 response = await getattr(self.websession, method)(
                     url, data=payload, headers=headers, params=params
                 )

--- a/homeassistant/components/mjpeg/camera.py
+++ b/homeassistant/components/mjpeg/camera.py
@@ -7,7 +7,6 @@ from contextlib import suppress
 
 import aiohttp
 from aiohttp import web
-import async_timeout
 import httpx
 from yarl import URL
 
@@ -144,7 +143,7 @@ class MjpegCamera(Camera):
 
         websession = async_get_clientsession(self.hass, verify_ssl=self._verify_ssl)
         try:
-            async with async_timeout.timeout(TIMEOUT):
+            async with asyncio.timeout(TIMEOUT):
                 response = await websession.get(self._still_image_url, auth=self._auth)
 
                 image = await response.read()
@@ -206,7 +205,7 @@ class MjpegCamera(Camera):
                 async for chunk in stream.aiter_bytes(BUFFER_SIZE):
                     if not self.hass.is_running:
                         break
-                    async with async_timeout.timeout(TIMEOUT):
+                    async with asyncio.timeout(TIMEOUT):
                         await response.write(chunk)
         return response
 

--- a/homeassistant/components/mobile_app/notify.py
+++ b/homeassistant/components/mobile_app/notify.py
@@ -7,7 +7,6 @@ from http import HTTPStatus
 import logging
 
 import aiohttp
-import async_timeout
 
 from homeassistant.components.notify import (
     ATTR_DATA,
@@ -166,7 +165,7 @@ class MobileAppNotificationService(BaseNotificationService):
         target_data["registration_info"] = reg_info
 
         try:
-            async with async_timeout.timeout(10):
+            async with asyncio.timeout(10):
                 response = await async_get_clientsession(self._hass).post(
                     push_url, json=target_data
                 )

--- a/homeassistant/components/mullvad/__init__.py
+++ b/homeassistant/components/mullvad/__init__.py
@@ -1,8 +1,8 @@
 """The Mullvad VPN integration."""
+import asyncio
 from datetime import timedelta
 import logging
 
-import async_timeout
 from mullvad_api import MullvadAPI
 
 from homeassistant.config_entries import ConfigEntry
@@ -19,7 +19,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Mullvad VPN integration."""
 
     async def async_get_mullvad_api_data():
-        async with async_timeout.timeout(10):
+        async with asyncio.timeout(10):
             api = await hass.async_add_executor_job(MullvadAPI)
             return api.data
 

--- a/homeassistant/components/mutesync/__init__.py
+++ b/homeassistant/components/mutesync/__init__.py
@@ -1,9 +1,9 @@
 """The mütesync integration."""
 from __future__ import annotations
 
+import asyncio
 import logging
 
-import async_timeout
 import mutesync
 
 from homeassistant.config_entries import ConfigEntry
@@ -27,7 +27,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     async def update_data():
         """Update the data."""
-        async with async_timeout.timeout(2.5):
+        async with asyncio.timeout(2.5):
             state = await client.get_state()
 
             if state["muted"] is None or state["in_meeting"] is None:

--- a/homeassistant/components/mutesync/config_flow.py
+++ b/homeassistant/components/mutesync/config_flow.py
@@ -5,7 +5,6 @@ import asyncio
 from typing import Any
 
 import aiohttp
-import async_timeout
 import mutesync
 import voluptuous as vol
 
@@ -27,7 +26,7 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
     """
     session = async_get_clientsession(hass)
     try:
-        async with async_timeout.timeout(5):
+        async with asyncio.timeout(5):
             token = await mutesync.authenticate(session, data["host"])
     except aiohttp.ClientResponseError as error:
         if error.status == 403:

--- a/homeassistant/components/mysensors/gateway.py
+++ b/homeassistant/components/mysensors/gateway.py
@@ -9,7 +9,6 @@ import socket
 import sys
 from typing import Any
 
-import async_timeout
 from mysensors import BaseAsyncGateway, Message, Sensor, mysensors
 import voluptuous as vol
 
@@ -107,7 +106,7 @@ async def try_connect(
         connect_task = None
         try:
             connect_task = asyncio.create_task(gateway.start())
-            async with async_timeout.timeout(GATEWAY_READY_TIMEOUT):
+            async with asyncio.timeout(GATEWAY_READY_TIMEOUT):
                 await gateway_ready.wait()
                 return True
         except asyncio.TimeoutError:
@@ -299,7 +298,7 @@ async def _gw_start(
         # Gatways connected via mqtt doesn't send gateway ready message.
         return
     try:
-        async with async_timeout.timeout(GATEWAY_READY_TIMEOUT):
+        async with asyncio.timeout(GATEWAY_READY_TIMEOUT):
             await gateway_ready.wait()
     except asyncio.TimeoutError:
         _LOGGER.warning(

--- a/homeassistant/components/nam/__init__.py
+++ b/homeassistant/components/nam/__init__.py
@@ -6,7 +6,6 @@ import logging
 from typing import cast
 
 from aiohttp.client_exceptions import ClientConnectorError, ClientError
-import async_timeout
 from nettigo_air_monitor import (
     ApiError,
     AuthFailedError,
@@ -111,7 +110,7 @@ class NAMDataUpdateCoordinator(DataUpdateCoordinator[NAMSensors]):
     async def _async_update_data(self) -> NAMSensors:
         """Update data via library."""
         try:
-            async with async_timeout.timeout(10):
+            async with asyncio.timeout(10):
                 data = await self.nam.async_update()
         # We do not need to catch AuthFailed exception here because sensor data is
         # always available without authorization.

--- a/homeassistant/components/nam/config_flow.py
+++ b/homeassistant/components/nam/config_flow.py
@@ -8,7 +8,6 @@ import logging
 from typing import Any
 
 from aiohttp.client_exceptions import ClientConnectorError
-import async_timeout
 from nettigo_air_monitor import (
     ApiError,
     AuthFailedError,
@@ -51,7 +50,7 @@ async def async_get_config(hass: HomeAssistant, host: str) -> NamConfig:
     options = ConnectionOptions(host)
     nam = await NettigoAirMonitor.create(websession, options)
 
-    async with async_timeout.timeout(10):
+    async with asyncio.timeout(10):
         mac = await nam.async_get_mac_address()
 
     return NamConfig(mac, nam.auth_enabled)
@@ -67,7 +66,7 @@ async def async_check_credentials(
 
     nam = await NettigoAirMonitor.create(websession, options)
 
-    async with async_timeout.timeout(10):
+    async with asyncio.timeout(10):
         await nam.async_check_credentials()
 
 

--- a/homeassistant/components/nextdns/__init__.py
+++ b/homeassistant/components/nextdns/__init__.py
@@ -7,7 +7,6 @@ import logging
 from typing import TypeVar
 
 from aiohttp.client_exceptions import ClientConnectorError
-from async_timeout import timeout
 from nextdns import (
     AnalyticsDnssec,
     AnalyticsEncryption,
@@ -75,7 +74,7 @@ class NextDnsUpdateCoordinator(DataUpdateCoordinator[CoordinatorDataT]):
     async def _async_update_data(self) -> CoordinatorDataT:
         """Update data via internal method."""
         try:
-            async with timeout(10):
+            async with asyncio.timeout(10):
                 return await self._async_update_data_internal()
         except (ApiError, ClientConnectorError, InvalidApiKeyError) as err:
             raise UpdateFailed(err) from err
@@ -162,7 +161,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     websession = async_get_clientsession(hass)
     try:
-        async with timeout(10):
+        async with asyncio.timeout(10):
             nextdns = await NextDns.create(websession, api_key)
     except (ApiError, ClientConnectorError, asyncio.TimeoutError) as err:
         raise ConfigEntryNotReady from err

--- a/homeassistant/components/nextdns/config_flow.py
+++ b/homeassistant/components/nextdns/config_flow.py
@@ -5,7 +5,6 @@ import asyncio
 from typing import Any
 
 from aiohttp.client_exceptions import ClientConnectorError
-from async_timeout import timeout
 from nextdns import ApiError, InvalidApiKeyError, NextDns
 import voluptuous as vol
 
@@ -38,7 +37,7 @@ class NextDnsFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             self.api_key = user_input[CONF_API_KEY]
             try:
-                async with timeout(10):
+                async with asyncio.timeout(10):
                     self.nextdns = await NextDns.create(
                         websession, user_input[CONF_API_KEY]
                     )

--- a/homeassistant/components/nina/__init__.py
+++ b/homeassistant/components/nina/__init__.py
@@ -1,11 +1,11 @@
 """The Nina integration."""
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 import re
 from typing import Any
 
-from async_timeout import timeout
 from pynina import ApiError, Nina
 
 from homeassistant.config_entries import ConfigEntry
@@ -103,7 +103,7 @@ class NINADataUpdateCoordinator(
 
     async def _async_update_data(self) -> dict[str, list[NinaWarningData]]:
         """Update data."""
-        async with timeout(10):
+        async with asyncio.timeout(10):
             try:
                 await self._nina.update()
             except ApiError as err:

--- a/homeassistant/components/no_ip/__init__.py
+++ b/homeassistant/components/no_ip/__init__.py
@@ -6,7 +6,6 @@ import logging
 
 import aiohttp
 from aiohttp.hdrs import AUTHORIZATION, USER_AGENT
-import async_timeout
 import voluptuous as vol
 
 from homeassistant.const import CONF_DOMAIN, CONF_PASSWORD, CONF_TIMEOUT, CONF_USERNAME
@@ -100,7 +99,7 @@ async def _update_no_ip(
     }
 
     try:
-        async with async_timeout.timeout(timeout):
+        async with asyncio.timeout(timeout):
             resp = await session.get(url, params=params, headers=headers)
             body = await resp.text()
 

--- a/homeassistant/components/nuki/__init__.py
+++ b/homeassistant/components/nuki/__init__.py
@@ -1,6 +1,7 @@
 """The nuki component."""
 from __future__ import annotations
 
+import asyncio
 from collections import defaultdict
 from datetime import timedelta
 from http import HTTPStatus
@@ -8,7 +9,6 @@ import logging
 from typing import Generic, TypeVar
 
 from aiohttp import web
-import async_timeout
 from pynuki import NukiBridge, NukiLock, NukiOpener
 from pynuki.bridge import InvalidCredentialsException
 from pynuki.device import NukiDevice
@@ -126,7 +126,7 @@ async def _create_webhook(
         ir.async_delete_issue(hass, DOMAIN, "https_webhook")
 
         try:
-            async with async_timeout.timeout(10):
+            async with asyncio.timeout(10):
                 await hass.async_add_executor_job(
                     _register_webhook, bridge, entry.entry_id, url
                 )
@@ -216,7 +216,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         """Stop and remove the Nuki webhook."""
         webhook.async_unregister(hass, entry.entry_id)
         try:
-            async with async_timeout.timeout(10):
+            async with asyncio.timeout(10):
                 await hass.async_add_executor_job(
                     _remove_webhook, bridge, entry.entry_id
                 )
@@ -252,7 +252,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload the Nuki entry."""
     webhook.async_unregister(hass, entry.entry_id)
     try:
-        async with async_timeout.timeout(10):
+        async with asyncio.timeout(10):
             await hass.async_add_executor_job(
                 _remove_webhook,
                 hass.data[DOMAIN][entry.entry_id][DATA_BRIDGE],
@@ -301,7 +301,7 @@ class NukiCoordinator(DataUpdateCoordinator[None]):
         try:
             # Note: asyncio.TimeoutError and aiohttp.ClientError are already
             # handled by the data update coordinator.
-            async with async_timeout.timeout(10):
+            async with asyncio.timeout(10):
                 events = await self.hass.async_add_executor_job(
                     self.update_devices, self.locks + self.openers
                 )

--- a/homeassistant/components/nut/__init__.py
+++ b/homeassistant/components/nut/__init__.py
@@ -1,12 +1,12 @@
 """The nut component."""
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
 from typing import cast
 
-import async_timeout
 from pynut2.nut2 import PyNUTClient, PyNUTError
 
 from homeassistant.config_entries import ConfigEntry
@@ -65,7 +65,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     async def async_update_data() -> dict[str, str]:
         """Fetch data from NUT."""
-        async with async_timeout.timeout(10):
+        async with asyncio.timeout(10):
             await hass.async_add_executor_job(data.update)
             if not data.status:
                 raise UpdateFailed("Error fetching UPS state")

--- a/homeassistant/components/nzbget/coordinator.py
+++ b/homeassistant/components/nzbget/coordinator.py
@@ -1,10 +1,10 @@
 """Provides the NZBGet DataUpdateCoordinator."""
+import asyncio
 from collections.abc import Mapping
 from datetime import timedelta
 import logging
 from typing import Any
 
-from async_timeout import timeout
 from pynzbgetapi import NZBGetAPI, NZBGetAPIException
 
 from homeassistant.const import (
@@ -96,7 +96,7 @@ class NZBGetDataUpdateCoordinator(DataUpdateCoordinator):
             }
 
         try:
-            async with timeout(4):
+            async with asyncio.timeout(4):
                 return await self.hass.async_add_executor_job(_update_data)
         except NZBGetAPIException as error:
             raise UpdateFailed(f"Invalid response from API: {error}") from error


### PR DESCRIPTION
## Proposed change
Replace `async_timeout.timeout` with `asyncio.timeout`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
