### PR TITLE
Refactor doorbird to avoid using events internally

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -217,6 +217,7 @@ omit =
     homeassistant/components/doorbird/device.py
     homeassistant/components/doorbird/entity.py
     homeassistant/components/doorbird/util.py
+    homeassistant/components/doorbird/view.py
     homeassistant/components/dormakaba_dkey/__init__.py
     homeassistant/components/dormakaba_dkey/binary_sensor.py
     homeassistant/components/dormakaba_dkey/entity.py

--- a/homeassistant/components/doorbird/__init__.py
+++ b/homeassistant/components/doorbird/__init__.py
@@ -5,13 +5,11 @@ from http import HTTPStatus
 import logging
 from typing import Any
 
-from aiohttp import web
 from doorbirdpy import DoorBird
 import requests
 import voluptuous as vol
 
 from homeassistant.components import persistent_notification
-from homeassistant.components.http import HomeAssistantView
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_HOST,
@@ -20,21 +18,20 @@ from homeassistant.const import (
     CONF_TOKEN,
     CONF_USERNAME,
 )
-from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
-from .const import API_URL, CONF_EVENTS, DOMAIN, PLATFORMS
+from .const import CONF_EVENTS, DOMAIN, PLATFORMS
 from .device import ConfiguredDoorBird
 from .models import DoorBirdData
-from .util import get_door_station_by_token
+from .view import DoorBirdRequestView
 
 _LOGGER = logging.getLogger(__name__)
 
 CONF_CUSTOM_URL = "hass_url_override"
 
