### PR TITLE
Update AEMET-OpenData to v0.3.0

### DIFF
--- a/homeassistant/components/aemet/__init__.py
+++ b/homeassistant/components/aemet/__init__.py
@@ -6,6 +6,7 @@ from aemet_opendata.interface import AEMET
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import aiohttp_client
 
 from .const import (
     CONF_STATION_UPDATES,
@@ -27,7 +28,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     longitude = entry.data[CONF_LONGITUDE]
     station_updates = entry.options.get(CONF_STATION_UPDATES, True)
 
-    aemet = AEMET(api_key)
+    aemet = AEMET(aiohttp_client.async_get_clientsession(hass), api_key)
     weather_coordinator = WeatherUpdateCoordinator(
         hass, aemet, latitude, longitude, station_updates
     )

--- a/homeassistant/components/aemet/config_flow.py
+++ b/homeassistant/components/aemet/config_flow.py
@@ -2,12 +2,13 @@
 from __future__ import annotations
 
 from aemet_opendata import AEMET
+from aemet_opendata.exceptions import AuthError
 import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME
 from homeassistant.core import callback
-import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers import aiohttp_client, config_validation as cv
 from homeassistant.helpers.schema_config_entry_flow import (
     SchemaFlowFormStep,
     SchemaOptionsFlowHandler,
@@ -39,8 +40,13 @@ class AemetConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             await self.async_set_unique_id(f"{latitude}-{longitude}")
             self._abort_if_unique_id_configured()
 
-            api_online = await _is_aemet_api_online(self.hass, user_input[CONF_API_KEY])
-            if not api_online:
+            aemet = AEMET(
+                aiohttp_client.async_get_clientsession(self.hass),
+                user_input[CONF_API_KEY],
+            )
+            try:
+                await aemet.get_conventional_observation_stations(False)
+            except AuthError:
                 errors["base"] = "invalid_api_key"
 
             if not errors:
@@ -70,10 +76,3 @@ class AemetConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> SchemaOptionsFlowHandler:
         """Get the options flow for this handler."""
         return SchemaOptionsFlowHandler(config_entry, OPTIONS_FLOW)
-
-
-async def _is_aemet_api_online(hass, api_key):
-    aemet = AEMET(api_key)
-    return await hass.async_add_executor_job(
-        aemet.get_conventional_observation_stations, False
-    )

--- a/homeassistant/components/aemet/manifest.json
+++ b/homeassistant/components/aemet/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/aemet",
   "iot_class": "cloud_polling",
   "loggers": ["aemet_opendata"],
-  "requirements": ["AEMET-OpenData==0.2.2"]
+  "requirements": ["AEMET-OpenData==0.3.0"]
 }

--- a/homeassistant/components/aemet/weather_update_coordinator.py
+++ b/homeassistant/components/aemet/weather_update_coordinator.py
@@ -146,13 +146,13 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator):
 
     async def _get_aemet_weather(self):
         """Poll weather data from AEMET OpenData."""
-        weather = await self.hass.async_add_executor_job(self._get_weather_and_forecast)
+        weather = await self._get_weather_and_forecast()
         return weather
 
-    def _get_weather_station(self):
+    async def _get_weather_station(self):
         if not self._station:
             self._station = (
-                self._aemet.get_conventional_observation_station_by_coordinates(
+                await self._aemet.get_conventional_observation_station_by_coordinates(
                     self._latitude, self._longitude
                 )
             )
@@ -171,9 +171,9 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator):
             )
         return self._station
 
-    def _get_weather_town(self):
+    async def _get_weather_town(self):
         if not self._town:
-            self._town = self._aemet.get_town_by_coordinates(
+            self._town = await self._aemet.get_town_by_coordinates(
                 self._latitude, self._longitude
             )
             if self._town:
@@ -192,18 +192,18 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator):
             raise TownNotFound
         return self._town
 
-    def _get_weather_and_forecast(self):
+    async def _get_weather_and_forecast(self):
         """Get weather and forecast data from AEMET OpenData."""
 
-        self._get_weather_town()
+        await self._get_weather_town()
 
-        daily = self._aemet.get_specific_forecast_town_daily(self._town[AEMET_ATTR_ID])
+        daily = await self._aemet.get_specific_forecast_town_daily(self._town[AEMET_ATTR_ID])
         if not daily:
             _LOGGER.error(
                 'Error fetching daily data for town "%s"', self._town[AEMET_ATTR_ID]
             )
 
-        hourly = self._aemet.get_specific_forecast_town_hourly(
+        hourly = await self._aemet.get_specific_forecast_town_hourly(
             self._town[AEMET_ATTR_ID]
         )
         if not hourly:
@@ -212,8 +212,8 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator):
             )
 
         station = None
-        if self._station_updates and self._get_weather_station():
-            station = self._aemet.get_conventional_observation_station_data(
+        if self._station_updates and await self._get_weather_station():
+            station = await self._aemet.get_conventional_observation_station_data(
                 self._station[AEMET_ATTR_IDEMA]
             )
             if not station:

--- a/homeassistant/components/aemet/weather_update_coordinator.py
+++ b/homeassistant/components/aemet/weather_update_coordinator.py
@@ -197,7 +197,9 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator):
 
         await self._get_weather_town()
 
