### PR TITLE
Split Nextcloud CPU load in separate sensors

### DIFF
--- a/homeassistant/components/nextcloud/coordinator.py
+++ b/homeassistant/components/nextcloud/coordinator.py
@@ -54,6 +54,11 @@ class NextcloudDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     key_path += f"{key}_"
                 leaf = True
                 result.update(self._get_data_points(value, key_path, leaf))
+            elif key == "cpuload" and isinstance(value, list):
+                result[f"{key_path}{key}_1"] = value[0]
+                result[f"{key_path}{key}_5"] = value[1]
+                result[f"{key_path}{key}_15"] = value[2]
+                leaf = False
             else:
                 result[f"{key_path}{key}"] = value
                 leaf = False

--- a/homeassistant/components/nextcloud/sensor.py
+++ b/homeassistant/components/nextcloud/sensor.py
@@ -171,10 +171,26 @@ SENSORS: Final[dict[str, SensorEntityDescription]] = {
         translation_key="nextcloud_system_apps_num_updates_available",
         icon="mdi:update",
     ),
-    "system_cpuload": SensorEntityDescription(
-        key="system_cpuload",
-        translation_key="nextcloud_system_cpuload",
+    "system_cpuload_1": SensorEntityDescription(
+        key="system_cpuload_1",
+        translation_key="nextcloud_system_cpuload_1",
+        native_unit_of_measurement=UNIT_OF_LOAD,
         icon="mdi:chip",
+        suggested_display_precision=2,
+    ),
+    "system_cpuload_5": SensorEntityDescription(
+        key="system_cpuload_5",
+        translation_key="nextcloud_system_cpuload_5",
+        native_unit_of_measurement=UNIT_OF_LOAD,
+        icon="mdi:chip",
+        suggested_display_precision=2,
+    ),
+    "system_cpuload_15": SensorEntityDescription(
+        key="system_cpuload_15",
+        translation_key="nextcloud_system_cpuload_15",
+        native_unit_of_measurement=UNIT_OF_LOAD,
+        icon="mdi:chip",
+        suggested_display_precision=2,
     ),
     "system_freespace": SensorEntityDescription(
         key="system_freespace",

--- a/homeassistant/components/nextcloud/strings.json
+++ b/homeassistant/components/nextcloud/strings.json
@@ -64,7 +64,7 @@
         "name": "Free space"
       },
       "nextcloud_system_cpuload_1": {
-        "name": "CPU Load last 1 minute"
+        "name": "CPU Load last minute"
       },
       "nextcloud_system_cpuload_15": {
         "name": "CPU Load last 15 minutes"

--- a/homeassistant/components/nextcloud/strings.json
+++ b/homeassistant/components/nextcloud/strings.json
@@ -63,8 +63,14 @@
       "nextcloud_system_freespace": {
         "name": "Free space"
       },
-      "nextcloud_system_cpuload": {
-        "name": "CPU Load"
+      "nextcloud_system_cpuload_1": {
+        "name": "CPU Load last 1 minute"
+      },
+      "nextcloud_system_cpuload_15": {
+        "name": "CPU Load last 15 minutes"
+      },
+      "nextcloud_system_cpuload_5": {
+        "name": "CPU Load last 5 minutes"
       },
       "nextcloud_system_mem_total": {
         "name": "Total memory"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The CPU load sensor has been replaced, it is not a list of 3 values anymore, but there are now three single sensors for CPU load within last 1, 5 and 15 minutes. 

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
