### PR TITLE
Add event sensors to the livisi Integration

### DIFF
--- a/homeassistant/components/livisi/__init__.py
+++ b/homeassistant/components/livisi/__init__.py
@@ -16,7 +16,12 @@ from homeassistant.helpers import aiohttp_client, device_registry as dr
 from .const import DOMAIN
 from .coordinator import LivisiDataUpdateCoordinator
 
-PLATFORMS: Final = [Platform.BINARY_SENSOR, Platform.CLIMATE, Platform.SWITCH]
+PLATFORMS: Final = [
+    Platform.BINARY_SENSOR,
+    Platform.CLIMATE,
+    Platform.SWITCH,
+    Platform.EVENT,
+]
 
 
 async def async_setup_entry(hass: core.HomeAssistant, entry: ConfigEntry) -> bool:
@@ -33,9 +38,11 @@ async def async_setup_entry(hass: core.HomeAssistant, entry: ConfigEntry) -> boo
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
     device_registry = dr.async_get(hass)
     device_registry.async_get_or_create(
-        config_entry_id=coordinator.serial_number,
+        config_entry_id=entry.entry_id,
         identifiers={(DOMAIN, entry.entry_id)},
         manufacturer="Livisi",
+        model=f"SHC {coordinator.controller_type}",
+        sw_version=coordinator.os_version,
         name=f"SHC {coordinator.controller_type} {coordinator.serial_number}",
     )
 

--- a/homeassistant/components/livisi/const.py
+++ b/homeassistant/components/livisi/const.py
@@ -17,6 +17,8 @@ LIVISI_REACHABILITY_CHANGE: Final = "livisi_reachability_change"
 SWITCH_DEVICE_TYPES: Final = ["ISS", "ISS2", "PSS", "PSSO"]
 VRCC_DEVICE_TYPE: Final = "VRCC"
 WDS_DEVICE_TYPE: Final = "WDS"
+WSC2_DEVICE_TYPE: Final = "WSC2"
+WMD_DEVICE_TYPE: Final = "WMD"
 
 
 MAX_TEMPERATURE: Final = 30.0

--- a/homeassistant/components/livisi/coordinator.py
+++ b/homeassistant/components/livisi/coordinator.py
@@ -48,6 +48,7 @@ class LivisiDataUpdateCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
         self.devices: set[str] = set()
         self.rooms: dict[str, Any] = {}
         self.serial_number: str = ""
+        self.os_version: str = ""
         self.controller_type: str = ""
         self.is_avatar: bool = False
         self.port: int = 0
@@ -86,6 +87,7 @@ class LivisiDataUpdateCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
             self.is_avatar = False
         self.controller_type = controller_type
         self.serial_number = controller_data["serialNumber"]
+        self.os_version = controller_data["osVersion"]
 
     async def async_get_devices(self) -> list[dict[str, Any]]:
         """Set the discovered devices list."""
@@ -110,18 +112,26 @@ class LivisiDataUpdateCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
 
     def on_data(self, event_data: LivisiEvent) -> None:
         """Define a handler to fire when the data is received."""
-        self._async_dispatcher_send(
-            LIVISI_STATE_CHANGE, event_data.source, event_data.onState
-        )
-        self._async_dispatcher_send(
-            LIVISI_STATE_CHANGE, event_data.source, event_data.vrccData
-        )
-        self._async_dispatcher_send(
-            LIVISI_REACHABILITY_CHANGE, event_data.source, event_data.isReachable
-        )
-        self._async_dispatcher_send(
-            LIVISI_STATE_CHANGE, event_data.source, event_data.isOpen
-        )
+        if event_data.onState is not None:
+            self._async_dispatcher_send(
+                LIVISI_STATE_CHANGE, event_data.source, event_data.onState
+            )
+        elif event_data.vrccData is not None:
+            self._async_dispatcher_send(
+                LIVISI_STATE_CHANGE, event_data.source, event_data.vrccData
+            )
+        elif event_data.isReachable is not None:
+            self._async_dispatcher_send(
+                LIVISI_REACHABILITY_CHANGE, event_data.source, event_data.isReachable
+            )
+        elif event_data.isOpen is not None:
+            self._async_dispatcher_send(
+                LIVISI_STATE_CHANGE, event_data.source, event_data.isOpen
+            )
+        else:
+            self._async_dispatcher_send(
+                LIVISI_STATE_CHANGE, event_data.source, event_data.properties
+            )
 
     async def on_close(self) -> None:
         """Define a handler to fire when the websocket is closed."""

