### PR TITLE
Fix inconsistent lyric temperature unit

### DIFF
--- a/homeassistant/components/lyric/climate.py
+++ b/homeassistant/components/lyric/climate.py
@@ -148,10 +148,10 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
         """Initialize Honeywell Lyric climate entity."""
         # Use the native temperature unit from the device settings
         if device.units == "Fahrenheit":
-            self._temperature_unit = UnitOfTemperature.FAHRENHEIT
+            self._attr_temperature_unit = UnitOfTemperature.FAHRENHEIT
             self._attr_precision = PRECISION_WHOLE
         else:
-            self._temperature_unit = UnitOfTemperature.CELSIUS
+            self._attr_temperature_unit = UnitOfTemperature.CELSIUS
             self._attr_precision = PRECISION_HALVES
 
         # Setup supported hvac modes
@@ -184,11 +184,6 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
         if self.device.changeableValues.thermostatSetpointStatus:
             return SUPPORT_FLAGS_LCC
         return SUPPORT_FLAGS_TCC
-
-    @property
-    def temperature_unit(self) -> str:
-        """Return the unit of measurement."""
-        return self._temperature_unit
 
     @property
     def current_temperature(self) -> float | None:

--- a/homeassistant/components/lyric/climate.py
+++ b/homeassistant/components/lyric/climate.py
@@ -117,10 +117,7 @@ async def async_setup_entry(
                         name=device.name,
                     ),
                     location,
-                    device,
-                    UnitOfTemperature.FAHRENHEIT
-                    if device.units == "Fahrenheit"
-                    else UnitOfTemperature.CELSIUS
+                    device
                 )
             )
 
@@ -146,11 +143,16 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
         coordinator: DataUpdateCoordinator[Lyric],
         description: ClimateEntityDescription,
         location: LyricLocation,
-        device: LyricDevice,
-        temperature_unit: str,
+        device: LyricDevice
     ) -> None:
         """Initialize Honeywell Lyric climate entity."""
-        self._temperature_unit = temperature_unit
+        # Use the native temperature unit from the device settings
+        if device.units == "Fahrenheit":
+            self._temperature_unit = UnitOfTemperature.FAHRENHEIT
+            self._attr_precision = PRECISION_WHOLE
+        else:
+            self._temperature_unit = UnitOfTemperature.CELSIUS
+            self._attr_precision = PRECISION_HALVES
 
         # Setup supported hvac modes
         self._attr_hvac_modes = [HVACMode.OFF]
@@ -187,13 +189,6 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
     def temperature_unit(self) -> str:
         """Return the unit of measurement."""
         return self._temperature_unit
-
-    @property
-    def precision(self) -> float:
-        """Return the precision of the system."""
-        return (
-            PRECISION_WHOLE if self.device.units == "Fahrenheit" else PRECISION_HALVES
-        )
 
     @property
     def current_temperature(self) -> float | None:

--- a/homeassistant/components/lyric/climate.py
+++ b/homeassistant/components/lyric/climate.py
@@ -117,7 +117,7 @@ async def async_setup_entry(
                         name=device.name,
                     ),
                     location,
-                    device
+                    device,
                 )
             )
 
@@ -143,7 +143,7 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
         coordinator: DataUpdateCoordinator[Lyric],
         description: ClimateEntityDescription,
         location: LyricLocation,
-        device: LyricDevice
+        device: LyricDevice,
     ) -> None:
         """Initialize Honeywell Lyric climate entity."""
         # Use the native temperature unit from the device settings

--- a/homeassistant/components/lyric/climate.py
+++ b/homeassistant/components/lyric/climate.py
@@ -21,7 +21,12 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature, PRECISION_HALVES, PRECISION_WHOLE
+from homeassistant.const import (
+    ATTR_TEMPERATURE,
+    PRECISION_HALVES,
+    PRECISION_WHOLE,
+    UnitOfTemperature,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_platform
@@ -113,7 +118,9 @@ async def async_setup_entry(
                     ),
                     location,
                     device,
-                    UnitOfTemperature.FAHRENHEIT if device.units == "Fahrenheit" else UnitOfTemperature.CELSIUS
+                    UnitOfTemperature.FAHRENHEIT
+                    if device.units == "Fahrenheit"
+                    else UnitOfTemperature.CELSIUS
                 )
             )
 
@@ -184,7 +191,9 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
     @property
     def precision(self) -> float:
         """Return the precision of the system."""
-        return PRECISION_WHOLE if self.device.units == "Fahrenheit" else PRECISION_HALVES
+        return (
+            PRECISION_WHOLE if self.device.units == "Fahrenheit" else PRECISION_HALVES
+        )
 
     @property
     def current_temperature(self) -> float | None:

--- a/homeassistant/components/lyric/climate.py
+++ b/homeassistant/components/lyric/climate.py
@@ -21,7 +21,7 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE
+from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature, PRECISION_HALVES, PRECISION_WHOLE
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_platform
@@ -113,7 +113,7 @@ async def async_setup_entry(
                     ),
                     location,
                     device,
-                    hass.config.units.temperature_unit,
+                    UnitOfTemperature.FAHRENHEIT if device.units == "Fahrenheit" else UnitOfTemperature.CELSIUS
                 )
             )
 
@@ -180,6 +180,11 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
     def temperature_unit(self) -> str:
         """Return the unit of measurement."""
         return self._temperature_unit
+
+    @property
+    def precision(self) -> float:
+        """Return the precision of the system."""
+        return PRECISION_WHOLE if self.device.units == "Fahrenheit" else PRECISION_HALVES
 
     @property
     def current_temperature(self) -> float | None:

