### PR TITLE
Add pipeline VAD events

### DIFF
--- a/tests/components/assist_pipeline/snapshots/test_init.ambr
+++ b/tests/components/assist_pipeline/snapshots/test_init.ambr
@@ -313,6 +313,12 @@
     }),
     dict({
       'data': dict({
+        'timestamp': 0,
+      }),
+      'type': <PipelineEventType.STT_VAD_START: 'stt-vad-start'>,
+    }),
+    dict({
+      'data': dict({
         'stt_output': dict({
           'text': 'test transcript',
         }),

--- a/tests/components/assist_pipeline/test_init.py
+++ b/tests/components/assist_pipeline/test_init.py
@@ -40,7 +40,7 @@ async def test_pipeline_from_audio_stream_auto(
     In this test, no pipeline is specified.
     """
 
-    events = []
+    events: list[assist_pipeline.PipelineEvent] = []
 
     async def audio_data():
         yield b"part1"
@@ -79,7 +79,7 @@ async def test_pipeline_from_audio_stream_legacy(
     """
     client = await hass_ws_client(hass)
 
-    events = []
+    events: list[assist_pipeline.PipelineEvent] = []
 
     async def audio_data():
         yield b"part1"
@@ -139,7 +139,7 @@ async def test_pipeline_from_audio_stream_entity(
     """
     client = await hass_ws_client(hass)
 
-    events = []
+    events: list[assist_pipeline.PipelineEvent] = []
 
     async def audio_data():
         yield b"part1"
@@ -199,7 +199,7 @@ async def test_pipeline_from_audio_stream_no_stt(
     """
     client = await hass_ws_client(hass)
 
-    events = []
+    events: list[assist_pipeline.PipelineEvent] = []
 
     async def audio_data():
         yield b"part1"
@@ -257,7 +257,7 @@ async def test_pipeline_from_audio_stream_unknown_pipeline(
 
     In this test, the pipeline does not exist.
     """
-    events = []
+    events: list[assist_pipeline.PipelineEvent] = []
 
     async def audio_data():
         yield b"part1"
@@ -294,7 +294,7 @@ async def test_pipeline_from_audio_stream_wake_word(
 ) -> None:
     """Test creating a pipeline from an audio stream with wake word."""
 
-    events = []
+    events: list[assist_pipeline.PipelineEvent] = []
 
     # [0, 1, ...]
     wake_chunk_1 = bytes(it.islice(it.cycle(range(256)), BYTES_ONE_SECOND))


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds `stt-vad-start` and `stt-vad-end` events to pipelines.

These events indicate the start and end of a voice command according to the VAD (voice activity detector). Both events include a timestamp (milliseconds) relative to the start of the audio stream.

The time between `stt-start` and `stt-vad-start` is the amount of silence before the user started speaking.
The time between `stt-vad-end` and `stt-end` is how long the STT took to transcribe the voice command.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/1880

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
