### PR TITLE
Wake word cleanup

### DIFF
--- a/homeassistant/components/assist_pipeline/__init__.py
+++ b/homeassistant/components/assist_pipeline/__init__.py
@@ -52,6 +52,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 async def async_pipeline_from_audio_stream(
     hass: HomeAssistant,
+    *,
     context: Context,
     event_callback: PipelineEventCallback,
     stt_metadata: stt.SpeechMetadata,

--- a/homeassistant/components/assist_pipeline/ring_buffer.py
+++ b/homeassistant/components/assist_pipeline/ring_buffer.py
@@ -1,0 +1,57 @@
+"""Implementation of a ring buffer using bytearray."""
+
+
+class RingBuffer:
+    """Basic ring buffer using a bytearray.
+
+    Not threadsafe.
+    """
+
+    def __init__(self, maxlen: int) -> None:
+        """Initialize empty buffer."""
+        self._buffer = bytearray(maxlen)
+        self._pos = 0
+        self._length = 0
+        self._maxlen = maxlen
+
+    @property
+    def maxlen(self) -> int:
+        """Return the maximum size of the buffer."""
+        return self._maxlen
+
+    @property
+    def pos(self) -> int:
+        """Return the current put position."""
+        return self._pos
+
+    def __len__(self) -> int:
+        """Return the length of data stored in the buffer."""
+        return self._length
+
+    def put(self, data: bytes) -> None:
+        """Put a chunk of data into the buffer, possibly wrapping around."""
+        data_len = len(data)
+        new_pos = self._pos + data_len
+        if new_pos >= self._maxlen:
+            # Split into two chunks
+            num_bytes_1 = self._maxlen - self._pos
+            num_bytes_2 = new_pos - self._maxlen
+
+            self._buffer[self._pos : self._maxlen] = data[:num_bytes_1]
+            self._buffer[:num_bytes_2] = data[num_bytes_1:]
+            new_pos = new_pos - self._maxlen
+        else:
+            # Entire chunk fits at current position
+            self._buffer[self._pos : self._pos + data_len] = data
+
+        self._pos = new_pos
+        self._length = min(self._maxlen, self._length + data_len)
+
+    def getvalue(self) -> bytes:
+        """Get bytes written to the buffer."""
+        if (self._pos + self._length) <= self._maxlen:
+            # Single chunk
+            return bytes(self._buffer[: self._length])
+
+        # Two chunks
+        return bytes(self._buffer[self._pos :] + self._buffer[: self._pos])

--- a/homeassistant/components/assist_pipeline/vad.py
+++ b/homeassistant/components/assist_pipeline/vad.py
@@ -1,12 +1,15 @@
 """Voice activity detection."""
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from enum import StrEnum
+from typing import Any, Final
 
 import webrtcvad
 
-_SAMPLE_RATE = 16000
+_SAMPLE_RATE: Final = 16000  # Hz
+_SAMPLE_WIDTH: Final = 2  # bytes
 
 
 class VadSensitivity(StrEnum):
@@ -29,6 +32,47 @@ class VadSensitivity(StrEnum):
         return 1.0
 
 
+class AudioBuffer:
+    """Fixed-sized audio buffer with variable internal length."""
+
+    def __init__(self, maxlen: int) -> None:
+        """Initialize buffer."""
+        self._buffer = bytearray(maxlen)
+        self._length = 0
+
+    @property
+    def length(self) -> int:
+        """Get number of bytes currently in the buffer."""
+        return self._length
+
+    @length.setter
+    def length(self, value: int) -> None:
+        """Set the number of bytes in the buffer."""
+        if value > len(self._buffer):
+            raise ValueError("Length cannot be greater than buffer size")
+
+        if value < 0:
+            raise ValueError("Length cannot be negative")
+
+        self._length = value
+
+    def __len__(self) -> int:
+        """Get the number of bytes currently in the buffer."""
+        return self._length
+
+    def __getitem__(self, item: Any) -> Any:
+        """Get a slice of the buffer."""
+        return self._buffer[item]
+
+    def __setitem__(self, item: Any, value: Any) -> Any:
+        """Set a slice of the buffer."""
+        self._buffer[item] = value
+
+    def __bytes__(self) -> bytes:
+        """Convert written portion of buffer to bytes."""
+        return bytes(self._buffer[: self._length])
+
+
 @dataclass
 class VoiceCommandSegmenter:
     """Segments an audio stream into voice commands using webrtcvad."""
@@ -36,7 +80,7 @@ class VoiceCommandSegmenter:
     vad_mode: int = 3
     """Aggressiveness in filtering out non-speech. 3 is the most aggressive."""
 
-    vad_frames: int = 480  # 30 ms
+    vad_samples_per_chunk: int = 480  # 30 ms
     """Must be 10, 20, or 30 ms at 16Khz."""
 
     speech_seconds: float = 0.3
@@ -67,20 +111,21 @@ class VoiceCommandSegmenter:
     """Seconds left before resetting start/stop time counters."""
 
     _vad: webrtcvad.Vad = None
-    _audio_buffer: bytes = field(default_factory=bytes)
-    _bytes_per_chunk: int = 480 * 2  # 16-bit samples
-    _seconds_per_chunk: float = 0.03  # 30 ms
+    _sample_buffer: AudioBuffer = field(init=False)
+    _bytes_per_chunk: int = field(init=False)
+    _seconds_per_chunk: float = field(init=False)
 
     def __post_init__(self) -> None:
         """Initialize VAD."""
         self._vad = webrtcvad.Vad(self.vad_mode)
-        self._bytes_per_chunk = self.vad_frames * 2
-        self._seconds_per_chunk = self.vad_frames / _SAMPLE_RATE
+        self._bytes_per_chunk = self.vad_samples_per_chunk * _SAMPLE_WIDTH
+        self._seconds_per_chunk = self.vad_samples_per_chunk / _SAMPLE_RATE
+        self._sample_buffer = AudioBuffer(self.vad_samples_per_chunk * _SAMPLE_WIDTH)
         self.reset()
 
     def reset(self) -> None:
         """Reset all counters and state."""
-        self._audio_buffer = b""
+        self._sample_buffer.length = 0
         self._speech_seconds_left = self.speech_seconds
         self._silence_seconds_left = self.silence_seconds
         self._timeout_seconds_left = self.timeout_seconds
@@ -92,26 +137,17 @@ class VoiceCommandSegmenter:
 
         Returns False when command is done.
         """
-        self._audio_buffer += samples
-
-        # Process in 10, 20, or 30 ms chunks.
-        num_chunks = len(self._audio_buffer) // self._bytes_per_chunk
-        for chunk_idx in range(num_chunks):
-            chunk_offset = chunk_idx * self._bytes_per_chunk
-            chunk = self._audio_buffer[
-                chunk_offset : chunk_offset + self._bytes_per_chunk
-            ]
+        for chunk in chunk_samples(samples, self._bytes_per_chunk, self._sample_buffer):
             if not self._process_chunk(chunk):
                 self.reset()
                 return False
 
-        if num_chunks > 0:
-            # Remove from buffer
-            self._audio_buffer = self._audio_buffer[
-                num_chunks * self._bytes_per_chunk :
-            ]
-
         return True
+
+    @property
+    def audio_buffer(self) -> bytes:
+        """Get partial chunk in the audio buffer."""
+        return bytes(self._sample_buffer)
 
     def _process_chunk(self, chunk: bytes) -> bool:
         """Process a single chunk of 16-bit 16Khz mono audio.
@@ -163,7 +199,7 @@ class VoiceActivityTimeout:
     vad_mode: int = 3
     """Aggressiveness in filtering out non-speech. 3 is the most aggressive."""
 
-    vad_frames: int = 480  # 30 ms
+    vad_samples_per_chunk: int = 480  # 30 ms
     """Must be 10, 20, or 30 ms at 16Khz."""
 
     _silence_seconds_left: float = 0.0
@@ -173,20 +209,21 @@ class VoiceActivityTimeout:
     """Seconds left before resetting start/stop time counters."""
 
     _vad: webrtcvad.Vad = None
-    _audio_buffer: bytes = field(default_factory=bytes)
-    _bytes_per_chunk: int = 480 * 2  # 16-bit samples
-    _seconds_per_chunk: float = 0.03  # 30 ms
+    _sample_buffer: AudioBuffer = field(init=False)
+    _bytes_per_chunk: int = field(init=False)
+    _seconds_per_chunk: float = field(init=False)
 
     def __post_init__(self) -> None:
         """Initialize VAD."""
         self._vad = webrtcvad.Vad(self.vad_mode)
-        self._bytes_per_chunk = self.vad_frames * 2
-        self._seconds_per_chunk = self.vad_frames / _SAMPLE_RATE
+        self._bytes_per_chunk = self.vad_samples_per_chunk * _SAMPLE_WIDTH
+        self._seconds_per_chunk = self.vad_samples_per_chunk / _SAMPLE_RATE
+        self._sample_buffer = AudioBuffer(self.vad_samples_per_chunk * _SAMPLE_WIDTH)
         self.reset()
 
     def reset(self) -> None:
         """Reset all counters and state."""
-        self._audio_buffer = b""
+        self._sample_buffer.length = 0
         self._silence_seconds_left = self.silence_seconds
         self._reset_seconds_left = self.reset_seconds
 
@@ -195,23 +232,9 @@ class VoiceActivityTimeout:
 
         Returns False when timeout is reached.
         """
-        self._audio_buffer += samples
-
-        # Process in 10, 20, or 30 ms chunks.
-        num_chunks = len(self._audio_buffer) // self._bytes_per_chunk
-        for chunk_idx in range(num_chunks):
-            chunk_offset = chunk_idx * self._bytes_per_chunk
-            chunk = self._audio_buffer[
-                chunk_offset : chunk_offset + self._bytes_per_chunk
-            ]
+        for chunk in chunk_samples(samples, self._bytes_per_chunk, self._sample_buffer):
             if not self._process_chunk(chunk):
                 return False
-
-        if num_chunks > 0:
-            # Remove from buffer
-            self._audio_buffer = self._audio_buffer[
-                num_chunks * self._bytes_per_chunk :
-            ]
 
         return True
 
@@ -239,3 +262,40 @@ class VoiceActivityTimeout:
             )
 
         return True
+
+
+def chunk_samples(
+    samples: bytes,
+    bytes_per_chunk: int,
+    sample_buffer: AudioBuffer,
+) -> Iterable[bytes]:
+    """Yield fixed-sized chunks from samples, keeping leftover bytes in a buffer."""
+    samples_offset = 0
+    num_chunks_in_samples = len(samples) // bytes_per_chunk
+    num_bytes_left = len(samples) % bytes_per_chunk
+
+    if len(sample_buffer) > 0:
+        # Add to partial chunk in buffer
+        bytes_to_copy = min(num_bytes_left, bytes_per_chunk - len(sample_buffer))
+        sample_buffer[len(sample_buffer) :] = samples[:bytes_to_copy]
+        sample_buffer.length += bytes_to_copy
+        samples_offset = bytes_to_copy
+        num_bytes_left -= bytes_to_copy
+
+    if len(sample_buffer) == bytes_per_chunk:
+        # Process full chunk in buffer
+        yield bytes(sample_buffer)
+        sample_buffer.length = 0
+
+    if num_bytes_left > 0:
+        # Keep bytes at the end of samples for next chunk
+        sample_buffer[:num_bytes_left] = samples[len(samples) - num_bytes_left :]
+        sample_buffer.length = num_bytes_left
+
+    # Process samples in chunks.
+    for chunk_idx in range(num_chunks_in_samples):
+        chunk_offset = samples_offset + (chunk_idx * bytes_per_chunk)
+        chunk = samples[chunk_offset : chunk_offset + bytes_per_chunk]
+        yield chunk
+
+    return True

--- a/homeassistant/components/assist_pipeline/vad.py
+++ b/homeassistant/components/assist_pipeline/vad.py
@@ -60,10 +60,6 @@ class AudioBuffer:
         """Get the number of bytes currently in the buffer."""
         return self._length
 
-    def __getitem__(self, item: Any) -> Any:
-        """Get a slice of the buffer."""
-        return self._buffer[item]
-
     def __setitem__(self, item: Any, value: Any) -> Any:
         """Set a slice of the buffer."""
         self._buffer[item] = value

--- a/homeassistant/components/wake_word/__init__.py
+++ b/homeassistant/components/wake_word/__init__.py
@@ -79,8 +79,6 @@ class WakeWordDetectionEntity(RestoreEntity):
     @final
     def state(self) -> str | None:
         """Return the state of the entity."""
-        if self.__last_detected is None:
-            return None
         return self.__last_detected
 
     @property

--- a/tests/components/assist_pipeline/snapshots/test_init.ambr
+++ b/tests/components/assist_pipeline/snapshots/test_init.ambr
@@ -319,6 +319,12 @@
     }),
     dict({
       'data': dict({
+        'timestamp': 1500,
+      }),
+      'type': <PipelineEventType.STT_VAD_END: 'stt-vad-end'>,
+    }),
+    dict({
+      'data': dict({
         'stt_output': dict({
           'text': 'test transcript',
         }),

--- a/tests/components/assist_pipeline/test_init.py
+++ b/tests/components/assist_pipeline/test_init.py
@@ -49,9 +49,9 @@ async def test_pipeline_from_audio_stream_auto(
 
     await assist_pipeline.async_pipeline_from_audio_stream(
         hass,
-        Context(),
-        events.append,
-        stt.SpeechMetadata(
+        context=Context(),
+        event_callback=events.append,
+        stt_metadata=stt.SpeechMetadata(
             language="",
             format=stt.AudioFormats.WAV,
             codec=stt.AudioCodecs.PCM,
@@ -59,7 +59,7 @@ async def test_pipeline_from_audio_stream_auto(
             sample_rate=stt.AudioSampleRates.SAMPLERATE_16000,
             channel=stt.AudioChannels.CHANNEL_MONO,
         ),
-        audio_data(),
+        stt_stream=audio_data(),
     )
 
     assert process_events(events) == snapshot
@@ -108,9 +108,9 @@ async def test_pipeline_from_audio_stream_legacy(
     # Use the created pipeline
     await assist_pipeline.async_pipeline_from_audio_stream(
         hass,
-        Context(),
-        events.append,
-        stt.SpeechMetadata(
+        context=Context(),
+        event_callback=events.append,
+        stt_metadata=stt.SpeechMetadata(
             language="en-UK",
             format=stt.AudioFormats.WAV,
             codec=stt.AudioCodecs.PCM,
@@ -118,7 +118,7 @@ async def test_pipeline_from_audio_stream_legacy(
             sample_rate=stt.AudioSampleRates.SAMPLERATE_16000,
             channel=stt.AudioChannels.CHANNEL_MONO,
         ),
-        audio_data(),
+        stt_stream=audio_data(),
         pipeline_id=pipeline_id,
     )
 
@@ -168,9 +168,9 @@ async def test_pipeline_from_audio_stream_entity(
     # Use the created pipeline
     await assist_pipeline.async_pipeline_from_audio_stream(
         hass,
-        Context(),
-        events.append,
-        stt.SpeechMetadata(
+        context=Context(),
+        event_callback=events.append,
+        stt_metadata=stt.SpeechMetadata(
             language="en-UK",
             format=stt.AudioFormats.WAV,
             codec=stt.AudioCodecs.PCM,
@@ -178,7 +178,7 @@ async def test_pipeline_from_audio_stream_entity(
             sample_rate=stt.AudioSampleRates.SAMPLERATE_16000,
             channel=stt.AudioChannels.CHANNEL_MONO,
         ),
-        audio_data(),
+        stt_stream=audio_data(),
         pipeline_id=pipeline_id,
     )
 
@@ -229,9 +229,9 @@ async def test_pipeline_from_audio_stream_no_stt(
     with pytest.raises(assist_pipeline.pipeline.PipelineRunValidationError):
         await assist_pipeline.async_pipeline_from_audio_stream(
             hass,
-            Context(),
-            events.append,
-            stt.SpeechMetadata(
+            context=Context(),
+            event_callback=events.append,
+            stt_metadata=stt.SpeechMetadata(
                 language="en-UK",
                 format=stt.AudioFormats.WAV,
                 codec=stt.AudioCodecs.PCM,
@@ -239,7 +239,7 @@ async def test_pipeline_from_audio_stream_no_stt(
                 sample_rate=stt.AudioSampleRates.SAMPLERATE_16000,
                 channel=stt.AudioChannels.CHANNEL_MONO,
             ),
-            audio_data(),
+            stt_stream=audio_data(),
             pipeline_id=pipeline_id,
         )
 
@@ -268,9 +268,9 @@ async def test_pipeline_from_audio_stream_unknown_pipeline(
     with pytest.raises(assist_pipeline.PipelineNotFound):
         await assist_pipeline.async_pipeline_from_audio_stream(
             hass,
-            Context(),
-            events.append,
-            stt.SpeechMetadata(
+            context=Context(),
+            event_callback=events.append,
+            stt_metadata=stt.SpeechMetadata(
                 language="en-UK",
                 format=stt.AudioFormats.WAV,
                 codec=stt.AudioCodecs.PCM,
@@ -278,7 +278,7 @@ async def test_pipeline_from_audio_stream_unknown_pipeline(
                 sample_rate=stt.AudioSampleRates.SAMPLERATE_16000,
                 channel=stt.AudioChannels.CHANNEL_MONO,
             ),
-            audio_data(),
+            stt_stream=audio_data(),
             pipeline_id="blah",
         )
 
@@ -312,9 +312,9 @@ async def test_pipeline_from_audio_stream_wake_word(
 
     await assist_pipeline.async_pipeline_from_audio_stream(
         hass,
-        Context(),
-        events.append,
-        stt.SpeechMetadata(
+        context=Context(),
+        event_callback=events.append,
+        stt_metadata=stt.SpeechMetadata(
             language="",
             format=stt.AudioFormats.WAV,
             codec=stt.AudioCodecs.PCM,
@@ -322,7 +322,7 @@ async def test_pipeline_from_audio_stream_wake_word(
             sample_rate=stt.AudioSampleRates.SAMPLERATE_16000,
             channel=stt.AudioChannels.CHANNEL_MONO,
         ),
-        audio_data(),
+        stt_stream=audio_data(),
         start_stage=assist_pipeline.PipelineStage.WAKE_WORD,
         wake_word_settings=assist_pipeline.WakeWordSettings(
             audio_seconds_to_buffer=1.5

--- a/tests/components/assist_pipeline/test_ring_buffer.py
+++ b/tests/components/assist_pipeline/test_ring_buffer.py
@@ -1,0 +1,35 @@
+"""Tests for audio ring buffer."""
+from homeassistant.components.assist_pipeline.ring_buffer import RingBuffer
+
+
+def test_ring_buffer_empty() -> None:
+    """Test empty ring buffer."""
+    rb = RingBuffer(10)
+    assert rb.maxlen == 10
+    assert rb.pos == 0
+    assert rb.getvalue() == b""
+
+
+def test_ring_buffer_put_1() -> None:
+    """Test putting some data smaller than the maximum length."""
+    rb = RingBuffer(10)
+    rb.put(bytes([1, 2, 3, 4, 5]))
+    assert rb.pos == 5
+    assert rb.getvalue() == bytes([1, 2, 3, 4, 5])
+
+
+def test_ring_buffer_put_2() -> None:
+    """Test putting some data past the end of the buffer."""
+    rb = RingBuffer(10)
+    rb.put(bytes([1, 2, 3, 4, 5]))
+    rb.put(bytes([6, 7, 8, 9, 10, 11, 12]))
+    assert rb.pos == 2
+    assert rb.getvalue() == bytes([3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
+
+
+def test_ring_buffer_put_too_large() -> None:
+    """Test putting data too large for the buffer."""
+    rb = RingBuffer(10)
+    rb.put(bytes([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]))
+    assert rb.pos == 2
+    assert rb.getvalue() == bytes([3, 4, 5, 6, 7, 8, 9, 10, 11, 12])

--- a/tests/components/assist_pipeline/test_ring_buffer.py
+++ b/tests/components/assist_pipeline/test_ring_buffer.py
@@ -14,6 +14,7 @@ def test_ring_buffer_put_1() -> None:
     """Test putting some data smaller than the maximum length."""
     rb = RingBuffer(10)
     rb.put(bytes([1, 2, 3, 4, 5]))
+    assert len(rb) == 5
     assert rb.pos == 5
     assert rb.getvalue() == bytes([1, 2, 3, 4, 5])
 
@@ -23,6 +24,7 @@ def test_ring_buffer_put_2() -> None:
     rb = RingBuffer(10)
     rb.put(bytes([1, 2, 3, 4, 5]))
     rb.put(bytes([6, 7, 8, 9, 10, 11, 12]))
+    assert len(rb) == 10
     assert rb.pos == 2
     assert rb.getvalue() == bytes([3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
 
@@ -31,5 +33,6 @@ def test_ring_buffer_put_too_large() -> None:
     """Test putting data too large for the buffer."""
     rb = RingBuffer(10)
     rb.put(bytes([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]))
+    assert len(rb) == 10
     assert rb.pos == 2
     assert rb.getvalue() == bytes([3, 4, 5, 6, 7, 8, 9, 10, 11, 12])

--- a/tests/components/assist_pipeline/test_vad.py
+++ b/tests/components/assist_pipeline/test_vad.py
@@ -2,8 +2,6 @@
 import itertools as it
 from unittest.mock import patch
 
-import pytest
-
 from homeassistant.components.assist_pipeline.vad import (
     AudioBuffer,
     VoiceCommandSegmenter,
@@ -101,17 +99,6 @@ def test_audio_buffer() -> None:
             assert mock_process.call_args_list[1][0][0] == two_chunks[bytes_per_chunk:]
 
 
-def test_audio_buffer_errors() -> None:
-    """Test audio buffer errors."""
-    audio_buffer = AudioBuffer(1)
-
-    with pytest.raises(ValueError):
-        audio_buffer.length = 2
-
-    with pytest.raises(ValueError):
-        audio_buffer.length = -2
-
-
 def test_partial_chunk() -> None:
     """Test that chunk_samples returns when given a partial chunk."""
     bytes_per_chunk = 5
@@ -120,7 +107,7 @@ def test_partial_chunk() -> None:
     chunks = list(chunk_samples(samples, bytes_per_chunk, leftover_chunk_buffer))
 
     assert len(chunks) == 0
-    assert bytes(leftover_chunk_buffer) == samples
+    assert leftover_chunk_buffer.bytes() == samples
 
 
 def test_chunk_samples_leftover() -> None:
@@ -131,10 +118,10 @@ def test_chunk_samples_leftover() -> None:
     chunks = list(chunk_samples(samples, bytes_per_chunk, leftover_chunk_buffer))
 
     assert len(chunks) == 1
-    assert bytes(leftover_chunk_buffer) == bytes([6])
+    assert leftover_chunk_buffer.bytes() == bytes([6])
 
     # Add some more to the chunk
     chunks = list(chunk_samples(samples, bytes_per_chunk, leftover_chunk_buffer))
 
     assert len(chunks) == 1
-    assert bytes(leftover_chunk_buffer) == bytes([5, 6])
+    assert leftover_chunk_buffer.bytes() == bytes([5, 6])

--- a/tests/components/assist_pipeline/test_vad.py
+++ b/tests/components/assist_pipeline/test_vad.py
@@ -2,7 +2,12 @@
 import itertools as it
 from unittest.mock import patch
 
-from homeassistant.components.assist_pipeline.vad import VoiceCommandSegmenter
+import pytest
+
+from homeassistant.components.assist_pipeline.vad import (
+    AudioBuffer,
+    VoiceCommandSegmenter,
+)
 
 _ONE_SECOND = 16000 * 2  # 16Khz 16-bit
 
@@ -93,3 +98,14 @@ def test_audio_buffer() -> None:
             assert len(segmenter.audio_buffer) == 0
             assert mock_process.call_args_list[0][0][0] == two_chunks[:bytes_per_chunk]
             assert mock_process.call_args_list[1][0][0] == two_chunks[bytes_per_chunk:]
+
+
+def test_audio_buffer_errors() -> None:
+    """Test audio buffer errors."""
+    audio_buffer = AudioBuffer(1)
+
+    with pytest.raises(ValueError):
+        audio_buffer.length = 2
+
+    with pytest.raises(ValueError):
+        audio_buffer.length = -2

--- a/tests/components/assist_pipeline/test_vad.py
+++ b/tests/components/assist_pipeline/test_vad.py
@@ -1,4 +1,5 @@
 """Tests for webrtcvad voice command segmenter."""
+import itertools as it
 from unittest.mock import patch
 
 from homeassistant.components.assist_pipeline.vad import VoiceCommandSegmenter
@@ -36,3 +37,59 @@ def test_speech() -> None:
         # silence
         # False return value indicates voice command is finished
         assert not segmenter.process(bytes(_ONE_SECOND))
+
+
+def test_audio_buffer() -> None:
+    """Test audio buffer wrapping."""
+
+    def is_speech(self, chunk, sample_rate):
+        """Disable VAD."""
+        return False
+
+    with patch(
+        "webrtcvad.Vad.is_speech",
+        new=is_speech,
+    ):
+        segmenter = VoiceCommandSegmenter()
+        bytes_per_chunk = segmenter.vad_samples_per_chunk * 2
+
+        with patch.object(
+            segmenter, "_process_chunk", return_value=True
+        ) as mock_process:
+            # Partially fill audio buffer
+            half_chunk = bytes(it.islice(it.cycle(range(256)), bytes_per_chunk // 2))
+            segmenter.process(half_chunk)
+
+            assert not mock_process.called
+            assert segmenter.audio_buffer == half_chunk
+
+            # Fill and wrap with 1/4 chunk left over
+            three_quarters_chunk = bytes(
+                it.islice(it.cycle(range(256)), int(0.75 * bytes_per_chunk))
+            )
+            segmenter.process(three_quarters_chunk)
+
+            assert mock_process.call_count == 1
+            assert (
+                segmenter.audio_buffer
+                == three_quarters_chunk[
+                    len(three_quarters_chunk) - (bytes_per_chunk // 4) :
+                ]
+            )
+            assert (
+                mock_process.call_args[0][0]
+                == half_chunk + three_quarters_chunk[: bytes_per_chunk // 2]
+            )
+
+            # Run 2 chunks through
+            segmenter.reset()
+            assert len(segmenter.audio_buffer) == 0
+
+            mock_process.reset_mock()
+            two_chunks = bytes(it.islice(it.cycle(range(256)), bytes_per_chunk * 2))
+            segmenter.process(two_chunks)
+
+            assert mock_process.call_count == 2
+            assert len(segmenter.audio_buffer) == 0
+            assert mock_process.call_args_list[0][0][0] == two_chunks[:bytes_per_chunk]
+            assert mock_process.call_args_list[1][0][0] == two_chunks[bytes_per_chunk:]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Clean up and refactoring of wake word code per commands in https://github.com/home-assistant/core/pull/96380

The largest changes are the use of `bytearray` for VAD and within a `RingBuffer` for audio to be forwarded to speech-to-text after wake-word-detection. Both `bytearray` buffers are fixed in size, which should be significantly faster than creating new `bytes` objects with every audio chunk.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
