### PR TITLE
Conditional category for temperature sensor entities in AVM Fritz!Smarthome

### DIFF
--- a/homeassistant/components/fritzbox/sensor.py
+++ b/homeassistant/components/fritzbox/sensor.py
@@ -48,6 +48,8 @@ class FritzSensorEntityDescription(
 ):
     """Description for Fritz!Smarthome sensor entities."""
 
+    entity_category_fn: Callable[[FritzhomeDevice], EntityCategory | None] | None = None
+
 
 def suitable_eco_temperature(device: FritzhomeDevice) -> bool:
     """Check suitablity for eco temperature sensor."""
@@ -74,6 +76,13 @@ def suitable_temperature(device: FritzhomeDevice) -> bool:
     return device.has_temperature_sensor and not device.has_thermostat
 
 
+def entity_category_temperature(device: FritzhomeDevice) -> EntityCategory | None:
+    """Determine proper entity category for temperature sensor."""
+    if device.has_switch or device.has_lightbulb:
+        return EntityCategory.DIAGNOSTIC
+    return None
+
+
 def value_nextchange_preset(device: FritzhomeDevice) -> str:
     """Return native value for next scheduled preset sensor."""
     if device.nextchange_temperature == device.eco_temperature:
@@ -94,7 +103,7 @@ SENSOR_TYPES: Final[tuple[FritzSensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
-        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_category_fn=entity_category_temperature,
         suitable=suitable_temperature,
         native_value=lambda device: device.temperature,
     ),
@@ -224,3 +233,10 @@ class FritzBoxSensor(FritzBoxDeviceEntity, SensorEntity):
     def native_value(self) -> StateType | datetime:
         """Return the state of the sensor."""
         return self.entity_description.native_value(self.data)
+
+    @property
+    def entity_category(self) -> EntityCategory | None:
+        """Return the category of the entity, if any."""
+        if self.entity_description.entity_category_fn is not None:
+            return self.entity_description.entity_category_fn(self.data)
+        return super().entity_category

--- a/tests/components/fritzbox/test_switch.py
+++ b/tests/components/fritzbox/test_switch.py
@@ -20,6 +20,7 @@ from homeassistant.const import (
     SERVICE_TURN_ON,
     STATE_ON,
     STATE_UNAVAILABLE,
+    EntityCategory,
     UnitOfElectricCurrent,
     UnitOfElectricPotential,
     UnitOfEnergy,
@@ -27,6 +28,7 @@ from homeassistant.const import (
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 import homeassistant.util.dt as dt_util
 
 from . import FritzDeviceSwitchMock, setup_config_entry
@@ -60,6 +62,7 @@ async def test_setup(hass: HomeAssistant, fritz: Mock) -> None:
             f"{CONF_FAKE_NAME} Temperature",
             UnitOfTemperature.CELSIUS,
             SensorStateClass.MEASUREMENT,
+            EntityCategory.DIAGNOSTIC,
         ],
         [
             f"{SENSOR_DOMAIN}.{CONF_FAKE_NAME}_power",
@@ -67,6 +70,7 @@ async def test_setup(hass: HomeAssistant, fritz: Mock) -> None:
             f"{CONF_FAKE_NAME} Power",
             UnitOfPower.WATT,
             SensorStateClass.MEASUREMENT,
+            None,
         ],
         [
             f"{SENSOR_DOMAIN}.{CONF_FAKE_NAME}_energy",
@@ -74,6 +78,7 @@ async def test_setup(hass: HomeAssistant, fritz: Mock) -> None:
             f"{CONF_FAKE_NAME} Energy",
             UnitOfEnergy.KILO_WATT_HOUR,
             SensorStateClass.TOTAL_INCREASING,
+            None,
         ],
         [
             f"{SENSOR_DOMAIN}.{CONF_FAKE_NAME}_voltage",
@@ -81,6 +86,7 @@ async def test_setup(hass: HomeAssistant, fritz: Mock) -> None:
             f"{CONF_FAKE_NAME} Voltage",
             UnitOfElectricPotential.VOLT,
             SensorStateClass.MEASUREMENT,
+            None,
         ],
         [
             f"{SENSOR_DOMAIN}.{CONF_FAKE_NAME}_current",
@@ -88,9 +94,11 @@ async def test_setup(hass: HomeAssistant, fritz: Mock) -> None:
             f"{CONF_FAKE_NAME} Current",
             UnitOfElectricCurrent.AMPERE,
             SensorStateClass.MEASUREMENT,
+            None,
         ],
     )
 
+    entity_registry = er.async_get(hass)
     for sensor in sensors:
         state = hass.states.get(sensor[0])
         assert state
@@ -98,6 +106,10 @@ async def test_setup(hass: HomeAssistant, fritz: Mock) -> None:
         assert state.attributes[ATTR_FRIENDLY_NAME] == sensor[2]
         assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == sensor[3]
         assert state.attributes[ATTR_STATE_CLASS] == sensor[4]
+        assert state.attributes[ATTR_STATE_CLASS] == sensor[4]
+        entry = entity_registry.async_get(sensor[0])
+        assert entry
+        assert entry.entity_category is sensor[5]
 
 
 async def test_turn_on(hass: HomeAssistant, fritz: Mock) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This will make the entity category for temperature sensors dependent on the device main function.
For a plug (_eq. [Fritz!DECT 210](https://en.avm.de/products/smart-home/fritzdect-210/)_) it will be a diagnostic entity, because it is intended to check the device own, but not the room temperature.
For a smart button with H&T sensors (_eq. [Fritz!DECT 440](https://en.avm.de/products/smart-home/fritzdect-440/)_) it will be main sensor.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #98049
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
