### PR TITLE
Switch async_track_same_state to use async_call_later

### DIFF
--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -1327,9 +1327,7 @@ def async_track_same_state(
         if not async_check_same_func(entity, from_state, to_state):
             clear_listener()
 
-    async_remove_state_for_listener = async_track_point_in_utc_time(
-        hass, state_for_listener, dt_util.utcnow() + period
-    )
+    async_remove_state_for_listener = async_call_later(hass, period, state_for_listener)
 
     if entity_ids == MATCH_ALL:
         async_remove_state_for_cancel = hass.bus.async_listen(

--- a/tests/components/homeassistant/triggers/test_numeric_state.py
+++ b/tests/components/homeassistant/triggers/test_numeric_state.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 import logging
 from unittest.mock import patch
 
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 import voluptuous as vol
 
@@ -1147,7 +1148,7 @@ async def test_if_fails_setup_for_without_above_below(
     ),
 )
 async def test_if_not_fires_on_entity_change_with_for(
-    hass: HomeAssistant, calls, above, below
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls, above, below
 ) -> None:
     """Test for not firing on entity change with for."""
     assert await async_setup_component(
@@ -1171,7 +1172,8 @@ async def test_if_not_fires_on_entity_change_with_for(
     await hass.async_block_till_done()
     hass.states.async_set("test.entity", 15)
     await hass.async_block_till_done()
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=10))
+    freezer.tick(timedelta(seconds=10))
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
     assert len(calls) == 0
 
@@ -1374,7 +1376,7 @@ async def test_wait_template_with_trigger(hass: HomeAssistant, calls, above) -> 
     ),
 )
 async def test_if_fires_on_entities_change_no_overlap(
-    hass: HomeAssistant, calls, above, below
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls, above, below
 ) -> None:
     """Test for firing on entities change with no overlap."""
     hass.states.async_set("test.entity_1", 0)
@@ -1402,24 +1404,21 @@ async def test_if_fires_on_entities_change_no_overlap(
     )
     await hass.async_block_till_done()
 
-    utcnow = dt_util.utcnow()
-    with patch("homeassistant.core.dt_util.utcnow") as mock_utcnow:
-        mock_utcnow.return_value = utcnow
-        hass.states.async_set("test.entity_1", 9)
-        await hass.async_block_till_done()
-        mock_utcnow.return_value += timedelta(seconds=10)
-        async_fire_time_changed(hass, mock_utcnow.return_value)
-        await hass.async_block_till_done()
-        assert len(calls) == 1
-        assert calls[0].data["some"] == "test.entity_1"
+    hass.states.async_set("test.entity_1", 9)
+    await hass.async_block_till_done()
+    freezer.tick(timedelta(seconds=10))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    assert calls[0].data["some"] == "test.entity_1"
 
-        hass.states.async_set("test.entity_2", 9)
-        await hass.async_block_till_done()
-        mock_utcnow.return_value += timedelta(seconds=10)
-        async_fire_time_changed(hass, mock_utcnow.return_value)
-        await hass.async_block_till_done()
-        assert len(calls) == 2
-        assert calls[1].data["some"] == "test.entity_2"
+    hass.states.async_set("test.entity_2", 9)
+    await hass.async_block_till_done()
+    freezer.tick(timedelta(seconds=10))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    assert len(calls) == 2
+    assert calls[1].data["some"] == "test.entity_2"
 
 
 @pytest.mark.parametrize(
@@ -1432,7 +1431,7 @@ async def test_if_fires_on_entities_change_no_overlap(
     ),
 )
 async def test_if_fires_on_entities_change_overlap(
-    hass: HomeAssistant, calls, above, below
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls, above, below
 ) -> None:
     """Test for firing on entities change with overlap."""
     hass.states.async_set("test.entity_1", 0)
@@ -1460,35 +1459,32 @@ async def test_if_fires_on_entities_change_overlap(
     )
     await hass.async_block_till_done()
 
