### PR TITLE
2023.8.3

### DIFF
--- a/homeassistant/components/esphome/const.py
+++ b/homeassistant/components/esphome/const.py
@@ -11,7 +11,7 @@ DEFAULT_ALLOW_SERVICE_CALLS = True
 DEFAULT_NEW_CONFIG_ALLOW_ALLOW_SERVICE_CALLS = False
 
 
-STABLE_BLE_VERSION_STR = "2023.6.0"
+STABLE_BLE_VERSION_STR = "2023.8.0"
 STABLE_BLE_VERSION = AwesomeVersion(STABLE_BLE_VERSION_STR)
 PROJECT_URLS = {
     "esphome.bluetooth-proxy": "https://esphome.github.io/bluetooth-proxies/",

--- a/homeassistant/components/flux_led/manifest.json
+++ b/homeassistant/components/flux_led/manifest.json
@@ -54,5 +54,5 @@
   "iot_class": "local_push",
   "loggers": ["flux_led"],
   "quality_scale": "platinum",
-  "requirements": ["flux-led==1.0.1"]
+  "requirements": ["flux-led==1.0.2"]
 }

--- a/homeassistant/components/frontend/manifest.json
+++ b/homeassistant/components/frontend/manifest.json
@@ -20,5 +20,5 @@
   "documentation": "https://www.home-assistant.io/integrations/frontend",
   "integration_type": "system",
   "quality_scale": "internal",
-  "requirements": ["home-assistant-frontend==20230802.0"]
+  "requirements": ["home-assistant-frontend==20230802.1"]
 }

--- a/homeassistant/components/gogogate2/common.py
+++ b/homeassistant/components/gogogate2/common.py
@@ -113,9 +113,10 @@ class GoGoGate2Entity(CoordinatorEntity[DeviceDataUpdateCoordinator]):
     def device_info(self) -> DeviceInfo:
         """Device info for the controller."""
         data = self.coordinator.data
-        configuration_url = (
-            f"https://{data.remoteaccess}" if data.remoteaccess else None
-        )
+        if data.remoteaccessenabled:
+            configuration_url = f"https://{data.remoteaccess}"
+        else:
+            configuration_url = f"http://{self._config_entry.data[CONF_IP_ADDRESS]}"
         return DeviceInfo(
             configuration_url=configuration_url,
             identifiers={(DOMAIN, str(self._config_entry.unique_id))},

--- a/homeassistant/components/homekit_controller/manifest.json
+++ b/homeassistant/components/homekit_controller/manifest.json
@@ -14,6 +14,6 @@
   "documentation": "https://www.home-assistant.io/integrations/homekit_controller",
   "iot_class": "local_push",
   "loggers": ["aiohomekit", "commentjson"],
-  "requirements": ["aiohomekit==2.6.15"],
+  "requirements": ["aiohomekit==2.6.16"],
   "zeroconf": ["_hap._tcp.local.", "_hap._udp.local."]
 }

--- a/homeassistant/components/honeywell/climate.py
+++ b/homeassistant/components/honeywell/climate.py
@@ -146,13 +146,13 @@ class HoneywellUSThermostat(ClimateEntity):
             | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
         )
 
-        if device._data["canControlHumidification"]:
+        if device._data.get("canControlHumidification"):
             self._attr_supported_features |= ClimateEntityFeature.TARGET_HUMIDITY
 
-        if device.raw_ui_data["SwitchEmergencyHeatAllowed"]:
+        if device.raw_ui_data.get("SwitchEmergencyHeatAllowed"):
             self._attr_supported_features |= ClimateEntityFeature.AUX_HEAT
 
-        if not device._data["hasFan"]:
+        if not device._data.get("hasFan"):
             return
 
         # not all honeywell fans support all modes

--- a/homeassistant/components/honeywell/sensor.py
+++ b/homeassistant/components/honeywell/sensor.py
@@ -20,6 +20,7 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
+from . import HoneywellData
 from .const import DOMAIN, HUMIDITY_STATUS_KEY, TEMPERATURE_STATUS_KEY
 
 
