### PR TITLE
Use freezegun in qnap_qsw tests

### DIFF
--- a/tests/components/qnap_qsw/test_coordinator.py
+++ b/tests/components/qnap_qsw/test_coordinator.py
@@ -3,6 +3,7 @@
 from unittest.mock import patch
 
 from aioqsw.exceptions import APIError, QswError
+from freezegun.api import FrozenDateTimeFactory
 
 from homeassistant.components.qnap_qsw.const import DOMAIN
 from homeassistant.components.qnap_qsw.coordinator import (
@@ -11,7 +12,6 @@ from homeassistant.components.qnap_qsw.coordinator import (
 )
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
-from homeassistant.util.dt import utcnow
 
 from .util import (
     CONFIG,
@@ -31,7 +31,9 @@ from .util import (
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 
-async def test_coordinator_client_connector_error(hass: HomeAssistant) -> None:
+async def test_coordinator_client_connector_error(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory
+) -> None:
     """Test ClientConnectorError on coordinator update."""
 
     entry = MockConfigEntry(domain=DOMAIN, data=CONFIG)
@@ -99,7 +101,8 @@ async def test_coordinator_client_connector_error(hass: HomeAssistant) -> None:
         mock_users_login.reset_mock()
 
         mock_system_sensor.side_effect = QswError
-        async_fire_time_changed(hass, utcnow() + DATA_SCAN_INTERVAL)
+        freezer.tick(DATA_SCAN_INTERVAL)
+        async_fire_time_changed(hass)
         await hass.async_block_till_done()
 
         mock_system_sensor.assert_called_once()
@@ -110,14 +113,16 @@ async def test_coordinator_client_connector_error(hass: HomeAssistant) -> None:
         assert state.state == STATE_UNAVAILABLE
 
         mock_firmware_update_check.side_effect = APIError
-        async_fire_time_changed(hass, utcnow() + FW_SCAN_INTERVAL)
+        freezer.tick(FW_SCAN_INTERVAL)
+        async_fire_time_changed(hass)
         await hass.async_block_till_done()
 
         mock_firmware_update_check.assert_called_once()
         mock_firmware_update_check.reset_mock()
 
         mock_firmware_update_check.side_effect = QswError
-        async_fire_time_changed(hass, utcnow() + FW_SCAN_INTERVAL)
+        freezer.tick(FW_SCAN_INTERVAL)
+        async_fire_time_changed(hass)
         await hass.async_block_till_done()
 
         mock_firmware_update_check.assert_called_once()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use freezegun in qnap_qsw tests

Needed by https://github.com/home-assistant/core/pull/98937

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
