### PR TITLE
Abort ESPHome connection when both name and mac address do not match

### DIFF
--- a/homeassistant/components/esphome/manager.py
+++ b/homeassistant/components/esphome/manager.py
@@ -366,7 +366,7 @@ class ESPHomeManager:
         try:
             device_info = await cli.device_info()
         except APIConnectionError as err:
-            _LOGGER.warning("Error getting initial data for %s: %s", self.host, err)
+            _LOGGER.warning("Error getting device info for %s: %s", self.host, err)
             # Re-connection logic will trigger after this
             await cli.disconnect()
             return

--- a/homeassistant/components/esphome/manager.py
+++ b/homeassistant/components/esphome/manager.py
@@ -384,9 +384,9 @@ class ESPHomeManager:
         # to the mac address. This is to handle a board change (ie
         # device replaced after failure, but config is the same)
         #
-        if (
+        if not mac_address_matches and (
             not unique_id_is_mac_address or name_matches or not stored_device_name
-        ) and not mac_address_matches:
+        ):
             hass.config_entries.async_update_entry(entry, unique_id=device_mac)
 
         if (
@@ -423,6 +423,9 @@ class ESPHomeManager:
 
         # Make sure we have the correct device name stored
         # so we can map the device to ESPHome Dashboard config
+        # If we got here, we know the mac address matches or we
+        # did a migration to the mac address so we can update
+        # the device name.
         if not name_matches:
             hass.config_entries.async_update_entry(
                 entry, data={**entry.data, CONF_DEVICE_NAME: device_info.name}

--- a/homeassistant/components/esphome/manager.py
+++ b/homeassistant/components/esphome/manager.py
@@ -376,11 +376,15 @@ class ESPHomeManager:
         name_matches = stored_device_name == device_info.name
         #
         # Migrate config entry to new unique ID if the current
-        # unique id is not a mac address
+        # unique id is not a mac address.
         #
         # This was changed in 2023.1
         #
-        if not unique_id_is_mac_address and not mac_address_matches:
+        # If the device name matches, we also update the unique id
+        # to the mac address. This is to handle a board change (ie
+        # device replaced after failure, but config is the same)
+        #
+        if (not unique_id_is_mac_address or name_matches) and not mac_address_matches:
             hass.config_entries.async_update_entry(entry, unique_id=device_mac)
 
         if (

--- a/homeassistant/components/esphome/manager.py
+++ b/homeassistant/components/esphome/manager.py
@@ -384,7 +384,9 @@ class ESPHomeManager:
         # to the mac address. This is to handle a board change (ie
         # device replaced after failure, but config is the same)
         #
-        if (not unique_id_is_mac_address or name_matches) and not mac_address_matches:
+        if (
+            not unique_id_is_mac_address or name_matches or not stored_device_name
+        ) and not mac_address_matches:
             hass.config_entries.async_update_entry(entry, unique_id=device_mac)
 
         if (
@@ -400,8 +402,8 @@ class ESPHomeManager:
             # connecting to the wrong device.
             _LOGGER.error(
                 "Unexpected device found at %s; "
-                "expected %s with mac address %s, "
-                "found %s with mac address %s",
+                "expected `%s` with mac address `%s`, "
+                "found `%s` with mac address `%s`",
                 self.host,
                 stored_device_name,
                 unique_id,

--- a/homeassistant/components/esphome/manager.py
+++ b/homeassistant/components/esphome/manager.py
@@ -373,30 +373,17 @@ class ESPHomeManager:
 
         device_mac = format_mac(device_info.mac_address)
         mac_address_matches = unique_id == device_mac
-        name_matches = stored_device_name == device_info.name
         #
         # Migrate config entry to new unique ID if the current
         # unique id is not a mac address.
         #
         # This was changed in 2023.1
-        #
-        # If the device name matches, we also update the unique id
-        # to the mac address. This is to handle a board change (ie
-        # device replaced after failure, but config is the same)
-        #
-        if not mac_address_matches and (
-            not unique_id_is_mac_address or name_matches or not stored_device_name
-        ):
+        if not mac_address_matches and not unique_id_is_mac_address:
             hass.config_entries.async_update_entry(entry, unique_id=device_mac)
 
-        if (
-            stored_device_name
-            and unique_id_is_mac_address
-            and not name_matches
-            and not mac_address_matches
-        ):
-            # If we have a stored named, the unique id is a mac address
-            # and nothing matches we have the wrong device and we need
+        if not mac_address_matches and unique_id_is_mac_address:
+            # If the unique id is a mac address
+            # and does not match we have the wrong device and we need
             # to abort the connection. This can happen if the DHCP
             # server changes the IP address of the device and we end up
             # connecting to the wrong device.
@@ -426,7 +413,7 @@ class ESPHomeManager:
         # If we got here, we know the mac address matches or we
         # did a migration to the mac address so we can update
         # the device name.
-        if not name_matches:
+        if stored_device_name != device_info.name:
             hass.config_entries.async_update_entry(
                 entry, data={**entry.data, CONF_DEVICE_NAME: device_info.name}
             )

--- a/tests/components/esphome/test_init.py
+++ b/tests/components/esphome/test_init.py
@@ -1,36 +1,11 @@
 """ESPHome set up tests."""
-from unittest.mock import AsyncMock
 
-from aioesphomeapi import DeviceInfo
 
 from homeassistant.components.esphome import DOMAIN
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
-
-
-async def test_unique_id_updated_to_mac(
-    hass: HomeAssistant, mock_client, mock_zeroconf: None
-) -> None:
-    """Test we update config entry unique ID to MAC address."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={CONF_HOST: "test.local", CONF_PORT: 6053, CONF_PASSWORD: ""},
-        unique_id="mock-config-name",
-    )
-    entry.add_to_hass(hass)
-
-    mock_client.device_info = AsyncMock(
-        return_value=DeviceInfo(
-            mac_address="1122334455aa",
-        )
-    )
-
-    await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
-
-    assert entry.unique_id == "11:22:33:44:55:aa"
 
 
 async def test_delete_entry(

--- a/tests/components/esphome/test_manager.py
+++ b/tests/components/esphome/test_manager.py
@@ -303,6 +303,7 @@ async def test_connection_aborted_wrong_device(
     await hass.async_block_till_done()
 
     assert (
-        "Unexpected device found at test.local; expected `test` with mac address `11:22:33:44:55:aa`, found `different` with mac address `11:22:33:44:55:ab`"
-        in caplog.text
+        "Unexpected device found at test.local; expected `test` "
+        "with mac address `11:22:33:44:55:aa`, found `different` "
+        "with mac address `11:22:33:44:55:ab`" in caplog.text
     )

--- a/tests/components/esphome/test_manager.py
+++ b/tests/components/esphome/test_manager.py
@@ -1,9 +1,15 @@
 """Test ESPHome manager."""
 from collections.abc import Awaitable, Callable
+from unittest.mock import AsyncMock
 
-from aioesphomeapi import APIClient, EntityInfo, EntityState, UserService
+from aioesphomeapi import APIClient, DeviceInfo, EntityInfo, EntityState, UserService
+import pytest
 
-from homeassistant.components.esphome.const import DOMAIN, STABLE_BLE_VERSION_STR
+from homeassistant.components.esphome.const import (
+    CONF_DEVICE_NAME,
+    DOMAIN,
+    STABLE_BLE_VERSION_STR,
+)
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import issue_registry as ir
@@ -112,4 +118,191 @@ async def test_esphome_device_with_current_bluetooth(
             "esphome", "ble_firmware_outdated-11:22:33:44:55:aa"
         )
         is None
+    )
+
+
+async def test_unique_id_updated_to_mac(
+    hass: HomeAssistant, mock_client, mock_zeroconf: None
+) -> None:
+    """Test we update config entry unique ID to MAC address."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "test.local", CONF_PORT: 6053, CONF_PASSWORD: ""},
+        unique_id="mock-config-name",
+    )
+    entry.add_to_hass(hass)
+
+    mock_client.device_info = AsyncMock(
+        return_value=DeviceInfo(
+            mac_address="1122334455aa",
+        )
+    )
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.unique_id == "11:22:33:44:55:aa"
+
+
+async def test_unique_id_updated_if_name_same_and_already_mac(
+    hass: HomeAssistant, mock_client: APIClient, mock_zeroconf: None
+) -> None:
+    """Test we update config entry unique ID if the name is the same."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: "test.local",
+            CONF_PORT: 6053,
+            CONF_PASSWORD: "",
+            CONF_DEVICE_NAME: "test",
+        },
+        unique_id="11:22:33:44:55:aa",
+    )
+    entry.add_to_hass(hass)
+
+    mock_client.device_info = AsyncMock(
+        return_value=DeviceInfo(mac_address="1122334455ab", name="test")
+    )
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Mac should be updated because name is the same
+    assert entry.unique_id == "11:22:33:44:55:ab"
+
+
+async def test_unique_id_updated_if_name_unset_and_already_mac(
+    hass: HomeAssistant, mock_client: APIClient, mock_zeroconf: None
+) -> None:
+    """Test we update config entry unique ID if the name is unset."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "test.local", CONF_PORT: 6053, CONF_PASSWORD: ""},
+        unique_id="11:22:33:44:55:aa",
+    )
+    entry.add_to_hass(hass)
+
+    mock_client.device_info = AsyncMock(
+        return_value=DeviceInfo(mac_address="1122334455ab", name="test")
+    )
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Mac should be updated because name was unset
+    assert entry.unique_id == "11:22:33:44:55:ab"
+
+
+async def test_unique_id_not_updated_if_name_different_and_already_mac(
+    hass: HomeAssistant, mock_client: APIClient, mock_zeroconf: None
+) -> None:
+    """Test we do not update config entry unique ID if the name is different."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: "test.local",
+            CONF_PORT: 6053,
+            CONF_PASSWORD: "",
+            CONF_DEVICE_NAME: "test",
+        },
+        unique_id="11:22:33:44:55:aa",
+    )
+    entry.add_to_hass(hass)
+
+    mock_client.device_info = AsyncMock(
+        return_value=DeviceInfo(mac_address="1122334455ab", name="different")
+    )
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Mac should not be updated because name is different
+    assert entry.unique_id == "11:22:33:44:55:aa"
+    # Name should not be updated either
+    assert entry.data[CONF_DEVICE_NAME] == "test"
+
+
+async def test_name_updated_only_if_mac_matches(
+    hass: HomeAssistant, mock_client: APIClient, mock_zeroconf: None
+) -> None:
+    """Test we update config entry name only if the mac matches."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: "test.local",
+            CONF_PORT: 6053,
+            CONF_PASSWORD: "",
+            CONF_DEVICE_NAME: "old",
+        },
+        unique_id="11:22:33:44:55:aa",
+    )
+    entry.add_to_hass(hass)
+
+    mock_client.device_info = AsyncMock(
+        return_value=DeviceInfo(mac_address="1122334455aa", name="new")
+    )
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.unique_id == "11:22:33:44:55:aa"
+    assert entry.data[CONF_DEVICE_NAME] == "new"
+
+
+async def test_name_updated_only_if_mac_was_unset(
+    hass: HomeAssistant, mock_client: APIClient, mock_zeroconf: None
+) -> None:
+    """Test we update config entry name if the old unique id was not a mac."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: "test.local",
+            CONF_PORT: 6053,
+            CONF_PASSWORD: "",
+            CONF_DEVICE_NAME: "old",
+        },
+        unique_id="notamac",
+    )
+    entry.add_to_hass(hass)
+
+    mock_client.device_info = AsyncMock(
+        return_value=DeviceInfo(mac_address="1122334455aa", name="new")
+    )
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.unique_id == "11:22:33:44:55:aa"
+    assert entry.data[CONF_DEVICE_NAME] == "new"
+
+
+async def test_connection_aborted_wrong_device(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_zeroconf: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test we abort the connection if the unique id is a mac and neither name or mac match."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: "test.local",
+            CONF_PORT: 6053,
+            CONF_PASSWORD: "",
+            CONF_DEVICE_NAME: "test",
+        },
+        unique_id="11:22:33:44:55:aa",
+    )
+    entry.add_to_hass(hass)
+
+    mock_client.device_info = AsyncMock(
+        return_value=DeviceInfo(mac_address="1122334455ab", name="different")
+    )
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert (
+        "Unexpected device found at test.local; expected `test` with mac address `11:22:33:44:55:aa`, found `different` with mac address `11:22:33:44:55:ab`"
+        in caplog.text
     )

--- a/tests/components/esphome/test_manager.py
+++ b/tests/components/esphome/test_manager.py
@@ -147,10 +147,10 @@ async def test_unique_id_updated_to_mac(
     assert entry.unique_id == "11:22:33:44:55:aa"
 
 
-async def test_unique_id_updated_if_name_same_and_already_mac(
+async def test_unique_id_not_updated_if_name_same_and_already_mac(
     hass: HomeAssistant, mock_client: APIClient, mock_zeroconf: None
 ) -> None:
-    """Test we update config entry unique ID if the name is the same."""
+    """Test we never update the entry unique ID event if the name is the same."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -170,14 +170,14 @@ async def test_unique_id_updated_if_name_same_and_already_mac(
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    # Mac should be updated because name is the same
-    assert entry.unique_id == "11:22:33:44:55:ab"
+    # Mac should never update
+    assert entry.unique_id == "11:22:33:44:55:aa"
 
 
 async def test_unique_id_updated_if_name_unset_and_already_mac(
     hass: HomeAssistant, mock_client: APIClient, mock_zeroconf: None
 ) -> None:
-    """Test we update config entry unique ID if the name is unset."""
+    """Test we never update config entry unique ID even if the name is unset."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={CONF_HOST: "test.local", CONF_PORT: 6053, CONF_PASSWORD: ""},
@@ -192,8 +192,8 @@ async def test_unique_id_updated_if_name_unset_and_already_mac(
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    # Mac should be updated because name was unset
-    assert entry.unique_id == "11:22:33:44:55:ab"
+    # Mac should never update
+    assert entry.unique_id == "11:22:33:44:55:aa"
 
 
 async def test_unique_id_not_updated_if_name_different_and_already_mac(
@@ -319,7 +319,7 @@ async def test_connection_aborted_wrong_device(
         macaddress="1122334455aa",
     )
     new_info = AsyncMock(
-        return_value=DeviceInfo(mac_address="1122334455ab", name="test")
+        return_value=DeviceInfo(mac_address="1122334455aa", name="test")
     )
     mock_client.device_info = new_info
     result = await hass.config_entries.flow.async_init(


### PR DESCRIPTION
## Breaking change

To prevent cross-linked devices, replacing a named ESPHome device with a different board is no longer allowed. Instead, delete the config entry and re-added the new device when the Mac address of the board changes.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

If the DHCP reservation changed and there is now a different ESPHome device at the saved IP address, abort the connection to avoid cross linking devices. 

Note: this will not fix existing cross linked devices. It will only prevent the problem from happening again. Existing config entries with the issue will have to be removed manually and set up again.

This is a more general problem as #97457 (tplink) and #92955 (lifx) also have the same problem (shelly was just fixed in #98807).  This solution is similar to the used in `flux_led` https://github.com/home-assistant/core/blob/3e7ec88703cf724ef29b00732b467704cf66c5e2/homeassistant/components/flux_led/__init__.py#L196 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #97913
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
