### PR TITLE
Add support for Shelly Gas Valve addon

### DIFF
--- a/homeassistant/components/shelly/const.py
+++ b/homeassistant/components/shelly/const.py
@@ -179,3 +179,5 @@ MAX_PUSH_UPDATE_FAILURES = 5
 PUSH_UPDATE_ISSUE_ID = "push_update_{unique}"
 
 NOT_CALIBRATED_ISSUE_ID = "not_calibrated_{unique}"
+
+GAS_VALVE_OPEN_STATES = ("opening", "opened")

--- a/homeassistant/components/shelly/sensor.py
+++ b/homeassistant/components/shelly/sensor.py
@@ -315,6 +315,7 @@ SENSORS: Final = {
     ("valve", "valve"): BlockSensorDescription(
         key="valve|valve",
         name="Valve state",
+        translation_key="valve_state",
         icon="mdi:valve",
         device_class=SensorDeviceClass.ENUM,
         options=[

--- a/homeassistant/components/shelly/sensor.py
+++ b/homeassistant/components/shelly/sensor.py
@@ -314,8 +314,8 @@ SENSORS: Final = {
     ),
     ("valve", "valve"): BlockSensorDescription(
         key="valve|valve",
-        name="Valve state",
-        translation_key="valve_state",
+        name="Valve status",
+        translation_key="valve_status",
         icon="mdi:valve",
         device_class=SensorDeviceClass.ENUM,
         options=[

--- a/homeassistant/components/shelly/sensor.py
+++ b/homeassistant/components/shelly/sensor.py
@@ -312,6 +312,23 @@ SENSORS: Final = {
         value=lambda value: value,
         extra_state_attributes=lambda block: {"self_test": block.selfTest},
     ),
+    ("valve", "valve"): BlockSensorDescription(
+        key="valve|valve",
+        name="Valve state",
+        icon="mdi:valve",
+        device_class=SensorDeviceClass.ENUM,
+        options=[
+            "checking",
+            "closed",
+            "closing",
+            "failure",
+            "opened",
+            "opening",
+            "unknown",
+        ],
+        entity_category=EntityCategory.DIAGNOSTIC,
+        removal_condition=lambda _, block: block.valve == "not_connected",
+    ),
 }
 
 REST_SENSORS: Final = {

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -116,6 +116,17 @@
             }
           }
         }
+      },
+      "valve_state": {
+        "state": {
+          "checking": "Checking",
+          "closed": "Closed",
+          "closing": "Closing",
+          "failure": "Failure",
+          "opened": "Opened",
+          "opening": "Opening",
+          "unknown": "[%key:component::shelly::entity::sensor::operation::state::unknown%]"
+        }
       }
     }
   },

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -117,7 +117,7 @@
           }
         }
       },
