### PR TITLE
Add missing `low` state for `ENUM` Tractive sensors

### DIFF
--- a/homeassistant/components/tractive/sensor.py
+++ b/homeassistant/components/tractive/sensor.py
@@ -176,8 +176,9 @@ SENSOR_TYPES: tuple[TractiveSensorEntityDescription, ...] = (
         value_fn=lambda state: state.lower() if isinstance(state, str) else state,
         device_class=SensorDeviceClass.ENUM,
         options=[
-            "ok",
             "good",
+            "low",
+            "ok",
         ],
     ),
     TractiveSensorEntityDescription(
@@ -188,8 +189,9 @@ SENSOR_TYPES: tuple[TractiveSensorEntityDescription, ...] = (
         value_fn=lambda state: state.lower() if isinstance(state, str) else state,
         device_class=SensorDeviceClass.ENUM,
         options=[
-            "ok",
             "good",
+            "low",
+            "ok",
         ],
     ),
 )

--- a/homeassistant/components/tractive/strings.json
+++ b/homeassistant/components/tractive/strings.json
@@ -33,8 +33,9 @@
       "activity": {
         "name": "Activity",
         "state": {
-          "ok": "OK",
-          "good": "Good"
+          "good": "Good",
+          "low": "Low",
+          "ok": "OK"
         }
       },
       "activity_time": {
@@ -58,8 +59,9 @@
       "sleep": {
         "name": "Sleep",
         "state": {
-          "ok": "OK",
-          "good": "Good"
+          "good": "Good",
+          "low": "Low",
+          "ok": "OK"
         }
       },
       "tracker_battery_level": {

--- a/homeassistant/components/tractive/strings.json
+++ b/homeassistant/components/tractive/strings.json
@@ -59,9 +59,9 @@
       "sleep": {
         "name": "Sleep",
         "state": {
-          "good": "Good",
-          "low": "Low",
-          "ok": "OK"
+          "good": "[%key:component::tractive::entity::sensor::activity::state::good%]",
+          "low": "[%key:component::tractive::entity::sensor::activity::state::low%]",
+          "ok": "[%key:component::tractive::entity::sensor::activity::state::ok%]"
         }
       },
       "tracker_battery_level": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I managed to force my dog's tracker to show a different state for sensors using device class `ENUM`. This PR adds the missing `low` state. Fixes: 
```
ValueError: Sensor sensor.luna_sleep provides state value 'low', which is not in the list of options provided
```
Related to: https://github.com/home-assistant/core/pull/98575#discussion_r1299147570

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