@@ -71,7 +72,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Honeywell thermostat."""
-    data = hass.data[DOMAIN][config_entry.entry_id]
+    data: HoneywellData = hass.data[DOMAIN][config_entry.entry_id]
     sensors = []
 
     for device in data.devices.values():

--- a/homeassistant/components/ipp/manifest.json
+++ b/homeassistant/components/ipp/manifest.json
@@ -8,6 +8,6 @@
   "iot_class": "local_polling",
   "loggers": ["deepmerge", "pyipp"],
   "quality_scale": "platinum",
-  "requirements": ["pyipp==0.14.2"],
+  "requirements": ["pyipp==0.14.3"],
   "zeroconf": ["_ipps._tcp.local.", "_ipp._tcp.local."]
 }

--- a/homeassistant/components/lyric/sensor.py
+++ b/homeassistant/components/lyric/sensor.py
@@ -17,7 +17,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import PERCENTAGE
+from homeassistant.const import PERCENTAGE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
@@ -76,6 +76,11 @@ async def async_setup_entry(
     for location in coordinator.data.locations:
         for device in location.devices:
             if device.indoorTemperature:
+                if device.units == "Fahrenheit":
+                    native_temperature_unit = UnitOfTemperature.FAHRENHEIT
+                else:
+                    native_temperature_unit = UnitOfTemperature.CELSIUS
+
                 entities.append(
                     LyricSensor(
                         coordinator,
@@ -84,7 +89,7 @@ async def async_setup_entry(
                             name="Indoor Temperature",
                             device_class=SensorDeviceClass.TEMPERATURE,
                             state_class=SensorStateClass.MEASUREMENT,
-                            native_unit_of_measurement=hass.config.units.temperature_unit,
+                            native_unit_of_measurement=native_temperature_unit,
                             value=lambda device: device.indoorTemperature,
                         ),
                         location,
@@ -108,6 +113,11 @@ async def async_setup_entry(
                     )
                 )
             if device.outdoorTemperature:
+                if device.units == "Fahrenheit":
+                    native_temperature_unit = UnitOfTemperature.FAHRENHEIT
+                else:
+                    native_temperature_unit = UnitOfTemperature.CELSIUS
+
                 entities.append(
                     LyricSensor(
                         coordinator,
@@ -116,7 +126,7 @@ async def async_setup_entry(
                             name="Outdoor Temperature",
                             device_class=SensorDeviceClass.TEMPERATURE,
                             state_class=SensorStateClass.MEASUREMENT,
-                            native_unit_of_measurement=hass.config.units.temperature_unit,
+                            native_unit_of_measurement=native_temperature_unit,
                             value=lambda device: device.outdoorTemperature,
                         ),
                         location,

--- a/homeassistant/components/modbus/base_platform.py
+++ b/homeassistant/components/modbus/base_platform.py
@@ -48,10 +48,12 @@ from .const import (
     CONF_MIN_VALUE,
     CONF_PRECISION,
     CONF_SCALE,
+    CONF_SLAVE_COUNT,
     CONF_STATE_OFF,
     CONF_STATE_ON,
     CONF_SWAP,
     CONF_SWAP_BYTE,
+    CONF_SWAP_NONE,
     CONF_SWAP_WORD,
     CONF_SWAP_WORD_BYTE,
     CONF_VERIFY,
@@ -155,15 +157,25 @@ class BaseStructPlatform(BasePlatform, RestoreEntity):
         """Initialize the switch."""
         super().__init__(hub, config)
         self._swap = config[CONF_SWAP]
+        if self._swap == CONF_SWAP_NONE:
+            self._swap = None
         self._data_type = config[CONF_DATA_TYPE]
         self._structure: str = config[CONF_STRUCTURE]
         self._precision = config[CONF_PRECISION]
         self._scale = config[CONF_SCALE]
         self._offset = config[CONF_OFFSET]
-        self._count = config[CONF_COUNT]
+        self._slave_count = config.get(CONF_SLAVE_COUNT, 0)
+        self._slave_size = self._count = config[CONF_COUNT]
 
-    def _swap_registers(self, registers: list[int]) -> list[int]:
+    def _swap_registers(self, registers: list[int], slave_count: int) -> list[int]:
         """Do swap as needed."""
+        if slave_count:
+            swapped = []
+            for i in range(0, self._slave_count + 1):
+                inx = i * self._slave_size
+                inx2 = inx + self._slave_size
+                swapped.extend(self._swap_registers(registers[inx:inx2], 0))
+            return swapped
         if self._swap in (CONF_SWAP_BYTE, CONF_SWAP_WORD_BYTE):
             # convert [12][34] --> [21][43]
             for i, register in enumerate(registers):
@@ -191,7 +203,8 @@ class BaseStructPlatform(BasePlatform, RestoreEntity):
     def unpack_structure_result(self, registers: list[int]) -> str | None:
         """Convert registers to proper result."""
 
-        registers = self._swap_registers(registers)
+        if self._swap:
+            registers = self._swap_registers(registers, self._slave_count)
         byte_string = b"".join([x.to_bytes(2, byteorder="big") for x in registers])
         if self._data_type == DataType.STRING:
             return byte_string.decode()

--- a/homeassistant/components/modbus/climate.py
+++ b/homeassistant/components/modbus/climate.py
@@ -206,7 +206,7 @@ class ModbusThermostat(BaseStructPlatform, RestoreEntity, ClimateEntity):
             int.from_bytes(as_bytes[i : i + 2], "big")
             for i in range(0, len(as_bytes), 2)
         ]
-        registers = self._swap_registers(raw_regs)
+        registers = self._swap_registers(raw_regs, 0)
 
         if self._data_type in (
             DataType.INT16,

--- a/homeassistant/components/modbus/sensor.py
+++ b/homeassistant/components/modbus/sensor.py
@@ -132,10 +132,7 @@ class ModbusRegisterSensor(BaseStructPlatform, RestoreSensor, SensorEntity):
                 self._coordinator.async_set_updated_data(None)
         else:
             self._attr_native_value = result
-        if self._attr_native_value is None:
-            self._attr_available = False
-        else:
-            self._attr_available = True
+        self._attr_available = self._attr_native_value is not None
         self._lazy_errors = self._lazy_error_count
         self.async_write_ha_state()
 

--- a/homeassistant/components/modbus/sensor.py
+++ b/homeassistant/components/modbus/sensor.py
@@ -68,7 +68,7 @@ class ModbusRegisterSensor(BaseStructPlatform, RestoreSensor, SensorEntity):
         """Initialize the modbus register sensor."""
         super().__init__(hub, entry)
         if slave_count:
-            self._count = self._count * slave_count
+            self._count = self._count * (slave_count + 1)
         self._coordinator: DataUpdateCoordinator[list[int] | None] | None = None
         self._attr_native_unit_of_measurement = entry.get(CONF_UNIT_OF_MEASUREMENT)
         self._attr_state_class = entry.get(CONF_STATE_CLASS)

--- a/homeassistant/components/modbus/validators.py
+++ b/homeassistant/components/modbus/validators.py
@@ -67,6 +67,17 @@ def struct_validator(config: dict[str, Any]) -> dict[str, Any]:
     slave_count = config.get(CONF_SLAVE_COUNT, 0) + 1
     slave = config.get(CONF_SLAVE, 0)
     swap_type = config.get(CONF_SWAP, CONF_SWAP_NONE)
+    if (
+        slave_count > 1
+        and count > 1
+        and data_type not in (DataType.CUSTOM, DataType.STRING)
+    ):
+        error = f"{name}  {CONF_COUNT} cannot be mixed with {data_type}"
+        raise vol.Invalid(error)
+    if config[CONF_DATA_TYPE] != DataType.CUSTOM:
+        if structure:
+            error = f"{name}  structure: cannot be mixed with {data_type}"
+
     if config[CONF_DATA_TYPE] == DataType.CUSTOM:
         if slave or slave_count > 1:
             error = f"{name}: `{CONF_STRUCTURE}` illegal with `{CONF_SLAVE_COUNT}` / `{CONF_SLAVE}`"
@@ -96,17 +107,11 @@ def struct_validator(config: dict[str, Any]) -> dict[str, Any]:
             CONF_STRUCTURE: structure,
             CONF_SWAP: swap_type,
         }
-
-    if structure:
-        error = f"{name}  structure: cannot be mixed with {data_type}"
-        raise vol.Invalid(error)
     if data_type not in DEFAULT_STRUCT_FORMAT:
         error = f"Error in sensor {name}. data_type `{data_type}` not supported"
         raise vol.Invalid(error)
-    if (slave or slave_count > 1) and data_type == DataType.STRING:
-        error = (
-            f"{name}: `{data_type}`  illegal with `{CONF_SLAVE_COUNT}` / `{CONF_SLAVE}`"
-        )
+    if slave_count > 1 and data_type == DataType.STRING:
+        error = f"{name}: `{data_type}`  illegal with `{CONF_SLAVE_COUNT}`"
         raise vol.Invalid(error)
 
     if CONF_COUNT not in config:

--- a/homeassistant/components/ness_alarm/__init__.py
+++ b/homeassistant/components/ness_alarm/__init__.py
@@ -3,7 +3,7 @@ from collections import namedtuple
 import datetime
 import logging
 
-from nessclient import ArmingState, Client
+from nessclient import ArmingMode, ArmingState, Client
 import voluptuous as vol
 
 from homeassistant.components.binary_sensor import (
@@ -136,9 +136,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             hass, SIGNAL_ZONE_CHANGED, ZoneChangedData(zone_id=zone_id, state=state)
         )
 
-    def on_state_change(arming_state: ArmingState):
+    def on_state_change(arming_state: ArmingState, arming_mode: ArmingMode | None):
         """Receives and propagates arming state updates."""
-        async_dispatcher_send(hass, SIGNAL_ARMING_STATE_CHANGED, arming_state)
+        async_dispatcher_send(
+            hass, SIGNAL_ARMING_STATE_CHANGED, arming_state, arming_mode
+        )
 
     client.on_zone_change(on_zone_change)
     client.on_state_change(on_state_change)

--- a/homeassistant/components/ness_alarm/manifest.json
+++ b/homeassistant/components/ness_alarm/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "https://www.home-assistant.io/integrations/ness_alarm",
   "iot_class": "local_push",
   "loggers": ["nessclient"],
-  "requirements": ["nessclient==0.10.0"]
+  "requirements": ["nessclient==1.0.0"]
 }

--- a/homeassistant/components/opower/coordinator.py
+++ b/homeassistant/components/opower/coordinator.py
@@ -12,6 +12,7 @@ from opower import (
     InvalidAuth,
     MeterType,
     Opower,
+    ReadResolution,
 )
 
 from homeassistant.components.recorder import get_instance
@@ -177,44 +178,55 @@ class OpowerCoordinator(DataUpdateCoordinator[dict[str, Forecast]]):
         """Get all cost reads since account activation but at different resolutions depending on age.
 
         - month resolution for all years (since account activation)
