### PR TITLE
Fix stream test aiohttp DeprecationWarning

### DIFF
--- a/tests/components/stream/test_ll_hls.py
+++ b/tests/components/stream/test_ll_hls.py
@@ -7,6 +7,7 @@ import math
 import re
 from urllib.parse import urlparse
 
+from aiohttp import web
 from dateutil import parser
 import pytest
 
@@ -394,6 +395,9 @@ async def test_ll_hls_playlist_bad_msn_part(
 ) -> None:
     """Test some playlist requests with invalid _HLS_msn/_HLS_part."""
 
+    async def _handler_bad_request(request):
+        raise web.HTTPBadRequest()
+
     await async_setup_component(
         hass,
         "stream",
@@ -412,6 +416,12 @@ async def test_ll_hls_playlist_bad_msn_part(
     hls = stream.add_provider(HLS_PROVIDER)
 
     hls_client = await hls_stream(stream)
+
+    # All GET calls to '/.../playlist.m3u8' should raise a HTTPBadRequest exception
+    hls_client.http_client.app.router._frozen = False
+    parsed_url = urlparse(stream.endpoint_url(HLS_PROVIDER))
+    url = "/".join(parsed_url.path.split("/")[:-1]) + "/playlist.m3u8"
+    hls_client.http_client.app.router.add_route("GET", url, _handler_bad_request)
 
     # If the Playlist URI contains an _HLS_part directive but no _HLS_msn
     # directive, the Server MUST return Bad Request, such as HTTP 400.


### PR DESCRIPTION
## Proposed change
_Let's fix some pytest warnings!_

```
tests/components/stream/test_ll_hls.py::test_ll_hls_playlist_bad_msn_part
  /home/runner/work/ha-core/ha-core/venv/lib/python3.11/site-packages/aiohttp/web_protocol.py:451:
      DeprecationWarning: returning HTTPException object is deprecated (#2415) and will be removed, please raise the exception instead
    warnings.warn(
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
