### PR TITLE
Use snapshot assertion for Discovergy diagnostics test

### DIFF
--- a/homeassistant/components/discovergy/diagnostics.py
+++ b/homeassistant/components/discovergy/diagnostics.py
@@ -8,13 +8,10 @@ from pydiscovergy.models import Meter
 
 from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, CONF_UNIQUE_ID
 from homeassistant.core import HomeAssistant
 
 from . import DiscovergyData
 from .const import DOMAIN
-
-TO_REDACT_CONFIG_ENTRY = {CONF_EMAIL, CONF_PASSWORD, CONF_UNIQUE_ID, "title"}
 
 TO_REDACT_METER = {
     "serial_number",
@@ -44,7 +41,6 @@ async def async_get_config_entry_diagnostics(
         last_readings[meter.meter_id] = asdict(coordinator.data)
 
     return {
-        "entry": async_redact_data(entry.as_dict(), TO_REDACT_CONFIG_ENTRY),
         "meters": flattened_meter,
         "readings": last_readings,
     }

--- a/tests/components/discovergy/snapshots/test_diagnostics.ambr
+++ b/tests/components/discovergy/snapshots/test_diagnostics.ambr
@@ -1,0 +1,47 @@
+# serializer version: 1
+# name: test_entry_diagnostics
+  dict({
+    'meters': list([
+      dict({
+        'additional': dict({
+          'administration_number': '**REDACTED**',
+          'current_scaling_factor': 1,
+          'first_measurement_time': 1517569090926,
+          'internal_meters': 1,
+          'last_measurement_time': 1678430543742,
+          'manufacturer_id': 'TST',
+          'printed_full_serial_number': '**REDACTED**',
+          'scaling_factor': 1,
+          'voltage_scaling_factor': 1,
+        }),
+        'full_serial_number': '**REDACTED**',
+        'load_profile_type': 'SLP',
+        'location': '**REDACTED**',
+        'measurement_type': 'ELECTRICITY',
+        'meter_id': 'f8d610b7a8cc4e73939fa33b990ded54',
+        'serial_number': '**REDACTED**',
+        'type': 'TST',
+      }),
+    ]),
+    'readings': dict({
+      'f8d610b7a8cc4e73939fa33b990ded54': dict({
+        'time': '2023-03-10T07:32:06.702000',
+        'values': dict({
+          'energy': 119348699715000.0,
+          'energy1': 2254180000.0,
+          'energy2': 119346445534000.0,
+          'energyOut': 55048723044000.0,
+          'energyOut1': 0.0,
+          'energyOut2': 0.0,
+          'power': 531750.0,
+          'power1': 142680.0,
+          'power2': 138010.0,
+          'power3': 251060.0,
+          'voltage1': 239800.0,
+          'voltage2': 239700.0,
+          'voltage3': 239000.0,
+        }),
+      }),
+    }),
+  })
+# ---

--- a/tests/components/discovergy/test_diagnostics.py
+++ b/tests/components/discovergy/test_diagnostics.py
@@ -1,7 +1,8 @@
 """Test Discovergy diagnostics."""
 from unittest.mock import patch
 
-from homeassistant.components.diagnostics import REDACTED
+from syrupy import SnapshotAssertion
+
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
@@ -14,6 +15,7 @@ async def test_entry_diagnostics(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
     mock_config_entry: MockConfigEntry,
+    snapshot: SnapshotAssertion,
 ) -> None:
     """Test config entry diagnostics."""
     with patch("pydiscovergy.Discovergy.meters", return_value=GET_METERS), patch(
@@ -26,60 +28,4 @@ async def test_entry_diagnostics(
         hass, hass_client, mock_config_entry
     )
 
-    assert result["entry"] == {
-        "entry_id": mock_config_entry.entry_id,
-        "version": 1,
-        "domain": "discovergy",
-        "title": REDACTED,
-        "data": {"email": REDACTED, "password": REDACTED},
-        "options": {},
-        "pref_disable_new_entities": False,
-        "pref_disable_polling": False,
-        "source": "user",
-        "unique_id": REDACTED,
-        "disabled_by": None,
-    }
-
-    assert result["meters"] == [
-        {
-            "additional": {
-                "administration_number": REDACTED,
-                "current_scaling_factor": 1,
-                "first_measurement_time": 1517569090926,
-                "internal_meters": 1,
-                "last_measurement_time": 1678430543742,
-                "manufacturer_id": "TST",
-                "printed_full_serial_number": REDACTED,
-                "scaling_factor": 1,
-                "voltage_scaling_factor": 1,
-            },
-            "full_serial_number": REDACTED,
-            "load_profile_type": "SLP",
-            "location": REDACTED,
-            "measurement_type": "ELECTRICITY",
-            "meter_id": "f8d610b7a8cc4e73939fa33b990ded54",
-            "serial_number": REDACTED,
-            "type": "TST",
-        }
-    ]
-
-    assert result["readings"] == {
-        "f8d610b7a8cc4e73939fa33b990ded54": {
-            "time": "2023-03-10T07:32:06.702000",
-            "values": {
-                "energy": 119348699715000.0,
-                "energy1": 2254180000.0,
-                "energy2": 119346445534000.0,
-                "energyOut": 55048723044000.0,
-                "energyOut1": 0.0,
-                "energyOut2": 0.0,
-                "power": 531750.0,
-                "power1": 142680.0,
-                "power2": 138010.0,
-                "power3": 251060.0,
-                "voltage1": 239800.0,
-                "voltage2": 239700.0,
-                "voltage3": 239000.0,
-            },
-        }
-    }
+    assert result == snapshot


### PR DESCRIPTION
## Proposed change
This PR adds snapshot assertion to Discovergy for the diagnostics test.
In addition, the config entry is removed from the diagnostic data as it does not contain any further useful information. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
