### PR TITLE
Add state_class to tomorrowio UV Index

### DIFF
--- a/homeassistant/components/tomorrowio/sensor.py
+++ b/homeassistant/components/tomorrowio/sensor.py
@@ -18,6 +18,7 @@ from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
+    SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -295,7 +296,7 @@ SENSOR_TYPES = (
     TomorrowioSensorEntityDescription(
         key=TMRW_ATTR_UV_INDEX,
         name="UV Index",
-        state_class="measurement",
+        state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:sun-wireless",
     ),
     TomorrowioSensorEntityDescription(

--- a/homeassistant/components/tomorrowio/sensor.py
+++ b/homeassistant/components/tomorrowio/sensor.py
@@ -295,6 +295,7 @@ SENSOR_TYPES = (
     TomorrowioSensorEntityDescription(
         key=TMRW_ATTR_UV_INDEX,
         name="UV Index",
+        state_class=measurement
         icon="mdi:sun-wireless",
     ),
     TomorrowioSensorEntityDescription(

--- a/homeassistant/components/tomorrowio/sensor.py
+++ b/homeassistant/components/tomorrowio/sensor.py
@@ -295,7 +295,7 @@ SENSOR_TYPES = (
     TomorrowioSensorEntityDescription(
         key=TMRW_ATTR_UV_INDEX,
         name="UV Index",
-        state_class=measurement
+        state_class=measurement,
         icon="mdi:sun-wireless",
     ),
     TomorrowioSensorEntityDescription(

--- a/homeassistant/components/tomorrowio/sensor.py
+++ b/homeassistant/components/tomorrowio/sensor.py
@@ -295,7 +295,7 @@ SENSOR_TYPES = (
     TomorrowioSensorEntityDescription(
         key=TMRW_ATTR_UV_INDEX,
         name="UV Index",
-        state_class=measurement,
+        state_class="measurement",
         icon="mdi:sun-wireless",
     ),
     TomorrowioSensorEntityDescription(


### PR DESCRIPTION
Forgot to add a `state_class` as other sensors got their `state_class` from their `device_class`. As there is no UV Index `device_class` I forgot to add it in the original merge request #96534. 

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Changes the behaviour from an enum to a linear graph display. 

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add state_class to UV Index sensor. Do note I literally just noticed this problem and edited it via the web editor as I'm not having access to my usual development environment. So I technically didn't verify it works with this code.

I "tested" it by overwriting the state class on my regular installation using `customize`

![grafik](https://github.com/home-assistant/core/assets/29854606/0f91e95d-0e39-4fbf-9a85-f1224d628252)

```
sensor.tomorrow_io_zuhause_uv_index:
  state_class: measurement

```

The values are still limited to integers from 1 to 12, but stuff like calculating averages as well as long-term statistics will work. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: UV Index values are enum. Not an issue per se, but perhaps not as designed?
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
