### PR TITLE
Improve performance of bluetooth coordinators

### DIFF
--- a/homeassistant/components/bluetooth/update_coordinator.py
+++ b/homeassistant/components/bluetooth/update_coordinator.py
@@ -39,6 +39,7 @@ class BasePassiveBluetoothCoordinator(ABC):
         self.mode = mode
         self._last_unavailable_time = 0.0
         self._last_name = address
+        self._available = async_address_present(hass, address, connectable)
 
     @callback
     def async_start(self) -> CALLBACK_TYPE:
@@ -85,7 +86,17 @@ class BasePassiveBluetoothCoordinator(ABC):
     @property
     def available(self) -> bool:
         """Return if the device is available."""
-        return async_address_present(self.hass, self.address, self.connectable)
+        return self._available
+
+    @callback
+    def _async_handle_bluetooth_event_internal(
+        self,
+        service_info: BluetoothServiceInfoBleak,
+        change: BluetoothChange,
+    ) -> None:
+        """Handle a bluetooth event."""
+        self._available = True
+        self._async_handle_bluetooth_event(service_info, change)
 
     @callback
     def _async_start(self) -> None:
@@ -93,7 +104,7 @@ class BasePassiveBluetoothCoordinator(ABC):
         self._on_stop.append(
             async_register_callback(
                 self.hass,
-                self._async_handle_bluetooth_event,
+                self._async_handle_bluetooth_event_internal,
                 BluetoothCallbackMatcher(
                     address=self.address, connectable=self.connectable
                 ),
@@ -123,3 +134,4 @@ class BasePassiveBluetoothCoordinator(ABC):
         """Handle the device going unavailable."""
         self._last_unavailable_time = service_info.time
         self._last_name = service_info.name
+        self._available = False

--- a/tests/components/bluetooth/test_passive_update_processor.py
+++ b/tests/components/bluetooth/test_passive_update_processor.py
@@ -406,7 +406,7 @@ async def test_exception_from_update_method(
         """Generate mock data."""
         nonlocal run_count
         run_count += 1
-        if run_count == 1:
+        if run_count == 2:
             raise Exception("Test exception")
         return GENERIC_PASSIVE_BLUETOOTH_DATA_UPDATE
 
@@ -436,6 +436,7 @@ async def test_exception_from_update_method(
     processor.async_add_listener(MagicMock())
 
     inject_bluetooth_service_info(hass, GENERIC_BLUETOOTH_SERVICE_INFO)
+    saved_callback(GENERIC_BLUETOOTH_SERVICE_INFO, BluetoothChange.ADVERTISEMENT)
     assert processor.available is True
 
     # We should go unavailable once we get an exception
@@ -473,7 +474,7 @@ async def test_bad_data_from_update_method(
         """Generate mock data."""
         nonlocal run_count
         run_count += 1
-        if run_count == 1:
+        if run_count == 2:
             return "bad_data"
         return GENERIC_PASSIVE_BLUETOOTH_DATA_UPDATE
 
@@ -503,6 +504,7 @@ async def test_bad_data_from_update_method(
     processor.async_add_listener(MagicMock())
 
     inject_bluetooth_service_info(hass, GENERIC_BLUETOOTH_SERVICE_INFO)
+    saved_callback(GENERIC_BLUETOOTH_SERVICE_INFO, BluetoothChange.ADVERTISEMENT)
     assert processor.available is True
 
     # We should go unavailable once we get bad data


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Avoid the need to call async_address_present in the available property which was called for each entities state write. Since we have a subscriber to unavailable and available we can flip a flag instead which is much less expensive so we get event driven behavior instead of polling like behavior.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
