### PR TITLE
baf: Raise ConfigEntryNotReady when the device has a mismatched UUID

### DIFF
--- a/homeassistant/components/baf/manifest.json
+++ b/homeassistant/components/baf/manifest.json
@@ -5,7 +5,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/baf",
   "iot_class": "local_push",
-  "requirements": ["aiobafi6==0.8.2"],
+  "requirements": ["aiobafi6==0.9.0"],
   "zeroconf": [
     {
       "type": "_api._tcp.local.",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -203,7 +203,7 @@ aioasuswrt==1.4.0
 aioazuredevops==1.3.5
 
 # homeassistant.components.baf
-aiobafi6==0.8.2
+aiobafi6==0.9.0
 
 # homeassistant.components.aws
 aiobotocore==2.6.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -184,7 +184,7 @@ aioasuswrt==1.4.0
 aioazuredevops==1.3.5
 
 # homeassistant.components.baf
-aiobafi6==0.8.2
+aiobafi6==0.9.0
 
 # homeassistant.components.aws
 aiobotocore==2.6.0

--- a/tests/components/baf/test_init.py
+++ b/tests/components/baf/test_init.py
@@ -1,0 +1,43 @@
+"""Test the baf init flow."""
+from unittest.mock import patch
+
+from aiobafi6.exceptions import DeviceUUIDMismatchError
+import pytest
+
+from homeassistant.components.baf.const import DOMAIN
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_IP_ADDRESS
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from . import MOCK_UUID, MockBAFDevice
+
+from tests.common import MockConfigEntry
+
+
+def _patch_device_init(side_effect=None):
+    """Mock out the BAF Device object."""
+
+    def _create_mock_baf(*args, **kwargs):
+        return MockBAFDevice(side_effect)
+
+    return patch("homeassistant.components.baf.Device", _create_mock_baf)
+
+
+async def test_config_entry_wrong_uuid(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test config entry enters setup retry when uuid mismatches."""
+    mismatched_uuid = MOCK_UUID + "0"
+    already_migrated_config_entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_IP_ADDRESS: "127.0.0.1"}, unique_id=mismatched_uuid
+    )
+    already_migrated_config_entry.add_to_hass(hass)
+    with _patch_device_init(DeviceUUIDMismatchError):
+        await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
+        await hass.async_block_till_done()
+    assert already_migrated_config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert (
+        "Unexpected device found at 127.0.0.1; expected 12340, found 1234"
+        in caplog.text
+    )


### PR DESCRIPTION
## Proposed change
aiobafi6 0.9.0 provides support for detecting that a device's UUID does not match the UUID provided in the Service object. This patch updates the integration to handle the resulting exception by aborting the config entry setup.

This resolves a situation where a configured BAF device can be assigned a new IP address and some other network device is assigned the prior IP address. If the new device at the IP address is not a BAF device, then the integration would fail to setup. But if it happens to be a BAF device, then suddently the config entry would be connected to the wrong device (i.e. cross-linking).

See also #98784, #97913, #92955, and #98807.

https://github.com/jfroy/aiobafi6/compare/0.8.2...0.9.0

## Type of change

- [X] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #98784, #97913, #92955, #98807
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

