### PR TITLE
Revert "Fix fanSpeed issue in Tado"

### DIFF
--- a/homeassistant/components/tado/__init__.py
+++ b/homeassistant/components/tado/__init__.py
@@ -327,7 +327,7 @@ class TadoConnector:
                 device_type,
                 "ON",
                 mode,
-                fan_speed=fan_speed,
+                fanSpeed=fan_speed,
                 swing=swing,
             )
 


### PR DESCRIPTION
I line with revert PR https://github.com/home-assistant/core/pull/98505. This is no longer needed if the revert of PyTado 0.15 is done.

Reverts home-assistant/core#98293