### PR TITLE
Filter some pytest warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -429,7 +429,96 @@ norecursedirs = [
 log_format = "%(asctime)s.%(msecs)03d %(levelname)-8s %(threadName)s %(name)s:%(filename)s:%(lineno)s %(message)s"
 log_date_format = "%Y-%m-%d %H:%M:%S"
 asyncio_mode = "auto"
-filterwarnings = ["error::sqlalchemy.exc.SAWarning"]
+filterwarnings = [
+    "error::sqlalchemy.exc.SAWarning",
+
+    # -- HomeAssistant - aiohttp
+    # Overwrite web.Application to pass a custom default argument to _make_request
+    "ignore:Inheritance class HomeAssistantApplication from web.Application is discouraged:DeprecationWarning",
+    # Hass wraps `ClientSession.close` to emit a warning if the session is closed accidentally
+    "ignore:Setting custom ClientSession.close attribute is discouraged:DeprecationWarning:homeassistant.helpers.aiohttp_client",
+    # Modify app state for testing
+    "ignore:Changing state of started or joined application is deprecated:DeprecationWarning:tests.components.http.test_ban",
+
+    # -- Tests
+    # Ignore custom pytest marks
+    "ignore:Unknown pytest.mark.disable_autouse_fixture:pytest.PytestUnknownMarkWarning:tests.components.met",
+
+    # -- design choice 3rd party
+    # https://github.com/gwww/elkm1/blob/2.2.5/elkm1_lib/util.py#L8-L19
+    "ignore:ssl.TLSVersion.TLSv1 is deprecated:DeprecationWarning:elkm1_lib.util",
+    # https://github.com/michaeldavie/env_canada/blob/v0.5.36/env_canada/ec_cache.py
+    "ignore:Inheritance class CacheClientSession from ClientSession is discouraged:DeprecationWarning:env_canada.ec_cache",
+    # https://github.com/bachya/regenmaschine/blob/2023.08.0/regenmaschine/client.py#L51
+    "ignore:ssl.TLSVersion.SSLv3 is deprecated:DeprecationWarning:regenmaschine.client",
+
+    # -- Setuptools DeprecationWarnings
+    # https://github.com/googleapis/google-cloud-python/issues/11184
+    # https://github.com/zopefoundation/meta/issues/194
+    "ignore:Deprecated call to `pkg_resources.declare_namespace\\(('google.*'|'pywinusb'|'repoze'|'xbox'|'zope')\\)`:DeprecationWarning:pkg_resources",
+    "ignore:Deprecated call to `pkg_resources.declare_namespace\\('google.*'\\)`:DeprecationWarning:google.rpc",
+
+    # -- tracked upstream / open PRs
+    # https://github.com/caronc/apprise/issues/659 - v1.4.5
+    "ignore:Use setlocale\\(\\), getencoding\\(\\) and getlocale\\(\\) instead:DeprecationWarning:apprise.AppriseLocal",
+    # https://github.com/beetbox/mediafile/issues/67 - v0.12.0
+    "ignore:'imghdr' is deprecated and slated for removal in Python 3.13:DeprecationWarning:mediafile",
+    # https://github.com/PythonCharmers/python-future/issues/488 - v0.18.3
+    "ignore:the imp module is deprecated in favour of importlib and slated for removal in Python 3.12:DeprecationWarning:future.standard_library",
+    # https://github.com/foxel/python_ndms2_client/issues/6 - v0.1.2
+    "ignore:'telnetlib' is deprecated and slated for removal in Python 3.13:DeprecationWarning:ndms2_client.connection",
+    # https://github.com/grahamwetzler/smart-meter-texas/pull/143
+    "ignore:ssl.OP_NO_SSL\\*/ssl.OP_NO_TLS\\* options are deprecated:DeprecationWarning:smart_meter_texas",
+    # https://github.com/pytest-dev/pytest-cov/issues/557 - v4.1.0
+    # Should resolve itself once pytest-xdist 4.0 is released and the option is removed
+    "ignore:The --rsyncdir command line argument and rsyncdirs config variable are deprecated:DeprecationWarning:xdist.plugin",
+    # https://github.com/eclipse/paho.mqtt.python/blob/v1.6.1/src/paho/mqtt/client.py#L788-L791
+
+    # -- fixed, waiting for release / update
+    # https://github.com/gurumitts/pylutron-caseta/pull/143 - >0.18.1
+    "ignore:ssl.PROTOCOL_TLSv1_2 is deprecated:DeprecationWarning:pylutron_caseta.smartbridge",
+    # https://github.com/Danielhiversen/pyMillLocal/pull/8 - >=0.3.0
+    "ignore:with timeout\\(\\) is deprecated:DeprecationWarning:mill_local",
+    # https://github.com/home-assistant/core/pull/98619 - update botocore to >=1.31.17
+    "ignore:'cgi' is deprecated and slated for removal in Python 3.13:DeprecationWarning:botocore.utils",
+    "ignore:'urllib3.contrib.pyopenssl' module is deprecated and will be removed in a future release of urllib3 2.x:DeprecationWarning:botocore.httpsession",
+
+    # -- not helpful
+    # pyatmo.__init__ imports deprecated moduls from itself - v7.5.0
+    "ignore:The module pyatmo.* is deprecated:DeprecationWarning:pyatmo",
+
+    # -- unmaintained projects, last release about 2+ years
+    # https://pypi.org/project/agent-py/ - v0.0.23 - 2020-06-04
+    "ignore:with timeout\\(\\) is deprecated:DeprecationWarning:agent.a",
+    # https://pypi.org/project/aiomodernforms/ - v0.1.8 - 2021-06-27
+    "ignore:with timeout\\(\\) is deprecated:DeprecationWarning:aiomodernforms.modernforms",
+    # https://pypi.org/project/directv/ - v0.4.0 - 2020-09-12
+    "ignore:with timeout\\(\\) is deprecated:DeprecationWarning:directv.directv",
+    # https://pypi.org/project/emulated-roku/ - v0.2.1 - 2020-01-23 (archived)
+    "ignore:loop argument is deprecated:DeprecationWarning:emulated_roku",
+    # https://pypi.org/project/foobot_async/ - v1.0.0 - 2020-11-24
+    "ignore:with timeout\\(\\) is deprecated:DeprecationWarning:foobot_async",
+    # https://pypi.org/project/lark-parser/ - v0.12.0 - 2021-08-30 -> moved to `lark`
+    # https://pypi.org/project/commentjson/ - v0.9.0 - 2020-10-05
+    # https://github.com/vaidik/commentjson/issues/51
+    # Fixed upstream, commentjson depends on old version and seems to be unmaintained
+    "ignore:module '(sre_parse|sre_constants)' is deprecate:DeprecationWarning:lark.utils",
+    # https://pypi.org/project/lomond/ - v0.3.3 - 2018-09-21
+    "ignore:ssl.PROTOCOL_TLS is deprecated:DeprecationWarning:lomond.session",
+    # https://pypi.org/project/paho-mqtt/ - v1.6.1 - 2021-10-21
+    "ignore:ssl.PROTOCOL_TLS is deprecated:DeprecationWarning:paho.mqtt.client",
+    # https://pypi.org/project/passlib/ - v1.7.4 - 2020-10-08
+    "ignore:'crypt' is deprecated and slated for removal in Python 3.13:DeprecationWarning:passlib.utils",
+    # https://pypi.org/project/pyqwikswitch/ - v0.94 - 2019-08-19
+    "ignore:client.loop property is deprecated:DeprecationWarning:pyqwikswitch.async_",
+    "ignore:with timeout\\(\\) is deprecated:DeprecationWarning:pyqwikswitch.async_",
+    # https://pypi.org/project/rxv/ - v0.7.0 - 2021-10-10
+    "ignore:defusedxml.cElementTree is deprecated, import from defusedxml.ElementTree instead:DeprecationWarning:rxv.ssdp",
+    # https://pypi.org/project/vilfo-api-client/ - v0.4.1 - 2021-11-06
+    "ignore:Function 'semver.compare' is deprecated. Deprecated since version 3.0.0:PendingDeprecationWarning:.*vilfo.client",
+    # https://pypi.org/project/webrtcvad/ - v2.0.10 - 2017-01-08
+    "ignore:pkg_resources is deprecated as an API:DeprecationWarning:webrtcvad",
+]
 
 [tool.ruff]
 target-version = "py310"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -470,7 +470,7 @@ filterwarnings = [
     "ignore:the imp module is deprecated in favour of importlib and slated for removal in Python 3.12:DeprecationWarning:future.standard_library",
     # https://github.com/foxel/python_ndms2_client/issues/6 - v0.1.2
     "ignore:'telnetlib' is deprecated and slated for removal in Python 3.13:DeprecationWarning:ndms2_client.connection",
-    # https://github.com/grahamwetzler/smart-meter-texas/pull/143
+    # https://github.com/grahamwetzler/smart-meter-texas/pull/143 - v0.5.3
     "ignore:ssl.OP_NO_SSL\\*/ssl.OP_NO_TLS\\* options are deprecated:DeprecationWarning:smart_meter_texas",
     # https://github.com/pytest-dev/pytest-cov/issues/557 - v4.1.0
     # Should resolve itself once pytest-xdist 4.0 is released and the option is removed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -475,7 +475,6 @@ filterwarnings = [
     # https://github.com/pytest-dev/pytest-cov/issues/557 - v4.1.0
     # Should resolve itself once pytest-xdist 4.0 is released and the option is removed
     "ignore:The --rsyncdir command line argument and rsyncdirs config variable are deprecated:DeprecationWarning:xdist.plugin",
-    # https://github.com/eclipse/paho.mqtt.python/blob/v1.6.1/src/paho/mqtt/client.py#L788-L791
 
     # -- fixed, waiting for release / update
     # https://github.com/gurumitts/pylutron-caseta/pull/143 - >0.18.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -463,6 +463,9 @@ filterwarnings = [
     "ignore:Use setlocale\\(\\), getencoding\\(\\) and getlocale\\(\\) instead:DeprecationWarning:apprise.AppriseLocal",
     # https://github.com/beetbox/mediafile/issues/67 - v0.12.0
     "ignore:'imghdr' is deprecated and slated for removal in Python 3.13:DeprecationWarning:mediafile",
+    # https://github.com/eclipse/paho.mqtt.python/issues/653 - v1.6.1
+    # https://github.com/eclipse/paho.mqtt.python/pull/665
+    "ignore:ssl.PROTOCOL_TLS is deprecated:DeprecationWarning:paho.mqtt.client",
     # https://github.com/PythonCharmers/python-future/issues/488 - v0.18.3
     "ignore:the imp module is deprecated in favour of importlib and slated for removal in Python 3.12:DeprecationWarning:future.standard_library",
     # https://github.com/foxel/python_ndms2_client/issues/6 - v0.1.2
@@ -505,8 +508,6 @@ filterwarnings = [
     "ignore:module '(sre_parse|sre_constants)' is deprecate:DeprecationWarning:lark.utils",
     # https://pypi.org/project/lomond/ - v0.3.3 - 2018-09-21
     "ignore:ssl.PROTOCOL_TLS is deprecated:DeprecationWarning:lomond.session",
-    # https://pypi.org/project/paho-mqtt/ - v1.6.1 - 2021-10-21
-    "ignore:ssl.PROTOCOL_TLS is deprecated:DeprecationWarning:paho.mqtt.client",
     # https://pypi.org/project/passlib/ - v1.7.4 - 2020-10-08
     "ignore:'crypt' is deprecated and slated for removal in Python 3.13:DeprecationWarning:passlib.utils",
     # https://pypi.org/project/pyqwikswitch/ - v0.94 - 2019-08-19


### PR DESCRIPTION
## Proposed change
Ignore unhelpful warnings to make it easier to spot the important ones.

The current pytest warnings overview is quite cluttered with a lot of DeprecationWarnings. In most cases we can't even do anything about it or they are already tracked upstream. There is no need for us to keep them around in our pytest output. Nobody is going to read 100+ entries just to find the one we can / should actually fix. As example, the logs from a recent Actions run on `dev`: https://github.com/home-assistant/core/suites/15266074255/artifacts/872069112

_All pytest logs can be downloaded via the `pytest-<run_no>` artifact from the run summary view._

I've added warnings filter for the following categories:
- The warning is a result of a specific design choice. I.e. unavoidable unless wrapped with `warnings.catch_warnings`.
https://docs.python.org/3/library/warnings.html#temporarily-suppressing-warnings
- The warning is tracked upstream either in an issue or a PR
- A fix has already been merged upstream but either there hasn't been a new release or the pinned version hasn't been updated yet. _The later should ideally be rather soon but that might not always be possible to do quickly._
- Warnings emitted on code from unmaintained projects. Last release **roughly** 2 or more years ago.
Those might still be fixed but there is no telling when and it would likely be wasted time to try and fix them.

Whenever possible I tried to be as precise as possible when adding a new entry. For example almost all filters are only applied to specific modules.

I've also added comments for each entry to make it easier to check if these are still needed in the future. 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
