### PR TITLE
Add input option to skip coverage [ci]

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,10 @@ on:
         description: "Skip pytest"
         default: false
         type: boolean
+      skip-coverage:
+        description: "Skip coverage"
+        default: false
+        type: boolean
       pylint-only:
         description: "Only run pylint"
         default: false
@@ -79,6 +83,7 @@ jobs:
       test_groups: ${{ steps.info.outputs.test_groups }}
       tests_glob: ${{ steps.info.outputs.tests_glob }}
       tests: ${{ steps.info.outputs.tests }}
+      skip_coverage: ${{ steps.info.outputs.skip_coverage }}
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code from GitHub
@@ -127,6 +132,7 @@ jobs:
           test_group_count=10
           tests="[]"
           tests_glob=""
+          skip_coverage=""
 
           if [[ "${{ steps.integrations.outputs.changes }}" != "[]" ]];
           then
@@ -176,6 +182,12 @@ jobs:
             test_full_suite="true"
           fi
 
+          if [[ "${{ github.event.inputs.skip-coverage }}" == "true" ]] \
+            || [[ "${{ contains(github.event.pull_request.labels.*.name, 'ci-skip-coverage') }}" == "true" ]];
+          then
+            skip_coverage="true"
+          fi
+
           # Output & sent to GitHub Actions
           echo "mariadb_groups: ${mariadb_groups}"
           echo "mariadb_groups=${mariadb_groups}" >> $GITHUB_OUTPUT
@@ -195,6 +207,8 @@ jobs:
           echo "tests=${tests}" >> $GITHUB_OUTPUT
           echo "tests_glob: ${tests_glob}"
           echo "tests_glob=${tests_glob}" >> $GITHUB_OUTPUT
+          echo "skip_coverage: ${skip_coverage}"
+          echo "skip_coverage=${skip_coverage}" >> $GITHUB_OUTPUT
 
   pre-commit:
     name: Prepare pre-commit base
@@ -741,6 +755,11 @@ jobs:
           . venv/bin/activate
           python --version
           set -o pipefail
+          cov_params=()
+          if [[ "${{ needs.info.outputs.skip_coverage }}" != "true" ]]; then
+            cov_params+=(--cov="homeassistant")
+            cov_params+=(--cov-report=xml)
+          fi
 
           python3 -X dev -m pytest \
             -qq \
@@ -750,8 +769,7 @@ jobs:
             --dist=loadfile \
             --test-group-count ${{ needs.info.outputs.test_group_count }} \
             --test-group=${{ matrix.group }} \
-            --cov="homeassistant" \
-            --cov-report=xml \
+            ${cov_params[@]} \
             -o console_output_style=count \
             -p no:sugar \
             tests \
@@ -773,13 +791,18 @@ jobs:
             exit 1
           fi
 
+          cov_params=()
+          if [[ "${{ needs.info.outputs.skip_coverage }}" != "true" ]]; then
+            cov_params+=(--cov="homeassistant.components.${{ matrix.group }}")
+            cov_params+=(--cov-report=xml)
+            cov_params+=(--cov-report=term-missing)
+          fi
+
           python3 -X dev -m pytest \
             -qq \
             --timeout=9 \
             -n auto \
-            --cov="homeassistant.components.${{ matrix.group }}" \
-            --cov-report=xml \
-            --cov-report=term-missing \
+            ${cov_params[@]} \
             -o console_output_style=count \
             --durations=0 \
             --durations-min=1 \
@@ -793,6 +816,7 @@ jobs:
           name: pytest-${{ github.run_number }}
           path: pytest-*.txt
       - name: Upload coverage artifact
+        if: needs.info.outputs.skip_coverage != 'true'
         uses: actions/upload-artifact@v3.1.2
         with:
           name: coverage-${{ matrix.python-version }}-${{ matrix.group }}
@@ -888,14 +912,18 @@ jobs:
           python --version
           set -o pipefail
           mariadb=$(echo "${{ matrix.mariadb-group }}" | sed "s/:/-/g")
+          cov_params=()
+          if [[ "${{ needs.info.outputs.skip_coverage }}" != "true" ]]; then
+            cov_params+=(--cov="homeassistant.components.recorder")
+            cov_params+=(--cov-report=xml)
+            cov_params+=(--cov-report=term-missing)
+          fi
 
           python3 -X dev -m pytest \
             -qq \
             --timeout=20 \
             -n 1 \
-            --cov="homeassistant.components.recorder" \
-            --cov-report=xml \
-            --cov-report=term-missing \
+            ${cov_params[@]} \
             -o console_output_style=count \
             --durations=10 \
             -p no:sugar \
@@ -912,6 +940,7 @@ jobs:
           name: pytest-${{ github.run_number }}
           path: pytest-*.txt
       - name: Upload coverage artifact
+        if: needs.info.outputs.skip_coverage != 'true'
         uses: actions/upload-artifact@v3.1.2
         with:
           name: coverage-${{ matrix.python-version }}-mariadb
@@ -1007,14 +1036,18 @@ jobs:
           python --version
           set -o pipefail
           postgresql=$(echo "${{ matrix.postgresql-group }}" | sed "s/:/-/g")
+          cov_params=()
+          if [[ "${{ needs.info.outputs.skip_coverage }}" != "true" ]]; then
+            cov_params+=(--cov="homeassistant.components.recorder")
+            cov_params+=(--cov-report=xml)
+            cov_params+=(--cov-report=term-missing)
+          fi
 
           python3 -X dev -m pytest \
             -qq \
             --timeout=9 \
             -n 1 \
-            --cov="homeassistant.components.recorder" \
-            --cov-report=xml \
-            --cov-report=term-missing \
+            ${cov_params[@]} \
             -o console_output_style=count \
             --durations=0 \
             --durations-min=10 \
@@ -1032,6 +1065,7 @@ jobs:
           name: pytest-${{ github.run_number }}
           path: pytest-*.txt
       - name: Upload coverage artifact
+        if: needs.info.outputs.skip_coverage != 'true'
         uses: actions/upload-artifact@v3.1.0
         with:
           name: coverage-${{ matrix.python-version }}-postgresql
@@ -1042,6 +1076,7 @@ jobs:
 
   coverage:
     name: Upload test coverage to Codecov
+    if: needs.info.outputs.skip_coverage != 'true'
     runs-on: ubuntu-22.04
     needs:
       - info


### PR DESCRIPTION
## Proposed change
Sometimes the coverage result is not important when triggering the workflow manually (via workflow_dispatch). To safe a lot of time, I found myself manually removing the `--cov` options. This PR adds a new input option for it.

_Aside from the new input, coverage could also be skipped by adding a `ci-skip-coverage` label. Similar to the `ci-full-run` label. However, this is primarily meant to help with testing on forks. I don't intent to add this label to core itself._

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