-    utcnow = dt_util.utcnow()
-    with patch("homeassistant.core.dt_util.utcnow") as mock_utcnow:
-        mock_utcnow.return_value = utcnow
-        hass.states.async_set("test.entity_1", 9)
-        await hass.async_block_till_done()
-        mock_utcnow.return_value += timedelta(seconds=1)
-        async_fire_time_changed(hass, mock_utcnow.return_value)
-        hass.states.async_set("test.entity_2", 9)
-        await hass.async_block_till_done()
-        mock_utcnow.return_value += timedelta(seconds=1)
-        async_fire_time_changed(hass, mock_utcnow.return_value)
-        hass.states.async_set("test.entity_2", 15)
-        await hass.async_block_till_done()
-        mock_utcnow.return_value += timedelta(seconds=1)
-        async_fire_time_changed(hass, mock_utcnow.return_value)
-        hass.states.async_set("test.entity_2", 9)
-        await hass.async_block_till_done()
-        assert len(calls) == 0
-        mock_utcnow.return_value += timedelta(seconds=3)
-        async_fire_time_changed(hass, mock_utcnow.return_value)
-        await hass.async_block_till_done()
-        assert len(calls) == 1
-        assert calls[0].data["some"] == "test.entity_1"
+    hass.states.async_set("test.entity_1", 9)
+    await hass.async_block_till_done()
+    freezer.tick(timedelta(seconds=1))
+    async_fire_time_changed(hass)
+    hass.states.async_set("test.entity_2", 9)
+    await hass.async_block_till_done()
+    freezer.tick(timedelta(seconds=1))
+    async_fire_time_changed(hass)
+    hass.states.async_set("test.entity_2", 15)
+    await hass.async_block_till_done()
+    freezer.tick(timedelta(seconds=1))
+    async_fire_time_changed(hass)
+    hass.states.async_set("test.entity_2", 9)
+    await hass.async_block_till_done()
+    assert len(calls) == 0
+    freezer.tick(timedelta(seconds=3))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    assert calls[0].data["some"] == "test.entity_1"
 
-        mock_utcnow.return_value += timedelta(seconds=3)
-        async_fire_time_changed(hass, mock_utcnow.return_value)
-        await hass.async_block_till_done()
-        assert len(calls) == 2
-        assert calls[1].data["some"] == "test.entity_2"
+    freezer.tick(timedelta(seconds=3))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    assert len(calls) == 2
+    assert calls[1].data["some"] == "test.entity_2"
 
 
 @pytest.mark.parametrize(

--- a/tests/components/homeassistant/triggers/test_numeric_state.py
+++ b/tests/components/homeassistant/triggers/test_numeric_state.py
@@ -1246,7 +1246,7 @@ async def test_if_not_fires_on_entities_change_with_for_after_stop(
     ),
 )
 async def test_if_fires_on_entity_change_with_for_attribute_change(
-    hass: HomeAssistant, calls, above, below
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls, above, below
 ) -> None:
     """Test for firing on entity change with for and attribute change."""
     hass.states.async_set("test.entity", 0)
@@ -1269,20 +1269,17 @@ async def test_if_fires_on_entity_change_with_for_attribute_change(
         },
     )
 
-    utcnow = dt_util.utcnow()
-    with patch("homeassistant.core.dt_util.utcnow") as mock_utcnow:
-        mock_utcnow.return_value = utcnow
-        hass.states.async_set("test.entity", 9)
-        await hass.async_block_till_done()
-        mock_utcnow.return_value += timedelta(seconds=4)
-        async_fire_time_changed(hass, mock_utcnow.return_value)
-        hass.states.async_set("test.entity", 9, attributes={"mock_attr": "attr_change"})
-        await hass.async_block_till_done()
-        assert len(calls) == 0
-        mock_utcnow.return_value += timedelta(seconds=4)
-        async_fire_time_changed(hass, mock_utcnow.return_value)
-        await hass.async_block_till_done()
-        assert len(calls) == 1
+    hass.states.async_set("test.entity", 9)
+    await hass.async_block_till_done()
+    freezer.tick(timedelta(seconds=4))
+    async_fire_time_changed(hass)
+    hass.states.async_set("test.entity", 9, attributes={"mock_attr": "attr_change"})
+    await hass.async_block_till_done()
+    assert len(calls) == 0
+    freezer.tick(timedelta(seconds=4))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    assert len(calls) == 1
 
 
 @pytest.mark.parametrize(
@@ -1695,7 +1692,7 @@ async def test_invalid_for_template(hass: HomeAssistant, calls, above, below) ->
     ),
 )
 async def test_if_fires_on_entities_change_overlap_for_template(
-    hass: HomeAssistant, calls, above, below
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls, above, below
 ) -> None:
     """Test for firing on entities change with overlap and for template."""
     hass.states.async_set("test.entity_1", 0)
@@ -1726,39 +1723,36 @@ async def test_if_fires_on_entities_change_overlap_for_template(
     )
     await hass.async_block_till_done()
 