--- a/homeassistant/components/lyric/sensor.py
+++ b/homeassistant/components/lyric/sensor.py
@@ -76,6 +76,11 @@ async def async_setup_entry(
     for location in coordinator.data.locations:
         for device in location.devices:
             if device.indoorTemperature:
+                if device.units == "Fahrenheit":
+                    native_temperature_unit = UnitOfTemperature.FAHRENHEIT
+                else:
+                    native_temperature_unit = UnitOfTemperature.CELSIUS
+
                 entities.append(
                     LyricSensor(
                         coordinator,
@@ -84,9 +89,7 @@ async def async_setup_entry(
                             name="Indoor Temperature",
                             device_class=SensorDeviceClass.TEMPERATURE,
                             state_class=SensorStateClass.MEASUREMENT,
-                            native_unit_of_measurement=UnitOfTemperature.FAHRENHEIT
-                            if device.units == "Fahrenheit"
-                            else UnitOfTemperature.CELSIUS,
+                            native_unit_of_measurement=native_temperature_unit,
                             value=lambda device: device.indoorTemperature,
                         ),
                         location,
@@ -110,6 +113,11 @@ async def async_setup_entry(
                     )
                 )
             if device.outdoorTemperature:
+                if device.units == "Fahrenheit":
+                    native_temperature_unit = UnitOfTemperature.FAHRENHEIT
+                else:
+                    native_temperature_unit = UnitOfTemperature.CELSIUS
+
                 entities.append(
                     LyricSensor(
                         coordinator,
@@ -118,9 +126,7 @@ async def async_setup_entry(
                             name="Outdoor Temperature",
                             device_class=SensorDeviceClass.TEMPERATURE,
                             state_class=SensorStateClass.MEASUREMENT,
-                            native_unit_of_measurement=UnitOfTemperature.FAHRENHEIT
-                            if device.units == "Fahrenheit"
-                            else UnitOfTemperature.CELSIUS,
+                            native_unit_of_measurement=native_temperature_unit,
                             value=lambda device: device.outdoorTemperature,
                         ),
                         location,

--- a/homeassistant/components/lyric/sensor.py
+++ b/homeassistant/components/lyric/sensor.py
@@ -17,7 +17,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import PERCENTAGE
+from homeassistant.const import PERCENTAGE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
@@ -84,7 +84,7 @@ async def async_setup_entry(
                             name="Indoor Temperature",
                             device_class=SensorDeviceClass.TEMPERATURE,
                             state_class=SensorStateClass.MEASUREMENT,
-                            native_unit_of_measurement=hass.config.units.temperature_unit,
+                            native_unit_of_measurement=UnitOfTemperature.FAHRENHEIT if device.units == "Fahrenheit" else UnitOfTemperature.CELSIUS,
                             value=lambda device: device.indoorTemperature,
                         ),
                         location,
@@ -116,7 +116,7 @@ async def async_setup_entry(
                             name="Outdoor Temperature",
                             device_class=SensorDeviceClass.TEMPERATURE,
                             state_class=SensorStateClass.MEASUREMENT,
-                            native_unit_of_measurement=hass.config.units.temperature_unit,
+                            native_unit_of_measurement=UnitOfTemperature.FAHRENHEIT if device.units == "Fahrenheit" else UnitOfTemperature.CELSIUS,
                             value=lambda device: device.outdoorTemperature,
                         ),
                         location,

--- a/homeassistant/components/lyric/sensor.py
+++ b/homeassistant/components/lyric/sensor.py
@@ -84,7 +84,9 @@ async def async_setup_entry(
                             name="Indoor Temperature",
                             device_class=SensorDeviceClass.TEMPERATURE,
                             state_class=SensorStateClass.MEASUREMENT,
-                            native_unit_of_measurement=UnitOfTemperature.FAHRENHEIT if device.units == "Fahrenheit" else UnitOfTemperature.CELSIUS,
+                            native_unit_of_measurement=UnitOfTemperature.FAHRENHEIT
+                            if device.units == "Fahrenheit"
+                            else UnitOfTemperature.CELSIUS,
                             value=lambda device: device.indoorTemperature,
                         ),
                         location,
@@ -116,7 +118,9 @@ async def async_setup_entry(
                             name="Outdoor Temperature",
                             device_class=SensorDeviceClass.TEMPERATURE,
                             state_class=SensorStateClass.MEASUREMENT,
-                            native_unit_of_measurement=UnitOfTemperature.FAHRENHEIT if device.units == "Fahrenheit" else UnitOfTemperature.CELSIUS,
+                            native_unit_of_measurement=UnitOfTemperature.FAHRENHEIT
+                            if device.units == "Fahrenheit"
+                            else UnitOfTemperature.CELSIUS,
                             value=lambda device: device.outdoorTemperature,
                         ),
                         location,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
None.

## Proposed change
The Honeywell Lyric cloud integration currently displays the user selected unit along with the thermostat reported numbers. This causes inconsistencies when the user wants to see Celsius degrees in the UI but the thermostat is set to Fahrenheit, and vice versa.

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
Please keep in mind I'm not a Python dev by nature and there's probably a more elegant way to achieve the same result. My only Python dev environment is my live HA machine so I have limited test capabilities. Please let me know if you have any suggestion.

- This PR fixes or closes issue: fixes #95696
- This PR is related to issue: n/a
- Link to documentation pull request: n/a

## Checklist
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure