### PR TITLE
Allow one retry before raising ConfigEntryAuthFailed for bmw_connected_drive

### DIFF
--- a/homeassistant/components/bmw_connected_drive/coordinator.py
+++ b/homeassistant/components/bmw_connected_drive/coordinator.py
@@ -58,7 +58,10 @@ class BMWDataUpdateCoordinator(DataUpdateCoordinator[None]):
         try:
             await self.account.get_vehicles()
         except MyBMWAuthError as err:
-            # Clear refresh token and trigger reauth
+            # Allow one retry interval before raising AuthFailed to avoid flaky API iissues
+            if self.last_update_success:
+                raise UpdateFailed(err) from err
+            # Clear refresh token and trigger reauth if previous update failed as well
             self._update_config_entry_refresh_token(None)
             raise ConfigEntryAuthFailed(err) from err
         except (MyBMWAPIError, RequestError) as err:

--- a/homeassistant/components/bmw_connected_drive/coordinator.py
+++ b/homeassistant/components/bmw_connected_drive/coordinator.py
@@ -58,7 +58,7 @@ class BMWDataUpdateCoordinator(DataUpdateCoordinator[None]):
         try:
             await self.account.get_vehicles()
         except MyBMWAuthError as err:
-            # Allow one retry interval before raising AuthFailed to avoid flaky API iissues
+            # Allow one retry interval before raising AuthFailed to avoid flaky API issues
             if self.last_update_success:
                 raise UpdateFailed(err) from err
             # Clear refresh token and trigger reauth if previous update failed as well

--- a/tests/components/bmw_connected_drive/test_coordinator.py
+++ b/tests/components/bmw_connected_drive/test_coordinator.py
@@ -1,0 +1,74 @@
+"""Test BMW coordinator."""
+from unittest.mock import patch
+
+from bimmer_connected.models import MyBMWAPIError, MyBMWAuthError
+import respx
+
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.update_coordinator import UpdateFailed
+
+from . import FIXTURE_CONFIG_ENTRY
+
+from tests.common import MockConfigEntry
+
+
+async def test_update_success(hass: HomeAssistant, bmw_fixture: respx.Router) -> None:
+    """Test the reauth form."""
+    config_entry = MockConfigEntry(**FIXTURE_CONFIG_ENTRY)
+    config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert (
+        hass.data[config_entry.domain][config_entry.entry_id].last_update_success
+        is True
+    )
+
+
+async def test_update_failed(hass: HomeAssistant, bmw_fixture: respx.Router) -> None:
+    """Test the reauth form."""
+    config_entry = MockConfigEntry(**FIXTURE_CONFIG_ENTRY)
+    config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = hass.data[config_entry.domain][config_entry.entry_id]
+
+    assert coordinator.last_update_success is True
+
+    with patch(
+        "bimmer_connected.account.MyBMWAccount.get_vehicles",
+        side_effect=MyBMWAPIError("Test error"),
+    ):
+        await coordinator.async_refresh()
+
+    assert coordinator.last_update_success is False
+    assert isinstance(coordinator.last_exception, UpdateFailed) is True
+
+
+async def test_update_reauth(hass: HomeAssistant, bmw_fixture: respx.Router) -> None:
+    """Test the reauth form."""
+    config_entry = MockConfigEntry(**FIXTURE_CONFIG_ENTRY)
+    config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = hass.data[config_entry.domain][config_entry.entry_id]
+
+    assert coordinator.last_update_success is True
+
+    with patch(
+        "bimmer_connected.account.MyBMWAccount.get_vehicles",
+        side_effect=MyBMWAuthError("Test error"),
+    ):
+        await coordinator.async_refresh()
+        assert coordinator.last_update_success is False
+        assert isinstance(coordinator.last_exception, UpdateFailed) is True
+
+        await coordinator.async_refresh()
+        assert coordinator.last_update_success is False
+        assert isinstance(coordinator.last_exception, ConfigEntryAuthFailed) is True


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow one retry before triggering config reauthentication. 

Hopefully helps smoothing issues like #https://github.com/home-assistant/core/issues/98966 when the API is flaky.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/98966
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