-        - day resolution for past 3 years
-        - hour resolution for past 2 months, only for electricity, not gas
+        - day resolution for past 3 years (if account's read resolution supports it)
+        - hour resolution for past 2 months (if account's read resolution supports it)
         """
         cost_reads = []
+
         start = None
-        end = datetime.now() - timedelta(days=3 * 365)
+        end = datetime.now()
+        if account.read_resolution != ReadResolution.BILLING:
+            end -= timedelta(days=3 * 365)
         cost_reads += await self.api.async_get_cost_reads(
             account, AggregateType.BILL, start, end
         )
+        if account.read_resolution == ReadResolution.BILLING:
+            return cost_reads
+
         start = end if not cost_reads else cost_reads[-1].end_time
-        end = (
-            datetime.now() - timedelta(days=2 * 30)
-            if account.meter_type == MeterType.ELEC
-            else datetime.now()
-        )
+        end = datetime.now()
+        if account.read_resolution != ReadResolution.DAY:
+            end -= timedelta(days=2 * 30)
         cost_reads += await self.api.async_get_cost_reads(
             account, AggregateType.DAY, start, end
         )
-        if account.meter_type == MeterType.ELEC:
-            start = end if not cost_reads else cost_reads[-1].end_time
-            end = datetime.now()
-            cost_reads += await self.api.async_get_cost_reads(
-                account, AggregateType.HOUR, start, end
-            )
+        if account.read_resolution == ReadResolution.DAY:
+            return cost_reads
+
+        start = end if not cost_reads else cost_reads[-1].end_time
+        end = datetime.now()
+        cost_reads += await self.api.async_get_cost_reads(
+            account, AggregateType.HOUR, start, end
+        )
         return cost_reads
 
     async def _async_get_recent_cost_reads(
         self, account: Account, last_stat_time: float
     ) -> list[CostRead]:
-        """Get cost reads within the past 30 days to allow corrections in data from utilities.
-
-        Hourly for electricity, daily for gas.
-        """
+        """Get cost reads within the past 30 days to allow corrections in data from utilities."""
+        if account.read_resolution in [
+            ReadResolution.HOUR,
+            ReadResolution.HALF_HOUR,
+            ReadResolution.QUARTER_HOUR,
+        ]:
+            aggregate_type = AggregateType.HOUR
+        elif account.read_resolution == ReadResolution.DAY:
+            aggregate_type = AggregateType.DAY
+        else:
+            aggregate_type = AggregateType.BILL
         return await self.api.async_get_cost_reads(
             account,
-            AggregateType.HOUR
-            if account.meter_type == MeterType.ELEC
-            else AggregateType.DAY,
+            aggregate_type,
             datetime.fromtimestamp(last_stat_time) - timedelta(days=30),
             datetime.now(),
         )

--- a/homeassistant/components/opower/manifest.json
+++ b/homeassistant/components/opower/manifest.json
@@ -6,5 +6,5 @@
   "dependencies": ["recorder"],
   "documentation": "https://www.home-assistant.io/integrations/opower",
   "iot_class": "cloud_polling",
-  "requirements": ["opower==0.0.26"]
+  "requirements": ["opower==0.0.29"]
 }

--- a/homeassistant/components/rainbird/manifest.json
+++ b/homeassistant/components/rainbird/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/rainbird",
   "iot_class": "local_polling",
   "loggers": ["pyrainbird"],
-  "requirements": ["pyrainbird==3.0.0"]
+  "requirements": ["pyrainbird==4.0.0"]
 }

--- a/homeassistant/components/reolink/binary_sensor.py
+++ b/homeassistant/components/reolink/binary_sensor.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 
 from reolink_aio.api import (
+    DUAL_LENS_DUAL_MOTION_MODELS,
     FACE_DETECTION_TYPE,
     PERSON_DETECTION_TYPE,
     PET_DETECTION_TYPE,
@@ -127,6 +128,9 @@ class ReolinkBinarySensorEntity(ReolinkChannelCoordinatorEntity, BinarySensorEnt
         """Initialize Reolink binary sensor."""
         super().__init__(reolink_data, channel)
         self.entity_description = entity_description
+
+        if self._host.api.model in DUAL_LENS_DUAL_MOTION_MODELS:
+            self._attr_name = f"{entity_description.name} lens {self._channel}"
 
         self._attr_unique_id = (
             f"{self._host.unique_id}_{self._channel}_{entity_description.key}"

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -163,7 +163,7 @@ class ReolinkHost:
         else:
             _LOGGER.debug(
                 "Camera model %s most likely does not push its initial state"
-                "upon ONVIF subscription, do not check",
+                " upon ONVIF subscription, do not check",
                 self._api.model,
             )
         self._cancel_onvif_check = async_call_later(

--- a/homeassistant/components/reolink/manifest.json
+++ b/homeassistant/components/reolink/manifest.json
@@ -18,5 +18,5 @@
   "documentation": "https://www.home-assistant.io/integrations/reolink",
   "iot_class": "local_push",
   "loggers": ["reolink_aio"],
-  "requirements": ["reolink-aio==0.7.6"]
+  "requirements": ["reolink-aio==0.7.7"]
 }

--- a/homeassistant/components/roborock/manifest.json
+++ b/homeassistant/components/roborock/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/roborock",
   "iot_class": "local_polling",
   "loggers": ["roborock"],
-  "requirements": ["python-roborock==0.32.2"]
+  "requirements": ["python-roborock==0.32.3"]
 }

--- a/homeassistant/components/roku/manifest.json
+++ b/homeassistant/components/roku/manifest.json
@@ -11,7 +11,7 @@
   "iot_class": "local_polling",
   "loggers": ["rokuecp"],
   "quality_scale": "silver",
-  "requirements": ["rokuecp==0.18.0"],
+  "requirements": ["rokuecp==0.18.1"],
   "ssdp": [
     {
       "st": "roku:ecp",

--- a/homeassistant/components/shelly/sensor.py
+++ b/homeassistant/components/shelly/sensor.py
@@ -533,7 +533,8 @@ RPC_SENSORS: Final = {
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT,
-        available=lambda status: status["n_current"] is not None,
+        available=lambda status: (status and status["n_current"]) is not None,
+        removal_condition=lambda _config, status, _key: "n_current" not in status,
         entity_registry_enabled_default=False,
     ),
     "total_current": RpcSensorDescription(

--- a/homeassistant/components/tado/__init__.py
+++ b/homeassistant/components/tado/__init__.py
@@ -163,11 +163,12 @@ class TadoConnector:
 
     def setup(self):
         """Connect to Tado and fetch the zones."""
-        self.tado = Tado(self._username, self._password, None, True)
+        self.tado = Tado(self._username, self._password)
+        self.tado.setDebugging(True)
         # Load zones and devices
-        self.zones = self.tado.get_zones()
-        self.devices = self.tado.get_devices()
-        tado_home = self.tado.get_me()["homes"][0]
+        self.zones = self.tado.getZones()
+        self.devices = self.tado.getDevices()
+        tado_home = self.tado.getMe()["homes"][0]
         self.home_id = tado_home["id"]
         self.home_name = tado_home["name"]
 
@@ -180,7 +181,7 @@ class TadoConnector:
 
     def update_devices(self):
         """Update the device data from Tado."""
-        devices = self.tado.get_devices()
+        devices = self.tado.getDevices()
         for device in devices:
             device_short_serial_no = device["shortSerialNo"]
             _LOGGER.debug("Updating device %s", device_short_serial_no)
@@ -189,7 +190,7 @@ class TadoConnector:
                     INSIDE_TEMPERATURE_MEASUREMENT
                     in device["characteristics"]["capabilities"]
                 ):
-                    device[TEMP_OFFSET] = self.tado.get_device_info(
+                    device[TEMP_OFFSET] = self.tado.getDeviceInfo(
                         device_short_serial_no, TEMP_OFFSET
                     )
             except RuntimeError:
@@ -217,7 +218,7 @@ class TadoConnector:
     def update_zones(self):
         """Update the zone data from Tado."""
         try:
-            zone_states = self.tado.get_zone_states()["zoneStates"]
+            zone_states = self.tado.getZoneStates()["zoneStates"]
         except RuntimeError:
             _LOGGER.error("Unable to connect to Tado while updating zones")
             return
@@ -229,7 +230,7 @@ class TadoConnector:
         """Update the internal data from Tado."""
         _LOGGER.debug("Updating zone %s", zone_id)
         try:
-            data = self.tado.get_zone_state(zone_id)
+            data = self.tado.getZoneState(zone_id)
         except RuntimeError:
             _LOGGER.error("Unable to connect to Tado while updating zone %s", zone_id)
             return
@@ -250,8 +251,8 @@ class TadoConnector:
     def update_home(self):
         """Update the home data from Tado."""
         try:
-            self.data["weather"] = self.tado.get_weather()
-            self.data["geofence"] = self.tado.get_home_state()
+            self.data["weather"] = self.tado.getWeather()
+            self.data["geofence"] = self.tado.getHomeState()
             dispatcher_send(
                 self.hass,
                 SIGNAL_TADO_UPDATE_RECEIVED.format(self.home_id, "home", "data"),
@@ -264,15 +265,15 @@ class TadoConnector:
 
     def get_capabilities(self, zone_id):
         """Return the capabilities of the devices."""
-        return self.tado.get_capabilities(zone_id)
+        return self.tado.getCapabilities(zone_id)
 
     def get_auto_geofencing_supported(self):
         """Return whether the Tado Home supports auto geofencing."""
-        return self.tado.get_auto_geofencing_supported()
+        return self.tado.getAutoGeofencingSupported()
 
     def reset_zone_overlay(self, zone_id):
         """Reset the zone back to the default operation."""
-        self.tado.reset_zone_overlay(zone_id)
+        self.tado.resetZoneOverlay(zone_id)
         self.update_zone(zone_id)
 
     def set_presence(
@@ -281,11 +282,11 @@ class TadoConnector:
     ):
         """Set the presence to home, away or auto."""
         if presence == PRESET_AWAY:
-            self.tado.set_away()
+            self.tado.setAway()
         elif presence == PRESET_HOME:
-            self.tado.set_home()
+            self.tado.setHome()
         elif presence == PRESET_AUTO:
-            self.tado.set_auto()
+            self.tado.setAuto()
 
         # Update everything when changing modes
         self.update_zones()
@@ -319,7 +320,7 @@ class TadoConnector:
         )
 
         try:
-            self.tado.set_zone_overlay(
+            self.tado.setZoneOverlay(
                 zone_id,
                 overlay_mode,
                 temperature,
@@ -339,7 +340,7 @@ class TadoConnector:
     def set_zone_off(self, zone_id, overlay_mode, device_type="HEATING"):
         """Set a zone to off."""
         try:
-            self.tado.set_zone_overlay(
+            self.tado.setZoneOverlay(
                 zone_id, overlay_mode, None, None, device_type, "OFF"
             )
         except RequestException as exc:
@@ -350,6 +351,6 @@ class TadoConnector:
     def set_temperature_offset(self, device_id, offset):
         """Set temperature offset of device."""
         try:
-            self.tado.set_temp_offset(device_id, offset)
+            self.tado.setTempOffset(device_id, offset)
         except RequestException as exc:
             _LOGGER.error("Could not set temperature offset: %s", exc)

--- a/homeassistant/components/tado/manifest.json
+++ b/homeassistant/components/tado/manifest.json
@@ -14,5 +14,5 @@
   },
   "iot_class": "cloud_polling",
   "loggers": ["PyTado"],
-  "requirements": ["python-tado==0.16.0"]
+  "requirements": ["python-tado==0.15.0"]
 }

--- a/homeassistant/components/tplink/sensor.py
+++ b/homeassistant/components/tplink/sensor.py
@@ -50,7 +50,6 @@ ENERGY_SENSORS: tuple[TPLinkSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
-        name="Current Consumption",
         emeter_attr="power",
         precision=1,
     ),
@@ -60,7 +59,6 @@ ENERGY_SENSORS: tuple[TPLinkSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        name="Total Consumption",
         emeter_attr="total",
         precision=3,
     ),
@@ -70,7 +68,6 @@ ENERGY_SENSORS: tuple[TPLinkSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        name="Today's Consumption",
         precision=3,
     ),
     TPLinkSensorEntityDescription(

--- a/homeassistant/components/tts/notify.py
+++ b/homeassistant/components/tts/notify.py
@@ -20,16 +20,19 @@ ENTITY_LEGACY_PROVIDER_GROUP = "entity_or_legacy_provider"
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Required(CONF_NAME): cv.string,
-        vol.Exclusive(CONF_TTS_SERVICE, ENTITY_LEGACY_PROVIDER_GROUP): cv.entity_id,
-        vol.Exclusive(CONF_ENTITY_ID, ENTITY_LEGACY_PROVIDER_GROUP): cv.entities_domain(
-            DOMAIN
-        ),
-        vol.Required(CONF_MEDIA_PLAYER): cv.entity_id,
-        vol.Optional(ATTR_LANGUAGE): cv.string,
-    }
+PLATFORM_SCHEMA = vol.All(
+    cv.has_at_least_one_key(CONF_TTS_SERVICE, CONF_ENTITY_ID),
+    PLATFORM_SCHEMA.extend(
+        {
+            vol.Required(CONF_NAME): cv.string,
+            vol.Exclusive(CONF_TTS_SERVICE, ENTITY_LEGACY_PROVIDER_GROUP): cv.entity_id,
+            vol.Exclusive(
+                CONF_ENTITY_ID, ENTITY_LEGACY_PROVIDER_GROUP
+            ): cv.entities_domain(DOMAIN),
+            vol.Required(CONF_MEDIA_PLAYER): cv.entity_id,
+            vol.Optional(ATTR_LANGUAGE): cv.string,
+        }
+    ),
 )
 
 

--- a/homeassistant/components/verisure/coordinator.py
+++ b/homeassistant/components/verisure/coordinator.py
@@ -83,13 +83,16 @@ class VerisureDataUpdateCoordinator(DataUpdateCoordinator):
             raise UpdateFailed("Could not read overview") from err
 
         def unpack(overview: list, value: str) -> dict | list:
-            return next(
-                (
-                    item["data"]["installation"][value]
-                    for item in overview
-                    if value in item.get("data", {}).get("installation", {})
-                ),
-                [],
+            return (
+                next(
+                    (
+                        item["data"]["installation"][value]
+                        for item in overview
+                        if value in item.get("data", {}).get("installation", {})
+                    ),
+                    [],
+                )
+                or []
             )
 
         # Store data in a way Home Assistant can easily consume it

--- a/homeassistant/components/withings/common.py
+++ b/homeassistant/components/withings/common.py
@@ -438,22 +438,16 @@ class DataManager:
     async def async_get_sleep_summary(self) -> dict[Measurement, Any]:
         """Get the sleep summary data."""
         _LOGGER.debug("Updating withing sleep summary")
-        now = dt_util.utcnow()
+        now = dt_util.now()
         yesterday = now - datetime.timedelta(days=1)
-        yesterday_noon = datetime.datetime(
-            yesterday.year,
-            yesterday.month,
-            yesterday.day,
-            12,
-            0,
-            0,
-            0,
-            datetime.UTC,
+        yesterday_noon = dt_util.start_of_local_day(yesterday) + datetime.timedelta(
+            hours=12
         )
+        yesterday_noon_utc = dt_util.as_utc(yesterday_noon)
 
         def get_sleep_summary() -> SleepGetSummaryResponse:
             return self._api.sleep_get_summary(
-                lastupdate=yesterday_noon,
+                lastupdate=yesterday_noon_utc,
                 data_fields=[
                     GetSleepSummaryField.BREATHING_DISTURBANCES_INTENSITY,
                     GetSleepSummaryField.DEEP_SLEEP_DURATION,

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -238,7 +238,7 @@ def _parse_custom_effects(effects_config) -> dict[str, dict[str, Any]]:
 def _async_cmd(func):
     """Define a wrapper to catch exceptions from the bulb."""
 
-    async def _async_wrap(self: YeelightGenericLight, *args, **kwargs):
+    async def _async_wrap(self: YeelightBaseLight, *args, **kwargs):
         for attempts in range(2):
             try:
                 _LOGGER.debug("Calling %s with %s %s", func, args, kwargs)
@@ -403,8 +403,8 @@ def _async_setup_services(hass: HomeAssistant):
     )
 
 
-class YeelightGenericLight(YeelightEntity, LightEntity):
-    """Representation of a Yeelight generic light."""
+class YeelightBaseLight(YeelightEntity, LightEntity):
+    """Abstract Yeelight light."""
 
     _attr_color_mode = ColorMode.BRIGHTNESS
     _attr_supported_color_modes = {ColorMode.BRIGHTNESS}
@@ -861,7 +861,13 @@ class YeelightGenericLight(YeelightEntity, LightEntity):
         await self._bulb.async_set_scene(scene_class, *args)
 
 
-class YeelightColorLightSupport(YeelightGenericLight):
+class YeelightGenericLight(YeelightBaseLight):
+    """Representation of a generic Yeelight."""
+
+    _attr_name = None
+
+
+class YeelightColorLightSupport(YeelightBaseLight):
     """Representation of a Color Yeelight light support."""
 
     _attr_supported_color_modes = {ColorMode.COLOR_TEMP, ColorMode.HS, ColorMode.RGB}
@@ -884,7 +890,7 @@ class YeelightColorLightSupport(YeelightGenericLight):
         return YEELIGHT_COLOR_EFFECT_LIST
 
 
-class YeelightWhiteTempLightSupport(YeelightGenericLight):
+class YeelightWhiteTempLightSupport(YeelightBaseLight):
     """Representation of a White temp Yeelight light."""
 
     _attr_name = None
@@ -904,7 +910,7 @@ class YeelightNightLightSupport:
         return PowerMode.NORMAL
 
 
-class YeelightWithoutNightlightSwitchMixIn(YeelightGenericLight):
+class YeelightWithoutNightlightSwitchMixIn(YeelightBaseLight):
     """A mix-in for yeelights without a nightlight switch."""
 
     @property
@@ -940,7 +946,7 @@ class YeelightColorLightWithoutNightlightSwitchLight(
 
 
 class YeelightColorLightWithNightlightSwitch(
-    YeelightNightLightSupport, YeelightColorLightSupport, YeelightGenericLight
+    YeelightNightLightSupport, YeelightColorLightSupport, YeelightBaseLight
 ):
     """Representation of a Yeelight with rgb support and nightlight.
 
@@ -964,7 +970,7 @@ class YeelightWhiteTempWithoutNightlightSwitch(
 
 
 class YeelightWithNightLight(
-    YeelightNightLightSupport, YeelightWhiteTempLightSupport, YeelightGenericLight
+    YeelightNightLightSupport, YeelightWhiteTempLightSupport, YeelightBaseLight
 ):
     """Representation of a Yeelight with temp only support and nightlight.
 
@@ -979,7 +985,7 @@ class YeelightWithNightLight(
         return super().is_on and not self.device.is_nightlight_enabled
 
 
-class YeelightNightLightMode(YeelightGenericLight):
+class YeelightNightLightMode(YeelightBaseLight):
     """Representation of a Yeelight when in nightlight mode."""
 
     _attr_color_mode = ColorMode.BRIGHTNESS

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -7,7 +7,7 @@ from typing import Final
 APPLICATION_NAME: Final = "HomeAssistant"
 MAJOR_VERSION: Final = 2023
 MINOR_VERSION: Final = 8
-PATCH_VERSION: Final = "2"
+PATCH_VERSION: Final = "3"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 11, 0)

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -22,7 +22,7 @@ ha-av==10.1.1
 hass-nabucasa==0.69.0
 hassil==1.2.5
 home-assistant-bluetooth==1.10.2
-home-assistant-frontend==20230802.0
+home-assistant-frontend==20230802.1
 home-assistant-intents==2023.8.2
 httpx==0.24.1
 ifaddr==0.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name        = "homeassistant"
-version     = "2023.8.2"
+version     = "2023.8.3"
 license     = {text = "Apache-2.0"}
 description = "Open-source home automation platform running on Python 3."
 readme      = "README.rst"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools~=68.0", "wheel~=0.40.0"]
+requires = ["setuptools==68.0.0", "wheel~=0.40.0"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2299,7 +2299,7 @@ rjpl==0.3.6
 rocketchat-API==0.6.1
 
 # homeassistant.components.roku
-rokuecp==0.18.0
+rokuecp==0.18.1
 
 # homeassistant.components.roomba
 roombapy==1.6.8

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -988,7 +988,7 @@ hole==0.8.0
 holidays==0.28
 
 # homeassistant.components.frontend
-home-assistant-frontend==20230802.0
+home-assistant-frontend==20230802.1
 
 # homeassistant.components.conversation
 home-assistant-intents==2023.8.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2159,7 +2159,7 @@ python-smarttub==0.0.33
 python-songpal==0.15.2
 
 # homeassistant.components.tado
-python-tado==0.16.0
+python-tado==0.15.0
 
 # homeassistant.components.telegram_bot
 python-telegram-bot==13.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1243,7 +1243,7 @@ nad-receiver==0.3.0
 ndms2-client==0.1.2
 
 # homeassistant.components.ness_alarm
-nessclient==0.10.0
+nessclient==1.0.0
 
 # homeassistant.components.netdata
 netdata==1.1.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1746,7 +1746,7 @@ pyintesishome==1.8.0
 pyipma==3.0.6
 
 # homeassistant.components.ipp
-pyipp==0.14.2
+pyipp==0.14.3
 
 # homeassistant.components.iqvia
 pyiqvia==2022.04.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2150,7 +2150,7 @@ python-qbittorrent==0.4.3
 python-ripple-api==0.0.3
 
 # homeassistant.components.roborock
-python-roborock==0.32.2
+python-roborock==0.32.3
 
 # homeassistant.components.smarttub
 python-smarttub==0.0.33

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -800,7 +800,7 @@ fjaraskupan==2.2.0
 flipr-api==1.5.0
 
 # homeassistant.components.flux_led
-flux-led==1.0.1
+flux-led==1.0.2
 
 # homeassistant.components.homekit
 # homeassistant.components.recorder

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1952,7 +1952,7 @@ pyqwikswitch==0.93
 pyrail==0.0.3
 
 # homeassistant.components.rainbird
-pyrainbird==3.0.0
+pyrainbird==4.0.0
 
 # homeassistant.components.recswitch
 pyrecswitch==1.0.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -249,7 +249,7 @@ aioguardian==2022.07.0
 aioharmony==0.2.10
 
 # homeassistant.components.homekit_controller
-aiohomekit==2.6.15
+aiohomekit==2.6.16
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1368,7 +1368,7 @@ openwrt-luci-rpc==1.1.16
 openwrt-ubus-rpc==0.0.2
 
 # homeassistant.components.opower
-opower==0.0.26
+opower==0.0.29
 
 # homeassistant.components.oralb
 oralb-ble==0.17.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2278,7 +2278,7 @@ renault-api==0.1.13
 renson-endura-delta==1.5.0
 
 # homeassistant.components.reolink
-reolink-aio==0.7.6
+reolink-aio==0.7.7
 
 # homeassistant.components.idteck_prox
 rfk101py==0.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1579,7 +1579,7 @@ python-picnic-api==1.1.0
 python-qbittorrent==0.4.3
 
 # homeassistant.components.roborock
-python-roborock==0.32.2
+python-roborock==0.32.3
 
 # homeassistant.components.smarttub
 python-smarttub==0.0.33

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1683,7 +1683,7 @@ rflink==0.0.65
 ring-doorbell==0.7.2
 
 # homeassistant.components.roku
-rokuecp==0.18.0
+rokuecp==0.18.1
 
 # homeassistant.components.roomba
 roombapy==1.6.8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -628,7 +628,7 @@ fjaraskupan==2.2.0
 flipr-api==1.5.0
 
 # homeassistant.components.flux_led
-flux-led==1.0.1
+flux-led==1.0.2
 
 # homeassistant.components.homekit
 # homeassistant.components.recorder

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1037,7 +1037,7 @@ openerz-api==0.2.0
 openhomedevice==2.2.0
 
 # homeassistant.components.opower
-opower==0.0.26
+opower==0.0.29
 
 # homeassistant.components.oralb
 oralb-ble==0.17.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1674,7 +1674,7 @@ renault-api==0.1.13
 renson-endura-delta==1.5.0
 
 # homeassistant.components.reolink
-reolink-aio==0.7.6
+reolink-aio==0.7.7
 
 # homeassistant.components.rflink
 rflink==0.0.65

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1588,7 +1588,7 @@ python-smarttub==0.0.33
 python-songpal==0.15.2
 
 # homeassistant.components.tado
-python-tado==0.16.0
+python-tado==0.15.0
 
 # homeassistant.components.telegram_bot
 python-telegram-bot==13.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1453,7 +1453,7 @@ pyps4-2ndscreen==1.3.1
 pyqwikswitch==0.93
 
 # homeassistant.components.rainbird
-pyrainbird==3.0.0
+pyrainbird==4.0.0
 
 # homeassistant.components.risco
 pyrisco==0.5.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -227,7 +227,7 @@ aioguardian==2022.07.0
 aioharmony==0.2.10
 
 # homeassistant.components.homekit_controller
-aiohomekit==2.6.15
+aiohomekit==2.6.16
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -957,7 +957,7 @@ mutesync==0.0.1
 ndms2-client==0.1.2
 
 # homeassistant.components.ness_alarm
-nessclient==0.10.0
+nessclient==1.0.0
 
 # homeassistant.components.nmap_tracker
 netmap==0.7.0.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -774,7 +774,7 @@ hole==0.8.0
 holidays==0.28
 
 # homeassistant.components.frontend
-home-assistant-frontend==20230802.0
+home-assistant-frontend==20230802.1
 
 # homeassistant.components.conversation
 home-assistant-intents==2023.8.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1292,7 +1292,7 @@ pyinsteon==1.4.3
 pyipma==3.0.6
 
 # homeassistant.components.ipp
-pyipp==0.14.2
+pyipp==0.14.3
 
 # homeassistant.components.iqvia
 pyiqvia==2022.04.0

--- a/tests/components/gogogate2/__init__.py
+++ b/tests/components/gogogate2/__init__.py
@@ -77,7 +77,7 @@ def _mocked_ismartgate_closed_door_response():
         ismartgatename="ismartgatename0",
         model="ismartgatePRO",
         apiversion="",
-        remoteaccessenabled=False,
+        remoteaccessenabled=True,
         remoteaccess="abc321.blah.blah",
         firmwareversion="555",
         pin=123,

--- a/tests/components/gogogate2/test_cover.py
+++ b/tests/components/gogogate2/test_cover.py
@@ -340,6 +340,7 @@ async def test_device_info_ismartgate(
     assert device.name == "mycontroller"
     assert device.model == "ismartgatePRO"
     assert device.sw_version == "555"
+    assert device.configuration_url == "https://abc321.blah.blah"
 
 
 @patch("homeassistant.components.gogogate2.common.GogoGate2Api")
@@ -375,3 +376,4 @@ async def test_device_info_gogogate2(
     assert device.name == "mycontroller"
     assert device.model == "gogogate2"
     assert device.sw_version == "222"
+    assert device.configuration_url == "http://127.0.0.1"

--- a/tests/components/honeywell/test_climate.py
+++ b/tests/components/honeywell/test_climate.py
@@ -48,13 +48,13 @@ FAN_ACTION = "fan_action"
 PRESET_HOLD = "Hold"
 
 
-async def test_no_thermostats(
+async def test_no_thermostat_options(
     hass: HomeAssistant, device: MagicMock, config_entry: MagicMock
 ) -> None:
-    """Test the setup of the climate entities when there are no appliances available."""
+    """Test the setup of the climate entities when there are no additional options available."""
     device._data = {}
     await init_integration(hass, config_entry)
-    assert len(hass.states.async_all()) == 0
+    assert len(hass.states.async_all()) == 1
 
 
 async def test_static_attributes(

--- a/tests/components/modbus/test_init.py
+++ b/tests/components/modbus/test_init.py
@@ -230,6 +230,12 @@ async def test_ok_struct_validator(do_config) -> None:
             CONF_DATA_TYPE: DataType.INT16,
             CONF_SWAP: CONF_SWAP_WORD,
         },
+        {
+            CONF_NAME: TEST_ENTITY_NAME,
+            CONF_COUNT: 2,
+            CONF_SLAVE_COUNT: 2,
+            CONF_DATA_TYPE: DataType.INT32,
+        },
     ],
 )
 async def test_exception_struct_validator(do_config) -> None:

--- a/tests/components/modbus/test_init.py
+++ b/tests/components/modbus/test_init.py
@@ -163,7 +163,6 @@ async def test_number_validator() -> None:
             CONF_COUNT: 2,
             CONF_DATA_TYPE: DataType.CUSTOM,
             CONF_STRUCTURE: ">i",
-            CONF_SWAP: CONF_SWAP_BYTE,
         },
     ],
 )
@@ -220,6 +219,16 @@ async def test_ok_struct_validator(do_config) -> None:
             CONF_DATA_TYPE: DataType.CUSTOM,
             CONF_STRUCTURE: ">f",
             CONF_SLAVE_COUNT: 5,
+        },
+        {
+            CONF_NAME: TEST_ENTITY_NAME,
+            CONF_DATA_TYPE: DataType.STRING,
+            CONF_SLAVE_COUNT: 2,
+        },
+        {
+            CONF_NAME: TEST_ENTITY_NAME,
+            CONF_DATA_TYPE: DataType.INT16,
+            CONF_SWAP: CONF_SWAP_WORD,
         },
     ],
 )

--- a/tests/components/modbus/test_sensor.py
+++ b/tests/components/modbus/test_sensor.py
@@ -243,7 +243,7 @@ async def test_config_sensor(hass: HomeAssistant, mock_modbus) -> None:
                     },
                 ]
             },
-            f"Error in sensor {TEST_ENTITY_NAME} swap(word) not possible due to the registers count: 1, needed: 2",
+            f"{TEST_ENTITY_NAME}: `structure` illegal with `swap`",
         ),
     ],
 )

--- a/tests/components/modbus/test_sensor.py
+++ b/tests/components/modbus/test_sensor.py
@@ -603,9 +603,7 @@ async def test_all_sensor(hass: HomeAssistant, mock_do_cycle, expected) -> None:
                     CONF_ADDRESS: 51,
                     CONF_INPUT_TYPE: CALL_TYPE_REGISTER_HOLDING,
                     CONF_DATA_TYPE: DataType.UINT32,
-                    CONF_SCALE: 1,
-                    CONF_OFFSET: 0,
-                    CONF_PRECISION: 0,
+                    CONF_SCAN_INTERVAL: 1,
                 },
             ],
         },
@@ -677,15 +675,182 @@ async def test_all_sensor(hass: HomeAssistant, mock_do_cycle, expected) -> None:
 )
 async def test_slave_sensor(hass: HomeAssistant, mock_do_cycle, expected) -> None:
     """Run test for sensor."""
-    assert hass.states.get(ENTITY_ID).state == expected[0]
     entity_registry = er.async_get(hass)
-
-    for i in range(1, len(expected)):
-        entity_id = f"{SENSOR_DOMAIN}.{TEST_ENTITY_NAME}_{i}".replace(" ", "_")
-        assert hass.states.get(entity_id).state == expected[i]
-        unique_id = f"{SLAVE_UNIQUE_ID}_{i}"
+    for i in range(0, len(expected)):
+        entity_id = f"{SENSOR_DOMAIN}.{TEST_ENTITY_NAME}".replace(" ", "_")
+        unique_id = f"{SLAVE_UNIQUE_ID}"
+        if i:
+            entity_id = f"{entity_id}_{i}"
+            unique_id = f"{unique_id}_{i}"
         entry = entity_registry.async_get(entity_id)
+        state = hass.states.get(entity_id).state
+        assert state == expected[i]
         assert entry.unique_id == unique_id
+
+
+@pytest.mark.parametrize(
+    "do_config",
+    [
+        {
+            CONF_SENSORS: [
+                {
+                    CONF_NAME: TEST_ENTITY_NAME,
+                    CONF_ADDRESS: 51,
+                    CONF_INPUT_TYPE: CALL_TYPE_REGISTER_HOLDING,
+                    CONF_SCAN_INTERVAL: 1,
+                },
+            ],
+        },
+    ],
+)
+@pytest.mark.parametrize(
+    ("config_addon", "register_words", "do_exception", "expected"),
+    [
+        (
+            {
+                CONF_SLAVE_COUNT: 0,
+                CONF_UNIQUE_ID: SLAVE_UNIQUE_ID,
+                CONF_SWAP: CONF_SWAP_BYTE,
+                CONF_DATA_TYPE: DataType.UINT16,
+            },
+            [0x0102],
+            False,
+            [str(int(0x0201))],
+        ),
+        (
+            {
+                CONF_SLAVE_COUNT: 0,
+                CONF_UNIQUE_ID: SLAVE_UNIQUE_ID,
+                CONF_SWAP: CONF_SWAP_WORD,
+                CONF_DATA_TYPE: DataType.UINT32,
+            },
+            [0x0102, 0x0304],
+            False,
+            [str(int(0x03040102))],
+        ),
+        (
+            {
+                CONF_SLAVE_COUNT: 0,
+                CONF_UNIQUE_ID: SLAVE_UNIQUE_ID,
+                CONF_SWAP: CONF_SWAP_WORD,
+                CONF_DATA_TYPE: DataType.UINT64,
+            },
+            [0x0102, 0x0304, 0x0506, 0x0708],
+            False,
+            [str(int(0x0708050603040102))],
+        ),
+        (
+            {
+                CONF_SLAVE_COUNT: 1,
+                CONF_UNIQUE_ID: SLAVE_UNIQUE_ID,
+                CONF_DATA_TYPE: DataType.UINT16,
+                CONF_SWAP: CONF_SWAP_BYTE,
+            },
+            [0x0102, 0x0304],
+            False,
+            [str(int(0x0201)), str(int(0x0403))],
+        ),
+        (
+            {
+                CONF_SLAVE_COUNT: 1,
+                CONF_UNIQUE_ID: SLAVE_UNIQUE_ID,
+                CONF_DATA_TYPE: DataType.UINT32,
+                CONF_SWAP: CONF_SWAP_WORD,
+            },
+            [0x0102, 0x0304, 0x0506, 0x0708],
+            False,
+            [str(int(0x03040102)), str(int(0x07080506))],
+        ),
+        (
+            {
+                CONF_SLAVE_COUNT: 1,
+                CONF_UNIQUE_ID: SLAVE_UNIQUE_ID,
+                CONF_DATA_TYPE: DataType.UINT64,
+                CONF_SWAP: CONF_SWAP_WORD,
+            },
+            [0x0102, 0x0304, 0x0506, 0x0708, 0x0901, 0x0902, 0x0903, 0x0904],
+            False,
+            [str(int(0x0708050603040102)), str(int(0x0904090309020901))],
+        ),
+        (
+            {
+                CONF_SLAVE_COUNT: 3,
+                CONF_UNIQUE_ID: SLAVE_UNIQUE_ID,
+                CONF_DATA_TYPE: DataType.UINT16,
+                CONF_SWAP: CONF_SWAP_BYTE,
+            },
+            [0x0102, 0x0304, 0x0506, 0x0708],
+            False,
+            [str(int(0x0201)), str(int(0x0403)), str(int(0x0605)), str(int(0x0807))],
+        ),
+        (
+            {
+                CONF_SLAVE_COUNT: 3,
+                CONF_UNIQUE_ID: SLAVE_UNIQUE_ID,
+                CONF_DATA_TYPE: DataType.UINT32,
+                CONF_SWAP: CONF_SWAP_WORD,
+            },
+            [
+                0x0102,
+                0x0304,
+                0x0506,
+                0x0708,
+                0x090A,
+                0x0B0C,
+                0x0D0E,
+                0x0F00,
+            ],
+            False,
+            [
+                str(int(0x03040102)),
+                str(int(0x07080506)),
+                str(int(0x0B0C090A)),
+                str(int(0x0F000D0E)),
+            ],
+        ),
+        (
+            {
+                CONF_SLAVE_COUNT: 3,
+                CONF_UNIQUE_ID: SLAVE_UNIQUE_ID,
+                CONF_DATA_TYPE: DataType.UINT64,
+                CONF_SWAP: CONF_SWAP_WORD,
+            },
+            [
+                0x0601,
+                0x0602,
+                0x0603,
+                0x0604,
+                0x0701,
+                0x0702,
+                0x0703,
+                0x0704,
+                0x0801,
+                0x0802,
+                0x0803,
+                0x0804,
+                0x0901,
+                0x0902,
+                0x0903,
+                0x0904,
+            ],
+            False,
+            [
+                str(int(0x0604060306020601)),
+                str(int(0x0704070307020701)),
+                str(int(0x0804080308020801)),
+                str(int(0x0904090309020901)),
+            ],
+        ),
+    ],
+)
+async def test_slave_swap_sensor(hass: HomeAssistant, mock_do_cycle, expected) -> None:
+    """Run test for sensor."""
+    for i in range(0, len(expected)):
+        entity_id = f"{SENSOR_DOMAIN}.{TEST_ENTITY_NAME}".replace(" ", "_")
+        if i:
+            entity_id = f"{entity_id}_{i}"
+        state = hass.states.get(entity_id).state
+        assert state == expected[i]
 
 
 @pytest.mark.parametrize(

--- a/tests/components/ness_alarm/test_init.py
+++ b/tests/components/ness_alarm/test_init.py
@@ -1,7 +1,7 @@
 """Tests for the ness_alarm component."""
-from enum import Enum
 from unittest.mock import MagicMock, patch
 
+from nessclient import ArmingMode, ArmingState
 import pytest
 
 from homeassistant.components import alarm_control_panel
@@ -24,6 +24,8 @@ from homeassistant.const import (
     SERVICE_ALARM_DISARM,
     SERVICE_ALARM_TRIGGER,
     STATE_ALARM_ARMED_AWAY,
+    STATE_ALARM_ARMED_HOME,
+    STATE_ALARM_ARMED_NIGHT,
     STATE_ALARM_ARMING,
     STATE_ALARM_DISARMED,
     STATE_ALARM_PENDING,
@@ -84,7 +86,7 @@ async def test_dispatch_state_change(hass: HomeAssistant, mock_nessclient) -> No
     await hass.async_block_till_done()
 
     on_state_change = mock_nessclient.on_state_change.call_args[0][0]
-    on_state_change(MockArmingState.ARMING)
+    on_state_change(ArmingState.ARMING, None)
 
     await hass.async_block_till_done()
     assert hass.states.is_state("alarm_control_panel.alarm_panel", STATE_ALARM_ARMING)
@@ -174,13 +176,16 @@ async def test_dispatch_zone_change(hass: HomeAssistant, mock_nessclient) -> Non
 async def test_arming_state_change(hass: HomeAssistant, mock_nessclient) -> None:
     """Test arming state change handing."""
     states = [
-        (MockArmingState.UNKNOWN, STATE_UNKNOWN),
-        (MockArmingState.DISARMED, STATE_ALARM_DISARMED),
-        (MockArmingState.ARMING, STATE_ALARM_ARMING),
-        (MockArmingState.EXIT_DELAY, STATE_ALARM_ARMING),
-        (MockArmingState.ARMED, STATE_ALARM_ARMED_AWAY),
-        (MockArmingState.ENTRY_DELAY, STATE_ALARM_PENDING),
-        (MockArmingState.TRIGGERED, STATE_ALARM_TRIGGERED),
+        (ArmingState.UNKNOWN, None, STATE_UNKNOWN),
+        (ArmingState.DISARMED, None, STATE_ALARM_DISARMED),
+        (ArmingState.ARMING, None, STATE_ALARM_ARMING),
+        (ArmingState.EXIT_DELAY, None, STATE_ALARM_ARMING),
+        (ArmingState.ARMED, None, STATE_ALARM_ARMED_AWAY),
+        (ArmingState.ARMED, ArmingMode.ARMED_AWAY, STATE_ALARM_ARMED_AWAY),
+        (ArmingState.ARMED, ArmingMode.ARMED_HOME, STATE_ALARM_ARMED_HOME),
+        (ArmingState.ARMED, ArmingMode.ARMED_NIGHT, STATE_ALARM_ARMED_NIGHT),
+        (ArmingState.ENTRY_DELAY, None, STATE_ALARM_PENDING),
+        (ArmingState.TRIGGERED, None, STATE_ALARM_TRIGGERED),
     ]
 
     await async_setup_component(hass, DOMAIN, VALID_CONFIG)
@@ -188,22 +193,10 @@ async def test_arming_state_change(hass: HomeAssistant, mock_nessclient) -> None
     assert hass.states.is_state("alarm_control_panel.alarm_panel", STATE_UNKNOWN)
     on_state_change = mock_nessclient.on_state_change.call_args[0][0]
 
-    for arming_state, expected_state in states:
-        on_state_change(arming_state)
+    for arming_state, arming_mode, expected_state in states:
+        on_state_change(arming_state, arming_mode)
         await hass.async_block_till_done()
         assert hass.states.is_state("alarm_control_panel.alarm_panel", expected_state)
-
-
-class MockArmingState(Enum):
-    """Mock nessclient.ArmingState enum."""
-
-    UNKNOWN = "UNKNOWN"
-    DISARMED = "DISARMED"
-    ARMING = "ARMING"
-    EXIT_DELAY = "EXIT_DELAY"
-    ARMED = "ARMED"
-    ENTRY_DELAY = "ENTRY_DELAY"
-    TRIGGERED = "TRIGGERED"
 
 
 class MockClient:
@@ -253,10 +246,5 @@ def mock_nessclient():
 
     with patch(
         "homeassistant.components.ness_alarm.Client", new=_mock_factory, create=True
-    ), patch(
-        "homeassistant.components.ness_alarm.ArmingState", new=MockArmingState
-    ), patch(
-        "homeassistant.components.ness_alarm.alarm_control_panel.ArmingState",
-        new=MockArmingState,
     ):
         yield _mock_instance

--- a/tests/components/tts/test_notify.py
+++ b/tests/components/tts/test_notify.py
@@ -68,6 +68,21 @@ async def test_setup_platform(hass: HomeAssistant) -> None:
     assert hass.services.has_service(notify.DOMAIN, "tts_test")
 
 
+async def test_setup_platform_missing_key(hass: HomeAssistant) -> None:
+    """Test platform without required tts_service or entity_id key."""
+    config = {
+        notify.DOMAIN: {
+            "platform": "tts",
+            "name": "tts_test",
+            "media_player": "media_player.demo",
+        }
+    }
+    with assert_setup_component(0, notify.DOMAIN):
+        assert await async_setup_component(hass, notify.DOMAIN, config)
+
+    assert not hass.services.has_service(notify.DOMAIN, "tts_test")
+
+
 async def test_setup_legacy_service(hass: HomeAssistant) -> None:
     """Set up the demo platform and call service."""
     calls = async_mock_service(hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)


### PR DESCRIPTION
- Fix ness alarm armed_home state appearing as disarmed/armed_away ([@nickw444] - [#94351]) ([ness_alarm docs])
- Correct modbus config validator: slave/swap ([@janiversen] - [#97798]) ([modbus docs])
- Fix Opower utilities that have different ReadResolution than previously assumed ([@tronikos] - [#97823]) ([opower docs]) (dependency)
- modbus config: count and slave_count can normally not be mixed. ([@janiversen] - [#97902]) ([modbus docs])
- Create abstraction for Generic YeeLight ([@joostlek] - [#97939]) ([yeelight docs])
- modbus: Repair swap for slaves ([@janiversen] - [#97960]) ([modbus docs])
- Use Local Timezone for Withings Integration ([@VidFerris] - [#98137]) ([withings docs])
- Bump pyrainbird to 4.0.0 ([@allenporter] - [#98271]) ([rainbird docs]) (dependency)
- Bump Python-Roborock to 0.32.3 ([@Lash-L] - [#98303]) ([roborock docs])
- Bump flux-led to 1.0.2 ([@bdraco] - [#98312]) ([flux_led docs])
- Use default translations by removing names from tplink descriptions ([@joostlek] - [#98338]) ([tplink docs])
- Fix tts notify config validation ([@MartinHjelmare] - [#98381]) ([tts docs])
- Fix GoGoGate2 configuration URL when remote access is disabled ([@oyvindwe] - [#98387]) ([gogogate2 docs])
- Handle missing keys in Honeywell ([@mkmer] - [#98392]) ([honeywell docs])
- Bump Reolink_aio to 0.7.7 ([@starkillerOG] - [#98425]) ([reolink docs]) (dependency)
- Update rokuecp to 0.18.1 ([@ctalkington] - [#98432]) ([roku docs])
- Update pyipp to 0.14.3 ([@ctalkington] - [#98434]) ([ipp docs]) (dependency)
- Fix inconsistent lyric temperature unit ([@lscorcia] - [#98457]) ([lyric docs])
- Bump aiohomekit to 2.6.16 ([@bdraco] - [#98490]) ([homekit_controller docs]) (dependency)
- Bump opower to 0.0.29 ([@tronikos] - [#98503]) ([opower docs]) (dependency)
- Revert "Integration tado bump" ([@erwindouna] - [#98505]) ([tado docs])
- Fix the availability condition for Shelly N current sensor ([@bieniu] - [#98518]) ([shelly docs])
- Correct number of registers to read for sensors for modbus ([@janiversen] - [#98534]) ([modbus docs])
- Pin setuptools to 68.0.0 ([@frenck] - [#98582])
- Bump ESPHome recommended BLE version to 2023.8.0 ([@bdraco] - [#98586]) ([esphome docs])
- Verisure unpack ([@niro1987] - [#98605]) ([verisure docs])
- Update frontend to 20230802.1 ([@bramkragten] - [#98616]) ([frontend docs])

[#94351]: https://github.com/home-assistant/core/pull/94351
[#97609]: https://github.com/home-assistant/core/pull/97609
[#97772]: https://github.com/home-assistant/core/pull/97772
[#97798]: https://github.com/home-assistant/core/pull/97798
[#97823]: https://github.com/home-assistant/core/pull/97823
[#97902]: https://github.com/home-assistant/core/pull/97902
[#97939]: https://github.com/home-assistant/core/pull/97939
[#97960]: https://github.com/home-assistant/core/pull/97960
[#98137]: https://github.com/home-assistant/core/pull/98137
[#98255]: https://github.com/home-assistant/core/pull/98255
[#98271]: https://github.com/home-assistant/core/pull/98271
[#98303]: https://github.com/home-assistant/core/pull/98303
[#98312]: https://github.com/home-assistant/core/pull/98312
[#98338]: https://github.com/home-assistant/core/pull/98338
[#98381]: https://github.com/home-assistant/core/pull/98381
[#98387]: https://github.com/home-assistant/core/pull/98387
[#98392]: https://github.com/home-assistant/core/pull/98392
[#98425]: https://github.com/home-assistant/core/pull/98425
[#98432]: https://github.com/home-assistant/core/pull/98432
[#98434]: https://github.com/home-assistant/core/pull/98434
[#98457]: https://github.com/home-assistant/core/pull/98457
[#98490]: https://github.com/home-assistant/core/pull/98490
[#98503]: https://github.com/home-assistant/core/pull/98503
[#98505]: https://github.com/home-assistant/core/pull/98505
[#98518]: https://github.com/home-assistant/core/pull/98518
[#98534]: https://github.com/home-assistant/core/pull/98534
[#98582]: https://github.com/home-assistant/core/pull/98582
[#98586]: https://github.com/home-assistant/core/pull/98586
[#98605]: https://github.com/home-assistant/core/pull/98605
[#98616]: https://github.com/home-assistant/core/pull/98616
[@Lash-L]: https://github.com/Lash-L
[@MartinHjelmare]: https://github.com/MartinHjelmare
[@VidFerris]: https://github.com/VidFerris
[@allenporter]: https://github.com/allenporter
[@bdraco]: https://github.com/bdraco
[@bieniu]: https://github.com/bieniu
[@bramkragten]: https://github.com/bramkragten
[@ctalkington]: https://github.com/ctalkington
[@erwindouna]: https://github.com/erwindouna
[@frenck]: https://github.com/frenck
[@janiversen]: https://github.com/janiversen
[@joostlek]: https://github.com/joostlek
[@lscorcia]: https://github.com/lscorcia
[@mkmer]: https://github.com/mkmer
[@nickw444]: https://github.com/nickw444
[@niro1987]: https://github.com/niro1987
[@oyvindwe]: https://github.com/oyvindwe
[@starkillerOG]: https://github.com/starkillerOG
[@tronikos]: https://github.com/tronikos
[esphome docs]: https://www.home-assistant.io/integrations/esphome/
[flux_led docs]: https://www.home-assistant.io/integrations/flux_led/
[frontend docs]: https://www.home-assistant.io/integrations/frontend/
[gogogate2 docs]: https://www.home-assistant.io/integrations/gogogate2/
[homekit_controller docs]: https://www.home-assistant.io/integrations/homekit_controller/
[honeywell docs]: https://www.home-assistant.io/integrations/honeywell/
[ipp docs]: https://www.home-assistant.io/integrations/ipp/
[lyric docs]: https://www.home-assistant.io/integrations/lyric/
[modbus docs]: https://www.home-assistant.io/integrations/modbus/
[ness_alarm docs]: https://www.home-assistant.io/integrations/ness_alarm/
[opower docs]: https://www.home-assistant.io/integrations/opower/
[rainbird docs]: https://www.home-assistant.io/integrations/rainbird/
[reolink docs]: https://www.home-assistant.io/integrations/reolink/
[roborock docs]: https://www.home-assistant.io/integrations/roborock/
[roku docs]: https://www.home-assistant.io/integrations/roku/
[shelly docs]: https://www.home-assistant.io/integrations/shelly/
[tado docs]: https://www.home-assistant.io/integrations/tado/
[tplink docs]: https://www.home-assistant.io/integrations/tplink/
[tts docs]: https://www.home-assistant.io/integrations/tts/
[verisure docs]: https://www.home-assistant.io/integrations/verisure/
[withings docs]: https://www.home-assistant.io/integrations/withings/
[yeelight docs]: https://www.home-assistant.io/integrations/yeelight/

Documentation PR: <https://github.com/home-assistant/home-assistant.io/pull/28622>