### PR TITLE
Switch async_track_time_interval to use async_call_later internally

### DIFF
--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -1488,19 +1488,13 @@ def async_track_time_interval(
         action, f"track time interval {interval}", cancel_on_shutdown=cancel_on_shutdown
     )
 
-    def next_interval() -> datetime:
-        """Return the next interval."""
-        return dt_util.utcnow() + interval
-
     @callback
     def interval_listener(now: datetime) -> None:
         """Handle elapsed intervals."""
         nonlocal remove
         nonlocal interval_listener_job
 
-        remove = async_track_point_in_utc_time(
-            hass, interval_listener_job, next_interval()
-        )
+        remove = async_call_later(hass, interval, interval_listener_job)
         hass.async_run_hass_job(job, now)
 
     if name:
@@ -1511,7 +1505,7 @@ def async_track_time_interval(
     interval_listener_job = HassJob(
         interval_listener, job_name, cancel_on_shutdown=cancel_on_shutdown
     )
-    remove = async_track_point_in_utc_time(hass, interval_listener_job, next_interval())
+    remove = async_call_later(hass, interval, interval_listener_job)
 
     def remove_listener() -> None:
         """Remove interval listener."""

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -1483,6 +1483,7 @@ def async_track_time_interval(
     """Add a listener that fires repetitively at every timedelta interval."""
     remove: CALLBACK_TYPE
     interval_listener_job: HassJob[[datetime], None]
+    interval_seconds = interval.total_seconds()
 
     job = HassJob(
         action, f"track time interval {interval}", cancel_on_shutdown=cancel_on_shutdown
@@ -1494,7 +1495,7 @@ def async_track_time_interval(
         nonlocal remove
         nonlocal interval_listener_job
 
-        remove = async_call_later(hass, interval, interval_listener_job)
+        remove = async_call_later(hass, interval_seconds, interval_listener_job)
         hass.async_run_hass_job(job, now)
 
     if name:
@@ -1505,7 +1506,7 @@ def async_track_time_interval(
     interval_listener_job = HassJob(
         interval_listener, job_name, cancel_on_shutdown=cancel_on_shutdown
     )
-    remove = async_call_later(hass, interval, interval_listener_job)
+    remove = async_call_later(hass, interval_seconds, interval_listener_job)
 
     def remove_listener() -> None:
         """Remove interval listener."""

--- a/tests/components/gardena_bluetooth/conftest.py
+++ b/tests/components/gardena_bluetooth/conftest.py
@@ -3,7 +3,7 @@ from collections.abc import Awaitable, Callable, Generator
 from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
-from freezegun import freeze_time
+from freezegun.api import FrozenDateTimeFactory
 from gardena_bluetooth.client import Client
 from gardena_bluetooth.const import DeviceInformation
 from gardena_bluetooth.exceptions import CharacteristicNotFound
@@ -49,19 +49,19 @@ def mock_read_char_raw():
 
 @pytest.fixture
 async def scan_step(
-    hass: HomeAssistant,
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory
 ) -> Generator[None, None, Callable[[], Awaitable[None]]]:
     """Step system time forward."""
 
-    with freeze_time("2023-01-01", tz_offset=1) as frozen_time:
+    freezer.move_to("2023-01-01T01:00:00Z")
 
-        async def delay():
-            """Trigger delay in system."""
-            frozen_time.tick(delta=SCAN_INTERVAL)
-            async_fire_time_changed(hass)
-            await hass.async_block_till_done()
+    async def delay():
+        """Trigger delay in system."""
+        freezer.tick(delta=SCAN_INTERVAL)
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
 
-        yield delay
+    return delay
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/modbus/conftest.py
+++ b/tests/components/modbus/conftest.py
@@ -5,11 +5,13 @@ from datetime import timedelta
 import logging
 from unittest import mock
 
+from freezegun.api import FrozenDateTimeFactory
 from pymodbus.exceptions import ModbusException
 import pytest
 
 from homeassistant.components.modbus.const import MODBUS_DOMAIN as DOMAIN, TCP
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT, CONF_SLAVE, CONF_TYPE
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -140,26 +142,26 @@ async def mock_pymodbus_return_fixture(hass, register_words, mock_modbus):
 
 
 @pytest.fixture(name="mock_do_cycle")
-async def mock_do_cycle_fixture(hass, mock_pymodbus_exception, mock_pymodbus_return):
+async def mock_do_cycle_fixture(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_pymodbus_exception,
+    mock_pymodbus_return,
+) -> FrozenDateTimeFactory:
     """Trigger update call with time_changed event."""
-    now = dt_util.utcnow() + timedelta(seconds=90)
-    with mock.patch(
-        "homeassistant.helpers.event.dt_util.utcnow", return_value=now, autospec=True
-    ):
-        async_fire_time_changed(hass, now)
-        await hass.async_block_till_done()
-        return now
+    freezer.tick(timedelta(seconds=90))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    return freezer
 
 
-async def do_next_cycle(hass, now, cycle):
+async def do_next_cycle(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, cycle: int
+) -> None:
     """Trigger update call with time_changed event."""
-    now += timedelta(seconds=cycle)
-    with mock.patch(
-        "homeassistant.helpers.event.dt_util.utcnow", return_value=now, autospec=True
-    ):
-        async_fire_time_changed(hass, now)
-        await hass.async_block_till_done()
-        return now
+    freezer.tick(timedelta(seconds=cycle))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
 
 
 @pytest.fixture(name="mock_test_state")

--- a/tests/components/modbus/test_binary_sensor.py
+++ b/tests/components/modbus/test_binary_sensor.py
@@ -1,4 +1,5 @@
 """Thetests for the Modbus sensor component."""
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 
 from homeassistant.components.binary_sensor import DOMAIN as SENSOR_DOMAIN
@@ -199,14 +200,13 @@ async def test_all_binary_sensor(hass: HomeAssistant, expected, mock_do_cycle) -
     ],
 )
 async def test_lazy_error_binary_sensor(
-    hass: HomeAssistant, start_expect, end_expect, mock_do_cycle
+    hass: HomeAssistant, start_expect, end_expect, mock_do_cycle: FrozenDateTimeFactory
 ) -> None:
     """Run test for given config."""
-    now = mock_do_cycle
     assert hass.states.get(ENTITY_ID).state == start_expect
-    now = await do_next_cycle(hass, now, 11)
+    await do_next_cycle(hass, mock_do_cycle, 11)
     assert hass.states.get(ENTITY_ID).state == start_expect
-    now = await do_next_cycle(hass, now, 11)
+    await do_next_cycle(hass, mock_do_cycle, 11)
     assert hass.states.get(ENTITY_ID).state == end_expect
 
 

--- a/tests/components/modbus/test_climate.py
+++ b/tests/components/modbus/test_climate.py
@@ -1,4 +1,5 @@
 """The tests for the Modbus climate component."""
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 
 from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
@@ -597,16 +598,15 @@ async def test_restore_state_climate(
     ],
 )
 async def test_lazy_error_climate(
-    hass: HomeAssistant, mock_do_cycle, start_expect, end_expect
+    hass: HomeAssistant, mock_do_cycle: FrozenDateTimeFactory, start_expect, end_expect
 ) -> None:
     """Run test for sensor."""
     hass.states.async_set(ENTITY_ID, 17)
     await hass.async_block_till_done()
-    now = mock_do_cycle
     assert hass.states.get(ENTITY_ID).state == start_expect
-    now = await do_next_cycle(hass, now, 11)
+    await do_next_cycle(hass, mock_do_cycle, 11)
     assert hass.states.get(ENTITY_ID).state == start_expect
-    now = await do_next_cycle(hass, now, 11)
+    await do_next_cycle(hass, mock_do_cycle, 11)
     assert hass.states.get(ENTITY_ID).state == end_expect
 
 

--- a/tests/components/modbus/test_cover.py
+++ b/tests/components/modbus/test_cover.py
@@ -1,4 +1,5 @@
 """The tests for the Modbus cover component."""
+from freezegun.api import FrozenDateTimeFactory
 from pymodbus.exceptions import ModbusException
 import pytest
 
@@ -142,14 +143,13 @@ async def test_coil_cover(hass: HomeAssistant, expected, mock_do_cycle) -> None:
     ],
 )
 async def test_lazy_error_cover(
-    hass: HomeAssistant, start_expect, end_expect, mock_do_cycle
+    hass: HomeAssistant, start_expect, end_expect, mock_do_cycle: FrozenDateTimeFactory
 ) -> None:
     """Run test for given config."""
