### PR TITLE
Remove repair issue for MQTT discovered items

### DIFF
--- a/homeassistant/components/mqtt/mixins.py
+++ b/homeassistant/components/mqtt/mixins.py
@@ -1144,11 +1144,8 @@ class MqttEntity(
                 )
             elif (device_name := config[CONF_DEVICE][CONF_NAME]) == entity_name:
                 self._attr_name = None
-                self._issue_key = (
-                    "entity_name_is_device_name_discovery"
-                    if self._discovery
-                    else "entity_name_is_device_name_yaml"
-                )
+                if not self._discovery:
+                    self._issue_key = "entity_name_is_device_name_yaml"
                 _LOGGER.warning(
                     "MQTT device name is equal to entity name in your config %s, "
                     "this is not expected. Please correct your configuration. "
@@ -1162,11 +1159,8 @@ class MqttEntity(
                 if device_name[:1].isupper():
                     # Ensure a capital if the device name first char is a capital
                     new_entity_name = new_entity_name[:1].upper() + new_entity_name[1:]
-                self._issue_key = (
-                    "entity_name_startswith_device_name_discovery"
-                    if self._discovery
-                    else "entity_name_startswith_device_name_yaml"
-                )
+                if not self._discovery:
+                    self._issue_key = "entity_name_startswith_device_name_yaml"
                 _LOGGER.warning(
                     "MQTT entity name starts with the device name in your config %s, "
                     "this is not expected. Please correct your configuration. "

--- a/homeassistant/components/mqtt/strings.json
+++ b/homeassistant/components/mqtt/strings.json
@@ -15,14 +15,6 @@
     "entity_name_startswith_device_name_yaml": {
       "title": "Manual configured MQTT entities with a name that starts with the device name",
       "description": "Some MQTT entities have an entity name that starts with the device name. This is not expected. To avoid a duplicate name the device name prefix is stripped off the entity name as a work-a-round. Please update your configuration and restart Home Assistant to fix this issue. \n\nList of affected entities:\n\n{config}"
-    },
-    "entity_name_is_device_name_discovery": {
-      "title": "Discovered MQTT entities with a name that is equal to the device name",
-      "description": "Some MQTT entities have an entity name equal to the device name. This is not expected. The entity name is set to `null` as a work-a-round to avoid a duplicate name. Please inform the maintainer of the software application that supplies the affected entities to fix this issue.\n\nList of affected entities:\n\n{config}"
-    },
-    "entity_name_startswith_device_name_discovery": {
-      "title": "Discovered entities with a name that starts with the device name",
-      "description": "Some MQTT entities have an entity name that starts with the device name. This is not expected. To avoid a duplicate name the device name prefix is stripped off the entity name as a work-a-round. Please inform the maintainer of the software application that supplies the affected entities to fix this issue. \n\nList of affected entities:\n\n{config}"
     }
   },
   "config": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR reverts/removes the creation of repairs issues for the MQTT integration, on entities that are created by MQTT discovery, as introduced in Home Assistant 2023.8.

- These repair issues seem to cause/trigger quite a lot of fuzz that should not be needed; there are quite a lot of topics across different socials on this.

- This repair issue is mostly misunderstood as a breaking change, while it is not breaking at all. The original intent was to inform and to get people to report issues upstream to third-party software that integrate with Home Assistant over MQTT. It is currently handled gracefully and in a backward-compatible manner for the end-user.

- Repair issues must be fixable by the user; however, in this case, it currently isn't actionable by most users as most discovery payloads aren't created by users but by the third-party software.

- One of the bigger pieces of software triggering this issue, is Zigbee2MQTT. An adjustment for this missed their release cut, meaning these users get these repairs too (which is a big part of our community).

- The goal of getting MQTT naming up to par with the rest of the Home Assistant integrations remains; This in order to support a better and more standardized naming of entities and devices across Home Assistant (so we can provide better naming depending on the user context in the future).

ℹ️ Marking this PR for the 2023.8.4 patch release that is planned for the 24th of August.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
