### PR TITLE
Use asyncio.timeout [s-z]

### DIFF
--- a/homeassistant/components/songpal/media_player.py
+++ b/homeassistant/components/songpal/media_player.py
@@ -5,7 +5,6 @@ import asyncio
 from collections import OrderedDict
 import logging
 
-import async_timeout
 from songpal import (
     ConnectChange,
     ContentChange,
@@ -68,7 +67,7 @@ async def async_setup_entry(
 
     device = Device(endpoint)
     try:
-        async with async_timeout.timeout(
+        async with asyncio.timeout(
             10
         ):  # set timeout to avoid blocking the setup process
             await device.get_supported_methods()

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -10,7 +10,6 @@ import logging
 import time
 from typing import Any, cast
 
-import async_timeout
 import defusedxml.ElementTree as ET
 from soco.core import SoCo
 from soco.events_base import Event as SonosEvent, SubscriptionBase
@@ -1122,7 +1121,7 @@ class SonosSpeaker:
             return True
 
         try:
-            async with async_timeout.timeout(5):
+            async with asyncio.timeout(5):
                 while not _test_groups(groups):
                     await hass.data[DATA_SONOS].topology_condition.wait()
         except asyncio.TimeoutError:

--- a/homeassistant/components/squeezebox/config_flow.py
+++ b/homeassistant/components/squeezebox/config_flow.py
@@ -4,7 +4,6 @@ from http import HTTPStatus
 import logging
 from typing import TYPE_CHECKING
 
-import async_timeout
 from pysqueezebox import Server, async_discover
 import voluptuous as vol
 
@@ -131,7 +130,7 @@ class SqueezeboxConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         # no host specified, see if we can discover an unconfigured LMS server
         try:
-            async with async_timeout.timeout(TIMEOUT):
+            async with asyncio.timeout(TIMEOUT):
                 await self._discover()
             return await self.async_step_edit()
         except asyncio.TimeoutError:

--- a/homeassistant/components/srp_energy/sensor.py
+++ b/homeassistant/components/srp_energy/sensor.py
@@ -1,9 +1,9 @@
 """Support for SRP Energy Sensor."""
 from __future__ import annotations
 
+import asyncio
 from datetime import timedelta
 
-import async_timeout
 from requests.exceptions import ConnectionError as ConnectError, HTTPError, Timeout
 
 from homeassistant.components.sensor import (
@@ -52,7 +52,7 @@ async def async_setup_entry(
             end_date = dt_util.now(phx_time_zone)
             start_date = end_date - timedelta(days=1)
 
-            async with async_timeout.timeout(10):
+            async with asyncio.timeout(10):
                 hourly_usage = await hass.async_add_executor_job(
                     api.usage,
                     start_date,

--- a/homeassistant/components/starlink/coordinator.py
+++ b/homeassistant/components/starlink/coordinator.py
@@ -1,11 +1,11 @@
 """Contains the shared Coordinator for Starlink systems."""
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
 
-import async_timeout
 from starlink_grpc import (
     AlertDict,
     ChannelContext,
@@ -48,7 +48,7 @@ class StarlinkUpdateCoordinator(DataUpdateCoordinator[StarlinkData]):
         )
 
     async def _async_update_data(self) -> StarlinkData:
-        async with async_timeout.timeout(4):
+        async with asyncio.timeout(4):
             try:
                 status = await self.hass.async_add_executor_job(
                     status_data, self.channel_context
@@ -59,7 +59,7 @@ class StarlinkUpdateCoordinator(DataUpdateCoordinator[StarlinkData]):
 
     async def async_stow_starlink(self, stow: bool) -> None:
         """Set whether Starlink system tied to this coordinator should be stowed."""
-        async with async_timeout.timeout(4):
+        async with asyncio.timeout(4):
             try:
                 await self.hass.async_add_executor_job(
                     set_stow_state, not stow, self.channel_context
@@ -69,7 +69,7 @@ class StarlinkUpdateCoordinator(DataUpdateCoordinator[StarlinkData]):
 
     async def async_reboot_starlink(self) -> None:
         """Reboot the Starlink system tied to this coordinator."""
-        async with async_timeout.timeout(4):
+        async with asyncio.timeout(4):
             try:
                 await self.hass.async_add_executor_job(reboot, self.channel_context)
             except GrpcError as exc:

--- a/homeassistant/components/startca/sensor.py
+++ b/homeassistant/components/startca/sensor.py
@@ -1,12 +1,12 @@
 """Support for Start.ca Bandwidth Monitor."""
 from __future__ import annotations
 
+import asyncio
 from datetime import timedelta
 from http import HTTPStatus
 import logging
 from xml.parsers.expat import ExpatError
 
-import async_timeout
 import voluptuous as vol
 import xmltodict
 
@@ -213,7 +213,7 @@ class StartcaData:
         """Get the Start.ca bandwidth data from the web service."""
         _LOGGER.debug("Updating Start.ca usage data")
         url = f"https://www.start.ca/support/usage/api?key={self.api_key}"
-        async with async_timeout.timeout(REQUEST_TIMEOUT):
+        async with asyncio.timeout(REQUEST_TIMEOUT):
             req = await self.websession.get(url)
         if req.status != HTTPStatus.OK:
             _LOGGER.error("Request failed with status: %u", req.status)

--- a/homeassistant/components/supla/__init__.py
+++ b/homeassistant/components/supla/__init__.py
@@ -1,10 +1,10 @@
 """Support for Supla devices."""
 from __future__ import annotations
 
+import asyncio
 from datetime import timedelta
 import logging
 
-import async_timeout
 from asyncpysupla import SuplaAPI
 import voluptuous as vol
 
@@ -99,7 +99,7 @@ async def discover_devices(hass, hass_config):
     for server_name, server in hass.data[DOMAIN][SUPLA_SERVERS].items():
 
         async def _fetch_channels():
-            async with async_timeout.timeout(SCAN_INTERVAL.total_seconds()):
+            async with asyncio.timeout(SCAN_INTERVAL.total_seconds()):
                 channels = {
                     channel["id"]: channel
                     # pylint: disable-next=cell-var-from-loop

--- a/homeassistant/components/switchbot/coordinator.py
+++ b/homeassistant/components/switchbot/coordinator.py
@@ -6,7 +6,6 @@ import contextlib
 import logging
 from typing import TYPE_CHECKING
 
-import async_timeout
 import switchbot
 from switchbot import SwitchbotModel
 
@@ -117,7 +116,7 @@ class SwitchbotDataUpdateCoordinator(ActiveBluetoothDataUpdateCoordinator[None])
     async def async_wait_ready(self) -> bool:
         """Wait for the device to be ready."""
         with contextlib.suppress(asyncio.TimeoutError):
-            async with async_timeout.timeout(DEVICE_STARTUP_TIMEOUT):
+            async with asyncio.timeout(DEVICE_STARTUP_TIMEOUT):
                 await self._ready_event.wait()
                 return True
         return False

--- a/homeassistant/components/syncthru/__init__.py
+++ b/homeassistant/components/syncthru/__init__.py
@@ -1,10 +1,10 @@
 """The syncthru component."""
 from __future__ import annotations
 
+import asyncio
 from datetime import timedelta
 import logging
 
-import async_timeout
 from pysyncthru import ConnectionMode, SyncThru, SyncThruAPINotSupported
 
 from homeassistant.config_entries import ConfigEntry
@@ -32,7 +32,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     async def async_update_data() -> SyncThru:
         """Fetch data from the printer."""
         try:
-            async with async_timeout.timeout(10):
+            async with asyncio.timeout(10):
                 await printer.update()
         except SyncThruAPINotSupported as api_error:
             # if an exception is thrown, printer does not support syncthru

--- a/homeassistant/components/system_bridge/__init__.py
+++ b/homeassistant/components/system_bridge/__init__.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import asyncio
 import logging
 
-import async_timeout
 from systembridgeconnector.exceptions import (
     AuthenticationException,
     ConnectionClosedException,
@@ -67,7 +66,7 @@ async def async_setup_entry(
         session=async_get_clientsession(hass),
     )
     try:
-        async with async_timeout.timeout(10):
+        async with asyncio.timeout(10):
             if not await version.check_supported():
                 raise ConfigEntryNotReady(
                     "You are not running a supported version of System Bridge. Please"
@@ -91,7 +90,7 @@ async def async_setup_entry(
         entry=entry,
     )
     try:
-        async with async_timeout.timeout(10):
+        async with asyncio.timeout(10):
             await coordinator.async_get_data(MODULES)
     except AuthenticationException as exception:
         _LOGGER.error("Authentication failed for %s: %s", entry.title, exception)
@@ -109,7 +108,7 @@ async def async_setup_entry(
 
     try:
         # Wait for initial data
-        async with async_timeout.timeout(10):
+        async with asyncio.timeout(10):
             while not coordinator.is_ready:
                 _LOGGER.debug(
                     "Waiting for initial data from %s (%s)",

--- a/homeassistant/components/system_bridge/config_flow.py
+++ b/homeassistant/components/system_bridge/config_flow.py
@@ -6,7 +6,6 @@ from collections.abc import Mapping
 import logging
 from typing import Any
 
-import async_timeout
 from systembridgeconnector.exceptions import (
     AuthenticationException,
     ConnectionClosedException,
@@ -55,7 +54,7 @@ async def _validate_input(
         data[CONF_API_KEY],
     )
     try:
-        async with async_timeout.timeout(15):
+        async with asyncio.timeout(15):
             await websocket_client.connect(session=async_get_clientsession(hass))
             hass.async_create_task(websocket_client.listen())
             response = await websocket_client.get_data(GetData(modules=["system"]))

--- a/homeassistant/components/system_bridge/coordinator.py
+++ b/homeassistant/components/system_bridge/coordinator.py
@@ -7,7 +7,6 @@ from datetime import timedelta
 import logging
 from typing import Any
 
-import async_timeout
 from pydantic import BaseModel  # pylint: disable=no-name-in-module
 from systembridgeconnector.exceptions import (
     AuthenticationException,
@@ -183,7 +182,7 @@ class SystemBridgeDataUpdateCoordinator(
     async def _setup_websocket(self) -> None:
         """Use WebSocket for updates."""
         try:
-            async with async_timeout.timeout(20):
+            async with asyncio.timeout(20):
                 await self.websocket_client.connect(
                     session=async_get_clientsession(self.hass),
                 )

--- a/homeassistant/components/tado/device_tracker.py
+++ b/homeassistant/components/tado/device_tracker.py
@@ -8,7 +8,6 @@ from http import HTTPStatus
 import logging
 
 import aiohttp
-import async_timeout
 import voluptuous as vol
 
 from homeassistant.components.device_tracker import (
@@ -109,7 +108,7 @@ class TadoDeviceScanner(DeviceScanner):
         last_results = []
 
         try:
-            async with async_timeout.timeout(10):
+            async with asyncio.timeout(10):
                 # Format the URL here, so we can log the template URL if
                 # anything goes wrong without exposing username and password.
                 url = self.tadoapiurl.format(

--- a/homeassistant/components/tellduslive/config_flow.py
+++ b/homeassistant/components/tellduslive/config_flow.py
@@ -3,7 +3,6 @@ import asyncio
 import logging
 import os
 
-import async_timeout
 from tellduslive import Session, supports_local_api
 import voluptuous as vol
 
@@ -91,7 +90,7 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             errors["base"] = "invalid_auth"
 
         try:
-            async with async_timeout.timeout(10):
+            async with asyncio.timeout(10):
                 auth_url = await self.hass.async_add_executor_job(self._get_auth_url)
             if not auth_url:
                 return self.async_abort(reason="unknown_authorize_url_generation")

--- a/homeassistant/components/thethingsnetwork/sensor.py
+++ b/homeassistant/components/thethingsnetwork/sensor.py
@@ -7,7 +7,6 @@ import logging
 
 import aiohttp
 from aiohttp.hdrs import ACCEPT, AUTHORIZATION
-import async_timeout
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA, SensorEntity
@@ -134,7 +133,7 @@ class TtnDataStorage:
         """Get the current state from The Things Network Data Storage."""
         try:
             session = async_get_clientsession(self._hass)
-            async with async_timeout.timeout(DEFAULT_TIMEOUT):
+            async with asyncio.timeout(DEFAULT_TIMEOUT):
                 response = await session.get(self._url, headers=self._headers)
 
         except (asyncio.TimeoutError, aiohttp.ClientError):

--- a/homeassistant/components/tplink_omada/coordinator.py
+++ b/homeassistant/components/tplink_omada/coordinator.py
@@ -1,9 +1,9 @@
 """Generic Omada API coordinator."""
+import asyncio
 from datetime import timedelta
 import logging
 from typing import Generic, TypeVar
 
-import async_timeout
 from tplink_omada_client.exceptions import OmadaClientException
 from tplink_omada_client.omadaclient import OmadaSiteClient
 
@@ -37,7 +37,7 @@ class OmadaCoordinator(DataUpdateCoordinator[dict[str, T]], Generic[T]):
     async def _async_update_data(self) -> dict[str, T]:
         """Fetch data from API endpoint."""
         try:
-            async with async_timeout.timeout(10):
+            async with asyncio.timeout(10):
                 return await self.poll_update()
         except OmadaClientException as err:
             raise UpdateFailed(f"Error communicating with API: {err}") from err

--- a/homeassistant/components/tradfri/config_flow.py
+++ b/homeassistant/components/tradfri/config_flow.py
@@ -5,7 +5,6 @@ import asyncio
 from typing import Any
 from uuid import uuid4
 
-import async_timeout
 from pytradfri import Gateway, RequestError
 from pytradfri.api.aiocoap_api import APIFactory
 import voluptuous as vol
@@ -141,7 +140,7 @@ async def authenticate(
     api_factory = await APIFactory.init(host, psk_id=identity)
 
     try:
-        async with async_timeout.timeout(5):
+        async with asyncio.timeout(5):
             key = await api_factory.generate_psk(security_code)
     except RequestError as err:
         raise AuthError("invalid_security_code") from err

--- a/homeassistant/components/unifi/controller.py
+++ b/homeassistant/components/unifi/controller.py
@@ -11,7 +11,6 @@ from aiohttp import CookieJar
 import aiounifi
 from aiounifi.interfaces.api_handlers import ItemEvent
 from aiounifi.websocket import WebsocketState
-import async_timeout
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -375,7 +374,7 @@ class UniFiController:
     async def async_reconnect(self) -> None:
         """Try to reconnect UniFi Network session."""
         try:
-            async with async_timeout.timeout(5):
+            async with asyncio.timeout(5):
                 await self.api.login()
                 self.api.start_websocket()
 
@@ -444,7 +443,7 @@ async def get_unifi_controller(
     )
 
     try:
-        async with async_timeout.timeout(10):
+        async with asyncio.timeout(10):
             await controller.check_unifi_os()
             await controller.login()
         return controller

--- a/homeassistant/components/upb/config_flow.py
+++ b/homeassistant/components/upb/config_flow.py
@@ -4,7 +4,6 @@ from contextlib import suppress
 import logging
 from urllib.parse import urlparse
 
-import async_timeout
 import upb_lib
 import voluptuous as vol
 
@@ -45,7 +44,7 @@ async def _validate_input(data):
     upb.connect(_connected_callback)
 
     with suppress(asyncio.TimeoutError):
-        async with async_timeout.timeout(VALIDATE_TIMEOUT):
+        async with asyncio.timeout(VALIDATE_TIMEOUT):
             await connected_event.wait()
 
     upb.disconnect()

--- a/homeassistant/components/upnp/__init__.py
+++ b/homeassistant/components/upnp/__init__.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import asyncio
 from datetime import timedelta
 
-import async_timeout
 from async_upnp_client.exceptions import UpnpConnectionError
 
 from homeassistant.components import ssdp
@@ -71,7 +70,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
 
     try:
-        async with async_timeout.timeout(10):
+        async with asyncio.timeout(10):
             await device_discovered_event.wait()
     except asyncio.TimeoutError as err:
         raise ConfigEntryNotReady(f"Device not discovered: {usn}") from err

--- a/homeassistant/components/viaggiatreno/sensor.py
+++ b/homeassistant/components/viaggiatreno/sensor.py
@@ -7,7 +7,6 @@ import logging
 import time
 
 import aiohttp
-import async_timeout
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA, SensorEntity
@@ -79,7 +78,7 @@ async def async_http_request(hass, uri):
     """Perform actual request."""
     try:
         session = async_get_clientsession(hass)
-        async with async_timeout.timeout(REQUEST_TIMEOUT):
+        async with asyncio.timeout(REQUEST_TIMEOUT):
             req = await session.get(uri)
         if req.status != HTTPStatus.OK:
             return {"error": req.status}

--- a/homeassistant/components/voicerss/tts.py
+++ b/homeassistant/components/voicerss/tts.py
@@ -4,7 +4,6 @@ from http import HTTPStatus
 import logging
 
 import aiohttp
-import async_timeout
 import voluptuous as vol
 
 from homeassistant.components.tts import CONF_LANG, PLATFORM_SCHEMA, Provider
@@ -196,7 +195,7 @@ class VoiceRSSProvider(Provider):
         form_data["hl"] = language
 
         try:
-            async with async_timeout.timeout(10):
+            async with asyncio.timeout(10):
                 request = await websession.post(VOICERSS_API_URL, data=form_data)
 
                 if request.status != HTTPStatus.OK:

--- a/homeassistant/components/voip/voip.py
+++ b/homeassistant/components/voip/voip.py
@@ -10,7 +10,6 @@ from pathlib import Path
 import time
 from typing import TYPE_CHECKING
 
-import async_timeout
 from voip_utils import (
     CallInfo,
     RtcpState,
@@ -259,7 +258,7 @@ class PipelineRtpDatagramProtocol(RtpDatagramProtocol):
                     self._clear_audio_queue()
 
             # Run pipeline with a timeout
-            async with async_timeout.timeout(self.pipeline_timeout):
+            async with asyncio.timeout(self.pipeline_timeout):
                 await async_pipeline_from_audio_stream(
                     self.hass,
                     context=self._context,
@@ -315,7 +314,7 @@ class PipelineRtpDatagramProtocol(RtpDatagramProtocol):
         """
         # Timeout if no audio comes in for a while.
         # This means the caller hung up.
-        async with async_timeout.timeout(self.audio_timeout):
+        async with asyncio.timeout(self.audio_timeout):
             chunk = await self._audio_queue.get()
 
         while chunk:
@@ -326,7 +325,7 @@ class PipelineRtpDatagramProtocol(RtpDatagramProtocol):
                 # Buffer until command starts
                 return True
 
-            async with async_timeout.timeout(self.audio_timeout):
+            async with asyncio.timeout(self.audio_timeout):
                 chunk = await self._audio_queue.get()
 
         return False
@@ -343,7 +342,7 @@ class PipelineRtpDatagramProtocol(RtpDatagramProtocol):
 
         # Timeout if no audio comes in for a while.
         # This means the caller hung up.
-        async with async_timeout.timeout(self.audio_timeout):
+        async with asyncio.timeout(self.audio_timeout):
             chunk = await self._audio_queue.get()
 
         while chunk:
@@ -353,7 +352,7 @@ class PipelineRtpDatagramProtocol(RtpDatagramProtocol):
 
             yield chunk
 
-            async with async_timeout.timeout(self.audio_timeout):
+            async with asyncio.timeout(self.audio_timeout):
                 chunk = await self._audio_queue.get()
 
     def _clear_audio_queue(self) -> None:
@@ -395,7 +394,7 @@ class PipelineRtpDatagramProtocol(RtpDatagramProtocol):
             tts_samples = len(audio_bytes) / (WIDTH * CHANNELS)
             tts_seconds = tts_samples / RATE
 
-            async with async_timeout.timeout(tts_seconds + self.tts_extra_timeout):
+            async with asyncio.timeout(tts_seconds + self.tts_extra_timeout):
                 # Assume TTS audio is 16Khz 16-bit mono
                 await self._async_send_audio(audio_bytes)
         except asyncio.TimeoutError as err:

--- a/homeassistant/components/volvooncall/__init__.py
+++ b/homeassistant/components/volvooncall/__init__.py
@@ -1,9 +1,9 @@
 """Support for Volvo On Call."""
 
+import asyncio
 import logging
 
 from aiohttp.client_exceptions import ClientResponseError
-import async_timeout
 from volvooncall import Connection
 from volvooncall.dashboard import Instrument
 
@@ -186,7 +186,7 @@ class VolvoUpdateCoordinator(DataUpdateCoordinator[None]):
     async def _async_update_data(self) -> None:
         """Fetch data from API endpoint."""
 
-        async with async_timeout.timeout(10):
+        async with asyncio.timeout(10):
             await self.volvo_data.update()
 
 

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -12,7 +12,6 @@ import ssl
 from typing import Any, Concatenate, ParamSpec, TypeVar, cast
 
 from aiowebostv import WebOsClient, WebOsTvPairError
-import async_timeout
 
 from homeassistant import util
 from homeassistant.components.media_player import (
@@ -480,7 +479,7 @@ class LgWebOSMediaPlayerEntity(RestoreEntity, MediaPlayerEntity):
 
         websession = async_get_clientsession(self.hass)
         with suppress(asyncio.TimeoutError):
-            async with async_timeout.timeout(10):
+            async with asyncio.timeout(10):
                 response = await websession.get(url, ssl=ssl_context)
                 if response.status == HTTPStatus.OK:
                     content = await response.read()

--- a/homeassistant/components/worxlandroid/sensor.py
+++ b/homeassistant/components/worxlandroid/sensor.py
@@ -5,7 +5,6 @@ import asyncio
 import logging
 
 import aiohttp
-import async_timeout
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA, SensorEntity
@@ -95,7 +94,7 @@ class WorxLandroidSensor(SensorEntity):
 
         try:
             session = async_get_clientsession(self.hass)
-            async with async_timeout.timeout(self.timeout):
+            async with asyncio.timeout(self.timeout):
                 auth = aiohttp.helpers.BasicAuth("admin", self.pin)
                 mower_response = await session.get(self.url, auth=auth)
         except (asyncio.TimeoutError, aiohttp.ClientError):

--- a/homeassistant/components/wyoming/data.py
+++ b/homeassistant/components/wyoming/data.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import asyncio
 
-import async_timeout
 from wyoming.client import AsyncTcpClient
 from wyoming.info import Describe, Info
 
@@ -55,9 +54,7 @@ async def load_wyoming_info(
 
     for _ in range(retries + 1):
         try:
-            async with AsyncTcpClient(host, port) as client, async_timeout.timeout(
-                timeout
-            ):
+            async with AsyncTcpClient(host, port) as client, asyncio.timeout(timeout):
                 # Describe -> Info
                 await client.write_event(Describe().event())
                 while True:

--- a/homeassistant/components/xiaomi_miio/__init__.py
+++ b/homeassistant/components/xiaomi_miio/__init__.py
@@ -1,13 +1,13 @@
 """Support for Xiaomi Miio."""
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
 from typing import Any
 
-import async_timeout
 from miio import (
     AirFresh,
     AirFreshA1,
@@ -176,7 +176,7 @@ def _async_update_data_default(hass, device):
 
         async def _async_fetch_data():
             """Fetch data from the device."""
-            async with async_timeout.timeout(POLLING_TIMEOUT_SEC):
+            async with asyncio.timeout(POLLING_TIMEOUT_SEC):
                 state = await hass.async_add_executor_job(device.status)
                 _LOGGER.debug("Got new state: %s", state)
                 return state
@@ -265,7 +265,7 @@ def _async_update_data_vacuum(
         """Fetch data from the device using async_add_executor_job."""
 
         async def execute_update() -> VacuumCoordinatorData:
-            async with async_timeout.timeout(POLLING_TIMEOUT_SEC):
+            async with asyncio.timeout(POLLING_TIMEOUT_SEC):
                 state = await hass.async_add_executor_job(update)
                 _LOGGER.debug("Got new vacuum state: %s", state)
                 return state

--- a/homeassistant/components/yandextts/tts.py
+++ b/homeassistant/components/yandextts/tts.py
@@ -4,7 +4,6 @@ from http import HTTPStatus
 import logging
 
 import aiohttp
-import async_timeout
 import voluptuous as vol
 
 from homeassistant.components.tts import CONF_LANG, PLATFORM_SCHEMA, Provider
@@ -120,7 +119,7 @@ class YandexSpeechKitProvider(Provider):
         actual_language = language
 
         try:
-            async with async_timeout.timeout(10):
+            async with asyncio.timeout(10):
                 url_param = {
                     "text": message,
                     "lang": actual_language,

--- a/homeassistant/components/yeelight/scanner.py
+++ b/homeassistant/components/yeelight/scanner.py
@@ -10,7 +10,6 @@ import logging
 from typing import Self
 from urllib.parse import urlparse
 
-import async_timeout
 from async_upnp_client.search import SsdpSearchListener
 from async_upnp_client.utils import CaseInsensitiveDict
 
@@ -157,7 +156,7 @@ class YeelightScanner:
             listener.async_search((host, SSDP_TARGET[1]))
 
         with contextlib.suppress(asyncio.TimeoutError):
-            async with async_timeout.timeout(DISCOVERY_TIMEOUT):
+            async with asyncio.timeout(DISCOVERY_TIMEOUT):
                 await host_event.wait()
 
         self._host_discovered_events[host].remove(host_event)

--- a/homeassistant/components/yolink/__init__.py
+++ b/homeassistant/components/yolink/__init__.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any
 
-import async_timeout
 from yolink.const import ATTR_DEVICE_SMART_REMOTER
 from yolink.device import YoLinkDevice
 from yolink.exception import YoLinkAuthFailError, YoLinkClientError
@@ -111,7 +110,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
     yolink_home = YoLinkHome()
     try:
-        async with async_timeout.timeout(10):
+        async with asyncio.timeout(10):
             await yolink_home.async_setup(
                 auth_mgr, YoLinkHomeMessageListener(hass, entry)
             )

--- a/homeassistant/components/yolink/coordinator.py
+++ b/homeassistant/components/yolink/coordinator.py
@@ -1,10 +1,10 @@
 """YoLink DataUpdateCoordinator."""
 from __future__ import annotations
 
+import asyncio
 from datetime import timedelta
 import logging
 
-import async_timeout
 from yolink.device import YoLinkDevice
 from yolink.exception import YoLinkAuthFailError, YoLinkClientError
 
@@ -41,7 +41,7 @@ class YoLinkCoordinator(DataUpdateCoordinator[dict]):
     async def _async_update_data(self) -> dict:
         """Fetch device state."""
         try:
-            async with async_timeout.timeout(10):
+            async with asyncio.timeout(10):
                 device_state_resp = await self.device.fetch_state()
                 device_state = device_state_resp.data.get(ATTR_DEVICE_STATE)
                 if self.paired_device is not None and device_state is not None:

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -7,7 +7,6 @@ from collections.abc import Coroutine
 from contextlib import suppress
 from typing import Any
 
-from async_timeout import timeout
 from zwave_js_server.client import Client as ZwaveClient
 from zwave_js_server.const import CommandClass, RemoveNodeReason
 from zwave_js_server.exceptions import BaseZwaveJSServerError, InvalidServerVersion
@@ -146,7 +145,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # connect and throw error if connection failed
     try:
-        async with timeout(CONNECT_TIMEOUT):
+        async with asyncio.timeout(CONNECT_TIMEOUT):
             await client.connect()
     except InvalidServerVersion as err:
         if use_addon:

--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -7,7 +7,6 @@ import logging
 from typing import Any
 
 import aiohttp
-from async_timeout import timeout
 from serial.tools import list_ports
 import voluptuous as vol
 from zwave_js_server.version import VersionInfo, get_server_version
@@ -115,7 +114,7 @@ async def validate_input(hass: HomeAssistant, user_input: dict) -> VersionInfo:
 async def async_get_version_info(hass: HomeAssistant, ws_address: str) -> VersionInfo:
     """Return Z-Wave JS version info."""
     try:
-        async with timeout(SERVER_VERSION_TIMEOUT):
+        async with asyncio.timeout(SERVER_VERSION_TIMEOUT):
             version_info: VersionInfo = await get_server_version(
                 ws_address, async_get_clientsession(hass)
             )

--- a/tests/components/sonos/test_init.py
+++ b/tests/components/sonos/test_init.py
@@ -1,13 +1,7 @@
 """Tests for the Sonos config flow."""
 import asyncio
 import logging
-import sys
 from unittest.mock import Mock, patch
-
-if sys.version_info[:2] < (3, 11):
-    from async_timeout import timeout as asyncio_timeout
-else:
-    from asyncio import timeout as asyncio_timeout
 
 import pytest
 
@@ -377,7 +371,7 @@ async def test_async_poll_manual_hosts_6(
             caplog.clear()
             # The discovery events should not fire, wait with a timeout.
             with pytest.raises(asyncio.TimeoutError):
-                async with asyncio_timeout(1.0):
+                async with asyncio.timeout(1.0):
                     await speaker_1_activity.event.wait()
             await hass.async_block_till_done()
             assert "Activity on Living Room" not in caplog.text

--- a/tests/components/upb/test_config_flow.py
+++ b/tests/components/upb/test_config_flow.py
@@ -82,7 +82,7 @@ async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     from asyncio import TimeoutError
 
     with patch(
-        "homeassistant.components.upb.config_flow.async_timeout.timeout",
+        "homeassistant.components.upb.config_flow.asyncio.timeout",
         side_effect=TimeoutError,
     ):
         result = await valid_tcp_flow(hass, sync_complete=False)

--- a/tests/components/voip/test_voip.py
+++ b/tests/components/voip/test_voip.py
@@ -3,7 +3,6 @@ import asyncio
 import time
 from unittest.mock import AsyncMock, Mock, patch
 
-import async_timeout
 import pytest
 
 from homeassistant.components import assist_pipeline, voip
@@ -118,7 +117,7 @@ async def test_pipeline(
         rtp_protocol.on_chunk(bytes(_ONE_SECOND))
 
         # Wait for mock pipeline to exhaust the audio stream
-        async with async_timeout.timeout(1):
+        async with asyncio.timeout(1):
             await done.wait()
 
 
@@ -159,7 +158,7 @@ async def test_pipeline_timeout(hass: HomeAssistant, voip_device: VoIPDevice) ->
         rtp_protocol.on_chunk(bytes(_ONE_SECOND))
 
         # Wait for mock pipeline to time out
-        async with async_timeout.timeout(1):
+        async with asyncio.timeout(1):
             await done.wait()
 
 
@@ -200,7 +199,7 @@ async def test_stt_stream_timeout(hass: HomeAssistant, voip_device: VoIPDevice) 
         rtp_protocol.on_chunk(bytes(_ONE_SECOND))
 
         # Wait for mock pipeline to time out
-        async with async_timeout.timeout(1):
+        async with asyncio.timeout(1):
             await done.wait()
 
 
@@ -319,5 +318,5 @@ async def test_tts_timeout(
         rtp_protocol.on_chunk(bytes(_ONE_SECOND * 4))
 
         # Wait for mock pipeline to exhaust the audio stream
-        async with async_timeout.timeout(1):
+        async with asyncio.timeout(1):
             await done.wait()

--- a/tests/components/wemo/test_wemo_device.py
+++ b/tests/components/wemo/test_wemo_device.py
@@ -4,7 +4,6 @@ from dataclasses import asdict
 from datetime import timedelta
 from unittest.mock import call, patch
 
-import async_timeout
 import pytest
 from pywemo.exceptions import ActionException, PyWeMoException
 from pywemo.subscribe import EVENT_TYPE_LONG_PRESS
@@ -77,7 +76,7 @@ async def test_long_press_event(
         "testing_params",
     )
 
-    async with async_timeout.timeout(8):
+    async with asyncio.timeout(8):
         await got_event.wait()
 
     assert event_data == {
@@ -108,7 +107,7 @@ async def test_subscription_callback(
         pywemo_registry.callbacks[device.wemo.name], device.wemo, "", ""
     )
 
-    async with async_timeout.timeout(8):
+    async with asyncio.timeout(8):
         await got_callback.wait()
     assert device.last_update_success
 


### PR DESCRIPTION
## Proposed change
Replace `async_timeout.timeout` with `asyncio.timeout`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
