### PR TITLE
Improve ecoal_boiler

### DIFF
--- a/homeassistant/components/ecoal_boiler/__init__.py
+++ b/homeassistant/components/ecoal_boiler/__init__.py
@@ -35,9 +35,8 @@ AVAILABLE_PUMPS = {
     "domestic_hot_water_pump": "Domestic hot water pump",
 }
 
-# Available temp sensor ids with assigned HA names
-# Available as sensors
-AVAILABLE_SENSORS = {
+# available temp sensor ids with assigned ha names
+TEMP_SENSORS = {
     "outdoor_temp": "Outdoor temperature",
     "indoor_temp": "Indoor temperature",
     "indoor2_temp": "Indoor temperature 2",
@@ -48,7 +47,16 @@ AVAILABLE_SENSORS = {
     "target_feedwater_temp": "Target feedwater temperature",
     "fuel_feeder_temp": "Fuel feeder temperature",
     "exhaust_temp": "Exhaust temperature",
+    }
+
+
+# Available percentage sensors
+PERCENTAGE_SENSORS = {
+    "fuel_left_percentage": "How many percent of fuel is left",
 }
+
+# Available sensor ids with assigned HA names
+AVAILABLE_SENSORS = TEMP_SENSORS | PERCENTAGE_SENSORS
 
 SWITCH_SCHEMA = vol.Schema(
     {

--- a/homeassistant/components/ecoal_boiler/manifest.json
+++ b/homeassistant/components/ecoal_boiler/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "https://www.home-assistant.io/integrations/ecoal_boiler",
   "iot_class": "local_polling",
   "loggers": ["ecoaliface"],
-  "requirements": ["ecoaliface==0.4.0"]
+  "requirements": ["ecoaliface==0.6.0"]
 }

--- a/homeassistant/components/ecoal_boiler/sensor.py
+++ b/homeassistant/components/ecoal_boiler/sensor.py
@@ -2,12 +2,21 @@
 from __future__ import annotations
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
-from homeassistant.const import UnitOfTemperature
+from homeassistant.const import PERCENTAGE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import AVAILABLE_SENSORS, DATA_ECOAL_BOILER
+from . import AVAILABLE_SENSORS, DATA_ECOAL_BOILER, PERCENTAGE_SENSORS, TEMP_SENSORS
+
+
+def getSensorClass(sensor_id):
+    if sensor_id in TEMP_SENSORS:
+        return EcoalTempSensor
+    elif sensor_id in PERCENTAGE_SENSORS:
+        return EcoalFuelPercentageSensor
+    else:
+        return None
 
 
 def setup_platform(
@@ -23,7 +32,7 @@ def setup_platform(
     ecoal_contr = hass.data[DATA_ECOAL_BOILER]
     for sensor_id in discovery_info:
         name = AVAILABLE_SENSORS[sensor_id]
-        devices.append(EcoalTempSensor(ecoal_contr, name, sensor_id))
+        devices.append(getSensorClass(sensor_id)(ecoal_contr, name, sensor_id))
     add_entities(devices, True)
 
 
@@ -47,3 +56,36 @@ class EcoalTempSensor(SensorEntity):
         # Old values read 0.5 back can still be used
         status = self._ecoal_contr.get_cached_status()
         self._attr_native_value = getattr(status, self._status_attr)
+
+
+class EcoalFuelPercentageSensor(SensorEntity):
+    """Representation of a fuel level in percent."""
+
+    _attr_device_class = SensorDeviceClass.BATTERY
+    _attr_native_unit_of_measurement = PERCENTAGE
+
+    def __init__(self, ecoal_contr, name, status_attr):
+        """Initialize the sensor."""
+        self._ecoal_contr = ecoal_contr
+        self._attr_name = name
+        self._status_attr = status_attr
+
+    def update(self) -> None:
+        """Fetch new state data for the sensor.
+
+        This is the only method that should fetch new data for Home Assistant.
+        """
+        # Old values read 0.5 back can still be used
+        status = self._ecoal_contr.get_cached_status()
+        self._attr_native_value = 100 - (
+            min(
+                round(
+                    status.feeder_current_run_time
+                    / 60
+                    / status.feeder_max_run_time
+                    * 100,
+                    1,
+                ),
+                100,
+            )
+        )

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -706,7 +706,7 @@ easyenergy==0.3.0
 ebusdpy==0.0.17
 
 # homeassistant.components.ecoal_boiler
-ecoaliface==0.4.0
+ecoaliface==0.6.0
 
 # homeassistant.components.electric_kiwi
 electrickiwi-api==0.8.5


### PR DESCRIPTION
Add boiler fuel level in percents

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
1. Add a fuel level gauge to ecoal_boiler component. Enable users to see how much coal is left in the feeder.
2. Fix a bug: according to documentation fuel_feeder_temp should be used, but the attributes name in interface is coal_feeder_temp

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