-    now = mock_do_cycle
     assert hass.states.get(ENTITY_ID).state == start_expect
-    now = await do_next_cycle(hass, now, 11)
+    await do_next_cycle(hass, mock_do_cycle, 11)
     assert hass.states.get(ENTITY_ID).state == start_expect
-    now = await do_next_cycle(hass, now, 11)
+    await do_next_cycle(hass, mock_do_cycle, 11)
     assert hass.states.get(ENTITY_ID).state == end_expect
 
 

--- a/tests/components/modbus/test_sensor.py
+++ b/tests/components/modbus/test_sensor.py
@@ -1,4 +1,5 @@
 """The tests for the Modbus sensor component."""
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 
 from homeassistant.components.modbus.const import (
@@ -928,16 +929,15 @@ async def test_wrong_unpack(hass: HomeAssistant, mock_do_cycle) -> None:
     ],
 )
 async def test_lazy_error_sensor(
-    hass: HomeAssistant, mock_do_cycle, start_expect, end_expect
+    hass: HomeAssistant, mock_do_cycle: FrozenDateTimeFactory, start_expect, end_expect
 ) -> None:
     """Run test for sensor."""
     hass.states.async_set(ENTITY_ID, 17)
     await hass.async_block_till_done()
-    now = mock_do_cycle
     assert hass.states.get(ENTITY_ID).state == start_expect
