### PR TITLE
Add back a timeout for service calls run from scripts

### DIFF
--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -642,7 +642,7 @@ class _ScriptRun:
         async def async_cancel_long_task() -> None:
             # Stop long task and wait for it to finish.
             long_task.cancel()
-            with suppress(Exception):
+            with suppress(Exception, asyncio.CancelledError):
                 await long_task
 
         # Wait for long task while monitoring for a stop request.
@@ -1582,7 +1582,6 @@ class Script:
         try:
             return await asyncio.shield(run.async_run())
         except asyncio.CancelledError:
-            script_execution_set("cancelled")
             await run.async_stop()
             self._changed()
             raise

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -585,7 +585,7 @@ async def test_service_call_timeout(hass: HomeAssistant) -> None:
 
     # The patch at the start of the function sets the service call timeout to
     # something much smaller than the sleep in the service call.
-    with pytest.raises(asyncio.CancelledError):
+    with pytest.raises(asyncio.TimeoutError):
         await hass.async_create_task(
             script_obj.async_run(
                 MappingProxyType({"fire1": "1"}),
@@ -605,11 +605,12 @@ async def test_service_call_timeout(hass: HomeAssistant) -> None:
                             "target": {},
                         },
                         "running_script": False,
-                    }
+                    },
+                    "error_type": asyncio.TimeoutError,
                 }
             ],
         },
-        expected_script_execution="cancelled",
+        expected_script_execution="error",
     )
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add back a timeout when running service calls from scripts. This prevents integration service calls that have no timeout from hanging indefinitely. Instead, they will fail with an explicit timeout error.

The timeout was removed in https://github.com/home-assistant/core/pull/94657 where it was previously baked into the service call. The old behavior was: When the timeout is reached, just return from the function anyway (!) which would effectively swallow/ignore the error. Now we explicitly raise an error.

This is an example of what a slow service call now looks like in the UI:
![image](https://github.com/home-assistant/core/assets/6026418/432d72ca-0fb8-4b70-aadf-9eca6a97c10b)

We may also want to update these steps with timeouts:
- _async_device_step
- _async_scene_step

There are likely a few other places where we want to add an explicit timeout which can happen in followup PRs (for example, device actions may be calling a service within the integration). As a result, may want to push this to a higher level (in the future?) however then we'd need a way to disable it for some actions.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue: #98073
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
