### PR TITLE
Deduplicate entities derived from GroupEntity

### DIFF
--- a/homeassistant/components/group/binary_sensor.py
+++ b/homeassistant/components/group/binary_sensor.py
@@ -1,9 +1,6 @@
 """Platform allowing several binary sensor to be grouped into one binary sensor."""
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping
-from typing import Any
-
 import voluptuous as vol
 
 from homeassistant.components.binary_sensor import (
@@ -24,14 +21,10 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
-from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv, entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.event import (
-    EventStateChangedData,
-    async_track_state_change_event,
-)
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType, EventType
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import GroupEntity
 
@@ -115,45 +108,6 @@ class BinarySensorGroup(GroupEntity, BinarySensorEntity):
         self.mode = any
         if mode:
             self.mode = all
-
-    @callback
-    def async_start_preview(
-        self,
-        preview_callback: Callable[[str, Mapping[str, Any]], None],
-    ) -> CALLBACK_TYPE:
-        """Render a preview."""
-
-        @callback
-        def async_state_changed_listener(
-            event: EventType[EventStateChangedData] | None,
-        ) -> None:
-            """Handle child updates."""
-            self.async_update_group_state()
-            preview_callback(*self._async_generate_attributes())
-
-        async_state_changed_listener(None)
-        return async_track_state_change_event(
-            self.hass, self._entity_ids, async_state_changed_listener
-        )
-
-    async def async_added_to_hass(self) -> None:
-        """Register callbacks."""
-
-        @callback
-        def async_state_changed_listener(
-            event: EventType[EventStateChangedData],
-        ) -> None:
-            """Handle child updates."""
-            self.async_set_context(event.context)
-            self.async_defer_or_update_ha_state()
-
-        self.async_on_remove(
-            async_track_state_change_event(
-                self.hass, self._entity_ids, async_state_changed_listener
-            )
-        )
-
-        await super().async_added_to_hass()
 
     @callback
     def async_update_group_state(self) -> None:

--- a/homeassistant/components/group/cover.py
+++ b/homeassistant/components/group/cover.py
@@ -41,11 +41,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, State, callback
 from homeassistant.helpers import config_validation as cv, entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.event import (
-    EventStateChangedData,
-    async_track_state_change_event,
-)
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType, EventType
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import GroupEntity
 from .util import attribute_equal, reduce_attribute
@@ -112,7 +108,7 @@ class CoverGroup(GroupEntity, CoverEntity):
 
     def __init__(self, unique_id: str | None, name: str, entities: list[str]) -> None:
         """Initialize a CoverGroup entity."""
-        self._entities = entities
+        self._entity_ids = entities
         self._covers: dict[str, set[str]] = {
             KEY_OPEN_CLOSE: set(),
             KEY_STOP: set(),
@@ -129,20 +125,10 @@ class CoverGroup(GroupEntity, CoverEntity):
         self._attr_unique_id = unique_id
 
     @callback
-    def _update_supported_features_event(
-        self, event: EventType[EventStateChangedData]
-    ) -> None:
-        self.async_set_context(event.context)
-        self.async_update_supported_features(
-            event.data["entity_id"], event.data["new_state"]
-        )
-
-    @callback
     def async_update_supported_features(
         self,
         entity_id: str,
         new_state: State | None,
-        update_state: bool = True,
     ) -> None:
         """Update dictionaries with supported features."""
         if not new_state:
@@ -150,8 +136,6 @@ class CoverGroup(GroupEntity, CoverEntity):
                 values.discard(entity_id)
             for values in self._tilts.values():
                 values.discard(entity_id)
-            if update_state:
-                self.async_defer_or_update_ha_state()
             return
 
         features = new_state.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
@@ -181,25 +165,6 @@ class CoverGroup(GroupEntity, CoverEntity):
             self._tilts[KEY_POSITION].add(entity_id)
         else:
             self._tilts[KEY_POSITION].discard(entity_id)
-
-        if update_state:
-            self.async_defer_or_update_ha_state()
-
-    async def async_added_to_hass(self) -> None:
-        """Register listeners."""
-        for entity_id in self._entities:
-            if (new_state := self.hass.states.get(entity_id)) is None:
-                continue
-            self.async_update_supported_features(
-                entity_id, new_state, update_state=False
-            )
-        self.async_on_remove(
-            async_track_state_change_event(
-                self.hass, self._entities, self._update_supported_features_event
-            )
-        )
-
-        await super().async_added_to_hass()
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Move the covers up."""
@@ -278,7 +243,7 @@ class CoverGroup(GroupEntity, CoverEntity):
 
         states = [
             state.state
-            for entity_id in self._entities
+            for entity_id in self._entity_ids
             if (state := self.hass.states.get(entity_id)) is not None
         ]
 
@@ -292,7 +257,7 @@ class CoverGroup(GroupEntity, CoverEntity):
         self._attr_is_closed = True
         self._attr_is_closing = False
         self._attr_is_opening = False
-        for entity_id in self._entities:
+        for entity_id in self._entity_ids:
             if not (state := self.hass.states.get(entity_id)):
                 continue
             if state.state == STATE_OPEN:
@@ -347,7 +312,7 @@ class CoverGroup(GroupEntity, CoverEntity):
         self._attr_supported_features = supported_features
 
         if not self._attr_assumed_state:
-            for entity_id in self._entities:
+            for entity_id in self._entity_ids:
                 if (state := self.hass.states.get(entity_id)) is None:
                     continue
                 if state and state.attributes.get(ATTR_ASSUMED_STATE):

--- a/homeassistant/components/group/fan.py
+++ b/homeassistant/components/group/fan.py
@@ -38,11 +38,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, State, callback
 from homeassistant.helpers import config_validation as cv, entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.event import (
-    EventStateChangedData,
-    async_track_state_change_event,
-)
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType, EventType
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import GroupEntity
 from .util import (
@@ -108,7 +104,7 @@ class FanGroup(GroupEntity, FanEntity):
 
     def __init__(self, unique_id: str | None, name: str, entities: list[str]) -> None:
         """Initialize a FanGroup entity."""
-        self._entities = entities
+        self._entity_ids = entities
         self._fans: dict[int, set[str]] = {flag: set() for flag in SUPPORTED_FLAGS}
         self._percentage = None
         self._oscillating = None
@@ -145,20 +141,10 @@ class FanGroup(GroupEntity, FanEntity):
         return self._oscillating
 
     @callback
-    def _update_supported_features_event(
-        self, event: EventType[EventStateChangedData]
-    ) -> None:
-        self.async_set_context(event.context)
-        self.async_update_supported_features(
-            event.data["entity_id"], event.data["new_state"]
-        )
-
-    @callback
     def async_update_supported_features(
         self,
         entity_id: str,
         new_state: State | None,
-        update_state: bool = True,
     ) -> None:
         """Update dictionaries with supported features."""
         if not new_state:
@@ -171,25 +157,6 @@ class FanGroup(GroupEntity, FanEntity):
                     self._fans[feature].add(entity_id)
                 else:
                     self._fans[feature].discard(entity_id)
-
-        if update_state:
-            self.async_defer_or_update_ha_state()
-
-    async def async_added_to_hass(self) -> None:
-        """Register listeners."""
-        for entity_id in self._entities:
-            if (new_state := self.hass.states.get(entity_id)) is None:
-                continue
-            self.async_update_supported_features(
-                entity_id, new_state, update_state=False
-            )
-        self.async_on_remove(
-            async_track_state_change_event(
-                self.hass, self._entities, self._update_supported_features_event
-            )
-        )
-
-        await super().async_added_to_hass()
 
     async def async_set_percentage(self, percentage: int) -> None:
         """Set the speed of the fan, as a percentage."""
@@ -250,7 +217,7 @@ class FanGroup(GroupEntity, FanEntity):
         await self.hass.services.async_call(
             DOMAIN,
             service,
-            {ATTR_ENTITY_ID: self._entities},
+            {ATTR_ENTITY_ID: self._entity_ids},
             blocking=True,
             context=self._context,
         )
@@ -275,7 +242,7 @@ class FanGroup(GroupEntity, FanEntity):
 
         states = [
             state
-            for entity_id in self._entities
+            for entity_id in self._entity_ids
             if (state := self.hass.states.get(entity_id)) is not None
         ]
         self._attr_assumed_state |= not states_equal(states)

--- a/homeassistant/components/group/light.py
+++ b/homeassistant/components/group/light.py
@@ -47,11 +47,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv, entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.event import (
-    EventStateChangedData,
-    async_track_state_change_event,
-)
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType, EventType
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import GroupEntity
 from .util import find_state_attributes, mean_tuple, reduce_attribute
@@ -152,25 +148,6 @@ class LightGroup(GroupEntity, LightEntity):
         self.mode = any
         if mode:
             self.mode = all
-
-    async def async_added_to_hass(self) -> None:
-        """Register callbacks."""
-
-        @callback
-        def async_state_changed_listener(
-            event: EventType[EventStateChangedData],
-        ) -> None:
-            """Handle child updates."""
-            self.async_set_context(event.context)
-            self.async_defer_or_update_ha_state()
-
-        self.async_on_remove(
-            async_track_state_change_event(
-                self.hass, self._entity_ids, async_state_changed_listener
-            )
-        )
-
-        await super().async_added_to_hass()
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Forward the turn_on command to all lights in the light group."""

--- a/homeassistant/components/group/lock.py
+++ b/homeassistant/components/group/lock.py
@@ -31,11 +31,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv, entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.event import (
-    EventStateChangedData,
-    async_track_state_change_event,
-)
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType, EventType
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import GroupEntity
 
@@ -113,25 +109,6 @@ class LockGroup(GroupEntity, LockEntity):
         self._attr_name = name
         self._attr_extra_state_attributes = {ATTR_ENTITY_ID: entity_ids}
         self._attr_unique_id = unique_id
-
-    async def async_added_to_hass(self) -> None:
-        """Register callbacks."""
-
-        @callback
-        def async_state_changed_listener(
-            event: EventType[EventStateChangedData],
-        ) -> None:
-            """Handle child updates."""
-            self.async_set_context(event.context)
-            self.async_defer_or_update_ha_state()
-
-        self.async_on_remove(
-            async_track_state_change_event(
-                self.hass, self._entity_ids, async_state_changed_listener
-            )
-        )
-
-        await super().async_added_to_hass()
 
     async def async_lock(self, **kwargs: Any) -> None:
         """Forward the lock command to all locks in the group."""

--- a/homeassistant/components/group/sensor.py
+++ b/homeassistant/components/group/sensor.py
@@ -1,7 +1,7 @@
 """Platform allowing several sensors to be grouped into one sensor to provide numeric combinations."""
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping
+from collections.abc import Callable
 from datetime import datetime
 import logging
 import statistics
@@ -33,19 +33,10 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
-from homeassistant.core import CALLBACK_TYPE, HomeAssistant, State, callback
+from homeassistant.core import HomeAssistant, State, callback
 from homeassistant.helpers import config_validation as cv, entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.event import (
-    EventStateChangedData,
-    async_track_state_change_event,
-)
-from homeassistant.helpers.typing import (
-    ConfigType,
-    DiscoveryInfoType,
-    EventType,
-    StateType,
-)
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType, StateType
 
 from . import GroupEntity
 from .const import CONF_IGNORE_NON_NUMERIC
@@ -302,45 +293,6 @@ class SensorGroup(GroupEntity, SensorEntity):
         ] = CALC_TYPES[self._sensor_type]
         self._state_incorrect: set[str] = set()
         self._extra_state_attribute: dict[str, Any] = {}
-
-    @callback
-    def async_start_preview(
-        self,
-        preview_callback: Callable[[str, Mapping[str, Any]], None],
-    ) -> CALLBACK_TYPE:
-        """Render a preview."""
-
-        @callback
-        def async_state_changed_listener(
-            event: EventType[EventStateChangedData] | None,
-        ) -> None:
-            """Handle child updates."""
-            self.async_update_group_state()
-            preview_callback(*self._async_generate_attributes())
-
-        async_state_changed_listener(None)
-        return async_track_state_change_event(
-            self.hass, self._entity_ids, async_state_changed_listener
-        )
-
-    async def async_added_to_hass(self) -> None:
-        """Register callbacks."""
-
-        @callback
-        def async_state_changed_listener(
-            event: EventType[EventStateChangedData],
-        ) -> None:
-            """Handle child updates."""
-            self.async_set_context(event.context)
-            self.async_defer_or_update_ha_state()
-
-        self.async_on_remove(
-            async_track_state_change_event(
-                self.hass, self._entity_ids, async_state_changed_listener
-            )
-        )
-
-        await super().async_added_to_hass()
 
     @callback
     def async_update_group_state(self) -> None:

--- a/homeassistant/components/group/switch.py
+++ b/homeassistant/components/group/switch.py
@@ -22,11 +22,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv, entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.event import (
-    EventStateChangedData,
-    async_track_state_change_event,
-)
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType, EventType
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import GroupEntity
 
@@ -111,25 +107,6 @@ class SwitchGroup(GroupEntity, SwitchEntity):
         self.mode = any
         if mode:
             self.mode = all
-
-    async def async_added_to_hass(self) -> None:
-        """Register callbacks."""
-
-        @callback
-        def async_state_changed_listener(
-            event: EventType[EventStateChangedData],
-        ) -> None:
-            """Handle child updates."""
-            self.async_set_context(event.context)
-            self.async_defer_or_update_ha_state()
-
-        self.async_on_remove(
-            async_track_state_change_event(
-                self.hass, self._entity_ids, async_state_changed_listener
-            )
-        )
-
-        await super().async_added_to_hass()
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Forward the turn_on command to all switches in the group."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Deduplicate entities derived from GroupEntity

State change event handling was mostly the same in all classes derived from `GroupEntity` leading to a lot of duplicated code.
This PR moves all the event handling from derived classes to `GroupEntity`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