-    now = await do_next_cycle(hass, now, 11)
+    await do_next_cycle(hass, mock_do_cycle, 11)
     assert hass.states.get(ENTITY_ID).state == start_expect
-    now = await do_next_cycle(hass, now, 11)
+    await do_next_cycle(hass, mock_do_cycle, 11)
     assert hass.states.get(ENTITY_ID).state == end_expect
 
 

--- a/tests/components/modbus/test_switch.py
+++ b/tests/components/modbus/test_switch.py
@@ -2,6 +2,7 @@
 from datetime import timedelta
 from unittest import mock
 
+from freezegun.api import FrozenDateTimeFactory
 from pymodbus.exceptions import ModbusException
 import pytest
 
@@ -237,14 +238,13 @@ async def test_all_switch(hass: HomeAssistant, mock_do_cycle, expected) -> None:
     ],
 )
 async def test_lazy_error_switch(
-    hass: HomeAssistant, start_expect, end_expect, mock_do_cycle
+    hass: HomeAssistant, start_expect, end_expect, mock_do_cycle: FrozenDateTimeFactory
 ) -> None:
     """Run test for given config."""
-    now = mock_do_cycle
     assert hass.states.get(ENTITY_ID).state == start_expect
-    now = await do_next_cycle(hass, now, 11)
+    await do_next_cycle(hass, mock_do_cycle, 11)
     assert hass.states.get(ENTITY_ID).state == start_expect
-    now = await do_next_cycle(hass, now, 11)
+    await do_next_cycle(hass, mock_do_cycle, 11)
     assert hass.states.get(ENTITY_ID).state == end_expect
 
 


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This avoids a lot of utcnow calls since we only need to call at an interval and do not need to convert back and forth from wall clock time


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
