### PR TITLE
Name unnamed update entities by their device class

### DIFF
--- a/homeassistant/components/ezviz/strings.json
+++ b/homeassistant/components/ezviz/strings.json
@@ -223,11 +223,6 @@
         "name": "Follow movement"
       }
     },
-    "update": {
-      "firmware": {
-        "name": "[%key:component::update::entity_component::firmware::name%]"
-      }
-    },
     "siren": {
       "siren": {
         "name": "[%key:component::siren::title%]"

--- a/homeassistant/components/ezviz/update.py
+++ b/homeassistant/components/ezviz/update.py
@@ -24,7 +24,6 @@ PARALLEL_UPDATES = 1
 
 UPDATE_ENTITY_TYPES = UpdateEntityDescription(
     key="version",
-    translation_key="firmware",
     device_class=UpdateDeviceClass.FIRMWARE,
 )
 

--- a/homeassistant/components/litterrobot/strings.json
+++ b/homeassistant/components/litterrobot/strings.json
@@ -131,11 +131,6 @@
       "litter_box": {
         "name": "Litter box"
       }
-    },
-    "update": {
-      "firmware": {
-        "name": "Firmware"
-      }
     }
   },
   "services": {

--- a/homeassistant/components/litterrobot/update.py
+++ b/homeassistant/components/litterrobot/update.py
@@ -24,7 +24,6 @@ SCAN_INTERVAL = timedelta(days=1)
 
 FIRMWARE_UPDATE_ENTITY = UpdateEntityDescription(
     key="firmware",
-    translation_key="firmware",
     device_class=UpdateDeviceClass.FIRMWARE,
 )
 

--- a/homeassistant/components/rainmachine/strings.json
+++ b/homeassistant/components/rainmachine/strings.json
@@ -91,11 +91,6 @@
       "hot_days_extra_watering": {
         "name": "Extra water on hot days"
       }
-    },
-    "update": {
-      "firmware": {
-        "name": "Firmware"
-      }
     }
   },
   "services": {

--- a/homeassistant/components/rainmachine/update.py
+++ b/homeassistant/components/rainmachine/update.py
@@ -44,7 +44,6 @@ UPDATE_STATE_MAP = {
 
 UPDATE_DESCRIPTION = RainMachineEntityDescription(
     key="update",
-    translation_key="firmware",
     api_category=DATA_MACHINE_FIRMWARE_UPDATE_STATUS,
 )
 

--- a/homeassistant/components/update/__init__.py
+++ b/homeassistant/components/update/__init__.py
@@ -216,6 +216,13 @@ class UpdateEntity(RestoreEntity):
         """Version installed and in use."""
         return self._attr_installed_version
 
+    def _default_to_device_class_name(self) -> bool:
+        """Return True if an unnamed entity should be named by its device class.
+
+        For updates this is True if the entity has a device class.
+        """
+        return self.device_class is not None
+
     @property
     def device_class(self) -> UpdateDeviceClass | None:
         """Return the class of this entity."""

--- a/tests/components/update/test_init.py
+++ b/tests/components/update/test_init.py
@@ -782,7 +782,7 @@ def config_flow_fixture(hass: HomeAssistant) -> Generator[None, None, None]:
 
 
 async def test_name(hass: HomeAssistant) -> None:
-    """Test number name."""
+    """Test update name."""
 
     async def async_setup_entry_init(
         hass: HomeAssistant, config_entry: ConfigEntry
@@ -800,22 +800,22 @@ async def test_name(hass: HomeAssistant) -> None:
         ),
     )
 
-    # Unnamed sensor without device class -> no name
+    # Unnamed update entity without device class -> no name
     entity1 = UpdateEntity()
     entity1.entity_id = "update.test1"
 
-    # Unnamed sensor with device class but has_entity_name False -> no name
+    # Unnamed update entity with device class but has_entity_name False -> no name
     entity2 = UpdateEntity()
     entity2.entity_id = "update.test2"
     entity2._attr_device_class = UpdateDeviceClass.FIRMWARE
 
-    # Unnamed sensor with device class and has_entity_name True -> named
+    # Unnamed update entity with device class and has_entity_name True -> named
     entity3 = UpdateEntity()
     entity3.entity_id = "update.test3"
     entity3._attr_device_class = UpdateDeviceClass.FIRMWARE
     entity3._attr_has_entity_name = True
 
-    # Unnamed sensor with device class and has_entity_name True -> named
+    # Unnamed update entity with device class and has_entity_name True -> named
     entity4 = UpdateEntity()
     entity4.entity_id = "update.test4"
     entity4.entity_description = UpdateEntityDescription(

--- a/tests/components/update/test_init.py
+++ b/tests/components/update/test_init.py
@@ -1,4 +1,5 @@
 """The tests for the Update component."""
+from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -24,6 +25,7 @@ from homeassistant.components.update.const import (
     ATTR_TITLE,
     UpdateEntityFeature,
 )
+from homeassistant.config_entries import ConfigEntry, ConfigFlow
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     CONF_PLATFORM,
@@ -34,11 +36,23 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant, State, callback
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.setup import async_setup_component
 
-from tests.common import MockEntityPlatform, mock_restore_cache
+from tests.common import (
+    MockConfigEntry,
+    MockEntityPlatform,
+    MockModule,
+    MockPlatform,
+    mock_config_flow,
+    mock_integration,
+    mock_platform,
+    mock_restore_cache,
+)
 from tests.typing import WebSocketGenerator
+
+TEST_DOMAIN = "test"
 
 
 class MockUpdateEntity(UpdateEntity):
@@ -752,3 +766,101 @@ async def test_release_notes_entity_does_not_support_release_notes(
     result = await client.receive_json()
     assert result["error"]["code"] == "not_supported"
     assert result["error"]["message"] == "Entity does not support release notes"
+
+
+class MockFlow(ConfigFlow):
+    """Test flow."""
+
+
+@pytest.fixture(autouse=True)
+def config_flow_fixture(hass: HomeAssistant) -> Generator[None, None, None]:
+    """Mock config flow."""
+    mock_platform(hass, f"{TEST_DOMAIN}.config_flow")
+
+    with mock_config_flow(TEST_DOMAIN, MockFlow):
+        yield
+
+
+async def test_name(hass: HomeAssistant) -> None:
+    """Test number name."""
+
+    async def async_setup_entry_init(
+        hass: HomeAssistant, config_entry: ConfigEntry
+    ) -> bool:
+        """Set up test config entry."""
+        await hass.config_entries.async_forward_entry_setup(config_entry, DOMAIN)
+        return True
+
+    mock_platform(hass, f"{TEST_DOMAIN}.config_flow")
+    mock_integration(
+        hass,
+        MockModule(
+            TEST_DOMAIN,
+            async_setup_entry=async_setup_entry_init,
+        ),
+    )
+
+    # Unnamed sensor without device class -> no name
+    entity1 = UpdateEntity()
+    entity1.entity_id = "update.test1"
+
+    # Unnamed sensor with device class but has_entity_name False -> no name
+    entity2 = UpdateEntity()
+    entity2.entity_id = "update.test2"
+    entity2._attr_device_class = UpdateDeviceClass.FIRMWARE
+
+    # Unnamed sensor with device class and has_entity_name True -> named
+    entity3 = UpdateEntity()
+    entity3.entity_id = "update.test3"
+    entity3._attr_device_class = UpdateDeviceClass.FIRMWARE
+    entity3._attr_has_entity_name = True
+
+    # Unnamed sensor with device class and has_entity_name True -> named
+    entity4 = UpdateEntity()
+    entity4.entity_id = "update.test4"
+    entity4.entity_description = UpdateEntityDescription(
+        "test",
+        UpdateDeviceClass.FIRMWARE,
+        has_entity_name=True,
+    )
+
+    async def async_setup_entry_platform(
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        async_add_entities: AddEntitiesCallback,
+    ) -> None:
+        """Set up test update platform via config entry."""
+        async_add_entities([entity1, entity2, entity3, entity4])
+
+    mock_platform(
+        hass,
+        f"{TEST_DOMAIN}.{DOMAIN}",
+        MockPlatform(async_setup_entry=async_setup_entry_platform),
+    )
+
+    config_entry = MockConfigEntry(domain=TEST_DOMAIN)
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity1.entity_id)
+    assert state
+    assert "device_class" not in state.attributes
+    assert "friendly_name" not in state.attributes
+
+    state = hass.states.get(entity2.entity_id)
+    assert state
+    assert state.attributes.get("device_class") == "firmware"
+    assert "friendly_name" not in state.attributes
+
+    expected = {
+        "device_class": "firmware",
+        "friendly_name": "Firmware",
+    }
+    state = hass.states.get(entity3.entity_id)
+    assert state
+    assert expected.items() <= state.attributes.items()
+
+    state = hass.states.get(entity4.entity_id)
+    assert state
+    assert expected.items() <= state.attributes.items()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Name unnamed update entities by their device class

Background in https://github.com/home-assistant/architecture/discussions/909

Previously merged
- button counterpart: https://github.com/home-assistant/core/pull/95084
- number counterpart: https://github.com/home-assistant/core/pull/95083
- sensor counterpart: https://github.com/home-assistant/core/pull/94646

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