-      "valve_state": {
+      "valve_status": {
         "state": {
           "checking": "Checking",
           "closed": "Closed",

--- a/homeassistant/components/shelly/switch.py
+++ b/homeassistant/components/shelly/switch.py
@@ -137,13 +137,13 @@ class BlockValveSwitch(ShellyBlockAttributeEntity, SwitchEntity):
         attribute: str,
         description: BlockSwitchDescription,
     ) -> None:
-        """Initialize relay switch."""
+        """Initialize valve."""
         super().__init__(coordinator, block, attribute, description)
         self.control_result: dict[str, Any] | None = None
 
     @property
     def is_on(self) -> bool:
-        """If switch is on."""
+        """If valve is open."""
         if self.control_result:
             return self.control_result["state"] in GAS_VALVE_OPEN_STATES
 
@@ -155,12 +155,12 @@ class BlockValveSwitch(ShellyBlockAttributeEntity, SwitchEntity):
         return "mdi:valve-open" if self.is_on else "mdi:valve-closed"
 
     async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn on relay."""
+        """Open valve."""
         self.control_result = await self.set_state(go="open")
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn off relay."""
+        """Close valve."""
         self.control_result = await self.set_state(go="close")
         self.async_write_ha_state()
 

--- a/homeassistant/components/shelly/switch.py
+++ b/homeassistant/components/shelly/switch.py
@@ -141,7 +141,7 @@ class BlockValveSwitch(ShellyBlockAttributeEntity, SwitchEntity):
     @property
     def is_on(self) -> bool:
         """If switch is on."""
-        return self.attribute_value == "opened"
+        return self.attribute_value in ("closing", "opening", "opened")
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on relay."""

--- a/homeassistant/components/shelly/switch.py
+++ b/homeassistant/components/shelly/switch.py
@@ -128,6 +128,8 @@ def async_setup_rpc_entry(
 class BlockValveSwitch(ShellyBlockAttributeEntity, SwitchEntity):
     """Entity that controls a Gas Valve on Block based Shelly devices."""
 
+    entity_description: BlockSwitchDescription
+
     def __init__(
         self,
         coordinator: ShellyBlockCoordinator,

--- a/homeassistant/components/shelly/switch.py
+++ b/homeassistant/components/shelly/switch.py
@@ -38,7 +38,7 @@ GAS_VALVE_SWITCH = BlockSwitchDescription(
     name="Valve opened",
     icon="mdi:valve",
     available=lambda block: block.valve not in ("failure", "checking"),
-    removal_condition=lambda _, block: block.valve in ("not_connected", "unknown"),
+    # removal_condition=lambda _, block: block.valve in ("not_connected", "unknown"),
 )
 
 
@@ -145,17 +145,12 @@ class BlockValveSwitch(ShellyBlockAttributeEntity, SwitchEntity):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on relay."""
-        await self.async_set_valve("open")
+        await self.set_state(go="open")
+        self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off relay."""
-        await self.async_set_valve("close")
-
-    async def async_set_valve(self, new_state: str) -> None:
-        """Set the valve state."""
-        await self.coordinator.device.http_request(
-            "get", f"settings/{self.block.type}/{self.block.channel}", {"go": new_state}
-        )
+        await self.set_state(go="close")
         self.async_write_ha_state()
 
 

--- a/homeassistant/components/shelly/switch.py
+++ b/homeassistant/components/shelly/switch.py
@@ -35,10 +35,9 @@ class BlockSwitchDescription(BlockEntityDescription, SwitchEntityDescription):
 
 GAS_VALVE_SWITCH = BlockSwitchDescription(
     key="valve|valve",
-    name="Valve opened",
-    icon="mdi:valve",
+    name="Valve",
     available=lambda block: block.valve not in ("failure", "checking"),
-    # removal_condition=lambda _, block: block.valve in ("not_connected", "unknown"),
+    removal_condition=lambda _, block: block.valve in ("not_connected", "unknown"),
 )
 
 
@@ -142,6 +141,11 @@ class BlockValveSwitch(ShellyBlockAttributeEntity, SwitchEntity):
     def is_on(self) -> bool:
         """If switch is on."""
         return self.attribute_value in ("closing", "opening", "opened")
+
+    @property
+    def icon(self) -> str:
+        """Return the icon."""
+        return "mdi:valve-open" if self.is_on else "mdi:valve-closed"
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on relay."""

--- a/homeassistant/components/shelly/switch.py
+++ b/homeassistant/components/shelly/switch.py
@@ -73,6 +73,7 @@ def async_setup_block_entry(
             {("valve", "valve"): GAS_VALVE_SWITCH},
             BlockValveSwitch,
         )
+        return
 
     # In roller mode the relay blocks exist but do not contain required info
     if (

--- a/homeassistant/components/shelly/switch.py
+++ b/homeassistant/components/shelly/switch.py
@@ -140,7 +140,7 @@ class BlockValveSwitch(ShellyBlockAttributeEntity, SwitchEntity):
     @property
     def is_on(self) -> bool:
         """If switch is on."""
-        return self.attribute_value in ("closing", "opening", "opened")
+        return self.attribute_value in ("opening", "opened")
 
     @property
     def icon(self) -> str:

--- a/tests/components/shelly/conftest.py
+++ b/tests/components/shelly/conftest.py
@@ -133,6 +133,7 @@ MOCK_BLOCKS = [
     ),
     Mock(
         sensor_ids={"valve": "closed"},
+        valve="closed",
         channel="0",
         description="valve_0",
         type="valve",

--- a/tests/components/shelly/conftest.py
+++ b/tests/components/shelly/conftest.py
@@ -131,6 +131,15 @@ MOCK_BLOCKS = [
         description="emeter_0",
         type="emeter",
     ),
+    Mock(
+        sensor_ids={"valve": "closed"},
+        channel="0",
+        description="valve_0",
+        type="valve",
+        set_state=AsyncMock(
+            side_effect=lambda go: {"state": "opening" if go == "open" else "closing"}
+        ),
+    ),
 ]
 
 MOCK_CONFIG = {

--- a/tests/components/shelly/test_climate.py
+++ b/tests/components/shelly/test_climate.py
@@ -32,6 +32,7 @@ from tests.common import mock_restore_cache, mock_restore_cache_with_extra_data
 SENSOR_BLOCK_ID = 3
 DEVICE_BLOCK_ID = 4
 EMETER_BLOCK_ID = 5
+GAS_VALVE_BLOCK_ID = 6
 ENTITY_ID = f"{CLIMATE_DOMAIN}.test_name"
 
 
@@ -47,6 +48,7 @@ async def test_climate_hvac_mode(
     )
     monkeypatch.setattr(mock_block_device.blocks[DEVICE_BLOCK_ID], "valveError", 0)
     monkeypatch.delattr(mock_block_device.blocks[EMETER_BLOCK_ID], "targetTemp")
+    monkeypatch.delattr(mock_block_device.blocks[GAS_VALVE_BLOCK_ID], "targetTemp")
     await init_integration(hass, 1, sleep_period=1000, model="SHTRV-01")
 
     # Make device online
@@ -103,6 +105,7 @@ async def test_climate_set_temperature(
     """Test climate set temperature service."""
     monkeypatch.delattr(mock_block_device.blocks[DEVICE_BLOCK_ID], "targetTemp")
     monkeypatch.setattr(mock_block_device.blocks[DEVICE_BLOCK_ID], "valveError", 0)
+    monkeypatch.delattr(mock_block_device.blocks[GAS_VALVE_BLOCK_ID], "targetTemp")
     await init_integration(hass, 1, sleep_period=1000)
 
     # Make device online
@@ -144,6 +147,7 @@ async def test_climate_set_preset_mode(
 ) -> None:
     """Test climate set preset mode service."""
     monkeypatch.delattr(mock_block_device.blocks[DEVICE_BLOCK_ID], "targetTemp")
+    monkeypatch.delattr(mock_block_device.blocks[GAS_VALVE_BLOCK_ID], "targetTemp")
     monkeypatch.setattr(mock_block_device.blocks[DEVICE_BLOCK_ID], "valveError", 0)
     monkeypatch.setattr(mock_block_device.blocks[DEVICE_BLOCK_ID], "mode", None)
     await init_integration(hass, 1, sleep_period=1000, model="SHTRV-01")
@@ -198,6 +202,7 @@ async def test_block_restored_climate(
 ) -> None:
     """Test block restored climate."""
     monkeypatch.delattr(mock_block_device.blocks[DEVICE_BLOCK_ID], "targetTemp")
+    monkeypatch.delattr(mock_block_device.blocks[GAS_VALVE_BLOCK_ID], "targetTemp")
     monkeypatch.setattr(mock_block_device.blocks[DEVICE_BLOCK_ID], "valveError", 0)
     monkeypatch.delattr(mock_block_device.blocks[EMETER_BLOCK_ID], "targetTemp")
     entry = await init_integration(hass, 1, sleep_period=1000, skip_setup=True)
@@ -261,6 +266,7 @@ async def test_block_restored_climate_us_customery(
     """Test block restored climate with US CUSTOMATY unit system."""
     hass.config.units = US_CUSTOMARY_SYSTEM
     monkeypatch.delattr(mock_block_device.blocks[DEVICE_BLOCK_ID], "targetTemp")
+    monkeypatch.delattr(mock_block_device.blocks[GAS_VALVE_BLOCK_ID], "targetTemp")
     monkeypatch.setattr(mock_block_device.blocks[DEVICE_BLOCK_ID], "valveError", 0)
     monkeypatch.delattr(mock_block_device.blocks[EMETER_BLOCK_ID], "targetTemp")
     entry = await init_integration(hass, 1, sleep_period=1000, skip_setup=True)

--- a/tests/components/shelly/test_switch.py
+++ b/tests/components/shelly/test_switch.py
@@ -9,6 +9,7 @@ from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.const import (
     ATTR_ENTITY_ID,
+    ATTR_ICON,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
     STATE_OFF,
@@ -16,6 +17,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
 
 from . import init_integration
 
@@ -226,3 +228,42 @@ async def test_rpc_auth_error(
     assert "context" in flow
     assert flow["context"].get("source") == SOURCE_REAUTH
     assert flow["context"].get("entry_id") == entry.entry_id
+
+
+async def test_block_device_gas_valve(
+    hass: HomeAssistant, mock_block_device, monkeypatch
+) -> None:
+    """Test block device Shelly Gas with Valve addon."""
+    registry = er.async_get(hass)
+    await init_integration(hass, 1, "SHGS-1")
+    entity_id = "switch.test_name_valve"
+
+    entry = registry.async_get(entity_id)
+    assert entry
+    assert entry.unique_id == "123456789ABC-valve_0-valve"
+
+    assert hass.states.get(entity_id).state == STATE_OFF  # valve is closed
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == STATE_ON  # valve is open
+    assert state.attributes.get(ATTR_ICON) == "mdi:valve-open"
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == STATE_OFF  # valve is closed
+    assert state.attributes.get(ATTR_ICON) == "mdi:valve-closed"

--- a/tests/components/shelly/test_switch.py
+++ b/tests/components/shelly/test_switch.py
@@ -22,6 +22,7 @@ from homeassistant.helpers import entity_registry as er
 from . import init_integration
 
 RELAY_BLOCK_ID = 0
+GAS_VALVE_BLOCK_ID = 6
 
 
 async def test_block_device_services(hass: HomeAssistant, mock_block_device) -> None:
@@ -267,3 +268,12 @@ async def test_block_device_gas_valve(
     assert state
     assert state.state == STATE_OFF  # valve is closed
     assert state.attributes.get(ATTR_ICON) == "mdi:valve-closed"
+
+    monkeypatch.setattr(mock_block_device.blocks[GAS_VALVE_BLOCK_ID], "valve", "opened")
+    mock_block_device.mock_update()
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == STATE_ON  # valve is open
+    assert state.attributes.get(ATTR_ICON) == "mdi:valve-open"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds:
- `switch` entity to control the valve
- `sensor` entity with exact valve statuses

for Shelly Gas with connceted Valve addon.

The change has been tested by the user https://github.com/home-assistant/core/issues/98107#issuecomment-1685254270 and https://github.com/home-assistant/core/issues/98107#issuecomment-1684919761

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #98107
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/28639

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
