### PR TITLE
Use asyncio.timeout [o-s]

### DIFF
--- a/homeassistant/components/openalpr_cloud/image_processing.py
+++ b/homeassistant/components/openalpr_cloud/image_processing.py
@@ -7,7 +7,6 @@ from http import HTTPStatus
 import logging
 
 import aiohttp
-import async_timeout
 import voluptuous as vol
 
 from homeassistant.components.image_processing import (
@@ -199,7 +198,7 @@ class OpenAlprCloudEntity(ImageProcessingAlprEntity):
         body = {"image_bytes": str(b64encode(image), "utf-8")}
 
         try:
-            async with async_timeout.timeout(self.timeout):
+            async with asyncio.timeout(self.timeout):
                 request = await websession.post(
                     OPENALPR_API_URL, params=params, data=body
                 )

--- a/homeassistant/components/openexchangerates/config_flow.py
+++ b/homeassistant/components/openexchangerates/config_flow.py
@@ -10,7 +10,6 @@ from aioopenexchangerates import (
     OpenExchangeRatesAuthError,
     OpenExchangeRatesClientError,
 )
-import async_timeout
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -40,7 +39,7 @@ async def validate_input(hass: HomeAssistant, data: dict[str, str]) -> dict[str,
     """Validate the user input allows us to connect."""
     client = Client(data[CONF_API_KEY], async_get_clientsession(hass))
 
-    async with async_timeout.timeout(CLIENT_TIMEOUT):
+    async with asyncio.timeout(CLIENT_TIMEOUT):
         await client.get_latest(base=data[CONF_BASE])
 
     return {"title": data[CONF_BASE]}
@@ -119,7 +118,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if not self.currencies:
             client = Client("dummy-api-key", async_get_clientsession(self.hass))
             try:
-                async with async_timeout.timeout(CLIENT_TIMEOUT):
+                async with asyncio.timeout(CLIENT_TIMEOUT):
                     self.currencies = await client.get_currencies()
             except OpenExchangeRatesClientError as err:
                 raise AbortFlow("cannot_connect") from err

--- a/homeassistant/components/openexchangerates/coordinator.py
+++ b/homeassistant/components/openexchangerates/coordinator.py
@@ -1,6 +1,7 @@
 """Provide an OpenExchangeRates data coordinator."""
 from __future__ import annotations
 
+import asyncio
 from datetime import timedelta
 
 from aiohttp import ClientSession
@@ -10,7 +11,6 @@ from aioopenexchangerates import (
     OpenExchangeRatesAuthError,
     OpenExchangeRatesClientError,
 )
-import async_timeout
 
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
@@ -40,7 +40,7 @@ class OpenexchangeratesCoordinator(DataUpdateCoordinator[Latest]):
     async def _async_update_data(self) -> Latest:
         """Update data from Open Exchange Rates."""
         try:
-            async with async_timeout.timeout(CLIENT_TIMEOUT):
+            async with asyncio.timeout(CLIENT_TIMEOUT):
                 latest = await self.client.get_latest(base=self.base)
         except OpenExchangeRatesAuthError as err:
             raise ConfigEntryAuthFailed(err) from err

--- a/homeassistant/components/opentherm_gw/__init__.py
+++ b/homeassistant/components/opentherm_gw/__init__.py
@@ -3,7 +3,6 @@ import asyncio
 from datetime import date, datetime
 import logging
 
-import async_timeout
 import pyotgw
 import pyotgw.vars as gw_vars
 from serial import SerialException
@@ -113,7 +112,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     config_entry.add_update_listener(options_updated)
 
     try:
-        async with async_timeout.timeout(CONNECTION_TIMEOUT):
+        async with asyncio.timeout(CONNECTION_TIMEOUT):
             await gateway.connect_and_subscribe()
     except (asyncio.TimeoutError, ConnectionError, SerialException) as ex:
         await gateway.cleanup()

--- a/homeassistant/components/opentherm_gw/config_flow.py
+++ b/homeassistant/components/opentherm_gw/config_flow.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import asyncio
 
-import async_timeout
 import pyotgw
 from pyotgw import vars as gw_vars
 from serial import SerialException
@@ -69,7 +68,7 @@ class OpenThermGwConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 return status[gw_vars.OTGW].get(gw_vars.OTGW_ABOUT)
 
             try:
-                async with async_timeout.timeout(CONNECTION_TIMEOUT):
+                async with asyncio.timeout(CONNECTION_TIMEOUT):
                     await test_connection()
             except asyncio.TimeoutError:
                 return self._show_form({"base": "timeout_connect"})

--- a/homeassistant/components/openweathermap/weather_update_coordinator.py
+++ b/homeassistant/components/openweathermap/weather_update_coordinator.py
@@ -1,8 +1,8 @@
 """Weather data coordinator for the OpenWeatherMap (OWM) service."""
+import asyncio
 from datetime import timedelta
 import logging
 
-import async_timeout
 from pyowm.commons.exceptions import APIRequestError, UnauthorizedError
 
 from homeassistant.components.weather import (
@@ -80,7 +80,7 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator):
     async def _async_update_data(self):
         """Update the data."""
         data = {}
-        async with async_timeout.timeout(20):
+        async with asyncio.timeout(20):
             try:
                 weather_response = await self._get_owm_weather()
                 data = self._convert_weather_response(weather_response)

--- a/homeassistant/components/ovo_energy/__init__.py
+++ b/homeassistant/components/ovo_energy/__init__.py
@@ -1,11 +1,11 @@
 """Support for OVO Energy."""
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timedelta
 import logging
 
 import aiohttp
-import async_timeout
 from ovoenergy import OVODailyUsage
 from ovoenergy.ovoenergy import OVOEnergy
 
@@ -47,7 +47,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     async def async_update_data() -> OVODailyUsage:
         """Fetch data from OVO Energy."""
-        async with async_timeout.timeout(10):
+        async with asyncio.timeout(10):
             try:
                 authenticated = await client.authenticate(
                     entry.data[CONF_USERNAME],

--- a/homeassistant/components/picnic/coordinator.py
+++ b/homeassistant/components/picnic/coordinator.py
@@ -1,10 +1,10 @@
 """Coordinator to fetch data from the Picnic API."""
+import asyncio
 from contextlib import suppress
 import copy
 from datetime import timedelta
 import logging
 
-import async_timeout
 from python_picnic_api import PicnicAPI
 from python_picnic_api.session import PicnicAuthError
 
@@ -44,7 +44,7 @@ class PicnicUpdateCoordinator(DataUpdateCoordinator):
         try:
             # Note: asyncio.TimeoutError and aiohttp.ClientError are already
             # handled by the data update coordinator.
-            async with async_timeout.timeout(10):
+            async with asyncio.timeout(10):
                 data = await self.hass.async_add_executor_job(self.fetch_data)
 
             # Update the auth token in the config entry if applicable

--- a/homeassistant/components/ping/binary_sensor.py
+++ b/homeassistant/components/ping/binary_sensor.py
@@ -8,7 +8,6 @@ import logging
 import re
 from typing import TYPE_CHECKING, Any
 
-import async_timeout
 from icmplib import NameLookupError, async_ping
 import voluptuous as vol
 
@@ -218,7 +217,7 @@ class PingDataSubProcess(PingData):
             close_fds=False,  # required for posix_spawn
         )
         try:
-            async with async_timeout.timeout(self._count + PING_TIMEOUT):
+            async with asyncio.timeout(self._count + PING_TIMEOUT):
                 out_data, out_error = await pinger.communicate()
 
             if out_data:

--- a/homeassistant/components/point/config_flow.py
+++ b/homeassistant/components/point/config_flow.py
@@ -3,7 +3,6 @@ import asyncio
 from collections import OrderedDict
 import logging
 
-import async_timeout
 from pypoint import PointSession
 import voluptuous as vol
 
@@ -94,7 +93,7 @@ class PointFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             errors["base"] = "follow_link"
 
         try:
-            async with async_timeout.timeout(10):
+            async with asyncio.timeout(10):
                 url = await self._get_authorization_url()
         except asyncio.TimeoutError:
             return self.async_abort(reason="authorize_url_timeout")

--- a/homeassistant/components/poolsense/__init__.py
+++ b/homeassistant/components/poolsense/__init__.py
@@ -1,8 +1,8 @@
 """The PoolSense integration."""
+import asyncio
 from datetime import timedelta
 import logging
 
-import async_timeout
 from poolsense import PoolSense
 from poolsense.exceptions import PoolSenseError
 
@@ -90,7 +90,7 @@ class PoolSenseDataUpdateCoordinator(DataUpdateCoordinator):
     async def _async_update_data(self):
         """Update data via library."""
         data = {}
-        async with async_timeout.timeout(10):
+        async with asyncio.timeout(10):
             try:
                 data = await self.poolsense.get_poolsense_data()
             except PoolSenseError as error:

--- a/homeassistant/components/progettihwsw/binary_sensor.py
+++ b/homeassistant/components/progettihwsw/binary_sensor.py
@@ -1,8 +1,8 @@
 """Control binary sensor instances."""
+import asyncio
 from datetime import timedelta
 import logging
 
-import async_timeout
 from ProgettiHWSW.input import Input
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
@@ -32,7 +32,7 @@ async def async_setup_entry(
 
     async def async_update_data():
         """Fetch data from API endpoint of board."""
-        async with async_timeout.timeout(5):
+        async with asyncio.timeout(5):
             return await board_api.get_inputs()
 
     coordinator = DataUpdateCoordinator(

--- a/homeassistant/components/progettihwsw/switch.py
+++ b/homeassistant/components/progettihwsw/switch.py
@@ -1,9 +1,9 @@
 """Control switches."""
+import asyncio
 from datetime import timedelta
 import logging
 from typing import Any
 
-import async_timeout
 from ProgettiHWSW.relay import Relay
 
 from homeassistant.components.switch import SwitchEntity
@@ -33,7 +33,7 @@ async def async_setup_entry(
 
     async def async_update_data():
         """Fetch data from API endpoint of board."""
-        async with async_timeout.timeout(5):
+        async with asyncio.timeout(5):
             return await board_api.get_switches()
 
     coordinator = DataUpdateCoordinator(

--- a/homeassistant/components/prowl/notify.py
+++ b/homeassistant/components/prowl/notify.py
@@ -5,7 +5,6 @@ import asyncio
 from http import HTTPStatus
 import logging
 
-import async_timeout
 import voluptuous as vol
 
 from homeassistant.components.notify import (
@@ -64,7 +63,7 @@ class ProwlNotificationService(BaseNotificationService):
         session = async_get_clientsession(self._hass)
 
         try:
-            async with async_timeout.timeout(10):
+            async with asyncio.timeout(10):
                 response = await session.post(url, data=payload)
                 result = await response.text()
 

--- a/homeassistant/components/prusalink/__init__.py
+++ b/homeassistant/components/prusalink/__init__.py
@@ -2,12 +2,12 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+import asyncio
 from datetime import timedelta
 import logging
 from time import monotonic
 from typing import Generic, TypeVar
 
-import async_timeout
 from pyprusalink import InvalidAuth, JobInfo, PrinterInfo, PrusaLink, PrusaLinkError
 
 from homeassistant.config_entries import ConfigEntry
@@ -77,7 +77,7 @@ class PrusaLinkUpdateCoordinator(DataUpdateCoordinator, Generic[T], ABC):
     async def _async_update_data(self) -> T:
         """Update the data."""
         try:
-            async with async_timeout.timeout(5):
+            async with asyncio.timeout(5):
                 data = await self._fetch_data()
         except InvalidAuth:
             raise UpdateFailed("Invalid authentication") from None

--- a/homeassistant/components/prusalink/config_flow.py
+++ b/homeassistant/components/prusalink/config_flow.py
@@ -6,7 +6,6 @@ import logging
 from typing import Any
 
 from aiohttp import ClientError
-import async_timeout
 from awesomeversion import AwesomeVersion, AwesomeVersionException
 from pyprusalink import InvalidAuth, PrusaLink
 import voluptuous as vol
@@ -39,7 +38,7 @@ async def validate_input(hass: HomeAssistant, data: dict[str, str]) -> dict[str,
     api = PrusaLink(async_get_clientsession(hass), data[CONF_HOST], data[CONF_API_KEY])
 
     try:
-        async with async_timeout.timeout(5):
+        async with asyncio.timeout(5):
             version = await api.get_version()
 
     except (asyncio.TimeoutError, ClientError) as err:

--- a/homeassistant/components/push/camera.py
+++ b/homeassistant/components/push/camera.py
@@ -7,7 +7,6 @@ from datetime import timedelta
 import logging
 
 import aiohttp
-import async_timeout
 import voluptuous as vol
 
 from homeassistant.components import webhook
@@ -74,7 +73,7 @@ async def async_setup_platform(
 async def handle_webhook(hass, webhook_id, request):
     """Handle incoming webhook POST with image files."""
     try:
-        async with async_timeout.timeout(5):
+        async with asyncio.timeout(5):
             data = dict(await request.post())
     except (asyncio.TimeoutError, aiohttp.web.HTTPException) as error:
         _LOGGER.error("Could not get information from POST <%s>", error)

--- a/homeassistant/components/qnap_qsw/coordinator.py
+++ b/homeassistant/components/qnap_qsw/coordinator.py
@@ -1,13 +1,13 @@
 """The QNAP QSW coordinator."""
 from __future__ import annotations
 
+import asyncio
 from datetime import timedelta
 import logging
 from typing import Any
 
 from aioqsw.exceptions import QswError
 from aioqsw.localapi import QnapQswApi
-import async_timeout
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -36,7 +36,7 @@ class QswDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Update data via library."""
-        async with async_timeout.timeout(QSW_TIMEOUT_SEC):
+        async with asyncio.timeout(QSW_TIMEOUT_SEC):
             try:
                 await self.qsw.update()
             except QswError as error:
@@ -60,7 +60,7 @@ class QswFirmwareCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Update firmware data via library."""
-        async with async_timeout.timeout(QSW_TIMEOUT_SEC):
+        async with asyncio.timeout(QSW_TIMEOUT_SEC):
             try:
                 await self.qsw.check_firmware()
             except QswError as error:

--- a/homeassistant/components/rainbird/config_flow.py
+++ b/homeassistant/components/rainbird/config_flow.py
@@ -6,7 +6,6 @@ import asyncio
 import logging
 from typing import Any
 
-import async_timeout
 from pyrainbird.async_client import (
     AsyncRainbirdClient,
     AsyncRainbirdController,
@@ -106,7 +105,7 @@ class RainbirdConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             )
         )
         try:
-            async with async_timeout.timeout(TIMEOUT_SECONDS):
+            async with asyncio.timeout(TIMEOUT_SECONDS):
                 return await controller.get_serial_number()
         except asyncio.TimeoutError as err:
             raise ConfigFlowError(

--- a/homeassistant/components/rainbird/coordinator.py
+++ b/homeassistant/components/rainbird/coordinator.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 import datetime
 import logging
 from typing import TypeVar
 
-import async_timeout
 from pyrainbird.async_client import (
     AsyncRainbirdController,
     RainbirdApiException,
@@ -86,7 +86,7 @@ class RainbirdUpdateCoordinator(DataUpdateCoordinator[RainbirdDeviceState]):
     async def _async_update_data(self) -> RainbirdDeviceState:
         """Fetch data from Rain Bird device."""
         try:
-            async with async_timeout.timeout(TIMEOUT_SECONDS):
+            async with asyncio.timeout(TIMEOUT_SECONDS):
                 return await self._fetch_data()
         except RainbirdDeviceBusyException as err:
             raise UpdateFailed("Rain Bird device is busy") from err

--- a/homeassistant/components/rainforest_eagle/data.py
+++ b/homeassistant/components/rainforest_eagle/data.py
@@ -1,12 +1,12 @@
 """Rainforest data."""
 from __future__ import annotations
 
+import asyncio
 from datetime import timedelta
 import logging
 
 import aioeagle
 import aiohttp
-import async_timeout
 from eagle100 import Eagle as Eagle100Reader
 from requests.exceptions import ConnectionError as ConnectError, HTTPError, Timeout
 
@@ -50,7 +50,7 @@ async def async_get_type(hass, cloud_id, install_code, host):
     )
 
     try:
-        async with async_timeout.timeout(30):
+        async with asyncio.timeout(30):
             meters = await hub.get_device_list()
     except aioeagle.BadAuth as err:
         raise InvalidAuth from err
@@ -150,7 +150,7 @@ class EagleDataCoordinator(DataUpdateCoordinator):
         else:
             is_connected = eagle200_meter.is_connected
 
-        async with async_timeout.timeout(30):
+        async with asyncio.timeout(30):
             data = await eagle200_meter.get_device_query()
 
         if self.eagle200_meter is None:

--- a/homeassistant/components/renson/__init__.py
+++ b/homeassistant/components/renson/__init__.py
@@ -1,12 +1,12 @@
 """The Renson integration."""
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
 from typing import Any
 
-import async_timeout
 from renson_endura_delta.renson import RensonVentilation
 
 from homeassistant.config_entries import ConfigEntry
@@ -84,5 +84,5 @@ class RensonCoordinator(DataUpdateCoordinator):
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data from API endpoint."""
-        async with async_timeout.timeout(30):
+        async with asyncio.timeout(30):
             return await self.hass.async_add_executor_job(self.api.get_all_data)

--- a/homeassistant/components/reolink/__init__.py
+++ b/homeassistant/components/reolink/__init__.py
@@ -8,7 +8,6 @@ from datetime import timedelta
 import logging
 from typing import Literal
 
-import async_timeout
 from reolink_aio.api import RETRY_ATTEMPTS
 from reolink_aio.exceptions import CredentialsInvalidError, ReolinkError
 
@@ -78,13 +77,13 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     async def async_device_config_update() -> None:
         """Update the host state cache and renew the ONVIF-subscription."""
-        async with async_timeout.timeout(host.api.timeout * (RETRY_ATTEMPTS + 2)):
+        async with asyncio.timeout(host.api.timeout * (RETRY_ATTEMPTS + 2)):
             try:
                 await host.update_states()
             except ReolinkError as err:
                 raise UpdateFailed(str(err)) from err
 
-        async with async_timeout.timeout(host.api.timeout * (RETRY_ATTEMPTS + 2)):
+        async with asyncio.timeout(host.api.timeout * (RETRY_ATTEMPTS + 2)):
             await host.renew()
 
     async def async_check_firmware_update() -> str | Literal[False]:
@@ -92,7 +91,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         if not host.api.supported(None, "update"):
             return False
 
-        async with async_timeout.timeout(host.api.timeout * (RETRY_ATTEMPTS + 2)):
+        async with asyncio.timeout(host.api.timeout * (RETRY_ATTEMPTS + 2)):
             try:
                 return await host.api.check_new_firmware()
             except (ReolinkError, asyncio.exceptions.CancelledError) as err:

--- a/homeassistant/components/rest/switch.py
+++ b/homeassistant/components/rest/switch.py
@@ -6,7 +6,6 @@ from http import HTTPStatus
 import logging
 from typing import Any
 
-import async_timeout
 import httpx
 import voluptuous as vol
 
@@ -203,7 +202,7 @@ class RestSwitch(ManualTriggerEntity, SwitchEntity):
         rendered_headers = template.render_complex(self._headers, parse_result=False)
         rendered_params = template.render_complex(self._params)
 
-        async with async_timeout.timeout(self._timeout):
+        async with asyncio.timeout(self._timeout):
             req: httpx.Response = await getattr(websession, self._method)(
                 self._resource,
                 auth=self._auth,
@@ -234,7 +233,7 @@ class RestSwitch(ManualTriggerEntity, SwitchEntity):
         rendered_headers = template.render_complex(self._headers, parse_result=False)
         rendered_params = template.render_complex(self._params)
 
-        async with async_timeout.timeout(self._timeout):
+        async with asyncio.timeout(self._timeout):
             req = await websession.get(
                 self._state_resource,
                 auth=self._auth,

--- a/homeassistant/components/rflink/__init__.py
+++ b/homeassistant/components/rflink/__init__.py
@@ -5,7 +5,6 @@ import asyncio
 from collections import defaultdict
 import logging
 
-import async_timeout
 from rflink.protocol import ProtocolBase, create_rflink_connection
 from serial import SerialException
 import voluptuous as vol
@@ -280,7 +279,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         )
 
         try:
-            async with async_timeout.timeout(CONNECTION_TIMEOUT):
+            async with asyncio.timeout(CONNECTION_TIMEOUT):
                 transport, protocol = await connection
 
         except (

--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -8,7 +8,6 @@ import copy
 import logging
 from typing import Any, NamedTuple, cast
 
-import async_timeout
 import RFXtrx as rfxtrxmod
 import voluptuous as vol
 
@@ -165,7 +164,7 @@ async def async_setup_internal(hass: HomeAssistant, entry: ConfigEntry) -> None:
     config = entry.data
 
     # Initialize library
-    async with async_timeout.timeout(30):
+    async with asyncio.timeout(30):
         rfx_object = await hass.async_add_executor_job(_create_rfx, config)
 
     # Setup some per device config

--- a/homeassistant/components/rfxtrx/config_flow.py
+++ b/homeassistant/components/rfxtrx/config_flow.py
@@ -8,7 +8,6 @@ import itertools
 import os
 from typing import Any, TypedDict, cast
 
-from async_timeout import timeout
 import RFXtrx as rfxtrxmod
 import serial
 import serial.tools.list_ports
@@ -374,7 +373,7 @@ class OptionsFlow(config_entries.OptionsFlow):
 
         # Wait for entities to finish cleanup
         with suppress(asyncio.TimeoutError):
-            async with timeout(10):
+            async with asyncio.timeout(10):
                 await wait_for_entities.wait()
         remove_track_state_changes()
 
@@ -409,7 +408,7 @@ class OptionsFlow(config_entries.OptionsFlow):
 
         # Wait for entities to finish renaming
         with suppress(asyncio.TimeoutError):
-            async with timeout(10):
+            async with asyncio.timeout(10):
                 await wait_for_entities.wait()
         remove_track_state_changes()
 

--- a/homeassistant/components/roomba/__init__.py
+++ b/homeassistant/components/roomba/__init__.py
@@ -3,7 +3,6 @@ import asyncio
 from functools import partial
 import logging
 
-import async_timeout
 from roombapy import RoombaConnectionError, RoombaFactory
 
 from homeassistant import exceptions
@@ -86,7 +85,7 @@ async def async_connect_or_timeout(hass, roomba):
     """Connect to vacuum."""
     try:
         name = None
-        async with async_timeout.timeout(10):
+        async with asyncio.timeout(10):
             _LOGGER.debug("Initialize connection to vacuum")
             await hass.async_add_executor_job(roomba.connect)
             while not roomba.roomba_connected or name is None:
@@ -110,7 +109,7 @@ async def async_connect_or_timeout(hass, roomba):
 async def async_disconnect_or_timeout(hass, roomba):
     """Disconnect to vacuum."""
     _LOGGER.debug("Disconnect vacuum")
-    async with async_timeout.timeout(3):
+    async with asyncio.timeout(3):
         await hass.async_add_executor_job(roomba.disconnect)
     return True
 

--- a/homeassistant/components/rtsp_to_webrtc/__init__.py
+++ b/homeassistant/components/rtsp_to_webrtc/__init__.py
@@ -18,10 +18,10 @@ Other integrations may use this integration with these steps:
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any
 
-import async_timeout
 from rtsp_to_webrtc.client import get_adaptive_client
 from rtsp_to_webrtc.exceptions import ClientError, ResponseError
 from rtsp_to_webrtc.interface import WebRTCClientInterface
@@ -48,7 +48,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     client: WebRTCClientInterface
     try:
-        async with async_timeout.timeout(TIMEOUT):
+        async with asyncio.timeout(TIMEOUT):
             client = await get_adaptive_client(
                 async_get_clientsession(hass), entry.data[DATA_SERVER_URL]
             )
@@ -71,7 +71,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         the stream itself happens directly between the client and proxy.
         """
         try:
-            async with async_timeout.timeout(TIMEOUT):
+            async with asyncio.timeout(TIMEOUT):
                 return await client.offer_stream_id(stream_id, offer_sdp, stream_source)
         except TimeoutError as err:
             raise HomeAssistantError("Timeout talking to RTSPtoWebRTC server") from err

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -5,7 +5,6 @@ import asyncio
 from collections.abc import Coroutine, Sequence
 from typing import Any
 
-import async_timeout
 from async_upnp_client.aiohttp import AiohttpNotifyServer, AiohttpSessionRequester
 from async_upnp_client.client import UpnpDevice, UpnpService, UpnpStateVariable
 from async_upnp_client.client_factory import UpnpFactory
@@ -217,7 +216,7 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
             # enter it unless we have to (Python 3.11 will have zero cost try)
             return
         try:
-            async with async_timeout.timeout(APP_LIST_DELAY):
+            async with asyncio.timeout(APP_LIST_DELAY):
                 await self._app_list_event.wait()
         except asyncio.TimeoutError as err:
             # No need to try again

--- a/homeassistant/components/sensibo/entity.py
+++ b/homeassistant/components/sensibo/entity.py
@@ -1,10 +1,10 @@
 """Base entity for Sensibo integration."""
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Callable, Coroutine
 from typing import TYPE_CHECKING, Any, Concatenate, ParamSpec, TypeVar
 
-import async_timeout
 from pysensibo.model import MotionSensor, SensiboDevice
 
 from homeassistant.exceptions import HomeAssistantError
@@ -27,7 +27,7 @@ def async_handle_api_call(
         """Wrap services for api calls."""
         res: bool = False
         try:
-            async with async_timeout.timeout(TIMEOUT):
+            async with asyncio.timeout(TIMEOUT):
                 res = await function(*args, **kwargs)
         except SENSIBO_ERRORS as err:
             raise HomeAssistantError from err

--- a/homeassistant/components/sensibo/util.py
+++ b/homeassistant/components/sensibo/util.py
@@ -1,7 +1,8 @@
 """Utils for Sensibo integration."""
 from __future__ import annotations
 
-import async_timeout
+import asyncio
+
 from pysensibo import SensiboClient
 from pysensibo.exceptions import AuthenticationError
 
@@ -20,7 +21,7 @@ async def async_validate_api(hass: HomeAssistant, api_key: str) -> str:
     )
 
     try:
-        async with async_timeout.timeout(TIMEOUT):
+        async with asyncio.timeout(TIMEOUT):
             device_query = await client.async_get_devices()
             user_query = await client.async_get_me()
     except AuthenticationError as err:

--- a/homeassistant/components/sharkiq/__init__.py
+++ b/homeassistant/components/sharkiq/__init__.py
@@ -2,7 +2,6 @@
 import asyncio
 from contextlib import suppress
 
-import async_timeout
 from sharkiq import (
     AylaApi,
     SharkIqAuthError,
@@ -35,7 +34,7 @@ class CannotConnect(exceptions.HomeAssistantError):
 async def async_connect_or_timeout(ayla_api: AylaApi) -> bool:
     """Connect to vacuum."""
     try:
-        async with async_timeout.timeout(API_TIMEOUT):
+        async with asyncio.timeout(API_TIMEOUT):
             LOGGER.debug("Initialize connection to Ayla networks API")
             await ayla_api.async_sign_in()
     except SharkIqAuthError:
@@ -87,7 +86,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 async def async_disconnect_or_timeout(coordinator: SharkIqUpdateCoordinator):
     """Disconnect to vacuum."""
     LOGGER.debug("Disconnecting from Ayla Api")
-    async with async_timeout.timeout(5):
+    async with asyncio.timeout(5):
         with suppress(
             SharkIqAuthError, SharkIqAuthExpiringError, SharkIqNotAuthedError
         ):

--- a/homeassistant/components/sharkiq/config_flow.py
+++ b/homeassistant/components/sharkiq/config_flow.py
@@ -6,7 +6,6 @@ from collections.abc import Mapping
 from typing import Any
 
 import aiohttp
-import async_timeout
 from sharkiq import SharkIqAuthError, get_ayla_api
 import voluptuous as vol
 
@@ -51,7 +50,7 @@ async def _validate_input(
     )
 
     try:
-        async with async_timeout.timeout(10):
+        async with asyncio.timeout(10):
             LOGGER.debug("Initialize connection to Ayla networks API")
             await ayla_api.async_sign_in()
     except (asyncio.TimeoutError, aiohttp.ClientError, TypeError) as error:

--- a/homeassistant/components/sharkiq/update_coordinator.py
+++ b/homeassistant/components/sharkiq/update_coordinator.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import asyncio
 from datetime import datetime, timedelta
 
-from async_timeout import timeout
 from sharkiq import (
     AylaApi,
     SharkIqAuthError,
@@ -55,7 +54,7 @@ class SharkIqUpdateCoordinator(DataUpdateCoordinator[bool]):
         """Asynchronously update the data for a single vacuum."""
         dsn = sharkiq.serial_number
         LOGGER.debug("Updating sharkiq data for device DSN %s", dsn)
-        async with timeout(API_TIMEOUT):
+        async with asyncio.timeout(API_TIMEOUT):
             await sharkiq.async_update()
 
     async def _async_update_data(self) -> bool:

--- a/homeassistant/components/shell_command/__init__.py
+++ b/homeassistant/components/shell_command/__init__.py
@@ -6,7 +6,6 @@ from contextlib import suppress
 import logging
 import shlex
 
-import async_timeout
 import voluptuous as vol
 
 from homeassistant.core import (
@@ -89,7 +88,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
         process = await create_process
         try:
-            async with async_timeout.timeout(COMMAND_TIMEOUT):
+            async with asyncio.timeout(COMMAND_TIMEOUT):
                 stdout_data, stderr_data = await process.communicate()
         except asyncio.TimeoutError:
             _LOGGER.error(

--- a/homeassistant/components/smarttub/controller.py
+++ b/homeassistant/components/smarttub/controller.py
@@ -5,7 +5,6 @@ from datetime import timedelta
 import logging
 
 from aiohttp import client_exceptions
-import async_timeout
 from smarttub import APIError, LoginFailed, SmartTub
 from smarttub.api import Account
 
@@ -85,7 +84,7 @@ class SmartTubController:
 
         data = {}
         try:
-            async with async_timeout.timeout(POLLING_TIMEOUT):
+            async with asyncio.timeout(POLLING_TIMEOUT):
                 for spa in self.spas:
                     data[spa.id] = await self._get_spa_data(spa)
         except APIError as err:

--- a/homeassistant/components/smarttub/switch.py
+++ b/homeassistant/components/smarttub/switch.py
@@ -1,7 +1,7 @@
 """Platform for switch integration."""
+import asyncio
 from typing import Any
 
-import async_timeout
 from smarttub import SpaPump
 
 from homeassistant.components.switch import SwitchEntity
@@ -80,6 +80,6 @@ class SmartTubPump(SmartTubEntity, SwitchEntity):
 
     async def async_toggle(self, **kwargs: Any) -> None:
         """Toggle the pump on or off."""
-        async with async_timeout.timeout(API_TIMEOUT):
+        async with asyncio.timeout(API_TIMEOUT):
             await self.pump.toggle()
         await self.coordinator.async_request_refresh()

--- a/homeassistant/components/smhi/weather.py
+++ b/homeassistant/components/smhi/weather.py
@@ -8,7 +8,6 @@ import logging
 from typing import Any, Final
 
 import aiohttp
-import async_timeout
 from smhi import Smhi
 from smhi.smhi_lib import SmhiForecast, SmhiForecastException
 
@@ -165,7 +164,7 @@ class SmhiWeather(WeatherEntity):
     async def async_update(self) -> None:
         """Refresh the forecast data from SMHI weather API."""
         try:
-            async with async_timeout.timeout(TIMEOUT):
+            async with asyncio.timeout(TIMEOUT):
                 self._forecast_daily = await self._smhi_api.async_get_forecast()
                 self._forecast_hourly = await self._smhi_api.async_get_forecast_hour()
                 self._fail_count = 0

--- a/homeassistant/components/sms/__init__.py
+++ b/homeassistant/components/sms/__init__.py
@@ -1,8 +1,8 @@
 """The sms component."""
+import asyncio
 from datetime import timedelta
 import logging
 
-import async_timeout
 import gammu  # pylint: disable=import-error
 import voluptuous as vol
 
@@ -125,7 +125,7 @@ class SignalCoordinator(DataUpdateCoordinator):
     async def _async_update_data(self):
         """Fetch device signal quality."""
         try:
-            async with async_timeout.timeout(10):
+            async with asyncio.timeout(10):
                 return await self._gateway.get_signal_quality_async()
         except gammu.GSMError as exc:
             raise UpdateFailed(f"Error communicating with device: {exc}") from exc
@@ -147,7 +147,7 @@ class NetworkCoordinator(DataUpdateCoordinator):
     async def _async_update_data(self):
         """Fetch device network info."""
         try:
-            async with async_timeout.timeout(10):
+            async with asyncio.timeout(10):
                 return await self._gateway.get_network_info_async()
         except gammu.GSMError as exc:
             raise UpdateFailed(f"Error communicating with device: {exc}") from exc

--- a/tests/components/rainbird/test_config_flow.py
+++ b/tests/components/rainbird/test_config_flow.py
@@ -108,7 +108,7 @@ async def test_controller_timeout(
     """Test an error talking to the controller."""
 
     with patch(
-        "homeassistant.components.rainbird.config_flow.async_timeout.timeout",
+        "homeassistant.components.rainbird.config_flow.asyncio.timeout",
         side_effect=asyncio.TimeoutError,
     ):
         result = await complete_flow(hass)


### PR DESCRIPTION
## Proposed change
Replace `async_timeout.timeout` with `asyncio.timeout`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