-RESET_DEVICE_FAVORITES = "doorbird_reset_favorites"
 
 DEVICE_SCHEMA = vol.Schema(
     {
@@ -54,29 +51,8 @@ CONFIG_SCHEMA = cv.removed(DOMAIN, raise_if_present=False)
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the DoorBird component."""
     hass.data.setdefault(DOMAIN, {})
-
     # Provide an endpoint for the door stations to call to trigger events
     hass.http.register_view(DoorBirdRequestView)
-
-    def _reset_device_favorites_handler(event: Event) -> None:
-        """Handle clearing favorites on device."""
-        if (token := event.data.get("token")) is None:
-            return
-
-        door_station = get_door_station_by_token(hass, token)
-
-        if door_station is None:
-            _LOGGER.error("Device not found for provided token")
-            return
-
-        # Clear webhooks
-        favorites: dict[str, list[str]] = door_station.device.favorites()
-        for favorite_type, favorite_ids in favorites.items():
-            for favorite_id in favorite_ids:
-                door_station.device.delete_favorite(favorite_type, favorite_id)
-
-    hass.bus.async_listen(RESET_DEVICE_FAVORITES, _reset_device_favorites_handler)
-
     return True
 
 
@@ -150,6 +126,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def _async_register_events(
     hass: HomeAssistant, door_station: ConfiguredDoorBird
 ) -> bool:
+    """Register events on device."""
     try:
         await hass.async_add_executor_job(door_station.register_events, hass)
     except requests.exceptions.HTTPError:
@@ -190,36 +167,3 @@ def _async_import_options_from_data_if_missing(hass: HomeAssistant, entry: Confi
 
     if modified:
         hass.config_entries.async_update_entry(entry, options=options)
-
-
-class DoorBirdRequestView(HomeAssistantView):
-    """Provide a page for the device to call."""
-
-    requires_auth = False
-    url = API_URL
-    name = API_URL[1:].replace("/", ":")
-    extra_urls = [API_URL + "/{event}"]
-
-    async def get(self, request: web.Request, event: str) -> web.Response:
-        """Respond to requests from the device."""
-        hass: HomeAssistant = request.app["hass"]
-        token: str | None = request.query.get("token")
-        if token is None or (device := get_door_station_by_token(hass, token)) is None:
-            return web.Response(
-                status=HTTPStatus.UNAUTHORIZED, text="Invalid token provided."
-            )
-
-        if device:
-            event_data = device.get_event_data(event)
-        else:
-            event_data = {}
-
-        if event == "clear":
-            hass.bus.async_fire(RESET_DEVICE_FAVORITES, {"token": token})
-
-            message = f"HTTP Favorites cleared for {device.slug}"
-            return web.Response(text=message)
-
-        hass.bus.async_fire(f"{DOMAIN}_{event}", event_data)
-
-        return web.Response(text="OK")

--- a/homeassistant/components/doorbird/camera.py
+++ b/homeassistant/components/doorbird/camera.py
@@ -128,5 +128,6 @@ class DoorBirdCamera(DoorBirdEntity, Camera):
         """Unsubscribe from events."""
         event_to_entity_id = self._door_bird_data.event_entity_ids
         for event in self._door_station.events:
-            del event_to_entity_id[event]
+            # If the clear api was called, the events may not be in the dict
+            event_to_entity_id.pop(event, None)
         await super().async_will_remove_from_hass()

--- a/homeassistant/components/doorbird/device.py
+++ b/homeassistant/components/doorbird/device.py
@@ -157,7 +157,8 @@ async def async_reset_device_favorites(
 def _reset_device_favorites(door_station: ConfiguredDoorBird) -> None:
     """Handle clearing favorites on device."""
     # Clear webhooks
-    favorites: dict[str, list[str]] = door_station.device.favorites()
+    door_bird = door_station.device
+    favorites: dict[str, list[str]] = door_bird.favorites()
     for favorite_type, favorite_ids in favorites.items():
         for favorite_id in favorite_ids:
-            door_station.device.delete_favorite(favorite_type, favorite_id)
+            door_bird.delete_favorite(favorite_type, favorite_id)

--- a/homeassistant/components/doorbird/device.py
+++ b/homeassistant/components/doorbird/device.py
@@ -145,3 +145,19 @@ class ConfiguredDoorBird:
             "html5_viewer_url": self._device.html5_viewer_url,
             ATTR_ENTITY_ID: self._event_entity_ids.get(event),
         }
+
+
+async def async_reset_device_favorites(
+    hass: HomeAssistant, door_station: ConfiguredDoorBird
+) -> None:
+    """Handle clearing favorites on device."""
+    await hass.async_add_executor_job(_reset_device_favorites, door_station)
+
+
+def _reset_device_favorites(door_station: ConfiguredDoorBird) -> None:
+    """Handle clearing favorites on device."""
+    # Clear webhooks
+    favorites: dict[str, list[str]] = door_station.device.favorites()
+    for favorite_type, favorite_ids in favorites.items():
+        for favorite_id in favorite_ids:
+            door_station.device.delete_favorite(favorite_type, favorite_id)

--- a/homeassistant/components/doorbird/util.py
+++ b/homeassistant/components/doorbird/util.py
@@ -1,5 +1,7 @@
 """DoorBird integration utils."""
 
+from typing import Any
+
 from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
@@ -7,7 +9,7 @@ from .device import ConfiguredDoorBird
 from .models import DoorBirdData
 
 
-def get_mac_address_from_door_station_info(door_station_info):
+def get_mac_address_from_door_station_info(door_station_info: dict[str, Any]) -> str:
     """Get the mac address depending on the device type."""
     return door_station_info.get("PRIMARY_MAC_ADDR", door_station_info["WIFI_MAC_ADDR"])
 

--- a/homeassistant/components/doorbird/view.py
+++ b/homeassistant/components/doorbird/view.py
@@ -1,0 +1,50 @@
+"""Support for DoorBird devices."""
+from __future__ import annotations
+
+from http import HTTPStatus
+import logging
+
+from aiohttp import web
+
+from homeassistant.components.http import HomeAssistantView
+from homeassistant.core import HomeAssistant
+
+from .const import API_URL, DOMAIN
+from .device import async_reset_device_favorites
+from .util import get_door_station_by_token
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class DoorBirdRequestView(HomeAssistantView):
+    """Provide a page for the device to call."""
+
+    requires_auth = False
+    url = API_URL
+    name = API_URL[1:].replace("/", ":")
+    extra_urls = [API_URL + "/{event}"]
+
+    async def get(self, request: web.Request, event: str) -> web.Response:
+        """Respond to requests from the device."""
+        hass: HomeAssistant = request.app["hass"]
+        token: str | None = request.query.get("token")
+        if (
+            token is None
+            or (door_station := get_door_station_by_token(hass, token)) is None
+        ):
+            return web.Response(
+                status=HTTPStatus.UNAUTHORIZED, text="Invalid token provided."
+            )
+
+        if door_station:
+            event_data = door_station.get_event_data(event)
+        else:
+            event_data = {}
+
+        if event == "clear":
+            await async_reset_device_favorites(hass, door_station)
+            message = f"HTTP Favorites cleared for {door_station.slug}"
+            return web.Response(text=message)
+
+        hass.bus.async_fire(f"{DOMAIN}_{event}", event_data)
+        return web.Response(text="OK")

--- a/homeassistant/components/doorbird/view.py
+++ b/homeassistant/components/doorbird/view.py
@@ -46,5 +46,14 @@ class DoorBirdRequestView(HomeAssistantView):
             message = f"HTTP Favorites cleared for {door_station.slug}"
             return web.Response(text=message)
 
+        #
+        # This integration uses a different event for
+        # each entity id. It would be a major breaking
+        # change to change this to a single event at this
+        # point.
+        #
+        # Do not copy this pattern in the future
+        # for any new integrations.
+        #
         hass.bus.async_fire(f"{DOMAIN}_{event}", event_data)
         return web.Response(text="OK")

--- a/homeassistant/components/doorbird/view.py
+++ b/homeassistant/components/doorbird/view.py
@@ -47,10 +47,9 @@ class DoorBirdRequestView(HomeAssistantView):
             return web.Response(text=message)
 
         #
-        # This integration uses a different event for
-        # each entity id. It would be a major breaking
-        # change to change this to a single event at this
-        # point.
+        # This integration uses a multiple different events.
+        # It would be a major breaking change to change this to
+        # a single event at this point.
         #
         # Do not copy this pattern in the future
         # for any new integrations.


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The `doorbird_reset_favorites` event is no longer fired when the clear webhook is called.

Note: this event was never documented.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This integration was using events to communicate internally. Create an executor job instead.

A future PR will make a config button, and than we can deprecate manually typing in a magic api url with a hard to find token like https://www.home-assistant.io/integrations/doorbird/#clearing-registered-events

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