--- a/homeassistant/components/livisi/event.py
+++ b/homeassistant/components/livisi/event.py
@@ -1,0 +1,164 @@
+"""Code for Livisi Events."""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.event import EventDeviceClass, EventEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import (
+    DOMAIN,
+    LIVISI_STATE_CHANGE,
+    LOGGER,
+    WMD_DEVICE_TYPE,
+    WSC2_DEVICE_TYPE,
+)
+from .coordinator import LivisiDataUpdateCoordinator
+from .entity import LivisiEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up button devices."""
+    coordinator: LivisiDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    known_devices = set()
+
+    @callback
+    def handle_coordinator_update() -> None:
+        """Add events."""
+        shc_devices: list[dict[str, Any]] = coordinator.data
+        entities: list[EventEntity] = []
+        for device in shc_devices:
+            if device["id"] not in known_devices and device["type"] == WSC2_DEVICE_TYPE:
+                livisi_event1: EventEntity = LivisiButtonEvent(
+                    config_entry, coordinator, device, entity_suffix="top"
+                )
+                entities.append(livisi_event1)
+                livisi_event2: EventEntity = LivisiButtonEvent(
+                    config_entry, coordinator, device, entity_suffix="bottom"
+                )
+                entities.append(livisi_event2)
+                LOGGER.debug("Include device type: %s", device["type"])
+                coordinator.devices.add(device["id"])
+                known_devices.add(device["id"])
+            if device["id"] not in known_devices and device["type"] == WMD_DEVICE_TYPE:
+                livisi_event: EventEntity = LivisiMotionEvent(
+                    config_entry, coordinator, device
+                )
+                entities.append(livisi_event)
+                LOGGER.debug("Include device type: %s", device["type"])
+                coordinator.devices.add(device["id"])
+                known_devices.add(device["id"])
+        async_add_entities(entities)
+
+    config_entry.async_on_unload(
+        coordinator.async_add_listener(handle_coordinator_update)
+    )
+
+
+class LivisiEvent(LivisiEntity, EventEntity):
+    """Represents the livisi Event base class."""
+
+    _attr_has_entity_name = False
+
+    def __init__(
+        self,
+        config_entry: ConfigEntry,
+        coordinator: LivisiDataUpdateCoordinator,
+        device: dict[str, Any],
+        capability_name: str,
+        entity_suffix: str | None = None,
+    ) -> None:
+        """Initialize the Livisi Event."""
+        super().__init__(config_entry, coordinator, device, entity_suffix=entity_suffix)
+        self._capability_id = self.capabilities[capability_name]
+
+    async def async_added_to_hass(self) -> None:
+        """Register callbacks."""
+        await super().async_added_to_hass()
+
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                f"{LIVISI_STATE_CHANGE}_{self._capability_id}",
+                self._async_handle_event,
+            )
+        )
+
+    @callback
+    def _async_handle_event(self, event: dict[str, Any] | None) -> None:
+        """Handle the event."""
+        raise NotImplementedError()
+
+
+class LivisiButtonEvent(LivisiEvent, EventEntity):
+    """Represents a wall mounted Switch."""
+
+    _attr_has_entity_name = False
+    _attr_device_class = EventDeviceClass.BUTTON
+    _attr_event_types = ["single_press"]
+
+    def __init__(
+        self,
+        config_entry: ConfigEntry,
+        coordinator: LivisiDataUpdateCoordinator,
+        device: dict[str, Any],
+        entity_suffix: str | None = None,
+    ) -> None:
+        """Initialize the Livisi Button Event."""
+        super().__init__(
+            config_entry,
+            coordinator,
+            device,
+            capability_name="PushButtonSensor",
+            entity_suffix=entity_suffix,
+        )
+        self.__trigger_index = 0 if entity_suffix == "top" else 1
+
+    @callback
+    def _async_handle_event(self, event: dict[str, Any] | None) -> None:
+        """Handle the push button event."""
+        if (
+            event is not None
+            and self.__trigger_index == event["lastPressedButtonIndex"]
+        ):
+            self._trigger_event("single_press", event)
+            self.async_write_ha_state()
+
+
+class LivisiMotionEvent(LivisiEvent, EventEntity):
+    """Represents a motion sensor."""
+
+    _attr_has_entity_name = False
+    _attr_device_class = EventDeviceClass.MOTION
+    _attr_event_types = ["motion"]
+    __motion_detection_count = 0
+
+    def __init__(
+        self,
+        config_entry: ConfigEntry,
+        coordinator: LivisiDataUpdateCoordinator,
+        device: dict[str, Any],
+    ) -> None:
+        """Initialize the Livisi Motion Event."""
+        super().__init__(
+            config_entry, coordinator, device, capability_name="MotionDetectionSensor"
+        )
+
+    @callback
+    def _async_handle_event(self, event: dict[str, Any] | None) -> None:
+        """Handle the motion sensor event."""
+        # Prevent multiple detection events
+        if (
+            event is not None
+            and event["motionDetectedCount"] > self.__motion_detection_count
+        ):
+            self._trigger_event("motion", event)
+            self.__motion_detection_count = event["motionDetectedCount"]
+            self.async_write_ha_state()


### PR DESCRIPTION
Support Events from Motion and Wall switch sensors via the livisi integration. 

I only tested it in the last few hours, so I will comment again after testing it for a more extended timeframe.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
