### PR TITLE
Change Enphase dry contact relay binary_sensor to switch

### DIFF
--- a/homeassistant/components/enphase_envoy/binary_sensor.py
+++ b/homeassistant/components/enphase_envoy/binary_sensor.py
@@ -5,7 +5,6 @@ from collections.abc import Callable
 from dataclasses import dataclass
 
 from pyenphase import EnvoyEncharge, EnvoyEnpower
-from pyenphase.models.dry_contacts import DryContactStatus
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -51,12 +50,6 @@ ENCHARGE_SENSORS = (
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda encharge: not encharge.dc_switch_off,
     ),
-)
-
-RELAY_STATUS_SENSOR = BinarySensorEntityDescription(
-    key="relay_status",
-    translation_key="relay",
-    icon="mdi:power-plug",
 )
 
 
@@ -114,11 +107,6 @@ async def async_setup_entry(
             for description in ENPOWER_SENSORS
         )
 
-    if envoy_data.dry_contact_status:
-        entities.extend(
-            EnvoyRelayBinarySensorEntity(coordinator, RELAY_STATUS_SENSOR, relay)
-            for relay in envoy_data.dry_contact_status
-        )
     async_add_entities(entities)
 
 
@@ -190,34 +178,3 @@ class EnvoyEnpowerBinarySensorEntity(EnvoyBaseBinarySensorEntity):
         enpower = self.data.enpower
         assert enpower is not None
         return self.entity_description.value_fn(enpower)
-
-
-class EnvoyRelayBinarySensorEntity(EnvoyBaseBinarySensorEntity):
-    """Defines an Enpower dry contact binary_sensor entity."""
-
-    def __init__(
-        self,
-        coordinator: EnphaseUpdateCoordinator,
-        description: BinarySensorEntityDescription,
-        relay_id: str,
-    ) -> None:
-        """Init the Enpower base entity."""
-        super().__init__(coordinator, description)
-        enpower = self.data.enpower
-        assert enpower is not None
-        self._relay_id = relay_id
-        self._attr_unique_id = f"{enpower.serial_number}_relay_{relay_id}"
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, relay_id)},
-            manufacturer="Enphase",
-            model="Dry contact relay",
-            name=self.data.dry_contact_settings[relay_id].load_name,
-            sw_version=str(enpower.firmware_version),
-            via_device=(DOMAIN, enpower.serial_number),
-        )
-
-    @property
-    def is_on(self) -> bool:
-        """Return the state of the Enpower binary_sensor."""
-        relay = self.data.dry_contact_status[self._relay_id]
-        return relay.status == DryContactStatus.CLOSED

--- a/homeassistant/components/enphase_envoy/manifest.json
+++ b/homeassistant/components/enphase_envoy/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://www.home-assistant.io/integrations/enphase_envoy",
   "iot_class": "local_polling",
   "loggers": ["pyenphase"],
