### PR TITLE
Fix imap test RuntimeWarning

### DIFF
--- a/tests/components/imap/test_init.py
+++ b/tests/components/imap/test_init.py
@@ -470,6 +470,8 @@ async def test_reset_last_message(
 ) -> None:
     """Test receiving a message successfully."""
     event = asyncio.Event()  # needed for pushed coordinator to make a new loop
+    idle_start_future = asyncio.Future()
+    idle_start_future.set_result(None)
 
     async def _sleep_till_event() -> None:
         """Simulate imap server waiting for pushes message and keep the push loop going.
@@ -479,10 +481,10 @@ async def test_reset_last_message(
         nonlocal event
         await event.wait()
         event.clear()
-        mock_imap_protocol.idle_start.return_value = AsyncMock()()
+        mock_imap_protocol.idle_start = AsyncMock(return_value=idle_start_future)
 
     # Make sure we make another cycle (needed for pushed coordinator)
-    mock_imap_protocol.idle_start.return_value = AsyncMock()()
+    mock_imap_protocol.idle_start = AsyncMock(return_value=idle_start_future)
     # Mock we wait till we push an update (needed for pushed coordinator)
     mock_imap_protocol.wait_server_push.side_effect = _sleep_till_event
 


### PR DESCRIPTION
## Proposed change
_Let's fix some pytest warnings!_

```
  /home/runner/work/core/core/tests/conftest.py:243: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
  Coroutine created at (most recent call last)
    ...
    File "/home/runner/work/core/core/homeassistant/components/imap/coordinator.py", line 408, in _async_wait_push_loop
      await self.imap_client.wait_server_push()
    File "/opt/hostedtoolcache/Python/3.11.4/x64/lib/python3.11/unittest/mock.py", line 2248, in _execute_mock_call
      result = await effect(*args, **kwargs)
    File "/home/runner/work/core/core/tests/components/imap/test_init.py", line 482, in _sleep_till_event
      mock_imap_protocol.idle_start.return_value = AsyncMock()()
    ...
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