-    utcnow = dt_util.utcnow()
-    with patch("homeassistant.util.dt.utcnow") as mock_utcnow:
-        mock_utcnow.return_value = utcnow
-        hass.states.async_set("test.entity_1", 9)
-        await hass.async_block_till_done()
-        mock_utcnow.return_value += timedelta(seconds=1)
-        async_fire_time_changed(hass, mock_utcnow.return_value)
-        hass.states.async_set("test.entity_2", 9)
-        await hass.async_block_till_done()
-        mock_utcnow.return_value += timedelta(seconds=1)
-        async_fire_time_changed(hass, mock_utcnow.return_value)
-        hass.states.async_set("test.entity_2", 15)
-        await hass.async_block_till_done()
-        mock_utcnow.return_value += timedelta(seconds=1)
-        async_fire_time_changed(hass, mock_utcnow.return_value)
-        hass.states.async_set("test.entity_2", 9)
-        await hass.async_block_till_done()
-        assert len(calls) == 0
-        mock_utcnow.return_value += timedelta(seconds=3)
-        async_fire_time_changed(hass, mock_utcnow.return_value)
-        await hass.async_block_till_done()
-        assert len(calls) == 1
-        assert calls[0].data["some"] == "test.entity_1 - 0:00:05"
+    hass.states.async_set("test.entity_1", 9)
+    await hass.async_block_till_done()
+    freezer.tick(timedelta(seconds=1))
+    async_fire_time_changed(hass)
+    hass.states.async_set("test.entity_2", 9)
+    await hass.async_block_till_done()
+    freezer.tick(timedelta(seconds=1))
+    async_fire_time_changed(hass)
+    hass.states.async_set("test.entity_2", 15)
+    await hass.async_block_till_done()
+    freezer.tick(timedelta(seconds=1))
+    async_fire_time_changed(hass)
+    hass.states.async_set("test.entity_2", 9)
+    await hass.async_block_till_done()
+    assert len(calls) == 0
+    freezer.tick(timedelta(seconds=3))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    assert calls[0].data["some"] == "test.entity_1 - 0:00:05"
 
-        mock_utcnow.return_value += timedelta(seconds=3)
-        async_fire_time_changed(hass, mock_utcnow.return_value)
-        await hass.async_block_till_done()
-        assert len(calls) == 1
-        mock_utcnow.return_value += timedelta(seconds=5)
-        async_fire_time_changed(hass, mock_utcnow.return_value)
-        await hass.async_block_till_done()
-        assert len(calls) == 2
-        assert calls[1].data["some"] == "test.entity_2 - 0:00:10"
+    freezer.tick(timedelta(seconds=3))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    freezer.tick(timedelta(seconds=5))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    assert len(calls) == 2
+    assert calls[1].data["some"] == "test.entity_2 - 0:00:10"
 
 
 async def test_below_above(hass: HomeAssistant) -> None:
@@ -1857,7 +1851,9 @@ async def test_attribute_if_not_fires_on_entities_change_with_for_after_stop(
     ("above", "below"),
     ((8, 12),),
 )
-async def test_variables_priority(hass: HomeAssistant, calls, above, below) -> None:
+async def test_variables_priority(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls, above, below
+) -> None:
     """Test an externally defined trigger variable is overridden."""
     hass.states.async_set("test.entity_1", 0)
     hass.states.async_set("test.entity_2", 0)
@@ -1888,29 +1884,26 @@ async def test_variables_priority(hass: HomeAssistant, calls, above, below) -> N
     )
     await hass.async_block_till_done()
 
-    utcnow = dt_util.utcnow()
-    with patch("homeassistant.util.dt.utcnow") as mock_utcnow:
-        mock_utcnow.return_value = utcnow
-        hass.states.async_set("test.entity_1", 9)
-        await hass.async_block_till_done()
-        mock_utcnow.return_value += timedelta(seconds=1)
-        async_fire_time_changed(hass, mock_utcnow.return_value)
-        hass.states.async_set("test.entity_2", 9)
-        await hass.async_block_till_done()
-        mock_utcnow.return_value += timedelta(seconds=1)
-        async_fire_time_changed(hass, mock_utcnow.return_value)
-        hass.states.async_set("test.entity_2", 15)
-        await hass.async_block_till_done()
-        mock_utcnow.return_value += timedelta(seconds=1)
-        async_fire_time_changed(hass, mock_utcnow.return_value)
-        hass.states.async_set("test.entity_2", 9)
-        await hass.async_block_till_done()
-        assert len(calls) == 0
-        mock_utcnow.return_value += timedelta(seconds=3)
-        async_fire_time_changed(hass, mock_utcnow.return_value)
-        await hass.async_block_till_done()
-        assert len(calls) == 1
-        assert calls[0].data["some"] == "test.entity_1 - 0:00:05"
+    hass.states.async_set("test.entity_1", 9)
+    await hass.async_block_till_done()
+    freezer.tick(timedelta(seconds=1))
+    async_fire_time_changed(hass)
+    hass.states.async_set("test.entity_2", 9)
+    await hass.async_block_till_done()
+    freezer.tick(timedelta(seconds=1))
+    async_fire_time_changed(hass)
+    hass.states.async_set("test.entity_2", 15)
+    await hass.async_block_till_done()
+    freezer.tick(timedelta(seconds=1))
+    async_fire_time_changed(hass)
+    hass.states.async_set("test.entity_2", 9)
+    await hass.async_block_till_done()
+    assert len(calls) == 0
+    freezer.tick(timedelta(seconds=3))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    assert calls[0].data["some"] == "test.entity_1 - 0:00:05"
 
 
 @pytest.mark.parametrize("multiplier", (1, 5))


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
There was no need to use async_track_point_in_utc_time here since we only need a delay


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
