### PR TITLE
Reduce Freebox router Raid warning to one occurence

### DIFF
--- a/homeassistant/components/freebox/router.py
+++ b/homeassistant/components/freebox/router.py
@@ -167,8 +167,8 @@ class FreeboxRouter:
             fbx_raids: list[dict[str, Any]] = await self._api.storage.get_raids() or []
         except HttpRequestError:
             self.supports_raid = False
-            _LOGGER.warning(
-                "Router %s API does not seem to support raid, will not enumerate further",
+            _LOGGER.info(
+                "Router %s API does not support RAID",
                 self.name,
             )
             return

--- a/homeassistant/components/freebox/router.py
+++ b/homeassistant/components/freebox/router.py
@@ -168,7 +168,8 @@ class FreeboxRouter:
         except HttpRequestError:
             self.supports_raid = False
             _LOGGER.warning(
-                "This router model apparently does not support raid, will not enumerate further"
+                "Router %s API does not seem to support raid, will not enumerate further",
+                self.name,
             )
             return
 


### PR DESCRIPTION
## Proposed change

https://github.com/home-assistant/core/pull/95242 added RAID info to disks attached to Freebox routers, but fail the integration to start for people without disks or RAID (with a generic error `(APIResponse: {"msg": "Erreur interne", "success": false, "error_code": "internal_error"}`), its fix https://github.com/home-assistant/core/pull/97696 added try-catch with a warn, but in the update function (causing thousands of warnings to appear in the logs). It should be at init, then use a boolean or other to not warn more.

This PR sets a boolean in case of failure so that subsequent calls are not done anymore.

Models that seemingly do not support raid enumeration are
- Freebox Pop
- Freebox Revolution

However, i believe that this kind of model-specific handling should be done at the underlying level, and opened a corresponding discussion here: https://github.com/hacf-fr/freebox-api/issues/567

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #98274
- This PR is related to issues:
  - https://github.com/home-assistant/core/issues/98274
  - https://github.com/home-assistant/core/pull/97696
  - https://github.com/home-assistant/core/issues/97652

## Checklist

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [] Tests have been added to verify that the new code works.