-  "requirements": ["pyenphase==1.6.0"],
+  "requirements": ["pyenphase==1.7.1"],
   "zeroconf": [
     {
       "type": "_enphase-envoy._tcp.local."

--- a/homeassistant/components/enphase_envoy/manifest.json
+++ b/homeassistant/components/enphase_envoy/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://www.home-assistant.io/integrations/enphase_envoy",
   "iot_class": "local_polling",
   "loggers": ["pyenphase"],
-  "requirements": ["pyenphase==1.7.1"],
+  "requirements": ["pyenphase==1.8.1"],
   "zeroconf": [
     {
       "type": "_enphase-envoy._tcp.local."

--- a/homeassistant/components/enphase_envoy/strings.json
+++ b/homeassistant/components/enphase_envoy/strings.json
@@ -31,9 +31,6 @@
       },
       "grid_status": {
         "name": "Grid status"
-      },
-      "relay": {
-        "name": "Relay status"
       }
     },
     "number": {

--- a/homeassistant/components/enphase_envoy/switch.py
+++ b/homeassistant/components/enphase_envoy/switch.py
@@ -183,12 +183,10 @@ class EnvoyDryContactSwitchEntity(EnvoyBaseEntity, SwitchEntity):
         """Turn on (close) the dry contact."""
         if await self.entity_description.turn_on_fn(self.envoy, self.relay_id):
             self.data.dry_contact_status[self.relay_id].status = DryContactStatus.CLOSED
-            self._attr_is_on = True
             self.async_write_ha_state()
 
     async def async_turn_off(self):
         """Turn off (open) the dry contact."""
         if await self.entity_description.turn_off_fn(self.envoy, self.relay_id):
             self.data.dry_contact_status[self.relay_id].status = DryContactStatus.OPEN
-            self._attr_is_on = False
             self.async_write_ha_state()

--- a/homeassistant/components/enphase_envoy/switch.py
+++ b/homeassistant/components/enphase_envoy/switch.py
@@ -182,11 +182,9 @@ class EnvoyDryContactSwitchEntity(EnvoyBaseEntity, SwitchEntity):
     async def async_turn_on(self):
         """Turn on (close) the dry contact."""
         if await self.entity_description.turn_on_fn(self.envoy, self.relay_id):
-            self.data.dry_contact_status[self.relay_id].status = DryContactStatus.CLOSED
             self.async_write_ha_state()
 
     async def async_turn_off(self):
         """Turn off (open) the dry contact."""
         if await self.entity_description.turn_off_fn(self.envoy, self.relay_id):
-            self.data.dry_contact_status[self.relay_id].status = DryContactStatus.OPEN
             self.async_write_ha_state()

--- a/homeassistant/components/enphase_envoy/switch.py
+++ b/homeassistant/components/enphase_envoy/switch.py
@@ -6,7 +6,8 @@ from dataclasses import dataclass
 import logging
 from typing import Any
 
-from pyenphase import Envoy, EnvoyEnpower
+from pyenphase import Envoy, EnvoyDryContactStatus, EnvoyEnpower
+from pyenphase.models.dry_contacts import DryContactStatus
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.config_entries import ConfigEntry
@@ -37,12 +38,35 @@ class EnvoyEnpowerSwitchEntityDescription(
     """Describes an Envoy Enpower switch entity."""
 
 
+@dataclass
+class EnvoyDryContactRequiredKeysMixin:
+    """Mixin for required keys."""
+
+    value_fn: Callable[[EnvoyDryContactStatus], bool]
+    turn_on_fn: Callable[[Any, Any], Any]
+    turn_off_fn: Callable[[Any, Any], Any]
+
+
+@dataclass
+class EnvoyDryContactSwitchEntityDescription(
+    SwitchEntityDescription, EnvoyDryContactRequiredKeysMixin
+):
+    """Describes an Envoy Enpower switch entity."""
+
+
 ENPOWER_GRID_SWITCH = EnvoyEnpowerSwitchEntityDescription(
     key="mains_admin_state",
     translation_key="grid_enabled",
     value_fn=lambda enpower: enpower.mains_admin_state == "closed",
     turn_on_fn=lambda envoy: envoy.go_on_grid(),
     turn_off_fn=lambda envoy: envoy.go_off_grid(),
+)
+
+RELAY_STATE_SWITCH = EnvoyDryContactSwitchEntityDescription(
+    key="relay_status",
+    value_fn=lambda dry_contact: dry_contact.status == DryContactStatus.CLOSED,
+    turn_on_fn=lambda envoy, id: envoy.close_dry_contact(id),
+    turn_off_fn=lambda envoy, id: envoy.open_dry_contact(id),
 )
 
 
@@ -64,6 +88,13 @@ async def async_setup_entry(
                 )
             ]
         )
+
+    if envoy_data.dry_contact_status:
+        entities.extend(
+            EnvoyDryContactSwitchEntity(coordinator, RELAY_STATE_SWITCH, relay)
+            for relay in envoy_data.dry_contact_status
+        )
+
     async_add_entities(entities)
 
 
@@ -109,3 +140,57 @@ class EnvoyEnpowerSwitchEntity(EnvoyBaseEntity, SwitchEntity):
         """Turn off the Enpower switch."""
         await self.entity_description.turn_off_fn(self.envoy)
         await self.coordinator.async_request_refresh()
+
+
+class EnvoyDryContactSwitchEntity(EnvoyBaseEntity, SwitchEntity):
+    """Representation of an Enphase dry contact switch entity."""
+
+    entity_description: EnvoyDryContactSwitchEntityDescription
+    _attr_name = None
+
+    def __init__(
+        self,
+        coordinator: EnphaseUpdateCoordinator,
+        description: EnvoyDryContactSwitchEntityDescription,
+        relay_id: str,
+    ) -> None:
+        """Initialize the Enphase dry contact switch entity."""
+        super().__init__(coordinator, description)
+        self.envoy = coordinator.envoy
+        self.enpower = self.data.enpower
+        assert self.enpower is not None
+        self.relay_id = relay_id
+        self._serial_number = self.enpower.serial_number
+        self._attr_unique_id = (
+            f"{self._serial_number}_relay_{relay_id}_{description.key}"
+        )
+        self.relay = self.data.dry_contact_settings[relay_id]
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, relay_id)},
+            manufacturer="Enphase",
+            model="Dry contact relay",
+            name=self.relay.load_name,
+            sw_version=str(self.enpower.firmware_version),
+            via_device=(DOMAIN, self.enpower.serial_number),
+        )
+
+    @property
+    def is_on(self) -> bool:
+        """Return the state of the dry contact."""
+        relay = self.data.dry_contact_status[self.relay_id]
+        assert relay is not None
+        return self.entity_description.value_fn(relay)
+
+    async def async_turn_on(self):
+        """Turn on (close) the dry contact."""
+        if await self.entity_description.turn_on_fn(self.envoy, self.relay_id):
+            self.data.dry_contact_status[self.relay_id].status = DryContactStatus.CLOSED
+            self._attr_is_on = True
+            self.async_write_ha_state()
+
+    async def async_turn_off(self):
+        """Turn off (open) the dry contact."""
+        if await self.entity_description.turn_off_fn(self.envoy, self.relay_id):
+            self.data.dry_contact_status[self.relay_id].status = DryContactStatus.OPEN
+            self._attr_is_on = False
+            self.async_write_ha_state()

