### PR TITLE
Make ESPHome deep sleep tests more robust

### DIFF
--- a/tests/components/esphome/test_entity.py
+++ b/tests/components/esphome/test_entity.py
@@ -8,10 +8,12 @@ from aioesphomeapi import (
     BinarySensorState,
     EntityInfo,
     EntityState,
+    SensorInfo,
+    SensorState,
     UserService,
 )
 
-from homeassistant.const import ATTR_RESTORED, STATE_ON, STATE_UNAVAILABLE
+from homeassistant.const import ATTR_RESTORED, STATE_OFF, STATE_ON, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 
 from .conftest import MockESPHomeDevice
@@ -149,10 +151,17 @@ async def test_deep_sleep_device(
             name="my binary_sensor",
             unique_id="my_binary_sensor",
         ),
+        SensorInfo(
+            object_id="my_sensor",
+            key=3,
+            name="my sensor",
+            unique_id="my_sensor",
+        ),
     ]
     states = [
         BinarySensorState(key=1, state=True, missing_state=False),
         BinarySensorState(key=2, state=True, missing_state=False),
+        SensorState(key=3, state=123.0, missing_state=False),
     ]
     user_service = []
     mock_device = await mock_esphome_device(
@@ -165,10 +174,16 @@ async def test_deep_sleep_device(
     state = hass.states.get("binary_sensor.test_mybinary_sensor")
     assert state is not None
     assert state.state == STATE_ON
+    state = hass.states.get("sensor.test_my_sensor")
+    assert state is not None
+    assert state.state == "123"
 
     await mock_device.mock_disconnect(False)
     await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.test_mybinary_sensor")
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+    state = hass.states.get("sensor.test_my_sensor")
     assert state is not None
     assert state.state == STATE_UNAVAILABLE
 
@@ -178,12 +193,43 @@ async def test_deep_sleep_device(
     state = hass.states.get("binary_sensor.test_mybinary_sensor")
     assert state is not None
     assert state.state == STATE_ON
+    state = hass.states.get("sensor.test_my_sensor")
+    assert state is not None
+    assert state.state == "123"
+
+    await mock_device.mock_disconnect(True)
+    await hass.async_block_till_done()
+    await mock_device.mock_connect()
+    await hass.async_block_till_done()
+    mock_device.set_state(BinarySensorState(key=1, state=False, missing_state=False))
+    mock_device.set_state(SensorState(key=3, state=56, missing_state=False))
+    await hass.async_block_till_done()
+    state = hass.states.get("binary_sensor.test_mybinary_sensor")
+    assert state is not None
+    assert state.state == STATE_OFF
+    state = hass.states.get("sensor.test_my_sensor")
+    assert state is not None
+    assert state.state == "56"
 
     await mock_device.mock_disconnect(True)
     await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.test_mybinary_sensor")
     assert state is not None
-    assert state.state == STATE_ON
+    assert state.state == STATE_OFF
+    state = hass.states.get("sensor.test_my_sensor")
+    assert state is not None
+    assert state.state == "56"
+
+    await mock_device.mock_connect()
+    await hass.async_block_till_done()
+    await mock_device.mock_disconnect(False)
+    await hass.async_block_till_done()
+    state = hass.states.get("binary_sensor.test_mybinary_sensor")
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+    state = hass.states.get("sensor.test_my_sensor")
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
 
 
 async def test_esphome_device_without_friendly_name(


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

I can't find a bug here, but the tests can be improved a bit.

related issue #98221


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