-        daily = await self._aemet.get_specific_forecast_town_daily(self._town[AEMET_ATTR_ID])
+        daily = await self._aemet.get_specific_forecast_town_daily(
+            self._town[AEMET_ATTR_ID]
+        )
         if not daily:
             _LOGGER.error(
                 'Error fetching daily data for town "%s"', self._town[AEMET_ATTR_ID]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2,7 +2,7 @@
 -r requirements.txt
 
 # homeassistant.components.aemet
-AEMET-OpenData==0.2.2
+AEMET-OpenData==0.3.0
 
 # homeassistant.components.aladdin_connect
 AIOAladdinConnect==0.1.57

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -4,7 +4,7 @@
 -r requirements_test.txt
 
 # homeassistant.components.aemet
-AEMET-OpenData==0.2.2
+AEMET-OpenData==0.3.0
 
 # homeassistant.components.aladdin_connect
 AIOAladdinConnect==0.1.57

--- a/tests/components/aemet/fixtures/station-3195.json
+++ b/tests/components/aemet/fixtures/station-3195.json
@@ -1,6 +1,0 @@
-{
-  "descripcion": "exito",
-  "estado": 200,
-  "datos": "https://opendata.aemet.es/opendata/sh/208c3ca3",
-  "metadatos": "https://opendata.aemet.es/opendata/sh/55c2971b"
-}

--- a/tests/components/aemet/fixtures/station-list.json
+++ b/tests/components/aemet/fixtures/station-list.json
@@ -1,6 +1,0 @@
-{
-  "descripcion": "exito",
-  "estado": 200,
-  "datos": "https://opendata.aemet.es/opendata/sh/2c55192f",
-  "metadatos": "https://opendata.aemet.es/opendata/sh/55c2971b"
-}

--- a/tests/components/aemet/fixtures/town-28065-forecast-daily.json
+++ b/tests/components/aemet/fixtures/town-28065-forecast-daily.json
@@ -1,6 +1,0 @@
-{
-  "descripcion": "exito",
-  "estado": 200,
-  "datos": "https://opendata.aemet.es/opendata/sh/64e29abb",
-  "metadatos": "https://opendata.aemet.es/opendata/sh/dfd88b22"
-}

--- a/tests/components/aemet/fixtures/town-28065-forecast-hourly.json
+++ b/tests/components/aemet/fixtures/town-28065-forecast-hourly.json
@@ -1,6 +1,0 @@
-{
-  "descripcion": "exito",
-  "estado": 200,
-  "datos": "https://opendata.aemet.es/opendata/sh/18ca1886",
-  "metadatos": "https://opendata.aemet.es/opendata/sh/93a7c63d"
-}

--- a/tests/components/aemet/test_init.py
+++ b/tests/components/aemet/test_init.py
@@ -1,15 +1,13 @@
 """Define tests for the AEMET OpenData init."""
 from unittest.mock import patch
 
-import requests_mock
-
 from homeassistant.components.aemet.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME
 from homeassistant.core import HomeAssistant
 import homeassistant.util.dt as dt_util
 
-from .util import aemet_requests_mock
+from .util import mock_api_call
 
 from tests.common import MockConfigEntry
 
@@ -27,9 +25,10 @@ async def test_unload_entry(hass: HomeAssistant) -> None:
     now = dt_util.parse_datetime("2021-01-09 12:00:00+00:00")
     with patch("homeassistant.util.dt.now", return_value=now), patch(
         "homeassistant.util.dt.utcnow", return_value=now
-    ), requests_mock.mock() as _m:
-        aemet_requests_mock(_m)
-
+    ), patch(
+        "homeassistant.components.aemet.AEMET.api_call",
+        side_effect=mock_api_call,
+    ):
         config_entry = MockConfigEntry(
             domain=DOMAIN, unique_id="aemet_unique_id", data=CONFIG
         )

--- a/tests/components/aemet/test_weather.py
+++ b/tests/components/aemet/test_weather.py
@@ -4,7 +4,6 @@ from unittest.mock import patch
 
 from freezegun.api import FrozenDateTimeFactory
 import pytest
-import requests_mock
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.aemet.const import ATTRIBUTION, DOMAIN
@@ -36,7 +35,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 import homeassistant.util.dt as dt_util
 
-from .util import aemet_requests_mock, async_init_integration
+from .util import async_init_integration, mock_api_call
 
 from tests.typing import WebSocketGenerator
 
@@ -191,8 +190,10 @@ async def test_forecast_subscription(
 
     assert forecast1 == snapshot
 
-    with requests_mock.mock() as _m:
-        aemet_requests_mock(_m)
+    with patch(
+        "homeassistant.components.aemet.AEMET.api_call",
+        side_effect=mock_api_call,
+    ):
         freezer.tick(WEATHER_UPDATE_INTERVAL + datetime.timedelta(seconds=1))
         await hass.async_block_till_done()
         msg = await client.receive_json()


### PR DESCRIPTION
## Proposed change
Update AEMET-OpenData to [v0.3.0](https://github.com/Noltari/AEMET-OpenData/compare/0.2.2...0.3.0), which switches from requests to aiohttp library.

Releases:
- https://github.com/Noltari/AEMET-OpenData/releases/tag/0.3.0

Git compare: https://github.com/Noltari/AEMET-OpenData/compare/0.2.2...0.3.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