--- a/homeassistant/components/enphase_envoy/switch.py
+++ b/homeassistant/components/enphase_envoy/switch.py
@@ -51,7 +51,7 @@ class EnvoyDryContactRequiredKeysMixin:
 class EnvoyDryContactSwitchEntityDescription(
     SwitchEntityDescription, EnvoyDryContactRequiredKeysMixin
 ):
-    """Describes an Envoy Enpower switch entity."""
+    """Describes an Envoy Enpower dry contact switch entity."""
 
 
 ENPOWER_GRID_SWITCH = EnvoyEnpowerSwitchEntityDescription(

--- a/homeassistant/components/enphase_envoy/switch.py
+++ b/homeassistant/components/enphase_envoy/switch.py
@@ -43,8 +43,8 @@ class EnvoyDryContactRequiredKeysMixin:
     """Mixin for required keys."""
 
     value_fn: Callable[[EnvoyDryContactStatus], bool]
-    turn_on_fn: Callable[[Any, Any], Any]
-    turn_off_fn: Callable[[Any, Any], Any]
+    turn_on_fn: Callable[[Envoy, str], Coroutine[Any, Any, dict[str, Any]]]
+    turn_off_fn: Callable[[Envoy, str], Coroutine[Any, Any, dict[str, Any]]]
 
 
 @dataclass
@@ -157,21 +157,19 @@ class EnvoyDryContactSwitchEntity(EnvoyBaseEntity, SwitchEntity):
         """Initialize the Enphase dry contact switch entity."""
         super().__init__(coordinator, description)
         self.envoy = coordinator.envoy
-        self.enpower = self.data.enpower
-        assert self.enpower is not None
+        enpower = self.data.enpower
+        assert enpower is not None
         self.relay_id = relay_id
-        self._serial_number = self.enpower.serial_number
-        self._attr_unique_id = (
-            f"{self._serial_number}_relay_{relay_id}_{description.key}"
-        )
-        self.relay = self.data.dry_contact_settings[relay_id]
+        serial_number = enpower.serial_number
+        self._attr_unique_id = f"{serial_number}_relay_{relay_id}_{description.key}"
+        relay = self.data.dry_contact_settings[relay_id]
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, relay_id)},
             manufacturer="Enphase",
             model="Dry contact relay",
-            name=self.relay.load_name,
-            sw_version=str(self.enpower.firmware_version),
-            via_device=(DOMAIN, self.enpower.serial_number),
+            name=relay.load_name,
+            sw_version=str(enpower.firmware_version),
+            via_device=(DOMAIN, enpower.serial_number),
         )
 
     @property

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1665,7 +1665,7 @@ pyedimax==0.2.1
 pyefergy==22.1.1
 
 # homeassistant.components.enphase_envoy
-pyenphase==1.6.0
+pyenphase==1.7.1
 
 # homeassistant.components.envisalink
 pyenvisalink==4.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1665,7 +1665,7 @@ pyedimax==0.2.1
 pyefergy==22.1.1
 
 # homeassistant.components.enphase_envoy
-pyenphase==1.7.1
+pyenphase==1.8.1
 
 # homeassistant.components.envisalink
 pyenvisalink==4.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1229,7 +1229,7 @@ pyeconet==0.1.20
 pyefergy==22.1.1
 
 # homeassistant.components.enphase_envoy
-pyenphase==1.6.0
+pyenphase==1.7.1
 
 # homeassistant.components.everlights
 pyeverlights==0.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1229,7 +1229,7 @@ pyeconet==0.1.20
 pyefergy==22.1.1
 
 # homeassistant.components.enphase_envoy
-pyenphase==1.7.1
+pyenphase==1.8.1
 
 # homeassistant.components.everlights
 pyeverlights==0.1.0


### PR DESCRIPTION
## Proposed change
Switch the dry contact relay state entity from a `binary_sensor` to a `switch` and add support for toggling the relay open and closed.

https://github.com/pyenphase/pyenphase/compare/v1.6.0...v1.8.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
