### PR TITLE
Fix Lutron_Caseta shade behavior to reflect how the LEAP protocol handles open/close commands

### DIFF
--- a/homeassistant/components/lutron_caseta/cover.py
+++ b/homeassistant/components/lutron_caseta/cover.py
@@ -17,6 +17,9 @@ from . import LutronCasetaDeviceUpdatableEntity
 from .const import DOMAIN as CASETA_DOMAIN
 from .models import LutronCasetaData
 
+LUTRON_SHADE_POSITION_OPEN = 100
+LUTRON_SHADE_POSITION_CLOSED = 0
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -42,7 +45,6 @@ class LutronCasetaCover(LutronCasetaDeviceUpdatableEntity, CoverEntity):
     _attr_supported_features = (
         CoverEntityFeature.OPEN
         | CoverEntityFeature.CLOSE
-        | CoverEntityFeature.STOP
         | CoverEntityFeature.SET_POSITION
     )
     _attr_device_class = CoverDeviceClass.SHADE
@@ -57,21 +59,13 @@ class LutronCasetaCover(LutronCasetaDeviceUpdatableEntity, CoverEntity):
         """Return the current position of cover."""
         return self._device["current_state"]
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:
-        """Top the cover."""
-        await self._smartbridge.stop_cover(self.device_id)
-
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the cover."""
-        await self._smartbridge.lower_cover(self.device_id)
-        await self.async_update()
-        self.async_write_ha_state()
+        await self._smartbridge.set_value(self.device_id, LUTRON_SHADE_POSITION_CLOSED)
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
-        await self._smartbridge.raise_cover(self.device_id)
-        await self.async_update()
-        self.async_write_ha_state()
+        await self._smartbridge.set_value(self.device_id, LUTRON_SHADE_POSITION_OPEN)
 
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move the shade to a specific position."""


### PR DESCRIPTION
…en/close commands

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The current behavior of the open/close cover commands on the Lutron Caseta integration is problematic. In the LEAP protocol, this is resulting in the effect of a user holding down the up or down button and never releasing it. This creates at least two problems: one is that the shades "stutter" when they start moving (start, pause, and start again), and if you use a system with keypads for up/stop/down/stop control of shades, the keypad ends up in an odd state where the first press will "stop" a shade that isn't moving (essentially making the user think something is wrong with the shade).

From the discussion in #98365, proposing this logic change so that the Home Assistant open/close commands set the shade to full open or closed positions explicitly. This has the side effect of the stop button not functioning, so it also removes the `STOP` feature from `_attr_supported_features` so the user isn't presented that button in the UI.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #98365
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
