### PR TITLE
Use loop.time in DataUpdateCoordinator

### DIFF
--- a/homeassistant/components/tomorrowio/__init__.py
+++ b/homeassistant/components/tomorrowio/__init__.py
@@ -221,7 +221,10 @@ class TomorrowioDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             await self.async_refresh()
 
         self.update_interval = async_set_update_interval(self.hass, self._api)
-        self._schedule_refresh()
+        self._next_refresh = None
+        self._async_unsub_refresh()
+        if self._listeners:
+            self._schedule_refresh()
 
     async def async_unload_entry(self, entry: ConfigEntry) -> bool | None:
         """Unload a config entry from coordinator.

--- a/homeassistant/helpers/update_coordinator.py
+++ b/homeassistant/helpers/update_coordinator.py
@@ -90,7 +90,7 @@ class DataUpdateCoordinator(BaseDataUpdateCoordinatorProtocol, Generic[_DataT]):
         # when it was already checked during setup.
         self.data: _DataT = None  # type: ignore[assignment]
 
-        # Pick a random microsecond to stagger the refreshes
+        # Pick a random microsecond in range 0.05..0.50 to stagger the refreshes
         # and avoid a thundering herd.
         self._microsecond = (
             randint(event.RANDOM_MICROSECOND_MIN, event.RANDOM_MICROSECOND_MAX)
@@ -218,10 +218,10 @@ class DataUpdateCoordinator(BaseDataUpdateCoordinatorProtocol, Generic[_DataT]):
         self._async_unsub_refresh()
 
         # We use event.async_call_at because DataUpdateCoordinator does
-        # not guarantee an exact update interval
+        # not need an exact update interval.
         now = self.hass.loop.time()
         if self._next_refresh is None or self._next_refresh <= now:
-            self._next_refresh = now + self._microsecond
+            self._next_refresh = int(now) + self._microsecond
         self._next_refresh += self.update_interval.total_seconds()
         self._unsub_refresh = event.async_call_at(
             self.hass,

--- a/homeassistant/helpers/update_coordinator.py
+++ b/homeassistant/helpers/update_coordinator.py
@@ -6,7 +6,6 @@ import asyncio
 from collections.abc import Awaitable, Callable, Coroutine, Generator
 from datetime import datetime, timedelta
 import logging
-from random import randint
 from time import monotonic
 from typing import Any, Generic, Protocol, TypeVar
 import urllib.error
@@ -89,12 +88,6 @@ class DataUpdateCoordinator(BaseDataUpdateCoordinatorProtocol, Generic[_DataT]):
         # Set type to just T to remove annoying checks that data is not None
         # when it was already checked during setup.
         self.data: _DataT = None  # type: ignore[assignment]
-
-        # Pick a random microsecond to stagger the refreshes
-        # and avoid a thundering herd.
-        self._microsecond = randint(
-            event.RANDOM_MICROSECOND_MIN, event.RANDOM_MICROSECOND_MAX
-        )
 
         self._listeners: dict[CALLBACK_TYPE, tuple[CALLBACK_TYPE, object | None]] = {}
         job_name = "DataUpdateCoordinator"

--- a/tests/common.py
+++ b/tests/common.py
@@ -412,12 +412,9 @@ def async_fire_time_changed(
     else:
         utc_datetime = dt_util.as_utc(datetime_)
 
-    if utc_datetime.microsecond < event.RANDOM_MICROSECOND_MAX:
-        # Allow up to 500000 microseconds to be added to the time
-        # to handle update_coordinator's and
-        # async_track_time_interval's
-        # staggering to avoid thundering herd.
-        utc_datetime = utc_datetime.replace(microsecond=event.RANDOM_MICROSECOND_MAX)
+    # Increase the mocked time by 0.5 s to account for up to 0.5 s delay
+    # added to events scheduled by update_coordinator and async_track_time_interval
+    utc_datetime += timedelta(microseconds=event.RANDOM_MICROSECOND_MAX)
 
     _async_fire_time_changed(hass, utc_datetime, fire_all)
 

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -4174,27 +4174,27 @@ async def test_periodic_task_entering_dst_2(
     )
 
     freezer.move_to(f"{today} 01:59:59.999999+01:00")
-    async_fire_time_changed(hass)
+    async_fire_time_changed_exact(hass)
     await hass.async_block_till_done()
     assert len(specific_runs) == 0
 
     freezer.move_to(f"{today} 03:00:00.999999+02:00")
-    async_fire_time_changed(hass)
+    async_fire_time_changed_exact(hass)
     await hass.async_block_till_done()
     assert len(specific_runs) == 1
 
     freezer.move_to(f"{today} 03:00:01.999999+02:00")
-    async_fire_time_changed(hass)
+    async_fire_time_changed_exact(hass)
     await hass.async_block_till_done()
     assert len(specific_runs) == 2
 
     freezer.move_to(f"{tomorrow} 01:59:59.999999+02:00")
-    async_fire_time_changed(hass)
+    async_fire_time_changed_exact(hass)
     await hass.async_block_till_done()
     assert len(specific_runs) == 3
 
     freezer.move_to(f"{tomorrow} 02:00:00.999999+02:00")
-    async_fire_time_changed(hass)
+    async_fire_time_changed_exact(hass)
     await hass.async_block_till_done()
     assert len(specific_runs) == 4
 

--- a/tests/helpers/test_update_coordinator.py
+++ b/tests/helpers/test_update_coordinator.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import urllib.error
 
 import aiohttp
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 import requests
 
@@ -329,11 +330,14 @@ async def test_refresh_no_update_method(
 
 
 async def test_update_interval(
-    hass: HomeAssistant, crd: update_coordinator.DataUpdateCoordinator[int]
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    crd: update_coordinator.DataUpdateCoordinator[int],
 ) -> None:
     """Test update interval works."""
     # Test we don't update without subscriber
-    async_fire_time_changed(hass, utcnow() + crd.update_interval)
+    freezer.tick(crd.update_interval)
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
     assert crd.data is None
 
@@ -342,18 +346,21 @@ async def test_update_interval(
     unsub = crd.async_add_listener(update_callback)
 
     # Test twice we update with subscriber
-    async_fire_time_changed(hass, utcnow() + crd.update_interval)
+    freezer.tick(crd.update_interval)
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
     assert crd.data == 1
 
-    async_fire_time_changed(hass, utcnow() + crd.update_interval)
+    freezer.tick(crd.update_interval)
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
     assert crd.data == 2
 
     # Test removing listener
     unsub()
 
-    async_fire_time_changed(hass, utcnow() + crd.update_interval)
+    freezer.tick(crd.update_interval)
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
     # Test we stop updating after we lose last subscriber


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use `loop.time` in `DataUpdateCoordinator`

Rationale: Calls to `utcnow()` are expensive on some platforms. The `DataUpdateCoordinator` does not need to sleep until a precise wall clock time, so we can use `loop.time()` instead


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
