### PR TITLE
Retry rainmachine setup later if the wrong device is found

### DIFF
--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -262,7 +262,7 @@ async def async_setup_entry(  # noqa: C901
         # and update the config entry so we do not mix up devices.
         raise ConfigEntryNotReady(
             f"Unexpected device found at {ip_address}; expected {entry.unique_id}, "
-            "found {controller.mac}"
+            f"found {controller.mac}"
         )
 
     async def async_update(api_category: str) -> dict:

--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -219,10 +219,11 @@ async def async_setup_entry(  # noqa: C901
     """Set up RainMachine as config entry."""
     websession = aiohttp_client.async_get_clientsession(hass)
     client = Client(session=websession)
+    ip_address = entry.data[CONF_IP_ADDRESS]
 
     try:
         await client.load_local(
-            entry.data[CONF_IP_ADDRESS],
+            ip_address,
             entry.data[CONF_PASSWORD],
             port=entry.data[CONF_PORT],
             use_ssl=entry.data.get(CONF_SSL, DEFAULT_SSL),
@@ -238,6 +239,7 @@ async def async_setup_entry(  # noqa: C901
     if not entry.unique_id or is_ip_address(entry.unique_id):
         # If the config entry doesn't already have a unique ID, set one:
         entry_updates["unique_id"] = controller.mac
+
     if CONF_DEFAULT_ZONE_RUN_TIME in entry.data:
         # If a zone run time exists in the config entry's data, pop it and move it to
         # options:
@@ -251,6 +253,17 @@ async def async_setup_entry(  # noqa: C901
         entry_updates["options"] = {**entry.options, CONF_USE_APP_RUN_TIMES: False}
     if entry_updates:
         hass.config_entries.async_update_entry(entry, **entry_updates)
+
+    if entry.unique_id and controller.mac != entry.unique_id:
+        # If the mac address of the device does not match the unique_id
+        # of the config entry, it likely means the DHCP lease has expired
+        # and the device has been assigned a new IP address. We need to
+        # wait for the next discovery to find the device at its new address
+        # and update the config entry so we do not mix up devices.
+        raise ConfigEntryNotReady(
+            f"Unexpected device found at {ip_address}; expected {entry.unique_id}, "
+            "found {controller.mac}"
+        )
 
     async def async_update(api_category: str) -> dict:
         """Update the appropriate API data based on a category."""


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If the DHCP reservation changed and there is now a different rain machine device at the saved IP address, retry setup later to avoid cross linking devices

Note: this will not fix existing cross linked devices. It will only prevent the problem from happening again. Existing config entries with the issue will have to be removed manually and set up again.

This is a more general problem.. see:

- #98783
- #98787
- #98807


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
