### PR TITLE
Add circular mean to statistics integration

### DIFF
--- a/homeassistant/components/statistics/sensor.py
+++ b/homeassistant/components/statistics/sensor.py
@@ -689,7 +689,7 @@ class StatisticsSensor(SensorEntity):
         if len(self.states) > 0:
             sin_sum = sum(math.sin(math.radians(x)) for x in self.states)
             cos_sum = sum(math.cos(math.radians(x)) for x in self.states)
-            return math.degrees(math.atan2(sin_sum, cos_sum))
+            return (math.degrees(math.atan2(sin_sum, cos_sum)) + 360) % 360
         return None
 
     def _stat_median(self) -> StateType:

--- a/homeassistant/components/statistics/sensor.py
+++ b/homeassistant/components/statistics/sensor.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 import contextlib
 from datetime import datetime, timedelta
 import logging
+import math
 import statistics
 from typing import Any, cast
 

--- a/homeassistant/components/statistics/sensor.py
+++ b/homeassistant/components/statistics/sensor.py
@@ -684,14 +684,14 @@ class StatisticsSensor(SensorEntity):
         if len(self.states) > 0:
             return statistics.mean(self.states)
         return None
-        
+
     def _stat_mean_circular(self) -> StateType:
         if len(self.states) > 0:
             sin_sum = sum(math.sin(math.radians(x)) for x in self.states)
             cos_sum = sum(math.cos(math.radians(x)) for x in self.states)
             return math.degrees(math.atan2(sin_sum, cos_sum))
         return None
-    
+
     def _stat_median(self) -> StateType:
         if len(self.states) > 0:
             return statistics.median(self.states)

--- a/homeassistant/components/statistics/sensor.py
+++ b/homeassistant/components/statistics/sensor.py
@@ -82,6 +82,7 @@ STAT_DISTANCE_95P = "distance_95_percent_of_values"
 STAT_DISTANCE_99P = "distance_99_percent_of_values"
 STAT_DISTANCE_ABSOLUTE = "distance_absolute"
 STAT_MEAN = "mean"
+STAT_MEAN_CIRCULAR = "mean_circular"
 STAT_MEDIAN = "median"
 STAT_NOISINESS = "noisiness"
 STAT_PERCENTILE = "percentile"
@@ -111,6 +112,7 @@ STATS_NUMERIC_SUPPORT = {
     STAT_DISTANCE_99P,
     STAT_DISTANCE_ABSOLUTE,
     STAT_MEAN,
+    STAT_MEAN_CIRCULAR,
     STAT_MEDIAN,
     STAT_NOISINESS,
     STAT_PERCENTILE,
@@ -160,6 +162,7 @@ STATS_NUMERIC_RETAIN_UNIT = {
     STAT_DISTANCE_99P,
     STAT_DISTANCE_ABSOLUTE,
     STAT_MEAN,
+    STAT_MEAN_CIRCULAR,
     STAT_MEDIAN,
     STAT_NOISINESS,
     STAT_PERCENTILE,
@@ -680,7 +683,14 @@ class StatisticsSensor(SensorEntity):
         if len(self.states) > 0:
             return statistics.mean(self.states)
         return None
-
+        
+    def _stat_mean_circular(self) -> StateType:
+        if len(self.states) > 0:
+            sin_sum = sum(math.sin(math.radians(x)) for x in self.states)
+            cos_sum = sum(math.cos(math.radians(x)) for x in self.states)
+            return math.degrees(math.atan2(sin_sum, cos_sum))
+        return None
+    
     def _stat_median(self) -> StateType:
         if len(self.states) > 0:
             return statistics.median(self.states)

--- a/tests/components/statistics/test_sensor.py
+++ b/tests/components/statistics/test_sensor.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from datetime import datetime, timedelta
-import statistics
 import math
+import statistics
 from typing import Any
 from unittest.mock import patch
 
@@ -926,8 +926,18 @@ async def test_state_characteristics(hass: HomeAssistant) -> None:
             "name": "mean_circular",
             "value_0": STATE_UNKNOWN,
             "value_1": float(VALUES_NUMERIC[-1]),
-            "value_9": float(round(math.degrees(math.atan2(sum(math.sin(math.radians(x)) for x in VALUES_NUMERIC), sum(math.cos(math.radians(x)) for x in VALUES_NUMERIC))), 2)),
-            "unit": "°",
+            "value_9": float(
+                round(
+                    math.degrees(
+                        math.atan2(
+                            sum(math.sin(math.radians(x)) for x in VALUES_NUMERIC),
+                            sum(math.cos(math.radians(x)) for x in VALUES_NUMERIC),
+                        )
+                    ),
+                    2,
+                )
+            ),
+            "unit": "°C",
         },
         {
             "source_sensor_domain": "sensor",

--- a/tests/components/statistics/test_sensor.py
+++ b/tests/components/statistics/test_sensor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from datetime import datetime, timedelta
 import statistics
+import math
 from typing import Any
 from unittest.mock import patch
 
@@ -919,6 +920,14 @@ async def test_state_characteristics(hass: HomeAssistant) -> None:
             "value_1": float(VALUES_NUMERIC[-1]),
             "value_9": float(round(sum(VALUES_NUMERIC) / len(VALUES_NUMERIC), 2)),
             "unit": "°C",
+        },
+        {
+            "source_sensor_domain": "sensor",
+            "name": "mean_circular",
+            "value_0": STATE_UNKNOWN,
+            "value_1": float(VALUES_NUMERIC[-1]),
+            "value_9": float(round(math.degrees(math.atan2(sum(math.sin(math.radians(x)) for x in VALUES_NUMERIC), sum(math.cos(math.radians(x)) for x in VALUES_NUMERIC))), 2)),
+            "unit": "°",
         },
         {
             "source_sensor_domain": "sensor",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
Add new characteristic to the statistics integration - circular mean. This allows averaging of circular/angular sensor data, e.g. wind direction, where arithmetic mean would give the wrong result when the value crosses over 0/360°. 

This would be useful, for example, to those running a weather station where the wind direction needs to be smoothed out. It could also be used for averaging a time of day, if converted to degrees (× 15) and then back to hours.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
- See attached example from my local testing showing how it diverges from arithmetic mean.
![mean_circular vs mean 2_104814](https://github.com/home-assistant/core/assets/542271/6627e9d5-7f79-4bdb-a2f9-e695a6c239e7)

- This is my first PR to Home Assistant, please forgive any errors. 
- For the test, I didn't want to mess around too much with the tests for this component by making exceptions just for this one characteristic. I left the unit as °C like the other characteristics, whereas in reality it should be degrees (°). The numeric values used for the test could ideally be more widespread, i.e. past 360, to prove that it works. I did check the math, though.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]
https://github.com/home-assistant/home-assistant.io/pull/28682

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
